### PR TITLE
feat(protocol-designer): promote custom labware upload to full feature

### DIFF
--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
@@ -25,7 +25,6 @@ type Props = {
   customLabwareDefs: LabwareDefByDefURI,
   slot: ?DeckSlotId,
   permittedTipracks: Array<string>,
-  showUploadCustomLabwareButton: ?boolean,
 }
 
 const CUSTOM_CATEGORY = 'custom'
@@ -139,27 +138,25 @@ const LabwareDropdown = (props: Props) => {
             </PDTitledList>
           ))}
         </ul>
-        {props.showUploadCustomLabwareButton && (
-          <>
-            <OutlineButton Component="label" className={styles.upload_button}>
-              {i18n.t('button.upload_custom_labware')}
-              <input
-                type="file"
-                onChange={e => {
-                  onUploadLabware(e)
-                  selectCategory(CUSTOM_CATEGORY)
-                }}
-              />
-            </OutlineButton>
-            <div className={styles.upload_helper_copy}>
-              {i18n.t('modal.labware_selection.creating_labware_defs')}{' '}
-              <KnowledgeBaseLink className={styles.link} to="customLabware">
-                here
-              </KnowledgeBaseLink>
-              .
-            </div>
-          </>
-        )}
+
+        <OutlineButton Component="label" className={styles.upload_button}>
+          {i18n.t('button.upload_custom_labware')}
+          <input
+            type="file"
+            onChange={e => {
+              onUploadLabware(e)
+              selectCategory(CUSTOM_CATEGORY)
+            }}
+          />
+        </OutlineButton>
+        <div className={styles.upload_helper_copy}>
+          {i18n.t('modal.labware_selection.creating_labware_defs')}{' '}
+          <KnowledgeBaseLink className={styles.link} to="customLabware">
+            here
+          </KnowledgeBaseLink>
+          .
+        </div>
+
         <OutlineButton onClick={onClose}>
           {i18n.t('button.close')}
         </OutlineButton>

--- a/protocol-designer/src/components/LabwareSelectionModal/index.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/index.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import { connect } from 'react-redux'
 import LabwareSelectionModal from './LabwareSelectionModal'
-import { selectors as featureFlagSelectors } from '../../feature-flags'
+// import { selectors as featureFlagSelectors } from '../../feature-flags'
 import {
   closeLabwareSelector,
   createContainer,
@@ -21,10 +21,6 @@ type SP = {|
   customLabwareDefs: $PropertyType<Props, 'customLabwareDefs'>,
   slot: $PropertyType<Props, 'slot'>,
   permittedTipracks: $PropertyType<Props, 'permittedTipracks'>,
-  showUploadCustomLabwareButton: $PropertyType<
-    Props,
-    'showUploadCustomLabwareButton'
-  >,
 |}
 
 function mapStateToProps(state: BaseState): SP {
@@ -32,9 +28,6 @@ function mapStateToProps(state: BaseState): SP {
     customLabwareDefs: labwareDefSelectors.getCustomLabwareDefsByURI(state),
     slot: labwareIngredSelectors.selectedAddLabwareSlot(state) || null,
     permittedTipracks: stepFormSelectors.getPermittedTipracks(state),
-    showUploadCustomLabwareButton: featureFlagSelectors.getShowUploadCustomLabwareButton(
-      state
-    ),
   }
 }
 

--- a/protocol-designer/src/components/SettingsPage/FeatureFlagCard/FeatureFlagCard.js
+++ b/protocol-designer/src/components/SettingsPage/FeatureFlagCard/FeatureFlagCard.js
@@ -34,9 +34,18 @@ const FeatureFlagCard = (props: Props) => {
         </p>
       </div>
     ))
+
+  const noFlagsFallback = (
+    <p className={styles.setting_row}>
+      No experimental settings are available in this version of Protocol
+      Designer.
+    </p>
+  )
   return (
     <Card title={i18n.t('card.title.feature_flags')}>
-      <div>{featureFlagRows}</div>
+      <div>
+        {featureFlagRows.length > 0 ? featureFlagRows : noFlagsFallback}
+      </div>
     </Card>
   )
 }

--- a/protocol-designer/src/feature-flags/reducers.js
+++ b/protocol-designer/src/feature-flags/reducers.js
@@ -1,8 +1,9 @@
 // @flow
+import omit from 'lodash/omit'
 import { combineReducers } from 'redux'
 import { handleActions } from 'redux-actions'
 import { rehydrate, type RehydratePersistedAction } from '../persist'
-import type { Flags } from './types'
+import { DEPRECATED_FLAGS, type Flags } from './types'
 import type { SetFeatureFlagAction } from './actions'
 import type { Action } from '../types'
 
@@ -19,10 +20,11 @@ const flags = handleActions<Flags, *>(
       ...state,
       ...action.payload,
     }),
