### PR TITLE
refactor(protocol-designer): Add edit/remove modules in FilePage

### DIFF
--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -15,8 +15,10 @@ import i18n from '../localization'
 import { Portal } from './portals/MainPageModalPortal'
 import styles from './FilePage.css'
 import EditPipettesModal from './modals/EditPipettesModal'
+import { EditModulesCard } from './modules'
 import formStyles from '../components/forms/forms.css'
 import type { FileMetadataFields } from '../file-data'
+import type { ModulesForEditModulesCard } from '../step-forms'
 
 export type Props = {
   formValues: FileMetadataFields,
@@ -24,16 +26,25 @@ export type Props = {
   goToNextPage: () => mixed,
   saveFileMetadata: FileMetadataFields => mixed,
   swapPipettes: () => mixed,
+  modulesEnabled: ?boolean,
 }
 
-type State = { isEditPipetteModalOpen: boolean }
+type State = { isEditPipetteModalOpen: boolean, isEditModuleModalOpen: boolean }
 
 const DATE_ONLY_FORMAT = 'MMM DD, YYYY'
 const DATETIME_FORMAT = 'MMM DD, YYYY | h:mm A'
 
+const _mockModulesByType: ModulesForEditModulesCard = {
+  magdeck: {
+    moduleId: 'module1234',
+    slot: '1',
+    model: 'GEN1',
+  },
+}
+
 // TODO: Ian 2019-03-15 use i18n for labels
 class FilePage extends React.Component<Props, State> {
-  state = { isEditPipetteModalOpen: false }
+  state = { isEditPipetteModalOpen: false, isEditModuleModalOpen: false }
 
   openEditPipetteModal = () => this.setState({ isEditPipetteModalOpen: true })
   closeEditPipetteModal = () => this.setState({ isEditPipetteModalOpen: false })
@@ -156,6 +167,10 @@ class FilePage extends React.Component<Props, State> {
             </div>
           </div>
         </Card>
+
+        {this.props.modulesEnabled && (
+          <EditModulesCard modules={_mockModulesByType} />
+        )}
 
         <div className={styles.button_row}>
           <PrimaryButton

--- a/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import i18n from '../../../localization'
 import { CheckboxField, DropdownField, FormGroup } from '@opentrons/components'
+import { ModuleDiagram } from '../../modules'
 
 import styles from './FilePipettesModal.css'
 
@@ -13,12 +14,6 @@ type Props = {|
   onFieldChange: (type: ModuleType, value: boolean) => mixed,
 |}
 
-const MODULE_IMG_BY_NAME = {
-  magdeck: require('../../../images/modules/magdeck.jpg'),
-  tempdeck: require('../../../images/modules/tempdeck.jpg'),
-  thermocycler: require('../../../images/modules/thermocycler.jpg'),
-}
-
 export default function ModuleFields(props: Props) {
   const { onFieldChange, values } = props
   const modules = Object.keys(values)
@@ -29,9 +24,7 @@ export default function ModuleFields(props: Props) {
   return (
     <div className={styles.modules_row}>
       {modules.map((moduleType, i) => {
-        const label = i18n.t(
-          `modal.new_protocol.module_display_names.${moduleType}`
-        )
+        const label = i18n.t(`modules.module_display_names.${moduleType}`)
         return (
           <div className={styles.module_form_group} key={`${moduleType}`}>
             <CheckboxField
@@ -40,7 +33,7 @@ export default function ModuleFields(props: Props) {
               onChange={handleOnDeckChange(moduleType)}
               tabIndex={i}
             />
-            <img src={MODULE_IMG_BY_NAME[moduleType]} alt={`${moduleType}`} />
+            <ModuleDiagram type={moduleType} />
             {/*
               TODO (ka 2019-10-22): This field is disabled until Gen 2 Modules are available
               - Until then, 'GEN1' is hardcoded

--- a/protocol-designer/src/components/modules/EditModulesCard.js
+++ b/protocol-designer/src/components/modules/EditModulesCard.js
@@ -1,0 +1,33 @@
+// @flow
+import * as React from 'react'
+import { Card } from '@opentrons/components'
+import ModuleRow from './ModuleRow'
+import styles from './styles.css'
+
+import type { ModuleType } from '@opentrons/shared-data'
+import type { ModulesForEditModulesCard } from '../../step-forms'
+
+type Props = {
+  modules: ModulesForEditModulesCard,
+}
+
+const MODULE_TYPES: Array<ModuleType> = ['magdeck', 'tempdeck', 'thermocycler']
+
+export default function EditModulesCard(props: Props) {
+  const { modules } = props
+
+  return (
+    <Card title="Modules">
+      <div className={styles.modules_card_content}>
+        {MODULE_TYPES.map((type, i) => {
+          const moduleData = modules[type]
+          if (moduleData) {
+            return <ModuleRow {...moduleData} type={type} key={i} />
+          } else {
+            return <ModuleRow type={type} key={i} />
+          }
+        })}
+      </div>
+    </Card>
+  )
+}

--- a/protocol-designer/src/components/modules/ModuleDiagram.js
+++ b/protocol-designer/src/components/modules/ModuleDiagram.js
@@ -1,0 +1,25 @@
+// @flow
+import * as React from 'react'
+import styles from './styles.css'
+
+import type { ModuleType } from '@opentrons/shared-data'
+
+type Props = {
+  type: ModuleType,
+}
+
+const MODULE_IMG_BY_TYPE = {
+  magdeck: require('../../images/modules/magdeck.jpg'),
+  tempdeck: require('../../images/modules/tempdeck.jpg'),
+  thermocycler: require('../../images/modules/thermocycler.jpg'),
+}
+
+export default function ModuleDiagram(props: Props) {
+  return (
+    <img
+      className={styles.module_diagram}
+      src={MODULE_IMG_BY_TYPE[`${props.type}`]}
+      alt={`${props.type}`}
+    />
+  )
+}

--- a/protocol-designer/src/components/modules/ModuleRow.js
+++ b/protocol-designer/src/components/modules/ModuleRow.js
@@ -1,0 +1,54 @@
+// @flow
+import * as React from 'react'
+import i18n from '../../localization'
+
+import { LabeledValue, OutlineButton } from '@opentrons/components'
+import ModuleDiagram from './ModuleDiagram'
+import styles from './styles.css'
+
+import type { ModuleType } from '@opentrons/shared-data'
+
+type Props = {
+  moduleId?: string,
+  slot?: string, // TODO make this PD specific slot type with spans
+  model?: string,
+  type: ModuleType,
+}
+
+export default function ModuleRow(props: Props) {
+  const { type, moduleId, slot, model } = props
+  const addRemoveText = moduleId ? 'remove' : 'add'
+  return (
+    <div>
+      <h4 className={styles.row_title}>
+        {i18n.t(`modules.module_display_names.${type}`)}
+      </h4>
+      <div className={styles.module_row}>
+        <div className={styles.module_diagram_container}>
+          <ModuleDiagram type={type} />
+        </div>
+        <div className={styles.module_col}>
+          {model && <LabeledValue label="Model" value={model} />}
+        </div>
+        <div className={styles.module_col}>
+          {slot && <LabeledValue label="Slot" value={`Slot ${slot}`} />}
+        </div>
+        <div className={styles.modules_button_group}>
+          {/* TODO (ka 2019-10-23): Hide/Show based on anySlot FF when in place
+          onClick needs to set edit modal open + pass moduleId for deleting */}
+          {moduleId && (
+            <OutlineButton className={styles.module_button} disabled>
+              Edit
+            </OutlineButton>
+          )}
+
+          {/* TODO (ka 2019-10-23): onClick needs to set edit modal open
+          + pass moduleId for deleting */}
+          <OutlineButton className={styles.module_button}>
+            {addRemoveText}
+          </OutlineButton>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/protocol-designer/src/components/modules/index.js
+++ b/protocol-designer/src/components/modules/index.js
@@ -1,0 +1,4 @@
+// @flow
+export { default as ModuleDiagram } from './ModuleDiagram'
+export { default as EditModulesCard } from './EditModulesCard'
+export { default as ModuleRow } from './ModuleRow'

--- a/protocol-designer/src/components/modules/styles.css
+++ b/protocol-designer/src/components/modules/styles.css
@@ -1,0 +1,52 @@
+@import '@opentrons/components';
+
+:root {
+  --size-20p: 20%;
+}
+
+.module_diagram {
+  max-width: 6rem;
+  width: 100%;
+  height: auto;
+}
+
+.modules_card_content {
+  padding: 1rem;
+}
+
+.module_row {
+  display: flex;
+  justify-content: space-between;
+  flex-direction: row;
+  align-items: flex-start;
+  margin-bottom: 1rem;
+}
+
+.module_diagram_container {
+  margin-right: 2rem;
+}
+
+.module_col {
+  flex: 1 0 20%;
+  padding-top: 0.5rem; /* TODO remove padding above once images are cropped properly */
+}
+
+.row_title {
+  @apply --font-body-2-dark;
+
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: var(--fw-semibold);
+}
+
+.modules_button_group {
+  flex: 1 0 40%;
+  padding-top: 0.5rem; /* TODO remove padding above once images are cropped properly */
+  text-align: right;
+}
+
+.module_button {
+  display: inline-block;
+  width: 6.75rem;
+  margin-left: 1rem;
+}

--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -11,6 +11,7 @@ import { INITIAL_DECK_SETUP_STEP_ID } from '../constants'
 import type { InitialDeckSetup } from '../step-forms'
 import type { FileMetadataFields } from '../file-data'
 import { actions as navActions } from '../navigation'
+import { selectors as featureFlagSelectors } from '../feature-flags'
 
 type Props = React.ElementProps<typeof FilePage>
 
@@ -18,6 +19,7 @@ type SP = {|
   instruments: $PropertyType<Props, 'instruments'>,
   formValues: $PropertyType<Props, 'formValues'>,
   _initialDeckSetup: InitialDeckSetup,
+  modulesEnabled: ?boolean,
 |}
 
 const mapStateToProps = (state: BaseState): SP => {
@@ -25,6 +27,7 @@ const mapStateToProps = (state: BaseState): SP => {
     formValues: fileSelectors.getFileMetadata(state),
     instruments: stepFormSelectors.getPipettesForInstrumentGroup(state),
     _initialDeckSetup: stepFormSelectors.getInitialDeckSetup(state),
+    modulesEnabled: featureFlagSelectors.getEnableModules(state),
   }
 }
 

--- a/protocol-designer/src/localization/en/index.js
+++ b/protocol-designer/src/localization/en/index.js
@@ -9,6 +9,7 @@ import deck from './deck.json'
 import feature_flags from './feature_flags.json'
 import form from './form.json'
 import modal from './modal.json'
+import modules from './modules.json'
 import nav from './nav.json'
 import tooltip from './tooltip.json'
 import well_selection from './well_selection.json'
@@ -24,6 +25,7 @@ export default {
     feature_flags,
     form,
     modal,
+    modules,
     nav,
     tooltip,
     well_selection,

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -37,11 +37,6 @@
       "PROTOCOL_FILE": "Create New Protocol",
       "PROTOCOL_PIPETTES": "Pipette & Tip Setup",
       "PROTOCOL_MODULES": "Add Modules"
-    },
-    "module_display_names": {
-      "tempdeck": "Temperature",
-      "magdeck": "Magnetic",
-      "thermocycler": "Thermocycler"
     }
   },
   "well_order": {

--- a/protocol-designer/src/localization/en/modules.json
+++ b/protocol-designer/src/localization/en/modules.json
@@ -1,0 +1,7 @@
+{
+  "module_display_names": {
+    "tempdeck": "Temperature",
+    "magdeck": "Magnet",
+    "thermocycler": "Thermocycler"
+  }
+}

--- a/protocol-designer/src/step-forms/types.js
+++ b/protocol-designer/src/step-forms/types.js
@@ -42,6 +42,15 @@ export type FormModulesByType = {
   [type: ModuleType]: FormModule,
 }
 
+// ModulesForEditModulesCard:  {
+export type ModulesForEditModulesCard = {
+  [type: ModuleType]: {
+    moduleId: string,
+    slot: string, // TODO make this PD specific slot type with spans
+    model: string,
+  },
+}
+
 // =========== LABWARE ========
 
 export type NormalizedLabwareById = {


### PR DESCRIPTION
## overview

addresses #4133 by adding an initial `EditModulesCard` to the `FilePage`

This card renders based on hardcoded mockData until selectors are in place. Add/Edit buttons do not yet open an `EditModulesModal`. Calling it quits here since I refactored and added a few atomic components.

## changelog

- refactor(protocol-designer): Add edit/remove modules in FilePage
- refactor(protocol-designer): Add atomic presentational modules components
- refactor(protocol-designer): Move module-display-names in i18n to modules.json

## review requests

Standard review. 

Please see notes above about that this PR does and does not do.  A follow up PR will add the modal and openModal etc.

- [ ] EditModulesCard does not render of FilePage if modules FF is off
- [ ] Add/remove module data to `_mockModulesByType` in `protocol-designer/src/components/FilePage.js`. ModuleRows within card should update accordingly.
