### PR TITLE
feat(protocol-designer): Enable slot selection for modules when FF enabled

### DIFF
--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -228,10 +228,7 @@ class FilePage extends React.Component<Props, State> {
 
         <Portal>
           {this.state.isEditPipetteModalOpen && (
-            <EditPipettesModal
-              key={String(this.state.isEditPipetteModalOpen)}
-              closeModal={this.closeEditPipetteModal}
-            />
+            <EditPipettesModal closeModal={this.closeEditPipetteModal} />
           )}
 
           {this.state.isEditModulesModalOpen &&
@@ -239,7 +236,6 @@ class FilePage extends React.Component<Props, State> {
               <EditModulesModal
                 moduleType={this.state.currentModule.moduleType}
                 moduleId={this.state.currentModule.moduleId}
-                key={String(this.state.isEditModulesModalOpen)}
                 onCloseClick={this.closeEditModulesModal}
               />
             )}

--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -33,7 +33,10 @@ export type Props = {
 type State = {
   isEditPipetteModalOpen: boolean,
   isEditModulesModalOpen: boolean,
-  currentModule: ?ModuleType,
+  currentModule: {
+    moduleType: ?ModuleType,
+    moduleId: ?string,
+  },
 }
 
 const DATE_ONLY_FORMAT = 'MMM DD, YYYY'
@@ -52,7 +55,10 @@ class FilePage extends React.Component<Props, State> {
   state = {
     isEditPipetteModalOpen: false,
     isEditModulesModalOpen: false,
-    currentModule: null,
+    currentModule: {
+      moduleType: null,
+      moduleId: null,
+    },
   }
 
   // TODO (ka 2019-10-28): This is a workaround,
@@ -69,13 +75,19 @@ class FilePage extends React.Component<Props, State> {
   }
   closeEditPipetteModal = () => this.setState({ isEditPipetteModalOpen: false })
 
-  handleEditModule = (type: ModuleType) => {
+  handleEditModule = (type: ModuleType, moduleId?: string) => {
     this.scrollToTop()
-    this.setState({ isEditModulesModalOpen: true, currentModule: type })
+    this.setState({
+      isEditModulesModalOpen: true,
+      currentModule: { moduleType: type, moduleId: moduleId },
+    })
   }
 
   closeEditModulesModal = () => {
-    this.setState({ isEditModulesModalOpen: false, currentModule: null })
+    this.setState({
+      isEditModulesModalOpen: false,
+      currentModule: { moduleType: null, moduleId: null },
+    })
   }
 
   render() {
@@ -222,13 +234,15 @@ class FilePage extends React.Component<Props, State> {
             />
           )}
 
-          {this.state.isEditModulesModalOpen && this.state.currentModule && (
-            <EditModulesModal
-              moduleType={this.state.currentModule}
-              key={String(this.state.isEditModulesModalOpen)}
-              onCloseClick={this.closeEditModulesModal}
-            />
-          )}
+          {this.state.isEditModulesModalOpen &&
+            this.state.currentModule.moduleType && (
+              <EditModulesModal
+                moduleType={this.state.currentModule.moduleType}
+                moduleId={this.state.currentModule.moduleId}
+                key={String(this.state.isEditModulesModalOpen)}
+                onCloseClick={this.closeEditModulesModal}
+              />
+            )}
         </Portal>
       </div>
     )

--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -3,6 +3,10 @@ import * as React from 'react'
 import cx from 'classnames'
 import { useSelector } from 'react-redux'
 import { selectors as featureFlagSelectors } from '../../../feature-flags'
+import {
+  SUPPORTED_MODULE_SLOTS,
+  getAllModuleSlotsByType,
+} from '../../../modules'
 import i18n from '../../../localization'
 import { getModuleDisplayName } from '@opentrons/shared-data'
 import {
@@ -22,35 +26,14 @@ type EditModulesProps = {
   moduleId: ?string,
   onCloseClick: () => mixed,
 }
-// TODO (ka 2019-10-29): Move this to modules/moduleData?
-const SUPPORTED_MODULE_SLOTS = {
-  magdeck: [{ name: 'Slot 1 (supported)', value: '1' }],
-  tempdeck: [{ name: 'Slot 3 (supported)', value: '3' }],
-  thermocycler: [],
-}
-
-const ALL_MODULE_SLOTS = [
-  { name: 'Slot 1', value: '1' },
-  { name: 'Slot 3', value: '3' },
-  { name: 'Slot 4', value: '4' },
-  { name: 'Slot 6', value: '6' },
-  { name: 'Slot 7', value: '7' },
-  { name: 'Slot 9', value: '9' },
-  { name: 'Slot 10', value: '10' },
-]
-
-function getAllModuleSlotsByType(moduleType: ModuleType) {
-  const supportedSlotOption = SUPPORTED_MODULE_SLOTS[moduleType]
-  const allOtherSlots = ALL_MODULE_SLOTS.filter(
-    s => s.value !== supportedSlotOption[0].value
-  )
-  return supportedSlotOption.concat(allOtherSlots)
-}
 
 export default function EditModulesModal(props: EditModulesProps) {
   const { moduleType, moduleId, onCloseClick } = props
+  /* TODO (ka 2019-10-31): This is a temporary hook workaround so the slot selection 'works'
+  Once selectors are in place for modules we can get the previously assigned slot from state
+  and have supported slot as fallback for new modules or failure to get slot from module by id */
   const [selectedSlot, setSelectedSlot] = React.useState<string | null>(
-    SUPPORTED_MODULE_SLOTS[moduleType][0].value
+    SUPPORTED_MODULE_SLOTS[moduleType][0].value || null
   )
 
   const handleSlotChange = (e: SyntheticInputEvent<*>) =>

--- a/protocol-designer/src/components/modules/EditModulesCard.js
+++ b/protocol-designer/src/components/modules/EditModulesCard.js
@@ -9,7 +9,7 @@ import type { ModulesForEditModulesCard } from '../../step-forms'
 
 type Props = {
   modules: ModulesForEditModulesCard,
-  openEditModuleModal: (type: ModuleType) => mixed,
+  openEditModuleModal: (type: ModuleType, moduleId?: string) => mixed,
 }
 
 // TODO (ka 2019-10-24): This will likely be resused a lot,

--- a/protocol-designer/src/components/modules/EditModulesCard.js
+++ b/protocol-designer/src/components/modules/EditModulesCard.js
@@ -5,6 +5,7 @@ import ModuleRow from './ModuleRow'
 import styles from './styles.css'
 
 import type { ModuleType } from '@opentrons/shared-data'
+import { SUPPORTED_MODULE_TYPES } from '../../modules'
 import type { ModulesForEditModulesCard } from '../../step-forms'
 
 type Props = {
@@ -12,17 +13,13 @@ type Props = {
   openEditModuleModal: (type: ModuleType, moduleId?: string) => mixed,
 }
 
-// TODO (ka 2019-10-24): This will likely be resused a lot,
-// Possble candidate for modules/module-data
-const MODULE_TYPES: Array<ModuleType> = ['magdeck', 'tempdeck', 'thermocycler']
-
 export default function EditModulesCard(props: Props) {
   const { modules, openEditModuleModal } = props
 
   return (
     <Card title="Modules">
       <div className={styles.modules_card_content}>
-        {MODULE_TYPES.map((moduleType, i) => {
+        {SUPPORTED_MODULE_TYPES.map((moduleType, i) => {
           const moduleData = modules[moduleType]
           if (moduleData) {
             return (

--- a/protocol-designer/src/components/modules/ModuleRow.js
+++ b/protocol-designer/src/components/modules/ModuleRow.js
@@ -48,8 +48,6 @@ export default function ModuleRow(props: Props) {
           {slot && <LabeledValue label="Slot" value={`Slot ${slot}`} />}
         </div>
         <div className={styles.modules_button_group}>
-          {/* TODO (ka 2019-10-23): Hide/Show based on anySlot FF when in place
-          onClick needs to set edit modal open + pass moduleId for deleting */}
           {moduleId && (
             <OutlineButton
               className={styles.module_button}
@@ -59,9 +57,6 @@ export default function ModuleRow(props: Props) {
               Edit
             </OutlineButton>
           )}
-
-          {/* TODO (ka 2019-10-23): onClick needs to set edit modal open
-          + pass moduleId for deleting */}
           <OutlineButton
             className={styles.module_button}
             onClick={handleAddOrRemove}

--- a/protocol-designer/src/components/modules/ModuleRow.js
+++ b/protocol-designer/src/components/modules/ModuleRow.js
@@ -1,7 +1,8 @@
 // @flow
 import * as React from 'react'
 import i18n from '../../localization'
-
+import { useSelector } from 'react-redux'
+import { selectors as featureFlagSelectors } from '../../feature-flags'
 import { LabeledValue, OutlineButton } from '@opentrons/components'
 import ModuleDiagram from './ModuleDiagram'
 import styles from './styles.css'
@@ -14,16 +15,23 @@ type Props = {
   slot?: DeckSlot,
   model?: string,
   type: ModuleType,
-  openEditModuleModal: (moduleType: ModuleType) => mixed,
+  openEditModuleModal: (moduleType: ModuleType, moduleId?: string) => mixed,
 }
 
 export default function ModuleRow(props: Props) {
   const { type, moduleId, slot, model, openEditModuleModal } = props
-  const setModuleType = (type: ModuleType) => () => openEditModuleModal(type)
+  const setCurrentModule = (type: ModuleType, moduleId?: string) => () =>
+    openEditModuleModal(type, moduleId)
   const addRemoveText = moduleId ? 'remove' : 'add'
   const handleAddOrRemove = moduleId
     ? () => console.log('remove ' + moduleId)
-    : setModuleType(type)
+    : setCurrentModule(type)
+
+  const enableEditModules = useSelector(
+    featureFlagSelectors.getDisableModuleRestrictions
+  )
+  const handleEditModule = setCurrentModule(type, moduleId)
+
   return (
     <div>
       <h4 className={styles.row_title}>
@@ -43,7 +51,11 @@ export default function ModuleRow(props: Props) {
           {/* TODO (ka 2019-10-23): Hide/Show based on anySlot FF when in place
           onClick needs to set edit modal open + pass moduleId for deleting */}
           {moduleId && (
-            <OutlineButton className={styles.module_button} disabled>
+            <OutlineButton
+              className={styles.module_button}
+              onClick={handleEditModule}
+              disabled={!enableEditModules}
+            >
               Edit
             </OutlineButton>
           )}

--- a/protocol-designer/src/modules/index.js
+++ b/protocol-designer/src/modules/index.js
@@ -1,0 +1,1 @@
+export * from './moduleData'

--- a/protocol-designer/src/modules/moduleData.js
+++ b/protocol-designer/src/modules/moduleData.js
@@ -1,4 +1,7 @@
 // @flow
+import { SPAN7_8_10_11_SLOT } from '../constants'
+import type { ModuleType } from '@opentrons/shared-data'
+import type { DropdownOption } from '@opentrons/components'
 
 export const SUPPORTED_MODULE_TYPES: Array<ModuleType> = [
   'magdeck',
@@ -6,13 +9,17 @@ export const SUPPORTED_MODULE_TYPES: Array<ModuleType> = [
   'thermocycler',
 ]
 
-export const SUPPORTED_MODULE_SLOTS = {
-  magdeck: [{ name: 'Slot 1 (supported)', value: '1' }],
-  tempdeck: [{ name: 'Slot 3 (supported)', value: '3' }],
-  thermocycler: [{ name: 'Thermocycler slots', value: 'span7_8_10_11' }],
+type SupportedSlotMap = {
+  [type: ModuleType]: Array<DropdownOption>,
 }
 
-export const ALL_MODULE_SLOTS = [
+export const SUPPORTED_MODULE_SLOTS: SupportedSlotMap = {
+  magdeck: [{ name: 'Slot 1 (supported)', value: '1' }],
+  tempdeck: [{ name: 'Slot 3 (supported)', value: '3' }],
+  thermocycler: [{ name: 'Thermocycler slots', value: SPAN7_8_10_11_SLOT }],
+}
+
+export const ALL_MODULE_SLOTS: Array<DropdownOption> = [
   { name: 'Slot 1', value: '1' },
   { name: 'Slot 3', value: '3' },
   { name: 'Slot 4', value: '4' },
@@ -22,7 +29,9 @@ export const ALL_MODULE_SLOTS = [
   { name: 'Slot 10', value: '10' },
 ]
 
-export function getAllModuleSlotsByType(moduleType: ModuleType) {
+export function getAllModuleSlotsByType(
+  moduleType: ModuleType
+): Array<DropdownOption> {
   const supportedSlotOption = SUPPORTED_MODULE_SLOTS[moduleType]
   if (moduleType === 'thermocycler') {
     return supportedSlotOption

--- a/protocol-designer/src/modules/moduleData.js
+++ b/protocol-designer/src/modules/moduleData.js
@@ -1,0 +1,34 @@
+// @flow
+
+export const SUPPORTED_MODULE_TYPES: Array<ModuleType> = [
+  'magdeck',
+  'tempdeck',
+  'thermocycler',
+]
+
+export const SUPPORTED_MODULE_SLOTS = {
+  magdeck: [{ name: 'Slot 1 (supported)', value: '1' }],
+  tempdeck: [{ name: 'Slot 3 (supported)', value: '3' }],
+  thermocycler: [{ name: 'Thermocycler slots', value: 'span7_8_10_11' }],
+}
+
+export const ALL_MODULE_SLOTS = [
+  { name: 'Slot 1', value: '1' },
+  { name: 'Slot 3', value: '3' },
+  { name: 'Slot 4', value: '4' },
+  { name: 'Slot 6', value: '6' },
+  { name: 'Slot 7', value: '7' },
+  { name: 'Slot 9', value: '9' },
+  { name: 'Slot 10', value: '10' },
+]
+
+export function getAllModuleSlotsByType(moduleType: ModuleType) {
+  const supportedSlotOption = SUPPORTED_MODULE_SLOTS[moduleType]
+  if (moduleType === 'thermocycler') {
+    return supportedSlotOption
+  }
+  const allOtherSlots = ALL_MODULE_SLOTS.filter(
+    s => s.value !== supportedSlotOption[0].value
+  )
+  return supportedSlotOption.concat(allOtherSlots)
+}


### PR DESCRIPTION
## overview

closes #4133 by adding the ability to select unsupported slots in EditModulesModal when unrestricted modules FF is enabled

## changelog

- feat(protocol-designer): Enable slot selection for modules when FF enabled
- refactor(protocol-designer): Move module data and functions to `modules/`

## review requests

Standard code review - See notes but I added a hook that defaults slot selection to the supported slot. This is either a workaround or throw away work until module data comes from state. I'm also open to suggestions on a different way to do this before implementing redux stuff and formik.

FF disabled:
- [ ] Slot selection is disabled, tooltip renders on hover
- [ ] Slot selection is not available for TC
- [ ] Edit module button is disabled (ModulesCard)

FF enabled:
- [ ] Slot selection is enabled, no tooltip renders
- [ ] Slot selection defaults to supported slot TODO - get the previously selected slot from state eventually
- [ ] Supported slot renders at top of list
- [ ] No duplicate slot selection options
- [ ] Edit modules button enabled (clicking save console logs update {moduleId})
