### PR TITLE
feat(protocol-designer): Implement prerelease mode + settings

### DIFF
--- a/protocol-designer/src/components/PrereleaseModeIndicator.js
+++ b/protocol-designer/src/components/PrereleaseModeIndicator.js
@@ -1,0 +1,28 @@
+// @flow
+import * as React from 'react'
+import { useSelector } from 'react-redux'
+import { Icon } from '@opentrons/components'
+import { selectors as featureFlagSelectors } from '../feature-flags'
+
+const PrereleaseModeIndicator = () => {
+  const prereleaseModeEnabled = useSelector(
+    featureFlagSelectors.getEnabledPrereleaseMode
+  )
+
+  return prereleaseModeEnabled === true ? (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        right: 0,
+        backgroundColor: 'red',
+        height: '2rem',
+        zIndex: 9999,
+      }}
+    >
+      <Icon name="alert" height="2rem" />
+    </div>
+  ) : null
+}
+
+export default PrereleaseModeIndicator

--- a/protocol-designer/src/components/ProtocolEditor.js
+++ b/protocol-designer/src/components/ProtocolEditor.js
@@ -3,6 +3,7 @@ import * as React from 'react'
 import cx from 'classnames'
 import { DragDropContext } from 'react-dnd'
 import MouseBackEnd from 'react-dnd-mouse-backend'
+import PrereleaseModeIndicator from './PrereleaseModeIndicator'
 import ConnectedNav from '../containers/ConnectedNav'
 import ConnectedSidebar from '../containers/ConnectedSidebar'
 import ConnectedTitleBar from '../containers/ConnectedTitleBar'
@@ -24,6 +25,7 @@ function ProtocolEditor() {
     <div>
       <TopPortalRoot />
       {showGateModal ? <GateModal /> : null}
+      <PrereleaseModeIndicator />
       <div className={styles.wrapper}>
         <ConnectedNav />
         <ConnectedSidebar />
@@ -36,7 +38,7 @@ function ProtocolEditor() {
               MAIN_CONTENT_FORCED_SCROLL_CLASSNAME
             )}
           >
-            <NewFileModal useProtocolFields />
+            <NewFileModal showProtocolFields />
             <FileUploadMessageModal />
             <LabwareUploadMessageModal />
             {/* TODO: Ian 2018-06-28 All main page modals will go here */}

--- a/protocol-designer/src/components/SettingsPage/FeatureFlagCard/FeatureFlagCard.js
+++ b/protocol-designer/src/components/SettingsPage/FeatureFlagCard/FeatureFlagCard.js
@@ -1,39 +1,50 @@
 // @flow
+import sortBy from 'lodash/sortBy'
 import * as React from 'react'
 import i18n from '../../../localization'
 import { Card, ToggleButton } from '@opentrons/components'
 import styles from '../SettingsPage.css'
-import type { Flags } from '../../../feature-flags'
+import { userFacingFlags, type Flags } from '../../../feature-flags'
 
