### PR TITLE
feat(api): add http endpoint for robot settings dump

### DIFF
--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -89,10 +89,10 @@ DEFAULT_CURRENT_STRING = ' '.join(
     ['{}{}'.format(key, value) for key, value in DEFAULT_CURRENT.items()])
 
 DEFAULT_DECK_CALIBRATION: List[List[float]] = [
-    [1.00, 0.00, 0.00,  0.00],
-    [0.00, 1.00, 0.00,  0.00],
-    [0.00, 0.00, 1.00,  0.00],
-    [0.00, 0.00, 0.00,  1.00]]
+    [1.00, 0.00, 0.00, 0.00],
+    [0.00, 1.00, 0.00, 0.00],
+    [0.00, 0.00, 1.00, 0.00],
+    [0.00, 0.00, 0.00, 1.00]]
 
 X_ACCELERATION = 3000
 Y_ACCELERATION = 2000

--- a/api/src/opentrons/server/endpoints/settings.py
+++ b/api/src/opentrons/server/endpoints/settings.py
@@ -334,5 +334,10 @@ async def get_robot_settings(request: web.Request) -> web.Response:
     representation of all internal robot settings and gantry calibration
     """
 
-    config = rc.load()
-    return web.json_response(config._asdict(), status=200)
+    hw = request.app['com.opentrons.hardware']
+
+    if ff.use_protocol_api_v2():
+        conf = await hw.config
+    else:
+        conf = hw.config
+    return web.json_response(conf._asdict(), status=200)

--- a/api/src/opentrons/server/endpoints/settings.py
+++ b/api/src/opentrons/server/endpoints/settings.py
@@ -247,7 +247,7 @@ async def pipette_settings_id(request: web.Request) -> web.Response:
             'model': whole_config.get('model')
         },
         'fields': pc.list_mutable_configs(pipette_id)
-        }
+    }
     return web.json_response(res, status=200)
 
 
@@ -326,3 +326,13 @@ async def set_log_level(request: web.Request) -> web.Response:
     return web.json_response(
         status=200,
         data={'message': f'log_level set to {log_level}'})
+
+
+async def get_robot_settings(request: web.Request) -> web.Response:
+    """
+    Handles a GET request and returns a body that is the JSON
+    representation of all internal robot settings and gantry calibration
+    """
+
+    config = rc.load()
+    return web.json_response(config, status=200)

--- a/api/src/opentrons/server/endpoints/settings.py
+++ b/api/src/opentrons/server/endpoints/settings.py
@@ -335,4 +335,4 @@ async def get_robot_settings(request: web.Request) -> web.Response:
     """
 
     config = rc.load()
-    return web.json_response(config, status=200)
+    return web.json_response(config._asdict, status=200)

--- a/api/src/opentrons/server/endpoints/settings.py
+++ b/api/src/opentrons/server/endpoints/settings.py
@@ -335,4 +335,4 @@ async def get_robot_settings(request: web.Request) -> web.Response:
     """
 
     config = rc.load()
-    return web.json_response(config._asdict, status=200)
+    return web.json_response(config._asdict(), status=200)

--- a/api/src/opentrons/server/http.py
+++ b/api/src/opentrons/server/http.py
@@ -104,3 +104,5 @@ class HTTPServer(object):
         self.app.router.add_patch(
             '/settings/pipettes/{id}', settings.modify_pipette_settings
         )
+        self.app.router.add_get(
+            '/settings/robot', settings.get_robot_settings)

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -281,8 +281,8 @@ async def test_modify_pipette_settings(async_client, attached_pipettes):
     no_changes = {
         'fields': {
             'pickUpCurrent': {'value': 1}
-            }
         }
+    }
 
     test_id = attached_pipettes['left']['id']
     # Check data has not been changed yet
@@ -306,8 +306,8 @@ async def test_modify_pipette_settings(async_client, attached_pipettes):
     changes2 = {
         'fields': {
             'pickUpCurrent': None
-            }
         }
+    }
     resp = await async_client.patch(
         '/settings/pipettes/{}'.format(test_id),
         json=changes2)
@@ -330,10 +330,10 @@ async def test_modify_pipette_settings(async_client, attached_pipettes):
 async def test_incorrect_modify_pipette_settings(
         async_client, attached_pipettes):
     out_of_range = {
-            'fields': {
-                'pickUpCurrent': {'value': 1000}
-                }
-            }
+        'fields': {
+            'pickUpCurrent': {'value': 1000}
+        }
+    }
     # check over max fails
     resp = await async_client.patch(
         '/settings/pipettes/{}'.format(attached_pipettes['left']['id']),
@@ -368,3 +368,15 @@ async def test_set_log_level(async_client):
     else:
         conf = await hardware.config
     assert conf.log_level == 'ERROR'
+
+
+async def test_get(async_client):
+    resp = await async_client.get('/settings/robot')
+    body = await resp.json()
+    assert resp.status == 200
+    hardware = async_client.app['com.opentrons.hardware']
+    if async_client.app['api_version'] == 1:
+        conf = hardware.config
+    else:
+        conf = await hardware.config
+    assert json.dumps(conf._asdict()) == json.dumps(body)

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -370,7 +370,7 @@ async def test_set_log_level(async_client):
     assert conf.log_level == 'ERROR'
 
 
-async def test_get(async_client):
+async def test_get_robot_settings(async_client):
     resp = await async_client.get('/settings/robot')
     body = await resp.json()
     assert resp.status == 200


### PR DESCRIPTION
## overview

Quality of life endpoint to aid in debugging.

A GET request to /settings/robot now returns a json blob that contains all raw robot settings and deck/gantry calibration values.
