### PR TITLE
fix(api): correctly handle mix optional arguments

### DIFF
--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -683,12 +683,13 @@ class Pipette(CommandPublisher):
         if not self.tip_attached:
             log.warning("Cannot mix without a tip attached.")
 
-        if volume is None:
-            volume = self._working_volume
+        if not helpers.is_number(volume):
+            if isinstance(volume, Placeable) and not location:
+                location = volume
+            volume = self._working_volume - self.current_volume
 
         if not location and self.previous_placeable:
             location = self.previous_placeable
-            volume = self._working_volume
 
         do_publish(self.broker, commands.mix, self.mix, 'before',
                    self, None, None, repetitions, volume, location, rate)

--- a/api/tests/opentrons/labware/test_pipette_unittest.py
+++ b/api/tests/opentrons/labware/test_pipette_unittest.py
@@ -988,21 +988,72 @@ def test_mix(local_test_pipette):
     p200.pick_up_tip()
     p200.aspirate = mock.Mock()
     p200.dispense = mock.Mock()
+
+    # scenario I: 3 arguments - repetitions, volume, location
     p200.mix(3, 100, plate[1])
 
-    dispense_expected = [
+    dispense_expected_1 = [
         mock.call.dispense(100, rate=1.0),
         mock.call.dispense(100, rate=1.0),
         mock.call.dispense(100, rate=1.0)
     ]
-    assert p200.dispense.mock_calls == dispense_expected
+    assert p200.dispense.mock_calls == dispense_expected_1
 
-    aspirate_expected = [
+    aspirate_expected_1 = [
         mock.call.aspirate(volume=100, location=plate[1], rate=1.0),
         mock.call.aspirate(100, rate=1.0),
         mock.call.aspirate(100, rate=1.0)
     ]
-    assert p200.aspirate.mock_calls == aspirate_expected
+    assert p200.aspirate.mock_calls == aspirate_expected_1
+
+    # scenario II: 2 arguments - repetitions, volume
+    p200.aspirate.reset_mock()
+    p200.dispense.reset_mock()
+    p200.mix(2, 100)
+
+    dispense_expected_2 = [
+        mock.call.dispense(100, rate=1.0),
+        mock.call.dispense(100, rate=1.0)
+    ]
+    assert p200.dispense.mock_calls == dispense_expected_2
+
+    aspirate_expected_2 = [
+        mock.call.aspirate(volume=100, location=None, rate=1.0),
+        mock.call.aspirate(100, rate=1.0)
+    ]
+    assert p200.aspirate.mock_calls == aspirate_expected_2
+
+    # scenario III: 2 arguments - repetitions, location
+    p200.aspirate.reset_mock()
+    p200.dispense.reset_mock()
+    p200.mix(2, plate[2])
+
+    dispense_expected_3 = [
+        mock.call.dispense(200, rate=1.0),
+        mock.call.dispense(200, rate=1.0)
+    ]
+    assert p200.dispense.mock_calls == dispense_expected_3
+
+    aspirate_expected_3 = [
+        mock.call.aspirate(volume=200, location=plate[2], rate=1.0),
+        mock.call.aspirate(200, rate=1.0)
+    ]
+    assert p200.aspirate.mock_calls == aspirate_expected_3
+
+    # scenario IV: 0 arguments
+    p200.aspirate.reset_mock()
+    p200.dispense.reset_mock()
+    p200.mix()
+
+    dispense_expected_3 = [
+        mock.call.dispense(200, rate=1.0)
+    ]
+    assert p200.dispense.mock_calls == dispense_expected_3
+
+    aspirate_expected_3 = [
+        mock.call.aspirate(volume=200, location=None, rate=1.0),
+    ]
+    assert p200.aspirate.mock_calls == aspirate_expected_3
 
 
 @pytest.mark.api1_only


### PR DESCRIPTION
## overview
A bug was introduced in `mix` in APIv1 by #3692. In APIv1, mix arguments - repetitions, volume, and location, are all optional. Currently, if a mix location is not present, the mix volume would always get updated to the working volume of the pipette. The pipette is therefore mixing at an incorrect volume.

Additionally, `mix` does not validate the type of the volume argument. This means that if a location is passed rather than a volume, it is mistakenly considered as the mix volume. The location would then be interpreted as absent and hence, both the mix volume and location will be updated based on the logic mentioned above.

## changelog
- check volume type, if it's a placeable and a mix location is missing, set it as the location and update the volume to be the pipette's available volume (working volume - current volume)
- add more tests to test different arg combinations for mix

## review requests
Simulate the following protocol before and after the changes:
```
from opentrons import labware, instruments

tips10 = labware.load('opentrons_96_tiprack_10ul', '4')
plate = labware.load('biorad_96_wellplate_200ul_pcr', '1')
pip10 = instruments.P10_Single(mount='right', tip_racks=[tips10])

pip10.pick_up_tip()
pip10.move_to(plate.wells('A1'))
pip10.mix(3, 5)
pip10.mix(2, plate.wells('A2'))
```
The pipette should mix 3 times at 5 uL in well A1, then mix 2 times at 10 uL in well A2.