-type Props = {
+type Props = {|
   flags: Flags,
   setFeatureFlags: (flags: Flags) => mixed,
-}
+|}
 
 const FeatureFlagCard = (props: Props) => {
-  const featureFlagRows = Object.keys(props.flags)
-    .sort()
-    .map(flagName => (
-      <div key={flagName}>
-        <div className={styles.setting_row}>
-          <p className={styles.toggle_label}>
-            {i18n.t(`feature_flags.${flagName}.title`)}
-          </p>
-          <ToggleButton
-            className={styles.toggle_button}
-            toggledOn={Boolean(props.flags[flagName])}
-            onClick={() =>
-              props.setFeatureFlags({
-                [flagName]: !props.flags[flagName],
-              })
-            }
-          />
-        </div>
-        <p className={styles.feature_flag_description}>
-          {i18n.t(`feature_flags.${flagName}.description`)}
+  const prereleaseModeEnabled = props.flags.PRERELEASE_MODE === true
+
+  const allFlags = sortBy(Object.keys(props.flags))
+
+  const userFacingFlagNames = allFlags.filter(flagName =>
+    userFacingFlags.includes(flagName)
+  )
+
+  const prereleaseFlagNames = allFlags.filter(
+    flagName => !userFacingFlags.includes(flagName)
+  )
+
+  const toFlagRow = flagName => (
+    <div key={flagName}>
+      <div className={styles.setting_row}>
+        <p className={styles.toggle_label}>
+          {i18n.t(`feature_flags.${flagName}.title`)}
         </p>
+        <ToggleButton
+          className={styles.toggle_button}
+          toggledOn={Boolean(props.flags[flagName])}
+          onClick={() =>
+            props.setFeatureFlags({
+              [flagName]: !props.flags[flagName],
+            })
+          }
+        />
       </div>
-    ))
+      <p className={styles.feature_flag_description}>
+        {i18n.t(`feature_flags.${flagName}.description`)}
+      </p>
+    </div>
+  )
 
   const noFlagsFallback = (
     <p className={styles.setting_row}>
@@ -41,12 +52,23 @@ const FeatureFlagCard = (props: Props) => {
       Designer.
     </p>
   )
+
+  const userFacingFlagRows = userFacingFlagNames.map(toFlagRow)
+  const prereleaseFlagRows = prereleaseFlagNames.map(toFlagRow)
+
   return (
-    <Card title={i18n.t('card.title.feature_flags')}>
-      <div>
-        {featureFlagRows.length > 0 ? featureFlagRows : noFlagsFallback}
-      </div>
-    </Card>
+    <>
+      <Card title={i18n.t('card.title.feature_flags')}>
+        <div>
+          {userFacingFlagRows.length > 0 ? userFacingFlagRows : noFlagsFallback}
+        </div>
+      </Card>
+      {prereleaseModeEnabled && (
+        <Card title={i18n.t('card.title.prerelease_mode_flags')}>
+          <div>{prereleaseFlagRows}</div>
+        </Card>
+      )}
+    </>
   )
 }
 

--- a/protocol-designer/src/components/modals/EditPipettesModal/index.js
+++ b/protocol-designer/src/components/modals/EditPipettesModal/index.js
@@ -8,6 +8,7 @@ import mapValues from 'lodash/mapValues'
 import { uuid } from '../../../utils'
 import { INITIAL_DECK_SETUP_STEP_ID } from '../../../constants'
 import { actions as steplistActions } from '../../../steplist'
+import { selectors as featureFlagSelectors } from '../../../feature-flags'
 import {
   actions as stepFormActions,
   selectors as stepFormSelectors,
@@ -27,6 +28,7 @@ type SP = {|
   initialPipetteValues: FormPipettesByMount,
   _prevPipettes: { [pipetteId: string]: PipetteOnDeck },
   _orderedStepIds: Array<StepIdType>,
+  modulesEnabled: ?boolean,
 |}
 
 type OP = {|
@@ -40,6 +42,7 @@ const mapSTP = (state: BaseState): SP => {
     initialPipetteValues: initialPipettes,
     _prevPipettes: stepFormSelectors.getInitialDeckSetup(state).pipettes, // TODO: Ian 2019-01-02 when multi-step editing is supported, don't use initial deck state. Instead, show the pipettes available for the selected step range
     _orderedStepIds: stepFormSelectors.getOrderedStepIds(state),
+    modulesEnabled: featureFlagSelectors.getEnableModules(state),
   }
 }
 
@@ -173,7 +176,7 @@ const mergeProps = (
 
   return {
     ...passThruStateProps,
-    useProtocolFields: false,
+    showProtocolFields: false,
     onSave: updatePipettes,
     onCancel: closeModal,
   }

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.js
@@ -36,7 +36,8 @@ type State = {|
 |}
 
 type Props = {|
-  useProtocolFields?: ?boolean,
+  showProtocolFields?: ?boolean,
+  showModulesFields?: ?boolean,
   hideModal?: boolean,
   onCancel: () => mixed,
   initialPipetteValues?: $PropertyType<State, 'pipettesByMount'>,
@@ -44,6 +45,7 @@ type Props = {|
     newProtocolFields: NewProtocolFields,
     pipettes: Array<PipetteFieldsData>,
   |}) => mixed,
+  modulesEnabled: ?boolean,
 |}
 
 const initialState: State = {
@@ -133,7 +135,7 @@ export default class FilePipettesModal extends React.Component<Props, State> {
 
   render() {
     if (this.props.hideModal) return null
-    const { useProtocolFields } = this.props
+    const { showProtocolFields } = this.props
 
     const { name } = this.state.fields
     const { left, right } = this.state.pipettesByMount
@@ -161,12 +163,12 @@ export default class FilePipettesModal extends React.Component<Props, State> {
             }}
           >
             <h2 className={styles.new_file_modal_title}>
-              {useProtocolFields
+              {showProtocolFields
                 ? i18n.t('modal.new_protocol.title')
                 : i18n.t('modal.edit_pipettes.title')}
             </h2>
 
-            {useProtocolFields && (
+            {showProtocolFields && (
               <FormGroup className={formStyles.stacked_row} label="Name">
                 <InputField
                   autoFocus
@@ -184,6 +186,9 @@ export default class FilePipettesModal extends React.Component<Props, State> {
               onFieldChange={this.handlePipetteFieldsChange}
             />
           </form>
+          {this.props.modulesEnabled && this.props.showModulesFields && (
+            <div>TODO modules here!</div>
+          )}
           <div className={styles.button_row}>
             <OutlineButton
               onClick={this.props.onCancel}
@@ -194,7 +199,7 @@ export default class FilePipettesModal extends React.Component<Props, State> {
             </OutlineButton>
             <OutlineButton
               onClick={
-                useProtocolFields
+                showProtocolFields
                   ? this.handleSubmit
                   : this.showEditPipetteConfirmationModal
               }

--- a/protocol-designer/src/components/modals/NewFileModal/index.js
+++ b/protocol-designer/src/components/modals/NewFileModal/index.js
@@ -7,6 +7,7 @@ import uniq from 'lodash/uniq'
 import { INITIAL_DECK_SETUP_STEP_ID } from '../../../constants'
 import { uuid } from '../../../utils'
 import i18n from '../../../localization'
+import { selectors as featureFlagSelectors } from '../../../feature-flags'
 import { selectors, actions as navigationActions } from '../../../navigation'
 import {
   actions as fileActions,
@@ -22,12 +23,13 @@ import type { PipetteOnDeck, NormalizedPipette } from '../../../step-forms'
 type Props = ElementProps<typeof FilePipettesModal>
 
 type OP = {|
-  useProtocolFields: $PropertyType<Props, 'useProtocolFields'>,
+  showProtocolFields: $PropertyType<Props, 'showProtocolFields'>,
 |}
 
 type SP = {|
   hideModal: $PropertyType<Props, 'hideModal'>,
   _hasUnsavedChanges: ?boolean,
+  modulesEnabled: ?boolean,
 |}
 
 type DP = {|
@@ -45,6 +47,7 @@ function mapStateToProps(state: BaseState): SP {
   return {
     hideModal: !selectors.getNewProtocolModal(state),
     _hasUnsavedChanges: loadFileSelectors.getHasUnsavedChanges(state),
+    modulesEnabled: featureFlagSelectors.getEnableModules(state),
   }
 }
 
@@ -101,6 +104,8 @@ function mapDispatchToProps(dispatch: ThunkDispatch<*>): DP {
 function mergeProps(stateProps: SP, dispatchProps: DP, ownProps: OP): Props {
   return {
     ...ownProps,
+    modulesEnabled: stateProps.modulesEnabled,
+    showModulesFields: true,
     hideModal: stateProps.hideModal,
     onCancel: dispatchProps.onCancel,
     onSave: fields => {

--- a/protocol-designer/src/configureStore.js
+++ b/protocol-designer/src/configureStore.js
@@ -77,6 +77,13 @@ export default function configureStore() {
   store.dispatch(rehydratePersistedAction())
   store.subscribe(makePersistSubscriber(store))
 
+  global.enablePrereleaseMode = () => {
+    store.dispatch({
+      type: 'SET_FEATURE_FLAGS',
+      payload: { PRERELEASE_MODE: true },
+    })
+  }
+
   function replaceReducers() {
     const nextRootReducer = getRootReducer()
     store.replaceReducer(nextRootReducer)

--- a/protocol-designer/src/feature-flags/reducers.js
+++ b/protocol-designer/src/feature-flags/reducers.js
@@ -1,9 +1,10 @@
 // @flow
 import omit from 'lodash/omit'
+import mapValues from 'lodash/mapValues'
 import { combineReducers } from 'redux'
 import { handleActions } from 'redux-actions'
 import { rehydrate, type RehydratePersistedAction } from '../persist'
-import { DEPRECATED_FLAGS, type Flags } from './types'
+import { userFacingFlags, DEPRECATED_FLAGS, type Flags } from './types'
 import type { SetFeatureFlagAction } from './actions'
 import type { Action } from '../types'
 
@@ -11,15 +12,23 @@ import type { Action } from '../types'
 // whenever the browser has seen the feature flag before and persisted it.
 // Only "never before seen" flags will take on the default values from `initialFlags`.
 const initialFlags: Flags = {
+  PRERELEASE_MODE: false,
   OT_PD_ENABLE_GEN2_PIPETTES: false,
+  OT_PD_ENABLE_MODULES: false,
 }
 
 const flags = handleActions<Flags, any>(
   {
-    SET_FEATURE_FLAGS: (state: Flags, action: SetFeatureFlagAction): Flags => ({
-      ...state,
-      ...action.payload,
-    }),
+    SET_FEATURE_FLAGS: (state: Flags, action: SetFeatureFlagAction): Flags => {
+      const nextState = { ...state, ...action.payload }
+      if (action.payload.PRERELEASE_MODE === false) {
+        // turn off all non-user-facing flags when prerelease mode disabled
+        return mapValues(nextState, (value, flagName) =>
+          userFacingFlags.includes(flagName) ? value : false
+        )
+      }
+      return nextState
+    },
     // Feature flags that are new (not yet in browser storage) should take on default values.
     // Deprecated flags should not be retrieved from browser storage
     REHYDRATE_PERSISTED: (

--- a/protocol-designer/src/feature-flags/selectors.js
+++ b/protocol-designer/src/feature-flags/selectors.js
@@ -8,3 +8,13 @@ export const getEnableGen2Pipettes: Selector<?boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ENABLE_GEN2_PIPETTES
 )
+
+export const getEnabledPrereleaseMode: Selector<?boolean> = createSelector(
+  getFeatureFlagData,
+  flags => flags.PRERELEASE_MODE
+)
+
+export const getEnableModules: Selector<?boolean> = createSelector(
+  getFeatureFlagData,
+  flags => flags.OT_PD_ENABLE_MODULES
+)

--- a/protocol-designer/src/feature-flags/types.js
+++ b/protocol-designer/src/feature-flags/types.js
@@ -7,7 +7,13 @@
 export const DEPRECATED_FLAGS = ['OT_PD_SHOW_UPLOAD_CUSTOM_LABWARE_BUTTON']
 
 // union of feature flag string constant IDs
-export type FlagTypes = 'OT_PD_ENABLE_GEN2_PIPETTES'
+export type FlagTypes =
+  | 'OT_PD_ENABLE_GEN2_PIPETTES'
+  | 'PRERELEASE_MODE'
+  | 'OT_PD_ENABLE_MODULES'
+
+// flags that are not in this list only show in prerelease mode
+export const userFacingFlags: Array<FlagTypes> = []
 
 export type Flags = $Shape<{|
   [flag: FlagTypes]: ?boolean,

--- a/protocol-designer/src/localization/en/card.json
+++ b/protocol-designer/src/localization/en/card.json
@@ -9,6 +9,7 @@
   "title": {
     "information": "Information",
     "feature_flags": "Experimental Settings",
+    "prerelease_mode_flags": "Prerelease Mode Flags (INTERNAL USE ONLY)",
     "hints": "Hints",
     "privacy": "Privacy"
   },

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -7,5 +7,13 @@
   "OT_PD_ENABLE_GEN2_PIPETTES": {
     "title": "Enable GEN2 pipettes",
     "description": "Enable the selection of Opentrons GEN2 pipettes when creating protocols"
+  },
+  "PRERELEASE_MODE": {
+    "title": "Use prerelease mode",
+    "description": "Show in-progress features for testing & internal use"
+  },
+  "OT_PD_ENABLE_MODULES": {
+    "title": "Enable modules in PD",
+    "description": "!"
   }
 }


### PR DESCRIPTION
## overview

Closes #4143. The goals of this "prerelease mode" are:
- allow us to release PD with latent features that don't get exposed to users
- allow internal stakeholders to try out these latent features in builds
- avoid blocking PD releases due to long-running projects being in a WIP state

## changelog

- implement prerelease mode flag and separate user-facing flags ("Experimental Settings") vs prerelease-mode-only flags
- add placeholder TODO for modules in the New File Modal (hidden under a flag)

## review requests

- To enter prerelease mode, open the JS console and type `enablePrereleaseMode()` and hit Enter. (To open the JS console in Chrome, press Command+Option+J for Mac or Control+Shift+J 
 for Windows/ Linux)
- When in prerelease mode, you should see a red and black ⚠️ icon in the top right
- When in prerelease mode, Settings > Prerelease Mode Flags card is visible
- Exit prerelease mode by turning off Settings > Prerelease Mode Flags > Use Prerelease Mode toggle. The red and black icon should disappear
- Exiting prerelease mode will clear all prerelease-mode-only flags that may have been set. This ensures that you are truly back in the normal user-facing mode. When you enable, disable, and re-enable prerelease mode, you'll have to set the prerelease-mode flags again