### PR TITLE
feat(app): add robot restart alert for FF changes that require restart

### DIFF
--- a/app/src/analytics/selectors.js
+++ b/app/src/analytics/selectors.js
@@ -24,7 +24,8 @@ import {
   getRobotSystemType,
 } from '../shell'
 
-import { getRobotSettingsState, getPipettesState } from '../robot-api'
+import { getRobotSettings } from '../robot-settings'
+import { getPipettesState } from '../robot-api'
 
 import hash from './hash'
 
@@ -77,7 +78,7 @@ export function getRobotAnalyticsData(state: State): RobotAnalyticsData | null {
 
   if (robot) {
     const pipettes = getPipettesState(state, robot.name)
-    const settings = getRobotSettingsState(state, robot.name)
+    const settings = getRobotSettings(state, robot.name)
 
     return settings.reduce(
       (result, setting) => ({

--- a/app/src/components/RobotSettings/AdvancedSettingsCard.js
+++ b/app/src/components/RobotSettings/AdvancedSettingsCard.js
@@ -7,13 +7,10 @@ import { Link } from 'react-router-dom'
 import {
   fetchSettings,
   updateSetting,
-  clearRestartRequired,
   getRobotSettings,
-  getRobotRestartRequired,
 } from '../../robot-settings'
 
 import { CONNECTABLE } from '../../discovery'
-import { restartRobot } from '../../robot-admin'
 import { downloadLogs } from '../../shell/robot-logs/actions'
 import { getRobotLogsDownloading } from '../../shell/robot-logs/selectors'
 import { Portal } from '../portal'
@@ -53,22 +50,11 @@ const ROBOT_LOGS_OPTOUT_MESSAGE = (
   </>
 )
 
-const RESTART_REQUIRED_HEADING = 'Robot Restart Required'
-const RESTART_REQUIRED_MESSAGE = (
-  <p>
-    You must restart your robot for this setting change to take effect. Would
-    you like to restart now?
-  </p>
-)
-
 export default function AdvancedSettingsCard(props: Props) {
   const { robot, resetUrl } = props
   const { name, health, status } = robot
   const settings = useSelector<State, RobotSettings>(state =>
     getRobotSettings(state, name)
-  )
-  const restartRequired = useSelector<State, boolean>(state =>
-    getRobotRestartRequired(state, name)
   )
   const robotLogsDownloading = useSelector(getRobotLogsDownloading)
   const dispatch = useDispatch<Dispatch>()
@@ -80,9 +66,6 @@ export default function AdvancedSettingsCard(props: Props) {
   )
   const setLogOptout = (value: boolean) =>
     dispatch(updateSetting(robot, ROBOT_LOGS_OPTOUT_ID, value))
-
-  const clearRestartAlert = () => dispatch(clearRestartRequired(name))
-  const restart = () => dispatch(restartRobot(robot))
 
   React.useEffect(() => {
     dispatch(fetchSettings(robot))
@@ -137,20 +120,6 @@ export default function AdvancedSettingsCard(props: Props) {
             ]}
           >
             {ROBOT_LOGS_OPTOUT_MESSAGE}
-          </AlertModal>
-        </Portal>
-      )}
-      {restartRequired && (
-        <Portal>
-          <AlertModal
-            alertOverlay
-            heading={RESTART_REQUIRED_HEADING}
-            buttons={[
-              { children: 'Now now', onClick: () => clearRestartAlert() },
-              { children: 'Restart', onClick: restart },
-            ]}
-          >
-            {RESTART_REQUIRED_MESSAGE}
           </AlertModal>
         </Portal>
       )}

--- a/app/src/components/RobotSettings/RestartRequiredBanner.js
+++ b/app/src/components/RobotSettings/RestartRequiredBanner.js
@@ -1,0 +1,47 @@
+// @flow
+import * as React from 'react'
+import { useDispatch } from 'react-redux'
+import { AlertItem, OutlineButton } from '@opentrons/components'
+
+import { restartRobot } from '../../robot-admin'
+import styles from './styles.css'
+
+import type { Dispatch } from '../../types'
+import type { RobotHost } from '../../robot-api/types'
+
+export type RestartRequiredBannerProps = {|
+  robot: RobotHost,
+|}
+
+// TODO(mc, 2019-10-24): i18n
+const TITLE = 'Robot restart required'
+const MESSAGE =
+  'You must restart your robot for your settings changes to take effect'
+const RESTART_NOW = 'Restart Now'
+
+function RestartRequiredBanner(props: RestartRequiredBannerProps) {
+  const { robot } = props
+  const [dismissed, setDismissed] = React.useState(false)
+  const dispatch = useDispatch<Dispatch>()
+  const restart = React.useCallback(() => dispatch(restartRobot(robot)), [
+    dispatch,
+    robot,
+  ])
+
+  if (dismissed) return null
+
+  return (
+    <AlertItem
+      type="warning"
+      onCloseClick={() => setDismissed(true)}
+      title={TITLE}
+    >
+      <div className={styles.restart_banner_message}>
+        <p>{MESSAGE}</p>
+        <OutlineButton onClick={restart}>{RESTART_NOW}</OutlineButton>
+      </div>
+    </AlertItem>
+  )
+}
+
+export default RestartRequiredBanner

--- a/app/src/components/RobotSettings/styles.css
+++ b/app/src/components/RobotSettings/styles.css
@@ -85,3 +85,12 @@
   position: fixed;
   clip: rect(1px 1px 1px 1px);
 }
+
+.restart_banner_message {
+  display: flex;
+
+  & > p {
+    max-width: 24rem;
+    margin-right: auto;
+  }
+}

--- a/app/src/epic.js
+++ b/app/src/epic.js
@@ -6,6 +6,7 @@ import { analyticsEpic } from './analytics'
 import { discoveryEpic } from './discovery/epic'
 import { robotApiEpic } from './robot-api'
 import { robotAdminEpic } from './robot-admin/epic'
+import { robotSettingsEpic } from './robot-settings/epic'
 import { shellEpic } from './shell'
 
 export default combineEpics(
@@ -13,5 +14,6 @@ export default combineEpics(
   discoveryEpic,
   robotApiEpic,
   robotAdminEpic,
+  robotSettingsEpic,
   shellEpic
 )

--- a/app/src/pages/Calibrate/Labware.js
+++ b/app/src/pages/Calibrate/Labware.js
@@ -7,7 +7,7 @@ import { push } from 'connected-react-router'
 
 import { selectors as robotSelectors } from '../../robot'
 import { getConnectedRobot } from '../../discovery'
-import { getRobotSettingsState, type Module } from '../../robot-api'
+import { getRobotSettings } from '../../robot-settings'
 import { getUnpreparedModules } from '../../robot-api/resources/modules'
 
 import Page from '../../components/Page'
@@ -22,6 +22,7 @@ import type { ContextRouter } from 'react-router-dom'
 import type { State, Dispatch } from '../../types'
 import type { Labware } from '../../robot'
 import type { Robot } from '../../discovery'
+import type { Module } from '../../robot-api'
 
 type OP = ContextRouter
 
@@ -106,7 +107,7 @@ function mapStateToProps(state: State, ownProps: OP): SP {
   const hasModulesLeftToReview =
     modules.length > 0 && !robotSelectors.getModulesReviewed(state)
   const robot = getConnectedRobot(state)
-  const settings = robot && getRobotSettingsState(state, robot.name)
+  const settings = robot && getRobotSettings(state, robot.name)
 
   // TODO(mc, 2018-07-23): make diagram component a container
   const calToBottomFlag =

--- a/app/src/pages/Robots/RobotSettings.js
+++ b/app/src/pages/Robots/RobotSettings.js
@@ -18,6 +18,7 @@ import {
 
 import { makeGetRobotHome, clearHomeResponse } from '../../http-api-client'
 import { getRobotRestarting } from '../../robot-admin'
+import { getRobotRestartRequired } from '../../robot-settings'
 
 import { SpinnerModalPage } from '@opentrons/components'
 import { ErrorModal } from '../../components/modals'
@@ -29,6 +30,7 @@ import UpdateBuildroot from '../../components/RobotSettings/UpdateBuildroot'
 import CalibrateDeck from '../../components/CalibrateDeck'
 import ConnectBanner from '../../components/RobotSettings/ConnectBanner'
 import ReachableRobotBanner from '../../components/RobotSettings/ReachableRobotBanner'
+import RestartRequiredBanner from '../../components/RobotSettings/RestartRequiredBanner'
 import ResetRobotModal from '../../components/RobotSettings/ResetRobotModal'
 
 import type { ContextRouter } from 'react-router-dom'
@@ -48,6 +50,7 @@ type SP = {|
   homeInProgress: ?boolean,
   homeError: ?Error,
   updateInProgress: boolean,
+  restartRequired: boolean,
   restarting: boolean,
 |}
 
@@ -82,6 +85,7 @@ function RobotSettingsPage(props: Props) {
     closeConnectAlert,
     showUpdateModal,
     updateInProgress,
+    restartRequired,
     restarting,
     match: { path, url },
   } = props
@@ -102,6 +106,9 @@ function RobotSettingsPage(props: Props) {
         )}
         {robot.status === CONNECTABLE && (
           <ConnectBanner {...robot} key={Number(robot.connected)} />
+        )}
+        {restartRequired && !restarting && (
+          <RestartRequiredBanner robot={robot} />
         )}
 
         <RobotSettings
@@ -195,7 +202,6 @@ function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
     const buildrootUpdateType = getBuildrootUpdateAvailable(state, robot)
     const updateInProgress = getBuildrootUpdateInProgress(state, robot)
     const currentBrRobot = getBuildrootRobot(state)
-    const restarting = getRobotRestarting(state, robot.name)
 
     const showUpdateModal =
       updateInProgress ||
@@ -205,7 +211,8 @@ function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
 
     return {
       updateInProgress,
-      restarting,
+      restarting: getRobotRestarting(state, robot.name),
+      restartRequired: getRobotRestartRequired(state, robot.name),
       showUpdateModal: !!showUpdateModal,
       homeInProgress: homeRequest && homeRequest.inProgress,
       homeError: homeRequest && homeRequest.error,

--- a/app/src/reducer.js
+++ b/app/src/reducer.js
@@ -17,6 +17,9 @@ import { robotApiReducer } from './robot-api'
 // robot administration state
 import { robotAdminReducer } from './robot-admin/reducer'
 
+// robot settings state
+import { robotSettingsReducer } from './robot-settings/reducer'
+
 // app shell state
 import { shellReducer } from './shell'
 
@@ -42,6 +45,7 @@ const rootReducer: Reducer<State, Action> = combineReducers<_, Action>({
   api: apiReducer,
   robotApi: robotApiReducer,
   robotAdmin: robotAdminReducer,
+  robotSettings: robotSettingsReducer,
   config: configReducer,
   discovery: discoveryReducer,
   labware: customLabwareReducer,

--- a/app/src/robot-admin/actions.js
+++ b/app/src/robot-admin/actions.js
@@ -7,6 +7,6 @@ import type { RobotAdminAction } from './types'
 
 export const restartRobot = (host: RobotHost): RobotAdminAction => ({
   type: RESTART,
-  payload: { host, method: POST, path: RESTART_PATH },
+  payload: { host, path: RESTART_PATH, method: POST },
   meta: { robot: true },
 })

--- a/app/src/robot-api/resources/settings.js
+++ b/app/src/robot-api/resources/settings.js
@@ -10,7 +10,6 @@ import {
   createBaseRobotApiEpic,
   passRobotApiResponseAction,
   GET,
-  POST,
   PATCH,
 } from '../utils'
 
@@ -20,22 +19,14 @@ import type { State as AppState, Action, ActionLike, Epic } from '../../types'
 import type { RobotHost, RobotApiAction, RobotApiRequestState } from '../types'
 import type {
   SettingsState as State,
-  RobotSettings,
   PipetteSettings,
-  RobotSettingsFieldUpdate,
   PipetteSettingsUpdate,
 } from './types'
 
-const INITIAL_STATE: State = { robot: [], pipettesById: {} }
+const INITIAL_STATE: State = { pipettesById: {} }
 
-export const SETTINGS_PATH = '/settings'
 export const PIPETTE_SETTINGS_PATH = '/settings/pipettes'
 const makePipetteSettingsPath = (id: string) => `${PIPETTE_SETTINGS_PATH}/${id}`
-
-export const FETCH_SETTINGS: 'robotApi:FETCH_SETTINGS' =
-  'robotApi:FETCH_SETTINGS'
-
-export const SET_SETTINGS: 'robotApi:SET_SETTINGS' = 'robotApi:SET_SETTINGS'
 
 export const FETCH_PIPETTE_SETTINGS: 'robotApi:FETCH_PIPETTE_SETTINGS' =
   'robotApi:FETCH_PIPETTE_SETTINGS'
@@ -43,22 +34,9 @@ export const FETCH_PIPETTE_SETTINGS: 'robotApi:FETCH_PIPETTE_SETTINGS' =
 export const SET_PIPETTE_SETTINGS: 'robotApi:SET_PIPETTE_SETTINGS' =
   'robotApi:SET_PIPETTE_SETTINGS'
 
-export const fetchSettings = (host: RobotHost): RobotApiAction => ({
-  type: FETCH_SETTINGS,
-  payload: { host, method: GET, path: SETTINGS_PATH },
-})
-
 export const fetchPipetteSettings = (host: RobotHost): RobotApiAction => ({
   type: FETCH_PIPETTE_SETTINGS,
   payload: { host, method: GET, path: PIPETTE_SETTINGS_PATH },
-})
-
-export const setSettings = (
-  host: RobotHost,
-  body: RobotSettingsFieldUpdate
-): RobotApiAction => ({
-  type: SET_SETTINGS,
-  payload: { host, body, method: POST, path: SETTINGS_PATH },
 })
 
 export const setPipetteSettings = (
@@ -72,8 +50,6 @@ export const setPipetteSettings = (
   meta: { id },
 })
 
-const fetchSettingsEpic = createBaseRobotApiEpic(FETCH_SETTINGS)
-const setSettingsEpic = createBaseRobotApiEpic(SET_SETTINGS)
 const fetchPipetteSettingsEpic = createBaseRobotApiEpic(FETCH_PIPETTE_SETTINGS)
 const setPipetteSettingsEpic = createBaseRobotApiEpic(SET_PIPETTE_SETTINGS)
 
@@ -88,8 +64,6 @@ const fetchPipettesForSettingsEpic: Epic = action$ =>
   )
 
 export const settingsEpic = combineEpics(
-  fetchSettingsEpic,
-  setSettingsEpic,
   fetchPipetteSettingsEpic,
   setPipetteSettingsEpic,
   fetchPipettesForSettingsEpic
@@ -104,12 +78,6 @@ export function settingsReducer(
   if (resAction) {
     const { payload, meta } = resAction
     const { method, path, body } = payload
-
-    // grabs responses from GET /settings and POST /settings
-    // settings in body check is a guard against an old version of GET /settings
-    if (path === SETTINGS_PATH && 'settings' in body) {
-      return { ...state, robot: body.settings }
-    }
 
     // grabs responses from GET /settings/pipettes
     if (path === PIPETTE_SETTINGS_PATH) {
@@ -133,15 +101,6 @@ export function settingsReducer(
   }
 
   return state
-}
-
-export function getRobotSettingsState(
-  state: AppState,
-  robotName: string
-): RobotSettings {
-  const robotState = getRobotApiState(state, robotName)
-
-  return robotState?.resources.settings.robot || []
 }
 
 export function getPipetteSettingsState(

--- a/app/src/robot-api/resources/types.js
+++ b/app/src/robot-api/resources/types.js
@@ -97,27 +97,12 @@ export type MotorAxis = 'a' | 'b' | 'c' | 'x' | 'y' | 'z'
 
 // settings
 export type SettingsState = {|
-  robot: RobotSettings,
   pipettesById: {| [id: string]: PipetteSettings |},
 |}
-
-export type RobotSettings = Array<RobotSettingsField>
 
 export type PipetteSettings = {|
   info: {| name: ?string, model: ?string |},
   fields: PipetteSettingsFieldsMap,
-|}
-
-export type RobotSettingsField = {|
-  id: string,
-  title: string,
-  description: string,
-  value: boolean | null,
-|}
-
-export type RobotSettingsFieldUpdate = {|
-  id: $PropertyType<RobotSettingsField, 'id'>,
-  value: $PropertyType<RobotSettingsField, 'value'>,
 |}
 
 export type PipetteSettingsFieldsMap = {|

--- a/app/src/robot-api/types.js
+++ b/app/src/robot-api/types.js
@@ -10,7 +10,7 @@ export * from './resources/types'
 
 export type Method = 'GET' | 'POST' | 'PATCH' | 'DELETE'
 
-export type RequestMeta = { [string]: mixed }
+export type RequestMeta = $Shape<{| [string]: mixed |}>
 
 // api call + response types
 
@@ -53,9 +53,7 @@ export type RobotApiAction =
       meta: {| id: string |},
     |}
   | {| type: 'robotApi:FETCH_PIPETTES', payload: RobotApiRequest |}
-  | {| type: 'robotApi:FETCH_SETTINGS', payload: RobotApiRequest |}
   | {| type: 'robotApi:FETCH_PIPETTE_SETTINGS', payload: RobotApiRequest |}
-  | {| type: 'robotApi:SET_SETTINGS', payload: RobotApiRequest |}
   | {|
       type: 'robotApi:SET_PIPETTE_SETTINGS',
       payload: RobotApiRequest,

--- a/app/src/robot-settings/__tests__/actions.test.js
+++ b/app/src/robot-settings/__tests__/actions.test.js
@@ -1,0 +1,59 @@
+// @flow
+
+import * as Actions from '../actions'
+
+import type { RobotSettingsAction } from '../types'
+
+type ActionSpec = {|
+  name: string,
+  creator: (...Array<any>) => mixed,
+  args: Array<mixed>,
+  expected: RobotSettingsAction,
+|}
+
+describe('robot settings actions', () => {
+  const SPECS: Array<ActionSpec> = [
+    {
+      name: 'robotSettings:FETCH_SETTINGS',
+      creator: Actions.fetchSettings,
+      args: [{ name: 'robotName', ip: 'localhost', port: 31950 }],
+      expected: {
+        type: 'robotSettings:FETCH_SETTINGS',
+        payload: {
+          host: { name: 'robotName', ip: 'localhost', port: 31950 },
+          method: 'GET',
+          path: '/settings',
+        },
+      },
+    },
+    {
+      name: 'robotSettings:UPDATE_SETTING',
+      creator: Actions.updateSetting,
+      args: [{ name: 'robotName', ip: 'localhost', port: 31950 }, 'foo', true],
+      expected: {
+        type: 'robotSettings:UPDATE_SETTING',
+        meta: { settingId: 'foo' },
+        payload: {
+          host: { name: 'robotName', ip: 'localhost', port: 31950 },
+          method: 'POST',
+          path: '/settings',
+          body: { id: 'foo', value: true },
+        },
+      },
+    },
+    {
+      name: 'robotSettings:CLEAR_RESTART_REQUIRED',
+      creator: Actions.clearRestartRequired,
+      args: ['robotName'],
+      expected: {
+        type: 'robotSettings:CLEAR_RESTART_REQUIRED',
+        payload: { robotName: 'robotName' },
+      },
+    },
+  ]
+
+  SPECS.forEach(spec => {
+    const { name, creator, args, expected } = spec
+    test(name, () => expect(creator(...args)).toEqual(expected))
+  })
+})

--- a/app/src/robot-settings/__tests__/actions.test.js
+++ b/app/src/robot-settings/__tests__/actions.test.js
@@ -11,43 +11,31 @@ type ActionSpec = {|
   expected: RobotSettingsAction,
 |}
 
+const mockRobot = { name: 'robotName', ip: 'localhost', port: 31950 }
+
 describe('robot settings actions', () => {
   const SPECS: Array<ActionSpec> = [
     {
       name: 'robotSettings:FETCH_SETTINGS',
       creator: Actions.fetchSettings,
-      args: [{ name: 'robotName', ip: 'localhost', port: 31950 }],
+      args: [mockRobot],
       expected: {
         type: 'robotSettings:FETCH_SETTINGS',
-        payload: {
-          host: { name: 'robotName', ip: 'localhost', port: 31950 },
-          method: 'GET',
-          path: '/settings',
-        },
+        payload: { host: mockRobot, method: 'GET', path: '/settings' },
       },
     },
     {
       name: 'robotSettings:UPDATE_SETTING',
       creator: Actions.updateSetting,
-      args: [{ name: 'robotName', ip: 'localhost', port: 31950 }, 'foo', true],
+      args: [mockRobot, 'foo', true],
       expected: {
         type: 'robotSettings:UPDATE_SETTING',
-        meta: { settingId: 'foo' },
         payload: {
-          host: { name: 'robotName', ip: 'localhost', port: 31950 },
+          host: mockRobot,
           method: 'POST',
           path: '/settings',
           body: { id: 'foo', value: true },
         },
-      },
-    },
-    {
-      name: 'robotSettings:CLEAR_RESTART_REQUIRED',
-      creator: Actions.clearRestartRequired,
-      args: ['robotName'],
-      expected: {
-        type: 'robotSettings:CLEAR_RESTART_REQUIRED',
-        payload: { robotName: 'robotName' },
       },
     },
   ]

--- a/app/src/robot-settings/__tests__/epics.test.js
+++ b/app/src/robot-settings/__tests__/epics.test.js
@@ -1,0 +1,78 @@
+// @flow
+import { TestScheduler } from 'rxjs/testing'
+
+import * as ApiUtils from '../../robot-api/utils'
+import * as Actions from '../actions'
+import { robotSettingsEpic } from '../epic'
+
+import type { RobotApiRequest, RequestMeta } from '../../robot-api/types'
+
+jest.mock('../../robot-api/utils')
+
+const mockMakeApiRequest: JestMockFn<[RobotApiRequest, RequestMeta], mixed> =
+  ApiUtils.makeRobotApiRequest
+
+const mockRobot = { name: 'robot', ip: '127.0.0.1', port: 31950 }
+
+const setupMockMakeApiRequest = cold => {
+  mockMakeApiRequest.mockImplementation((req, meta) =>
+    cold('-a', { a: { req, meta } })
+  )
+}
+
+describe('robotSettingsEpic', () => {
+  let testScheduler
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  test('makes GET /settings request on FETCH_SETTINGS', () => {
+    const action = Actions.fetchSettings(mockRobot)
+
+    testScheduler.run(({ hot, cold, expectObservable }) => {
+      setupMockMakeApiRequest(cold)
+
+      const action$ = hot('-a', { a: action })
+      const state$: any = null
+      const output$ = robotSettingsEpic(action$, state$)
+
+      expectObservable(output$).toBe('--a', {
+        a: {
+          req: { host: mockRobot, method: 'GET', path: '/settings' },
+          meta: {},
+        },
+      })
+    })
+  })
+
+  test('makes POST /settings request on UPDATE_SETTING', () => {
+    const action = Actions.updateSetting(mockRobot, 'settingId', true)
+
+    testScheduler.run(({ hot, cold, expectObservable }) => {
+      setupMockMakeApiRequest(cold)
+
+      const action$ = hot('-a', { a: action })
+      const state$: any = null
+      const output$ = robotSettingsEpic(action$, state$)
+
+      expectObservable(output$).toBe('--a', {
+        a: {
+          req: {
+            host: mockRobot,
+            method: 'POST',
+            path: '/settings',
+            body: { id: 'settingId', value: true },
+          },
+          meta: { settingId: 'settingId' },
+        },
+      })
+    })
+  })
+})

--- a/app/src/robot-settings/__tests__/epics.test.js
+++ b/app/src/robot-settings/__tests__/epics.test.js
@@ -70,7 +70,7 @@ describe('robotSettingsEpic', () => {
             path: '/settings',
             body: { id: 'settingId', value: true },
           },
-          meta: { settingId: 'settingId' },
+          meta: {},
         },
       })
     })

--- a/app/src/robot-settings/__tests__/reducer.test.js
+++ b/app/src/robot-settings/__tests__/reducer.test.js
@@ -38,12 +38,12 @@ describe('robotSettingsReducer', () => {
             { id: 'foo', title: 'Foo', description: 'foobar', value: true },
             { id: 'bar', title: 'Bar', description: 'bazqux', value: false },
           ],
-          restartRequired: false,
+          restartPath: null,
         },
       },
     },
     {
-      name: 'handles subsequent robotApi:RESPONSE for GET /settings',
+      name: 'handles robotApi:RESPONSE for GET /settings with restart required',
       action: {
         type: 'robotApi:RESPONSE__GET__/settings',
         meta: {},
@@ -55,6 +55,7 @@ describe('robotSettingsReducer', () => {
             settings: [
               { id: 'foo', title: 'Foo', description: 'foobar', value: true },
             ],
+            links: { restart: '/server/restart' },
           },
         },
       },
@@ -64,7 +65,7 @@ describe('robotSettingsReducer', () => {
             { id: 'foo', title: 'Foo', description: 'foobar', value: true },
             { id: 'bar', title: 'Bar', description: 'bazqux', value: false },
           ],
-          restartRequired: true,
+          restartPath: null,
         },
       },
       expected: {
@@ -72,7 +73,7 @@ describe('robotSettingsReducer', () => {
           settings: [
             { id: 'foo', title: 'Foo', description: 'foobar', value: true },
           ],
-          restartRequired: true,
+          restartPath: '/server/restart',
         },
       },
     },
@@ -96,7 +97,7 @@ describe('robotSettingsReducer', () => {
       state: {
         robotName: {
           settings: [],
-          restartRequired: false,
+          restartPath: null,
         },
       },
       expected: {
@@ -105,43 +106,7 @@ describe('robotSettingsReducer', () => {
             { id: 'foo', title: 'Foo', description: 'foobar', value: true },
             { id: 'bar', title: 'Bar', description: 'bazqux', value: false },
           ],
-          restartRequired: false,
-        },
-      },
-    },
-    {
-      name: 'handles robotApi:RESPONSE for POST /settings',
-      action: {
-        type: 'robotApi:RESPONSE__POST__/settings',
-        meta: { settingId: 'bar' },
-        payload: {
-          host: { name: 'robotName' },
-          method: 'POST',
-          path: '/settings',
-          body: {
-            settings: [
-              { id: 'foo', title: 'Foo', description: 'foobar', value: true },
-              { id: 'bar', title: 'Bar', description: 'bazqux', value: true },
-            ],
-          },
-        },
-      },
-      state: {
-        robotName: {
-          settings: [
-            { id: 'foo', title: 'Foo', description: 'foobar', value: true },
-            { id: 'bar', title: 'Bar', description: 'bazqux', value: false },
-          ],
-          restartRequired: false,
-        },
-      },
-      expected: {
-        robotName: {
-          settings: [
-            { id: 'foo', title: 'Foo', description: 'foobar', value: true },
-            { id: 'bar', title: 'Bar', description: 'bazqux', value: true },
-          ],
-          restartRequired: false,
+          restartPath: null,
         },
       },
     },
@@ -165,6 +130,7 @@ describe('robotSettingsReducer', () => {
                 restart_required: true,
               },
             ],
+            links: { restart: '/server/restart' },
           },
         },
       },
@@ -179,7 +145,7 @@ describe('robotSettingsReducer', () => {
               restart_required: true,
             },
           ],
-          restartRequired: false,
+          restartPath: null,
         },
       },
       expected: {
@@ -193,28 +159,9 @@ describe('robotSettingsReducer', () => {
               restart_required: true,
             },
           ],
-          restartRequired: true,
+          restartPath: '/server/restart',
         },
       },
-    },
-    {
-      name: 'handles CLEAR_RESTART_REQUIRED',
-      action: {
-        type: 'robotSettings:CLEAR_RESTART_REQUIRED',
-        payload: { robotName: 'robotName' },
-      },
-      state: { robotName: { settings: [], restartRequired: true } },
-      expected: { robotName: { settings: [], restartRequired: false } },
-    },
-    {
-      name: 'handles robotAdmin:RESTART',
-      action: {
-        type: 'robotAdmin:RESTART',
-        meta: { robot: true },
-        payload: { host: { name: 'robotName', ip: 'localhost', port: 31950 } },
-      },
-      state: { robotName: { settings: [], restartRequired: true } },
-      expected: { robotName: { settings: [], restartRequired: false } },
     },
   ]
 

--- a/app/src/robot-settings/__tests__/reducer.test.js
+++ b/app/src/robot-settings/__tests__/reducer.test.js
@@ -1,0 +1,228 @@
+// @flow
+
+import { robotSettingsReducer } from '../reducer'
+
+import type { Action, ActionLike } from '../../types'
+import type { RobotSettingsState } from '../types'
+
+type ReducerSpec = {|
+  name: string,
+  action: Action | ActionLike,
+  state: RobotSettingsState,
+  expected: RobotSettingsState,
+|}
+
+describe('robotSettingsReducer', () => {
+  const SPECS: Array<ReducerSpec> = [
+    {
+      name: 'handles initial robotApi:RESPONSE for GET /settings',
+      action: {
+        type: 'robotApi:RESPONSE__GET__/settings',
+        meta: {},
+        payload: {
+          host: { name: 'robotName' },
+          method: 'GET',
+          path: '/settings',
+          body: {
+            settings: [
+              { id: 'foo', title: 'Foo', description: 'foobar', value: true },
+              { id: 'bar', title: 'Bar', description: 'bazqux', value: false },
+            ],
+          },
+        },
+      },
+      state: {},
+      expected: {
+        robotName: {
+          settings: [
+            { id: 'foo', title: 'Foo', description: 'foobar', value: true },
+            { id: 'bar', title: 'Bar', description: 'bazqux', value: false },
+          ],
+          restartRequired: false,
+        },
+      },
+    },
+    {
+      name: 'handles subsequent robotApi:RESPONSE for GET /settings',
+      action: {
+        type: 'robotApi:RESPONSE__GET__/settings',
+        meta: {},
+        payload: {
+          host: { name: 'robotName' },
+          method: 'GET',
+          path: '/settings',
+          body: {
+            settings: [
+              { id: 'foo', title: 'Foo', description: 'foobar', value: true },
+            ],
+          },
+        },
+      },
+      state: {
+        robotName: {
+          settings: [
+            { id: 'foo', title: 'Foo', description: 'foobar', value: true },
+            { id: 'bar', title: 'Bar', description: 'bazqux', value: false },
+          ],
+          restartRequired: true,
+        },
+      },
+      expected: {
+        robotName: {
+          settings: [
+            { id: 'foo', title: 'Foo', description: 'foobar', value: true },
+          ],
+          restartRequired: true,
+        },
+      },
+    },
+    {
+      name: 'handles robotApi:RESPONSE for POST /settings',
+      action: {
+        type: 'robotApi:RESPONSE__POST__/settings',
+        meta: {},
+        payload: {
+          host: { name: 'robotName' },
+          method: 'POST',
+          path: '/settings',
+          body: {
+            settings: [
+              { id: 'foo', title: 'Foo', description: 'foobar', value: true },
+              { id: 'bar', title: 'Bar', description: 'bazqux', value: false },
+            ],
+          },
+        },
+      },
+      state: {
+        robotName: {
+          settings: [],
+          restartRequired: false,
+        },
+      },
+      expected: {
+        robotName: {
+          settings: [
+            { id: 'foo', title: 'Foo', description: 'foobar', value: true },
+            { id: 'bar', title: 'Bar', description: 'bazqux', value: false },
+          ],
+          restartRequired: false,
+        },
+      },
+    },
+    {
+      name: 'handles robotApi:RESPONSE for POST /settings',
+      action: {
+        type: 'robotApi:RESPONSE__POST__/settings',
+        meta: { settingId: 'bar' },
+        payload: {
+          host: { name: 'robotName' },
+          method: 'POST',
+          path: '/settings',
+          body: {
+            settings: [
+              { id: 'foo', title: 'Foo', description: 'foobar', value: true },
+              { id: 'bar', title: 'Bar', description: 'bazqux', value: true },
+            ],
+          },
+        },
+      },
+      state: {
+        robotName: {
+          settings: [
+            { id: 'foo', title: 'Foo', description: 'foobar', value: true },
+            { id: 'bar', title: 'Bar', description: 'bazqux', value: false },
+          ],
+          restartRequired: false,
+        },
+      },
+      expected: {
+        robotName: {
+          settings: [
+            { id: 'foo', title: 'Foo', description: 'foobar', value: true },
+            { id: 'bar', title: 'Bar', description: 'bazqux', value: true },
+          ],
+          restartRequired: false,
+        },
+      },
+    },
+    {
+      name:
+        'handles robotApi:RESPONSE for POST /settings where restart is required',
+      action: {
+        type: 'robotApi:RESPONSE__POST__/settings',
+        meta: { settingId: 'baz' },
+        payload: {
+          host: { name: 'robotName' },
+          method: 'POST',
+          path: '/settings',
+          body: {
+            settings: [
+              {
+                id: 'baz',
+                title: 'Baz',
+                description: 'bazqux',
+                value: true,
+                restart_required: true,
+              },
+            ],
+          },
+        },
+      },
+      state: {
+        robotName: {
+          settings: [
+            {
+              id: 'baz',
+              title: 'Baz',
+              description: 'bazqux',
+              value: false,
+              restart_required: true,
+            },
+          ],
+          restartRequired: false,
+        },
+      },
+      expected: {
+        robotName: {
+          settings: [
+            {
+              id: 'baz',
+              title: 'Baz',
+              description: 'bazqux',
+              value: true,
+              restart_required: true,
+            },
+          ],
+          restartRequired: true,
+        },
+      },
+    },
+    {
+      name: 'handles CLEAR_RESTART_REQUIRED',
+      action: {
+        type: 'robotSettings:CLEAR_RESTART_REQUIRED',
+        payload: { robotName: 'robotName' },
+      },
+      state: { robotName: { settings: [], restartRequired: true } },
+      expected: { robotName: { settings: [], restartRequired: false } },
+    },
+    {
+      name: 'handles robotAdmin:RESTART',
+      action: {
+        type: 'robotAdmin:RESTART',
+        meta: { robot: true },
+        payload: { host: { name: 'robotName', ip: 'localhost', port: 31950 } },
+      },
+      state: { robotName: { settings: [], restartRequired: true } },
+      expected: { robotName: { settings: [], restartRequired: false } },
+    },
+  ]
+
+  SPECS.forEach(spec => {
+    const { name, action, state, expected } = spec
+
+    test(name, () => {
+      expect(robotSettingsReducer(state, action)).toEqual(expected)
+    })
+  })
+})

--- a/app/src/robot-settings/__tests__/selectors.test.js
+++ b/app/src/robot-settings/__tests__/selectors.test.js
@@ -1,0 +1,55 @@
+// @flow
+import * as Selectors from '../selectors'
+import type { State } from '../../types'
+
+type SelectorSpec = {|
+  name: string,
+  selector: ($Shape<State>, ...Array<any>) => mixed,
+  state: $Shape<State>,
+  args?: Array<any>,
+  expected: mixed,
+|}
+
+describe('robot settings selectors', () => {
+  const SPECS: Array<SelectorSpec> = [
+    {
+      name: 'getRobotSettings',
+      selector: Selectors.getRobotSettings,
+      state: {
+        robotSettings: {
+          robotName: {
+            restartRequired: false,
+            settings: [
+              { id: 'foo', title: 'Foo', description: 'Foo', value: true },
+            ],
+          },
+        },
+      },
+      args: ['robotName'],
+      expected: [{ id: 'foo', title: 'Foo', description: 'Foo', value: true }],
+    },
+    {
+      name: 'getRobotRestartRequired',
+      selector: Selectors.getRobotRestartRequired,
+      state: {
+        robotSettings: {
+          robotName: {
+            restartRequired: true,
+            settings: [],
+          },
+        },
+      },
+      args: ['robotName'],
+      expected: true,
+    },
+  ]
+
+  SPECS.forEach(spec => {
+    const { name, selector, state, args = [], expected } = spec
+
+    test(name, () => {
+      const result = selector(state, ...args)
+      expect(result).toEqual(expected)
+    })
+  })
+})

--- a/app/src/robot-settings/__tests__/selectors.test.js
+++ b/app/src/robot-settings/__tests__/selectors.test.js
@@ -18,7 +18,7 @@ describe('robot settings selectors', () => {
       state: {
         robotSettings: {
           robotName: {
-            restartRequired: false,
+            restartPath: null,
             settings: [
               { id: 'foo', title: 'Foo', description: 'Foo', value: true },
             ],
@@ -29,18 +29,31 @@ describe('robot settings selectors', () => {
       expected: [{ id: 'foo', title: 'Foo', description: 'Foo', value: true }],
     },
     {
-      name: 'getRobotRestartRequired',
+      name: 'getRobotRestartPath',
+      selector: Selectors.getRobotRestartPath,
+      state: {
+        robotSettings: { robotName: { restartPath: '/restart', settings: [] } },
+      },
+      args: ['robotName'],
+      expected: '/restart',
+    },
+    {
+      name: 'getRobotRestartRequired when required',
       selector: Selectors.getRobotRestartRequired,
       state: {
-        robotSettings: {
-          robotName: {
-            restartRequired: true,
-            settings: [],
-          },
-        },
+        robotSettings: { robotName: { restartPath: '/restart', settings: [] } },
       },
       args: ['robotName'],
       expected: true,
+    },
+    {
+      name: 'getRobotRestartRequired when not required',
+      selector: Selectors.getRobotRestartRequired,
+      state: {
+        robotSettings: { robotName: { restartPath: null, settings: [] } },
+      },
+      args: ['robotName'],
+      expected: false,
     },
   ]
 

--- a/app/src/robot-settings/actions.js
+++ b/app/src/robot-settings/actions.js
@@ -1,0 +1,39 @@
+// @flow
+import { GET, POST } from '../robot-api/utils'
+
+import {
+  FETCH_SETTINGS,
+  UPDATE_SETTING,
+  CLEAR_RESTART_REQUIRED,
+  SETTINGS_PATH,
+} from './constants'
+
+import type { RobotHost } from '../robot-api/types'
+import type { RobotSettingsAction } from './types'
+
+export const fetchSettings = (host: RobotHost): RobotSettingsAction => ({
+  type: FETCH_SETTINGS,
+  payload: { host, method: GET, path: SETTINGS_PATH },
+})
+
+export const updateSetting = (
+  host: RobotHost,
+  settingId: string,
+  value: boolean | null
+): RobotSettingsAction => ({
+  type: UPDATE_SETTING,
+  meta: { settingId },
+  payload: {
+    host,
+    method: POST,
+    path: SETTINGS_PATH,
+    body: { id: settingId, value },
+  },
+})
+
+export const clearRestartRequired = (
+  robotName: string
+): RobotSettingsAction => ({
+  type: CLEAR_RESTART_REQUIRED,
+  payload: { robotName },
+})

--- a/app/src/robot-settings/actions.js
+++ b/app/src/robot-settings/actions.js
@@ -1,12 +1,7 @@
 // @flow
 import { GET, POST } from '../robot-api/utils'
 
-import {
-  FETCH_SETTINGS,
-  UPDATE_SETTING,
-  CLEAR_RESTART_REQUIRED,
-  SETTINGS_PATH,
-} from './constants'
+import { FETCH_SETTINGS, UPDATE_SETTING, SETTINGS_PATH } from './constants'
 
 import type { RobotHost } from '../robot-api/types'
 import type { RobotSettingsAction } from './types'
@@ -22,18 +17,10 @@ export const updateSetting = (
   value: boolean | null
 ): RobotSettingsAction => ({
   type: UPDATE_SETTING,
-  meta: { settingId },
   payload: {
     host,
     method: POST,
     path: SETTINGS_PATH,
     body: { id: settingId, value },
   },
-})
-
-export const clearRestartRequired = (
-  robotName: string
-): RobotSettingsAction => ({
-  type: CLEAR_RESTART_REQUIRED,
-  payload: { robotName },
 })

--- a/app/src/robot-settings/constants.js
+++ b/app/src/robot-settings/constants.js
@@ -1,0 +1,12 @@
+// @flow
+
+export const SETTINGS_PATH: '/settings' = '/settings'
+
+export const FETCH_SETTINGS: 'robotSettings:FETCH_SETTINGS' =
+  'robotSettings:FETCH_SETTINGS'
+
+export const UPDATE_SETTING: 'robotSettings:UPDATE_SETTING' =
+  'robotSettings:UPDATE_SETTING'
+
+export const CLEAR_RESTART_REQUIRED: 'robotSettings:CLEAR_RESTART_REQUIRED' =
+  'robotSettings:CLEAR_RESTART_REQUIRED'

--- a/app/src/robot-settings/constants.js
+++ b/app/src/robot-settings/constants.js
@@ -8,5 +8,5 @@ export const FETCH_SETTINGS: 'robotSettings:FETCH_SETTINGS' =
 export const UPDATE_SETTING: 'robotSettings:UPDATE_SETTING' =
   'robotSettings:UPDATE_SETTING'
 
-export const CLEAR_RESTART_REQUIRED: 'robotSettings:CLEAR_RESTART_REQUIRED' =
-  'robotSettings:CLEAR_RESTART_REQUIRED'
+export const APPLY_WITH_RESTART: 'robotSettings:APPLY_WITH_RESTART' =
+  'robotSettings:APPLY_WITH_RESTART'

--- a/app/src/robot-settings/epic.js
+++ b/app/src/robot-settings/epic.js
@@ -1,0 +1,19 @@
+// @flow
+import { ofType } from 'redux-observable'
+import { switchMap } from 'rxjs/operators'
+import { makeRobotApiRequest } from '../robot-api/utils'
+import { FETCH_SETTINGS, UPDATE_SETTING } from './constants'
+
+import type { Epic } from '../types'
+import type { RequestMeta } from '../robot-api/types'
+import type { RobotSettingsApiAction } from './types'
+
+export const robotSettingsEpic: Epic = action$ => {
+  return action$.pipe(
+    ofType(FETCH_SETTINGS, UPDATE_SETTING),
+    switchMap<RobotSettingsApiAction, _, _>(a => {
+      const meta: RequestMeta = a.meta || {}
+      return makeRobotApiRequest(a.payload, meta)
+    })
+  )
+}

--- a/app/src/robot-settings/epic.js
+++ b/app/src/robot-settings/epic.js
@@ -5,15 +5,13 @@ import { makeRobotApiRequest } from '../robot-api/utils'
 import { FETCH_SETTINGS, UPDATE_SETTING } from './constants'
 
 import type { Epic } from '../types'
-import type { RequestMeta } from '../robot-api/types'
-import type { RobotSettingsApiAction } from './types'
+import type { RobotSettingsAction } from './types'
 
 export const robotSettingsEpic: Epic = action$ => {
   return action$.pipe(
     ofType(FETCH_SETTINGS, UPDATE_SETTING),
-    switchMap<RobotSettingsApiAction, _, _>(a => {
-      const meta: RequestMeta = a.meta || {}
-      return makeRobotApiRequest(a.payload, meta)
+    switchMap<RobotSettingsAction, _, _>(a => {
+      return makeRobotApiRequest(a.payload, {})
     })
   )
 }

--- a/app/src/robot-settings/index.js
+++ b/app/src/robot-settings/index.js
@@ -1,0 +1,5 @@
+// @flow
+// robot settings actions, constants, selectors re-exports for convenience
+export * from './actions'
+export * from './constants'
+export * from './selectors'

--- a/app/src/robot-settings/reducer.js
+++ b/app/src/robot-settings/reducer.js
@@ -1,0 +1,61 @@
+// @flow
+import { passRobotApiResponseAction, POST } from '../robot-api/utils'
+import { RESTART } from '../robot-admin'
+import { CLEAR_RESTART_REQUIRED, SETTINGS_PATH } from './constants'
+
+import type { Action, ActionLike } from '../types'
+import type { RobotSettings, RobotSettingsState } from './types'
+
+export const INITIAL_STATE: RobotSettingsState = {}
+
+export function robotSettingsReducer(
+  state: RobotSettingsState = INITIAL_STATE,
+  action: Action | ActionLike
+): RobotSettingsState {
+  const resAction = passRobotApiResponseAction(action)
+
+  if (resAction) {
+    const { payload, meta } = resAction
+    const { host, method, path, body } = payload
+    const { name: robotName } = host
+
+    // grabs responses from GET /settings and POST /settings
+    // settings in body check is a guard against an old version of GET /settings
+    if (path === SETTINGS_PATH && 'settings' in body) {
+      const robotState = state[robotName]
+      const settings: RobotSettings = body.settings
+      // restart is required if the setting we just updated (meta.settingId)
+      // is a restart_required setting, or if restart was already required
+      const restartRequired =
+        Boolean(robotState?.restartRequired) ||
+        (method === POST &&
+          settings.some(
+            s => s.id === meta.settingId && s.restart_required === true
+          ))
+
+      return { ...state, [robotName]: { settings, restartRequired } }
+    }
+  }
+
+  switch (action.type) {
+    case CLEAR_RESTART_REQUIRED: {
+      const { robotName } = action.payload
+
+      return {
+        ...state,
+        [robotName]: { ...state[robotName], restartRequired: false },
+      }
+    }
+
+    case RESTART: {
+      const { name: robotName } = action.payload.host
+
+      return {
+        ...state,
+        [robotName]: { ...state[robotName], restartRequired: false },
+      }
+    }
+  }
+
+  return state
+}

--- a/app/src/robot-settings/selectors.js
+++ b/app/src/robot-settings/selectors.js
@@ -1,0 +1,19 @@
+// @flow
+import type { State } from '../types'
+import type { RobotSettings } from './types'
+
+const robotState = (state: State, name: string) => state.robotSettings[name]
+
+export function getRobotSettings(
+  state: State,
+  robotName: string
+): RobotSettings {
+  return robotState(state, robotName)?.settings || []
+}
+
+export function getRobotRestartRequired(
+  state: State,
+  robotName: string
+): boolean {
+  return robotState(state, robotName)?.restartRequired || false
+}

--- a/app/src/robot-settings/selectors.js
+++ b/app/src/robot-settings/selectors.js
@@ -11,9 +11,16 @@ export function getRobotSettings(
   return robotState(state, robotName)?.settings || []
 }
 
+export function getRobotRestartPath(
+  state: State,
+  robotName: string
+): string | null {
+  return robotState(state, robotName)?.restartPath || null
+}
+
 export function getRobotRestartRequired(
   state: State,
   robotName: string
 ): boolean {
-  return robotState(state, robotName)?.restartRequired || false
+  return getRobotRestartPath(state, robotName) !== null
 }

--- a/app/src/robot-settings/types.js
+++ b/app/src/robot-settings/types.js
@@ -1,0 +1,42 @@
+// @flow
+
+import type { RobotApiRequest } from '../robot-api/types'
+
+export type RobotSettingsField = {|
+  id: string,
+  title: string,
+  description: string,
+  value: boolean | null,
+  restart_required?: boolean,
+|}
+
+export type RobotSettings = Array<RobotSettingsField>
+
+export type PerRobotRobotSettingsState = {|
+  settings: RobotSettings,
+  restartRequired: boolean,
+|}
+
+export type RobotSettingsState = $Shape<{|
+  [robotName: string]: void | PerRobotRobotSettingsState,
+|}>
+
+export type RobotSettingsFieldUpdate = {|
+  id: $PropertyType<RobotSettingsField, 'id'>,
+  value: $PropertyType<RobotSettingsField, 'value'>,
+|}
+
+export type RobotSettingsApiAction =
+  | {| type: 'robotSettings:FETCH_SETTINGS', payload: RobotApiRequest |}
+  | {|
+      type: 'robotSettings:UPDATE_SETTING',
+      payload: RobotApiRequest,
+      meta: {| settingId: string |},
+    |}
+
+export type RobotSettingsAction =
+  | RobotSettingsApiAction
+  | {|
+      type: 'robotSettings:CLEAR_RESTART_REQUIRED',
+      payload: {| robotName: string |},
+    |}

--- a/app/src/robot-settings/types.js
+++ b/app/src/robot-settings/types.js
@@ -12,9 +12,14 @@ export type RobotSettingsField = {|
 
 export type RobotSettings = Array<RobotSettingsField>
 
+export type RobotSettingsResponse = {|
+  settings: RobotSettings,
+  links?: {| restart?: string |},
+|}
+
 export type PerRobotRobotSettingsState = {|
   settings: RobotSettings,
-  restartRequired: boolean,
+  restartPath: string | null,
 |}
 
 export type RobotSettingsState = $Shape<{|
@@ -26,17 +31,6 @@ export type RobotSettingsFieldUpdate = {|
   value: $PropertyType<RobotSettingsField, 'value'>,
 |}
 
-export type RobotSettingsApiAction =
-  | {| type: 'robotSettings:FETCH_SETTINGS', payload: RobotApiRequest |}
-  | {|
-      type: 'robotSettings:UPDATE_SETTING',
-      payload: RobotApiRequest,
-      meta: {| settingId: string |},
-    |}
-
 export type RobotSettingsAction =
-  | RobotSettingsApiAction
-  | {|
-      type: 'robotSettings:CLEAR_RESTART_REQUIRED',
-      payload: {| robotName: string |},
-    |}
+  | {| type: 'robotSettings:FETCH_SETTINGS', payload: RobotApiRequest |}
+  | {| type: 'robotSettings:UPDATE_SETTING', payload: RobotApiRequest |}

--- a/app/src/types.js
+++ b/app/src/types.js
@@ -18,11 +18,17 @@ import type {
   CustomLabwareAction,
 } from './custom-labware/types'
 
+import type {
+  RobotSettingsState,
+  RobotSettingsAction,
+} from './robot-settings/types'
+
 export type State = $ReadOnly<{|
   robot: RobotState,
   api: HttpApiState,
   robotApi: RobotApiState,
   robotAdmin: RobotAdminState,
+  robotSettings: RobotSettingsState,
   config: Config,
   discovery: DiscoveryState,
   labware: CustomLabwareState,
@@ -36,6 +42,7 @@ export type Action =
   | HttpApiAction
   | RobotApiAction
   | RobotAdminAction
+  | RobotSettingsAction
   | ShellAction
   | ConfigAction
   | RouterAction


### PR DESCRIPTION
## overview

~Blocked by #4283, PR will be rebased when 4283 is merged~ Rebased and ready

This PR closes #4267 by wiring the new restart action+state from #4283 to the AdvancedSettingsCard.

Following up on what we established with buildroot, this PR also refactors robot settings into its own state subtree (`robotSettings`) to finally bail out of the organizational problems that have plagued the app's HTTP-fed state

## changelog

- feat(app): add robot restart alert for FF changes that require restart

## review requests

**Requires a robot or virtual smoothie running #4290 or later**

If you want to test with virtual smoothie *before* 4290 is merged:

1. Checkout 4290 branch
2. Start API dev server
3. Checkout **this branch** to run your dev app
3. To simulate a "restart", kill your server and restart it
4. After you kill your server, you're going to need to restart from step (1) to get virtual smoothie back on the "correct" branch

After 4290 is merged, there are no special considerations for testing with virtual smoothie

- [ ] Change API v2 feature flag for a robot, restart modal should pop up
- [ ] Change a different setting, restart modal should not pop up
