### PR TITLE
fix(labware-creator): fix radio group touched on change in Mac FF

### DIFF
--- a/labware-library/src/labware-creator/components/RadioField.js
+++ b/labware-library/src/labware-creator/components/RadioField.js
@@ -24,13 +24,16 @@ const RadioField = (props: Props) => (
             labelTextClassName={props.labelTextClassName}
             onChange={e => {
               field.onChange(e)
-              // do not wait until blur to make radio field 'dirty', so that alerts show up immediately.
-              // NOTE: Ian 2019-10-02 this setTimeout seems necessary to avoid a race condition where
-              // Formik blurs the field before setting its value, surfacing a transient error
-              // (eg "this field is required") which messes up error analytics
-              const blurTarget = e.currentTarget
+              // do not wait until blur to make radio field 'touched', so that alerts show up immediately.
               setTimeout(() => {
-                blurTarget.blur()
+                // NOTE: Ian 2019-10-02 this setTimeout seems necessary to avoid a race condition where
+                // Formik blurs the field before setting its value, surfacing a transient error
+                // (eg "this field is required") which messes up error analytics.
+                // See https://github.com/jaredpalmer/formik/issues/1863
+                //
+                // NOTE: onBlur doesn't work on Firefox on Mac for radio fields,
+                // so we can't do `e.currentTarget.blur()`. See https://bugzilla.mozilla.org/show_bug.cgi?id=756028
+                form.setTouched({ [props.name]: true })
               }, 0)
 
               reportFieldEdit({ value: field.value, name: field.name })


### PR DESCRIPTION
## overview

closes #4209

## changelog

## review requests

- [x] Choosing the wrong answer for any of the radio buttons in LC should immediately show a red Alert (eg "same shape & size" - No; "all your rows/columns evenly spaced?" - No)
- [x] Test specifically in Firefox on Mac