### PR TITLE
fix(api): apiv2: correctly set smoothie speed

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -655,7 +655,7 @@ class SmoothieDriver_3_0_0:
         ''' set total axes movement speed in mm/second'''
         if update:
             self._combined_speed = float(value)
-        speed_per_min = int(self._combined_speed * SEC_PER_MIN)
+        speed_per_min = int(float(value) * SEC_PER_MIN)
         command = GCODES['SET_SPEED'] + str(speed_per_min)
         log.debug("set_speed: {}".format(command))
         self._send_command(command)


### PR DESCRIPTION
ed483822a014061f031c64aaff717a32e9f606aa was actually broken in its
implementation, because if update=false the old saved speed would be set instead
of the new value. This fixes the issue.


Testing: set a non-default flow rate and notice that it actually has an effect now.