### PR TITLE
feat(api): apiv2: conditionally enable backcompat

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -282,7 +282,8 @@ class Session(object):
         if isinstance(self._protocol, PythonProtocol):
             self.metadata = self._protocol.metadata
             if ff.use_protocol_api_v2()\
-               and self._protocol.api_level == '1':
+               and self._protocol.api_level == '1'\
+               and not ff.enable_backcompat():
                 raise RuntimeError(
                     'This protocol targets Protocol API V1, but the robot is '
                     'set to Protocol API V2. If this is actually a V2 '

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -1,34 +1,29 @@
-import os
 from opentrons.config import advanced_settings as advs
 
 
-def get_setting_with_env_overload(setting_name):
-    env_name = 'OT_API_FF_' + setting_name
-    if env_name in os.environ:
-        return os.environ[env_name].lower() in ('1', 'true', 'on')
-    else:
-        return advs.get_adv_setting(setting_name) is True
-
-
 def short_fixed_trash():
-    return get_setting_with_env_overload('shortFixedTrash')
+    return advs.get_setting_with_env_overload('shortFixedTrash')
 
 
 def calibrate_to_bottom():
-    return get_setting_with_env_overload('calibrateToBottom')
+    return advs.get_setting_with_env_overload('calibrateToBottom')
 
 
 def dots_deck_type():
-    return get_setting_with_env_overload('deckCalibrationDots')
+    return advs.get_setting_with_env_overload('deckCalibrationDots')
 
 
 def disable_home_on_boot():
-    return get_setting_with_env_overload('disableHomeOnBoot')
+    return advs.get_setting_with_env_overload('disableHomeOnBoot')
 
 
 def use_protocol_api_v2():
-    return get_setting_with_env_overload('useProtocolApi2')
+    return advs.get_setting_with_env_overload('useProtocolApi2')
 
 
 def use_old_aspiration_functions():
-    return get_setting_with_env_overload('useOldAspirationFunctions')
+    return advs.get_setting_with_env_overload('useOldAspirationFunctions')
+
+
+def enable_backcompat():
+    return advs.get_setting_with_env_overload('enableApi1BackCompat')

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -18,7 +18,7 @@ from opentrons.protocol_api import execute as execute_apiv2
 from opentrons import commands
 from opentrons.config import feature_flags as ff
 from opentrons.protocols.parse import parse
-from opentrons.protocols.types import JsonProtocol
+from opentrons.protocols.types import JsonProtocol, PythonProtocol
 from opentrons.hardware_control import API
 
 _HWCONTROL: Optional[API] = None
@@ -179,7 +179,8 @@ def execute(protocol_file: TextIO,
     contents = protocol_file.read()
     protocol = parse(contents, protocol_file.name)
     if ff.use_protocol_api_v2():
-        if protocol.api_level == '1'\
+        if isinstance(protocol, PythonProtocol)\
+           and protocol.api_level == '1'\
            and not ff.enable_backcompat():
             raise RuntimeError(
                 'This protocol targets Protocol API V1, but the robot is '

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -179,6 +179,15 @@ def execute(protocol_file: TextIO,
     contents = protocol_file.read()
     protocol = parse(contents, protocol_file.name)
     if ff.use_protocol_api_v2():
+        if protocol.api_level == '1'\
+           and not ff.enable_backcompat():
+            raise RuntimeError(
+                'This protocol targets Protocol API V1, but the robot is '
+                'set to Protocol API V2. If this is actually a V2 '
+                'protocol, please set the \'apiLevel\' to \'2\' in the '
+                'metadata. If you do not want to be on API V2, please '
+                'disable the \'Use Protocol API version 2\' toggle in the '
+                'robot\'s Advanced Settings and restart the robot.')
         context = get_protocol_api(
             bundled_labware=getattr(protocol, 'bundled_labware', None),
             bundled_data=getattr(protocol, 'bundled_data', None))

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -207,6 +207,15 @@ def simulate(protocol_file: TextIO,
                            extra_data=extra_data)
 
     if opentrons.config.feature_flags.use_protocol_api_v2():
+        if protocol.api_level == '1'\
+           and not opentrons.config.feature_flags.enable_backcompat():
+            raise RuntimeError(
+                'This protocol targets Protocol API V1, but the robot is '
+                'set to Protocol API V2. If this is actually a V2 '
+                'protocol, please set the \'apiLevel\' to \'2\' in the '
+                'metadata. If you do not want to be on API V2, please '
+                'disable the \'Use Protocol API version 2\' toggle in the '
+                'robot\'s Advanced Settings and restart the robot.')
         context = opentrons.protocol_api.contexts.ProtocolContext(
             bundled_labware=getattr(protocol, 'bundled_labware', None),
             bundled_data=getattr(protocol, 'bundled_data', None))

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -207,7 +207,8 @@ def simulate(protocol_file: TextIO,
                            extra_data=extra_data)
 
     if opentrons.config.feature_flags.use_protocol_api_v2():
-        if protocol.api_level == '1'\
+        if isinstance(protocol, PythonProtocol)\
+           and protocol.api_level == '1'\
            and not opentrons.config.feature_flags.enable_backcompat():
             raise RuntimeError(
                 'This protocol targets Protocol API V1, but the robot is '

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -1,19 +1,24 @@
 from opentrons.config.advanced_settings import _migrate
 
 
+good_file_version = 3
+good_file_settings = {
+    'shortFixedTrash': None,
+    'calibrateToBottom': None,
+    'deckCalibrationDots': None,
+    'disableHomeOnBoot': None,
+    'useProtocolApi2': None,
+    'useOldAspirationFunctions': None,
+    'disableLogAggregation': None,
+    'enableApi1BackCompat': None
+}
+
+
 def test_migrates_empty_object():
     settings, version = _migrate({})
 
-    assert(version == 2)
-    assert(settings == {
-      'shortFixedTrash': None,
-      'calibrateToBottom': None,
-      'deckCalibrationDots': None,
-      'disableHomeOnBoot': None,
-      'useProtocolApi2': None,
-      'useOldAspirationFunctions': None,
-      'disableLogAggregation': None
-    })
+    assert version == good_file_version
+    assert settings == good_file_settings
 
 
 def test_migrates_versionless_new_config():
@@ -26,8 +31,8 @@ def test_migrates_versionless_new_config():
       'useOldAspirationFunctions': True,
     })
 
-    assert(version == 2)
-    assert(settings == {
+    assert version == good_file_version
+    assert settings == {
       'shortFixedTrash': True,
       'calibrateToBottom': True,
       'deckCalibrationDots': None,
@@ -35,7 +40,8 @@ def test_migrates_versionless_new_config():
       'useProtocolApi2': None,
       'useOldAspirationFunctions': True,
       'disableLogAggregation': None,
-    })
+      'enableApi1BackCompat': None
+    }
 
 
 def test_migrates_versionless_old_config():
@@ -46,16 +52,17 @@ def test_migrates_versionless_old_config():
       'disable-home-on-boot': False,
     })
 
-    assert(version == 2)
-    assert(settings == {
+    assert version == good_file_version
+    assert settings == {
       'shortFixedTrash': None,
       'calibrateToBottom': None,
       'deckCalibrationDots': True,
       'disableHomeOnBoot': None,
       'useProtocolApi2': None,
       'useOldAspirationFunctions': None,
-      'disableLogAggregation': None
-    })
+      'disableLogAggregation': None,
+      'enableApi1BackCompat': None
+    }
 
 
 def test_ignores_invalid_keys():
@@ -64,8 +71,8 @@ def test_ignores_invalid_keys():
       'splitLabwareDefinitions': True
     })
 
