### PR TITLE
feat(protocol-designer): add reducers for module placement

### DIFF
--- a/protocol-designer/src/labware-ingred/actions/actions.js
+++ b/protocol-designer/src/labware-ingred/actions/actions.js
@@ -53,6 +53,7 @@ export type CreateContainerAction = {
   type: 'CREATE_CONTAINER',
   payload: {
     ...CreateContainerArgs,
+    slot: DeckSlot,
     id: string,
   },
 }

--- a/protocol-designer/src/step-forms/actions/modules.js
+++ b/protocol-designer/src/step-forms/actions/modules.js
@@ -3,7 +3,7 @@ import { uuid } from '../../utils'
 import type { ModuleType } from '@opentrons/shared-data'
 import type { DeckSlot } from '../../types'
 
-type CreateModuleAction = {|
+export type CreateModuleAction = {|
   type: 'CREATE_MODULE',
   payload: {|
     slot: DeckSlot,
@@ -19,7 +19,7 @@ export const createModule = (
   payload: { ...args, id: `${uuid()}:${args.type}` },
 })
 
-type EditModuleAction = {|
+export type EditModuleAction = {|
   type: 'EDIT_MODULE',
   payload: {| id: string, model: string |},
 |}
@@ -30,7 +30,7 @@ export const editModule = (
   payload: args,
 })
 
-type DeleteModuleAction = {|
+export type DeleteModuleAction = {|
   type: 'DELETE_MODULE',
   payload: {| id: string |},
 |}

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -59,6 +59,9 @@ import type {
   CreatePipettesAction,
   DeletePipettesAction,
   SubstituteStepFormPipettesAction,
+  CreateModuleAction,
+  EditModuleAction,
+  DeleteModuleAction,
 } from '../actions'
 
 type FormState = FormData | null
@@ -147,7 +150,7 @@ export const initialDeckSetupStepForm: FormData = {
   pipetteLocationUpdate: {},
 }
 
-const initialSavedStepFormsState: SavedStepFormState = {
+export const initialSavedStepFormsState: SavedStepFormState = {
   [INITIAL_DECK_SETUP_STEP_ID]: initialDeckSetupStepForm,
 }
 type SavedStepFormsActions =
@@ -526,6 +529,40 @@ export const labwareInvariantProperties = handleActions<
       ),
   },
   initialLabwareState
+)
+
+type InvariantModulesTodoType = Object // TODO IMMEDIATELY import from types.js
+export const moduleInvariantProperties = handleActions<
+  InvariantModulesTodoType,
+  *
+>(
+  {
+    CREATE_MODULE: (
+      state: InvariantModulesTodoType,
+      action: CreateModuleAction
+    ): InvariantModulesTodoType => ({
+      ...state,
+      [action.payload.id]: {
+        type: action.payload.type,
+        model: action.payload.model,
+      },
+    }),
+    EDIT_MODULE: (
+      state: InvariantModulesTodoType,
+      action: EditModuleAction
+    ): InvariantModulesTodoType => ({
+      ...state,
+      [action.payload.id]: {
+        ...state[action.payload.id],
+        model: action.payload.model,
+      },
+    }),
+    DELETE_MODULE: (
+      state: InvariantModulesTodoType,
+      action: DeleteModuleAction
+    ): InvariantModulesTodoType => omit(state, action.payload.id),
+  },
+  {}
 )
 
 const initialPipetteState = {}

--- a/protocol-designer/src/step-forms/types.js
+++ b/protocol-designer/src/step-forms/types.js
@@ -37,10 +37,14 @@ export type PipetteEntities = {
 }
 
 // =========== MODULES ========
+// Note: 'model' is like 'GEN1'/'GEN2' etc
 export type FormModule = { onDeck: boolean, model: string }
 export type FormModulesByType = {
   [type: ModuleType]: FormModule,
 }
+
+export type ModuleEntity = {| id: string, type: ModuleType, model: string |}
+export type ModuleEntities = { [moduleId: string]: ModuleEntity }
 
 // =========== LABWARE ========
 

--- a/protocol-designer/src/step-forms/utils.js
+++ b/protocol-designer/src/step-forms/utils.js
@@ -32,18 +32,19 @@ export function getIdsInRange<T: string | number>(
   return orderedIds.slice(startIdx, endIdx + 1)
 }
 
-export function getLabwareIdInSlot(
-  labwareIdToSlot: { [labwareId: string]: DeckSlotId },
+// NOTE: deck items include labware and modules
+export function getDeckItemIdInSlot(
+  itemIdToSlot: { [itemId: string]: DeckSlotId },
   slot: DeckSlotId
 ): ?string {
-  const labwareIdsForSourceSlot = Object.entries(labwareIdToSlot)
+  const idsForSourceSlot = Object.entries(itemIdToSlot)
     .filter(([id, labwareSlot]) => labwareSlot === slot)
     .map(([id, labwareSlot]) => id)
   assert(
-    labwareIdsForSourceSlot.length < 2,
-    `multiple labware in slot ${slot}, expected none or one`
+    idsForSourceSlot.length < 2,
+    `multiple deck items in slot ${slot}, expected none or one`
   )
-  return labwareIdsForSourceSlot[0]
+  return idsForSourceSlot[0]
 }
 
 export function denormalizePipetteEntities(


### PR DESCRIPTION
## overview

Addresses #4132 - for module creation/deletion/placement on the deck. All that should be left is selectors which will come next!

This should set us up to have meaningful data representation of modules on the deck which responds correctly to all the module/labware actions

This PR adds a bunch of tests to existing labware placement behavior in the reducers, and a bunch more for modules on the deck and labware-module swap interactions as we've diagrammed on paper.

## changelog

* add module invariant properties reducer
* expand the savedStepForms reducer's initial deck setup step to respond to module placement
* add tests for existing labware stuff (added passing tests before making changes to the reducers) and add tests for new module state stuff

## review requests

- This was TDD'd and has good coverage so reviewing tests should give you an idea of the behavior
- Using Redux DevTools, dispatch modules actions (CREATE_MODULE, EDIT_MODULE, DELETE_MODULE), plus MOVE_DECK_ITEM action. Observe the diff in `savedStepForms[INITIAL_DECK_SETUP_STEP]` and in `moduleInvariantProperties` when modules are created, edited, deleted, or moved. Also moving labware should interact with module movement appropriately. We'll really "see" that this works once modules are visualized on the deck, but for now we can only look at Redux state.