### PR TITLE
fix(api): Allow Location types in advanced liquid handling functions

### DIFF
--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -30,6 +30,12 @@ ModuleTypes = Union[
     'ThermocyclerContext'
 ]
 
+AdvancedLiquidHandling = Union[
+    Well,
+    types.Location,
+    List[Union[Well, types.Location]],
+    List[List[Well]]]
+
 
 class ProtocolContext(CommandPublisher):
     """ The Context class is a container for the state of a protocol.
@@ -1391,8 +1397,8 @@ class InstrumentContext(CommandPublisher):
     @cmds.publish.both(command=cmds.transfer)
     def transfer(self,
                  volume: Union[float, Sequence[float]],
-                 source,
-                 dest,
+                 source: AdvancedLiquidHandling,
+                 dest: AdvancedLiquidHandling,
                  trash=True,
                  **kwargs) -> 'InstrumentContext':
         # source: Union[Well, List[Well], List[List[Well]]],

--- a/api/src/opentrons/protocol_api/transfers.py
+++ b/api/src/opentrons/protocol_api/transfers.py
@@ -383,12 +383,13 @@ class TransferPlan:
             if isinstance(sources, List) and isinstance(sources[0], List):
                 # Source is a List[List[Well]]
                 sources = [well for well_list in sources for well in well_list]
-            elif isinstance(sources, Well):
+            elif isinstance(sources, Well)\
+                    or isinstance(sources, types.Location):
                 sources = [sources]
             if isinstance(dests, List) and isinstance(dests[0], List):
                 # Dest is a List[List[Well]]
                 dests = [well for well_list in dests for well in well_list]
-            elif isinstance(dests, Well):
+            elif isinstance(dests, Well) or isinstance(dests, types.Location):
                 dests = [dests]
 
         total_xfers = max(len(sources), len(dests))
@@ -483,8 +484,8 @@ class TransferPlan:
 
     @staticmethod
     def _extend_source_target_lists(
-            sources: List[Well],
-            targets: List[Well]):
+            sources: List[Union[Well, types.Location]],
+            targets: List[Union[Well, types.Location]]):
         """Extend source or target list to match the length of the other
         """
         if len(sources) < len(targets):
@@ -789,7 +790,7 @@ class TransferPlan:
         if isinstance(s, List) and isinstance(s[0], List):
             # s is a List[List]]; flatten to 1D list
             s = [well for list_elem in s for well in list_elem]
-        elif isinstance(s, Well):
+        elif isinstance(s, Well) or isinstance(s, types.Location):
             s = [s]
         new_src = []
         for well in s:
@@ -800,7 +801,7 @@ class TransferPlan:
         if isinstance(d, List) and isinstance(d[0], List):
             # s is a List[List]]; flatten to 1D list
             d = [well for list_elem in d for well in list_elem]
-        elif isinstance(d, Well):
+        elif isinstance(d, Well) or isinstance(d, types.Location):
             d = [d]
         new_dst = []
         for well in d:

--- a/api/tests/opentrons/protocol_api/test_transfers.py
+++ b/api/tests/opentrons/protocol_api/test_transfers.py
@@ -226,6 +226,30 @@ def test_uneven_transfers(_instr_labware):
     assert many_to_one_plan_list == exp3
 
 
+def test_location_wells(_instr_labware):
+    _instr_labware['ctx'].home()
+    lw1 = _instr_labware['lw1']
+    lw2 = _instr_labware['lw2']
+    aspirate_loc = lw1.wells()[0].top()
+    list_of_locs = [
+        well.bottom(5) for col in lw2.columns()[0:11] for well in col]
+    xfer_plan = tx.TransferPlan(
+        30,
+        aspirate_loc,
+        list_of_locs,
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        mode='transfer')
+    idx_dest = 0
+    for step in xfer_plan:
+        if step['method'] == 'aspirate':
+            assert step['args'][1].point == aspirate_loc.point
+        elif step['method'] == 'dispense':
+            assert step['args'][1].point\
+                    == list_of_locs[idx_dest].point
+            idx_dest += 1
+
+
 def test_no_new_tip(_instr_labware):
     _instr_labware['ctx'].home()
     lw1 = _instr_labware['lw1']


### PR DESCRIPTION
## overview

API v2 did not accept Location types as valid places to perform transfers. As that behavior does not align with API v1, this PR fixes that and serves as a ticket for documenting the issue.

## changelog

- Also check whether an argument for source/dest is a location
- Add test that uses Location types as inputs for source and destination

## review requests

You can mess around with different combinations using this protocol and see that the location inside the well changes as expected:

```
from opentrons import types

def run(ctx):
    tiprack1 = ctx.load_labware('opentrons_96_tiprack_300ul', 2)
    pip = ctx.load_instrument('p300_single_gen2', mount='right', tip_racks=[tiprack1])
    plate = ctx.load_labware('corning_96_wellplate_360ul_flat', 3)
    pip.pick_up_tip()
    plate_to_move = types.Location(types.Point(0.5, 0.5, 1.0) + plate.wells()[0]._position, plate.wells()[0])
    list_of_tops = [well.top(-5) for col in plate.columns()[1:11] for well in col]
    pip.transfer(50, plate_to_move, list_of_tops, new_tip='never')
    pip.return_tip()
```