### PR TITLE
refactor(shared-data): remove enum from protocol schema pipette type

### DIFF
--- a/shared-data/protocol/schemas/3.json
+++ b/shared-data/protocol/schemas/3.json
@@ -5,17 +5,7 @@
   "definitions": {
     "pipetteName": {
       "description": "Name of a pipette. Does not contain info about specific model/version. Should match keys in pipetteNameSpecs.json file",
-      "type": "string",
-      "enum": [
-        "p10_single",
-        "p10_multi",
-        "p50_single",
-        "p50_multi",
-        "p300_single",
-        "p300_multi",
-        "p1000_single",
-        "p1000_multi"
-      ]
+      "type": "string"
     },
 
     "mmOffset": {


### PR DESCRIPTION
This allows applications to specify new generations of pipette without having to
modify the schema every time.

Closes #4235