-    // feature flags that are new (to browser storage) should take on default values
+    // Feature flags that are new (not yet in browser storage) should take on default values.
+    // Deprecated flags should not be retrieved from browser storage
     REHYDRATE_PERSISTED: (state, action: RehydratePersistedAction) => ({
       ...state,
-      ...rehydrate('featureFlags.flags', initialFlags),
+      ...omit(rehydrate('featureFlags.flags', initialFlags), DEPRECATED_FLAGS),
     }),
   },
   initialFlags

--- a/protocol-designer/src/feature-flags/reducers.js
+++ b/protocol-designer/src/feature-flags/reducers.js
@@ -10,7 +10,7 @@ import type { Action } from '../types'
 // whenever the browser has seen the feature flag before and persisted it.
 // Only "never before seen" flags will take on the default values from `initialFlags`.
 const initialFlags: Flags = {
-  OT_PD_SHOW_UPLOAD_CUSTOM_LABWARE_BUTTON: false,
+  // OT_PD_SHOW_UPLOAD_CUSTOM_LABWARE_BUTTON: false, // NOTE: Ian 2019-10-09 this FF was removed, leaving comment as placeholder
 }
 
 const flags = handleActions<Flags, *>(

--- a/protocol-designer/src/feature-flags/selectors.js
+++ b/protocol-designer/src/feature-flags/selectors.js
@@ -1,10 +1,11 @@
 // @flow
-import { createSelector } from 'reselect'
-import type { BaseState, Selector } from '../types'
+// import { createSelector } from 'reselect'
+import type { BaseState /*, Selector */ } from '../types'
 
 export const getFeatureFlagData = (state: BaseState) => state.featureFlags.flags
 
-export const getShowUploadCustomLabwareButton: Selector<?boolean> = createSelector(
-  getFeatureFlagData,
-  flags => flags.OT_PD_SHOW_UPLOAD_CUSTOM_LABWARE_BUTTON
-)
+// NOTE: Ian 2019-10-09 this FF has been removed, but I'm leaving these comments as a placeholder for when we add another FF
+// export const getShowUploadCustomLabwareButton: Selector<?boolean> = createSelector(
+//   getFeatureFlagData,
+//   flags => flags.OT_PD_SHOW_UPLOAD_CUSTOM_LABWARE_BUTTON
+// )

--- a/protocol-designer/src/feature-flags/types.js
+++ b/protocol-designer/src/feature-flags/types.js
@@ -2,12 +2,10 @@
 
 // When flag types are removed from this list, the browser will hold on to that value indefinitely.
 // To avoid being surprised when/if we deprecate and then re-introduce a flag with the same type string,
-// let's keep this list here.
+// items should never be removed from this list.
 // Deprecated types should never be reused (unless there's a really good reason).
-//
-// LIST OF DEPRECATED FLAG TYPES:
-// - OT_PD_SHOW_UPLOAD_CUSTOM_LABWARE_BUTTON
-//
+export const DEPRECATED_FLAGS = ['OT_PD_SHOW_UPLOAD_CUSTOM_LABWARE_BUTTON']
+
 export type FlagTypes = '(add flags here)' // NOTE: any additional flag types should be added here with | (Union)
 
 export type Flags = {

--- a/protocol-designer/src/feature-flags/types.js
+++ b/protocol-designer/src/feature-flags/types.js
@@ -6,8 +6,9 @@
 // Deprecated types should never be reused (unless there's a really good reason).
 //
 // LIST OF DEPRECATED FLAG TYPES:
-// - (none yet)
-export type FlagTypes = 'OT_PD_SHOW_UPLOAD_CUSTOM_LABWARE_BUTTON' // NOTE: any additional flag types should be added here with | (Union)
+// - OT_PD_SHOW_UPLOAD_CUSTOM_LABWARE_BUTTON
+//
+export type FlagTypes = '(add flags here)' // NOTE: any additional flag types should be added here with | (Union)
 
 export type Flags = {
   [FlagTypes]: ?boolean,

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -1,5 +1,6 @@
 {
   "OT_PD_SHOW_UPLOAD_CUSTOM_LABWARE_BUTTON": {
+    "TODO": "TODO: IL 2019-10-09 delete this, leaving as placeholder b/c no FFs remain",
     "title": "Upload custom labware",
     "description": "Show the \"Upload Custom Labware\" button to enable adding custom labware to protocol"
   }


### PR DESCRIPTION
## overview

With LC release, custom labware in PD can be a full-on feature! This PR promotes custom labware from an experimental feature to a normal one.

Since this PR removes the only feature flag that PD has, I made some placeholder comment junk so that we have a template for where in the code to add feature flags again.

~Soon after or maybe before this is merged, @mcous will have a PR to add a "Gen 2 Pipettes" feature flag to PD, so we can get rid of the placeholder stuff.~

*UPDATE:* Mike & I just talked -- in order not to rush, we'll merge this then do the Gen 2 pipette PR after the PD release

## changelog

## review requests

- see note above about the cruft & timing vs Mike's PR
- [ ] Upload custom labware button shows up in Labware Selection Modal always
- [ ] No more custom labware feature flag in the Settings page
- [ ] Placeholder text in Experimental Settings card when PD has no feature flags