### PR TITLE
refactor(app): add empty More > Custom Labware page behind feature flag

### DIFF
--- a/app/src/components/AddLabwareCard/__tests__/AddLabwareCard.test.js
+++ b/app/src/components/AddLabwareCard/__tests__/AddLabwareCard.test.js
@@ -1,0 +1,13 @@
+// @flow
+import * as React from 'react'
+import { shallow } from 'enzyme'
+
+import AddLabwareCard from '..'
+
+describe('AddLabwareCard', () => {
+  test('component renders', () => {
+    const tree = shallow(<AddLabwareCard />)
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/app/src/components/AddLabwareCard/__tests__/__snapshots__/AddLabwareCard.test.js.snap
+++ b/app/src/components/AddLabwareCard/__tests__/__snapshots__/AddLabwareCard.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddLabwareCard component renders 1`] = `
+<Card
+  title="Labware Management"
+/>
+`;

--- a/app/src/components/AddLabwareCard/index.js
+++ b/app/src/components/AddLabwareCard/index.js
@@ -1,0 +1,12 @@
+// @flow
+import * as React from 'react'
+import { Card } from '@opentrons/components'
+
+// TODO(mc, 2019-10-17): i18n
+const ADD_LABWARE_CARD_TITLE = 'Labware Management'
+
+function AddLabwareCard() {
+  return <Card title={ADD_LABWARE_CARD_TITLE}></Card>
+}
+
+export default AddLabwareCard

--- a/app/src/components/AppSettings/AdvancedSettingsCard.js
+++ b/app/src/components/AppSettings/AdvancedSettingsCard.js
@@ -99,7 +99,7 @@ function AdvancedSettingsCard(props: Props) {
             <LabeledToggle
               key={flag}
               label={`__DEV__ ${startCase(flag)}`}
-              toggledOn={props.devInternal ? props.devInternal[flag] : false}
+              toggledOn={Boolean(props.devInternal?.[flag])}
               onClick={() => props.toggleDevInternalFlag(flag)}
             />
           ))}

--- a/app/src/components/InstrumentSettings/AttachedModulesCard.js
+++ b/app/src/components/InstrumentSettings/AttachedModulesCard.js
@@ -32,7 +32,7 @@ export default function AttachedModulesCard(props: Props) {
   )
 
   return (
-    <Card title={TITLE} column>
+    <Card title={TITLE}>
       <ModulesCardContents robot={robot} modules={modules} />
     </Card>
   )

--- a/app/src/components/ListLabwareCard/__tests__/ListLabwareCard.test.js
+++ b/app/src/components/ListLabwareCard/__tests__/ListLabwareCard.test.js
@@ -1,0 +1,13 @@
+// @flow
+import * as React from 'react'
+import { shallow } from 'enzyme'
+
+import ListLabwareCard from '..'
+
+describe('ListLabwareCard', () => {
+  test('component renders', () => {
+    const tree = shallow(<ListLabwareCard />)
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/app/src/components/ListLabwareCard/__tests__/__snapshots__/ListLabwareCard.test.js.snap
+++ b/app/src/components/ListLabwareCard/__tests__/__snapshots__/ListLabwareCard.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ListLabwareCard component renders 1`] = `
+<Card
+  title="Custom Labware Listing"
+/>
+`;

--- a/app/src/components/ListLabwareCard/index.js
+++ b/app/src/components/ListLabwareCard/index.js
@@ -1,0 +1,12 @@
+// @flow
+import * as React from 'react'
+import { Card } from '@opentrons/components'
+
+// TODO(mc, 2019-10-17): i18n
+const LIST_LABWARE_CARD_TITLE = 'Custom Labware Listing'
+
+function ListLabwareCard() {
+  return <Card title={LIST_LABWARE_CARD_TITLE}></Card>
+}
+
+export default ListLabwareCard

--- a/app/src/components/MenuPanel/index.js
+++ b/app/src/components/MenuPanel/index.js
@@ -1,31 +1,38 @@
 // @flow
 import * as React from 'react'
+import { useSelector } from 'react-redux'
 
+import { getFeatureFlags } from '../../config/selectors'
 import { SidePanel, ListItem, Icon } from '@opentrons/components'
 
 import styles from './styles.css'
 
 export default function MenuPanel() {
+  const featureFlags = useSelector(getFeatureFlags)
+
+  const items = [
+    { label: 'App', url: '/menu/app' },
+    featureFlags.customLabware
+      ? { label: 'Custom Labware', url: '/menu/custom-labware' }
+      : null,
+    { label: 'Resources', url: '/menu/resources' },
+  ].filter(Boolean)
+
   return (
     <SidePanel title="Menu">
       <div className={styles.menu_panel}>
         <ol className={styles.menu_list}>
-          <ListItem
-            className={styles.menu_item}
-            url={'/menu/app'}
-            activeClassName={styles.active}
-          >
-            <span>App</span>
-            <Icon name={'chevron-right'} className={styles.menu_icon} />
-          </ListItem>
-          <ListItem
-            className={styles.menu_item}
-            url={'/menu/resources'}
-            activeClassName={styles.active}
-          >
-            <span>Resources</span>
-            <Icon name={'chevron-right'} className={styles.menu_icon} />
-          </ListItem>
+          {items.map(item => (
+            <ListItem
+              key={item.url}
+              url={item.url}
+              className={styles.menu_item}
+              activeClassName={styles.active}
+            >
+              <span>{item.label}</span>
+              <Icon name={'chevron-right'} className={styles.menu_icon} />
+            </ListItem>
+          ))}
         </ol>
       </div>
     </SidePanel>

--- a/app/src/components/RobotSettings/AdvancedSettingsCard.js
+++ b/app/src/components/RobotSettings/AdvancedSettingsCard.js
@@ -71,7 +71,7 @@ export default function AdvancedSettingsCard(props: Props) {
   }, [dispatch, robot])
 
   return (
-    <Card title={TITLE} disabled={disabled} column>
+    <Card title={TITLE} disabled={disabled}>
       <LabeledButton
         label="Download Logs"
         buttonProps={{

--- a/app/src/components/RobotSettings/ControlsCard.js
+++ b/app/src/components/RobotSettings/ControlsCard.js
@@ -77,7 +77,6 @@ function ControlsCard(props: Props) {
       watch={name}
       refresh={fetchLights}
       disabled={disabled}
-      column
     >
       <LabeledButton
         label="Calibrate deck"

--- a/app/src/components/analytics-settings/AnalyticsSettingsCard.js
+++ b/app/src/components/analytics-settings/AnalyticsSettingsCard.js
@@ -9,7 +9,7 @@ const TITLE = 'Privacy Settings'
 
 export default function AnalyticsSettingsCard() {
   return (
-    <Card title={TITLE} column>
+    <Card title={TITLE}>
       <AnalyticsToggle />
     </Card>
   )

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -16,6 +16,7 @@ export const DEV_INTERNAL_FLAGS: Array<DevInternalFlag> = [
   'allPipetteConfig',
   'tempdeckControls',
   'enablePipettePlus',
+  'customLabware',
 ]
 
 // trigger a config value update to the app-shell via shell middleware

--- a/app/src/config/selectors.js
+++ b/app/src/config/selectors.js
@@ -1,9 +1,12 @@
 // @flow
 import type { DropdownOption } from '@opentrons/components'
 import type { State } from '../types'
-import type { Config, UpdateChannel } from './types'
+import type { Config, FeatureFlags, UpdateChannel } from './types'
 
 export const getConfig = (state: State): Config => state.config
+
+export const getFeatureFlags = (state: State): FeatureFlags =>
+  getConfig(state).devInternal || {}
 
 const UPDATE_CHANNEL_OPTS = [
   { name: 'Stable', value: (('latest': UpdateChannel): string) },

--- a/app/src/config/types.js
+++ b/app/src/config/types.js
@@ -11,6 +11,11 @@ export type DevInternalFlag =
   | 'allPipetteConfig'
   | 'tempdeckControls'
   | 'enablePipettePlus'
+  | 'customLabware'
+
+export type FeatureFlags = $Shape<{|
+  [DevInternalFlag]: boolean | void,
+|}>
 
 export type Config = {
   devtools: boolean,
@@ -69,9 +74,7 @@ export type Config = {
   },
 
   // internal development flags
-  devInternal?: {
-    [DevInternalFlag]: boolean,
-  },
+  devInternal?: FeatureFlags,
 }
 
 export type UpdateConfigAction = {|

--- a/app/src/pages/More/CustomLabware.js
+++ b/app/src/pages/More/CustomLabware.js
@@ -1,0 +1,29 @@
+// @flow
+// custom labware page
+import * as React from 'react'
+import type { ContextRouter } from 'react-router-dom'
+
+import Page from '../../components/Page'
+import { CardContainer, CardRow } from '../../components/layout'
+import AddLabwareCard from '../../components/AddLabwareCard'
+import ListLabwareCard from '../../components/ListLabwareCard'
+
+// TODO(mc, 2019-10-17): i18n
+const CUSTOM_LABWARE_PAGE_TITLE = 'Custom Labware'
+
+function CustomLabware(props: ContextRouter) {
+  return (
+    <Page titleBarProps={{ title: CUSTOM_LABWARE_PAGE_TITLE }}>
+      <CardContainer>
+        <CardRow>
+          <AddLabwareCard />
+        </CardRow>
+        <CardRow>
+          <ListLabwareCard />
+        </CardRow>
+      </CardContainer>
+    </Page>
+  )
+}
+
+export default CustomLabware

--- a/app/src/pages/More/index.js
+++ b/app/src/pages/More/index.js
@@ -1,25 +1,28 @@
 // @flow
 // more nav button routes
 import * as React from 'react'
-import { Switch, Route, Redirect, type Match } from 'react-router-dom'
+import { useSelector } from 'react-redux'
+import { Switch, Route, Redirect } from 'react-router-dom'
 
+import { getFeatureFlags } from '../../config/selectors'
 import AppSettings from './AppSettings'
+import CustomLabware from './CustomLabware'
 import Resources from './Resources'
 
-type Props = {
-  match: Match,
-}
+import type { ContextRouter } from 'react-router-dom'
 
-export default function More(props: Props) {
-  const {
-    match: { path },
-  } = props
+export default function More(props: ContextRouter) {
+  const featureFlags = useSelector(getFeatureFlags)
+  const { path } = props.match
   const appPath = `${path}/app`
 
   return (
     <Switch>
       <Redirect exact from={path} to={appPath} />
       <Route path={appPath} component={AppSettings} />
+      {featureFlags.customLabware && (
+        <Route path={`${path}/custom-labware`} component={CustomLabware} />
+      )}
       <Route path={`${path}/resources`} component={Resources} />
     </Switch>
   )

--- a/components/src/structure/Card.js
+++ b/components/src/structure/Card.js
@@ -6,16 +6,16 @@ import cx from 'classnames'
 
 import styles from './structure.css'
 
-type Props = {
+type Props = {|
   /** Title for card, all cards should receive a title. */
   title?: React.Node,
   /** Card contents */
-  children: React.Node,
+  children?: React.Node,
   /** If card can not be used, gray it out and remove pointer events */
   disabled?: boolean,
   /** Additional class names */
   className?: string,
-}
+|}
 
 /**
  * Renders a basic card element with a white background, dropshadow, and zero padding.

--- a/components/src/structure/RefreshCard.js
+++ b/components/src/structure/RefreshCard.js
@@ -1,19 +1,21 @@
 // @flow
 // refreshable card component
+// DO NOT USE THIS COMPONENT; prefer useInterval hook
 import * as React from 'react'
 
 import { IconButton } from '../buttons'
 import Card from './Card'
 import styles from './structure.css'
 
-type Props = React.ElementProps<typeof Card> & {
+type Props = {|
+  ...React.ElementProps<typeof Card>,
   /** a change in the watch prop will trigger a refresh */
   watch?: string,
   /** refreshing flag */
   refreshing?: boolean,
   /** refresh function */
   refresh: () => mixed,
-}
+|}
 
 /**
  * Card variant for displaying refreshable data. `props.refresh` will be called
@@ -22,10 +24,10 @@ type Props = React.ElementProps<typeof Card> & {
  */
 export default class RefreshCard extends React.Component<Props> {
   render() {
-    const { refresh, refreshing, children } = this.props
+    const { watch, refresh, refreshing, children, ...cardProps } = this.props
 
     return (
-      <Card {...this.props}>
+      <Card {...cardProps}>
         {refreshing != null && (
           <IconButton
             name={refreshing ? 'ot-spinner' : 'refresh'}


### PR DESCRIPTION
## overview

Closes #4243. See ticket for more details and acceptance criteria.

This PR:

- Adds a feature flag to the app for custom labware: `customLabware`
- Adds a More > Custom Labware page with empty cards to the app behind that feature flag

## changelog

- refactor(app): add empty More > Custom Labware page behind feature flag

## review requests

1. Navigate to More > App Settings
2. Toggle `__DEV__ Custom Labware` to enabled

- [ ] Custom labware link shows up in More sidebard
- [ ] Clicking link in sidebar navigates to "Custom Labware" page

Card titles are still a design WIP. Please ignore them for the purposes of this review.
