### PR TITLE
feat(api): apiv2: implement robot methods backcompat

### DIFF
--- a/api/src/opentrons/hardware_control/adapters.py
+++ b/api/src/opentrons/hardware_control/adapters.py
@@ -33,6 +33,7 @@ class SynchronousAdapter(HardwareAPILike, threading.Thread):
         :param args: Args to forward to the builder method
         :param kwargs: Kwargs to forward to the builder method
         """
+        print("called ")
         loop = asyncio.new_event_loop()
         kwargs['loop'] = loop
         args = [arg for arg in args
@@ -42,6 +43,7 @@ class SynchronousAdapter(HardwareAPILike, threading.Thread):
             api = checked_loop.run_until_complete(builder(*args, **kwargs))
         else:
             api = builder(*args, **kwargs)
+        print("called")
         return cls(api, loop)
 
     def __init__(self,
@@ -66,6 +68,7 @@ class SynchronousAdapter(HardwareAPILike, threading.Thread):
         super().__init__(
             target=self._event_loop_in_thread,
             name='SynchAdapter thread for {}'.format(repr(api)))
+        print(f"Building {id(self)}, self is {str(self)}")
         super().start()
 
     def __repr__(self):

--- a/api/src/opentrons/hardware_control/adapters.py
+++ b/api/src/opentrons/hardware_control/adapters.py
@@ -33,7 +33,6 @@ class SynchronousAdapter(HardwareAPILike, threading.Thread):
         :param args: Args to forward to the builder method
         :param kwargs: Kwargs to forward to the builder method
         """
