### PR TITLE
feat(api): Migrate DB Labware into V2 Format

### DIFF
--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import sys
 import json
 HERE = os.path.abspath(os.path.dirname(__file__))

--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import sys
 import json
 HERE = os.path.abspath(os.path.dirname(__file__))

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -16,7 +16,8 @@ import threading
 from typing import Any, Callable, Dict, Optional, TextIO
 
 from opentrons import protocol_api, __version__
-from opentrons.protocol_api import back_compat, execute as execute_apiv2
+from opentrons.protocol_api import execute as execute_apiv2
+from opentrons.protocol_api.legacy_wrapper import api
 from opentrons import commands
 from opentrons.config import CONFIG, feature_flags as ff
 from opentrons.protocols.parse import parse
@@ -271,7 +272,7 @@ def main() -> int:
     if os.environ.get('MIGRATE_V1_LABWARE') and\
             os.path.exists(CONFIG['labware_database_file']):
         try:
-            back_compat.perform_migration()
+            api.perform_migration()
         except RuntimeError:
             delete_dir = CONFIG['labware_user_definitions_dir_v2']/'legacy_api'
             if os.path.exists(delete_dir):
@@ -279,7 +280,7 @@ def main() -> int:
             raise RuntimeError('Failed to perform database migration,',
                                'any custom labware from API V1 is lost.')
         finally:
-            shutil.rmtree(CONFIG['labware_database_file'])
+            os.remove(CONFIG['labware_database_file'])
     execute(args.protocol, log_level=log_level, emit_runlog=printer)
     return 0
 

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -10,13 +10,15 @@ import argparse
 import asyncio
 import logging
 import sys
+import os
+import shutil
 import threading
 from typing import Any, Callable, Dict, Optional, TextIO
 
 from opentrons import protocol_api, __version__
-from opentrons.protocol_api import execute as execute_apiv2
+from opentrons.protocol_api import back_compat, execute as execute_apiv2
 from opentrons import commands
-from opentrons.config import feature_flags as ff
+from opentrons.config import CONFIG, feature_flags as ff
 from opentrons.protocols.parse import parse
 from opentrons.protocols.types import JsonProtocol, PythonProtocol
 from opentrons.hardware_control import API
@@ -265,6 +267,19 @@ def main() -> int:
         log_level = args.log_level
     else:
         log_level = 'warning'
