### PR TITLE
feat(api): Specify if a restart is required after changing some ffs

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -16,11 +16,20 @@ log = logging.getLogger(__name__)
 
 
 class Setting:
-    def __init__(self, _id, title, description, old_id=None):
+    def __init__(self, _id: str, title: str, description: str,
+                 old_id: str = None,
+                 restart_required: bool = False):
         self.id = _id
+        #: The id of the setting for programmatic access through
+        #: get_adv_setting
         self.old_id = old_id
+        #: the old id before migration, if any
         self.title = title
+        #: User facing title
         self.description = description
+        #: User facing description
+        self.restart_required = restart_required
+        #: True if the user must restart
 
     def __repr__(self):
         return '{}: {}'.format(self.__class__, self.id)
@@ -59,9 +68,10 @@ settings = [
     Setting(
         _id='useProtocolApi2',
         title='Use Protocol API version 2',
-        description='Use new implementation of protocol API. This should not'
-                    ' be activated except by developers or testers. Please'
-                    ' power cycle the robot after changing this setting.'
+        description='Enable to use the Protocol API V2 Beta. With this flag '
+                    'set, only Protocol API v2 protocols can be executed by '
+                    'the robot.',
+        restart_required=True
     ),
     Setting(
         _id='useOldAspirationFunctions',
@@ -97,7 +107,8 @@ def get_adv_setting(setting: str) -> Optional[bool]:
 def get_all_adv_settings() -> Dict[str, Dict[str, Union[str, bool, None]]]:
     """
     :return: a dict of settings keyed by setting ID, where each value is a
-        dict with keys "id", "title", "description", and "value"
+        dict with keys "id", "title", "description", "value",
+        "restart_required"
     """
     settings_file = CONFIG['feature_flags_file']
 
@@ -185,7 +196,7 @@ def _migrate0to1(previous: Mapping[str, Any]) -> SettingsMap:
 
         if previous.get(id) is True:
             next[id] = True
-        elif previous.get(old_id) is True:
+        elif old_id and previous.get(old_id) is True:
             next[id] = True
         else:
             next[id] = None

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -70,7 +70,7 @@ settings = [
         title='Use Protocol API version 2',
         description='Enable to use the Protocol API V2 Beta. With this flag '
                     'set, only Protocol API v2 protocols can be executed by '
-                    'the robot.',
+                    'the robot. A restart of the robot is required.',
         restart_required=True
     ),
     Setting(

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -63,6 +63,7 @@ def validate_response_body(body):
         assert 'description' in obj, '"description" not found for {}'.format(
             obj['id'])
         assert 'value' in obj, '"value" not found for {}'.format(obj['id'])
+        assert 'restart_required' in obj
 
 
 async def test_get(virtual_smoothie_env, loop, aiohttp_client):


### PR DESCRIPTION
GET /settings now has an additional "restart_required" key in the individual
settings objects, which should be true or false. If true, the robot should be
restarted after changing the flag.

Also changes the wording of the api2 feature flag now that it is entering beta.

@Opentrons/js This should allow the runapp to automatically pop a modal to restart the robot after changing these flags.

## Testing

`restart_required` should be `True` for the api v2 flag, and `False` for everything else.