### PR TITLE
feat(app): Enable GEN2 pipettes

### DIFF
--- a/app/src/components/ChangePipette/Instructions.js
+++ b/app/src/components/ChangePipette/Instructions.js
@@ -56,10 +56,7 @@ export default function Instructions(props: ChangePipetteProps) {
       contentsClassName={styles.modal_contents}
     >
       {!actualPipette && !wantedPipette && (
-        <PipetteSelection
-          onPipetteChange={props.onPipetteSelect}
-          __pipettePlusEnabled={props.__pipettePlusEnabled}
-        />
+        <PipetteSelection onPipetteChange={props.onPipetteSelect} />
       )}
 
       {(actualPipette || wantedPipette) && (

--- a/app/src/components/ChangePipette/PipetteSelection.js
+++ b/app/src/components/ChangePipette/PipetteSelection.js
@@ -8,19 +8,10 @@ const LABEL = 'Select the pipette you wish to attach:'
 
 export type PipetteSelectionProps = {
   ...React.ElementProps<typeof PipetteSelect>,
-  __pipettePlusEnabled: boolean,
 }
 
 export default function PipetteSelection(props: PipetteSelectionProps) {
-  let nameBlacklist = ['p20_multi_gen2', 'p300_multi_gen2']
-  if (!props.__pipettePlusEnabled) {
-    nameBlacklist = [
-      ...nameBlacklist,
-      'p20_single_gen2',
-      'p300_single_gen2',
-      'p1000_single_gen2',
-    ]
-  }
+  const nameBlacklist = ['p20_multi_gen2', 'p300_multi_gen2']
   return (
     <label className={styles.pipette_selection}>
       <span className={styles.pipette_selection_label}>{LABEL}</span>

--- a/app/src/components/ChangePipette/index.js
+++ b/app/src/components/ChangePipette/index.js
@@ -9,7 +9,6 @@ import {
   type PipetteDisplayCategory,
 } from '@opentrons/shared-data'
 
-import { getConfig } from '../../config'
 import { fetchPipettes, getPipettesState } from '../../robot-api'
 import {
   home,
@@ -65,7 +64,6 @@ type SP = {|
   direction: Direction,
   success: boolean,
   attachedWrong: boolean,
-  __pipettePlusEnabled: boolean,
 |}
 
 type DP = {|
@@ -144,9 +142,6 @@ function makeMapStateToProps(): (State, OP) => SP {
       displayCategory,
       moveRequest: getRobotMove(state, robot),
       homeRequest: getRobotHome(state, robot),
-      __pipettePlusEnabled: Boolean(
-        getConfig(state).devInternal?.enablePipettePlus
-      ),
     }
   }
 }

--- a/app/src/components/ChangePipette/types.js
+++ b/app/src/components/ChangePipette/types.js
@@ -37,5 +37,4 @@ export type ChangePipetteProps = {|
   onPipetteSelect: $PropertyType<PipetteSelectionProps, 'onPipetteChange'>,
   checkPipette: () => mixed,
   goToConfirmUrl: () => mixed,
-  __pipettePlusEnabled: boolean,
 |}

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -15,7 +15,6 @@ export * from './types'
 export const DEV_INTERNAL_FLAGS: Array<DevInternalFlag> = [
   'allPipetteConfig',
   'tempdeckControls',
-  'enablePipettePlus',
   'customLabware',
 ]
 

--- a/app/src/config/types.js
+++ b/app/src/config/types.js
@@ -10,7 +10,6 @@ export type DiscoveryCandidates = string | Array<string>
 export type DevInternalFlag =
   | 'allPipetteConfig'
   | 'tempdeckControls'
-  | 'enablePipettePlus'
   | 'customLabware'
 
 export type FeatureFlags = $Shape<{|


### PR DESCRIPTION
## overview

This PR closes #3601 by removing the GEN2 pipettes FF + enabling them by default in the add/change pipettes wizard.

## changelog

- feat(app): Enable GEN2 pipettes

## review requests

- [ ] Gen 2 single channel pipettes show up in both add/change pipettes pipette selection dropdowns
