### PR TITLE
refactor(api): Remove FF in simulation and add simulating context

### DIFF
--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Mapping, TextIO, Tuple, BinaryIO, Optional
 import opentrons
 import opentrons.commands
 import opentrons.broker
-import opentrons.config
+from opentrons.config import feature_flags as ff
 from opentrons import protocol_api
 from opentrons.protocols import parse, bundle
 from opentrons.protocols.types import (
@@ -247,7 +247,9 @@ def simulate(protocol_file: TextIO,
                            extra_labware=extra_labware,
                            extra_data=extra_data)
 
-    if isinstance(protocol, JsonProtocol) or protocol.api_level == '2':
+    if isinstance(protocol, JsonProtocol)\
+            or protocol.api_level == '2'\
+            or (ff.enable_backcompat() and ff.use_protocol_api_v2()):
         context = get_protocol_api(protocol)
         scraper = CommandScraper(stack_logger, log_level, context.broker)
         execute.run_protocol(protocol,
@@ -368,7 +370,7 @@ def get_arguments(
         help='Specify the level filter for logs to show on the command line. '
         'Log levels below warning can be chatty. If "none", do not show logs')
 
-    if opentrons.config.feature_flags.use_protocol_api_v2():
+    if ff.use_protocol_api_v2():
         parser = _get_bundle_args(parser)
 
     parser.add_argument(

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -79,21 +79,3 @@ def test_simulate_function_apiv1(ensure_api1, protocol, protocol_file):
         'Dispensing 10 uL into well H12 in "11"',
         'Dropping tip well A1 in "12"'
     ]
-
-
-@pytest.mark.api1_only
-def test_simulate_function_json_apiv1(ensure_api1,
-                                      get_json_protocol_fixture):
-    jp = get_json_protocol_fixture('3', 'simple', False)
-    filelike = io.StringIO(jp)
-    runlog, bundle = simulate.simulate(filelike, 'simple.json')
-    assert bundle is None
-    assert [item['payload']['text'] for item in runlog] == [
-        'Picking up tip well B1 in "1"',
-        'Aspirating 5 uL from well A1 in "2" at 1.0 speed',
-        'Delaying for 0:00:42',
-        'Dispensing 4.5 uL into well B1 in "3"',
-        'Touching tip',
-        'Blowing out at well B1 in "3"',
-        'Dropping tip well A1 in "12"'
-    ]


### PR DESCRIPTION
## overview
With API v2 beta imminently approaching we want to encourage users to convert and/or write new protocols in API v2. Instead of forcing them to specify a feature flag every time they want to locally simulate their protocols, we should assume the version. Also, for jupyter notebook, people should be able to easily simulate their commands in API v2. This PR adds in a method which allows you to access a simulating context.

## changelog
- Remove the feature flag check for server versions and only check based on protocol type + version
- Add method to access a simulating protocol context

## review requests

1. Simulate API v2 protocol and make sure no errors occur
2. Simulate API v1 protocol and make sure no errors occur
3. Simulate JSON protocol
4. Import `opentrons.simulate.get_protocol_api` and see that you can simulate commands in jupyter notebook