### PR TITLE
fix(labware-library): fix leaky creator CSS from creator breaking filter link styling

### DIFF
--- a/labware-library/src/labware-creator/components/IntroCopy.js
+++ b/labware-library/src/labware-creator/components/IntroCopy.js
@@ -23,7 +23,10 @@ const IntroCopy = () => (
       This tool will allow you to create definitions for well plates,
       reservoirs, tubes in Opentrons tube racks, and plates/tubes in Opentrons
       aluminum blocks that do not already exist on the{' '}
-      <Link to={LINK_LABWARE_LIBRARY}>Labware Library</Link>.
+      <Link to={LINK_LABWARE_LIBRARY} className={styles.link}>
+        Labware Library
+      </Link>
+      .
     </p>
     <p>
       Use this tool only if your labware meets the following{' '}
@@ -39,7 +42,10 @@ const IntroCopy = () => (
     </ol>
     <p>
       For all other custom labware, please use this{' '}
-      <LinkOut href={LINK_CUSTOM_LABWARE_FORM}>request form</LinkOut>.
+      <LinkOut href={LINK_CUSTOM_LABWARE_FORM} className={styles.link}>
+        request form
+      </LinkOut>
+      .
     </p>
 
     <div className={styles.callout}>
@@ -48,8 +54,11 @@ const IntroCopy = () => (
         mechanical drawings directly from your supplier/manufacturer and only
         rely on manual measurements (using calipers when possible) to supplement
         missing information. Refer to the bottom of{' '}
-        <LinkOut href={LINK_CUSTOM_LABWARE_GUIDE}>this guide </LinkOut> for some
-        tips on how to get the most accuracy with your manual measurements.
+        <LinkOut href={LINK_CUSTOM_LABWARE_GUIDE} className={styles.link}>
+          this guide
+        </LinkOut>{' '}
+        for some tips on how to get the most accuracy with your manual
+        measurements.
       </p>
     </div>
   </>

--- a/labware-library/src/labware-creator/components/LabwareCreator.css
+++ b/labware-library/src/labware-creator/components/LabwareCreator.css
@@ -11,8 +11,13 @@
   & h2 {
     @apply --font-default-dark;
 
+    line-height: var(--lh-title);
     font-weight: var(--fw-semibold);
     padding-bottom: 1rem;
+  }
+
+  & p {
+    line-height: var(--lh-copy);
   }
 }
 
@@ -21,11 +26,6 @@
 
   /* nav height plus breadcrumbs */
   padding-top: calc(var(--size-mobile-nav) + var(--size-breadcrumb-nav));
-
-  & a,
-  & a:visited {
-    color: var(--c-blue);
-  }
 
   & h2 {
     @apply --font-header-dark;

--- a/labware-library/src/labware-creator/components/LabwareCreator.css
+++ b/labware-library/src/labware-creator/components/LabwareCreator.css
@@ -22,9 +22,13 @@
   /* nav height plus breadcrumbs */
   padding-top: calc(var(--size-mobile-nav) + var(--size-breadcrumb-nav));
 
-  a,
-  a:visited {
+  & a,
+  & a:visited {
     color: var(--c-blue);
+  }
+
+  & h2 {
+    @apply --font-header-dark;
   }
 }
 

--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -54,16 +54,6 @@
   }
 }
 
-a,
-a:visited {
-  color: var(--c-blue);
-}
-
-/* TODO (ka 2019-8-23): Removed nesting here to allow for easier style overrides/reduce specificity */
-h2 {
-  @apply --font-header-dark;
-}
-
 .labware_creator .labware_guide_button {
   @apply --link-btn-blue;
 }

--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -15,12 +15,12 @@
     font-family: 'AkkoPro-Regular', 'Ropa Sans', 'Open Sans', sans-serif;
     text-transform: uppercase;
 
-    &:hover {
-      background-color: #00f;
-    }
-
     &:visited {
       color: white;
+    }
+
+    &:hover {
+      background-color: #00f;
     }
   }
 }
@@ -52,6 +52,11 @@
   & strong {
     font-weight: var(--fw-semibold);
   }
+}
+
+.link,
+.link:visited {
+  color: var(--c-blue);
 }
 
 .labware_creator .labware_guide_button {


### PR DESCRIPTION
## overview

Bug report + fix

#4031 inadvertently introduced global CSS into the Labware Library stylesheet, breaking the filter link highlighting in labware library

## changelog

- Removed global styles from labware creator CSS

## review requests

Please remember that CSS modules **only works with class names** and things nested under classNames. If you use element tags or put element tags nested without an `&` first, the style becomes global

- [ ] Styles that the labware creator needs are still applied to links and headers
    - Please check the sandbox as well as local dev
- [ ] Labware filter links don't become permanently blue once you've clicked it one time and made it "visited"