-    assert(version == 2)
-    assert(settings == {
+    assert version == good_file_version
+    assert settings == {
       'shortFixedTrash': None,
       'calibrateToBottom': None,
       'deckCalibrationDots': None,
@@ -73,7 +80,8 @@ def test_ignores_invalid_keys():
       'useProtocolApi2': None,
       'useOldAspirationFunctions': None,
       'disableLogAggregation': None,
-    })
+      'enableApi1BackCompat': None
+    }
 
 
 def test_migrates_v1_config():
@@ -86,7 +94,7 @@ def test_migrates_v1_config():
       'useProtocolApi2': False,
       'useOldAspirationFunctions': True,
     })
-    assert version == 2
+    assert version == 3
     assert settings == {
         'shortFixedTrash': True,
         'calibrateToBottom': True,
@@ -94,5 +102,31 @@ def test_migrates_v1_config():
         'disableHomeOnBoot': True,
         'useProtocolApi2': False,
         'useOldAspirationFunctions': True,
-        'disableLogAggregation': None
+        'disableLogAggregation': None,
+        'enableApi1BackCompat': None
+    }
+
+
+def test_migrates_v2_config():
+    settings, version = _migrate({
+        '_version': 2,
+        'shortFixedTrash': True,
+        'calibrateToBottom': True,
+        'deckCalibrationDots': False,
+        'disableHomeOnBoot': True,
+        'useProtocolApi2': False,
+        'useOldAspirationFunctions': True,
+        'disableLogAggregation': False,
+    })
+
+    assert version == 3
+    assert settings == {
+        'shortFixedTrash': True,
+        'calibrateToBottom': True,
+        'deckCalibrationDots': False,
+        'disableHomeOnBoot': True,
+        'useProtocolApi2': False,
+        'useOldAspirationFunctions': True,
+        'disableLogAggregation': False,
+        'enableApi1BackCompat': None
     }

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -66,14 +66,16 @@ def validate_response_body(body):
         assert 'restart_required' in obj
 
 
-async def test_get(virtual_smoothie_env, loop, aiohttp_client):
-    app = init()
-    cli = await loop.create_task(aiohttp_client(app))
-
-    resp = await cli.get('/settings')
+async def test_get(async_client, async_server):
+    resp = await async_client.get('/settings')
     body = await resp.json()
     assert resp.status == 200
     validate_response_body(body)
+    if async_server['api_version'] == 2:
+        assert 'enableApi1BackCompat' in [s['id'] for s in body['settings']]
+    else:
+        assert 'enableApi1BackCompat' not in [
+            s['id'] for s in body['settings']]
 
 
 async def test_set(virtual_smoothie_env, loop, aiohttp_client):


### PR DESCRIPTION
Adds a new feature flag to enable apiv1 backcompat when apiv2 is enabled.

This feature flag should only show up in GET /settings when apiv2 is enabled.

If this new feature flag is enabled, pass apiv1 protocols uploaded when apiv2 is
selected to the backcompat executors.

Gate this functionality in opentrons_simulate and opentrons_execute behind the
new flag.


## Testing
- The feature flag should only appear if apiv2 is set
- If the feature flag is not set, using an apiv1 protocol with runapp upload, `opentrons_simulate`, or `opentrons_execute` should give you an error
- If the feature flag is set, using an apiv1 protocol with runapp upload, `opentrons_simulate` or `opentrons_execute` should "work" (it will try to execute it using the backcompat executor, which does not currently work)