### PR TITLE
refactor(app,pd): add GEN1 category to OG pipettes, FF'd GEN2 select to PD

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -11,6 +11,7 @@
 
 [untyped]
 ; TODO(mc, 2019-06-28): upgrade react-select for types that don't fail
+; https://github.com/JedWatson/react-select/issues/3612
 .*/node_modules/react-select/.*
 
 [include]

--- a/app/src/components/ChangePipette/InstructionStep.js
+++ b/app/src/components/ChangePipette/InstructionStep.js
@@ -33,7 +33,7 @@ export function getDiagramsSrc(props: DiagramProps) {
   switch (displayCategory) {
     case 'GEN2':
       return require(`./images/${direction}-${mount}-${channelsKey}-GEN2-${diagram}@3x.png`)
-    case 'OG':
+    case 'GEN1':
     default:
       return require(`./images/${direction}-${mount}-${channelsKey}-${diagram}@3x.png`)
   }

--- a/app/src/components/ChangePipette/index.js
+++ b/app/src/components/ChangePipette/index.js
@@ -162,7 +162,7 @@ function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
     exit: () =>
       dispatch(home(robot, mount)).then(() => dispatch(push(parentUrl))),
     back: () => dispatch(goBack()),
-    onPipetteSelect: spec => ownProps.setWantedName(spec.name),
+    onPipetteSelect: spec => spec && ownProps.setWantedName(spec.name),
     moveToFront: () =>
       dispatch(
         moveRobotTo(robot, {

--- a/components/src/__tests__/instrument-diagram.test.js
+++ b/components/src/__tests__/instrument-diagram.test.js
@@ -6,7 +6,7 @@ import { InstrumentDiagram, InstrumentGroup } from '..'
 describe('InstrumentDiagram', () => {
   test('Single-channel renders correctly', () => {
     const tree = Renderer.create(
-      <InstrumentDiagram channels={1} displayCategory="OG" />
+      <InstrumentDiagram channels={1} displayCategory="GEN1" />
     ).toJSON()
 
     expect(tree).toMatchSnapshot()
@@ -14,7 +14,7 @@ describe('InstrumentDiagram', () => {
 
   test('Multi-channel renders correctly', () => {
     const tree = Renderer.create(
-      <InstrumentDiagram channels={8} displayCategory="OG" />
+      <InstrumentDiagram channels={8} displayCategory="GEN1" />
     ).toJSON()
 
     expect(tree).toMatchSnapshot()
@@ -45,14 +45,14 @@ describe('InstrumentGroup', () => {
           mount: 'left',
           description: 'p300 8-Channel',
           tipType: '150',
-          pipetteSpecs: { channels: 8, displayCategory: 'OG' },
+          pipetteSpecs: { channels: 8, displayCategory: 'GEN1' },
           className: 'foo',
         }}
         right={{
           mount: 'right',
           description: 'p10 Single',
           tipType: '10',
-          pipetteSpecs: { channels: 1, displayCategory: 'OG' },
+          pipetteSpecs: { channels: 1, displayCategory: 'GEN1' },
           isDisabled: true,
           className: 'blah',
         }}

--- a/components/src/instrument/InstrumentDiagram.js
+++ b/components/src/instrument/InstrumentDiagram.js
@@ -30,7 +30,7 @@ export default function InstrumentDiagram(props: Props) {
       break
     }
     default:
-    case 'OG': {
+    case 'GEN1': {
       imgSrc = channels === 1 ? singleSrc : multiSrc
     }
   }

--- a/components/src/instrument/InstrumentDiagram.md
+++ b/components/src/instrument/InstrumentDiagram.md
@@ -1,17 +1,17 @@
-Single channel OG:
+Single channel GEN1:
 
 ````js
 <InstrumentDiagram
   mount="left"
-  pipetteSpecs={{ channels: 1, displayCategory: 'OG' }}
+  pipetteSpecs={{ channels: 1, displayCategory: 'GEN1' }}
 />```
 
-Multi channel OG:
+Multi channel GEN1:
 
 ```js
 <InstrumentDiagram
   mount="right"
-  pipetteSpecs={{ channels: 8, displayCategory: 'OG' }}
+  pipetteSpecs={{ channels: 8, displayCategory: 'GEN1' }}
 />```
 
 Single channel GEN2:

--- a/components/src/instrument/InstrumentGroup.md
+++ b/components/src/instrument/InstrumentGroup.md
@@ -3,7 +3,7 @@
   left={{
     mount: 'left',
     description: 'p300 8-Channel',
-    pipetteSpecs: { channels: 8, displayCategory: 'OG' },
+    pipetteSpecs: { channels: 8, displayCategory: 'GEN1' },
   }}
   right={{
     mount: 'right',

--- a/components/src/instrument/PipetteSelect.css
+++ b/components/src/instrument/PipetteSelect.css
@@ -60,10 +60,6 @@
   font-size: var(--fs-caption);
 }
 
-.pipette_select {
-  max-width: 15rem;
-}
-
 .pipette_option {
   display: flex;
   padding: 0.25rem 0.75rem;

--- a/components/src/instrument/PipetteSelect.md
+++ b/components/src/instrument/PipetteSelect.md
@@ -7,13 +7,29 @@ initialState = { selectedValue: null }
 ;<div style={{ paddingBottom: '10rem' }}>
   {/* Add some space because options menu does not behave well when overlapping with styleguidist's code blocks! */}
   <PipetteSelect
-    onPipetteChange={option => {
-      console.log(option)
-      const { value } = option
-      setState({ selectedValue: value })
+    onPipetteChange={selectedValue => {
+      console.log(selectedValue)
+      setState({ selectedValue })
     }}
     value={state.selectedValue}
     nameBlacklist={['p20_multi_gen2', 'p300_multi_gen2']}
+  />
+</div>
+```
+
+Allow "None" as the default option
+
+```js
+initialState = { selectedValue: null }
+;<div style={{ paddingBottom: '10rem' }}>
+  {/* Add some space because options menu does not behave well when overlapping with styleguidist's code blocks! */}
+  <PipetteSelect
+    onPipetteChange={selectedValue => {
+      console.log(selectedValue)
+      setState({ selectedValue })
+    }}
+    value={state.selectedValue}
+    allowNone
   />
 </div>
 ```

--- a/components/src/instrument/PipetteSelect.md
+++ b/components/src/instrument/PipetteSelect.md
@@ -29,7 +29,7 @@ initialState = { selectedValue: null }
       setState({ selectedValue })
     }}
     value={state.selectedValue}
-    allowNone
+    enableNoneOption
   />
 </div>
 ```

--- a/protocol-designer/src/components/modals/EditPipettesModal/index.js
+++ b/protocol-designer/src/components/modals/EditPipettesModal/index.js
@@ -157,24 +157,25 @@ const makeUpdatePipettes = (
 
 const mergeProps = (
   stateProps: SP,
-  dispatchProps: { dispatch: ThunkDispatch<*> },
+  dispatchProps: {| dispatch: ThunkDispatch<*> |},
   ownProps: OP
 ): Props => {
-  const { dispatch } = dispatchProps
   const { _prevPipettes, _orderedStepIds, ...passThruStateProps } = stateProps
+  const { dispatch } = dispatchProps
+  const { closeModal } = ownProps
+
   const updatePipettes = makeUpdatePipettes(
     _prevPipettes,
     _orderedStepIds,
     dispatch,
-    ownProps.closeModal
+    closeModal
   )
 
   return {
-    ...ownProps,
-    useProtocolFields: false,
     ...passThruStateProps,
+    useProtocolFields: false,
     onSave: updatePipettes,
-    onCancel: ownProps.closeModal,
+    onCancel: closeModal,
   }
 }
 

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.js
@@ -1,9 +1,20 @@
 // @flow
 import React, { useMemo } from 'react'
-import { DropdownField, FormGroup } from '@opentrons/components'
-import { getLabwareDefURI, getLabwareDisplayName } from '@opentrons/shared-data'
+import { useSelector } from 'react-redux'
+import {
+  DropdownField,
+  FormGroup,
+  PipetteSelect,
+  type Mount,
+} from '@opentrons/components'
+import {
+  getLabwareDefURI,
+  getLabwareDisplayName,
+  getPipetteNameSpecs,
+} from '@opentrons/shared-data'
 import isEmpty from 'lodash/isEmpty'
 import reduce from 'lodash/reduce'
+
 import i18n from '../../../localization'
 import { pipetteOptions } from '../../../pipettes/pipetteData'
 import PipetteDiagram from './PipetteDiagram'
@@ -11,19 +22,28 @@ import TiprackDiagram from './TiprackDiagram'
 import styles from './FilePipettesModal.css'
 import formStyles from '../../forms/forms.css'
 import { getOnlyLatestDefs } from '../../../labware-defs/utils'
-import type { FormPipettesByMount } from '../../../step-forms'
+import { selectors as ffSelectors } from '../../../feature-flags'
+
+import type { FormPipette, FormPipettesByMount } from '../../../step-forms'
 
 const pipetteOptionsWithNone = [{ name: 'None', value: '' }, ...pipetteOptions]
 
-type Props = {
+type Props = {|
   initialTabIndex?: number,
   values: FormPipettesByMount,
-  // this handleChange should expect all fields to have name={Mount.pipetteFieldName}
-  handleChange: (SyntheticInputEvent<*>) => mixed,
-}
+  onFieldChange: (
+    mount: Mount,
+    fieldName: $Keys<FormPipette>,
+    value: string | null
+  ) => mixed,
+|}
+
+// TODO(mc, 2019-10-14): delete this typedef when gen2 ff is removed
+type PipetteSelectProps = {| mount: Mount, tabIndex: number |}
 
 export default function ChangePipetteFields(props: Props) {
-  const { values, handleChange } = props
+  const { values, onFieldChange } = props
+  const enableGen2Pipettes = useSelector(ffSelectors.getEnableGen2Pipettes)
 
   const tiprackOptions = useMemo(() => {
     const defs = getOnlyLatestDefs()
@@ -44,6 +64,37 @@ export default function ChangePipetteFields(props: Props) {
   }, [])
 
   const initialTabIndex = props.initialTabIndex || 1
+
+  const makeHandleChange = (mount: Mount, fieldName: $Keys<FormPipette>) => (
+    e: SyntheticInputEvent<HTMLInputElement | HTMLSelectElement>
+  ) => onFieldChange(mount, fieldName, e.currentTarget.value || null)
+
+  const renderPipetteSelect = (props: PipetteSelectProps) => {
+    const { tabIndex, mount } = props
+    const pipetteName = values[mount].pipetteName
+    const fieldName = `${mount}.pipetteName`
+
+    return enableGen2Pipettes === true ? (
+      <PipetteSelect
+        enableNoneOption
+        tabIndex={`${tabIndex}`}
+        value={pipetteName != null ? getPipetteNameSpecs(pipetteName) : null}
+        onPipetteChange={value => {
+          const name = value !== null ? value.name : null
+          onFieldChange(mount, 'pipetteName', name)
+        }}
+      />
+    ) : (
+      <DropdownField
+        tabIndex={tabIndex}
+        options={pipetteOptionsWithNone}
+        value={pipetteName}
+        name={fieldName}
+        onChange={makeHandleChange(mount, 'pipetteName')}
+      />
+    )
+  }
+
   return (
     <React.Fragment>
       <div className={styles.mount_fields_row}>
@@ -53,13 +104,10 @@ export default function ChangePipetteFields(props: Props) {
             label={i18n.t('modal.pipette_fields.left_pipette')}
             className={formStyles.stacked_row}
           >
-            <DropdownField
-              tabIndex={initialTabIndex + 1}
-              options={pipetteOptionsWithNone}
-              value={values.left.pipetteName}
-              name="left.pipetteName"
-              onChange={handleChange}
-            />
+            {renderPipetteSelect({
+              mount: 'left',
+              tabIndex: initialTabIndex + 1,
+            })}
           </FormGroup>
           <FormGroup
             disabled={isEmpty(values.left.pipetteName)}
@@ -73,7 +121,7 @@ export default function ChangePipetteFields(props: Props) {
               options={tiprackOptions}
               value={values.left.tiprackDefURI}
               name="left.tiprackDefURI"
-              onChange={handleChange}
+              onChange={makeHandleChange('left', 'tiprackDefURI')}
             />
           </FormGroup>
         </div>
@@ -83,13 +131,10 @@ export default function ChangePipetteFields(props: Props) {
             label={i18n.t('modal.pipette_fields.right_pipette')}
             className={formStyles.stacked_row}
           >
-            <DropdownField
-              tabIndex={initialTabIndex + 3}
-              options={pipetteOptionsWithNone}
-              value={values.right.pipetteName}
-              name="right.pipetteName"
-              onChange={handleChange}
-            />
+            {renderPipetteSelect({
+              mount: 'right',
+              tabIndex: initialTabIndex + 3,
+            })}
           </FormGroup>
           <FormGroup
             disabled={isEmpty(values.right.pipetteName)}
@@ -103,7 +148,7 @@ export default function ChangePipetteFields(props: Props) {
               options={tiprackOptions}
               value={values.right.tiprackDefURI}
               name="right.tiprackDefURI"
-              onChange={handleChange}
+              onChange={makeHandleChange('right', 'tiprackDefURI')}
             />
           </FormGroup>
         </div>

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.js
@@ -26,25 +26,25 @@ import type {
 
 type PipetteFieldsData = $Diff<
   PipetteOnDeck,
-  { id: *, spec: *, tiprackLabwareDef: * }
+  {| id: mixed, spec: mixed, tiprackLabwareDef: mixed |}
 >
 
-type State = {
+type State = {|
   fields: NewProtocolFields,
   pipettesByMount: FormPipettesByMount,
   showEditPipetteConfirmation: boolean,
-}
+|}
 
-type Props = {
+type Props = {|
   useProtocolFields?: ?boolean,
   hideModal?: boolean,
   onCancel: () => mixed,
   initialPipetteValues?: $PropertyType<State, 'pipettesByMount'>,
-  onSave: ({
+  onSave: ({|
     newProtocolFields: NewProtocolFields,
     pipettes: Array<PipetteFieldsData>,
-  }) => mixed,
-}
+  |}) => mixed,
+|}
 
 const initialState: State = {
   fields: { name: '' },
@@ -74,21 +74,16 @@ export default class FilePipettesModal extends React.Component<Props, State> {
       this.setState(initialState)
   }
 
-  handlePipetteFieldsChange = (e: SyntheticInputEvent<*>) => {
-    const value: string = e.currentTarget.value
-    if (!e.currentTarget.name) {
-      console.error(
-        'handlePipetteFieldsChange expected nested field name, got no name with value:',
-        e.currentTarget.value
-      )
-      return
+  handlePipetteFieldsChange = (
+    mount: Mount,
+    fieldName: $Keys<FormPipette>,
+    value: string | null
+  ) => {
+    let nextMountState: $Shape<FormPipette> = { [fieldName]: value }
+    if (fieldName === 'pipetteName') {
+      nextMountState = { ...nextMountState, tiprackDefURI: null }
     }
-    const splitFieldName: [Mount, string] = e.currentTarget.name.split('.')
-    const mount = splitFieldName[0]
-    const fieldName = splitFieldName[1]
-    let nextMountState = { [fieldName]: value }
-    if (fieldName === 'pipetteName')
-      nextMountState = { ...nextMountState, tiprackModel: null }
+
     this.setState({
       pipettesByMount: {
         ...this.state.pipettesByMount,
@@ -186,7 +181,7 @@ export default class FilePipettesModal extends React.Component<Props, State> {
             <PipetteFields
               initialTabIndex={1}
               values={this.state.pipettesByMount}
-              handleChange={this.handlePipetteFieldsChange}
+              onFieldChange={this.handlePipetteFieldsChange}
             />
           </form>
           <div className={styles.button_row}>

--- a/protocol-designer/src/feature-flags/reducers.js
+++ b/protocol-designer/src/feature-flags/reducers.js
@@ -11,19 +11,24 @@ import type { Action } from '../types'
 // whenever the browser has seen the feature flag before and persisted it.
 // Only "never before seen" flags will take on the default values from `initialFlags`.
 const initialFlags: Flags = {
-  // OT_PD_SHOW_UPLOAD_CUSTOM_LABWARE_BUTTON: false, // NOTE: Ian 2019-10-09 this FF was removed, leaving comment as placeholder
+  OT_PD_ENABLE_GEN2_PIPETTES: false,
 }
 
-const flags = handleActions<Flags, *>(
+const flags = handleActions<Flags, any>(
   {
-    SET_FEATURE_FLAGS: (state, action: SetFeatureFlagAction) => ({
+    SET_FEATURE_FLAGS: (state: Flags, action: SetFeatureFlagAction): Flags => ({
       ...state,
       ...action.payload,
     }),
     // Feature flags that are new (not yet in browser storage) should take on default values.
     // Deprecated flags should not be retrieved from browser storage
-    REHYDRATE_PERSISTED: (state, action: RehydratePersistedAction) => ({
+    REHYDRATE_PERSISTED: (
+      state: Flags,
+      action: RehydratePersistedAction
+    ): Flags => ({
       ...state,
+      // TODO(mc, 2019-10-15): reading from localStorage is not appropriate
+      // inside a reducer; move this logic elsewhere
       ...omit(rehydrate('featureFlags.flags', initialFlags), DEPRECATED_FLAGS),
     }),
   },

--- a/protocol-designer/src/feature-flags/selectors.js
+++ b/protocol-designer/src/feature-flags/selectors.js
@@ -1,11 +1,10 @@
 // @flow
-// import { createSelector } from 'reselect'
-import type { BaseState /*, Selector */ } from '../types'
+import { createSelector } from 'reselect'
+import type { BaseState, Selector } from '../types'
 
 export const getFeatureFlagData = (state: BaseState) => state.featureFlags.flags
 
-// NOTE: Ian 2019-10-09 this FF has been removed, but I'm leaving these comments as a placeholder for when we add another FF
-// export const getShowUploadCustomLabwareButton: Selector<?boolean> = createSelector(
-//   getFeatureFlagData,
-//   flags => flags.OT_PD_SHOW_UPLOAD_CUSTOM_LABWARE_BUTTON
-// )
+export const getEnableGen2Pipettes: Selector<?boolean> = createSelector(
+  getFeatureFlagData,
+  flags => flags.OT_PD_ENABLE_GEN2_PIPETTES
+)

--- a/protocol-designer/src/feature-flags/types.js
+++ b/protocol-designer/src/feature-flags/types.js
@@ -6,8 +6,9 @@
 // Deprecated types should never be reused (unless there's a really good reason).
 export const DEPRECATED_FLAGS = ['OT_PD_SHOW_UPLOAD_CUSTOM_LABWARE_BUTTON']
 
-export type FlagTypes = '(add flags here)' // NOTE: any additional flag types should be added here with | (Union)
+// union of feature flag string constant IDs
+export type FlagTypes = 'OT_PD_ENABLE_GEN2_PIPETTES'
 
-export type Flags = {
-  [FlagTypes]: ?boolean,
-}
+export type Flags = $Shape<{|
+  [flag: FlagTypes]: ?boolean,
+|}>

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -3,5 +3,9 @@
     "TODO": "TODO: IL 2019-10-09 delete this, leaving as placeholder b/c no FFs remain",
     "title": "Upload custom labware",
     "description": "Show the \"Upload Custom Labware\" button to enable adding custom labware to protocol"
+  },
+  "OT_PD_ENABLE_GEN2_PIPETTES": {
+    "title": "Enable GEN2 pipettes",
+    "description": "Enable the selection of Opentrons GEN2 pipettes when creating protocols"
   }
 }

--- a/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
+++ b/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
@@ -57,6 +57,7 @@ Object {
   },
   "maxVolume": 10,
   "minVolume": 1,
+  "model": "p10_multi_v1",
   "modelOffset": Array [
     0,
     31.5,
@@ -263,6 +264,7 @@ Object {
   },
   "maxVolume": 10,
   "minVolume": 1,
+  "model": "p10_multi_v1.3",
   "modelOffset": Array [
     0,
     31.5,
@@ -469,6 +471,7 @@ Object {
   },
   "maxVolume": 10,
   "minVolume": 1,
+  "model": "p10_multi_v1.4",
   "modelOffset": Array [
     0,
     31.5,
@@ -675,6 +678,7 @@ Object {
   },
   "maxVolume": 10,
   "minVolume": 1,
+  "model": "p10_multi_v1.5",
   "modelOffset": Array [
     0,
     31.5,
@@ -851,6 +855,7 @@ Object {
   },
   "maxVolume": 10,
   "minVolume": 1,
+  "model": "p10_single_v1",
   "modelOffset": Array [
     0,
     0,
@@ -1062,6 +1067,7 @@ Object {
   },
   "maxVolume": 10,
   "minVolume": 1,
+  "model": "p10_single_v1.3",
   "modelOffset": Array [
     0,
     0,
@@ -1273,6 +1279,7 @@ Object {
   },
   "maxVolume": 10,
   "minVolume": 1,
+  "model": "p10_single_v1.4",
   "modelOffset": Array [
     0,
     0,
@@ -1484,6 +1491,7 @@ Object {
   },
   "maxVolume": 10,
   "minVolume": 1,
+  "model": "p10_single_v1.5",
   "modelOffset": Array [
     0,
     0,
@@ -1659,6 +1667,7 @@ Object {
   },
   "maxVolume": 50,
   "minVolume": 5,
+  "model": "p50_multi_v1",
   "modelOffset": Array [
     0,
     31.5,
@@ -1854,6 +1863,7 @@ Object {
   },
   "maxVolume": 50,
   "minVolume": 5,
+  "model": "p50_multi_v1.3",
   "modelOffset": Array [
     0,
     31.5,
@@ -2049,6 +2059,7 @@ Object {
   },
   "maxVolume": 50,
   "minVolume": 5,
+  "model": "p50_multi_v1.4",
   "modelOffset": Array [
     0,
     31.5,
@@ -2244,6 +2255,7 @@ Object {
   },
   "maxVolume": 50,
   "minVolume": 5,
+  "model": "p50_multi_v1.5",
   "modelOffset": Array [
     0,
     31.5,
@@ -2419,6 +2431,7 @@ Object {
   },
   "maxVolume": 50,
   "minVolume": 5,
+  "model": "p50_single_v1",
   "modelOffset": Array [
     0,
     0,
@@ -2614,6 +2627,7 @@ Object {
   },
   "maxVolume": 50,
   "minVolume": 5,
+  "model": "p50_single_v1.3",
   "modelOffset": Array [
     0,
     0,
@@ -2809,6 +2823,7 @@ Object {
   },
   "maxVolume": 50,
   "minVolume": 5,
+  "model": "p50_single_v1.4",
   "modelOffset": Array [
     0,
     0,
@@ -3004,6 +3019,7 @@ Object {
   },
   "maxVolume": 300,
   "minVolume": 30,
+  "model": "p300_multi_v1",
   "modelOffset": Array [
     0,
     31.5,
@@ -3163,6 +3179,7 @@ Object {
   },
   "maxVolume": 300,
   "minVolume": 30,
+  "model": "p300_multi_v1.3",
   "modelOffset": Array [
     0,
     31.5,
@@ -3322,6 +3339,7 @@ Object {
   },
   "maxVolume": 300,
   "minVolume": 30,
+  "model": "p300_multi_v1.4",
   "modelOffset": Array [
     0,
     31.5,
@@ -3481,6 +3499,7 @@ Object {
   },
   "maxVolume": 300,
   "minVolume": 30,
+  "model": "p300_multi_v1.5",
   "modelOffset": Array [
     0,
     31.5,
@@ -3641,6 +3660,7 @@ Object {
   },
   "maxVolume": 300,
   "minVolume": 30,
+  "model": "p300_single_v1",
   "modelOffset": Array [
     0,
     0,
@@ -3856,6 +3876,7 @@ Object {
   },
   "maxVolume": 300,
   "minVolume": 30,
+  "model": "p300_single_v1.3",
   "modelOffset": Array [
     0,
     0,
@@ -4071,6 +4092,7 @@ Object {
   },
   "maxVolume": 300,
   "minVolume": 30,
+  "model": "p300_single_v1.4",
   "modelOffset": Array [
     0,
     0,
@@ -4286,6 +4308,7 @@ Object {
   },
   "maxVolume": 300,
   "minVolume": 30,
+  "model": "p300_single_v1.5",
   "modelOffset": Array [
     0,
     0,
@@ -4465,6 +4488,7 @@ Object {
   },
   "maxVolume": 1000,
   "minVolume": 100,
+  "model": "p1000_single_v1",
   "modelOffset": Array [
     0,
     0,
@@ -4646,6 +4670,7 @@ Object {
   },
   "maxVolume": 1000,
   "minVolume": 100,
+  "model": "p1000_single_v1.3",
   "modelOffset": Array [
     0,
     0,
@@ -4827,6 +4852,7 @@ Object {
   },
   "maxVolume": 1000,
   "minVolume": 100,
+  "model": "p1000_single_v1.4",
   "modelOffset": Array [
     0,
     0,
@@ -5008,6 +5034,7 @@ Object {
   },
   "maxVolume": 1000,
   "minVolume": 100,
+  "model": "p1000_single_v1.5",
   "modelOffset": Array [
     0,
     0,

--- a/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
+++ b/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
@@ -32,7 +32,7 @@ Object {
     "min": 0.001,
     "value": 10,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P10 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -238,7 +238,7 @@ Object {
     "min": 0.001,
     "value": 10,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P10 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -444,7 +444,7 @@ Object {
     "min": 0.001,
     "value": 10,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P10 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -650,7 +650,7 @@ Object {
     "min": 0.001,
     "value": 10,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P10 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -826,7 +826,7 @@ Object {
     "min": 0.001,
     "value": 10,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P10 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -1037,7 +1037,7 @@ Object {
     "min": 0.001,
     "value": 10,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P10 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -1248,7 +1248,7 @@ Object {
     "min": 0.001,
     "value": 10,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P10 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -1459,7 +1459,7 @@ Object {
     "min": 0.001,
     "value": 10,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P10 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -1634,7 +1634,7 @@ Object {
     "min": 0.001,
     "value": 50,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P50 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -1829,7 +1829,7 @@ Object {
     "min": 0.001,
     "value": 50,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P50 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -2024,7 +2024,7 @@ Object {
     "min": 0.001,
     "value": 50,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P50 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -2219,7 +2219,7 @@ Object {
     "min": 0.001,
     "value": 50,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P50 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -2394,7 +2394,7 @@ Object {
     "min": 0.001,
     "value": 50,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P50 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -2589,7 +2589,7 @@ Object {
     "min": 0.001,
     "value": 50,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P50 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -2784,7 +2784,7 @@ Object {
     "min": 0.001,
     "value": 50,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P50 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -2979,7 +2979,7 @@ Object {
     "min": 0.001,
     "value": 300,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P300 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -3138,7 +3138,7 @@ Object {
     "min": 0.001,
     "value": 300,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P300 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -3297,7 +3297,7 @@ Object {
     "min": 0.001,
     "value": 300,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P300 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -3456,7 +3456,7 @@ Object {
     "min": 0.001,
     "value": 300,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P300 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -3616,7 +3616,7 @@ Object {
     "min": 0.001,
     "value": 300,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P300 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -3831,7 +3831,7 @@ Object {
     "min": 0.001,
     "value": 300,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P300 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -4046,7 +4046,7 @@ Object {
     "min": 0.001,
     "value": 300,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P300 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -4261,7 +4261,7 @@ Object {
     "min": 0.001,
     "value": 300,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P300 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -4440,7 +4440,7 @@ Object {
     "min": 50,
     "value": 1000,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P1000 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -4621,7 +4621,7 @@ Object {
     "min": 50,
     "value": 1000,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P1000 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -4802,7 +4802,7 @@ Object {
     "min": 50,
     "value": 1000,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P1000 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -4983,7 +4983,7 @@ Object {
     "min": 50,
     "value": 1000,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P1000 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -5150,7 +5150,7 @@ Object {
     "min": 0.001,
     "value": 10,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P10 8-Channel",
   "maxVolume": 10,
   "minVolume": 1,
@@ -5181,7 +5181,7 @@ Object {
     "min": 0.001,
     "value": 10,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P10 Single-Channel",
   "maxVolume": 10,
   "minVolume": 1,
@@ -5212,7 +5212,7 @@ Object {
     "min": 0.001,
     "value": 50,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P50 8-Channel",
   "maxVolume": 50,
   "minVolume": 5,
@@ -5243,7 +5243,7 @@ Object {
     "min": 0.001,
     "value": 50,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P50 Single-Channel",
   "maxVolume": 50,
   "minVolume": 5,
@@ -5274,7 +5274,7 @@ Object {
     "min": 0.001,
     "value": 300,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P300 8-Channel",
   "maxVolume": 300,
   "minVolume": 30,
@@ -5305,7 +5305,7 @@ Object {
     "min": 0.001,
     "value": 300,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P300 Single-Channel",
   "maxVolume": 300,
   "minVolume": 30,
@@ -5336,7 +5336,7 @@ Object {
     "min": 50,
     "value": 1000,
   },
-  "displayCategory": "OG",
+  "displayCategory": "GEN1",
   "displayName": "P1000 Single-Channel",
   "maxVolume": 1000,
   "minVolume": 100,

--- a/shared-data/js/helpers/wellSets.js
+++ b/shared-data/js/helpers/wellSets.js
@@ -15,8 +15,7 @@
 import { getLabwareDefURI } from '@opentrons/shared-data'
 import uniq from 'lodash/uniq'
 import { getWellNamePerMultiTip } from './getWellNamePerMultiTip'
-import type { LabwareDefinition2 } from '../types'
-import type { PipetteNameSpecs } from '../pipettes'
+import type { LabwareDefinition2, PipetteNameSpecs } from '../types'
 
 type WellSetByPrimaryWell = Array<Array<string>>
 

--- a/shared-data/js/pipettes.js
+++ b/shared-data/js/pipettes.js
@@ -1,25 +1,7 @@
 // @flow
 import pipetteNameSpecs from '../pipette/definitions/pipetteNameSpecs.json'
 import pipetteModelSpecs from '../pipette/definitions/pipetteModelSpecs.json'
-
-export type PipetteChannels = 1 | 8
-export type PipetteDisplayCategory = 'OG' | 'GEN2'
-
-export type PipetteNameSpecs = {
-  name: string,
-  displayName: string,
-  displayCategory?: PipetteDisplayCategory,
-  minVolume: number,
-  maxVolume: number,
-  defaultAspirateFlowRate: { value: number },
-  defaultDispenseFlowRate: { value: number },
-  channels: PipetteChannels,
-}
-
-export type PipetteModelSpecs = {
-  model: string,
-  tipLength: { value: number },
-} & PipetteNameSpecs
+import type { PipetteNameSpecs, PipetteModelSpecs } from './types'
 
 type SortableProps = 'maxVolume' | 'channels'
 
@@ -29,9 +11,9 @@ const ALL_PIPETTE_NAMES: Array<string> = Object.keys(pipetteNameSpecs).sort(
 )
 
 // use a name like 'p10_single' to get specs true for all models under that name
-export function getPipetteNameSpecs(name: string): ?PipetteNameSpecs {
+export function getPipetteNameSpecs(name: string): PipetteNameSpecs | null {
   const config = pipetteNameSpecs[name]
-  return config && { ...config, name }
+  return config != null ? { ...config, name } : null
 }
 
 // specify a model, eg 'p10_single_v1.3' to get
@@ -41,7 +23,8 @@ export function getPipetteModelSpecs(model: string): ?PipetteModelSpecs {
   const modelSpecificFields = pipetteModelSpecs.config[model]
   const modelFields =
     modelSpecificFields && getPipetteNameSpecs(modelSpecificFields.name)
-  return modelFields && { ...modelFields, ...modelSpecificFields }
+
+  return modelFields && { ...modelFields, ...modelSpecificFields, model }
 }
 
 export function getAllPipetteNames(

--- a/shared-data/js/types.js
+++ b/shared-data/js/types.js
@@ -234,23 +234,36 @@ export type ModuleDefinition = {|
   quirks: Array<string>,
 |}
 
+export type PipetteChannels = 1 | 8
+
+export type PipetteDisplayCategory = 'GEN1' | 'GEN2'
+
 export type FlowRateSpec = {|
   value: number,
   min: number,
   max: number,
 |}
-export type PipetteNameSpec = {|
+
+export type PipetteNameSpecs = {|
+  name: string,
   displayName: string,
-  displayCategory?: string,
+  displayCategory: PipetteDisplayCategory,
   minVolume: number,
   maxVolume: number,
-  channels: number,
+  channels: PipetteChannels,
   defaultAspirateFlowRate: FlowRateSpec,
   defaultDispenseFlowRate: FlowRateSpec,
   defaultBlowOutFlowRate: FlowRateSpec,
-  smoothieConfigs?: {
+  smoothieConfigs?: {|
     stepsPerMM: number,
     homePosition: number,
     travelDistance: number,
-  },
+  |},
 |}
+
+// TODO(mc, 2019-10-14): update this type according to the schema
+export type PipetteModelSpecs = {
+  ...PipetteNameSpecs,
+  model: string,
+  tipLength: { value: number },
+}

--- a/shared-data/pipette/definitions/pipetteNameSpecs.json
+++ b/shared-data/pipette/definitions/pipetteNameSpecs.json
@@ -1,7 +1,7 @@
 {
   "p10_single": {
     "displayName": "P10 Single-Channel",
-    "displayCategory": "OG",
+    "displayCategory": "GEN1",
     "minVolume": 1,
     "maxVolume": 10,
     "channels": 1,
@@ -28,7 +28,7 @@
   },
   "p10_multi": {
     "displayName": "P10 8-Channel",
-    "displayCategory": "OG",
+    "displayCategory": "GEN1",
     "minVolume": 1,
     "maxVolume": 10,
     "defaultAspirateFlowRate": {
@@ -109,7 +109,7 @@
   },
   "p50_single": {
     "displayName": "P50 Single-Channel",
-    "displayCategory": "OG",
+    "displayCategory": "GEN1",
     "defaultAspirateFlowRate": {
       "value": 25,
       "min": 0.001,
@@ -136,7 +136,7 @@
   },
   "p50_multi": {
     "displayName": "P50 8-Channel",
-    "displayCategory": "OG",
+    "displayCategory": "GEN1",
     "defaultAspirateFlowRate": {
       "value": 25,
       "min": 0.001,
@@ -163,7 +163,7 @@
   },
   "p300_single": {
     "displayName": "P300 Single-Channel",
-    "displayCategory": "OG",
+    "displayCategory": "GEN1",
     "defaultAspirateFlowRate": {
       "value": 150,
       "min": 0.001,
@@ -244,7 +244,7 @@
   },
   "p300_multi": {
     "displayName": "P300 8-Channel",
-    "displayCategory": "OG",
+    "displayCategory": "GEN1",
     "defaultAspirateFlowRate": {
       "value": 150,
       "min": 0.001,
@@ -271,7 +271,7 @@
   },
   "p1000_single": {
     "displayName": "P1000 Single-Channel",
-    "displayCategory": "OG",
+    "displayCategory": "GEN1",
     "defaultAspirateFlowRate": {
       "value": 500,
       "min": 50,

--- a/shared-data/pipette/schemas/pipetteNameSpecsSchema.json
+++ b/shared-data/pipette/schemas/pipetteNameSpecsSchema.json
@@ -11,7 +11,7 @@
     },
     "displayCategory": {
       "type": "string",
-      "enum": ["OG", "GEN2"]
+      "enum": ["GEN1", "GEN2"]
     }
   },
 


### PR DESCRIPTION
## overview

This PR adds the new pipette select component from #3996 and adds it to PD behind a feature flag.

## changelog

- refactor(app,pd): add GEN1 category to OG pipettes, FF'd GEN2 select to PD

## review requests

Due to lack specs/screens, I had to make the following judgement calls:

- A `displayCategory` for original pipettes of `GEN1` was added to the pipette config and UI as per various ad-hoc Slack conversations and #4138 
    - No design assets existed for this, but since they followed the GEN2 designs I don't think this is a problem
- There were no specs nor screens for the selected state of the pipette dropdown, so I chose to use the given pipette's `displayName`
    - At the moment, the original pipette's `displayName` properties **do not include "GEN1"**
    - Do they need to be updated?

### testing

App:

1. Enable dev tools
2. Go to the app's advanced settings
3. Enable `__DEV__ enablePipettePlus`

PD:

1. Go to the PD settings page
2. Enable the `Enable GEN2 pipettes` setting