### PR TITLE
refactor(app-shell): fix BR premigration paths with webpackification

### DIFF
--- a/app-shell/src/buildroot/index.js
+++ b/app-shell/src/buildroot/index.js
@@ -18,7 +18,7 @@ import type {
   BuildrootAction,
 } from '@opentrons/app/src/shell'
 
-const log = createLogger(__filename)
+const log = createLogger('buildroot/index')
 
 const DIRECTORY = path.join(app.getPath('userData'), '__ot_buildroot__')
 

--- a/app-shell/src/buildroot/release-files.js
+++ b/app-shell/src/buildroot/release-files.js
@@ -16,7 +16,7 @@ import type { ReleaseSetUrls, ReleaseSetFilepaths, UserFileInfo } from './types'
 
 const VERSION_FILENAME = 'VERSION.json'
 
-const log = createLogger(__filename)
+const log = createLogger('buildroot/release-files')
 const outPath = (dir: string, url: string) => path.join(dir, path.basename(url))
 
 // checks `directory` for buildroot files matching the given `urls`, and

--- a/app-shell/src/buildroot/update.js
+++ b/app-shell/src/buildroot/update.js
@@ -8,8 +8,9 @@ import { fetch, postFile } from '../http'
 import type { RobotHost } from '@opentrons/app/src/robot-api'
 
 const PREMIGRATION_WHL_DIR = path.join(
+  // NOTE: __dirname refers to output directory
   __dirname,
-  '../../build/br-premigration-wheels'
+  '../build/br-premigration-wheels'
 )
 
 const PREMIGRATION_API_WHL = path.join(

--- a/app-shell/src/config.js
+++ b/app-shell/src/config.js
@@ -98,7 +98,7 @@ let _over
 let _log
 const store = () => _store || (_store = new Store({ defaults: DEFAULTS }))
 const overrides = () => _over || (_over = yargsParser(argv, PARSE_ARGS_OPTS))
-const log = () => _log || (_log = createLogger(__filename))
+const log = () => _log || (_log = createLogger('config'))
 
 // initialize and register the config module with dispatches from the UI
 export function registerConfig(dispatch: Dispatch) {

--- a/app-shell/src/discovery.js
+++ b/app-shell/src/discovery.js
@@ -16,7 +16,7 @@ import type { Service } from '@opentrons/discovery-client'
 
 import type { Action, Dispatch } from './types'
 
-const log = createLogger(__filename)
+const log = createLogger('discovery')
 
 // TODO(mc, 2018-08-09): values picked arbitrarily and should be researched
 const FAST_POLL_INTERVAL_MS = 3000

--- a/app-shell/src/log.js
+++ b/app-shell/src/log.js
@@ -44,7 +44,7 @@ function initializeTransports() {
   }
 
   transports = createTransports()
-  log = createLogger(__filename)
+  log = createLogger('log')
 
   if (error) log.error('Could not create log directory', { error })
   log.info(`Level "error" and higher logging to ${ERROR_LOG}`)
@@ -97,22 +97,17 @@ function createTransports() {
   ]
 }
 
-function createLogger(filename) {
-  log && log.debug(`Creating logger for ${filename}`)
+function createLogger(label) {
+  log && log.debug(`Creating logger for ${label}`)
 
   const formats = [
+    winston.format.label({ label }),
     winston.format.timestamp(),
     winston.format.metadata({
       key: 'meta',
       fillExcept: ['level', 'message', 'timestamp', 'label'],
     }),
   ]
-
-  if (filename) {
-    const label = path.relative(path.join(__dirname, '../..'), filename)
-
-    formats.unshift(winston.format.label({ label }))
-  }
 
   return winston.createLogger({
     transports,

--- a/app-shell/src/main.js
+++ b/app-shell/src/main.js
@@ -12,7 +12,7 @@ import { registerUpdate } from './update'
 import { registerBuildrootUpdate } from './buildroot'
 
 const config = getConfig()
-const log = createLogger(__filename)
+const log = createLogger('main')
 
 log.debug('App config', {
   config,
@@ -76,7 +76,7 @@ function startUp() {
 function createRendererLogger() {
   log.info('Creating renderer logger')
 
-  const logger = createLogger()
+  const logger = createLogger('renderer')
   ipcMain.on('log', (_, info) => logger.log(info))
 
   return logger

--- a/app-shell/src/robot-logs.js
+++ b/app-shell/src/robot-logs.js
@@ -3,7 +3,7 @@
 import { download } from 'electron-dl'
 import createLogger from './log'
 
-const log = createLogger(__dirname)
+const log = createLogger('robot-logs')
 
 export function registerRobotLogs(dispatch, mainWindow) {
   return function handleIncomingAction(action) {

--- a/app-shell/src/ui.js
+++ b/app-shell/src/ui.js
@@ -5,7 +5,7 @@ import { getConfig } from './config'
 import createLogger from './log'
 
 const config = getConfig('ui')
-const log = createLogger(__filename)
+const log = createLogger('ui')
 
 const urlPath =
   config.url.protocol === 'file:'
@@ -22,6 +22,7 @@ const WINDOW_OPTS = {
   // allow webPreferences to be set at launchtime from config
   webPreferences: Object.assign(
     {
+      // NOTE: __dirname refers to output directory
       preload: path.join(__dirname, './preload.js'),
       nodeIntegration: false,
     },

--- a/app-shell/src/update.js
+++ b/app-shell/src/update.js
@@ -10,11 +10,12 @@ import { getConfig } from './config'
 import type { UpdateInfo } from '@opentrons/app/src/shell'
 import type { Action, Dispatch, PlainError } from './types'
 
-updater.logger = createLogger(__filename)
+updater.logger = createLogger('update')
 updater.autoDownload = false
 
 export const CURRENT_VERSION: string = updater.currentVersion.version
 export const CURRENT_RELEASE_NOTES: string = fs.readFileSync(
+  // NOTE: __dirname refers to output directory
   path.join(__dirname, '../build/release-notes.md'),
   'utf8'
 )

--- a/app-shell/webpack.config.js
+++ b/app-shell/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = [
 
   // preload script (runs in the browser window)
   webpackMerge(nodeBaseConfig, COMMON_CONFIG, {
-    target: 'web',
+    target: 'electron-preload',
     entry: { preload: ENTRY_PRELOAD },
   }),
 ]

--- a/babel.config.js
+++ b/babel.config.js
@@ -29,10 +29,12 @@ module.exports = {
   overrides: [
     {
       test: 'app-shell/**/*',
+      plugins: [['react-hot-loader/babel', false]],
       presets: [['@babel/preset-env', { targets: { electron: '6' } }]],
     },
     {
       test: ['discovery-client/**/*'],
+      plugins: [['react-hot-loader/babel', false]],
       presets: [['@babel/preset-env', { targets: { node: '8' } }]],
     },
     // app that should be polyfilled


### PR DESCRIPTION
## overview

#4260 switched the build process of app-shell from babel to webpack. Because the source files are now bundled, `__filename` and `__dirname` refer to **the bundle** rather than the source files. This threw off the path resolution to the BR pre-migration wheels.

This PR fixes usage of `__dirname` and `__filename` in app-shell to resolve premigration issues, and adds a guard to the `http::postFile` utility function to properly throw errors if the function is called with a file that can't be found

## changelog

- refactor(app-shell): fix BR premigration paths with webpackification

## review requests

- [ ] Balena > BR upgrade works