### PR TITLE
fix(protocol-designer): fix copy & link for custom labware

### DIFF
--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
@@ -10,7 +10,6 @@ import startCase from 'lodash/startCase'
 import reduce from 'lodash/reduce'
 import i18n from '../../localization'
 import { getOnlyLatestDefs } from '../../labware-defs/utils'
-import KnowledgeBaseLink from '../KnowledgeBaseLink'
 import { Portal } from '../portals/TopPortal'
 import { PDTitledList } from '../lists'
 import LabwareItem from './LabwareItem'
@@ -27,6 +26,7 @@ type Props = {
   permittedTipracks: Array<string>,
 }
 
+const LABWARE_CREATOR_URL = 'https://labware.opentrons.com/create'
 const CUSTOM_CATEGORY = 'custom'
 
 const orderedCategories: Array<string> = [
@@ -151,9 +151,15 @@ const LabwareDropdown = (props: Props) => {
         </OutlineButton>
         <div className={styles.upload_helper_copy}>
           {i18n.t('modal.labware_selection.creating_labware_defs')}{' '}
-          <KnowledgeBaseLink className={styles.link} to="customLabware">
+          {/* TODO: Ian 2019-10-15 use LinkOut component once it's in components library, see Opentrons/opentrons#4229 */}
+          <a
+            className={styles.link}
+            href={LABWARE_CREATOR_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             here
-          </KnowledgeBaseLink>
+          </a>
           .
         </div>
 

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -8,7 +8,7 @@
     "max_vol": "Max Volume",
     "see_details": "See detail page",
     "view_measurements": "view measurements",
-    "creating_labware_defs": "Learn more about creating custom labware definitions"
+    "creating_labware_defs": "Access the Labware Creator"
   },
   "tip_position": {
     "title": "Tip Positioning",

--- a/protocol-designer/webpack.config.js
+++ b/protocol-designer/webpack.config.js
@@ -16,7 +16,7 @@ const PROTOCOL_DESIGNER_ENV_VAR_PREFIX = 'OT_PD_'
 // Also remove all OT_PD_VERSION env vars, the version should always
 // be gleaned from the package.json
 
-const OT_PD_VERSION = '3.0.5'
+const OT_PD_VERSION = '3.0.6'
 const OT_PD_BUILD_DATE = new Date().toUTCString()
 
 const JS_ENTRY = path.join(__dirname, 'src/index.js')


### PR DESCRIPTION
## overview

Oops I missed this copy + link change. Now it should be "Access Labware Creator here" and the "here" should link to https://labware.opentrons.com/create

![image](https://user-images.githubusercontent.com/11590381/66857281-f2b8cf00-ef54-11e9-98b4-4007f0a6ce46.png)

## changelog

- bump version for next RC

## review requests

- Copy OK
- Link goes directly to LC