### PR TITLE
feat(protocol-designer): Add edit modules modal

### DIFF
--- a/protocol-designer/src/components/FilePage.css
+++ b/protocol-designer/src/components/FilePage.css
@@ -1,5 +1,11 @@
 @import '@opentrons/components';
 
+.file_page {
+  position: relative;
+  height: 100%;
+  min-height: 100vh;
+}
+
 .card_content {
   padding: 1rem;
 }

--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -200,7 +200,7 @@ class FilePage extends React.Component<Props, State> {
         {this.props.modulesEnabled && (
           <EditModulesCard
             modules={_mockModulesByType}
-            editModule={this.handleEditModule}
+            openEditModuleModal={this.handleEditModule}
           />
         )}
 

--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -75,7 +75,6 @@ class FilePage extends React.Component<Props, State> {
   }
 
   closeEditModulesModal = () => {
-    console.log('closing')
     this.setState({ isEditModulesModalOpen: false, currentModule: null })
   }
 

--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -15,11 +15,12 @@ import i18n from '../localization'
 import { Portal } from './portals/MainPageModalPortal'
 import styles from './FilePage.css'
 import EditPipettesModal from './modals/EditPipettesModal'
+import EditModulesModal from './modals/EditModulesModal'
 import { EditModulesCard } from './modules'
 import formStyles from '../components/forms/forms.css'
 import type { FileMetadataFields } from '../file-data'
 import type { ModulesForEditModulesCard } from '../step-forms'
-
+import type { ModuleType } from '@opentrons/shared-data'
 export type Props = {
   formValues: FileMetadataFields,
   instruments: React.ElementProps<typeof InstrumentGroup>,
@@ -29,7 +30,11 @@ export type Props = {
   modulesEnabled: ?boolean,
 }
 
-type State = { isEditPipetteModalOpen: boolean, isEditModuleModalOpen: boolean }
+type State = {
+  isEditPipetteModalOpen: boolean,
+  isEditModulesModalOpen: boolean,
+  currentModule: ?ModuleType,
+}
 
 const DATE_ONLY_FORMAT = 'MMM DD, YYYY'
 const DATETIME_FORMAT = 'MMM DD, YYYY | h:mm A'
@@ -44,10 +49,35 @@ const _mockModulesByType: ModulesForEditModulesCard = {
 
 // TODO: Ian 2019-03-15 use i18n for labels
 class FilePage extends React.Component<Props, State> {
-  state = { isEditPipetteModalOpen: false, isEditModuleModalOpen: false }
+  state = {
+    isEditPipetteModalOpen: false,
+    isEditModulesModalOpen: false,
+    currentModule: null,
+  }
 
-  openEditPipetteModal = () => this.setState({ isEditPipetteModalOpen: true })
+  // TODO (ka 2019-10-28): This is a workaround,
+  // but it solves the modal positioning problem caused by main page wrapper
+  // being positioned absolute until we can figure out something better
+  scrollToTop = () => {
+    const editPage = document.getElementById('main-page')
+    if (editPage) editPage.scrollTop = 0
+  }
+
+  openEditPipetteModal = () => {
+    this.scrollToTop()
+    this.setState({ isEditPipetteModalOpen: true })
+  }
   closeEditPipetteModal = () => this.setState({ isEditPipetteModalOpen: false })
+
+  handleEditModule = (type: ModuleType) => {
+    this.scrollToTop()
+    this.setState({ isEditModulesModalOpen: true, currentModule: type })
+  }
+
+  closeEditModulesModal = () => {
+    console.log('closing')
+    this.setState({ isEditModulesModalOpen: false, currentModule: null })
+  }
 
   render() {
     const {
@@ -169,7 +199,10 @@ class FilePage extends React.Component<Props, State> {
         </Card>
 
         {this.props.modulesEnabled && (
-          <EditModulesCard modules={_mockModulesByType} />
+          <EditModulesCard
+            modules={_mockModulesByType}
+            editModule={this.handleEditModule}
+          />
         )}
 
         <div className={styles.button_row}>
@@ -187,6 +220,14 @@ class FilePage extends React.Component<Props, State> {
             <EditPipettesModal
               key={String(this.state.isEditPipetteModalOpen)}
               closeModal={this.closeEditPipetteModal}
+            />
+          )}
+
+          {this.state.isEditModulesModalOpen && this.state.currentModule && (
+            <EditModulesModal
+              moduleType={this.state.currentModule}
+              key={String(this.state.isEditModulesModalOpen)}
+              onCloseClick={this.closeEditModulesModal}
             />
           )}
         </Portal>

--- a/protocol-designer/src/components/ProtocolEditor.css
+++ b/protocol-designer/src/components/ProtocolEditor.css
@@ -5,7 +5,7 @@
   flex-direction: row;
   align-items: stretch;
   width: 100%;
-  height: 100vh;
+  min-height: 100vh;
 }
 
 .main_page_wrapper {

--- a/protocol-designer/src/components/ProtocolEditor.js
+++ b/protocol-designer/src/components/ProtocolEditor.js
@@ -33,6 +33,7 @@ function ProtocolEditor() {
           <ConnectedTitleBar />
 
           <div
+            id="main-page"
             className={cx(
               styles.main_page_content,
               MAIN_CONTENT_FORCED_SCROLL_CLASSNAME

--- a/protocol-designer/src/components/modals/EditModulesModal/EditModules.css
+++ b/protocol-designer/src/components/modals/EditModulesModal/EditModules.css
@@ -4,6 +4,30 @@
   width: 100%;
   height: 100%;
   z-index: 9999;
+  border-radius: 0;
+}
+
+.modal_contents {
+  border-radius: 0;
+  max-width: 90%;
+}
+
+.form_row {
+  display: flex;
+  justify-content: flex-start;
+  margin: 2rem 0;
+}
+
+.form_option {
+  flex: 0 1 11rem;
+  margin-right: 3rem;
+}
+
+.slot_tooltip {
+  width: 19rem;
+  padding: 0.5rem 1rem;
+  line-height: 1.5;
+  font-size: var(--fs-caption);
 }
 
 .button_row {

--- a/protocol-designer/src/components/modals/EditModulesModal/EditModules.css
+++ b/protocol-designer/src/components/modals/EditModulesModal/EditModules.css
@@ -1,0 +1,17 @@
+@import '@opentrons/components';
+
+.edit_module_modal {
+  width: 100%;
+  height: 100%;
+  z-index: 9999;
+}
+
+.button_row {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: flex-end;
+
+  & button {
+    margin-left: 1rem;
+  }
+}

--- a/protocol-designer/src/components/modals/EditModulesModal/EditModules.css
+++ b/protocol-designer/src/components/modals/EditModulesModal/EditModules.css
@@ -18,9 +18,14 @@
   margin: 2rem 0;
 }
 
-.form_option {
-  flex: 0 1 11rem;
-  margin-right: 3rem;
+.option_model {
+  flex: 0 0 11rem;
+}
+
+.option_slot {
+  flex: 0 0 11rem;
+  margin-left: 3rem;
+  padding: 0 0.25rem 0.25rem;
 }
 
 .slot_tooltip {

--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
 import cx from 'classnames'
+import i18n from '../../../localization'
 import { getModuleDisplayName } from '@opentrons/shared-data'
 import {
   Modal,
@@ -38,8 +39,7 @@ export default function EditModulesModal(props: EditModulesProps) {
 
   const slotOptionTooltip = (
     <div className={styles.slot_tooltip}>
-      To enable non-default/unrestricted positioning, go to Settings &gt; App
-      &gt; Experimental settings.
+      {i18n.t('tooltip.edit_module_modal.slot_selection')}
     </div>
   )
   return (

--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -53,7 +53,7 @@ export default function EditModulesModal(props: EditModulesProps) {
       TODO (ka 2019-10-29): This field is enabled, but only GEN1 available for now
       - onChange returns null because onChange is required by DropdownFields
       */}
-        <FormGroup label="Model" className={styles.form_option}>
+        <FormGroup label="Model" className={styles.option_model}>
           <DropdownField
             tabIndex={0}
             options={[{ name: 'GEN1', value: 'GEN1' }]}
@@ -61,14 +61,16 @@ export default function EditModulesModal(props: EditModulesProps) {
             onChange={() => null}
           />
         </FormGroup>
+        {/*
+      TODO (ka 2019-10-30):
+      - Remove tooltip when endabled by feature flag, enable dropdown with all slots
+      - onChange returns null because onChange is required by DropdownFields
+      */}
         {showSlotOption && (
-          <FormGroup label="Position" className={styles.form_option}>
-            <HoverTooltip
-              placement="bottom"
-              tooltipComponent={slotOptionTooltip}
-            >
-              {hoverTooltipHandlers => (
-                <div {...hoverTooltipHandlers}>
+          <HoverTooltip placement="bottom" tooltipComponent={slotOptionTooltip}>
+            {hoverTooltipHandlers => (
+              <div {...hoverTooltipHandlers} className={styles.option_slot}>
+                <FormGroup label="Position">
                   <DropdownField
                     tabIndex={1}
                     options={SUPPORTED_MODULE_SLOTS[moduleType]}
@@ -76,10 +78,10 @@ export default function EditModulesModal(props: EditModulesProps) {
                     disabled
                     onChange={() => null}
                   />
-                </div>
-              )}
-            </HoverTooltip>
-          </FormGroup>
+                </FormGroup>
+              </div>
+            )}
+          </HoverTooltip>
         )}
       </div>
 

--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -1,0 +1,29 @@
+// @flow
+import * as React from 'react'
+import { Modal, OutlineButton } from '@opentrons/components'
+import styles from './EditModules.css'
+import type { ModuleType } from '@opentrons/shared-data'
+
+type EditModulesProps = {
+  moduleType: ModuleType,
+  moduleId?: string,
+  onCloseClick: () => mixed,
+}
+export default function EditModulesModal(props: EditModulesProps) {
+  const { moduleType, moduleId, onCloseClick } = props
+  const onSaveClick = moduleId
+    ? () => moduleId && console.log('update module ' + moduleId)
+    : () => moduleType && console.log('add module ' + moduleType)
+  const heading = `${moduleType}` || ''
+  return (
+    <Modal heading={heading} className={styles.edit_module_modal}>
+      <h2>{moduleType}</h2>
+      <div className={styles.button_row}>
+        <OutlineButton onClick={onCloseClick}>Cancel</OutlineButton>
+        <OutlineButton onClick={onSaveClick} disabled>
+          Save
+        </OutlineButton>
+      </div>
+    </Modal>
+  )
+}

--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -1,7 +1,17 @@
 // @flow
 import * as React from 'react'
-import { Modal, OutlineButton } from '@opentrons/components'
+import cx from 'classnames'
+import { getModuleDisplayName } from '@opentrons/shared-data'
+import {
+  Modal,
+  OutlineButton,
+  FormGroup,
+  DropdownField,
+  HoverTooltip,
+} from '@opentrons/components'
 import styles from './EditModules.css'
+import modalStyles from '../modal.css'
+
 import type { ModuleType } from '@opentrons/shared-data'
 
 type EditModulesProps = {
@@ -11,19 +21,81 @@ type EditModulesProps = {
 }
 export default function EditModulesModal(props: EditModulesProps) {
   const { moduleType, moduleId, onCloseClick } = props
-  const onSaveClick = moduleId
-    ? () => moduleId && console.log('update module ' + moduleId)
-    : () => moduleType && console.log('add module ' + moduleType)
-  const heading = `${moduleType}` || ''
+
+  let onSaveClick = () => {
+    moduleType && console.log('add module ' + moduleType)
+    onCloseClick()
+  }
+  if (moduleId) {
+    onSaveClick = () => {
+      console.log('update module ' + moduleId)
+      onCloseClick()
+    }
+  }
+
+  const heading = getModuleDisplayName(moduleType)
+  const showSlotOption = moduleType !== 'thermocycler'
+
+  const slotOptionTooltip = (
+    <div className={styles.slot_tooltip}>
+      To enable non-default/unrestricted positioning, go to Settings &gt; App
+      &gt; Experimental settings.
+    </div>
+  )
   return (
-    <Modal heading={heading} className={styles.edit_module_modal}>
-      <h2>{moduleType}</h2>
+    <Modal
+      heading={heading}
+      className={cx(modalStyles.modal, styles.edit_module_modal)}
+      contentsClassName={styles.modal_contents}
+    >
+      <div className={styles.form_row}>
+        {/*
+      TODO (ka 2019-10-29): This field is enabled, but only GEN1 available for now
+      - onChange returns null because onChange is required by DropdownFields
+      */}
+        <FormGroup label="Model" className={styles.form_option}>
+          <DropdownField
+            tabIndex={0}
+            options={[{ name: 'GEN1', value: 'GEN1' }]}
+            value={'GEN1'}
+            onChange={() => null}
+          />
+        </FormGroup>
+        {showSlotOption && (
+          <FormGroup label="Position" className={styles.form_option}>
+            <HoverTooltip
+              placement="bottom"
+              tooltipComponent={slotOptionTooltip}
+            >
+              {hoverTooltipHandlers => (
+                <div {...hoverTooltipHandlers}>
+                  <DropdownField
+                    tabIndex={1}
+                    options={SUPPORTED_MODULE_SLOTS[moduleType]}
+                    value={'GEN1'}
+                    disabled
+                    onChange={() => null}
+                  />
+                </div>
+              )}
+            </HoverTooltip>
+          </FormGroup>
+        )}
+      </div>
+
       <div className={styles.button_row}>
         <OutlineButton onClick={onCloseClick}>Cancel</OutlineButton>
-        <OutlineButton onClick={onSaveClick} disabled>
-          Save
-        </OutlineButton>
+        <OutlineButton onClick={onSaveClick}>Save</OutlineButton>
       </div>
     </Modal>
   )
+}
+
+// TODO (ka 2019-10-29): Not sure where this should ultimately live,
+// but hardcoding here for now since this is the only place it will be used
+// Will update with all slots when implementing FF in next PR
+const SUPPORTED_MODULE_SLOTS = {
+  magdeck: [{ name: 'Slot 1 (supported)', value: '1' }],
+  tempdeck: [{ name: 'Slot 3 (supported)', value: '3' }],
+  thermocycler: [],
 }

--- a/protocol-designer/src/components/modules/EditModulesCard.js
+++ b/protocol-designer/src/components/modules/EditModulesCard.js
@@ -9,7 +9,7 @@ import type { ModulesForEditModulesCard } from '../../step-forms'
 
 type Props = {
   modules: ModulesForEditModulesCard,
-  editModule: (type: ModuleType) => mixed,
+  openEditModuleModal: (type: ModuleType) => mixed,
 }
 
 // TODO (ka 2019-10-24): This will likely be resused a lot,
@@ -17,7 +17,7 @@ type Props = {
 const MODULE_TYPES: Array<ModuleType> = ['magdeck', 'tempdeck', 'thermocycler']
 
 export default function EditModulesCard(props: Props) {
-  const { modules, editModule } = props
+  const { modules, openEditModuleModal } = props
 
   return (
     <Card title="Modules">
@@ -30,12 +30,16 @@ export default function EditModulesCard(props: Props) {
                 {...moduleData}
                 type={moduleType}
                 key={i}
-                editModule={editModule}
+                openEditModuleModal={openEditModuleModal}
               />
             )
           } else {
             return (
-              <ModuleRow type={moduleType} key={i} editModule={editModule} />
+              <ModuleRow
+                type={moduleType}
+                key={i}
+                openEditModuleModal={openEditModuleModal}
+              />
             )
           }
         })}

--- a/protocol-designer/src/components/modules/EditModulesCard.js
+++ b/protocol-designer/src/components/modules/EditModulesCard.js
@@ -9,6 +9,7 @@ import type { ModulesForEditModulesCard } from '../../step-forms'
 
 type Props = {
   modules: ModulesForEditModulesCard,
+  editModule: (type: ModuleType) => mixed,
 }
 
 // TODO (ka 2019-10-24): This will likely be resused a lot,
@@ -16,7 +17,7 @@ type Props = {
 const MODULE_TYPES: Array<ModuleType> = ['magdeck', 'tempdeck', 'thermocycler']
 
 export default function EditModulesCard(props: Props) {
-  const { modules } = props
+  const { modules, editModule } = props
 
   return (
     <Card title="Modules">
@@ -24,9 +25,18 @@ export default function EditModulesCard(props: Props) {
         {MODULE_TYPES.map((moduleType, i) => {
           const moduleData = modules[moduleType]
           if (moduleData) {
-            return <ModuleRow {...moduleData} type={moduleType} key={i} />
+            return (
+              <ModuleRow
+                {...moduleData}
+                type={moduleType}
+                key={i}
+                editModule={editModule}
+              />
+            )
           } else {
-            return <ModuleRow type={moduleType} key={i} />
+            return (
+              <ModuleRow type={moduleType} key={i} editModule={editModule} />
+            )
           }
         })}
       </div>

--- a/protocol-designer/src/components/modules/ModuleRow.js
+++ b/protocol-designer/src/components/modules/ModuleRow.js
@@ -14,14 +14,14 @@ type Props = {
   slot?: DeckSlot,
   model?: string,
   type: ModuleType,
-  editModule: (moduleType: ModuleType) => mixed,
+  openEditModuleModal: (moduleType: ModuleType) => mixed,
 }
 
 export default function ModuleRow(props: Props) {
-  const { type, moduleId, slot, model, editModule } = props
-  const setModuleType = (type: ModuleType) => () => editModule(type)
+  const { type, moduleId, slot, model, openEditModuleModal } = props
+  const setModuleType = (type: ModuleType) => () => openEditModuleModal(type)
   const addRemoveText = moduleId ? 'remove' : 'add'
-  const addRemoveAction = moduleId
+  const handleAddOrRemove = moduleId
     ? () => console.log('remove ' + moduleId)
     : setModuleType(type)
   return (
@@ -52,7 +52,7 @@ export default function ModuleRow(props: Props) {
           + pass moduleId for deleting */}
           <OutlineButton
             className={styles.module_button}
-            onClick={addRemoveAction}
+            onClick={handleAddOrRemove}
           >
             {addRemoveText}
           </OutlineButton>

--- a/protocol-designer/src/components/modules/ModuleRow.js
+++ b/protocol-designer/src/components/modules/ModuleRow.js
@@ -14,11 +14,16 @@ type Props = {
   slot?: DeckSlot,
   model?: string,
   type: ModuleType,
+  editModule: (moduleType: ModuleType) => mixed,
 }
 
 export default function ModuleRow(props: Props) {
-  const { type, moduleId, slot, model } = props
+  const { type, moduleId, slot, model, editModule } = props
+  const setModuleType = (type: ModuleType) => () => editModule(type)
   const addRemoveText = moduleId ? 'remove' : 'add'
+  const addRemoveAction = moduleId
+    ? () => console.log('remove ' + moduleId)
+    : setModuleType(type)
   return (
     <div>
       <h4 className={styles.row_title}>
@@ -45,7 +50,10 @@ export default function ModuleRow(props: Props) {
 
           {/* TODO (ka 2019-10-23): onClick needs to set edit modal open
           + pass moduleId for deleting */}
-          <OutlineButton className={styles.module_button}>
+          <OutlineButton
+            className={styles.module_button}
+            onClick={addRemoveAction}
+          >
             {addRemoveText}
           </OutlineButton>
         </div>

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -37,5 +37,8 @@
         "blowout_checkbox": "Redundant with disposal volume"
       }
     }
+  },
+  "edit_module_modal": {
+    "slot_selection": "To enable non-default/unrestricted positioning, go to Settings > App > Experimental settings."
   }
 }


### PR DESCRIPTION
## overview

This PR addresses #4133 by adding the Add/Edit modules modal with disabled slot dropdown.

Follow up PR will enable slot dropdown upon presence of unrestricted modules FF.

## changelog

- feat(protocol-designer): Add edit modules modal

## review requests

Standard code and UI review