### PR TITLE
fix(api): Modify list check to return first item of source and dest

### DIFF
--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -23,7 +23,10 @@ def is_new_loc(location: Union[Location, Well, None,
 
 def listify(location: Any) -> List:
     if isinstance(location, list):
-        return sum([listify(loc) for loc in location], [])
+        try:
+            return listify(location[0])
+        except IndexError:
+            return [location]
     else:
         return [location]
 


### PR DESCRIPTION
## overview

In V2, transfer run logs usually looked something like this image
<img width="633" alt="Screen Shot 2019-10-30 at 11 43 48 AM" src="https://user-images.githubusercontent.com/31892318/67885232-92fa2080-fb1d-11e9-8954-408ab8a31beb.png">


whereas the run logs in api v1 looked like this image 
![Screen Shot 2019-10-30 at 1 56 36 PM](https://user-images.githubusercontent.com/31892318/67884967-2121d700-fb1d-11e9-83c0-0223defc6c83.png)

## changelog

- Make recursive func return once a list is not nested

## review requests

Check that transfer logs don't look ugly now
