### PR TITLE
feat(labware-library): add P20 tip rack image to library

### DIFF
--- a/labware-library/src/components/labware-ui/labware-images.js
+++ b/labware-library/src/components/labware-ui/labware-images.js
@@ -167,6 +167,9 @@ export default {
   opentrons_96_tiprack_10ul: [
     require('../../images/opentrons_96_tiprack_10ul_side_view.jpg'),
   ],
+  opentrons_96_tiprack_20ul: [
+    require('../../images/opentrons_96_tiprack_10ul_side_view.jpg'),
+  ],
   opentrons_96_tiprack_300ul: [
     require('../../images/opentrons_96_tiprack_300ul_side_view.jpg'),
   ],


### PR DESCRIPTION
## overview
We want to make sure the P20 tip rack definition (created in #3929) is added to the Labware Library so that users can use it with the P20 Gen2 pipettes. 

closes #3964