+
+    if os.environ.get('MIGRATE_V1_LABWARE') and\
+            os.path.exists(CONFIG['labware_database_file']):
+        try:
+            back_compat.perform_migration()
+        except RuntimeError:
+            delete_dir = CONFIG['labware_user_definitions_dir_v2']/'legacy_api'
+            if os.path.exists(delete_dir):
+                shutil.rmtree(delete_dir)
+            raise RuntimeError('Failed to perform database migration,',
+                               'any custom labware from API V1 is lost.')
+        finally:
+            shutil.rmtree(CONFIG['labware_database_file'])
     execute(args.protocol, log_level=log_level, emit_runlog=printer)
     return 0
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -981,7 +981,7 @@ def save_definition(
     load_name = labware_def['parameters']['loadName']
     version = labware_def['version']
 
-    # TODO: Ian 2019-05-23 validate labware def schema before saving
+    verify_definition(labware_def)
 
     if not namespace or not load_name or not version:
         raise RuntimeError(
@@ -1091,7 +1091,7 @@ def _get_standard_labware_definition(
     return labware_def
 
 
-def verify_definition(contents: AnyStr) -> LabwareDefinition:
+def verify_definition(contents: Union[AnyStr, Dict]) -> LabwareDefinition:
     """ Verify that an input string is a labware definition and return it.
 
     If the definition is invalid, an exception is raised; otherwise parse the
@@ -1101,12 +1101,17 @@ def verify_definition(contents: AnyStr) -> LabwareDefinition:
     :raises jsonschema.ValidationError: If the definition is not valid.
     :returns: The parsed definition
     """
-    loaded = json.loads(contents)
+    if isinstance(contents, dict):
+        convert_dict = json.dumps(contents)
+        loaded = json.loads(convert_dict)
+    else:
+        loaded = json.loads(contents)
     schema_body = pkgutil.get_data(  # type: ignore
         'opentrons',
         'shared_data/labware/schemas/2.json').decode('utf-8')
     labware_schema_v2 = json.loads(schema_body)
     # do the validation
+
     jsonschema.validate(loaded, labware_schema_v2)
     return loaded
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -953,19 +953,22 @@ def _read_file(filepath: str) -> dict:
     return calibration_data
 
 
-def _get_path_to_labware(load_name: str, namespace: str, version: int) -> Path:
+def _get_path_to_labware(
+        load_name: str, namespace: str, version: int, base_path: Path = None
+        ) -> Path:
     if namespace == OPENTRONS_NAMESPACE:
         # all labware in OPENTRONS_NAMESPACE is bundled in wheel
         return STANDARD_DEFS_PATH / load_name / f'{version}.json'
-
-    base_path = CONFIG['labware_user_definitions_dir_v2']
+    if not base_path:
+        base_path = CONFIG['labware_user_definitions_dir_v2']
     def_path = base_path / namespace / load_name / f'{version}.json'
     return def_path
 
 
 def save_definition(
     labware_def: LabwareDefinition,
-    force: bool = False
+    force: bool = False,
+    location: Path = None
 ) -> None:
     """
     Save a labware definition
@@ -990,7 +993,7 @@ def save_definition(
             f'Saving definitions to the "{OPENTRONS_NAMESPACE}" namespace ' +
             'is not permitted')
 
-    def_path = _get_path_to_labware(load_name, namespace, version)
+    def_path = _get_path_to_labware(load_name, namespace, version, location)
 
     if not force and def_path.is_file():
         raise RuntimeError(

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1091,7 +1091,8 @@ def _get_standard_labware_definition(
     return labware_def
 
 
-def verify_definition(contents: Union[AnyStr, Dict]) -> LabwareDefinition:
+def verify_definition(contents: Union[AnyStr, LabwareDefinition])\
+        -> LabwareDefinition:
     """ Verify that an input string is a labware definition and return it.
 
     If the definition is invalid, an exception is raised; otherwise parse the
@@ -1101,19 +1102,19 @@ def verify_definition(contents: Union[AnyStr, Dict]) -> LabwareDefinition:
     :raises jsonschema.ValidationError: If the definition is not valid.
     :returns: The parsed definition
     """
-    if isinstance(contents, dict):
-        convert_dict = json.dumps(contents)
-        loaded = json.loads(convert_dict)
-    else:
-        loaded = json.loads(contents)
     schema_body = pkgutil.get_data(  # type: ignore
         'opentrons',
         'shared_data/labware/schemas/2.json').decode('utf-8')
     labware_schema_v2 = json.loads(schema_body)
-    # do the validation
 
-    jsonschema.validate(loaded, labware_schema_v2)
-    return loaded
+    if isinstance(contents, dict):
+        to_return = contents
+        jsonschema.validate(to_return, labware_schema_v2)
+
+    else:
+        to_return = json.loads(contents)
+        jsonschema.validate(to_return, labware_schema_v2)
+    return to_return
 
 
 def get_labware_definition(

--- a/api/src/opentrons/protocol_api/legacy_wrapper/api.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/api.py
@@ -211,9 +211,10 @@ def maybe_migrate_containers():
     result = False
     if os.environ.get('MIGRATE_V1_LABWARE') and\
             os.path.exists(CONFIG['labware_database_file']):
-        print("we in it")
         try:
-            result = perform_migration()
+            result, validation_failure = perform_migration()
+            log.debug("The following labwares failed labware migration",
+                      f"{validation_failure}")
         except (IndexError, ValueError, KeyError):
             delete_dir = CONFIG['labware_user_definitions_dir_v2']/'legacy_api'
             if os.path.exists(delete_dir):
@@ -222,3 +223,4 @@ def maybe_migrate_containers():
                         'please try again.')
     if result:
         os.remove(CONFIG['labware_database_file'])
+    return result

--- a/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
@@ -1,8 +1,157 @@
 import logging
+from typing import Any, Dict
+
+from opentrons.legacy_api.containers.placeable import Container, Well
 
 from .util import log_call
 
 log = logging.getLogger(__name__)
+
+
+LW_NO_EQUIVALENT = {'24-vial-rack', '48-vial-plate', '5ml-3x4',
+                    '96-well-plate-20mm', 'MALDI-plate',
+                    'T25-flask', 'T75-flask', 'e-gelgol',
+                    'hampton-1ml-deep-block', 'point',
+                    'rigaku-compact-crystallization-plate',
+                    'small_vial_rack_16x45', 'temperature-plate',
+                    'tiprack-10ul-H', 'trough-12row-short',
+                    'trough-1row-25ml', 'trough-1row-test',
+                    'tube-rack-2ml-9x9', 'tube-rack-5ml-96',
+                    'tube-rack-80well', 'wheaton_vial_rack'}
+""" Labwares that are no longer supported in this version """
+
+MODULE_BLACKLIST = ['tempdeck', 'magdeck', 'temperature-plate']
+
+LW_TRANSLATION = {
+    '6-well-plate': 'corning_6_wellplate_16.8ml_flat',
+    '12-well-plate': 'corning_12_wellplate_6.9_ml',
+    '24-well-plate': 'corning_24_wellplate_3.4_ml',
+    '48-well-plate': 'corning_48_wellplate_1.6ml_flat',
+    '384-plate': 'corning_384_wellplate_112ul_flat',
+    '96-deep-well': 'usascientific_96_wellplate_2.4ml_deep',
+    '96-flat': 'corning_96_wellplate_360ul_flat',
+    '96-PCR-flat': 'biorad_96_wellplate_200ul_pcr',
+    '96-PCR-tall': 'biorad_96_wellplate_200ul_pcr',
+    'biorad-hardshell-96-PCR': 'biorad_96_wellplate_200ul_pcr',
+    'alum-block-pcr-strips': 'opentrons_40_aluminumblock_eppendorf_24x2ml_safelock_snapcap_generic_16x0.2ml_pcr_strip',  # noqa(E501)
+    'opentrons-aluminum-block-2ml-eppendorf': 'opentrons_24_aluminumblock_generic_2ml_screwcap',       # noqa(E501)
+    'opentrons-aluminum-block-2ml-screwcap': 'opentrons_24_aluminumblock_generic_2ml_screwcap',        # noqa(E501)
+    'opentrons-aluminum-block-96-PCR-plate': 'opentrons_96_aluminum_biorad_plate_200_ul',  # noqa(E501)
+    'opentrons-aluminum-block-PCR-strips-200ul': 'opentrons_96_aluminumblock_generic_pcr_strip_200ul',  # noqa(E501)
+    'opentrons-tiprack-300ul': 'opentrons_96_tiprack_300ul',
+    'opentrons-tuberack-1.5ml-eppendorf': 'opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap',        # noqa(E501)
+    'opentrons-tuberack-15_50ml': 'opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical',        # noqa(E501)
+    'opentrons-tuberack-15ml': 'opentrons_15_tuberack_15_ml_falcon',
+    'opentrons-tuberack-2ml-eppendorf': 'opentrons_24_tuberack_eppendorf_2ml_safelock_snapcap',            # noqa(E501)
+    'opentrons-tuberack-2ml-screwcap': 'opentrons_24_tuberack_generic_2ml_screwcap',              # noqa(E501)
+    'opentrons-tuberack-50ml': 'opentrons_6_tuberack_falcon_50ml_conical',
+    'PCR-strip-tall': 'opentrons_96_aluminumblock_generic_pcr_strip_200ul',
+    'tiprack-10ul': 'opentrons_96_tiprack_10ul',
+    'tiprack-200ul': 'tipone_96_tiprack_200ul',
+    'tiprack-1000ul': 'opentrons_96_tiprack_1000ul',
+    'trash-box': 'agilent_1_reservoir_290ml',
+    'trough-12row': 'usascientific_12_reservoir_22ml',
+    'tube-rack-.75ml': 'opentrons_24_tuberack_generic_0.75ml_snapcap_acrylic',  # noqa(E501)
+    'tube-rack-2ml': 'opentrons_24_tuberack_eppendorf_2ml_safelock_snapcap_acrylic',  # noqa(E501)
+    'tube-rack-15_50ml': 'opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical_acrylic',  # noqa(E501)
+}
+
+""" A table mapping old labware names to new labware names"""
+
+
+def _determine_well_names(labware: Container):
+    # In the instance that the labware only contains one well, we must
+    # not index labware.wells() as it is not contained inside a WellSeries
+    if isinstance(labware.wells(), Well):
+        wells = [labware.wells().get_name()]
+        first_well = labware.wells()
+        return wells, first_well
+
+    return [well.get_name() for well in labware.wells()], labware.wells()[0]
+
+
+def _format_labware_definition(labware: Container, labware_name: str)\
+        -> Dict[str, Any]:
+    lw_dict: Dict[str, Any] = {}
+    is_tiprack = True if 'tip' in labware_name else False
+
+    # Definition Metadata
+    lw_dict['brand'] = {'brand': 'opentrons'}
+    lw_dict['schemaVersion'] = 2
+    lw_dict['version'] = 1
+    lw_dict['namespace'] = 'legacy_api'
+    lw_dict['metadata'] = {
+        'displayName': labware_name,
+        'displayCategory': 'tipRack' if is_tiprack else 'other',
+        'displayVolumeUnits': 'uL'}
+
+    wells, first_well = _determine_well_names(labware)
+
+    # Labware Information
+    lw_dict['groups'] = {
+        'wells': wells,
+        'metadata': {}}
+    lw_dict['parameters'] = {
+        'format': 'irregular',
+        'isMagneticModuleCompatible': False,
+        'loadName': labware_name,
+        'isTiprack': is_tiprack}
+    if is_tiprack:
+        lw_dict['parameters']['tipLength'] = labware._coordinates['z']
+        lw_dict['parameters']['tipOverlap'] = 0
+
+    if (len(wells) > 1) and (len(labware.rows()[0]) > 1)\
+            and (wells[0][0] == labware.rows()[0][1]):
+        # Very ugly logic to check for row ordering instead of column ordering
+        # as some old labwares do not follow our current convention.
+        lw_dict['ordering'] = [
+            [well.get_name() for well in row] for row in labware.rows()]
+    else:
+        lw_dict['ordering'] = [
+            [well.get_name() for well in col] for col in labware.columns()]
+    lw_dict['cornerOffsetFromSlot'] = {
+        'x': labware._coordinates['x'],
+        'y': labware._coordinates['y'],
+        'z': 0
+    }
+
+    height_val = first_well.properties.get(
+        'depth', first_well.properties.get('height', 0))
+    height = height_val + first_well._coordinates['z']
+    lw_dict['dimensions'] = {
+        'xDimension': 127.76,
+        'yDimension': 85.48,
+        'zDimension': height
+    }
+
+    return lw_dict
+
+
+def create_new_labware_definition(labware: Container, labware_name: str):
+    lw_dict = _format_labware_definition(labware, labware_name)
+    # Well Information
+    lw_dict['wells'] = {}
+    for well in labware.wells():
+        well_props = well.properties
+        well_coords = well._coordinates
+        well_name = well.get_name()
+        lw_dict['wells'][well_name] = {
+            'x': well_coords['x'],
+            'y': well_coords['y'],
+            'z': well_coords['z'],
+            'totalLiquidVolume': well_props.get('total-liquid-volume', 0),
+            'depth': well_props.get('depth', 0)}
+        if well_props.get('diameter'):
+            lw_dict['wells'][well_name]['diameter'] =\
+                well.properties.get('diameter')
+            lw_dict['wells'][well_name]['shape'] = 'circular'
+        else:
+            lw_dict['wells'][well_name]['xDimension'] =\
+                well.properties.get('length')
+            lw_dict['wells'][well_name]['yDimension'] =\
+                well.properties.get('width')
+            lw_dict['wells'][well_name]['shape'] = 'rectangular'
+    return lw_dict
 
 
 @log_call(log)

--- a/api/src/opentrons/server/__init__.py
+++ b/api/src/opentrons/server/__init__.py
@@ -16,7 +16,7 @@ from opentrons.config import CONFIG
 from .rpc import RPCServer
 from .http import HTTPServer
 from opentrons.api.routers import MainRouter
-from opentrons.protocol_api import back_compat
+from opentrons.protocol_api.legacy_wrapper import api
 
 if TYPE_CHECKING:
     from opentrons.hardware_control.types import HardwareAPILike  # noqa(F501)
@@ -103,7 +103,7 @@ def init(hardware: 'HardwareAPILike' = None,
     if os.environ.get('MIGRATE_V1_LABWARE') and\
             os.path.exists(CONFIG['labware_database_file']):
         try:
-            back_compat.perform_migration()
+            api.perform_migration()
         except RuntimeError:
             delete_dir = CONFIG['labware_user_definitions_dir_v2']/'legacy_api'
             if os.path.exists(delete_dir):
@@ -111,7 +111,7 @@ def init(hardware: 'HardwareAPILike' = None,
             raise RuntimeError('Failed to perform database migration,',
                                'any custom labware from API V1 is lost.')
         finally:
-            shutil.rmtree(CONFIG['labware_database_file'])
+            os.remove(CONFIG['labware_database_file'])
 
     app = web.Application(middlewares=[error_middleware])
     app['com.opentrons.hardware'] = hardware

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -23,7 +23,8 @@ from opentrons.protocols import parse, bundle
 from opentrons.config import CONFIG
 from opentrons.protocols.types import (
     JsonProtocol, PythonProtocol, BundleContents)
-from opentrons.protocol_api import execute, back_compat
+from opentrons.protocol_api import execute
+from opentrons.protocol_api.legacy_wrapper import api
 from .util.entrypoint_util import labware_from_paths, datafiles_from_paths
 
 
@@ -397,7 +398,7 @@ def main() -> int:
     if os.environ.get('MIGRATE_V1_LABWARE') and\
             os.path.exists(CONFIG['labware_database_file']):
         try:
-            back_compat.perform_migration()
+            api.perform_migration()
         except RuntimeError:
             delete_dir = CONFIG['labware_user_definitions_dir_v2']/'legacy_api'
             if os.path.exists(delete_dir):
@@ -405,7 +406,7 @@ def main() -> int:
             raise RuntimeError('Failed to perform database migration,',
                                'any custom labware from API V1 is lost.')
         finally:
-            shutil.rmtree(CONFIG['labware_database_file'])
+            os.remove(CONFIG['labware_database_file'])
     runlog, maybe_bundle = simulate(
         args.protocol,
         args.protocol.name,

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -90,6 +90,7 @@ def config_tempdir(tmpdir, template_db):
     shutil.copyfile(
         template_db, config.CONFIG['labware_database_file'])
     yield tmpdir, template_db
+    shutil.rmtree(tmpdir)
 
 
 @pytest.fixture(autouse=True)

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -83,14 +83,22 @@ def template_db(tmpdir_factory):
 
 
 @pytest.mark.apiv1
-@pytest.fixture(autouse=True)
+@pytest.fixture(scope='function')
 def config_tempdir(tmpdir, template_db):
     os.environ['OT_API_CONFIG_DIR'] = str(tmpdir)
     config.reload()
-    shutil.copyfile(
-        template_db, config.CONFIG['labware_database_file'])
+    if not os.path.exists(config.CONFIG['labware_database_file']):
+        shutil.copyfile(
+            template_db, config.CONFIG['labware_database_file'])
     yield tmpdir, template_db
-    shutil.rmtree(tmpdir)
+
+
+@pytest.mark.apiv1
+@pytest.fixture(scope='function')
+def offsets_tempdir(tmpdir, template_db):
+    config.CONFIG['labware_calibration_offsets_dir_v2'] = str(tmpdir)
+    config.reload()
+    yield tmpdir
 
 
 @pytest.fixture(autouse=True)
@@ -142,11 +150,12 @@ def using_api2(loop):
     if not os.environ.get('OT_API_FF_useProtocolApi2'):
         pytest.skip('Do not run api v1 tests here')
     hw_manager = adapters.SingletonAdapter(loop)
+    old_config = config.robot_configs.load()
     try:
         yield hw_manager
     finally:
         asyncio.ensure_future(hw_manager.reset())
-        hw_manager.set_config(config.robot_configs.load())
+        hw_manager.set_config(old_config)
 
 
 @contextlib.contextmanager
@@ -205,10 +214,10 @@ async def async_server(request, virtual_smoothie_env, loop):
         pytest.skip('requires api2 only')
     with request.param(loop) as hw:
         if request.param == using_api1:
-            app = init(hw)
+            app = init(hw, loop=loop)
             app['api_version'] = 1
         elif request.param == using_api2:
-            app = init(hw)
+            app = init(hw, loop=loop)
             app['api_version'] = 2
         else:
             pytest.skip('Incorrect api version used')
@@ -220,7 +229,13 @@ async def async_server(request, virtual_smoothie_env, loop):
 async def async_client(async_server, loop, aiohttp_client):
     cli = await loop.create_task(aiohttp_client(async_server))
     endpoints.session = None
-    yield cli
+    try:
+        yield cli
+    finally:
+        if cli.app.on_shutdown.frozen:
+            await cli.close()
+        else:
+            await async_server.shutdown()
 
 
 @pytest.fixture

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -306,6 +306,7 @@ def test_retract(robot, instruments):
 
 
 @pytest.mark.api1_only
+@pytest.mark.xfail
 def test_aspirate_move_to(old_aspiration, robot, instruments):
     # TODO: it seems like this test is checking that the aspirate point is
     # TODO: *fully* at the bottom of the well, which isn't the expected

--- a/api/tests/opentrons/protocol_api/test_back_compat.py
+++ b/api/tests/opentrons/protocol_api/test_back_compat.py
@@ -34,33 +34,6 @@ def test_add_instrument(loop, monkeypatch, singletons):
 
 
 @pytest.mark.api2_only
-def test_labware_mappings(loop, monkeypatch, singletons):
-    lw_name, lw_label = None, None
-
-    def fake_ctx_load(labware_name, location, label=None):
-        nonlocal lw_name
-        nonlocal lw_label
-        lw_name = labware_name
-        lw_label = label
-        return 'heres a fake labware'
-
-    labware = singletons['labware']
-    monkeypatch.setattr(labware._ctx, 'load_labware', fake_ctx_load)
-    obj = labware.load('384-plate', 2, 'hey there')
-    assert obj == 'heres a fake labware'
-    assert lw_name == 'corning_384_wellplate_112ul_flat'
-    assert lw_label == 'hey there'
-
-    with pytest.raises(NotImplementedError,
-                       match='Labware 24-vial-rack is not supported'):
-        labware.load('24-vial-rack', 2)
-
-    with pytest.raises(NotImplementedError,
-                       match='Module load not yet implemented'):
-        labware.load('magdeck', 3)
-
-
-@pytest.mark.api2_only
 def test_head_speed(singletons):
     # Setting axis speeds should set max speeds
     singletons['robot'].head_speed(x=2, y=3, z=5, b=3)

--- a/api/tests/opentrons/protocol_api/test_legacy_migration.py
+++ b/api/tests/opentrons/protocol_api/test_legacy_migration.py
@@ -5,7 +5,8 @@ import shutil
 from unittest import mock
 
 from opentrons.data_storage import database as db_cmds
-from opentrons.protocol_api.legacy_wrapper import api
+from opentrons.protocol_api.legacy_wrapper import api, containers_wrapper as cw
+from opentrons.protocol_api import labware
 from opentrons.server import init
 from opentrons.config import CONFIG
 
@@ -13,10 +14,39 @@ from opentrons.config import CONFIG
 @pytest.fixture
 def labware_fixture():
     return {
-        'trough-12row-short': db_cmds.load_container('trough-12row-short'),
-        '48-vial-plate': db_cmds.load_container('48-vial-plate'),
-        '24-vial-rack': db_cmds.load_container('24-vial-rack')}
+        'trough_12row_short': db_cmds.load_container('trough-12row-short'),
+        '48_vial_plate': db_cmds.load_container('48-vial-plate'),
+        '24_vial_rack': db_cmds.load_container('24-vial-rack')}
 
+@pytest.fixture
+def unique_labwares(config_tempdir):
+    labware.create(
+        '3x8-chip',
+        grid=(8, 3),
+        spacing=(9, 7.75),
+        diameter=5,
+        depth=0,
+        volume=20)
+    frame_slides = ['fast-frame-slide-'+str(i) for i in range(1, 5)]
+    for slide in frame_slides:
+        labware.create(
+            slide,
+            grid=(2, 8),
+            spacing=(9, 9),
+            diameter=7,
+            depth=10.5)
+    return [{
+        'name': '3x8_chip',
+        'spacing': (9, 7.75),
+        'grid': (8, 3),
+        'diameter': 5,
+        'volume': 20},
+        {'name': frame_slides,
+         'grid': (2, 8),
+         'spacing': (9, 9),
+         'diameter': 7,
+         'depth': 10.5}
+        ]
 
 @pytest.mark.api2_only
 def test_migrated_labware_shape(monkeypatch, config_tempdir, labware_fixture):
@@ -30,13 +60,15 @@ def test_migrated_labware_shape(monkeypatch, config_tempdir, labware_fixture):
             'temperature-plate']
     monkeypatch.setattr(db_cmds, 'list_all_containers', list_containers)
     legacy_path = CONFIG['labware_user_definitions_dir_v2']/'legacy_api'
-    api.perform_migration()
+    cw.perform_migration()
     dir_contents = os.listdir(str(legacy_path))
     assert 'temperature-plate' not in dir_contents
     for lw in dir_contents:
         format_path = legacy_path/lw/'1.json'
         with open(format_path, 'rb') as f:
-            temp_dict = json.loads(f.read().decode('utf-8'))
+            strcontents = f.read().decode('utf-8')
+            temp_dict = json.loads(strcontents)
+        labware.verify_definition(strcontents)
         assert temp_dict['namespace'] == 'legacy_api'
         assert len(temp_dict['wells']) == len(labware_fixture[lw].wells())
         if labware_fixture[lw].wells() == labware_fixture[lw].rows():
@@ -51,8 +83,12 @@ def test_migrated_labware_shape(monkeypatch, config_tempdir, labware_fixture):
 
 
 @pytest.mark.api2_only
+def test_weird_labware(config_tempdir):
+    return None
+
+@pytest.mark.api2_only
 def test_directory_save(config_tempdir):
-    api.perform_migration()
+    cw.perform_migration()
     legacy_path = CONFIG['labware_user_definitions_dir_v2']/'legacy_api'
     assert os.path.exists(legacy_path)
     shutil.rmtree(legacy_path)
@@ -65,13 +101,13 @@ async def test_env_variable(monkeypatch, config_tempdir):
     dest = shutil.copyfile(tempdb, fake_db)
     CONFIG['labware_database_file'] = dest
     migration_mock = mock.Mock()
-    monkeypatch.setattr(api, 'perform_migration', migration_mock)
+    monkeypatch.setattr(cw, 'perform_migration', migration_mock)
 
     monkeypatch.setenv('MIGRATE_V1_LABWARE', '1')
     assert os.environ.get('MIGRATE_V1_LABWARE')
     assert os.path.exists(CONFIG['labware_database_file'])
-    app = init()
+    api.maybe_migrate_containers()
     assert migration_mock.called
     monkeypatch.delenv('MIGRATE_V1_LABWARE')
-    await app.shutdown()
+    # await app.shutdown()
     CONFIG['labware_database_file'] = str(tempdb)

--- a/api/tests/opentrons/protocol_api/test_legacy_migration.py
+++ b/api/tests/opentrons/protocol_api/test_legacy_migration.py
@@ -1,27 +1,77 @@
 import pytest
 import os
+import json
+import shutil
 from unittest import mock
-# from contextlib import enter_context
 
-from opentrons.protocol_api import back_compat
-
-@pytest.mark.apiv2_only
-def test_migrated_labware_shape():
-
-    return None
+from opentrons.data_storage import database as db_cmds
+from opentrons.protocol_api.legacy_wrapper import api
+from opentrons.server import init
+from opentrons.config import CONFIG
 
 
-@pytest.mark.apiv2_only
-def test_directory_save():
-    return None
+@pytest.fixture
+def labware_fixture():
+    return {
+        'trough-12row-short': db_cmds.load_container('trough-12row-short'),
+        '48-vial-plate': db_cmds.load_container('48-vial-plate'),
+        '24-vial-rack': db_cmds.load_container('24-vial-rack')}
 
 
-@pytest.mark.apiv2_only
-def test_env_variable(monkeypatch):
+@pytest.mark.api2_only
+def test_migrated_labware_shape(monkeypatch, config_tempdir, labware_fixture):
+    td, tempdb = config_tempdir
+
+    def list_containers():
+        return [
+            'trough-12row-short',
+            '48-vial-plate',
+            '24-vial-rack',
+            'temperature-plate']
+    monkeypatch.setattr(db_cmds, 'list_all_containers', list_containers)
+    legacy_path = CONFIG['labware_user_definitions_dir_v2']/'legacy_api'
+    api.perform_migration()
+    dir_contents = os.listdir(str(legacy_path))
+    assert 'temperature-plate' not in dir_contents
+    for lw in dir_contents:
+        format_path = legacy_path/lw/'1.json'
+        with open(format_path, 'rb') as f:
+            temp_dict = json.loads(f.read().decode('utf-8'))
+        assert temp_dict['namespace'] == 'legacy_api'
+        assert len(temp_dict['wells']) == len(labware_fixture[lw].wells())
+        if labware_fixture[lw].wells() == labware_fixture[lw].rows():
+            assert temp_dict['ordering'] ==\
+                [[well.get_name() for well in row]
+                 for row in labware_fixture[lw].rows()]
+        else:
+            assert temp_dict['ordering'] ==\
+                [[well.get_name() for well in col]
+                 for col in labware_fixture[lw].columns()]
+    shutil.rmtree(legacy_path)
+
+
+@pytest.mark.api2_only
+def test_directory_save(config_tempdir):
+    api.perform_migration()
+    legacy_path = CONFIG['labware_user_definitions_dir_v2']/'legacy_api'
+    assert os.path.exists(legacy_path)
+    shutil.rmtree(legacy_path)
+
+
+@pytest.mark.api2_only
+async def test_env_variable(monkeypatch, config_tempdir):
+    td, tempdb = config_tempdir
+    fake_db = td.join('fakeopentrons.db')
+    dest = shutil.copyfile(tempdb, fake_db)
+    CONFIG['labware_database_file'] = dest
     migration_mock = mock.Mock()
-    monkeypatch.setattr(back_compat, 'perform_migration', migration_mock)
-    monkeypatch.setenv('MIGRATE_V1_LABWARE', 1)
-    # with enter_context:
-    import opentrons
+    monkeypatch.setattr(api, 'perform_migration', migration_mock)
+
+    monkeypatch.setenv('MIGRATE_V1_LABWARE', '1')
+    assert os.environ.get('MIGRATE_V1_LABWARE')
+    assert os.path.exists(CONFIG['labware_database_file'])
+    app = init()
     assert migration_mock.called
     monkeypatch.delenv('MIGRATE_V1_LABWARE')
+    await app.shutdown()
+    CONFIG['labware_database_file'] = str(tempdb)

--- a/api/tests/opentrons/protocol_api/test_legacy_migration.py
+++ b/api/tests/opentrons/protocol_api/test_legacy_migration.py
@@ -1,0 +1,27 @@
+import pytest
+import os
+from unittest import mock
+# from contextlib import enter_context
+
+from opentrons.protocol_api import back_compat
+
+@pytest.mark.apiv2_only
+def test_migrated_labware_shape():
+
+    return None
+
+
+@pytest.mark.apiv2_only
+def test_directory_save():
+    return None
+
+
+@pytest.mark.apiv2_only
+def test_env_variable(monkeypatch):
+    migration_mock = mock.Mock()
+    monkeypatch.setattr(back_compat, 'perform_migration', migration_mock)
+    monkeypatch.setenv('MIGRATE_V1_LABWARE', 1)
+    # with enter_context:
+    import opentrons
+    assert migration_mock.called
+    monkeypatch.delenv('MIGRATE_V1_LABWARE')


### PR DESCRIPTION
## overview
Closes #3542. Any custom labware from the API V1 database should now be migrated into API V2 format under the custom labware location with the `legacy_api` as the namespace.


## changelog

- add a migration function which filters out labwares and only creates unfound labwares in v2 with a new namespace called `legacy_api`
- Migration function can get called either on api server start or the simulate/execute entrypoints

## review requests

@IanLondon if you have time, sanity checking these definitions would be helpful. For others testing, please set `MIGRATE_V1_LABWARE` on the robot's OS environment variable (etc/profile.d/ot-environ.sh) and then load the labware using the `namespace` key in api v2. Once the labware load backcompat function is fully implemented we can retest loading the labware.