### PR TITLE
feat(api): reflect original instrument name via rpc

### DIFF
--- a/api/src/opentrons/api/models.py
+++ b/api/src/opentrons/api/models.py
@@ -67,6 +67,9 @@ class Instrument:
         if ff.use_protocol_api_v2():
             self.tip_racks.extend([
                 c for c in self.containers if c._container.is_tiprack])
+            self.requested_as = instrument.requested_as
+        else:
+            self.requested_as = instrument.name
 
 
 class Module:

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -485,7 +485,8 @@ class ProtocolContext(CommandPublisher):
             hardware_mgr=self._hw_manager,
             mount=checked_mount,
             tip_racks=tip_racks,
-            log_parent=self._log)
+            log_parent=self._log,
+            requested_as=instrument_name)
         self._instruments[checked_mount] = new_instr
         self._log.info("Instrument {} loaded".format(new_instr))
         return new_instr
@@ -640,6 +641,7 @@ class InstrumentContext(CommandPublisher):
                  tip_racks: List[Labware] = None,
                  trash: Labware = None,
                  default_speed: float = 400.0,
+                 requested_as: str = None,
                  **config_kwargs) -> None:
 
         super().__init__(ctx.broker)
@@ -666,6 +668,7 @@ class InstrumentContext(CommandPublisher):
         self._flow_rates = FlowRates(self)
         self._speeds = PlungerSpeeds(self)
         self._starting_tip: Union[Well, None] = None
+        self.requested_as = requested_as
 
     @property
     def starting_tip(self) -> Union[Well, None]:

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -319,6 +319,20 @@ async def test_session_model_functional(session_manager, protocol):
     assert names == ['p300_single_v1']
 
 
+@pytest.mark.parametrize('protocol_file', ['testosaur-gen2.py'])
+@pytest.mark.api1_only
+async def test_requested_as_v1(session_manager, protocol, protocol_file):
+    session = session_manager.create(name='<blank>', contents=protocol.text)
+    assert session.get_instruments()[0].requested_as == 'p300_single_gen2'
+
+
+@pytest.mark.parametrize('protocol_file', ['testosaur-gen2-v2.py'])
+@pytest.mark.api2_only
+async def test_requested_as_v2(session_manager, protocol, protocol_file):
+    session = session_manager.create(name='<blank>', contents=protocol.text)
+    assert session.get_instruments()[0].requested_as == 'p300_single_gen2'
+
+
 # TODO(artyom 20171018): design a small protocol specifically for the test
 @pytest.mark.api1_only
 @pytest.mark.parametrize('protocol_file', ['bradford_assay.py'])

--- a/api/tests/opentrons/data/testosaur-gen2-v2.py
+++ b/api/tests/opentrons/data/testosaur-gen2-v2.py
@@ -1,0 +1,19 @@
+from opentrons import types
+
+metadata = {
+    'protocolName': 'Testosaur',
+    'author': 'Opentrons <engineering@opentrons.com>',
+    'description': 'A variant on "Dinosaur" for testing',
+    'source': 'Opentrons Repository'
+}
+
+
+def run(ctx):
+    ctx.home()
+    tr = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
+    right = ctx.load_instrument('p300_single_gen2', types.Mount.RIGHT, [tr])
+    lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 2)
+    right.pick_up_tip()
+    right.aspirate(10, lw.wells()[0].bottom())
+    right.dispense(10, lw.wells()[1].bottom())
+    right.drop_tip(tr.wells()[-1].top())

--- a/api/tests/opentrons/data/testosaur-gen2.py
+++ b/api/tests/opentrons/data/testosaur-gen2.py
@@ -1,0 +1,32 @@
+from opentrons import instruments, containers, robot
+
+metadata = {
+    'protocolName': 'Testosaur',
+    'author': 'Opentrons <engineering@opentrons.com>',
+    'description': 'A variant on "Dinosaur" for testing',
+    'source': 'Opentrons Repository'
+}
+
+p200rack = containers.load('tiprack-200ul', '5', 'tiprack')
+
+# create a p20 con0 pipette on robot axis B
+p300 = instruments.P300_Single_GEN2(
+    mount="right",
+    tip_racks=[p200rack])
+
+p300.pick_up_tip()
+
+containers = [
+    containers.load('96-PCR-flat', slot)
+    for slot
+    in ('8', '11')
+]
+
+# Uncomment these to test precision
+p300.move_to(robot.deck['11'])
+p300.move_to(robot.deck['6'])
+
+for container in containers:
+    p300.aspirate(10, container[0]).dispense(10, container[-1].top(5))
+
+p300.drop_tip()


### PR DESCRIPTION
When the user specifies an instrument as the name ("p300_single", "p10_single")
but a compatible GEN2 pipette is connected, the instrument name in rpc shows up
as the pipette connected to the robot.

Add an RPC-visible element called "requested_as" to the instrument model that is
the string the user used to request the instrument.
