### PR TITLE
build(app-shell,discovery-client): switch from babel-cli to webpack

### DIFF
--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -8,16 +8,9 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 # dev server port
 PORT ?= 8090
 
-# source and output directories for main process code
-src_dir := src
-lib_dir := lib
-src_ignore := "**/__tests__/**","**/__mocks__/**","**/__fixtures__/**"
-babel := babel $(src_dir) --root-mode upward --out-dir $(lib_dir) --ignore $(src_ignore)
-
 # dep directories for production build
 # TODO(mc, 2018-08-07): figure out a better way to do this
 ui_dir := ../app
-discovery_client_dir := ../discovery-client
 
 # cross-platform noop command
 noop := cd .
@@ -67,13 +60,13 @@ clean:
 #####################################################################
 
 .PHONY: lib
+lib: export NODE_ENV := production
 lib:
-	$(babel)
+	webpack --profile
 
 .PHONY: deps
 deps:
 	$(MAKE) -C $(ui_dir)
-	$(MAKE) -C $(discovery_client_dir)
 
 .PHONY: package-deps
 package-deps: clean lib deps
@@ -118,5 +111,6 @@ _dist-collect-artifacts:
 
 .PHONY: dev
 dev: export NODE_ENV := development
-dev: lib
+dev:
+	webpack
 	$(electron)

--- a/app-shell/src/exports.js
+++ b/app-shell/src/exports.js
@@ -1,0 +1,5 @@
+// @flow
+// remote exports entry-point for the preload script to remote-load
+export { getConfig } from './config'
+export { getRobots } from './discovery'
+export { CURRENT_VERSION, CURRENT_RELEASE_NOTES } from './update'

--- a/app-shell/src/preload.js
+++ b/app-shell/src/preload.js
@@ -5,9 +5,12 @@
 import { ipcRenderer, remote } from 'electron'
 import cloneDeep from 'lodash/cloneDeep'
 
