### PR TITLE
feat(api): v1: Add version specification to labware.load

### DIFF
--- a/api/docs/source/v1/labware.rst
+++ b/api/docs/source/v1/labware.rst
@@ -43,6 +43,8 @@ newest version of a labware definition; however, the older definitions remain
 available for use with previously-written protocols that may have been customized
 to work with the older definition.
 
+If you do not specify a version when loading labware, version 1 will be used by default.
+
 
 **********************
 
@@ -118,15 +120,16 @@ parameter:
 
    from opentrons import labware
    block1 = labware.load(
-                'opentrons_96_aluminumblock_biorad_wellplate_200ul', 1,
+                'opentrons_96_aluminumblock_biorad_wellplate_200ul',
+                slot='1',
                 version=2)  # version 2 of the aluminum block definition
    block2 = labware.load(
                 'opentrons_96_aluminumblock_biorad_wellplate_200ul',
-                 2,
+                 slot='2',
                  version=1)  # version 1 of the aluminum block definition
    block3 = labware.load(
                 'opentrons_96_aluminumblock_biorad_wellplate_200ul',
-                2)  # if you don't specify version, version 1 is used
+                slot='2')  # if you don't specify version, version 1 is used
 
 
 Create

--- a/api/docs/source/v1/labware.rst
+++ b/api/docs/source/v1/labware.rst
@@ -11,9 +11,9 @@ wells and groups of wells.
 
 ************************************
 
-******************
+***************
 Labware Library
-******************
+***************
 
 The Opentrons API comes with many common labware built in. These can be loaded
 into your Python protocol by using the ``labware.load()`` method with the
@@ -33,10 +33,22 @@ If you are interested in using your own labware that is not included in the
 API, please take a look at how to create custom labware definitions using
 ``labware.create()``, or contact Opentrons Support.
 
+Labware Versions
+================
+
+Some labware on the Opentrons Labware Library have multiple versions of their
+definitions available. Opentrons publishes new versions of a labware definition
+when we find an issue with a labware definition. In general, you should use the
+newest version of a labware definition; however, the older definitions remain
+available for use with previously-written protocols that may have been customized
+to work with the older definition.
+
+
 **********************
 
+*********************************
 Placing labware on the robot deck
-=================================
+*********************************
 
 The robot deck is made up of slots labeled 1, 2, 3, 4, and so on.
 
@@ -98,6 +110,24 @@ deck, like modules. For this, you should use the ``share`` parameter.
     plate = labware.load('opentrons_96_aluminumblock_biorad_wellplate_200ul',
                          slot='1',
                          share=True)
+
+To specify the version of the labware definition to use, you can use the ``version``
+parameter:
+
+.. code-block:: python
+
+   from opentrons import labware
+   block1 = labware.load(
+                'opentrons_96_aluminumblock_biorad_wellplate_200ul', 1,
+                version=2)  # version 2 of the aluminum block definition
+   block2 = labware.load(
+                'opentrons_96_aluminumblock_biorad_wellplate_200ul',
+                 2,
+                 version=1)  # version 1 of the aluminum block definition
+   block3 = labware.load(
+                'opentrons_96_aluminumblock_biorad_wellplate_200ul',
+                2)  # if you don't specify version, version 1 is used
+
 
 Create
 ======

--- a/api/docs/source/v2/new_labware.rst
+++ b/api/docs/source/v2/new_labware.rst
@@ -23,6 +23,24 @@ Labware is loaded into a protocol using :py:meth:`.ProtocolContext.load_labware`
 :py:class:`opentrons.protocol_api.labware.Labware` object. You'll never create one of these objects
 directly, only store them in variables from the return value of :py:meth:`.ProtocolContext.load_labware`.
 
