### PR TITLE
fix(protocol-designer): fix bug in manualIntervention step

### DIFF
--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -72,6 +72,12 @@ export default function getDefaultsForStepType(
         pauseSecond: null,
         pauseMessage: '',
       }
+    case 'manualIntervention':
+      return {
+        labwareLocationUpdate: {},
+        pipetteLocationUpdate: {},
+        moduleLocationUpdate: {},
+      }
     default:
       return {}
   }


### PR DESCRIPTION
## overview

closes #4334 - bug causing drag-and-drop of labware to fail when you loaded a file

Note: this bug was never released to production

## review requests

Make sure it fixes the bug:
- [ ] Restart PD (just to make sure hot reloading doesn't give false positive)
- [ ] Import a PD protocol file that was made in production PD (don't make a new protocol, the make-new flow wasn't affected by the bug)
- [ ] Dragging and dropping labware should work again
- [ ] `stepForms.savedStepForms.__INITIAL_DECK_SETUP_STEP__` should have key `moduleLocationUpdate: {}` (it didn't before when you loaded a file, that was the bug)