-        print("called ")
         loop = asyncio.new_event_loop()
         kwargs['loop'] = loop
         args = [arg for arg in args
@@ -43,7 +42,6 @@ class SynchronousAdapter(HardwareAPILike, threading.Thread):
             api = checked_loop.run_until_complete(builder(*args, **kwargs))
         else:
             api = builder(*args, **kwargs)
-        print("called")
         return cls(api, loop)
 
     def __init__(self,
@@ -68,7 +66,6 @@ class SynchronousAdapter(HardwareAPILike, threading.Thread):
         super().__init__(
             target=self._event_loop_in_thread,
             name='SynchAdapter thread for {}'.format(repr(api)))
-        print(f"Building {id(self)}, self is {str(self)}")
         super().start()
 
     def __repr__(self):

--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -4,7 +4,7 @@ This package defines classes and functions for access through a protocol to
 control the OT2.
 
 """
-from . import back_compat, labware
+from . import labware
 from .contexts import (ProtocolContext,
                        InstrumentContext,
                        TemperatureModuleContext,
@@ -17,5 +17,4 @@ __all__ = ['ProtocolContext',
            'TemperatureModuleContext',
            'MagneticModuleContext',
            'ThermocyclerContext',
-           'back_compat',
            'labware']

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -41,7 +41,7 @@ class ProtocolContext(CommandPublisher):
     Unlike the old robot class, it is designed to be ephemeral. The lifetime
     of a particular instance should be about the same as the lifetime of a
     protocol. The only exception is the one stored in
-    :py:attr:`.back_compat.robot`, which is provided only for back
+    :py:attr:`.legacy_api.api.robot`, which is provided only for back
     compatibility and should be used less and less as time goes by.
     """
 

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -228,6 +228,9 @@ class ProtocolContext(CommandPublisher):
         """
         self._hw_manager.reset_hw()
 
+    def is_simulating(self) -> bool:
+        return self._hw_manager.hardware.get_is_simulator()
+
     def load_labware_from_definition(
             self,
             labware_def: LabwareDefinition,

--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -121,7 +121,7 @@ def _run_python(
 def _run_python_legacy(proto: PythonProtocol, context: ProtocolContext):
     new_locs = locals()
     new_globs = globals()
-    namespace_mapping = legacy_wrapper.api.build_globals()
+    namespace_mapping = legacy_wrapper.api.build_globals(context)
     for key, value in namespace_mapping.items():
         setattr(opentrons, key, value)
     try:

--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -6,7 +6,7 @@ from typing import Any, Callable
 
 import opentrons
 from .contexts import ProtocolContext
-from . import execute_v3, back_compat
+from . import execute_v3, legacy_wrapper
 
 from opentrons import config
 from opentrons.protocols.types import PythonProtocol, Protocol
@@ -121,7 +121,7 @@ def _run_python(
 def _run_python_legacy(proto: PythonProtocol, context: ProtocolContext):
     new_locs = locals()
     new_globs = globals()
-    namespace_mapping = back_compat.build_globals()
+    namespace_mapping = legacy_wrapper.api.build_globals()
     for key, value in namespace_mapping.items():
         setattr(opentrons, key, value)
     try:

--- a/api/src/opentrons/protocol_api/legacy_wrapper/__init__.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/__init__.py
@@ -4,3 +4,5 @@ The functions and modules here implement an API wrapper that looks like the
 old robot singleton based api for python protocols, but in fact rely on the
 protocol api for behavior.
 """
+
+from .api import *  # noqa(F401)

--- a/api/src/opentrons/protocol_api/legacy_wrapper/api.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/api.py
@@ -241,5 +241,6 @@ def build_globals(context: 'ProtocolContext'):
     instr = BCInstruments(rob)
     lw = BCLabware(context)
     mod = BCModules(context)
+    rob._set_globals(instr, lw, mod)
 
     return {'robot': rob, 'instruments': instr, 'labware': lw, 'modules': mod}

--- a/api/src/opentrons/protocol_api/legacy_wrapper/api.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/api.py
@@ -11,8 +11,8 @@ from typing import Any, List
 import opentrons.hardware_control as hc
 from opentrons.config.pipette_config import config_models
 from opentrons.types import Mount
-from .labware import Labware
-from .contexts import ProtocolContext, InstrumentContext
+from ..labware import Labware
+from ..contexts import ProtocolContext, InstrumentContext
 
 
 def run(protocol_bytes: bytes, context: ProtocolContext):

--- a/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
@@ -1,7 +1,7 @@
 # pylama:ignore=E731
 
 import logging
-from typing import TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 from opentrons import commands
 from .util import log_call
 
@@ -38,6 +38,7 @@ class Pipette():
             self,
             instrument_context: 'InstrumentContext'):
         self._ctx = instrument_context
+        self._max_plunger_speed: Optional[float] = None
 
     @log_call(log)
     def reset(self):
@@ -164,6 +165,7 @@ class Pipette():
         >>> # aspirate the pipette's remaining volume (80uL) from a Well
         >>> p300.aspirate(plate[2]) # doctest: +SKIP
         """
+        # TODO: When implementing this, cap rate to self._max_plunger_speed
         return self
 
     @log_call(log)
@@ -222,6 +224,7 @@ class Pipette():
         # dispense the pipette's remaining volume (80uL) to a Well
         >>> p300.dispense(plate[2]) # doctest: +SKIP
         """
+        # TODO: When implementing this, cap rate to self._max_plunger_speed
         return self
 
     @log_call(log)
@@ -321,6 +324,7 @@ class Pipette():
         >>> p300 = instruments.P300_Single(mount='left') # doctest: +SKIP
         >>> p300.aspirate(50).dispense().blow_out() # doctest: +SKIP
         """
+        # TODO: When implementing this, cap rate to self._max_plunger_speed
         return self
 
     @log_call(log)
@@ -759,6 +763,7 @@ class Pipette():
             The speed in millimeters-per-second, at which the plunger will
             move while performing an dispense
         """
+        # TODO: When implementing this, cap it to self._max_plunger_speed
         return self
 
     @log_call(log)
@@ -777,6 +782,7 @@ class Pipette():
             The speed in microliters-per-second, at which the plunger will
             move while performing an dispense
         """
+        # TODO: When implementing this, cap it to self._max_plunger_speed
         return self
 
     @log_call(log)
@@ -796,3 +802,6 @@ class Pipette():
     def type(self):
         log.info('instrument.type')
         return 'single'
+
+    def _set_plunger_max_speed_override(self, speed: float):
+        self._max_plunger_speed = speed

--- a/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
@@ -1,19 +1,19 @@
 # pylama:ignore=E731
 
 import logging
+from typing import TYPE_CHECKING
 from opentrons import commands
-from opentrons.commands import CommandPublisher
 from .util import log_call
+
+if TYPE_CHECKING:
+    from ..contexts import InstrumentContext
 
 log = logging.getLogger(__name__)
 
 
-class Pipette(CommandPublisher):
+class Pipette():
     """
-    DIRECT USE OF THIS CLASS IS DEPRECATED -- this class should not be used
-    directly. Its parameters, defaults, methods, and behaviors are subject to
-    change without a major version release. Use the model-specific constructors
-    available through ``from opentrons import instruments``.
+    This class should not be used directly.
 
     All model-specific instrument constructors are inheritors of this class.
     With any of those instances you can can:
@@ -32,46 +32,12 @@ class Pipette(CommandPublisher):
     Methods in this class include assertions where needed to ensure that any
     action that requires a tip must be preceeded by `pick_up_tip`. For example:
     `mix`, `transfer`, `aspirate`, `blow_out`, and `drop_tip`.
-
-    Parameters
-    ----------
-    mount : str
-        The mount of the pipette's actuator on the Opentrons robot
-        ('left' or 'right')
-    trash_container : Container
-        Sets the default location :meth:`drop_tip()` will put tips
-        (Default: `fixed-trash`)
-    tip_racks : list
-        A list of Containers for this Pipette to track tips when calling
-        :meth:`pick_up_tip` (Default: [])
-    aspirate_flow_rate : int
-        The speed (in ul/sec) the plunger will move while aspirating
-        (Default: See Model Type)
-    dispense_flow_rate : int
-        The speed (in ul/sec) the plunger will move while dispensing
-        (Default: See Model Type)
-
-    Returns
-    -------
-
-    A new instance of :class:`Pipette`.
-
-    Examples
-    --------
-    >>> from opentrons import instruments, labware, robot # doctest: +SKIP
-    >>> robot.reset() # doctest: +SKIP
-    >>> tip_rack_300ul = labware.load(
-    ...     'GEB-tiprack-300ul', '1') # doctest: +SKIP
-    >>> p300 = instruments.P300_Single(mount='left',
-    ...     tip_racks=[tip_rack_300ul]) # doctest: +SKIP
     """
 
     def __init__(  # noqa(C901)
             self,
-            robot):
-
-        super().__init__(robot.broker)
-        self.robot = robot
+            instrument_context: 'InstrumentContext'):
+        self._ctx = instrument_context
 
     @log_call(log)
     def reset(self):

--- a/api/src/opentrons/protocol_api/legacy_wrapper/robot_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/robot_wrapper.py
@@ -1,15 +1,20 @@
 import logging
+from typing import Any, Dict, Optional, TYPE_CHECKING
 
-from opentrons.commands import CommandPublisher, commands
-
-from opentrons.config.robot_configs import load
+from opentrons.hardware_control import adapters, API
 from .util import log_call
+
+
+if TYPE_CHECKING:
+    from .instrument_wrapper import Pipette
+    from ..contexts import ProtocolContext
+    from .api import BCInstruments, BCLabware, BCModules
 
 
 log = logging.getLogger(__name__)
 
 
-class Robot(CommandPublisher):
+class Robot():
     """
     This class is the main legacy interface to the robot.
 
@@ -41,7 +46,15 @@ class Robot(CommandPublisher):
     See :class:`Pipette` for the list of supported instructions.
     """
 
-    def __init__(self, config=None, broker=None):
+    def _add_instrument(self, mount: str, instr: 'Pipette'):
+        """ Internal. Register intrument with this wrapper """
+        self._instrs[mount] = instr
+        if self._head_speed_override:
+            instr._ctx.default_speed = self._head_speed_override
+
+    def __init__(
+            self,
+            protocol_ctx: 'ProtocolContext'):
         """
         Initializes a robot instance.
 
@@ -51,21 +64,16 @@ class Robot(CommandPublisher):
         :func:`__init__` the same instance will be returned. There's
         only once instance of a robot.
         """
-        super().__init__(broker)
-        self.config = config or load()
+        self.config = protocol_ctx.config
+        self._ctx = protocol_ctx
+        self._head_speed_override: Optional[float] = None
+        self._instrs: Dict[str, 'Pipette'] = {}
 
-    @log_call(log)
-    def clear_tips(self):
-        """
-        If reset is called with a tip attached, the tip must be removed
-        before the poses and _instruments members are cleared. If the tip is
-        not removed, the effective length of the pipette remains increased by
-        the length of the tip, and subsequent `_add_tip` calls will increase
-        the length in addition to this. This should be fixed by changing pose
-        tracking to that it tracks the tip as a separate node rather than
-        adding and subtracting the tip length to the pipette length.
-        """
-        return None
+    def _set_globals(
+            self, instr: 'BCInstruments', lw: 'BCLabware', mod: 'BCModules'):
+        self._bc_instr = instr
+        self._bc_lw = lw
+        self._bc_mods = mod
 
     @log_call(log)
     def reset(self):
@@ -76,80 +84,43 @@ class Robot(CommandPublisher):
             * Command queue
             * Runtime warnings
 
-        Examples
-        --------
-
-        >>> from opentrons import robot # doctest: +SKIP
-        >>> robot.reset() # doctest: +SKIP
+        This is necessary only when you are using this object interactively
+        from Jupyter or a Python session. It does not need to be used in
+        protocols.
         """
-        return None
+        self._head_speed_override = None
+        self._intrs = {}
+        self._bc_instruments._robot_wrapper = self
+        self._bc_mods._ctx = self._ctx
+        self._bc_lw._ctx = self._ctx
 
     @log_call(log)
-    def cache_instrument_models(self):
+    def connect(self, port: str = None, options: Any = None):
         """
-        Queries Smoothie for the model and ID strings of attached pipettes, and
-        saves them so they can be reported without querying Smoothie again (as
-        this could interrupt a command if done during a run or other movement).
+        Connects the robot to a serial port. In most cases, this does not need
+        to be called; for instance, it does not need to be called in a protocol
+        uploaded through the Opentrons App, executed with opentrons_execute,
+        or simulated with opentrons_simulate. It only needs to be called when
+        you use a robot object from the Jupyter notebook.
 
-        Shape of return dict should be:
+        :param port: The port to connect to. If not specified, autodetected. If
+                     set to ``'Virtual Smoothie'``, connects to a virtual port.
+        :param options: Unused argument provided for backwards compatibility
 
-        ```
-        {
-          "left": {
-            "model": "<model_string>" or None,
-            "id": "<pipette_id_string>" or None
-          },
-          "right": {
-            "model": "<model_string>" or None,
-            "id": "<pipette_id_string>" or None
-          }
-        }
-        ```
-
-        :return: a dict with pipette data (shape described above)
+        :returns bool: ``True`` for success, ``False`` for failure.
         """
-        return None
-
-    @log_call(log)
-    def connect(self, port=None, options=None):
-        """
-        Connects the robot to a serial port.
-
-        Parameters
-        ----------
-        port : str
-            OS-specific port name or ``'Virtual Smoothie'``
-        options : dict
-            if :attr:`port` is set to ``'Virtual Smoothie'``, provide
-            the list of options to be passed to :func:`get_virtual_device`
-
-        Returns
-        -------
-        ``True`` for success, ``False`` for failure.
-
-        Note
-        ----
-        If you wish to connect to the robot without using the OT App, you will
-        need to use this function.
-
-        Examples
-        --------
-
-        >>> from opentrons import robot # doctest: +SKIP
-        >>> robot.connect() # doctest: +SKIP
-        """
-        return None
+        hw = adapters.SynchronousAdapter.build(
+            API.build_hardware_controller,
+            port=port)
+        self._ctx.connect(hw)
+        return True
 
     @log_call(log)
     def home(self, *args, **kwargs):
         """
         Home robot's head and plunger motors.
         """
-        return None
-
-    @log_call(log)
-    def home_z(self):
-        return None
+        self._ctx.home()
 
     @log_call(log)
     def head_speed(
@@ -158,22 +129,20 @@ class Robot(CommandPublisher):
         """
         Set the speeds (mm/sec) of the robot
 
-        Parameters
-        ----------
-        combined_speed : number specifying a combined-axes speed
-        <axis> : key/value pair, specifying the maximum speed of that axis
-
-        Examples
-        ---------
-
-        >>> from opentrons import robot # doctest: +SKIP
-        >>> robot.reset() # doctest: +SKIP
-        >>> robot.head_speed(combined_speed=400) # doctest: +SKIP
-        #  sets the head speed to 400 mm/sec or the axis max per axis
-        >>> robot.head_speed(x=400, y=200) # doctest: +SKIP
-        # sets max speeds of X and Y
+        :param combined_speed: If specified, a positive number setting the
+                               straight-line speed at which to move.
+        :param x, y, z, a: If specified by axis, sets the maximum speed at
+                           which that axis will move.
         """
-        return None
+        if combined_speed:
+            self._head_speed_override = combined_speed
+            for instr in self._instrs.values():
+                instr._ctx.default_speed = combined_speed
+
+        maxes = {'x': x, 'y': y, 'z': z, 'a': a}
+        for ax, m in maxes.items():
+            if m:
+                self._ctx.max_speeds[ax] = m
 
     @log_call(log)
     def move_to(
@@ -186,118 +155,91 @@ class Robot(CommandPublisher):
         Move an instrument to a coordinate, container or a coordinate within
         a container.
 
-        Parameters
-        ----------
-        location : one of the following:
-            1. :class:`Placeable` (i.e. Container, Deck, Slot, Well) — will
-            move to the origin of a container.
-            2. :class:`Vector` move to the given coordinate in Deck coordinate
-            system.
-            3. (:class:`Placeable`, :class:`Vector`) move to a given coordinate
-            within object's coordinate system.
+        Most of the time, you should just call
+        :py:meth:`.instrument_wrapper.Pipette.move_to`.
 
-        instrument :
-            Instrument to move relative to. If ``None``, move relative to the
-            center of a gantry.
+        :param location: A location derived from some other method. For
+                         instance, you can pass a well here, or the result of
+                         ``well.top()``. Fundamentally, this is a tuple of
+                         a labware reference and a point.
+        :param instrument: The instrument object to move.
+        :param strategy: ``'arc'`` or ``'direct'``. Forces the robot to either
+                         move up and over to the destination, or move in a
+                         straight line.
 
-        strategy : {'arc', 'direct'}
-            ``arc`` : move to the point using arc trajectory
-            avoiding obstacles.
-
-            ``direct`` : move to the point in a straight line.
+        :return Robot: This instance.
         """
-        return None
+        instrument.move_to(location, strategy)
+        return self
 
     @log_call(log)
     def disconnect(self):
         """
         Disconnects from the robot.
         """
-        return None
+        return self._ctx.disconnect()
 
     @log_call(log)
     def deck(self):
-        log.info('robot.deck')
-        return None
+        return self._ctx.deck
 
     @log_call(log)
     def fixed_trash(self):
-        log.info('robot.fixed_trash')
-        return None
+        return self._ctx.fixed_trash
 
     @log_call(log)
-    def get_instruments_by_name(self, name):
-        return None
-
-    @log_call(log)
-    def get_instruments(self, name=None):
-        """
-        :returns: sorted list of (mount, instrument)
-        """
-        return None
-
-    @log_call(log)
-    def get_containers(self):
-        """
-        Returns all containers currently on the deck.
-        """
-        return None
-
-    @log_call(log)
-    def add_container(self, name, slot, label=None, share=False):
-        return None
-
-    @log_call(log)
-    @commands.publish.both(command=commands.pause)
     def pause(self, msg=None):
         """
         Pauses execution of the protocol. Use :meth:`resume` to resume
         """
-        return None
+        return self._ctx.pause(msg)
 
     @log_call(log)
-    def execute_pause(self):
-        """ Pause the driver
-
-        This method should not be called inside a protocol. Use
-        :py:meth:`pause` instead
-        """
-        return None
-
-    @log_call(log)
-    @commands.publish.both(command=commands.resume)
     def resume(self):
         """
         Resume execution of the protocol after :meth:`pause`
         """
-        return None
+        return self._ctx.resume()
 
     @log_call(log)
     def is_connected(self):
-        return None
+        """ Check if this robot is connected.
+
+        This is the inverse of :py:meth:`.is_simulating`.
+        """
+        return not self._ctx.is_simulating()
 
     @log_call(log)
     def is_simulating(self):
-        return None
+        """ Check if the robot is simulating or running.
+
+        If this is a simulation, returns ``True``; if calls will cause the
+        robot to move, return ``False``.
+        """
+        return self._ctx.is_simulating()
 
     @log_call(log)
-    @commands.publish.both(command=commands.comment)
     def comment(self, msg):
-        return None
+        """ Publish a message into the run log.
+
+        For instance, if you do
+
+        .. code-block:: python
+
+            from opentrons import robot
+            robot.comment("Hello, world!")
+
+        The runlog will display "Hello, world!".
+        """
+        return self._ctx.comment(msg)
 
     @log_call(log)
     def commands(self):
-        return None
+        return self._ctx.commands()
 
     @log_call(log)
     def clear_commands(self):
-        return None
-
-    @property  # type: ignore
-    @log_call(log)
-    def engaged_axes(self):
-        """ Which axes are engaged and holding. """
-        return None
+        return self._ctx.clear_commands()
 
     def discover_modules(self):
         pass

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -256,8 +256,8 @@ def apiv1_singletons(config_tempdir, virtual_smoothie_env):
 
 @pytest.mark.apiv2
 def apiv2_singletons_factory(virtual_smoothie_env):
-    from opentrons.protocol_api import back_compat
-    return {**back_compat.build_globals()}
+    from opentrons.protocol_api.legacy_wrapper import api
+    return {**api.build_globals()}
 
 
 @pytest.fixture

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -257,7 +257,8 @@ def apiv1_singletons(config_tempdir, virtual_smoothie_env):
 @pytest.mark.apiv2
 def apiv2_singletons_factory(virtual_smoothie_env):
     from opentrons.protocol_api.legacy_wrapper import api
-    return {**api.build_globals()}
+    ctx = ProtocolContext()
+    return {**api.build_globals(ctx)}
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_api/test_back_compat.py
+++ b/api/tests/opentrons/protocol_api/test_back_compat.py
@@ -110,7 +110,7 @@ def test_resume(singletons, monkeypatch):
     resume_mock.assert_called_once()
 
 
-@pytest.mark.api2_ony
+@pytest.mark.api2_only
 def test_comment(singletons, monkeypatch):
     comment_mock = mock.Mock()
     monkeypatch.setattr(singletons['robot']._ctx,

--- a/api/tests/opentrons/protocol_api/test_back_compat.py
+++ b/api/tests/opentrons/protocol_api/test_back_compat.py
@@ -63,7 +63,7 @@ def test_labware_mappings(loop, monkeypatch, singletons):
 @pytest.mark.api2_only
 def test_head_speed(singletons):
     # Setting axis speeds should set max speeds
-    singletons['robot'].head_speed(x=2, y=3, z=5)
+    singletons['robot'].head_speed(x=2, y=3, z=5, b=3)
     assert singletons['robot']._ctx.max_speeds['X'] == 2
     assert singletons['robot']._ctx.max_speeds['Y'] == 3
     assert singletons['robot']._ctx.max_speeds['Z'] == 5
@@ -82,9 +82,12 @@ def test_head_speed(singletons):
     # Default speed should be provisioned on pipette create from the cache
     left = singletons['instruments'].P50_Single('left')
     assert left._ctx._default_speed == 10
+    # and so should plunger max
+    assert left._max_plunger_speed == 3
     # And setting it with already-created instruments should work
-    singletons['robot'].head_speed(combined_speed=20)
+    singletons['robot'].head_speed(combined_speed=20, b=4)
     assert left._ctx._default_speed == 20
+    assert left._max_plunger_speed == 4
 
 
 @pytest.mark.api2_only

--- a/api/tests/opentrons/protocol_api/test_back_compat.py
+++ b/api/tests/opentrons/protocol_api/test_back_compat.py
@@ -143,7 +143,7 @@ def test_connect_simulating(singletons, monkeypatch):
 
 
 @pytest.mark.api2_only
-def test_robot_move(singletons):
-    instr_mock = mock.MagicMock()
+def test_robot_move(singletons, monkeypatch):
+    instr_mock = mock.Mock()
     singletons['robot'].move_to('hi', instr_mock)
-    assert instr_mock.call_args_list[0] == (('hi', 'arc'), {})
+    assert instr_mock.move_to.call_args_list[0] == (('hi', 'arc'), {})

--- a/api/tests/opentrons/protocol_api/test_back_compat.py
+++ b/api/tests/opentrons/protocol_api/test_back_compat.py
@@ -150,3 +150,13 @@ def test_robot_move(singletons, monkeypatch):
     instr_mock = mock.Mock()
     singletons['robot'].move_to('hi', instr_mock)
     assert instr_mock.move_to.call_args_list[0] == (('hi', 'arc'), {})
+
+
+@pytest.mark.api2_only
+def test_robot_reset(singletons):
+    singletons['instruments'].P300_Single('right')
+    singletons['robot'].head_speed(204, x=2)
+    singletons['robot'].reset()
+    assert singletons['robot']._instrs == {}
+    assert singletons['robot']._head_speed_override is None
+    assert singletons['robot']._ctx.max_speeds == {}

--- a/api/tests/opentrons/protocol_api/test_back_compat.py
+++ b/api/tests/opentrons/protocol_api/test_back_compat.py
@@ -1,46 +1,36 @@
+from unittest import mock
+
 import pytest
 
 from opentrons.types import Mount
+from opentrons.hardware_control import API
 
 
 @pytest.mark.api2_only
 def test_add_instrument(loop, monkeypatch, singletons):
-    requested_instr, requested_mount = None, None
-
-    def fake_load(instr_name, mount):
-        nonlocal requested_instr
-        nonlocal requested_mount
-        requested_instr = instr_name
-        requested_mount = mount
-
+    fake_load = mock.Mock()
     instruments = singletons['instruments']
-    monkeypatch.setattr(instruments._ctx,
+    monkeypatch.setattr(instruments._robot_wrapper._ctx,
                         'load_instrument', fake_load)
 
     instruments.P1000_Single('left')
-    assert requested_instr == 'p1000_single'
-    assert requested_mount == Mount.LEFT
     instruments.P10_Single('right')
-    assert requested_instr == 'p10_single'
-    assert requested_mount == Mount.RIGHT
     instruments.P10_Multi('left')
-    assert requested_instr == 'p10_multi'
-    assert requested_mount == Mount.LEFT
     instruments.P50_Single('right')
-    assert requested_instr == 'p50_single'
-    assert requested_mount == Mount.RIGHT
     instruments.P50_Multi('left')
-    assert requested_instr == 'p50_multi'
-    assert requested_mount == Mount.LEFT
     instruments.P300_Single('right')
-    assert requested_instr == 'p300_single'
-    assert requested_mount == Mount.RIGHT
     instruments.P300_Multi('left')
-    assert requested_instr == 'p300_multi'
-    assert requested_mount == Mount.LEFT
     instruments.P1000_Single('right')
-    assert requested_instr == 'p1000_single'
-    assert requested_mount == Mount.RIGHT
+    assert fake_load.call_args_list == [
+        (('p1000_single', Mount.LEFT), {}),
+        (('p10_single', Mount.RIGHT), {}),
+        (('p10_multi', Mount.LEFT), {}),
+        (('p50_single', Mount.RIGHT), {}),
+        (('p50_multi', Mount.LEFT), {}),
+        (('p300_single', Mount.RIGHT), {}),
+        (('p300_multi', Mount.LEFT), {}),
+        (('p1000_single', Mount.RIGHT), {})
+    ]
 
 
 @pytest.mark.api2_only
@@ -68,3 +58,92 @@ def test_labware_mappings(loop, monkeypatch, singletons):
     with pytest.raises(NotImplementedError,
                        match='Module load not yet implemented'):
         labware.load('magdeck', 3)
+
+
+@pytest.mark.api2_only
+def test_head_speed(singletons):
+    # Setting axis speeds should set max speeds
+    singletons['robot'].head_speed(x=2, y=3, z=5)
+    assert singletons['robot']._ctx.max_speeds['X'] == 2
+    assert singletons['robot']._ctx.max_speeds['Y'] == 3
+    assert singletons['robot']._ctx.max_speeds['Z'] == 5
+    assert 'A' not in singletons['robot']._ctx.max_speeds
+    # but not default speeds
+    assert singletons['robot']._head_speed_override is None
+
+    # Setting default speed shouldn't affect max speeds
+    singletons['robot'].head_speed(combined_speed=10)
+    assert singletons['robot']._ctx.max_speeds['X'] == 2
+    assert singletons['robot']._ctx.max_speeds['Y'] == 3
+    assert singletons['robot']._ctx.max_speeds['Z'] == 5
+    assert 'A' not in singletons['robot']._ctx.max_speeds
+    # And should be cached
+    assert singletons['robot']._head_speed_override == 10
+    # Default speed should be provisioned on pipette create from the cache
+    left = singletons['instruments'].P50_Single('left')
+    assert left._ctx._default_speed == 10
+    # And setting it with already-created instruments should work
+    singletons['robot'].head_speed(combined_speed=20)
+    assert left._ctx._default_speed == 20
+
+
+@pytest.mark.api2_only
+def test_pause(singletons, monkeypatch):
+    pause_mock = mock.Mock()
+    monkeypatch.setattr(singletons['robot']._ctx,
+                        'pause', pause_mock)
+    singletons['robot'].pause()
+    pause_mock.assert_called_once_with(None)
+    pause_mock.reset_mock()
+    singletons['robot'].pause(msg='Hi')
+    pause_mock.assert_called_once_with('Hi')
+
+
+@pytest.mark.api2_only
+def test_resume(singletons, monkeypatch):
+    resume_mock = mock.Mock()
+    monkeypatch.setattr(
+        singletons['robot']._ctx,
+        'resume',
+        resume_mock)
+    singletons['robot'].resume()
+    resume_mock.assert_called_once()
+
+
+@pytest.mark.api2_ony
+def test_comment(singletons, monkeypatch):
+    comment_mock = mock.Mock()
+    monkeypatch.setattr(singletons['robot']._ctx,
+                        'comment',
+                        comment_mock)
+    singletons['robot'].comment('hello')
+    comment_mock.assert_called_once_with('hello')
+
+
+@pytest.mark.api2_only
+def test_connect_simulating(singletons, monkeypatch):
+    assert singletons['robot'].is_simulating()
+    assert not singletons['robot'].is_connected()
+    build_mock = mock.Mock()
+    new_sim = API.build_hardware_simulator()
+    build_mock.return_value = new_sim
+    is_sim_mock = mock.Mock()
+    is_sim_mock.return_value = False
+    monkeypatch.setattr(new_sim, 'get_is_simulator',
+                        is_sim_mock)
+    monkeypatch.setattr(API, 'build_hardware_controller',
+                        build_mock)
+    singletons['robot'].connect('testport')
+    assert build_mock.call_args_list[0][1]['port'] == 'testport'
+    assert not singletons['robot'].is_simulating()
+    assert singletons['robot'].is_connected()
+    singletons['robot'].disconnect()
+    assert singletons['robot'].is_simulating()
+    assert not singletons['robot'].is_connected()
+
+
+@pytest.mark.api2_only
+def test_robot_move(singletons):
+    instr_mock = mock.MagicMock()
+    singletons['robot'].move_to('hi', instr_mock)
+    assert instr_mock.call_args_list[0] == (('hi', 'arc'), {})

--- a/api/tests/opentrons/tools/test_qc_scripts.py
+++ b/api/tests/opentrons/tools/test_qc_scripts.py
@@ -34,7 +34,7 @@ def driver_import(monkeypatch, robot):
         monkeypatch.setattr(
             tools,
             'driver',
-            robot._hw_manager._current._backend._smoothie_driver)
+            robot._ctx._hw_manager._current._backend._smoothie_driver)
     else:
         monkeypatch.setattr(tools, 'driver', robot._driver)
 


### PR DESCRIPTION

## overview

Implements the most common publically accessible robot methods on top of the protocol contexts. Using this, you should be able to connect and disconnect, pause and resume, reset, set comments, and the like. Most of the work here is in the structure, and the individual calls are very simple as a result. 

## Testing
Run some back compat protocols, using only these robot methods. Also make sure it works in jupyter and from a python interactive shell if you build the globals manually.
