### PR TITLE
feat(shared-data): add "GEN1" to gen 1 pipette display names

### DIFF
--- a/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
+++ b/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
@@ -33,7 +33,7 @@ Object {
     "value": 10,
   },
   "displayCategory": "GEN1",
-  "displayName": "P10 8-Channel",
+  "displayName": "P10 8-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -240,7 +240,7 @@ Object {
     "value": 10,
   },
   "displayCategory": "GEN1",
-  "displayName": "P10 8-Channel",
+  "displayName": "P10 8-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -447,7 +447,7 @@ Object {
     "value": 10,
   },
   "displayCategory": "GEN1",
-  "displayName": "P10 8-Channel",
+  "displayName": "P10 8-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -654,7 +654,7 @@ Object {
     "value": 10,
   },
   "displayCategory": "GEN1",
-  "displayName": "P10 8-Channel",
+  "displayName": "P10 8-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -831,7 +831,7 @@ Object {
     "value": 10,
   },
   "displayCategory": "GEN1",
-  "displayName": "P10 Single-Channel",
+  "displayName": "P10 Single-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -1043,7 +1043,7 @@ Object {
     "value": 10,
   },
   "displayCategory": "GEN1",
-  "displayName": "P10 Single-Channel",
+  "displayName": "P10 Single-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -1255,7 +1255,7 @@ Object {
     "value": 10,
   },
   "displayCategory": "GEN1",
-  "displayName": "P10 Single-Channel",
+  "displayName": "P10 Single-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -1467,7 +1467,7 @@ Object {
     "value": 10,
   },
   "displayCategory": "GEN1",
-  "displayName": "P10 Single-Channel",
+  "displayName": "P10 Single-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -1643,7 +1643,7 @@ Object {
     "value": 50,
   },
   "displayCategory": "GEN1",
-  "displayName": "P50 8-Channel",
+  "displayName": "P50 8-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -1839,7 +1839,7 @@ Object {
     "value": 50,
   },
   "displayCategory": "GEN1",
-  "displayName": "P50 8-Channel",
+  "displayName": "P50 8-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -2035,7 +2035,7 @@ Object {
     "value": 50,
   },
   "displayCategory": "GEN1",
-  "displayName": "P50 8-Channel",
+  "displayName": "P50 8-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -2231,7 +2231,7 @@ Object {
     "value": 50,
   },
   "displayCategory": "GEN1",
-  "displayName": "P50 8-Channel",
+  "displayName": "P50 8-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -2407,7 +2407,7 @@ Object {
     "value": 50,
   },
   "displayCategory": "GEN1",
-  "displayName": "P50 Single-Channel",
+  "displayName": "P50 Single-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -2603,7 +2603,7 @@ Object {
     "value": 50,
   },
   "displayCategory": "GEN1",
-  "displayName": "P50 Single-Channel",
+  "displayName": "P50 Single-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -2799,7 +2799,7 @@ Object {
     "value": 50,
   },
   "displayCategory": "GEN1",
-  "displayName": "P50 Single-Channel",
+  "displayName": "P50 Single-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -2995,7 +2995,7 @@ Object {
     "value": 300,
   },
   "displayCategory": "GEN1",
-  "displayName": "P300 8-Channel",
+  "displayName": "P300 8-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -3155,7 +3155,7 @@ Object {
     "value": 300,
   },
   "displayCategory": "GEN1",
-  "displayName": "P300 8-Channel",
+  "displayName": "P300 8-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -3315,7 +3315,7 @@ Object {
     "value": 300,
   },
   "displayCategory": "GEN1",
-  "displayName": "P300 8-Channel",
+  "displayName": "P300 8-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -3475,7 +3475,7 @@ Object {
     "value": 300,
   },
   "displayCategory": "GEN1",
-  "displayName": "P300 8-Channel",
+  "displayName": "P300 8-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -3636,7 +3636,7 @@ Object {
     "value": 300,
   },
   "displayCategory": "GEN1",
-  "displayName": "P300 Single-Channel",
+  "displayName": "P300 Single-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -3852,7 +3852,7 @@ Object {
     "value": 300,
   },
   "displayCategory": "GEN1",
-  "displayName": "P300 Single-Channel",
+  "displayName": "P300 Single-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -4068,7 +4068,7 @@ Object {
     "value": 300,
   },
   "displayCategory": "GEN1",
-  "displayName": "P300 Single-Channel",
+  "displayName": "P300 Single-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -4284,7 +4284,7 @@ Object {
     "value": 300,
   },
   "displayCategory": "GEN1",
-  "displayName": "P300 Single-Channel",
+  "displayName": "P300 Single-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -4464,7 +4464,7 @@ Object {
     "value": 1000,
   },
   "displayCategory": "GEN1",
-  "displayName": "P1000 Single-Channel",
+  "displayName": "P1000 Single-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -4646,7 +4646,7 @@ Object {
     "value": 1000,
   },
   "displayCategory": "GEN1",
-  "displayName": "P1000 Single-Channel",
+  "displayName": "P1000 Single-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -4828,7 +4828,7 @@ Object {
     "value": 1000,
   },
   "displayCategory": "GEN1",
