### PR TITLE
refactor(components): remove spacing variables from components library

### DIFF
--- a/app/src/components/ListLabwareCard/styles.css
+++ b/app/src/components/ListLabwareCard/styles.css
@@ -2,13 +2,13 @@
 
 .card {
   line-height: 1.5;
-  padding-bottom: var(--spacing-2);
+  padding-bottom: 0.5rem;
 }
 
 .list_column_titles {
   @apply --font-body-1-dark;
 
-  padding: var(--spacing-3) var(--spacing-3) var(--spacing-2);
+  padding: 1rem 1rem 0.5rem;
   text-transform: uppercase;
 }
 
@@ -16,7 +16,7 @@
   @apply --font-body-2-dark;
 
   border-top: var(--bd-light);
-  padding: var(--spacing-3);
+  padding: 1rem;
 }
 
 .item_category_column,
@@ -33,7 +33,7 @@
 
 .item_name_column {
   width: calc(100% - 14rem);
-  padding-left: var(--spacing-3);
+  padding-left: 1rem;
 }
 
 .item_date_column {

--- a/components/src/index.css
+++ b/components/src/index.css
@@ -5,7 +5,6 @@
 @import './styles/borders.css';
 @import './styles/cursors.css';
 @import './styles/positioning.css';
-@import './styles/spacing.css';
 
 :global(*) {
   box-sizing: border-box;

--- a/components/src/styles/spacing.css
+++ b/components/src/styles/spacing.css
@@ -1,8 +1,0 @@
-:root {
-  --spacing-1: 0.25rem;
-  --spacing-2: 0.5rem;
-  --spacing-3: 1rem;
-  --spacing-4: 2rem;
-  --spacing-5: 4rem;
-  --spacing-6: 8rem;
-}


### PR DESCRIPTION
## overview

I added some CSS spacing variables to the components library in #4268. The variables names were attached to :root and conflicted with the spacing variable names already in Labware Library, severely breaking the labware library styling

## changelog

- refactor(components): remove spacing variables from components library

## review requests

- [ ] Labware library doesn't look like <http://sandbox.labware.opentrons.com/edge>