+
+.. tip::
+
+    Copy and paste load names directly from the Labware Library to ensure your ``protocol.load_labware``
+    statements get the correct definitions.
+
+
+Labware Versions
+================
+
+Some labware on the Opentrons Labware Library have multiple versions of their
+definitions available. Opentrons publishes new versions of a labware definition
+when we find an issue with a labware definition. In general, you should use the
+newest version of a labware definition; however, the older definitions remain
+available for use with previously-written protocols that may have been customized
+to work with the older definition.
+
+
 .. _new-well-access:
 
 **************************

--- a/api/src/opentrons/legacy_api/api.py
+++ b/api/src/opentrons/legacy_api/api.py
@@ -35,8 +35,7 @@ class ContainersWrapper(object):
                 self.robot, container_name, slot, label, share, version)
         except FileNotFoundError:
             LOG.exception(f"Exception opening labware {container_name}")
-            raise RuntimeError(
-                f"Could not load labware {container_name}")
+            raise
 
 
 class InstrumentsWrapper(object):

--- a/api/src/opentrons/legacy_api/api.py
+++ b/api/src/opentrons/legacy_api/api.py
@@ -28,9 +28,11 @@ class ContainersWrapper(object):
     def list(self, *args, **kwargs):
         return cnt.list(*args, **kwargs)
 
-    def load(self, container_name, slot, label=None, share=False):
+    def load(
+            self, container_name, slot, label=None, share=False, version=None):
         try:
