### PR TITLE
ci(travis): deploy API docs to s3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,8 +62,8 @@ jobs:
         - # push docs
           <<: *deploy_s3
           local-dir: api/docs/dist
-          bucket: $OT_DOCS_SANDBOX_BUCKET
-          upload-dir: $OT_DOCS_SANDBOX_FOLDER
+          bucket: $OT_DOCS_DEPLOY_BUCKET
+          upload-dir: $TRAVIS_BRANCH
 
         # push to real pypi on tag
         - provider: script
@@ -169,9 +169,6 @@ env:
     # TODO(mc, 2019-03-13): move to Travis settings
     - OT_APP_DEPLOY_BUCKET: opentrons-app
     - OT_APP_DEPLOY_FOLDER: builds
-
-    - OT_DOCS_SANDBOX_BUCKET: sandbox.docs.opentrons.com
-    - OT_DOCS_SANDBOX_FOLDER: $OT_BRANCH
 
     # GITHUB_TOKEN
     # TODO(mc, 2019-03-13): move to Travis settings

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,15 +59,11 @@ jobs:
         - make coverage
         - aws s3 sync ./api/dist $OT_CI_TEMP_S3_PATH/api/dist
       deploy:
-        # push docs on tag
-        - provider: pages
-          skip_cleanup: true
-          keep-history: false
+        - # push docs
+          <<: *deploy_s3
           local-dir: api/docs/dist
-          github-token: $GITHUB_TOKEN
-          on:
-            branch: master
-            repo: Opentrons/opentrons
+          bucket: $OT_DOCS_SANDBOX_BUCKET
+          upload-dir: $OT_DOCS_SANDBOX_FOLDER
 
         # push to real pypi on tag
         - provider: script
@@ -173,6 +169,9 @@ env:
     # TODO(mc, 2019-03-13): move to Travis settings
     - OT_APP_DEPLOY_BUCKET: opentrons-app
     - OT_APP_DEPLOY_FOLDER: builds
+
+    - OT_DOCS_SANDBOX_BUCKET: sandbox.docs.opentrons.com
+    - OT_DOCS_SANDBOX_FOLDER: $OT_BRANCH
 
     # GITHUB_TOKEN
     # TODO(mc, 2019-03-13): move to Travis settings

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,7 +35,7 @@ git checkout -b chore_bump-${version}
 - Scope: `release`
 - Message: `${version}`
 
-11. Gather reviews on changelogs and release notes until everybody is satisfied
+11. Gather reviews on changelogs and release notes until everybody is satisfied. Check the docs at sandbox.docs.opentrons.com/release_${version}
 12. Once your chore bump branch is ready, squash merge the `chore_bump-${version}` into the `release_${version}` branch.
 13. Tag the release branch as the version you just bumped to; this is a release candidate that will undergo QA:
 
@@ -77,6 +77,7 @@ git merge --no-ff master
 ```
 
 20. Use the PR title for the merge commit title. You can then `git push origin edge`, which will succeed as long as the PR is approved and status checks pass.
+21. Release the docs for this version (see below under Releasing Web Projects)
 
 ## Releasing Robot Software Stack Hotfixes
 
@@ -150,6 +151,7 @@ git merge --no-ff master
 ```
 
 20. Use the PR title for the merge commit title. You can then `git push origin edge`, which will succeed as long as the PR is approved and status checks pass.
+21. Release the docs for this version (see below under Releasing Web Projects)
 
 ### make bump usage
 
@@ -202,6 +204,11 @@ yarn run lerna [opts]
 The following web projects are versioned and released independently from the app and API:
 
 - `protocol-designer`
+  - designer.opentrons.com
 - `labware-library`
+  - labware.opentrons.com
+- API documentation
+  - docs.opentrons.com
 
 See [scripts/deploy/README.md](./scripts/deploy/README.md) for the release process of these projects.
+

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,7 +35,7 @@ git checkout -b chore_bump-${version}
 - Scope: `release`
 - Message: `${version}`
 
-11. Gather reviews on changelogs and release notes until everybody is satisfied. Check the docs at sandbox.docs.opentrons.com/release_${version}
+11. Gather reviews on changelogs and release notes until everybody is satisfied. Check the docs at sandbox.docs.opentrons.com/release\_\${version}
 12. Once your chore bump branch is ready, squash merge the `chore_bump-${version}` into the `release_${version}` branch.
 13. Tag the release branch as the version you just bumped to; this is a release candidate that will undergo QA:
 
@@ -211,4 +211,3 @@ The following web projects are versioned and released independently from the app
   - docs.opentrons.com
 
 See [scripts/deploy/README.md](./scripts/deploy/README.md) for the release process of these projects.
-


### PR DESCRIPTION
Deploy docs builds to an s3 bucket with a branch-named prefix.

This is prep for using our website deploy scripts to make the docs site live
instead of using github pages.

Note that as currently implemented, a minority of the links in the sidebar (among others) aren't relative and will direct you to docs.opentrons.com; that's going to be fixed in #4248 
