### PR TITLE
fix(api): apiv2: always touch tip before blow out

### DIFF
--- a/api/src/opentrons/protocol_api/transfers.py
+++ b/api/src/opentrons/protocol_api/transfers.py
@@ -705,6 +705,10 @@ class TransferPlan:
                     yield self._format_dict('blow_out', [loc])
             # If we're not empty but we're about to aspirate, we need a
             # blowout.
+            if self._strategy.touch_tip_strategy == TouchTipStrategy.ALWAYS:
+                yield self._format_dict('touch_tip',
+                                        kwargs=self._touch_tip_opts)
+
             if self._strategy.blow_out_strategy == BlowOutStrategy.TRASH:
                 yield self._format_dict('blow_out', [
                     self._instr.trash_container.wells()[0]])
@@ -718,8 +722,9 @@ class TransferPlan:
             # Used by distribute
             if self._strategy.air_gap:
                 yield self._format_dict('air_gap', [self._strategy.air_gap])
-        if self._strategy.touch_tip_strategy == TouchTipStrategy.ALWAYS:
-            yield self._format_dict('touch_tip', kwargs=self._touch_tip_opts)
+            if self._strategy.touch_tip_strategy == TouchTipStrategy.ALWAYS:
+                yield self._format_dict('touch_tip',
+                                        kwargs=self._touch_tip_opts)
 
     def _new_tip_action(self):
         if self._strategy.new_tip == types.TransferTipPolicy.ALWAYS:


### PR DESCRIPTION
## overview
In transfer and distribute commands in APIv2, touch tip is set to happen after any blow out commands. This means that if there is a disposal volume, or the user-specified blow-out location is at the trash, the pipette would blow out and then touch tip at the trash!

_Note_ this behavior has already been fixed in APIv1 by #4231

## changelog
- make touch tip always happen before blow out
- add test to check desired behaviors

## review requests
Run this protocol and make sure the pipette touches tip before blowing out at the trash or at the specified location.
```
def run(protocol):

    tiprack = protocol.load_labware('opentrons_96_tiprack_300ul', '1')
    res12 = protocol.load_labware('usascientific_12_reservoir_22ml', '4')

    m300 = protocol.load_instrument(
        'p300_multi', 'left', tip_racks=[tiprack])
    
   # distribute w/ touch tip (disposal volume is the pipette's min volume)
    m300.distribute(30, res12.wells()[0], res12.wells()[1:3], touch_tip=True)
    
    # transfer w/ blow out and touch tip
    m300.transfer(30, res12.wells()[0], res12.wells()[1:3], blow_out=True, touch_tip=True)
```