-const { getConfig } = remote.require('./config')
-const { getRobots } = remote.require('./discovery')
-const { CURRENT_VERSION, CURRENT_RELEASE_NOTES } = remote.require('./update')
+const {
+  getConfig,
+  getRobots,
+  CURRENT_VERSION,
+  CURRENT_RELEASE_NOTES,
+} = remote.require('./exports')
 
 global.APP_SHELL_REMOTE = {
   ipcRenderer,

--- a/app-shell/webpack.config.js
+++ b/app-shell/webpack.config.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const path = require('path')
+const webpackMerge = require('webpack-merge')
+const { nodeBaseConfig } = require('@opentrons/webpack-config')
+
+const ENTRY_MAIN = path.join(__dirname, 'src/main.js')
+const ENTRY_EXPORTS = path.join(__dirname, 'src/exports.js')
+const ENTRY_PRELOAD = path.join(__dirname, 'src/preload.js')
+const OUTPUT_PATH = path.join(__dirname, 'lib')
+
+const COMMON_CONFIG = { output: { path: OUTPUT_PATH } }
+
+module.exports = [
+  // main process (runs in electron)
+  webpackMerge(nodeBaseConfig, COMMON_CONFIG, {
+    target: 'electron-main',
+    entry: { main: ENTRY_MAIN, exports: ENTRY_EXPORTS },
+  }),
+
+  // preload script (runs in the browser window)
+  webpackMerge(nodeBaseConfig, COMMON_CONFIG, {
+    target: 'web',
+    entry: { preload: ENTRY_PRELOAD },
+  }),
+]

--- a/app/Makefile
+++ b/app/Makefile
@@ -40,7 +40,7 @@ dist:
 .PHONY: dev
 dev: export NODE_ENV := development
 dev: export PORT := $(PORT)
-dev: dev-deps
+dev:
 	concurrently --no-color --kill-others --names "server,shell" \
 		"$(MAKE) dev-server" \
 		"$(MAKE) dev-shell"
@@ -54,7 +54,3 @@ dev-shell:
 	wait-on http-get://localhost:$(PORT)
 	$(MAKE) -C $(shell_dir) dev
 
-.PHONY: dev-deps
-dev-deps:
-	$(MAKE) -C $(discovery_client_dir)
-	$(MAKE) -C $(shell_dir) clean lib

--- a/babel.config.js
+++ b/babel.config.js
@@ -29,18 +29,11 @@ module.exports = {
   overrides: [
     {
       test: 'app-shell/**/*',
-      presets: [
-        [
-          '@babel/preset-env',
-          { modules: 'commonjs', targets: { electron: '6' } },
-        ],
-      ],
+      presets: [['@babel/preset-env', { targets: { electron: '6' } }]],
     },
     {
       test: ['discovery-client/**/*'],
-      presets: [
-        ['@babel/preset-env', { modules: 'commonjs', targets: { node: '8' } }],
-      ],
+      presets: [['@babel/preset-env', { targets: { node: '8' } }]],
     },
     // app that should be polyfilled
     // these projects require `core-js` in their package.json `dependencies`

--- a/discovery-client/Makefile
+++ b/discovery-client/Makefile
@@ -5,19 +5,11 @@ SHELL := /bin/bash
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)
 
-# source and output directories for main process code
-src_dir := src
-lib_dir := lib
-src_ignore_glob := "**/__@(tests|mocks|fixtures)__/**"
-src_ignore := "**/__tests__/**","**/__mocks__/**","**/__fixtures__/**"
-babel := babel $(src_dir) --root-mode upward --ignore $(src_ignore) --out-dir $(lib_dir)
-flow_copy := flow-copy-source --ignore $(src_ignore_glob) $(src_dir) $(lib_dir)
-
 # standard targets
 #####################################################################
 
 .PHONY: all
-all: dist
+all: clean lib
 
 .PHONY: install
 install:
@@ -33,11 +25,5 @@ clean:
 .PHONY: lib
 lib: export NODE_ENV := production
 lib:
-	$(babel)
-	$(flow_copy)
+	webpack
 
-.PHONY: dist
-dist: clean lib
-	@shx mkdir -p dist
-	npm pack
-	shx mv '*.tgz' dist

--- a/discovery-client/package.json
+++ b/discovery-client/package.json
@@ -2,7 +2,7 @@
   "name": "@opentrons/discovery-client",
   "version": "3.13.2",
   "description": "Node.js client for discovering Opentrons robots on the network",
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "bin": {
     "discovery": "bin/index.js",
     "discovery-ssh": "bin/discovery-ssh"

--- a/discovery-client/webpack.config.js
+++ b/discovery-client/webpack.config.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const path = require('path')
+const webpackMerge = require('webpack-merge')
+const { nodeBaseConfig } = require('@opentrons/webpack-config')
+
+const ENTRY_CLI = path.join(__dirname, 'src/cli.js')
+const OUTPUT_PATH = path.join(__dirname, 'lib')
+
+module.exports = webpackMerge(nodeBaseConfig, {
+  entry: { cli: ENTRY_CLI },
+  output: { path: OUTPUT_PATH },
+})

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "node": ">=12"
   },
   "devDependencies": {
-    "@babel/cli": "^7.6.0",
     "@babel/core": "^7.6.0",
     "@babel/plugin-proposal-class-properties": "^7.5.5",
     "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
@@ -70,7 +69,6 @@
     "favicons-webpack-plugin": "^1.0.2",
     "file-loader": "^4.2.0",
     "flow-bin": "^0.106.2",
-    "flow-copy-source": "^2.0.2",
     "flow-typed": "^2.6.1",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",
@@ -114,6 +112,7 @@
     "webpack-cli": "^3.3.9",
     "webpack-dev-server": "^3.8.1",
     "webpack-merge": "^4.2.2",
+    "webpack-node-externals": "^1.7.2",
     "worker-loader": "^2.0.0",
     "ws": "7.1.2"
   }

--- a/webpack-config/index.js
+++ b/webpack-config/index.js
@@ -6,6 +6,7 @@ const envConstants = require('./lib/env')
 module.exports = Object.assign(
   {
     baseConfig: require('./lib/base-config'),
+    nodeBaseConfig: require('./lib/node-base-config'),
     rules: require('./lib/rules'),
   },
   envConstants

--- a/webpack-config/lib/node-base-config.js
+++ b/webpack-config/lib/node-base-config.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const path = require('path')
+const webpackMerge = require('webpack-merge')
+const nodeExternals = require('webpack-node-externals')
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
+
+const baseConfig = require('./base-config')
+const { ENABLE_ANALYZER } = require('./env')
+
+const MERGE_STRATEGY = {
+  entry: 'replace',
+  plugins: 'replace',
+}
+
+const EXTERNALS_CONFIG = {
+  whitelist: /^@opentrons\/.*/,
+}
+
+module.exports = webpackMerge.strategy(MERGE_STRATEGY)(baseConfig, {
+  target: 'node',
+
+  entry: {},
+
+  output: {
+    filename: '[name].js',
+    libraryTarget: 'commonjs',
+  },
+
+  plugins: [
+    ENABLE_ANALYZER &&
+      new BundleAnalyzerPlugin({ analyzerMode: 'server', openAnalyzer: true }),
+  ].filter(Boolean),
+
+  // do not attempt to polyfill nor mock built-in Node libraries and globals
+  node: false,
+
+  externals: [
+    // exclude package.json dependencies from the bundle
+    nodeExternals(EXTERNALS_CONFIG),
+    // also exclude workspace hoisted packages from the bundle
+    nodeExternals(
+      Object.assign(
+        { modulesDir: path.join(__dirname, '../../node_modules') },
+        EXTERNALS_CONFIG
+      )
+    ),
+  ],
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,23 +15,6 @@
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/7zip/-/7zip-0.0.6.tgz#9cafb171af82329490353b4816f03347aa150a30"
 
-"@babel/cli@^7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.6.0.tgz#1470a04394eaf37862989ea4912adf440fa6ff8d"
-  integrity sha512-1CTDyGUjQqW3Mz4gfKZ04KGOckyyaNmKneAMlABPS+ZyuxWv3FrVEVz7Ag08kNIztVx8VaJ8YgvYLSNlMKAT5Q==
-  dependencies:
-    commander "^2.8.1"
-    convert-source-map "^1.1.0"
-    fs-readdir-recursive "^1.1.0"
-    glob "^7.0.0"
-    lodash "^4.17.13"
-    mkdirp "^0.5.1"
-    output-file-sync "^2.0.0"
-    slash "^2.0.0"
-    source-map "^0.5.0"
-  optionalDependencies:
-    chokidar "^2.1.8"
-
 "@babel/code-frame@7.0.0", "@babel/code-frame@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
@@ -3102,14 +3085,6 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-anymatch@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.0.tgz#e609350e50a9313b472789b2f14ef35808ee14d6"
-  integrity sha512-Ozz7l4ixzI7Oxj2+cw+p0tVUt27BpaJ+1+q1TCeANWxHpvyn2+Un+YamBdfKu0uh8xLodGhoa1v7595NhKDAuA==
-  dependencies:
-    normalize-path "^3.0.0"
-    picomatch "^2.0.4"
-
 app-builder-bin@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-2.0.0.tgz#bda985bee14370b254841a9982753b8f383415c5"
@@ -3664,11 +3639,6 @@ binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
 
-binary-extensions@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
-  integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
-
 binary@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/binary/-/binary-0.3.0.tgz#9f60553bc5ce8c3386f3b553cff47462adecaa79"
@@ -3857,7 +3827,7 @@ braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@^3.0.1, braces@^3.0.2:
+braces@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -4473,21 +4443,6 @@ chokidar@^2.0.2, chokidar@^2.1.8:
   optionalDependencies:
     fsevents "^1.2.7"
 
-chokidar@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.1.0.tgz#ff23d077682a90eadd209bfa76eb10ed6d359668"
-  integrity sha512-6vZfo+7W0EOlbSo0nhVKMz4yyssrwiPbBZ8wj1lq8/+l4ZhGZ2U4Md7PspvmijXp1a26D3B7AHEBmIB7aVtaOQ==
-  dependencies:
-    anymatch "^3.1.0"
-    braces "^3.0.2"
-    glob-parent "^5.0.0"
-    is-binary-path "^2.1.0"
-    is-glob "^4.0.1"
-    normalize-path "^3.0.0"
-    readdirp "^3.1.1"
-  optionalDependencies:
-    fsevents "^2.0.6"
-
 chownr@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
@@ -4819,13 +4774,13 @@ commander@^2.11.0, commander@^2.18.0, commander@^2.19.0, commander@^2.20.0, comm
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
-commander@^2.8.1, commander@~2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
-
 commander@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.1.0.tgz#d121bbae860d9992a3d517ba96f56588e47c6781"
+
+commander@~2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
 
 common-dir@^2.0.2:
   version "2.0.2"
@@ -7452,17 +7407,6 @@ flow-bin@^0.106.2:
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.106.2.tgz#624db7c04b00879ac14853434817c7bc5e1419db"
   integrity sha512-pALWFKf+AQiX4VfSEdxruj2bSMigsrAcg8djV6Hue2y3FJyiA/Z42UkEv6zEvSIpDj1EL+cRBvJNUx6L2+gdTQ==
 
-flow-copy-source@^2.0.2:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/flow-copy-source/-/flow-copy-source-2.0.8.tgz#0281676590b28ad6a9bbc63a1e0d36bcea9e2db5"
-  integrity sha512-BGOxGcUbNvEwLaoy7YsAMuIG6S0qOLAJiPzuRQI84WFv+V4oLBFj9Mt5HPH5BMCmS0eGncdKZidJu7VSJ57V5A==
-  dependencies:
-    chokidar "^3.0.0"
-    fs-extra "^8.1.0"
-    glob "^7.0.0"
-    kefir "^3.7.3"
-    yargs "^14.0.0"
-
 flow-typed@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/flow-typed/-/flow-typed-2.6.1.tgz#e991f53840ad121d9e1f61bd8f8b844cfae57ab1"
@@ -7669,10 +7613,6 @@ fs-minipass@^1.2.5:
   dependencies:
     minipass "^2.2.1"
 
-fs-readdir-recursive@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
-
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
@@ -7693,11 +7633,6 @@ fsevents@^1.2.7:
   dependencies:
     nan "^2.12.1"
     node-pre-gyp "^0.12.0"
-
-fsevents@^2.0.6:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.0.7.tgz#382c9b443c6cbac4c57187cdda23aa3bf1ccfc2a"
-  integrity sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==
 
 fstream@^1.0.12:
   version "1.0.12"
@@ -9093,13 +9028,6 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-binary-path@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
-  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
-  dependencies:
-    binary-extensions "^2.0.0"
-
 is-boolean-object@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
@@ -10305,12 +10233,6 @@ jszip@^3.2.2:
 kebab-case@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/kebab-case/-/kebab-case-1.0.0.tgz#3f9e4990adcad0c686c0e701f7645868f75f91eb"
-
-kefir@^3.7.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/kefir/-/kefir-3.8.3.tgz#8e0ab10084ed8a01cbb5d4f7f18a0b859f7b9bd9"
-  dependencies:
-    symbol-observable "1.0.4"
 
 keyboardevent-from-electron-accelerator@^1.1.0:
   version "1.1.0"
@@ -12168,14 +12090,6 @@ osenv@^0.1.5:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
-output-file-sync@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/output-file-sync/-/output-file-sync-2.0.1.tgz#f53118282f5f553c2799541792b723a4c71430c0"
-  dependencies:
-    graceful-fs "^4.1.11"
-    is-plain-obj "^1.1.0"
-    mkdirp "^0.5.1"
-
 p-cancelable@^0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.4.1.tgz#35f363d67d52081c8d9585e37bcceb7e0bbcb2a0"
@@ -12589,7 +12503,7 @@ phin@^2.9.1:
   resolved "https://registry.yarnpkg.com/phin/-/phin-2.9.3.tgz#f9b6ac10a035636fb65dfc576aaaa17b8743125c"
   integrity sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==
 
-picomatch@^2.0.4, picomatch@^2.0.5:
+picomatch@^2.0.5:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
   integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
@@ -14537,13 +14451,6 @@ readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
-readdirp@^3.1.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.1.2.tgz#fa85d2d14d4289920e4671dead96431add2ee78a"
-  integrity sha512-8rhl0xs2cxfVsqzreYCvs8EwBfn/DhVdqtoLmw19uI3SC5avYX9teCurlErfpPXGmYtMHReGaP2RsLnFvz/lnw==
-  dependencies:
-    picomatch "^2.0.4"
-
 realpath-native@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.1.0.tgz#2003294fea23fb0672f2476ebe22fcf498a2d65c"
@@ -16446,10 +16353,6 @@ svgo@^1.0.0:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-symbol-observable@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
-
 symbol-observable@^1.0.3, symbol-observable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.1.0.tgz#5c68fd8d54115d9dfb72a84720549222e8db9b32"
@@ -17783,6 +17686,11 @@ webpack-merge@^4.1.4, webpack-merge@^4.2.2:
   dependencies:
     lodash "^4.17.15"
 
+webpack-node-externals@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz#6e1ee79ac67c070402ba700ef033a9b8d52ac4e3"
+  integrity sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg==
+
 webpack-sources@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.3.0.tgz#2a28dcb9f1f45fe960d8f1493252b5ee6530fa85"
@@ -18272,23 +18180,6 @@ yargs@^13.3.0:
   integrity sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==
   dependencies:
     cliui "^5.0.0"
-    find-up "^3.0.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^3.0.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^13.1.1"
-
-yargs@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.0.0.tgz#ba4cacc802b3c0b3e36a9e791723763d57a85066"
-  integrity sha512-ssa5JuRjMeZEUjg7bEL99AwpitxU/zWGAGpdj0di41pOEmJti8NR6kyUIJBkR78DTYNPZOU08luUo0GTHuB+ow==
-  dependencies:
-    cliui "^5.0.0"
-    decamelize "^1.2.0"
     find-up "^3.0.0"
     get-caller-file "^2.0.1"
     require-directory "^2.1.1"


### PR DESCRIPTION
## overview

This PR switches the build process of app-shell and discovery-client from `babel-cli` to `webpack`. This enables:

1. app-shell to pull in pre-compiled opentrons dependencies (like shared-data)
2. a consistent, compile-free experience for discovery-client consumers

(1) makes implementing #4244 a lot easier, because we'll be able to pull shared-data's labware validation functions into app-shell. (2) is just a nice to have that we get for free with this switch.

This PR adds a new base config to @opentrons/webpack-config: `nodeBaseConfig`. It has the following differences from `baseConfig`:

- The compile target is `node` rather than `web`
- The export is `commonjs` instead of the default `var`
- `BundleAnalyzerPlugin` is the only included plugin
- `node_modules` dependencies (other than `@opentrons/*`) are **not bundled**

## changelog

- build(app-shell,discovery-client): switch from babel-cli to webpack

## review requests

Because of the change in build process and the removal of some dev dependencies, go ahead and **run `make install-js` after cloning** (note: I do mean `make install-js`, not just `yarn`. The make task runs the DC build process, which is still necessary to build the discovery client CLI certain dev tasks rely on).

- [ ] `make -C app-shell dist-${platform}` builds a working app distributable
    - **Highest priority**
- [ ] `make -C app dev` still works as expected
- [ ] Tasks that rely on the discovery-client CLI work as expected
    - e.g. `make -C api term`

Thanks for @b-cooper for pushing me to try this switch out. Turns out it's a good idea and makes our builds a little simpler without sacrificing any build speed