-  "displayName": "P1000 Single-Channel",
+  "displayName": "P1000 Single-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -5010,7 +5010,7 @@ Object {
     "value": 1000,
   },
   "displayCategory": "GEN1",
-  "displayName": "P1000 Single-Channel",
+  "displayName": "P1000 Single-Channel GEN1",
   "dropTip": Object {
     "max": 2,
     "min": -6,
@@ -5178,7 +5178,7 @@ Object {
     "value": 10,
   },
   "displayCategory": "GEN1",
-  "displayName": "P10 8-Channel",
+  "displayName": "P10 8-Channel GEN1",
   "maxVolume": 10,
   "minVolume": 1,
   "name": "p10_multi",
@@ -5209,7 +5209,7 @@ Object {
     "value": 10,
   },
   "displayCategory": "GEN1",
-  "displayName": "P10 Single-Channel",
+  "displayName": "P10 Single-Channel GEN1",
   "maxVolume": 10,
   "minVolume": 1,
   "name": "p10_single",
@@ -5240,7 +5240,7 @@ Object {
     "value": 50,
   },
   "displayCategory": "GEN1",
-  "displayName": "P50 8-Channel",
+  "displayName": "P50 8-Channel GEN1",
   "maxVolume": 50,
   "minVolume": 5,
   "name": "p50_multi",
@@ -5271,7 +5271,7 @@ Object {
     "value": 50,
   },
   "displayCategory": "GEN1",
-  "displayName": "P50 Single-Channel",
+  "displayName": "P50 Single-Channel GEN1",
   "maxVolume": 50,
   "minVolume": 5,
   "name": "p50_single",
@@ -5302,7 +5302,7 @@ Object {
     "value": 300,
   },
   "displayCategory": "GEN1",
-  "displayName": "P300 8-Channel",
+  "displayName": "P300 8-Channel GEN1",
   "maxVolume": 300,
   "minVolume": 30,
   "name": "p300_multi",
@@ -5333,7 +5333,7 @@ Object {
     "value": 300,
   },
   "displayCategory": "GEN1",
-  "displayName": "P300 Single-Channel",
+  "displayName": "P300 Single-Channel GEN1",
   "maxVolume": 300,
   "minVolume": 30,
   "name": "p300_single",
@@ -5364,7 +5364,7 @@ Object {
     "value": 1000,
   },
   "displayCategory": "GEN1",
-  "displayName": "P1000 Single-Channel",
+  "displayName": "P1000 Single-Channel GEN1",
   "maxVolume": 1000,
   "minVolume": 100,
   "name": "p1000_single",

--- a/shared-data/pipette/definitions/pipetteNameSpecs.json
+++ b/shared-data/pipette/definitions/pipetteNameSpecs.json
@@ -1,6 +1,6 @@
 {
   "p10_single": {
-    "displayName": "P10 Single-Channel",
+    "displayName": "P10 Single-Channel GEN1",
     "displayCategory": "GEN1",
     "minVolume": 1,
     "maxVolume": 10,
@@ -27,7 +27,7 @@
     }
   },
   "p10_multi": {
-    "displayName": "P10 8-Channel",
+    "displayName": "P10 8-Channel GEN1",
     "displayCategory": "GEN1",
     "minVolume": 1,
     "maxVolume": 10,
@@ -108,7 +108,7 @@
     }
   },
   "p50_single": {
-    "displayName": "P50 Single-Channel",
+    "displayName": "P50 Single-Channel GEN1",
     "displayCategory": "GEN1",
     "defaultAspirateFlowRate": {
       "value": 25,
@@ -135,7 +135,7 @@
     }
   },
   "p50_multi": {
-    "displayName": "P50 8-Channel",
+    "displayName": "P50 8-Channel GEN1",
     "displayCategory": "GEN1",
     "defaultAspirateFlowRate": {
       "value": 25,
@@ -162,7 +162,7 @@
     }
   },
   "p300_single": {
-    "displayName": "P300 Single-Channel",
+    "displayName": "P300 Single-Channel GEN1",
     "displayCategory": "GEN1",
     "defaultAspirateFlowRate": {
       "value": 150,
@@ -243,7 +243,7 @@
     }
   },
   "p300_multi": {
-    "displayName": "P300 8-Channel",
+    "displayName": "P300 8-Channel GEN1",
     "displayCategory": "GEN1",
     "defaultAspirateFlowRate": {
       "value": 150,
@@ -270,7 +270,7 @@
     }
   },
   "p1000_single": {
-    "displayName": "P1000 Single-Channel",
+    "displayName": "P1000 Single-Channel GEN1",
     "displayCategory": "GEN1",
     "defaultAspirateFlowRate": {
       "value": 500,


### PR DESCRIPTION
## overview

Per discussion in Slack, this PR adds "GEN1" to the end of gen1 pipettes display names

## changelog

- feat(shared-data): add "GEN1" to gen 1 pipette display names

## review requests

- [ ] "GEN1" shows up in
    - Pipette select
    - Protocol info page in app
    - Calibration page in app
    - Pipette select in PD