### PR TITLE
fix(api): api1: consider model offset in cli deck cal tip pickup

### DIFF
--- a/api/src/opentrons/deck_calibration/dc_main.py
+++ b/api/src/opentrons/deck_calibration/dc_main.py
@@ -324,8 +324,10 @@ class CLITool:
             p.instrument_mover.set_active_current(p._pick_up_current)
             p.instrument_mover.set_speed(p._pick_up_speed)
             dist = (-1 * p._pick_up_distance) + (-1 * p._pick_up_increment * i)
-            self.hardware._driver.move({self._current_mount: dist + top[2]})
-            self.hardware._driver.move({self._current_mount: top[2]})
+            self.hardware._driver.move(
+                {self._current_mount: dist + top[2] - self.model_offset[2]})
+            self.hardware._driver.move(
+                {self._current_mount: top[2] - self.model_offset[2]})
             # move nozzle back up
             p.instrument_mover.pop_active_current()
             p.instrument_mover.pop_speed()


### PR DESCRIPTION
The _helper_tip_pickup function in cli deck cal operates on a position that was
calculated in deck coordinates taking model offset into account, but sends it
directly back into the driver. Positions are therefore off by the model offset,
meaning p1000s move up 20mm before picking up a tip and p10s move down 17mm
before picking up a tip.

This removes the model offset before picking up a tip.

Closes #4250

## Testing
- Pick up a tip during CLI deck calibration on APIv1 using a p10, a p1000, and a p50 (or p300)