### PR TITLE
refactor(api): make apiv2 tempdeck set_temp behave like TC

### DIFF
--- a/api/docs/source/v2/new_modules.rst
+++ b/api/docs/source/v2/new_modules.rst
@@ -97,9 +97,6 @@ To set the temperature module to 4 degrees celsius do the following:
 
 This function will pause your protocol until your target temperature is reached.
 
-If no target temperature is set via ``set_temperature()``, the protocol will be stuck in
-an indefinite loop.
-
 Read the Current Temperature
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 You can read the current real-time temperature of the module by the following:

--- a/api/docs/source/v2/new_modules.rst
+++ b/api/docs/source/v2/new_modules.rst
@@ -95,18 +95,7 @@ To set the temperature module to 4 degrees celsius do the following:
 
     temp_mod.set_temperature(4)
 
-Wait Until Setpoint Reached
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
 This function will pause your protocol until your target temperature is reached.
-
-.. code-block:: python
-
-    temp_mod.set_temperature(4)
-    temp_mod.wait_for_temp()
-
-Before using ``wait_for_temp()`` you must set a target temperature with ``set_temperature()``.
-Once the target temperature is set, when you want the protocol to wait until the module
-reaches the target you can call ``wait_for_temp().``
 
 If no target temperature is set via ``set_temperature()``, the protocol will be stuck in
 an indefinite loop.

--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -1,5 +1,6 @@
 from os import environ
 import logging
+import asyncio
 from threading import Event, Thread
 from time import sleep
 from typing import Optional, Mapping
@@ -92,7 +93,7 @@ class TempDeck:
             return str(e)
         return ''
 
-    def set_temperature(self, celsius) -> str:
+    async def set_temperature(self, celsius) -> str:
         self.run_flag.wait()
         celsius = round(float(celsius),
                         utils.TEMPDECK_GCODE_ROUNDING_PRECISION)
@@ -102,7 +103,8 @@ class TempDeck:
         except (TempDeckError, SerialException, SerialNoResponse) as e:
             return str(e)
         self._temperature.update({'target': celsius})
-        return ''
+        while self.status != 'holding at target':
+            await asyncio.sleep(0.1)
 
     def update_temperature(self, default=None) -> str:
         if self._update_thread and self._update_thread.is_alive():

--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -107,7 +107,7 @@ class TempDeck:
             await asyncio.sleep(0.1)
         return ''
 
