### PR TITLE
refactor(app): cleanup restart required state during restart

### DIFF
--- a/app/src/pages/Robots/RobotSettings.js
+++ b/app/src/pages/Robots/RobotSettings.js
@@ -101,14 +101,16 @@ function RobotSettingsPage(props: Props) {
   return (
     <>
       <Page titleBarProps={titleBarProps}>
-        {robot.status === REACHABLE && !updateInProgress && (
-          <ReachableRobotBanner key={robot.name} {...robot} />
-        )}
-        {robot.status === CONNECTABLE && (
-          <ConnectBanner {...robot} key={Number(robot.connected)} />
-        )}
-        {restartRequired && !restarting && (
-          <RestartRequiredBanner robot={robot} />
+        {!restarting && !updateInProgress && (
+          <>
+            {robot.status === REACHABLE && (
+              <ReachableRobotBanner key={robot.name} {...robot} />
+            )}
+            {robot.status === CONNECTABLE && (
+              <ConnectBanner {...robot} key={Number(robot.connected)} />
+            )}
+            {restartRequired && <RestartRequiredBanner robot={robot} />}
+          </>
         )}
 
         <RobotSettings

--- a/app/src/robot-admin/__tests__/reducer.test.js
+++ b/app/src/robot-admin/__tests__/reducer.test.js
@@ -89,6 +89,22 @@ describe('robotAdminReducer', () => {
       },
       expected: { a: { status: 'restarting' } },
     },
+    {
+      name:
+        'discovery:UPDATE_LIST leaves restarting alone if restarting and ok: false',
+      action: {
+        type: 'discovery:UPDATE_LIST',
+        payload: {
+          robots: [
+            ({ name: 'a', ip: '192.168.1.1', port: 31950, ok: false }: any),
+          ],
+        },
+      },
+      state: {
+        a: { status: 'restarting' },
+      },
+      expected: { a: { status: 'restarting' } },
+    },
   ]
 
   SPECS.forEach(spec => {

--- a/app/src/robot-admin/__tests__/selectors.test.js
+++ b/app/src/robot-admin/__tests__/selectors.test.js
@@ -13,6 +13,20 @@ type SelectorSpec = {|
 describe('robot admin selectors', () => {
   const SPECS: Array<SelectorSpec> = [
     {
+      name: 'getRobotAdminStatus returns null by default',
+      selector: Selectors.getRobotAdminStatus,
+      state: { robotAdmin: {} },
+      args: ['robotName'],
+      expected: null,
+    },
+    {
+      name: 'getRobotAdminStatus',
+      selector: Selectors.getRobotAdminStatus,
+      state: { robotAdmin: { robotName: { status: 'up' } } },
+      args: ['robotName'],
+      expected: 'up',
+    },
+    {
       name: 'getRobotRestarting with status up',
       selector: Selectors.getRobotRestarting,
       state: { robotAdmin: { robotName: { status: 'up' } } },

--- a/app/src/robot-admin/reducer.js
+++ b/app/src/robot-admin/reducer.js
@@ -60,7 +60,7 @@ export function robotAdminReducer(
             status = UP_STATUS
           } else if (!up && status === RESTART_PENDING_STATUS) {
             status = RESTARTING_STATUS
-          } else if (!up) {
+          } else if (!up && status !== RESTARTING_STATUS) {
             status = DOWN_STATUS
           }
 

--- a/app/src/robot-admin/selectors.js
+++ b/app/src/robot-admin/selectors.js
@@ -2,10 +2,18 @@
 import { RESTART_PENDING_STATUS, RESTARTING_STATUS } from './constants'
 
 import type { State } from '../types'
+import type { RobotAdminStatus } from './types'
 
 const robotState = (state: State, name: string) => state.robotAdmin[name]
 
+export function getRobotAdminStatus(
+  state: State,
+  robotName: string
+): RobotAdminStatus | null {
+  return robotState(state, robotName)?.status || null
+}
+
 export function getRobotRestarting(state: State, robotName: string): boolean {
-  const status = robotState(state, robotName)?.status
+  const status = getRobotAdminStatus(state, robotName)
   return status === RESTART_PENDING_STATUS || status === RESTARTING_STATUS
 }

--- a/app/src/robot-settings/__tests__/actions.test.js
+++ b/app/src/robot-settings/__tests__/actions.test.js
@@ -38,6 +38,15 @@ describe('robot settings actions', () => {
         },
       },
     },
+    {
+      name: 'clearRestartPath',
+      creator: Actions.clearRestartPath,
+      args: [mockRobot.name],
+      expected: {
+        type: 'robotSettings:CLEAR_RESTART_PATH',
+        payload: { robotName: mockRobot.name },
+      },
+    },
   ]
 
   SPECS.forEach(spec => {

--- a/app/src/robot-settings/__tests__/reducer.test.js
+++ b/app/src/robot-settings/__tests__/reducer.test.js
@@ -163,6 +163,15 @@ describe('robotSettingsReducer', () => {
         },
       },
     },
+    {
+      name: 'handles robotSettings:CLEAR_RESTART_PATH',
+      action: {
+        type: 'robotSettings:CLEAR_RESTART_PATH',
+        payload: { robotName: 'robotName' },
+      },
+      state: { robotName: { settings: [], restartPath: '/restart' } },
+      expected: { robotName: { settings: [], restartPath: null } },
+    },
   ]
 
   SPECS.forEach(spec => {

--- a/app/src/robot-settings/__tests__/selectors.test.js
+++ b/app/src/robot-settings/__tests__/selectors.test.js
@@ -55,6 +55,19 @@ describe('robot settings selectors', () => {
       args: ['robotName'],
       expected: false,
     },
+    {
+      name: 'getAllRestartRequiredRobots',
+      selector: Selectors.getAllRestartRequiredRobots,
+      state: {
+        robotSettings: {
+          a: { restartPath: '/restart', settings: [] },
+          b: { restartPath: null, settings: [] },
+          c: { restartPath: '/restart', settings: [] },
+        },
+      },
+      args: [],
+      expected: ['a', 'c'],
+    },
   ]
 
   SPECS.forEach(spec => {

--- a/app/src/robot-settings/actions.js
+++ b/app/src/robot-settings/actions.js
@@ -1,12 +1,17 @@
 // @flow
 import { GET, POST } from '../robot-api/utils'
 
-import { FETCH_SETTINGS, UPDATE_SETTING, SETTINGS_PATH } from './constants'
+import {
+  FETCH_SETTINGS,
+  UPDATE_SETTING,
+  CLEAR_RESTART_PATH,
+  SETTINGS_PATH,
+} from './constants'
 
 import type { RobotHost } from '../robot-api/types'
-import type { RobotSettingsAction } from './types'
+import type { RobotSettingsApiAction, ClearRestartPathAction } from './types'
 
-export const fetchSettings = (host: RobotHost): RobotSettingsAction => ({
+export const fetchSettings = (host: RobotHost): RobotSettingsApiAction => ({
   type: FETCH_SETTINGS,
   payload: { host, method: GET, path: SETTINGS_PATH },
 })
@@ -15,7 +20,7 @@ export const updateSetting = (
   host: RobotHost,
   settingId: string,
   value: boolean | null
-): RobotSettingsAction => ({
+): RobotSettingsApiAction => ({
   type: UPDATE_SETTING,
   payload: {
     host,
@@ -23,4 +28,11 @@ export const updateSetting = (
     path: SETTINGS_PATH,
     body: { id: settingId, value },
   },
+})
+
+export const clearRestartPath = (
+  robotName: string
+): ClearRestartPathAction => ({
+  type: CLEAR_RESTART_PATH,
+  payload: { robotName },
 })

--- a/app/src/robot-settings/constants.js
+++ b/app/src/robot-settings/constants.js
@@ -8,5 +8,5 @@ export const FETCH_SETTINGS: 'robotSettings:FETCH_SETTINGS' =
 export const UPDATE_SETTING: 'robotSettings:UPDATE_SETTING' =
   'robotSettings:UPDATE_SETTING'
 
-export const APPLY_WITH_RESTART: 'robotSettings:APPLY_WITH_RESTART' =
-  'robotSettings:APPLY_WITH_RESTART'
+export const CLEAR_RESTART_PATH: 'robotSettings:CLEAR_RESTART_PATH' =
+  'robotSettings:CLEAR_RESTART_PATH'

--- a/app/src/robot-settings/epic.js
+++ b/app/src/robot-settings/epic.js
@@ -1,17 +1,38 @@
 // @flow
-import { ofType } from 'redux-observable'
-import { switchMap } from 'rxjs/operators'
+import { of } from 'rxjs'
+import { map, filter, switchMap, mergeMap } from 'rxjs/operators'
+import { ofType, combineEpics } from 'redux-observable'
 import { makeRobotApiRequest } from '../robot-api/utils'
+import { getRobotAdminStatus, RESTARTING_STATUS } from '../robot-admin'
+import { clearRestartPath } from './actions'
+import { getAllRestartRequiredRobots } from './selectors'
 import { FETCH_SETTINGS, UPDATE_SETTING } from './constants'
 
 import type { Epic } from '../types'
-import type { RobotSettingsAction } from './types'
+import type { RobotSettingsApiAction } from './types'
 
-export const robotSettingsEpic: Epic = action$ => {
+const robotSettingsApiEpic: Epic = action$ => {
   return action$.pipe(
     ofType(FETCH_SETTINGS, UPDATE_SETTING),
-    switchMap<RobotSettingsAction, _, _>(a => {
+    switchMap<RobotSettingsApiAction, _, _>(a => {
       return makeRobotApiRequest(a.payload, {})
     })
   )
 }
+
+const clearRestartPathOnRestarting: Epic = (action$, state$) => {
+  return state$.pipe(
+    map(state => {
+      return getAllRestartRequiredRobots(state)
+        .filter(name => getRobotAdminStatus(state, name) === RESTARTING_STATUS)
+        .map(robotName => clearRestartPath(robotName))
+    }),
+    filter(actions => actions.length > 0),
+    mergeMap(actions => of(...actions))
+  )
+}
+
+export const robotSettingsEpic: Epic = combineEpics(
+  robotSettingsApiEpic,
+  clearRestartPathOnRestarting
+)

--- a/app/src/robot-settings/reducer.js
+++ b/app/src/robot-settings/reducer.js
@@ -1,6 +1,6 @@
 // @flow
 import { passRobotApiResponseAction } from '../robot-api/utils'
-import { SETTINGS_PATH } from './constants'
+import { CLEAR_RESTART_PATH, SETTINGS_PATH } from './constants'
 
 import type { Action, ActionLike } from '../types'
 import type { RobotSettingsResponse, RobotSettingsState } from './types'
@@ -26,6 +26,17 @@ export function robotSettingsReducer(
       const restartPath = links?.restart || null
 
       return { ...state, [robotName]: { settings, restartPath } }
+    }
+  }
+
+  const strictAction: Action = (action: any)
+
+  switch (strictAction.type) {
+    case CLEAR_RESTART_PATH: {
+      const { robotName } = strictAction.payload
+      const robotState = state[robotName]
+
+      return { ...state, [robotName]: { ...robotState, restartPath: null } }
     }
   }
 

--- a/app/src/robot-settings/selectors.js
+++ b/app/src/robot-settings/selectors.js
@@ -24,3 +24,9 @@ export function getRobotRestartRequired(
 ): boolean {
   return getRobotRestartPath(state, robotName) !== null
 }
+
+export function getAllRestartRequiredRobots(state: State): Array<string> {
+  return Object.keys(state.robotSettings).filter(name => {
+    return getRobotRestartRequired(state, name)
+  })
+}

--- a/app/src/robot-settings/types.js
+++ b/app/src/robot-settings/types.js
@@ -31,6 +31,15 @@ export type RobotSettingsFieldUpdate = {|
   value: $PropertyType<RobotSettingsField, 'value'>,
 |}
 
-export type RobotSettingsAction =
+export type ClearRestartPathAction = {|
+  type: 'robotSettings:CLEAR_RESTART_PATH',
+  payload: { robotName: string },
+|}
+
+export type RobotSettingsApiAction =
   | {| type: 'robotSettings:FETCH_SETTINGS', payload: RobotApiRequest |}
   | {| type: 'robotSettings:UPDATE_SETTING', payload: RobotApiRequest |}
+
+export type RobotSettingsAction =
+  | ClearRestartPathAction
+  | RobotSettingsApiAction


### PR DESCRIPTION
## overview

This PR fixes some state mistakes in #4285 that resulted in:

- The restart spinner going away prematurely
- The restart required banner persisting even after the robot was restarted

## changelog

- refactor(app): cleanup restart required state during restart

## review requests

- [ ] Restart button behaves normally
- [ ] Restart button in alert banner after FF change behaves normally

Where "behaves normally" means:

- [ ] Any banners go away
- [ ] Full page spinner takes over
- [ ] Full page spinner goes until robot is actually back online
- [ ] Restart required banner does not re-appear after restart