### PR TITLE
fix(api): update all pose tree state when calibrating labware

### DIFF
--- a/api/src/opentrons/legacy_api/containers/__init__.py
+++ b/api/src/opentrons/legacy_api/containers/__init__.py
@@ -219,7 +219,22 @@ def save_new_offsets(labware_hash, delta):
     if not calibration_path.exists():
         calibration_path.mkdir(parents=True, exist_ok=True)
     old_delta = _look_up_offsets(labware_hash)
+
+    # Note that the next line looks incorrect (like it's letting the prior
+    # value leak into the new one). That's sort of correct, but this actually
+    # functions properly as is--the old labware system was designed to not go
+    # back to an offset of (0,0,0) as a factory default, so once you have
+    # calibrated once, you can't get the original back without deleting the
+    # entire database. Instead of modifying the database to allow resetting a
+    # single labware, we're replacing the old data representation with a new
+    # one that does have (0,0,0) as its base offset. Once the old data is
+    # removed from the system, it will be possible to modify this so that it
+    # replaces the coordinates with the exact offset calibrated, instead of the
+    # delta between the old and new offests, but for now this is necessary to
+    # make both v1 and v2 labware work. This function only handles v2, but that
+    # is why the delta is passed here instead of an absolute.
     new_delta = old_delta + Point(x=delta[0], y=delta[1], z=delta[2])
+
     labware_offset_path = calibration_path / '{}.json'.format(labware_hash)
     calibration_data = new_labware._helper_offset_data_format(
         str(labware_offset_path), new_delta)

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -1056,7 +1056,6 @@ class Robot(CommandPublisher):
 
         delta = pose_tracker.Point(delta_x, delta_y, delta_z)
 
-
         # Note: pose tree is updated here, in order to update in-memory state.
         # Separately from that, on-disk state is updated. This is a point of
         # possible dis-unity. Would probably work better to un-load the labware

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -93,6 +93,14 @@ def config_tempdir(tmpdir, template_db):
     yield tmpdir, template_db
 
 
+@pytest.mark.apiv1
+@pytest.fixture(scope='function')
+def offsets_tempdir(tmpdir, template_db):
+    config.CONFIG['labware_calibration_offsets_dir_v2'] = str(tmpdir)
+    config.reload()
+    yield tmpdir
+
+
 @pytest.fixture(autouse=True)
 def clear_feature_flags():
     ff_file = config.CONFIG['feature_flags_file']

--- a/api/tests/opentrons/robot/test_robot.py
+++ b/api/tests/opentrons/robot/test_robot.py
@@ -286,7 +286,6 @@ def test_calibrate_multiple(robot, instruments, labware, offsets_tempdir):
     assert isclose(new_offset2, expected2).all()
 
 
-
 @pytest.mark.api1_only
 def test_cache_instruments(robot, monkeypatch):
     # Test that smoothie runtime configs are set at run when

--- a/api/tests/opentrons/robot/test_robot.py
+++ b/api/tests/opentrons/robot/test_robot.py
@@ -4,7 +4,9 @@ from numpy import isclose
 from unittest import mock
 
 from opentrons.legacy_api.containers import load as containers_load
+from opentrons.legacy_api.containers import _look_up_offsets
 from opentrons.trackers import pose_tracker
+from opentrons.types import Point
 from opentrons.util import vector
 
 
@@ -227,6 +229,62 @@ def test_calibrate_labware(robot, instruments, labware, monkeypatch):
     new_pose = pose_tracker.absolute(robot.poses, plate[0])
 
     assert isclose(new_pose, (old_x + 1, old_y + 2, old_z - 3)).all()
+
+
+@pytest.mark.api1_only
+def test_calibrate_multiple(robot, instruments, labware, offsets_tempdir):
+    # Note: labware_name must be a v2 labware definition
+    labware_name = 'agilent_1_reservoir_290ml'
+
+    reservoir1 = labware.load(labware_name, '1')
+    reservoir2 = labware.load(labware_name, '2')
+
+    pip = instruments.P300_Single(mount='right')
+
+    old_x1, old_y1, old_z1 = pose_tracker.absolute(robot.poses, reservoir1[0])
+    old_x2, old_y2, old_z2 = pose_tracker.absolute(robot.poses, reservoir2[0])
+
+    pip.move_to(reservoir1[0])
+    delta_x1, delta_y1, delta_z1 = (1, 2, -3)
+    robot.poses = pip._jog(robot.poses, 'x', delta_x1)
+    robot.poses = pip._jog(robot.poses, 'y', delta_y1)
+    robot.poses = pip._jog(robot.poses, 'z', delta_z1)
+    robot.calibrate_container_with_instrument(reservoir1, pip, save=True)
+
+    # Check pose tree, also check data on disk
+    new_pose1 = pose_tracker.absolute(robot.poses, reservoir1[0])
+    new_pose2 = pose_tracker.absolute(robot.poses, reservoir2[0])
+
+    assert isclose(new_pose1, (
+        old_x1 + delta_x1, old_y1 + delta_y1, old_z1 + delta_z1)).all()
+    assert isclose(new_pose2, (
+        old_x2 + delta_x1, old_y2 + delta_y1, old_z2 + delta_z1)).all()
+
+    lw_hash = reservoir1.properties.get('labware_hash')
+    new_offset1 = _look_up_offsets(lw_hash)
+    expected1 = Point(delta_x1, delta_y1, delta_z1)
+    assert isclose(new_offset1, expected1).all()
+
+    pip.move_to(reservoir2[0])
+    robot.poses = pip._jog(robot.poses, 'x', -1 * delta_x1)
+    robot.poses = pip._jog(robot.poses, 'y', -1 * delta_y1)
+    robot.poses = pip._jog(robot.poses, 'z', -1 * delta_z1)
+    robot.calibrate_container_with_instrument(reservoir2, pip, save=True)
+
+    # Check pose tree, also check data on disk
+    new_pose1 = pose_tracker.absolute(robot.poses, reservoir1[0])
+    new_pose2 = pose_tracker.absolute(robot.poses, reservoir2[0])
+
+    assert isclose(new_pose1, (
+        old_x1, old_y1, old_z1)).all()
+    assert isclose(new_pose2, (
+        old_x2, old_y2, old_z2)).all()
+
+    lw_hash = reservoir1.properties.get('labware_hash')
+    new_offset2 = _look_up_offsets(lw_hash)
+    expected2 = Point(0, 0, 0)
+    assert isclose(new_offset2, expected2).all()
+
 
 
 @pytest.mark.api1_only


### PR DESCRIPTION
## overview

During labware calibration, the pose tree was being updated only for the single instance that was being calibrated, but the calibration delta was being added to the calibration file on disk, so if you calibrated more than one labware of the same load name (or, more specifically, with the same labware hash) in a single session, you would get the sum of all of the deltas for that session as the new offset. This PR updates all the matching items in the pose tree to avoid this behavior.

Still needs to be tested on robots

Fixes #4288 