### PR TITLE
chore(deploy): only deploy api docs on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
           local-dir: api/docs/dist
           github-token: $GITHUB_TOKEN
           on:
-            branch: edge
+            branch: master
             repo: Opentrons/opentrons
 
         # push to real pypi on tag


### PR DESCRIPTION
Since we now merge to master before tagging, we can change the docs deploy to
trigger on master builds.

When we switch to a separate build/deploy model, we can upload docs during the deploy. For now, deploying on master means we only deploy on actual customer-facing builds.