### PR TITLE
feat(api): add ability to update TC firmware from robot

### DIFF
--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import os
 import threading
-import serial
+import serial  # type: ignore
 from queue import Queue
 try:
     import select
@@ -431,7 +431,7 @@ class Thermocycler:
             pass
         return ret
 
-    async def enter_programming_mode(self) -> str:
+    async def enter_programming_mode(self):
         trigger_connection = serial.Serial(
             self.port, TC_BOOTLOADER_BAUDRATE, timeout=1)
         await asyncio.sleep(0.005)

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -433,7 +433,7 @@ class Thermocycler:
 
     async def enter_programming_mode(self) -> str:
         trigger_connection = serial.Serial(
-            self._poller.port, TC_BOOTLOADER_BAUDRATE, timeout=1)
+            self.port, TC_BOOTLOADER_BAUDRATE, timeout=1)
         await asyncio.sleep(0.005)
         trigger_connection.close()
 

--- a/api/src/opentrons/hardware_control/modules/__init__.py
+++ b/api/src/opentrons/hardware_control/modules/__init__.py
@@ -85,10 +85,11 @@ async def update_firmware(
     flash_port = await module.prep_for_update()
     callback = module.interrupt_callback
     del module
-    after_port, results = await update.upload_firmware(port=flash_port,
-                                                       firmware_file_path=firmware_file,
-                                                       bootloader_type=cls.bootloader_type(),
-                                                       loop=loop)
+    after_port, results = await update.upload_firmware(
+        port=flash_port,
+        firmware_file_path=firmware_file,
+        bootloader_type=cls.bootloader_type(),
+        loop=loop)
     await asyncio.sleep(1.0)
     new_port = after_port or old_port
     if not results[0]:

--- a/api/src/opentrons/hardware_control/modules/__init__.py
+++ b/api/src/opentrons/hardware_control/modules/__init__.py
@@ -88,7 +88,7 @@ async def update_firmware(
     after_port, results = await update.upload_firmware(
         port=flash_port,
         firmware_file_path=firmware_file,
-        bootloader_type=cls.bootloader_type(),
+        upload_function=cls.bootloader(),
         loop=loop)
     await asyncio.sleep(1.0)
     new_port = after_port or old_port

--- a/api/src/opentrons/hardware_control/modules/__init__.py
+++ b/api/src/opentrons/hardware_control/modules/__init__.py
@@ -85,9 +85,10 @@ async def update_firmware(
     flash_port = await module.prep_for_update()
     callback = module.interrupt_callback
     del module
-    after_port, results = await update.update_firmware(flash_port,
-                                                       firmware_file,
-                                                       loop)
+    after_port, results = await update.update_firmware(port=flash_port,
+                                                       firmware_file_path=firmware_file,
+                                                       bootloader_type=cls.bootloader_type(),
+                                                       loop=loop)
     await asyncio.sleep(1.0)
     new_port = after_port or old_port
     if not results[0]:

--- a/api/src/opentrons/hardware_control/modules/__init__.py
+++ b/api/src/opentrons/hardware_control/modules/__init__.py
@@ -93,6 +93,7 @@ async def update_firmware(
     await asyncio.sleep(1.0)
     new_port = after_port or old_port
     if not results[0]:
+        log.debug(f'Bootloader reponse: {results[1]}')
         raise UpdateError(results[1])
     return await cls.build(
         port=new_port,

--- a/api/src/opentrons/hardware_control/modules/__init__.py
+++ b/api/src/opentrons/hardware_control/modules/__init__.py
@@ -85,7 +85,7 @@ async def update_firmware(
     flash_port = await module.prep_for_update()
     callback = module.interrupt_callback
     del module
-    after_port, results = await update.update_firmware(port=flash_port,
+    after_port, results = await update.upload_firmware(port=flash_port,
                                                        firmware_file_path=firmware_file,
                                                        bootloader_type=cls.bootloader_type(),
                                                        loop=loop)

--- a/api/src/opentrons/hardware_control/modules/__init__.py
+++ b/api/src/opentrons/hardware_control/modules/__init__.py
@@ -75,7 +75,7 @@ async def update_firmware(
         loop: Optional[asyncio.AbstractEventLoop]) -> AbstractModule:
     """ Update a module.
 
-    If the update succeeds, an Module instance will be returned.
+    If the update succeeds, a Module instance will be returned.
 
     Otherwise, raises an UpdateError with the reason for the failure.
     """

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -36,7 +36,7 @@ class SimulatingDriver:
     def disconnect(self):
         pass
 
-    def enter_programming_mode(self):
+    async def enter_programming_mode(self):
         pass
 
     @property

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -26,9 +26,9 @@ class SimulatingDriver:
         self._height = location
 
     def get_device_info(self):
-        return {'serial': 'dummySerial',
-                'model': 'dummyModel',
-                'version': 'dummyVersion'}
+        return {'serial': 'dummySerialMD',
+                'model': 'dummyModelMD',
+                'version': 'dummyVersionMD'}
 
     def connect(self, port):
         pass

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -69,8 +69,8 @@ class MagDeck(mod_abc.AbstractModule):
         return 'Magnetic Deck'
 
     @classmethod
-    def bootloader_type(cls) -> str:
-        return 'avrdude'
+    def bootloader(cls) -> mod_abc.UploadFunction:
+        return update.upload_via_avrdude
 
     @staticmethod
     def _build_driver(

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -36,7 +36,7 @@ class SimulatingDriver:
     def disconnect(self):
         pass
 
-    async def enter_programming_mode(self):
+    def enter_programming_mode(self):
         pass
 
     @property

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -68,6 +68,10 @@ class MagDeck(mod_abc.AbstractModule):
     def display_name(cls) -> str:
         return 'Magnetic Deck'
 
+    @classmethod
+    def bootloader_type(cls) -> str:
+        return 'avrdude'
+
     @staticmethod
     def _build_driver(
             simulating: bool) -> Union['SimulatingDriver', 'MagDeckDriver']:

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -1,7 +1,8 @@
 import abc
-from typing import Dict, Callable
+from typing import Dict, Callable, Any, Tuple
 
 InterruptCallback = Callable[[str], None]
+UploadFunction = Callable[[str, str, Dict[str, Any]], Tuple[bool, str]]
 
 
 class AbstractModule(abc.ABC):
@@ -87,6 +88,6 @@ class AbstractModule(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    def bootloader_type(cls) -> str:
-        """ The type of bootloader this module uses. """
+    def bootloader(cls) -> UploadFunction:
+        """ Method used to upload file to this module's bootloader. """
         pass

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -1,8 +1,9 @@
 import abc
-from typing import Dict, Callable, Any, Tuple
+from typing import Dict, Callable, Any, Tuple, Awaitable
 
 InterruptCallback = Callable[[str], None]
-UploadFunction = Callable[[str, str, Dict[str, Any]], Tuple[bool, str]]
+UploadFunction = Callable[[str, str, Dict[str, Any]],
+                          Awaitable[Tuple[bool, str]]]
 
 
 class AbstractModule(abc.ABC):

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -84,3 +84,9 @@ class AbstractModule(abc.ABC):
     def display_name(cls) -> str:
         """ A user-facing name for this kind of module. """
         pass
+
+    @classmethod
+    @abc.abstractmethod
+    def bootloader_type(cls) -> str:
+        """ The type of bootloader this module uses. """
+        pass

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -34,7 +34,7 @@ class SimulatingDriver:
     def disconnect(self):
         pass
 
-    def enter_programming_mode(self):
+    async def enter_programming_mode(self):
         pass
 
     @property

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -50,9 +50,9 @@ class SimulatingDriver:
         return 'holding at target' if self._active else 'idle'
 
     def get_device_info(self):
-        return {'serial': 'dummySerial',
-                'model': 'dummyModel',
-                'version': 'dummyVersion'}
+        return {'serial': 'dummySerialTD',
+                'model': 'dummyModelTD',
+                'version': 'dummyVersionTD'}
 
 
 class Poller(Thread):

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -213,5 +213,5 @@ class TempDeck(mod_abc.AbstractModule):
         del self._poller
         self._poller = None
         new_port = await update.enter_bootloader(self._driver,
-                                                 self.name())
+                                                 self._device_info['model'])
         return new_port or self.port

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -212,6 +212,6 @@ class TempDeck(mod_abc.AbstractModule):
             self._poller.join()
         del self._poller
         self._poller = None
-        model = self._device_info.get('model')
+        model = self._device_info and self._device_info.get('model')
         new_port = await update.enter_bootloader(self._driver, model)
         return new_port or self.port

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -97,6 +97,10 @@ class TempDeck(mod_abc.AbstractModule):
     def display_name(cls) -> str:
         return 'Temperature Deck'
 
+    @classmethod
+    def bootloader_type(cls) -> str:
+        return 'avrdude'
+
     @staticmethod
     def _build_driver(
             simulating: bool) -> Union['SimulatingDriver', 'TempDeckDriver']:

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -34,7 +34,7 @@ class SimulatingDriver:
     def disconnect(self):
         pass
 
-    async def enter_programming_mode(self):
+    def enter_programming_mode(self):
         pass
 
     @property

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -212,6 +212,6 @@ class TempDeck(mod_abc.AbstractModule):
             self._poller.join()
         del self._poller
         self._poller = None
-        new_port = await update.enter_bootloader(self._driver,
-                                                 self._device_info['model'])
+        model = self._device_info.get('model')
+        new_port = await update.enter_bootloader(self._driver, model)
         return new_port or self.port

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -98,8 +98,8 @@ class TempDeck(mod_abc.AbstractModule):
         return 'Temperature Deck'
 
     @classmethod
-    def bootloader_type(cls) -> str:
-        return 'avrdude'
+    def bootloader(cls) -> mod_abc.UploadFunction:
+        return update.upload_via_avrdude
 
     @staticmethod
     def _build_driver(

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -97,9 +97,9 @@ class SimulatingDriver:
         self._lid_target = None
 
     async def get_device_info(self):
-        return {'serial': 'dummySerial',
-                'model': 'dummyModel',
-                'version': 'dummyVersion'}
+        return {'serial': 'dummySerialTC',
+                'model': 'dummyModelTC',
+                'version': 'dummyVersionTC'}
 
     async def enter_programming_mode(self):
         pass

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -20,12 +20,6 @@ class SimulatingDriver:
         self._lid_heating_active = False
 
     async def open(self):
-        # TODO: BC 2019-07-11 once safe threshold is established in
-        # firmware, handle UI level warning responsibly here
-
-        # if self._active:
-        #     raise ThermocyclerError(
-        #         'Cannot open Thermocycler while it is active')
         self._lid_status = 'open'
         return self._lid_status
 
@@ -106,6 +100,9 @@ class SimulatingDriver:
         return {'serial': 'dummySerial',
                 'model': 'dummyModel',
                 'version': 'dummyVersion'}
+
+    async def enter_programming_mode(self):
+        pass
 
 
 class Thermocycler(mod_abc.AbstractModule):

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -131,8 +131,8 @@ class Thermocycler(mod_abc.AbstractModule):
         return 'Thermocycler'
 
     @classmethod
-    def bootloader_type(cls):
-        return 'bossa'
+    def bootloader(cls) -> mod_abc.UploadFunction:
+        return update.upload_via_bossa
 
     @staticmethod
     def _build_driver(

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -1,5 +1,5 @@
 import asyncio
-from . import mod_abc, types
+from . import mod_abc, types, update
 from typing import Union, Optional, List, Callable
 from opentrons.drivers.thermocycler.driver import (
     Thermocycler as ThermocyclerDriver)
@@ -133,6 +133,10 @@ class Thermocycler(mod_abc.AbstractModule):
     def display_name(cls):
         return 'Thermocycler'
 
+    @classmethod
+    def bootloader_type(cls):
+        return 'bossa'
+
     @staticmethod
     def _build_driver(
             simulating: bool,
@@ -158,7 +162,6 @@ class Thermocycler(mod_abc.AbstractModule):
 
         self._port = port
         self._device_info = None
-        self._poller = None
 
         self._running_flag = asyncio.Event(loop=self._loop)
         self._current_cycle_task: Optional[asyncio.Task] = None
@@ -370,4 +373,6 @@ class Thermocycler(mod_abc.AbstractModule):
         return self._port
 
     async def prep_for_update(self):
-        pass
+        new_port = await update.enter_bootloader(self._driver,
+                                                 self.name())
+        return new_port or self.port

--- a/api/src/opentrons/hardware_control/modules/update.py
+++ b/api/src/opentrons/hardware_control/modules/update.py
@@ -58,8 +58,8 @@ async def upload_firmware(port: str,
     a new port after the update (since the board is automatically reset).
     Scan for such a port change and use the appropriate port.
 
-    Returns a tuple of the new port to communicate on (or None if it was not
-    found) and a tuple of success and message from bootloader.
+    Returns a tuple of the new port to communicate on (or empty string
+    if it was not found) and a tuple of success and message from bootloader.
     """
 
     ports_before_update = await _discover_ports()
@@ -140,7 +140,7 @@ async def upload_via_bossa(port: str,
         log.error(f"Failed to update module firmware for {port}: {res}")
         log.error(f"Error given: {stderr.decode()}")
         return False, res
-    return False, None
+    return False, ''
 
 
 async def _port_on_mode_switch(ports_before_switch):

--- a/api/src/opentrons/hardware_control/modules/update.py
+++ b/api/src/opentrons/hardware_control/modules/update.py
@@ -124,7 +124,10 @@ async def _upload_via_bossa(port, firmware_file_path, kwargs):
     #   modules/thermo-cycler/production/firmware/thermo-cycler-arduino.ino.bin
     # NOTE: bossac cannot traverse symlinks to port,
     # so we resolve to real path
-    bossa_args = ['bossac', f'-p{os.path.realpath(port)}',
+    resolved_symlink = os.path.realpath(port)
+    log.info(
+        f"device at symlinked port: {port} resolved to path: {resolved_symlink}")
+    bossa_args = ['bossac', f'-p{resolved_symlink}',
                   '-e', '-w', '-v', '-R',
                   '--offset=0x2000', f'{firmware_file_path}']
 

--- a/api/src/opentrons/hardware_control/modules/update.py
+++ b/api/src/opentrons/hardware_control/modules/update.py
@@ -122,7 +122,9 @@ def _format_avrdude_response(raw_response: str) -> Tuple[bool, str]:
 
 async def _upload_via_bossa(port, firmware_file_path, kwargs):
     # bossac -p/dev/cu.usbmodem14101 -e -w -v -R --offset=0x2000 modules/thermo-cycler/production/firmware/thermo-cycler-arduino.ino.bin
-    bossa_args = ['bossac', f'-p{port}',
+
+    log.debug(f'\n\nsymlink origin {os.path.realpath(port)}\n\n')
+    bossa_args = ['bossac', f'-p{os.path.realpath(port)}',
                   '-e', '-w', '-v', '-R',
                   '--offset=0x2000', f'{firmware_file_path}']
 

--- a/api/src/opentrons/hardware_control/modules/update.py
+++ b/api/src/opentrons/hardware_control/modules/update.py
@@ -79,9 +79,8 @@ async def update_firmware(port: str,
         raise ValueError(
             f"cannot handle specified bootloader type: {bootloader_type}")
 
+    await asyncio.sleep(2)  # wait for com port to reappear
     new_port = await _port_on_mode_switch(ports_before_update)
-    log.info("Res: {}".format(res))
-    log.info("New port: {}".format(new_port))
     return new_port, res
 
 

--- a/api/src/opentrons/hardware_control/modules/update.py
+++ b/api/src/opentrons/hardware_control/modules/update.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import os
 from typing import Any, Dict, Optional, Tuple
-from opentrons.config import feature_flags as ff
 from opentrons import HERE as package_root
 
 log = logging.getLogger(__name__)

--- a/api/src/opentrons/hardware_control/modules/update.py
+++ b/api/src/opentrons/hardware_control/modules/update.py
@@ -30,10 +30,11 @@ async def enter_bootloader(driver, model):
     # Required for old bootloader
     ports_before_dfu_mode = await _discover_ports()
 
-    if not ff.use_protocol_api_v2():
-        driver.enter_programming_mode()
-    else:
+    if model == 'thermocycler':
         await driver.enter_programming_mode()
+    else:
+        driver.enter_programming_mode()
+
     driver.disconnect()
     new_port = ''
     try:

--- a/api/src/opentrons/hardware_control/modules/update.py
+++ b/api/src/opentrons/hardware_control/modules/update.py
@@ -45,7 +45,7 @@ async def enter_bootloader(driver, model):
     return new_port
 
 
-async def update_firmware(port: str,
+async def upload_firmware(port: str,
                           firmware_file_path: str,
                           bootloader_type: str,
                           loop: Optional[asyncio.AbstractEventLoop])\
@@ -58,7 +58,7 @@ async def update_firmware(port: str,
     Scan for such a port change and use the appropriate port.
 
     Returns a tuple of the new port to communicate on (or None if it was not
-    found) and a tuple of success and message from avrdude.
+    found) and a tuple of success and message from bootloader.
     """
 
     ports_before_update = await _discover_ports()
@@ -120,9 +120,8 @@ def _format_avrdude_response(raw_response: str) -> Tuple[bool, str]:
 
 
 async def _upload_via_bossa(port, firmware_file_path, kwargs):
-    # bossac -p/dev/cu.usbmodem14101 -e -w -v -R --offset=0x2000 modules/thermo-cycler/production/firmware/thermo-cycler-arduino.ino.bin
-
-    log.debug(f'\n\nsymlink origin {os.path.realpath(port)}\n\n')
+    # bossac -p/dev/ttyACM1 -e -w -v -R --offset=0x2000 modules/thermo-cycler/production/firmware/thermo-cycler-arduino.ino.bin
+    # NOTE: bossac cannot traverse symlinks to udev port, so we resolve to real path
     bossa_args = ['bossac', f'-p{os.path.realpath(port)}',
                   '-e', '-w', '-v', '-R',
                   '--offset=0x2000', f'{firmware_file_path}']

--- a/api/src/opentrons/hardware_control/modules/update.py
+++ b/api/src/opentrons/hardware_control/modules/update.py
@@ -126,7 +126,8 @@ async def _upload_via_bossa(port, firmware_file_path, kwargs):
     # so we resolve to real path
     resolved_symlink = os.path.realpath(port)
     log.info(
-        f"device at symlinked port: {port} resolved to path: {resolved_symlink}")
+        f"device at symlinked port: {port}"
+        f"resolved to path: {resolved_symlink}")
     bossa_args = ['bossac', f'-p{resolved_symlink}',
                   '-e', '-w', '-v', '-R',
                   '--offset=0x2000', f'{firmware_file_path}']

--- a/api/src/opentrons/hardware_control/modules/update.py
+++ b/api/src/opentrons/hardware_control/modules/update.py
@@ -120,8 +120,10 @@ def _format_avrdude_response(raw_response: str) -> Tuple[bool, str]:
 
 
 async def _upload_via_bossa(port, firmware_file_path, kwargs):
-    # bossac -p/dev/ttyACM1 -e -w -v -R --offset=0x2000 modules/thermo-cycler/production/firmware/thermo-cycler-arduino.ino.bin
-    # NOTE: bossac cannot traverse symlinks to udev port, so we resolve to real path
+    # bossac -p/dev/ttyACM1 -e -w -v -R --offset=0x2000
+    #   modules/thermo-cycler/production/firmware/thermo-cycler-arduino.ino.bin
+    # NOTE: bossac cannot traverse symlinks to port,
+    # so we resolve to real path
     bossa_args = ['bossac', f'-p{os.path.realpath(port)}',
                   '-e', '-w', '-v', '-R',
                   '--offset=0x2000', f'{firmware_file_path}']

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -41,6 +41,7 @@ class Simulator:
     hardware actions. It is suitable for use on a dev machine or on
     a robot with no smoothie connected.
     """
+
     def __init__(
             self,
             attached_instruments: Dict[types.Mount, Dict[str, Optional[str]]],
@@ -65,7 +66,7 @@ class Simulator:
                                  `'tempdeck'` or `'magdeck'`) representing
                                  modules the simulator should assume are
                                  attached. Like `attached_instruments`, used
-                                 to make the simnulator match the setup of the
+                                 to make the simulator match the setup of the
                                  real hardware.
         :param config: The robot config to use
         :param loop: The asyncio event loop to use.
@@ -219,7 +220,7 @@ class Simulator:
     @property
     def axis_bounds(self) -> Dict[str, Tuple[float, float]]:
         """ The (minimum, maximum) bounds for each axis. """
-        return {ax: (0, pos+0.5) for ax, pos in _HOME_POSITION.items()
+        return {ax: (0, pos + 0.5) for ax, pos in _HOME_POSITION.items()
                 if ax not in 'BC'}
 
     @property

--- a/api/src/opentrons/legacy_api/modules/__init__.py
+++ b/api/src/opentrons/legacy_api/modules/__init__.py
@@ -166,17 +166,17 @@ async def update_firmware(module, firmware_file_path, loop):
 
 
 def _format_avrdude_response(raw_response):
-    response = {'message': '', 'avrdudeResponse': ''}
+    response = {'message': '', 'bootloaderResponse': ''}
     avrdude_log = ''
     for line in raw_response.splitlines():
         if 'avrdude:' in line and line != raw_response.splitlines()[1]:
             avrdude_log += line.lstrip('avrdude:') + '..'
             if 'flash verified' in line:
                 response['message'] = 'Firmware update successful'
-                response['avrdudeResponse'] = line.lstrip('avrdude: ')
+                response['bootloaderResponse'] = line.lstrip('avrdude: ')
     if not response['message']:
         response['message'] = 'Firmware update failed'
-        response['avrdudeResponse'] = avrdude_log
+        response['bootloaderResponse'] = avrdude_log
     return response
 
 

--- a/api/src/opentrons/legacy_api/modules/__init__.py
+++ b/api/src/opentrons/legacy_api/modules/__init__.py
@@ -1,11 +1,10 @@
 import os
 import logging
 import re
-import asyncio
 from typing import List, Tuple, Any
 from .magdeck import MagDeck
 from .tempdeck import TempDeck
-from opentrons import HERE as package_root, config
+from opentrons import config
 
 log = logging.getLogger(__name__)
 

--- a/api/src/opentrons/legacy_api/modules/__init__.py
+++ b/api/src/opentrons/legacy_api/modules/__init__.py
@@ -9,18 +9,12 @@ from opentrons import HERE as package_root, config
 
 log = logging.getLogger(__name__)
 
-PORT_SEARCH_TIMEOUT = 5.5
 SUPPORTED_MODULES = {
     'magdeck': MagDeck,
     'magnetic module': MagDeck,
     'tempdeck': TempDeck,
     'temperature module': TempDeck
 }
-
-# avrdude_options
-PART_NO = 'atmega32u4'
-PROGRAMMER_ID = 'avr109'
-BAUDRATE = '57600'
 
 
 class UnsupportedModuleError(Exception):
@@ -103,130 +97,3 @@ def discover() -> List[Tuple[str, Any]]:
     log.debug('Discovered modules: {}'.format(discovered_modules))
 
     return discovered_modules
-
-
-async def enter_bootloader(module):
-    """
-    Using the driver method, enter bootloader mode of the atmega32u4.
-    The bootloader mode opens a new port on the uC to upload the hex file.
-    After receiving a 'dfu' command, the firmware provides a 3-second window to
-    close the current port so as to do a clean switch to the bootloader port.
-    The new port shows up as 'ttyn_bootloader' on the pi; upload fw through it.
-    NOTE: Modules with old bootloader will have the bootloader port show up as
-    a regular module port- 'ttyn_tempdeck'/ 'ttyn_magdeck' with the port number
-    being either different or same as the one that the module was originally on
-    So we check for changes in ports and use the appropriate one
-    """
-    # Required for old bootloader
-    ports_before_dfu_mode = await _discover_ports()
-
-    module._driver.enter_programming_mode()
-    module.disconnect()
-    new_port = ''
-    try:
-        new_port = await asyncio.wait_for(
-            _port_poll(_has_old_bootloader(module), ports_before_dfu_mode),
-            PORT_SEARCH_TIMEOUT)
-    except asyncio.TimeoutError:
-        pass
-    return new_port
-
-
-async def update_firmware(module, firmware_file_path, loop):
-    """
-    Run avrdude firmware upload command. Switch back to normal module port
-
-    Note: For modules with old bootloader, the kernel could assign the module
-    a new port after the update (since the board is automatically reset).
-    Scan for such a port change and use the appropriate port
-    """
-    # TODO: Make sure the module isn't in the middle of operation
-
-    ports_before_update = await _discover_ports()
-    config_file_path = os.path.join(package_root,
-                                    'config', 'modules', 'avrdude.conf')
-    proc = await asyncio.create_subprocess_exec(
-        'avrdude', '-C{}'.format(config_file_path), '-v',
-        '-p{}'.format(PART_NO),
-        '-c{}'.format(PROGRAMMER_ID),
-        '-P{}'.format(module.port),
-        '-b{}'.format(BAUDRATE), '-D',
-        '-Uflash:w:{}:i'.format(firmware_file_path),
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE, loop=loop)
-    await proc.wait()
-
-    _result = await proc.communicate()
-    result = _result[1].decode()
-    log.debug(result)
-    log.debug("Switching back to non-bootloader port")
-    module._port = _port_on_mode_switch(ports_before_update)
-
-    return _format_avrdude_response(result)
-
-
-def _format_avrdude_response(raw_response):
-    response = {'message': '', 'bootloaderResponse': ''}
-    avrdude_log = ''
-    for line in raw_response.splitlines():
-        if 'avrdude:' in line and line != raw_response.splitlines()[1]:
-            avrdude_log += line.lstrip('avrdude:') + '..'
-            if 'flash verified' in line:
-                response['message'] = 'Firmware update successful'
-                response['bootloaderResponse'] = line.lstrip('avrdude: ')
-    if not response['message']:
-        response['message'] = 'Firmware update failed'
-        response['bootloaderResponse'] = avrdude_log
-    return response
-
-
-async def _port_on_mode_switch(ports_before_switch):
-    ports_after_switch = await _discover_ports()
-    new_port = ''
-    if ports_after_switch and \
-            len(ports_after_switch) >= len(ports_before_switch) and \
-            not set(ports_before_switch) == set(ports_after_switch):
-        new_ports = list(filter(
-            lambda x: x not in ports_before_switch,
-            ports_after_switch))
-        if len(new_ports) > 1:
-            raise OSError('Multiple new ports found on mode switch')
-        new_port = '/dev/modules/{}'.format(new_ports[0])
-    return new_port
-
-
-async def _port_poll(is_old_bootloader, ports_before_switch=None):
-    """
-    Checks for the bootloader port
-    """
-    new_port = ''
-    while not new_port:
-        if is_old_bootloader:
-            new_port = await _port_on_mode_switch(ports_before_switch)
-        else:
-            ports = await _discover_ports()
-            if ports:
-                discovered_ports = list(filter(
-                    lambda x: x.endswith('bootloader'), ports))
-                if len(discovered_ports) == 1:
-                    new_port = '/dev/modules/{}'.format(discovered_ports[0])
-        await asyncio.sleep(0.05)
-    return new_port
-
-
-def _has_old_bootloader(module):
-    return True if module.device_info.get('model') == 'temp_deck_v1' or \
-                   module.device_info.get('model') == 'temp_deck_v2' else False
-
-
-async def _discover_ports():
-    if os.environ.get('RUNNING_ON_PI') and os.path.isdir('/dev/modules'):
-        for attempt in range(2):
-            # Measure for race condition where port is being switched in
-            # between calls to isdir() and listdir()
-            try:
-                return os.listdir('/dev/modules')
-            except (FileNotFoundError, OSError):
-                pass
-            await asyncio.sleep(2)
-        raise Exception("No /dev/modules found. Try again")

--- a/api/src/opentrons/server/endpoints/update.py
+++ b/api/src/opentrons/server/endpoints/update.py
@@ -68,11 +68,10 @@ async def _upload_to_module(hw, serialnum, fw_filename, loop):
     """
 
     if not ff.use_protocol_api_v2():
-        return _upload_to_module_legacy(hw, serialnum, fw_filename, loop)
+        return await _upload_to_module_legacy(hw, serialnum, fw_filename, loop)
 
     hw.discover_modules()
     hw_mods = hw.attached_modules.values()
-    res = {}
     for module in hw_mods:
         if module.device_info.get('serial') == serialnum:
             log.info("Module with serial {} found".format(serialnum))
@@ -81,15 +80,15 @@ async def _upload_to_module(hw, serialnum, fw_filename, loop):
                     modules.update_firmware(module, fw_filename, loop),
                     UPDATE_TIMEOUT)
                 if updated_instance:
-                    res['message'] = f'Sucessfully updated module {serialnum}'
+                    return {'message': f'Sucessfully updated module {serialnum}'}
 
             except asyncio.TimeoutError:
                 return {'message': 'Bootloader not responding'}
             break
         if not res:
-            res = {'message': 'Module {} not found'.format(serialnum)}
+            return {'message': 'Module {} not found'.format(serialnum)}
 
-    return res
+    return {}
 
 # TODO: BC(2019-10-23) remove this legacy update pathway, unused
 

--- a/api/src/opentrons/server/endpoints/update.py
+++ b/api/src/opentrons/server/endpoints/update.py
@@ -63,11 +63,13 @@ async def _upload_to_module(hw, serialnum, fw_filename, loop):
         if module.device_info.get('serial') == serialnum:
             log.info("Module with serial {} found".format(serialnum))
             try:
-                _new_port, res = await asyncio.wait_for(
+                new_instance = await asyncio.wait_for(
                     modules.update_firmware(module, fw_filename, loop),
                     UPDATE_TIMEOUT)
-                successful, message = res
-                return message, 200 if successful else 400
+                print(f'\n\n\ninstance {new_instance}\n')
+                return f'Successully updated module {serialnum}', 200
+            except modules.UpdateError as e:
+                return f'Bootloader error: {e}', 400
             except asyncio.TimeoutError:
                 return 'Bootloader not responding', 500
             break

--- a/api/src/opentrons/server/endpoints/update.py
+++ b/api/src/opentrons/server/endpoints/update.py
@@ -2,7 +2,6 @@ import logging
 import asyncio
 import tempfile
 from aiohttp import web
-from opentrons.config import feature_flags as ff
 from opentrons.hardware_control import modules
 
 
@@ -28,9 +27,9 @@ async def update_module_firmware(request):
     """
      This handler accepts a POST request with Content-Type: multipart/form-data
      and a file field in the body named "module_firmware". The file should
-     be a valid HEX/binary image to be flashed to the module. The received file is
-     sent via USB to the board and flashed by the bootloader. The file
-     is then deleted and a success code is returned
+     be a valid HEX/binary image to be flashed to the module. The received
+     file is sent via USB to the board and flashed by the bootloader.
+     The file is then deleted and a success code is returned
     """
     log.debug('Update Firmware request received')
     data = await request.post()

--- a/api/src/opentrons/server/endpoints/update.py
+++ b/api/src/opentrons/server/endpoints/update.py
@@ -80,15 +80,13 @@ async def _upload_to_module(hw, serialnum, fw_filename, loop):
                     modules.update_firmware(module, fw_filename, loop),
                     UPDATE_TIMEOUT)
                 if updated_instance:
-                    return {'message': f'Sucessfully updated module {serialnum}'}
+                    return {'message':
+                            f'Sucessfully updated module {serialnum}'}
 
             except asyncio.TimeoutError:
                 return {'message': 'Bootloader not responding'}
             break
-        if not res:
-            return {'message': 'Module {} not found'.format(serialnum)}
-
-    return {}
+    return {'message': 'Module {} not found'.format(serialnum)}
 
 # TODO: BC(2019-10-23) remove this legacy update pathway, unused
 

--- a/api/src/opentrons/server/endpoints/update.py
+++ b/api/src/opentrons/server/endpoints/update.py
@@ -67,10 +67,9 @@ async def _upload_to_module(hw, serialnum, fw_filename, loop):
     moving the drivers themselves to the serverlib)
     """
 
-    if not ff.use_protocol_api_v2():
-        # ensure there is a reference to the port
-        if not hw.is_connected():
-            hw.connect()
+    # ensure there is a reference to the port
+    if not ff.use_protocol_api_v2() and not hw.is_connected():
+        hw.connect()
 
     hw.discover_modules()
     hw_mods = hw.attached_modules.values()

--- a/api/src/opentrons/server/endpoints/update.py
+++ b/api/src/opentrons/server/endpoints/update.py
@@ -4,122 +4,69 @@ import tempfile
 from aiohttp import web
 from opentrons.config import feature_flags as ff
 from opentrons.hardware_control import modules
-try:
-    from opentrons import modules as legacy_modules
-except ImportError:
-    pass
 
 
 log = logging.getLogger(__name__)
 UPDATE_TIMEOUT = 15
 
 
+# TODO: (BC, 2019-10-24): once APIv1 server ff toggle is gone,
+#  this should be removed
+async def cannot_update_firmware(request):
+    """
+     This handler refuses a module firmware update request
+     in the case that the API server isn't equipped to handle it.
+    """
+    log.debug('Cannot update module firmware on this server version')
+    status = 501
+    res = {'message': 'Cannot update module firmware \
+                        via APIv1 server, please update server to APIv2'}
+    return web.json_response(res, status=status)
+
+
 async def update_module_firmware(request):
     """
      This handler accepts a POST request with Content-Type: multipart/form-data
      and a file field in the body named "module_firmware". The file should
-     be a valid HEX image to be flashed to the atmega32u4. The received file is
-     sent via USB to the board and flashed by the avr109 bootloader. The file
+     be a valid HEX/binary image to be flashed to the module. The received file is
+     sent via USB to the board and flashed by the bootloader. The file
      is then deleted and a success code is returned
     """
     log.debug('Update Firmware request received')
     data = await request.post()
     module_serial = request.match_info['serial']
+    fw_filename = data['module_firmware'].filename
+    message = 'Server failed to update module firmware'
+    status = 500
 
-    res = await _update_module_firmware(request.app['com.opentrons.hardware'],
-                                        module_serial,
-                                        data['module_firmware'],
-                                        request.loop)
-    if 'successful' not in res['message']:
-        if 'bootloaderResponse' in res and \
-           'checksum mismatch' in res['bootloaderResponse']:
-            status = 400
-        elif 'not found' in res['message']:
-            status = 404
-        else:
-            status = 500
-        log.error(res)
-    else:
-        status = 200
-        log.info(res)
+    log.info('Preparing to flash firmware image {}'.format(fw_filename))
+    content = data['module_firmware'].file.read()
+    with tempfile.NamedTemporaryFile(suffix=fw_filename) as fp:
+        fp.write(content)
+        message, status = await _upload_to_module(
+            request.app['com.opentrons.hardware'],
+            module_serial,
+            fp.name,
+            loop=request.loop)
+        log.info('Firmware update complete')
+
+    res = {'filename': fw_filename, 'message': message}
     return web.json_response(res, status=status)
 
 
-async def _update_module_firmware(hw, module_serial, data, loop=None):
-    fw_filename = data.filename
-    content = data.file.read()
-    log.info('Preparing to flash firmware image {}'.format(fw_filename))
-
-    with tempfile.NamedTemporaryFile(suffix=fw_filename) as fp:
-        fp.write(content)
-        # returns a dict of 'message' & 'bootloaderResponse' or
-        res = await _upload_to_module(hw, module_serial, fp.name, loop=loop)
-    log.info('Firmware update complete')
-    res['filename'] = fw_filename
-    return res
-
-
 async def _upload_to_module(hw, serialnum, fw_filename, loop):
-    """
-    This method remains in the API currently because of its use of the robot
-    singleton's copy of the api object & driver. This should move to the server
-    lib project eventually and use its own driver object (preferably involving
-    moving the drivers themselves to the serverlib)
-    """
-
-    if not ff.use_protocol_api_v2():
-        return await _upload_to_module_legacy(hw, serialnum, fw_filename, loop)
-
     hw.discover_modules()
     hw_mods = hw.attached_modules.values()
     for module in hw_mods:
         if module.device_info.get('serial') == serialnum:
             log.info("Module with serial {} found".format(serialnum))
             try:
-                updated_instance = await asyncio.wait_for(
+                _new_port, res = await asyncio.wait_for(
                     modules.update_firmware(module, fw_filename, loop),
                     UPDATE_TIMEOUT)
-                if updated_instance:
-                    return {'message':
-                            f'Sucessfully updated module {serialnum}'}
-
+                successful, message = res
+                return message, 200 if successful else 400
             except asyncio.TimeoutError:
-                return {'message': 'Bootloader not responding'}
+                return 'Bootloader not responding', 500
             break
-    return {'message': 'Module {} not found'.format(serialnum)}
-
-# TODO: BC(2019-10-23) remove this legacy update pathway, unused
-
-
-async def _upload_to_module_legacy(hw, serialnum, fw_filename, loop):
-    # ensure there is a reference to the port
-    if not hw.is_connected():
-        hw.connect()
-
-    hw.discover_modules()
-    hw_mods = hw.attached_modules.values()
-    res = {}
-    for module in hw_mods:
-        if module.device_info.get('serial') == serialnum:
-            log.info("Module with serial {} found".format(serialnum))
-
-            bootloader_port = await legacy_modules.enter_bootloader(module)
-            if bootloader_port:
-                module._port = bootloader_port
-            # else assume old bootloader connection on existing module port
-            log.info("Uploading file to port: {}".format(
-                module.port))
-            log.info("Flashing firmware. This will take a few seconds")
-
-            try:
-                res = await asyncio.wait_for(
-                    legacy_modules.update_firmware(
-                        module, fw_filename, loop),
-                    UPDATE_TIMEOUT)
-            except asyncio.TimeoutError:
-                res = {'message': 'AVRDUDE not responding'}
-            break
-        if not res:
-            res = {'message': 'Module {} not found'.format(serialnum)}
-
-    return res
+    return f'Module {serialnum} not found', 404

--- a/api/src/opentrons/server/endpoints/update.py
+++ b/api/src/opentrons/server/endpoints/update.py
@@ -50,12 +50,14 @@ async def update_module_firmware(request):
             loop=request.loop)
         log.info('Firmware update complete')
 
+    print(f'message: {message} \n')
+    print(f'status: {status} \n')
     res = {'filename': fw_filename, 'message': message}
     return web.json_response(res, status=status)
 
 
 async def _upload_to_module(hw, serialnum, fw_filename, loop):
-    hw.discover_modules()
+    await hw.discover_modules()
     hw_mods = hw.attached_modules.values()
     for module in hw_mods:
         if module.device_info.get('serial') == serialnum:

--- a/api/src/opentrons/server/http.py
+++ b/api/src/opentrons/server/http.py
@@ -4,7 +4,6 @@ from opentrons import config
 from .endpoints import (networking, control, settings, update)
 from opentrons.deck_calibration import endpoints as dc_endp
 
-
 from .endpoints import serverlib_fallback as endpoints
 log = logging.getLogger(__name__)
 
@@ -37,14 +36,18 @@ class HTTPServer(object):
             '/modules/{serial}/data', control.get_module_data)
         self.app.router.add_post(
             '/modules/{serial}', control.execute_module_command)
+        if config.feature_flags.use_protocol_api_v2():
+            self.app.router.add_post(
+                '/modules/{serial}/update', update.update_module_firmware)
+        else:
+            self.app.router.add_post(
+                '/modules/{serial}/update', update.cannot_update_firmware)
         self.app.router.add_post(
             '/camera/picture', control.take_picture)
         self.app.router.add_post(
             '/server/update', endpoints.update_api)
         self.app.router.add_post(
             '/server/update/firmware', endpoints.update_firmware)
-        self.app.router.add_post(
-            '/modules/{serial}/update', update.update_module_firmware)
         self.app.router.add_get(
             '/update/ignore', endpoints.get_ignore_version)
         self.app.router.add_post(

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -44,7 +44,7 @@ Protocol = namedtuple(
 
 @pytest.fixture(autouse=True)
 def asyncio_loop_exception_handler(loop):
-    def exception_handler(loop, context):
+    def exception_handler(loop, iontext):
         pytest.fail(str(context))
     loop.set_exception_handler(exception_handler)
     yield
@@ -554,7 +554,10 @@ def cntrlr_mock_connect(monkeypatch):
 
 @pytest.fixture
 def hardware_api(loop):
-    hw_api = API.build_hardware_simulator(loop=loop)
+    hw_api = API.build_hardware_simulator(loop=loop,
+                                          attached_modules=['magdeck',
+                                                            'tempdeck',
+                                                            'thermocycler'])
     return hw_api
 
 

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -44,7 +44,7 @@ Protocol = namedtuple(
 
 @pytest.fixture(autouse=True)
 def asyncio_loop_exception_handler(loop):
-    def exception_handler(loop, iontext):
+    def exception_handler(loop, context):
         pytest.fail(str(context))
     loop.set_exception_handler(exception_handler)
     yield
@@ -554,10 +554,7 @@ def cntrlr_mock_connect(monkeypatch):
 
 @pytest.fixture
 def hardware_api(loop):
-    hw_api = API.build_hardware_simulator(loop=loop,
-                                          attached_modules=['magdeck',
-                                                            'tempdeck',
-                                                            'thermocycler'])
+    hw_api = API.build_hardware_simulator(loop=loop)
     return hw_api
 
 

--- a/api/tests/opentrons/hardware_control/modules/test_hc_magdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_magdeck.py
@@ -9,9 +9,9 @@ async def test_sim_initialization():
 async def test_sim_data():
     mag = await modules.build('', 'magdeck', True, lambda x: None)
     assert mag.status == 'disengaged'
-    assert mag.device_info['serial'] == 'dummySerial'
-    assert mag.device_info['model'] == 'dummyModel'
-    assert mag.device_info['version'] == 'dummyVersion'
+    assert mag.device_info['serial'] == 'dummySerialMD'
+    assert mag.device_info['model'] == 'dummyModelMD'
+    assert mag.device_info['version'] == 'dummyVersionMD'
     assert mag.live_data['status'] == mag.status
     assert 'data' in mag.live_data
 

--- a/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
@@ -17,9 +17,9 @@ async def test_sim_state():
     assert temp.live_data['data']['currentTemp'] == temp.temperature
     assert temp.live_data['data']['targetTemp'] == temp.target
     status = temp.device_info
-    assert status['serial'] == 'dummySerial'
-    assert status['model'] == 'dummyModel'
-    assert status['version'] == 'dummyVersion'
+    assert status['serial'] == 'dummySerialTD'
+    assert status['model'] == 'dummyModelTD'
+    assert status['version'] == 'dummyVersionTD'
 
 
 async def test_sim_update():

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -36,9 +36,9 @@ async def test_sim_state():
     assert therm.live_data['data']['currentTemp'] == therm.temperature
     assert therm.live_data['data']['targetTemp'] == therm.target
     status = therm.device_info
-    assert status['serial'] == 'dummySerial'
-    assert status['model'] == 'dummyModel'
-    assert status['version'] == 'dummyVersion'
+    assert status['serial'] == 'dummySerialTC'
+    assert status['model'] == 'dummyModelTC'
+    assert status['version'] == 'dummyVersionTC'
 
 
 async def test_sim_update():

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -81,11 +81,11 @@ async def test_module_update_integration(monkeypatch, loop,
     monkeypatch.setattr(hardware_control.modules.update,
                         '_discover_ports', mock_discover_ports)
 
-    async def mock_update(port, fname, loop):
+    async def mock_upload(port, fname, loop):
         return (port, (True, 'it all worked'))
 
     monkeypatch.setattr(hardware_control.modules.update,
-                        'update_firmware', mock_update)
+                        'upload_firmware', mock_upload)
 
     modules = await api.discover_modules()
     ok, msg = await api.update_module(modules[0], 'some-fake-file', loop)

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -81,7 +81,7 @@ async def test_module_update_integration(monkeypatch, loop,
     monkeypatch.setattr(hardware_control.modules.update,
                         '_discover_ports', mock_discover_ports)
 
-    async def mock_upload(port, fname, loop):
+    async def mock_upload(port, firmware_file_path, bootloader_type, loop):
         return (port, (True, 'it all worked'))
 
     monkeypatch.setattr(hardware_control.modules.update,

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -81,7 +81,7 @@ async def test_module_update_integration(monkeypatch, loop,
     monkeypatch.setattr(hardware_control.modules.update,
                         '_discover_ports', mock_discover_ports)
 
-    async def mock_upload(port, firmware_file_path, bootloader_type, loop):
+    async def mock_upload(port, firmware_file_path, upload_function, loop):
         return (port, (True, 'it all worked'))
 
     monkeypatch.setattr(hardware_control.modules.update,

--- a/api/tests/opentrons/labware/test_modules.py
+++ b/api/tests/opentrons/labware/test_modules.py
@@ -156,7 +156,9 @@ async def test_enter_bootloader(
     monkeypatch.setattr(
         TempDeckDriver, 'enter_programming_mode', mock_enter_programming_mode)
     monkeypatch.setattr(
-        hw_modules.update, '_discover_ports', mock_discover_ports_before_dfu_mode)
+        hw_modules.update,
+        '_discover_ports',
+        mock_discover_ports_before_dfu_mode)
     monkeypatch.setattr(hw_modules.update, '_port_poll', mock_port_poll)
 
     bootloader_port = await hw_modules.update.enter_bootloader(

--- a/api/tests/opentrons/labware/test_modules.py
+++ b/api/tests/opentrons/labware/test_modules.py
@@ -7,6 +7,7 @@ import asyncio
 from opentrons.drivers.mag_deck import MagDeck as MagDeckDriver
 from opentrons.drivers.temp_deck import TempDeck as TempDeckDriver
 from opentrons.drivers import serial_communication
+from opentrons.hardware_control import modules as hw_modules
 
 
 @pytest.fixture
@@ -116,109 +117,124 @@ def test_load_correct_engage_height(robot, modules, labware):
 
 
 @pytest.fixture
-def old_bootloader_module(modules):
-    module = modules.TempDeck(port='/dev/modules/tty0_tempdeck')
+async def old_bootloader_module():
+    module = await hw_modules.build(
+        port='/dev/modules/tty0_tempdeck',
+        which='tempdeck',
+        simulating=True,
+        interrupt_callback=lambda x: None)
     module._device_info = {'model': 'temp_deck_v1'}
     module._driver = TempDeckDriver()
     return module
 
 
 @pytest.fixture
-def new_bootloader_module(modules):
-    module = modules.TempDeck(port='/dev/modules/tty0_tempdeck')
+async def new_bootloader_module():
+    module = await hw_modules.build(
+        port='/dev/modules/tty0_tempdeck',
+        which='tempdeck',
+        simulating=True,
+        interrupt_callback=lambda x: None)
     module._device_info = {'model': 'temp_deck_v1.1'}
     module._driver = TempDeckDriver()
     return module
 
 
-# @pytest.mark.api2_only
-# async def test_enter_bootloader(
-#         new_bootloader_module, virtual_smoothie_env, monkeypatch, modules):
+@pytest.mark.api2_only
+async def test_enter_bootloader(
+        new_bootloader_module, virtual_smoothie_env, monkeypatch):
 
-#     async def mock_discover_ports_before_dfu_mode():
-#         return 'tty0_tempdeck'
+    async def mock_discover_ports_before_dfu_mode():
+        return 'tty0_tempdeck'
 
-#     def mock_enter_programming_mode(self):
-#         return 'ok\n\rok\n\r'
+    def mock_enter_programming_mode(self):
+        return 'ok\n\rok\n\r'
 
-#     async def mock_port_poll(_has_old_bootloader, ports_before_dfu_mode):
-#         return '/dev/modules/tty0_bootloader'
+    async def mock_port_poll(_has_old_bootloader, ports_before_dfu_mode):
+        return '/dev/modules/tty0_bootloader'
 
-#     monkeypatch.setattr(
-#         TempDeckDriver, 'enter_programming_mode', mock_enter_programming_mode)
-#     monkeypatch.setattr(
-#         modules, '_discover_ports', mock_discover_ports_before_dfu_mode)
-#     monkeypatch.setattr(modules, '_port_poll', mock_port_poll)
+    monkeypatch.setattr(
+        TempDeckDriver, 'enter_programming_mode', mock_enter_programming_mode)
+    monkeypatch.setattr(
+        hw_modules.update, '_discover_ports', mock_discover_ports_before_dfu_mode)
+    monkeypatch.setattr(hw_modules.update, '_port_poll', mock_port_poll)
 
-#     bootloader_port = await modules.enter_bootloader(new_bootloader_module)
-#     assert bootloader_port == '/dev/modules/tty0_bootloader'
+    bootloader_port = await hw_modules.update.enter_bootloader(
+        new_bootloader_module._driver,
+        new_bootloader_module.name())
 
-
-# @pytest.mark.api1_only
-# def test_old_bootloader_check(
-#         old_bootloader_module, new_bootloader_module, virtual_smoothie_env,
-#         modules):
-#     assert modules._has_old_bootloader(old_bootloader_module)
-#     assert not modules._has_old_bootloader(new_bootloader_module)
+    assert bootloader_port == '/dev/modules/tty0_bootloader'
 
 
-# @pytest.mark.api1_only
-# async def test_port_poll(virtual_smoothie_env, monkeypatch, modules):
-#     has_old_bootloader = False
-#     timeout = 0.1
-#     monkeypatch.setattr(modules, 'PORT_SEARCH_TIMEOUT', timeout)
-
-#     # Case 1: Bootloader port is successfully opened on the module
-#     async def mock_discover_ports1():
-#         return ['tty0_magdeck', 'tty1_bootloader']
-#     monkeypatch.setattr(modules, '_discover_ports', mock_discover_ports1)
-
-#     port_found = await asyncio.wait_for(
-#         modules._port_poll(has_old_bootloader, None),
-#         modules.PORT_SEARCH_TIMEOUT)
-#     assert port_found == '/dev/modules/tty1_bootloader'
-
-#     # Case 2: Switching to bootloader mode failed
-#     async def mock_discover_ports2():
-#         return ['tty0_magdeck', 'tty1_tempdeck']
-#     monkeypatch.setattr(modules, '_discover_ports', mock_discover_ports2)
-
-#     with pytest.raises(asyncio.TimeoutError):
-#         port_found = await asyncio.wait_for(
-#             modules._port_poll(has_old_bootloader, None),
-#             modules.PORT_SEARCH_TIMEOUT)
-#         assert not port_found
+@pytest.mark.api2_only
+def test_old_bootloader_check(
+        old_bootloader_module, new_bootloader_module, virtual_smoothie_env,
+):
+    assert hw_modules.update._has_old_bootloader(
+        old_bootloader_module._device_info['model'])
+    assert not hw_modules.update._has_old_bootloader(
+        new_bootloader_module._device_info['model'])
 
 
-# @pytest.mark.api1_only
-# async def test_old_bootloader_port_poll(
-#         virtual_smoothie_env, monkeypatch, modules):
+@pytest.mark.api2_only
+async def test_port_poll(virtual_smoothie_env, monkeypatch):
+    has_old_bootloader = False
+    timeout = 0.1
+    monkeypatch.setattr(hw_modules.update, 'PORT_SEARCH_TIMEOUT', timeout)
 
-#     # TODO: Will need to write separate tests for backcompat to ensure that
-#     # functionality for modules in v1 still works.
+    # Case 1: Bootloader port is successfully opened on the module
+    async def mock_discover_ports1():
+        return ['tty0_magdeck', 'tty1_bootloader']
+    monkeypatch.setattr(hw_modules.update,
+                        '_discover_ports', mock_discover_ports1)
 
-#     ports_before_switch = ['tty0_magdeck', 'tty1_tempdeck']
-#     has_old_bootloader = True
-#     timeout = 0.1
-#     monkeypatch.setattr(modules, 'PORT_SEARCH_TIMEOUT', timeout)
+    port_found = await asyncio.wait_for(
+        hw_modules.update._port_poll(has_old_bootloader, None),
+        hw_modules.update.PORT_SEARCH_TIMEOUT)
+    assert port_found == '/dev/modules/tty1_bootloader'
 
-#     # Case 1: Bootloader is opened on same port
-#     async def mock_discover_ports():
-#         return ['tty0_magdeck', 'tty1_tempdeck']
-#     monkeypatch.setattr(modules, '_discover_ports', mock_discover_ports)
+    # Case 2: Switching to bootloader mode failed
+    async def mock_discover_ports2():
+        return ['tty0_magdeck', 'tty1_tempdeck']
+    monkeypatch.setattr(hw_modules.update,
+                        '_discover_ports', mock_discover_ports2)
 
-#     with pytest.raises(asyncio.TimeoutError):
-#         port_found = await asyncio.wait_for(
-#             modules._port_poll(has_old_bootloader, ports_before_switch),
-#             modules.PORT_SEARCH_TIMEOUT)
-#         assert not port_found
+    with pytest.raises(asyncio.TimeoutError):
+        port_found = await asyncio.wait_for(
+            hw_modules.update._port_poll(has_old_bootloader, None),
+            hw_modules.update.PORT_SEARCH_TIMEOUT)
+        assert not port_found
 
-#     # Case 2: Bootloader is opened on a different port
-#     async def mock_discover_ports():
-#         return ['tty2_magdeck', 'tty1_tempdeck']
-#     monkeypatch.setattr(modules, '_discover_ports', mock_discover_ports)
 
-#     port_found = await asyncio.wait_for(
-#         modules._port_poll(has_old_bootloader, ports_before_switch),
-#         modules.PORT_SEARCH_TIMEOUT)
-#     assert port_found == '/dev/modules/tty2_magdeck'
+@pytest.mark.api2_only
+async def test_old_bootloader_port_poll(
+        virtual_smoothie_env, monkeypatch):
+
+    ports_before_switch = ['tty0_magdeck', 'tty1_tempdeck']
+    has_old_bootloader = True
+    timeout = 0.1
+    monkeypatch.setattr(hw_modules.update, 'PORT_SEARCH_TIMEOUT', timeout)
+
+    # Case 1: Bootloader is opened on same port
+    async def mock_discover_ports():
+        return ['tty0_magdeck', 'tty1_tempdeck']
+    monkeypatch.setattr(hw_modules.update,
+                        '_discover_ports', mock_discover_ports)
+
+    with pytest.raises(asyncio.TimeoutError):
+        port_found = await asyncio.wait_for(
+            hw_modules.update._port_poll(
+                has_old_bootloader, ports_before_switch),
+            hw_modules.update.PORT_SEARCH_TIMEOUT)
+        assert not port_found
+
+    # Case 2: Bootloader is opened on a different port
+    async def mock_discover_ports():
+        return ['tty2_magdeck', 'tty1_tempdeck']
+    monkeypatch.setattr(hw_modules.update,
+                        '_discover_ports', mock_discover_ports)
+
+    port_found = await asyncio.wait_for(
+        hw_modules.update._port_poll(has_old_bootloader, ports_before_switch),
+        hw_modules.update.PORT_SEARCH_TIMEOUT)
+    assert port_found == '/dev/modules/tty2_magdeck'

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -172,12 +172,12 @@ def dummy_attached_leg_modules():
 
 @pytest.mark.api2_only
 async def test_execute_module_command_v2(
-          dummy_discover_modules,
-          virtual_smoothie_env,
-          loop,
-          async_server,
-          async_client,
-          monkeypatch):
+        dummy_discover_modules,
+        virtual_smoothie_env,
+        loop,
+        async_server,
+        async_client,
+        monkeypatch):
     hw = async_server['com.opentrons.hardware']
 
     def dummy_get_attached_modules():
@@ -185,7 +185,7 @@ async def test_execute_module_command_v2(
 
     monkeypatch.setattr(hw, 'discover_modules', dummy_discover_modules)
 
-    resp = await async_client.post('/modules/dummySerial',
+    resp = await async_client.post('/modules/dummySerialMD',
                                    json={'command_type': 'deactivate'})
     body = await resp.json()
     assert resp.status == 200
@@ -195,12 +195,12 @@ async def test_execute_module_command_v2(
 
 @pytest.mark.api1_only
 async def test_execute_module_command_v1(
-          dummy_attached_leg_modules,
-          virtual_smoothie_env,
-          loop,
-          async_server,
-          async_client,
-          monkeypatch):
+        dummy_attached_leg_modules,
+        virtual_smoothie_env,
+        loop,
+        async_server,
+        async_client,
+        monkeypatch):
     hw = async_server['com.opentrons.hardware']
     monkeypatch.setattr(hw, '_attached_modules', dummy_attached_leg_modules)
 

--- a/api/tests/opentrons/server/test_update_endpoints.py
+++ b/api/tests/opentrons/server/test_update_endpoints.py
@@ -111,7 +111,6 @@ async def test_update_module_firmware(
         async_server):
 
     client = async_client
-    hw = async_server['com.opentrons.hardware']._api
     serial_num = 'dummySerialTC'
     fw_filename = 'dummyFirmware.hex'
     tmpdir = tempfile.mkdtemp("files")
@@ -161,7 +160,6 @@ async def test_fail_update_module_firmware(
         async_server):
 
     client = async_client
-    hw = async_server['com.opentrons.hardware']._api
     serial_num = 'dummySerialTC'
     fw_filename = 'dummyFirmware.hex'
     tmpdir = tempfile.mkdtemp("files")

--- a/api/tests/opentrons/server/test_update_endpoints.py
+++ b/api/tests/opentrons/server/test_update_endpoints.py
@@ -151,7 +151,7 @@ async def test_update_module_firmware(
 
     # ========= Happy path ==========
     res_msg = {'message': 'Firmware update successful',
-               'avrdudeResponse': '1234 bytes of flash verified',
+               'bootloaderResponse': '1234 bytes of flash verified',
                'filename': fw_filename}
 
     async def mock_successful_upload_to_module(
@@ -203,7 +203,7 @@ async def test_fail_update_module_firmware(
 
     # ========= Case 1: Port not accessible =========
     res_msg1 = {'message': 'Firmware update failed',
-                'avrdudeResponse': 'ser_open(): can\'t open device',
+                'bootloaderResponse': 'ser_open(): can\'t open device',
                 'filename': fw_filename}
 
     async def mock_failed_upload_to_module1(
@@ -224,7 +224,7 @@ async def test_fail_update_module_firmware(
 
     # ========= Case 2: Corrupted file =========
     res_msg2 = {'message': 'Firmware update failed',
-                'avrdudeResponse': 'checksum mismatch in line 1234',
+                'bootloaderResponse': 'checksum mismatch in line 1234',
                 'filename': fw_filename}
 
     async def mock_failed_upload_to_module2(

--- a/api/tests/opentrons/server/test_update_endpoints.py
+++ b/api/tests/opentrons/server/test_update_endpoints.py
@@ -134,7 +134,7 @@ async def test_update_module_firmware(
                'filename': fw_filename}
 
     async def mock_successful_upload_to_module(
-            port, firmware_file_path, bootloader_type, loop):
+            port, firmware_file_path, upload_function, loop):
         return True, res_msg['message']
 
     expected_res = res_msg
@@ -184,7 +184,7 @@ async def test_fail_update_module_firmware(
                 'filename': fw_filename}
 
     async def mock_failed_upload_to_module1(
-            port, firmware_file_path, bootloader_type, loop):
+            port, firmware_file_path, upload_function, loop):
         return ('mod1', (False, bootloader_error))
 
     expected_res1 = res_msg1
@@ -205,7 +205,7 @@ async def test_fail_update_module_firmware(
                      'filename': fw_filename}
 
     async def mock_failed_upload_to_module2(
-            port, firmware_file_path, bootloader_type, loop):
+            port, firmware_file_path, upload_function, loop):
         await asyncio.sleep(2)
 
     monkeypatch.setattr(hw_modules.update,

--- a/api/tests/opentrons/server/test_update_endpoints.py
+++ b/api/tests/opentrons/server/test_update_endpoints.py
@@ -8,6 +8,7 @@ from aiohttp import web
 from opentrons.server import init
 from opentrons.server.endpoints import update
 from opentrons.server.endpoints import serverlib_fallback
+from opentrons.hardware_control import modules
 
 
 async def test_restart(
@@ -46,7 +47,7 @@ async def test_update(
     async def mock_install(filename, loop=None, modeset=True):
         return msg
     monkeypatch.setattr(serverlib_fallback, '_install', mock_install)
-    monkeypatch.setattr(hw, 'update_firmware', mock_install)
+    monkeypatch.setattr(hw, 'upload_firmware', mock_install)
 
     cli = async_client
 
@@ -72,7 +73,7 @@ async def test_update(
 
 
 async def test_ignore_updates(
-        virtual_smoothie_env, loop, aiohttp_client, async_client):
+        virtual_smoothie_env, loop, async_client):
     tmpdir = tempfile.mkdtemp("files")
     ignore_name = "testy_ignore.json"
     serverlib_fallback.filepath = os.path.join(tmpdir, ignore_name)
@@ -100,54 +101,34 @@ async def test_ignore_updates(
     assert json.loads(r3body) == {'version': '3.1.3'}
 
 
-@pytest.mark.api1_only
-@pytest.fixture
-def dummy_attached_modules(modules):
-    temp_module = modules.TempDeck()
-    temp_port = 'tty1_tempdeck'
-    temp_serial = 'tdYYYYMMDD987'
-    temp_module._device_info = {'serial': temp_serial}
-    mag_module = modules.MagDeck()
-    mag_port = 'tty1_magdeck'
-    mag_serial = 'mdYYYYMMDD123'
-    mag_module._device_info = {'serial': mag_serial}
-    return {
-        temp_port + 'tempdeck': temp_module,
-        mag_port + 'magdeck': mag_module
-    }
-
-
-@pytest.mark.api1_only
+@pytest.mark.api2_only
+# @pytest.mark.parametrize('attached_modules', ['tempdeck', 'magdeck', 'thermocycler'])
 async def test_update_module_firmware(
-        dummy_attached_modules,
         virtual_smoothie_env,
         loop,
-        aiohttp_client,
         monkeypatch,
         async_client,
-        async_server,
-        modules):
+        async_server):
 
     client = async_client
     hw = async_server['com.opentrons.hardware']
-    if async_server['api_version'] == 2:
-        hw = hw._api
-    serial_num = 'mdYYYYMMDD123'
+    serial_num = 'dummySerialTC'
     fw_filename = 'dummyFirmware.hex'
     tmpdir = tempfile.mkdtemp("files")
 
     with open(os.path.join(tmpdir, fw_filename), 'wb') as fd:
         fd.write(bytes(0x1234))
 
-    def dummy_discover_modules():
-        return
+    @pytest.fixture
+    async def dummy_discover_modules():
+        pass
 
     async def mock_enter_bootloader(module):
         return '/dev/modules/tty0_bootloader'
 
-    monkeypatch.setattr(hw, 'discover_modules', dummy_discover_modules)
-    monkeypatch.setattr(hw, '_attached_modules', dummy_attached_modules)
-    monkeypatch.setattr(modules, 'enter_bootloader', mock_enter_bootloader)
+    monkeypatch.setattr(hw._api, 'discover_modules', dummy_discover_modules)
+    monkeypatch.setattr(modules.update, 'enter_bootloader',
+                        mock_enter_bootloader)
 
     # ========= Happy path ==========
     res_msg = {'message': 'Firmware update successful',
@@ -160,8 +141,8 @@ async def test_update_module_firmware(
 
     expected_res = res_msg
 
-    monkeypatch.setattr(modules,
-                        'update_firmware', mock_successful_upload_to_module)
+    monkeypatch.setattr(modules.update,
+                        'upload_firmware', mock_successful_upload_to_module)
     resp = await client.post(
         '/modules/{}/update'.format(serial_num),
         data={'module_firmware': open(os.path.join(tmpdir, fw_filename))})
@@ -171,26 +152,27 @@ async def test_update_module_firmware(
     assert res == expected_res
 
 
-@pytest.mark.api1_only
+@pytest.mark.api2_only
+# @pytest.mark.parametrize('attached_modules', ['tempdeck', 'magdeck', 'thermocycler'])
 async def test_fail_update_module_firmware(
-        dummy_attached_modules,
         virtual_smoothie_env,
         monkeypatch,
         async_client,
         async_server,
-        modules):
+        hardware_api):
 
     client = async_client
     hw = async_server['com.opentrons.hardware']
     if async_server['api_version'] == 2:
         hw = hw._api
-    serial_num = 'mdYYYYMMDD123'
+    serial_num = 'dummySerialMD'
     fw_filename = 'dummyFirmware.hex'
     tmpdir = tempfile.mkdtemp("files")
 
     with open(os.path.join(tmpdir, fw_filename), 'wb') as fd:
         fd.write(bytes(0x1234))
 
+    @pytest.fixture
     def dummy_discover_modules():
         return
 
@@ -198,8 +180,8 @@ async def test_fail_update_module_firmware(
         return '/dev/modules/tty0_bootloader'
 
     monkeypatch.setattr(hw, 'discover_modules', dummy_discover_modules)
-    monkeypatch.setattr(hw, '_attached_modules', dummy_attached_modules)
-    monkeypatch.setattr(modules, 'enter_bootloader', mock_enter_bootloader)
+    monkeypatch.setattr(modules.update, 'enter_bootloader',
+                        mock_enter_bootloader)
 
     # ========= Case 1: Port not accessible =========
     res_msg1 = {'message': 'Firmware update failed',
@@ -212,8 +194,8 @@ async def test_fail_update_module_firmware(
 
     expected_res1 = res_msg1
 
-    monkeypatch.setattr(modules,
-                        'update_firmware', mock_failed_upload_to_module1)
+    monkeypatch.setattr(modules.update,
+                        'upload_firmware', mock_failed_upload_to_module1)
     resp1 = await client.post(
         '/modules/{}/update'.format(serial_num),
         data={'module_firmware': open(os.path.join(tmpdir, fw_filename))})
@@ -233,8 +215,8 @@ async def test_fail_update_module_firmware(
 
     expected_res2 = res_msg2
 
-    monkeypatch.setattr(modules,
-                        'update_firmware', mock_failed_upload_to_module2)
+    monkeypatch.setattr(modules.update,
+                        'upload_firmware', mock_failed_upload_to_module2)
     resp2 = await client.post(
         '/modules/{}/update'.format(serial_num),
         data={'module_firmware': open(os.path.join(tmpdir, fw_filename))})
@@ -243,16 +225,16 @@ async def test_fail_update_module_firmware(
     j2 = await resp2.json()
     assert j2 == expected_res2
 
-    # ========= Case 3: AVRDUDE not responding =========
-    expected_res3 = {'message': 'AVRDUDE not responding',
+    # ========= Case 3: Bootloader not responding =========
+    expected_res3 = {'message': 'Bootloader not responding',
                      'filename': fw_filename}
 
     async def mock_failed_upload_to_module3(
             serialnum, fw_file, loop):
         await asyncio.sleep(2)
 
-    monkeypatch.setattr(modules,
-                        'update_firmware', mock_failed_upload_to_module3)
+    monkeypatch.setattr(modules.update,
+                        'upload_firmware', mock_failed_upload_to_module3)
     update.UPDATE_TIMEOUT = 0.1
 
     resp3 = await client.post(


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

Use bossac to upload firmware binaries to a connected thermocycler. Add logic to differentiate
module bootloader types and update accordingly.

Closes #3973

## changelog

  - fix up apiv2 firmware update endpoint to function proper
  - use `bossac` subprocess to upload received firmware to connected TC
  - bootloader_type class property
  - remove unused apiv1 module firmware update code
  - return prompt to update api server if attempting to update module via apiv1 


## review requests

 - [ ] make sure code looks sound
 - [ ] check apiv2 update of TD and MD functions
 - [ ] check apiv2 update of TC firmware functions