-    # NOTE: this is only present to support apiV1 non-blocking by default behavior
+    # NOTE: only present to support apiV1 non-blocking by default behavior
     def legacy_set_temperature(self, celsius) -> str:
         self.run_flag.wait()
         celsius = round(float(celsius),

--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -105,6 +105,7 @@ class TempDeck:
         self._temperature.update({'target': celsius})
         while self.status != 'holding at target':
             await asyncio.sleep(0.1)
+        return ''
 
     # NOTE: this is only present to support apiV1 non-blocking by default behavior
     def legacy_set_temperature(self, celsius) -> str:

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -17,7 +17,7 @@ class SimulatingDriver:
         self._active = False
         self._port = None
 
-    def set_temperature(self, celsius):
+    async def set_temperature(self, celsius):
         self._target_temp = celsius
         self._active = True
 

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -120,7 +120,7 @@ class TempDeck(mod_abc.AbstractModule):
         self._device_info = None
         self._poller = None
 
-    def set_temperature(self, celsius):
+    async def set_temperature(self, celsius):
         """
         Set temperature in degree Celsius
         Range: 4 to 95 degree Celsius (QA tested).
@@ -128,18 +128,11 @@ class TempDeck(mod_abc.AbstractModule):
         temperature display. Any input outside of this range will be clipped
         to the nearest limit
         """
-        return self._driver.set_temperature(celsius)
+        return await self._driver.set_temperature(celsius)
 
     def deactivate(self):
         """ Stop heating/cooling and turn off the fan """
         self._driver.deactivate()
-
-    async def wait_for_temp(self):
-        """
-        This method exits only if set temperature has reached.Subject to change
-        """
-        while self.status != 'holding at target':
-            await asyncio.sleep(0.1)
 
     @property
     def device_info(self):

--- a/api/src/opentrons/legacy_api/modules/tempdeck.py
+++ b/api/src/opentrons/legacy_api/modules/tempdeck.py
@@ -16,6 +16,7 @@ class TempDeck(commands.CommandPublisher):
     """
     Under development. API subject to change without a version bump
     """
+
     def __init__(self, lw=None, port=None, broker=None):
         super().__init__(broker)
         self.labware = lw
@@ -34,7 +35,7 @@ class TempDeck(commands.CommandPublisher):
         to the nearest limit
         """
         if self._driver and self._driver.is_connected():
-            self._driver.set_temperature(celsius)
+            self._driver.legacy_set_temperature(celsius)
 
     @commands.publish.both(command=commands.tempdeck_deactivate)
     def deactivate(self):

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1922,7 +1922,6 @@ class TemperatureModuleContext(ModuleContext):
                 'biorad_96_wellplate_200ul_pcr')
 
             temp_mod.set_temperature(45.5)
-            temp_mod.wait_for_temp()
             temp_mod.deactivate()
 
     .. note::
@@ -1956,11 +1955,6 @@ class TemperatureModuleContext(ModuleContext):
         """ Stop heating (or cooling) and turn off the fan.
         """
         return self._module.deactivate()
-
-    def wait_for_temp(self):
-        """ Block until the module reaches its setpoint.
-        """
-        self._module.wait_for_temp()
 
     @property
     def temperature(self):

--- a/api/tests/opentrons/drivers/module_drivers/test_temp_deck_driver.py
+++ b/api/tests/opentrons/drivers/module_drivers/test_temp_deck_driver.py
@@ -137,7 +137,8 @@ async def test_fail_set_temp_deck_temperature(monkeypatch):
     temp_deck.simulating = False
 
     try:
-        res = await asyncio.wait_for(temp_deck.set_temperature(-9), timeout=0.2)
+        res = await asyncio.wait_for(temp_deck.set_temperature(-9),
+                                     timeout=0.2)
     except asyncio.TimeoutError:
         pass
     assert res == error_msg
@@ -153,7 +154,8 @@ async def test_fail_set_temp_deck_temperature(monkeypatch):
         _raise_error, serial_communication)
 
     try:
-        res = await asyncio.wait_for(temp_deck.set_temperature(-9), timeout=0.2)
+        res = await asyncio.wait_for(temp_deck.set_temperature(-9),
+                                     timeout=0.2)
     except asyncio.TimeoutError:
         pass
     assert res == error_msg

--- a/api/tests/opentrons/drivers/module_drivers/test_temp_deck_driver.py
+++ b/api/tests/opentrons/drivers/module_drivers/test_temp_deck_driver.py
@@ -99,12 +99,22 @@ async def test_set_temp_deck_temperature(monkeypatch):
         command_log += [command]
         return ''
 
-    temp_deck._send_command = types.MethodType(_mock_send_command, temp_deck)
+    def _mock_update_temp(self):
+        return 'holding at target'
 
-    await asyncio.wait_for(temp_deck.set_temperature(99), 0.2)
+    temp_deck._send_command = types.MethodType(_mock_send_command, temp_deck)
+    temp_deck._update_temp = types.MethodType(_mock_send_command, temp_deck)
+
+    try:
+        await asyncio.wait_for(temp_deck.set_temperature(99), timeout=0.2)
+    except asyncio.TimeoutError:
+        pass
     assert command_log[-1] == 'M104 S99.0'
 
-    await asyncio.wait_for(temp_deck.set_temperature(-9), 0.2)
+    try:
+        await asyncio.wait_for(temp_deck.set_temperature(-9), timeout=0.2)
+    except asyncio.TimeoutError:
+        pass
     assert command_log[-1] == 'M104 S-9.0'
 
 
@@ -126,7 +136,10 @@ async def test_fail_set_temp_deck_temperature(monkeypatch):
     temp_deck = TempDeck()
     temp_deck.simulating = False
 
-    res = await asyncio.wait_for(temp_deck.set_temperature(-9), 0.2)
+    try:
+        res = await asyncio.wait_for(temp_deck.set_temperature(-9), timeout=0.2)
+    except asyncio.TimeoutError:
+        pass
     assert res == error_msg
 
     error_msg = 'Alarm: something alarming happened here'
@@ -139,7 +152,10 @@ async def test_fail_set_temp_deck_temperature(monkeypatch):
     serial_communication.write_and_return = types.MethodType(
         _raise_error, serial_communication)
 
-    res = await asyncio.wait_for(temp_deck.set_temperature(-9), 0.2)
+    try:
+        res = await asyncio.wait_for(temp_deck.set_temperature(-9), timeout=0.2)
+    except asyncio.TimeoutError:
+        pass
     assert res == error_msg
 
 

--- a/api/tests/opentrons/drivers/module_drivers/test_temp_deck_driver.py
+++ b/api/tests/opentrons/drivers/module_drivers/test_temp_deck_driver.py
@@ -9,6 +9,7 @@
 # expected ACK, then it'll eventually time out and return an error
 
 import time
+import asyncio
 
 
 def test_get_temp_deck_temperature():
@@ -84,7 +85,7 @@ def test_fail_get_temp_deck_temperature():
     assert temp_deck._temperature == {'current': 90, 'target': None}
 
 
-def test_set_temp_deck_temperature(monkeypatch):
+async def test_set_temp_deck_temperature(monkeypatch):
     # Set target temperature
     import types
     from opentrons.drivers.temp_deck import TempDeck
@@ -100,14 +101,14 @@ def test_set_temp_deck_temperature(monkeypatch):
 
     temp_deck._send_command = types.MethodType(_mock_send_command, temp_deck)
 
-    temp_deck.set_temperature(99)
+    await asyncio.wait_for(temp_deck.set_temperature(99), 0.2)
     assert command_log[-1] == 'M104 S99.0'
 
-    temp_deck.set_temperature(-9)
+    await asyncio.wait_for(temp_deck.set_temperature(-9), 0.2)
     assert command_log[-1] == 'M104 S-9.0'
 
 
-def test_fail_set_temp_deck_temperature(monkeypatch):
+async def test_fail_set_temp_deck_temperature(monkeypatch):
     import types
     from opentrons.drivers import serial_communication
 
@@ -125,7 +126,7 @@ def test_fail_set_temp_deck_temperature(monkeypatch):
     temp_deck = TempDeck()
     temp_deck.simulating = False
 
-    res = temp_deck.set_temperature(-9)
+    res = await asyncio.wait_for(temp_deck.set_temperature(-9), 0.2)
     assert res == error_msg
 
     error_msg = 'Alarm: something alarming happened here'
@@ -138,7 +139,7 @@ def test_fail_set_temp_deck_temperature(monkeypatch):
     serial_communication.write_and_return = types.MethodType(
         _raise_error, serial_communication)
 
-    res = temp_deck.set_temperature(-9)
+    res = await asyncio.wait_for(temp_deck.set_temperature(-9), 0.2)
     assert res == error_msg
 
 

--- a/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
@@ -24,11 +24,10 @@ async def test_sim_state():
 
 async def test_sim_update():
     temp = await modules.build('', 'tempdeck', True, lambda x: None)
-    temp.set_temperature(10)
+    await asyncio.wait_for(temp.set_temperature(10), 0.2)
     assert temp.temperature == 10
     assert temp.target == 10
     assert temp.status == 'holding at target'
-    await asyncio.wait_for(temp.wait_for_temp(), timeout=0.2)
     temp.deactivate()
     assert temp.temperature == 0
     assert temp.target is None

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -80,7 +80,6 @@ def test_tempdeck(loop):
     mod.set_temperature(20)
     assert 'setting temperature' in ','.join([cmd.lower()
                                               for cmd in ctx.commands()])
-    mod.wait_for_temp()
 
     assert mod.target == 20
     assert mod.temperature == 20


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

In the interest of consistency, this makes the tempdeck's set_temp call hold until the temperature
is reached by default. This is the same behavior as the thermocycler api. The ability to continue
work while an on going set temperature command is occuring will be covered by an upcoming addition
that handles that concern at the top protocol scope.

## changelog

APIv2's tempdeck context's `set_temperature` function should not proceed with the execution of the protocol until the temperature is reached. In addition, the `wait_for_temp` function is no longer present on the tempdeck's context. Its behavior will be recaptured by a generalized "wait for condition" solution that is forthcoming.  

## review requests

- [ ] ensure APIv2 protocol blocks until temp reached
- [ ] ensure APIv1 protocol still behaves as expected