-            return cnt.load(self.robot, container_name, slot, label, share)
+            return cnt.load(
+                self.robot, container_name, slot, label, share, version)
         except FileNotFoundError:
             LOG.exception(f"Exception opening labware {container_name}")
             raise RuntimeError(

--- a/api/src/opentrons/legacy_api/containers/__init__.py
+++ b/api/src/opentrons/legacy_api/containers/__init__.py
@@ -33,7 +33,7 @@ __all__ = [
 log = logging.getLogger(__name__)
 
 
-def load(robot, container_name, slot, label=None, share=False):
+def load(robot, container_name, slot, label=None, share=False, version=None):
     """
     Examples
     --------
@@ -73,7 +73,7 @@ def load(robot, container_name, slot, label=None, share=False):
             raise ValueError('Unknown slot: {}'.format(slot))
         slot = str(slot)
 
-    return robot.add_container(container_name, slot, label, share)
+    return robot.add_container(container_name, slot, label, share, version)
 
 
 def list():
@@ -227,12 +227,16 @@ def save_new_offsets(labware_hash, delta):
         json.dump(calibration_data, f)
 
 
-def load_new_labware(container_name):
-    """ Load a labware in the new schema into a placeable, by name
+def load_new_labware(container_name, version=None):
+    """ Load a labware in the new schema into a placeable, by name and version
+
+    :param container_name: The load name of the container
+    :param version: the version to load.
 
     :raises KeyError: If the labware name is not found
     """
-    defn = new_labware.get_labware_definition(load_name=container_name)
+    defn = new_labware.get_labware_definition(load_name=container_name,
+                                              version=version)
     return load_new_labware_def(defn)
 
 

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -46,7 +46,7 @@ def _load_weird_container(container_name):
     return container
 
 
-def _load_container_by_name(container_name):
+def _load_container_by_name(container_name, version=None):
     """ Try and find a container in a variety of methods.
 
     Returns the container or raises a KeyError if it could not be found
@@ -57,7 +57,10 @@ def _load_container_by_name(container_name):
         log.debug(
             f"Trying to load container {container_name} via {meth.__name__}")
         try:
-            container = meth(container_name)
+            if meth == load_new_labware:
+                container = meth(container_name, version=version)
+            else:
+                container = meth(container_name)
             if meth == _load_weird_container:
                 container.properties['type'] = container_name
             log.info(f"Loaded {container_name} from {meth.__name__}")
@@ -840,8 +843,8 @@ class Robot(CommandPublisher):
             container_patched, container_patched.properties['type'],
             slot, label, share)
 
-    def add_container(self, name, slot, label=None, share=False):
-        container = _load_container_by_name(name)
+    def add_container(self, name, slot, label=None, share=False, version=None):
+        container = _load_container_by_name(name, version=version)
         container_patched = _setup_container(container)
         if not container_patched:
             return None

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -52,15 +52,11 @@ def _load_container_by_name(container_name, version=None):
     Returns the container or raises a KeyError if it could not be found
     """
     for meth in (database.load_container,  # From the labware database
-                 load_new_labware,         # Fallback to built in v2 labware
                  _load_weird_container):   # honestly don't know
         log.debug(
             f"Trying to load container {container_name} via {meth.__name__}")
         try:
-            if meth == load_new_labware:
-                container = meth(container_name, version=version)
-            else:
-                container = meth(container_name)
+            container = meth(container_name)
             if meth == _load_weird_container:
                 container.properties['type'] = container_name
             log.info(f"Loaded {container_name} from {meth.__name__}")
@@ -68,7 +64,10 @@ def _load_container_by_name(container_name, version=None):
         except (ValueError, KeyError) as e:
             log.debug(f"{container_name} not in {meth.__name__} ({repr(e)})")
     else:
-        raise KeyError(f"Unknown labware {container_name}")
+        log.debug(
+            f"Trying to load container {container_name} version {version}"
+            f"from v2 labware store")
+        container = load_new_labware(container_name, version=version)
     return container
 
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1069,8 +1069,8 @@ def _get_standard_labware_definition(
             except (FileNotFoundError):
                 pass
         raise FileNotFoundError(
-            f'Labware "{load_name}" not found with version {version}. If ' +
-            f'you are using a namespace besides {OPENTRONS_NAMESPACE} or ' +
+            f'Labware "{load_name}" not found with version {checked_version}. '
+            f'If you are using a namespace besides {OPENTRONS_NAMESPACE} or '
             f'{CUSTOM_NAMESPACE}, please specify it')
 
     namespace = namespace.lower()
@@ -1081,7 +1081,7 @@ def _get_standard_labware_definition(
             labware_def = json.loads(f.read().decode('utf-8'))
     except FileNotFoundError:
         raise FileNotFoundError(
-            f'Labware "{load_name}" not found with version {version} ' +
+            f'Labware "{load_name}" not found with version {checked_version} '
             f'in namespace "{namespace}".'
         )
 

--- a/api/tests/opentrons/containers/test_containers.py
+++ b/api/tests/opentrons/containers/test_containers.py
@@ -118,9 +118,6 @@ def test_new_container_versioning(
     loaded = singletons['labware'].load('fixture_12_trough_v2', 2, version=2)
     assert loaded.get_name() == fixt['parameters']['loadName']
 
-    with pytest.raises(RuntimeError):
-        singletons['labware'].load('fixture_12_trough_v2', 3, version=1)
-
 
 @pytest.mark.api1_only
 def test_load_fixed_trash(robot):

--- a/labware-library/src/components/LabwareList/__tests__/__snapshots__/LabwareList.test.js.snap
+++ b/labware-library/src/components/LabwareList/__tests__/__snapshots__/LabwareList.test.js.snap
@@ -100,6 +100,235 @@ exports[`LabwareList component renders 1`] = `
           "format": "trough",
           "isMagneticModuleCompatible": false,
           "isTiprack": false,
+          "loadName": "fixture_12_trough_v2",
+          "quirks": Array [
+            "centerMultichannelOnWells",
+          ],
+        },
+        "schemaVersion": 2,
+        "version": 2,
+        "wells": Object {
+          "A1": Object {
+            "depth": 42.16,
+            "shape": "rectangular",
+            "totalLiquidVolume": 22000,
+            "x": 13.94,
+            "xDimension": 8.33,
+            "y": 42.9,
+            "yDimension": 71.88,
+            "z": 2.29,
+          },
+          "A10": Object {
+            "depth": 42.16,
+            "shape": "rectangular",
+            "totalLiquidVolume": 22000,
+            "x": 95.75,
+            "xDimension": 8.33,
+            "y": 42.9,
+            "yDimension": 71.88,
+            "z": 2.29,
+          },
+          "A11": Object {
+            "depth": 42.16,
+            "shape": "rectangular",
+            "totalLiquidVolume": 22000,
+            "x": 104.84,
+            "xDimension": 8.33,
+            "y": 42.9,
+            "yDimension": 71.88,
+            "z": 2.29,
+          },
+          "A12": Object {
+            "depth": 42.16,
+            "shape": "rectangular",
+            "totalLiquidVolume": 22000,
+            "x": 113.93,
+            "xDimension": 8.33,
+            "y": 42.9,
+            "yDimension": 71.88,
+            "z": 2.29,
+          },
+          "A2": Object {
+            "depth": 42.16,
+            "shape": "rectangular",
+            "totalLiquidVolume": 22000,
+            "x": 23.03,
+            "xDimension": 8.33,
+            "y": 42.9,
+            "yDimension": 71.88,
+            "z": 2.29,
+          },
+          "A3": Object {
+            "depth": 42.16,
+            "shape": "rectangular",
+            "totalLiquidVolume": 22000,
+            "x": 32.12,
+            "xDimension": 8.33,
+            "y": 42.9,
+            "yDimension": 71.88,
+            "z": 2.29,
+          },
+          "A4": Object {
+            "depth": 42.16,
+            "shape": "rectangular",
+            "totalLiquidVolume": 22000,
+            "x": 41.21,
+            "xDimension": 8.33,
+            "y": 42.9,
+            "yDimension": 71.88,
+            "z": 2.29,
+          },
+          "A5": Object {
+            "depth": 42.16,
+            "shape": "rectangular",
+            "totalLiquidVolume": 22000,
+            "x": 50.3,
+            "xDimension": 8.33,
+            "y": 42.9,
+            "yDimension": 71.88,
+            "z": 2.29,
+          },
+          "A6": Object {
+            "depth": 42.16,
+            "shape": "rectangular",
+            "totalLiquidVolume": 22000,
+            "x": 59.39,
+            "xDimension": 8.33,
+            "y": 42.9,
+            "yDimension": 71.88,
+            "z": 2.29,
+          },
+          "A7": Object {
+            "depth": 42.16,
+            "shape": "rectangular",
+            "totalLiquidVolume": 22000,
+            "x": 68.48,
+            "xDimension": 8.33,
+            "y": 42.9,
+            "yDimension": 71.88,
+            "z": 2.29,
+          },
+          "A8": Object {
+            "depth": 42.16,
+            "shape": "rectangular",
+            "totalLiquidVolume": 22000,
+            "x": 77.57,
+            "xDimension": 8.33,
+            "y": 42.9,
+            "yDimension": 71.88,
+            "z": 2.29,
+          },
+          "A9": Object {
+            "depth": 42.16,
+            "shape": "rectangular",
+            "totalLiquidVolume": 22000,
+            "x": 86.66,
+            "xDimension": 8.33,
+            "y": 42.9,
+            "yDimension": 71.88,
+            "z": 2.29,
+          },
+        },
+      }
+    }
+    key="fixture/fixture_12_trough_v2/2"
+  />
+  <LabwareCard
+    definition={
+      Object {
+        "brand": Object {
+          "brand": "USA Scientific",
+          "brandId": Array [
+            "1061-8150",
+          ],
+        },
+        "cornerOffsetFromSlot": Object {
+          "x": 0,
+          "y": 0,
+          "z": 0,
+        },
+        "dimensions": Object {
+          "xDimension": 127.76,
+          "yDimension": 85.8,
+          "zDimension": 44.45,
+        },
+        "groups": Array [
+          Object {
+            "brand": Object {
+              "brand": "USA Scientific",
+              "brandId": Array [
+                "1061-8150",
+              ],
+            },
+            "metadata": Object {
+              "displayCategory": "reservoir",
+              "displayName": "12 Channel Trough",
+              "wellBottomShape": "v",
+            },
+            "wells": Array [
+              "A1",
+              "A2",
+              "A3",
+              "A4",
+              "A5",
+              "A6",
+              "A7",
+              "A8",
+              "A9",
+              "A10",
+              "A11",
+              "A12",
+            ],
+          },
+        ],
+        "metadata": Object {
+          "displayCategory": "reservoir",
+          "displayName": "12 Channel Trough",
+          "displayVolumeUnits": "mL",
+        },
+        "namespace": "fixture",
+        "ordering": Array [
+          Array [
+            "A1",
+          ],
+          Array [
+            "A2",
+          ],
+          Array [
+            "A3",
+          ],
+          Array [
+            "A4",
+          ],
+          Array [
+            "A5",
+          ],
+          Array [
+            "A6",
+          ],
+          Array [
+            "A7",
+          ],
+          Array [
+            "A8",
+          ],
+          Array [
+            "A9",
+          ],
+          Array [
+            "A10",
+          ],
+          Array [
+            "A11",
+          ],
+          Array [
+            "A12",
+          ],
+        ],
+        "parameters": Object {
+          "format": "trough",
+          "isMagneticModuleCompatible": false,
+          "isTiprack": false,
           "loadName": "fixture_12_trough",
           "quirks": Array [
             "centerMultichannelOnWells",

--- a/shared-data/js/__tests__/labwareDefSchemaV2.test.js
+++ b/shared-data/js/__tests__/labwareDefSchemaV2.test.js
@@ -85,9 +85,6 @@ describe('test schemas of all v2 labware fixtures', () => {
       expect(validationErrors).toBe(null)
       expect(valid).toBe(true)
     })
-    test(`version is 1 for all fixtures: ${labwarePath}`, () => {
-      expect(labwareDef.version).toEqual(1)
-    })
     test(`fixture file name matches loadName: ${labwarePath}`, () => {
       expect(labwareDef.parameters.loadName).toEqual(
         path.basename(filename, '.json')

--- a/shared-data/labware/fixtures/2/fixture_12_trough_v2.json
+++ b/shared-data/labware/fixtures/2/fixture_12_trough_v2.json
@@ -1,0 +1,194 @@
+{
+  "ordering": [
+    ["A1"],
+    ["A2"],
+    ["A3"],
+    ["A4"],
+    ["A5"],
+    ["A6"],
+    ["A7"],
+    ["A8"],
+    ["A9"],
+    ["A10"],
+    ["A11"],
+    ["A12"]
+  ],
+  "schemaVersion": 2,
+  "version": 2,
+  "namespace": "fixture",
+  "metadata": {
+    "displayName": "12 Channel Trough",
+    "displayVolumeUnits": "mL",
+    "displayCategory": "reservoir"
+  },
+  "dimensions": {
+    "xDimension": 127.76,
+    "yDimension": 85.8,
+    "zDimension": 44.45
+  },
+  "parameters": {
+    "format": "trough",
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "loadName": "fixture_12_trough_v2",
+    "quirks": ["centerMultichannelOnWells"]
+  },
+  "wells": {
+    "A1": {
+      "shape": "rectangular",
+      "depth": 42.16,
+      "xDimension": 8.33,
+      "yDimension": 71.88,
+      "totalLiquidVolume": 22000,
+      "x": 13.94,
+      "y": 42.9,
+      "z": 2.29
+    },
+    "A2": {
+      "shape": "rectangular",
+      "depth": 42.16,
+      "xDimension": 8.33,
+      "yDimension": 71.88,
+      "totalLiquidVolume": 22000,
+      "x": 23.03,
+      "y": 42.9,
+      "z": 2.29
+    },
+    "A3": {
+      "shape": "rectangular",
+      "depth": 42.16,
+      "xDimension": 8.33,
+      "yDimension": 71.88,
+      "totalLiquidVolume": 22000,
+      "x": 32.12,
+      "y": 42.9,
+      "z": 2.29
+    },
+    "A4": {
+      "shape": "rectangular",
+      "depth": 42.16,
+      "xDimension": 8.33,
+      "yDimension": 71.88,
+      "totalLiquidVolume": 22000,
+      "x": 41.21,
+      "y": 42.9,
+      "z": 2.29
+    },
+    "A5": {
+      "shape": "rectangular",
+      "depth": 42.16,
+      "xDimension": 8.33,
+      "yDimension": 71.88,
+      "totalLiquidVolume": 22000,
+      "x": 50.3,
+      "y": 42.9,
+      "z": 2.29
+    },
+    "A6": {
+      "shape": "rectangular",
+      "depth": 42.16,
+      "xDimension": 8.33,
+      "yDimension": 71.88,
+      "totalLiquidVolume": 22000,
+      "x": 59.39,
+      "y": 42.9,
+      "z": 2.29
+    },
+    "A7": {
+      "shape": "rectangular",
+      "depth": 42.16,
+      "xDimension": 8.33,
+      "yDimension": 71.88,
+      "totalLiquidVolume": 22000,
+      "x": 68.48,
+      "y": 42.9,
+      "z": 2.29
+    },
+    "A8": {
+      "shape": "rectangular",
+      "depth": 42.16,
+      "xDimension": 8.33,
+      "yDimension": 71.88,
+      "totalLiquidVolume": 22000,
+      "x": 77.57,
+      "y": 42.9,
+      "z": 2.29
+    },
+    "A9": {
+      "shape": "rectangular",
+      "depth": 42.16,
+      "xDimension": 8.33,
+      "yDimension": 71.88,
+      "totalLiquidVolume": 22000,
+      "x": 86.66,
+      "y": 42.9,
+      "z": 2.29
+    },
+    "A10": {
+      "shape": "rectangular",
+      "depth": 42.16,
+      "xDimension": 8.33,
+      "yDimension": 71.88,
+      "totalLiquidVolume": 22000,
+      "x": 95.75,
+      "y": 42.9,
+      "z": 2.29
+    },
+    "A11": {
+      "shape": "rectangular",
+      "depth": 42.16,
+      "xDimension": 8.33,
+      "yDimension": 71.88,
+      "totalLiquidVolume": 22000,
+      "x": 104.84,
+      "y": 42.9,
+      "z": 2.29
+    },
+    "A12": {
+      "shape": "rectangular",
+      "depth": 42.16,
+      "xDimension": 8.33,
+      "yDimension": 71.88,
+      "totalLiquidVolume": 22000,
+      "x": 113.93,
+      "y": 42.9,
+      "z": 2.29
+    }
+  },
+  "brand": {
+    "brand": "USA Scientific",
+    "brandId": ["1061-8150"]
+  },
+  "groups": [
+    {
+      "wells": [
+        "A1",
+        "A2",
+        "A3",
+        "A4",
+        "A5",
+        "A6",
+        "A7",
+        "A8",
+        "A9",
+        "A10",
+        "A11",
+        "A12"
+      ],
+      "brand": {
+        "brand": "USA Scientific",
+        "brandId": ["1061-8150"]
+      },
+      "metadata": {
+        "displayName": "12 Channel Trough",
+        "displayCategory": "reservoir",
+        "wellBottomShape": "v"
+      }
+    }
+  ],
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  }
+}


### PR DESCRIPTION
V2 labware definitions have versions, which are bumped whenever the geometry
definitions change. It's important to be able to specify the version to load.
APIv2 allows this; the patch to add labware v2 loads from apiv1 does not. This
closes that gap.

Closes #4216


The code here is ready to review, but this PR shouldn't be merged until docs are in.