### PR TITLE
feat(protocol-designer): Wire up modules card with actual data

### DIFF
--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -68,11 +68,11 @@ class FilePage extends React.Component<Props, State> {
   }
   closeEditPipetteModal = () => this.setState({ isEditPipetteModalOpen: false })
 
-  handleEditModule = (type: ModuleType, moduleId?: string) => {
+  handleEditModule = (moduleType: ModuleType, moduleId?: string) => {
     this.scrollToTop()
     this.setState({
       isEditModulesModalOpen: true,
-      currentModule: { moduleType: type, moduleId: moduleId },
+      currentModule: { moduleType: moduleType, moduleId: moduleId },
     })
   }
 

--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -28,6 +28,7 @@ export type Props = {
   saveFileMetadata: FileMetadataFields => mixed,
   swapPipettes: () => mixed,
   modulesEnabled: ?boolean,
+  modules: ModulesForEditModulesCard,
 }
 
 type State = {
@@ -41,14 +42,6 @@ type State = {
 
 const DATE_ONLY_FORMAT = 'MMM DD, YYYY'
 const DATETIME_FORMAT = 'MMM DD, YYYY | h:mm A'
-
-const _mockModulesByType: ModulesForEditModulesCard = {
-  magdeck: {
-    moduleId: 'module1234',
-    slot: '1',
-    model: 'GEN1',
-  },
-}
 
 // TODO: Ian 2019-03-15 use i18n for labels
 class FilePage extends React.Component<Props, State> {
@@ -97,6 +90,7 @@ class FilePage extends React.Component<Props, State> {
       goToNextPage,
       saveFileMetadata,
       swapPipettes,
+      modules,
     } = this.props
 
     return (
@@ -211,7 +205,7 @@ class FilePage extends React.Component<Props, State> {
 
         {this.props.modulesEnabled && (
           <EditModulesCard
-            modules={_mockModulesByType}
+            modules={modules}
             openEditModuleModal={this.handleEditModule}
           />
         )}

--- a/protocol-designer/src/components/modules/EditModulesCard.js
+++ b/protocol-designer/src/components/modules/EditModulesCard.js
@@ -15,7 +15,6 @@ type Props = {
 
 export default function EditModulesCard(props: Props) {
   const { modules, openEditModuleModal } = props
-
   return (
     <Card title="Modules">
       <div className={styles.modules_card_content}>

--- a/protocol-designer/src/components/modules/EditModulesCard.js
+++ b/protocol-designer/src/components/modules/EditModulesCard.js
@@ -23,8 +23,8 @@ export default function EditModulesCard(props: Props) {
           if (moduleData) {
             return (
               <ModuleRow
-                {...moduleData}
                 type={moduleType}
+                module={moduleData}
                 key={i}
                 openEditModuleModal={openEditModuleModal}
               />

--- a/protocol-designer/src/components/modules/EditModulesCard.js
+++ b/protocol-designer/src/components/modules/EditModulesCard.js
@@ -10,7 +10,7 @@ import type { ModulesForEditModulesCard } from '../../step-forms'
 
 type Props = {
   modules: ModulesForEditModulesCard,
-  openEditModuleModal: (type: ModuleType, moduleId?: string) => mixed,
+  openEditModuleModal: (moduleType: ModuleType, moduleId?: string) => mixed,
 }
 
 export default function EditModulesCard(props: Props) {

--- a/protocol-designer/src/components/modules/ModuleRow.js
+++ b/protocol-designer/src/components/modules/ModuleRow.js
@@ -8,15 +8,22 @@ import ModuleDiagram from './ModuleDiagram'
 import styles from './styles.css'
 
 import type { ModuleType } from '@opentrons/shared-data'
-import type { MaybeModuleOnDeck } from '../../step-forms'
+import type { ModuleOnDeck } from '../../step-forms'
 
 type Props = {
-  ...MaybeModuleOnDeck,
+  module?: ModuleOnDeck,
+  type: ModuleType,
   openEditModuleModal: (moduleType: ModuleType, id?: string) => mixed,
 }
 
 export default function ModuleRow(props: Props) {
-  const { type, id, slot, model, openEditModuleModal } = props
+  const { module, openEditModuleModal } = props
+  const type = module?.type || props.type
+
+  const model = module?.model
+  const id = module?.id
+  const slot = module?.slot
+
   const setCurrentModule = (type: ModuleType, id?: string) => () =>
     openEditModuleModal(type, id)
   const addRemoveText = id ? 'remove' : 'add'

--- a/protocol-designer/src/components/modules/ModuleRow.js
+++ b/protocol-designer/src/components/modules/ModuleRow.js
@@ -8,29 +8,26 @@ import ModuleDiagram from './ModuleDiagram'
 import styles from './styles.css'
 
 import type { ModuleType } from '@opentrons/shared-data'
-import type { DeckSlot } from '../../types'
+import type { MaybeModuleOnDeck } from '../../step-forms'
 
 type Props = {
-  moduleId?: string,
-  slot?: DeckSlot,
-  model?: string,
-  type: ModuleType,
-  openEditModuleModal: (moduleType: ModuleType, moduleId?: string) => mixed,
+  ...MaybeModuleOnDeck,
+  openEditModuleModal: (moduleType: ModuleType, id?: string) => mixed,
 }
 
 export default function ModuleRow(props: Props) {
-  const { type, moduleId, slot, model, openEditModuleModal } = props
-  const setCurrentModule = (type: ModuleType, moduleId?: string) => () =>
-    openEditModuleModal(type, moduleId)
-  const addRemoveText = moduleId ? 'remove' : 'add'
-  const handleAddOrRemove = moduleId
-    ? () => console.log('remove ' + moduleId)
+  const { type, id, slot, model, openEditModuleModal } = props
+  const setCurrentModule = (type: ModuleType, id?: string) => () =>
+    openEditModuleModal(type, id)
+  const addRemoveText = id ? 'remove' : 'add'
+  const handleAddOrRemove = id
+    ? () => console.log('remove ' + id)
     : setCurrentModule(type)
 
   const enableEditModules = useSelector(
     featureFlagSelectors.getDisableModuleRestrictions
   )
-  const handleEditModule = setCurrentModule(type, moduleId)
+  const handleEditModule = setCurrentModule(type, id)
 
   return (
     <div>
@@ -48,7 +45,7 @@ export default function ModuleRow(props: Props) {
           {slot && <LabeledValue label="Slot" value={`Slot ${slot}`} />}
         </div>
         <div className={styles.modules_button_group}>
-          {moduleId && (
+          {id && (
             <OutlineButton
               className={styles.module_button}
               onClick={handleEditModule}

--- a/protocol-designer/src/components/modules/ModuleRow.js
+++ b/protocol-designer/src/components/modules/ModuleRow.js
@@ -6,6 +6,7 @@ import { actions as stepFormActions } from '../../step-forms'
 import { selectors as featureFlagSelectors } from '../../feature-flags'
 import { LabeledValue, OutlineButton } from '@opentrons/components'
 import ModuleDiagram from './ModuleDiagram'
+import { SPAN7_8_10_11_SLOT } from '../../constants'
 import styles from './styles.css'
 
 import type { ModuleType } from '@opentrons/shared-data'
@@ -14,7 +15,7 @@ import type { ModuleOnDeck } from '../../step-forms'
 type Props = {
   module?: ModuleOnDeck,
   type: ModuleType,
-  openEditModuleModal: (moduleType: ModuleType, id?: string) => mixed,
+  openEditModuleModal: (moduleType: ModuleType, moduleId?: string) => mixed,
 }
 
 export default function ModuleRow(props: Props) {
@@ -22,18 +23,18 @@ export default function ModuleRow(props: Props) {
   const type = module?.type || props.type
 
   const model = module?.model
-  const id = module?.id
   const slot = module?.slot
 
   let slotDisplayName = null
   if (slot) {
     slotDisplayName = `Slot ${slot}`
-  } else if (slot === 'span7_8_10_11') {
+  }
+  if (slot === SPAN7_8_10_11_SLOT) {
     slotDisplayName = 'Slot 7'
   }
 
-  const setCurrentModule = (type: ModuleType, id?: string) => () =>
-    openEditModuleModal(type, id)
+  const setCurrentModule = (moduleType: ModuleType, moduleId?: string) => () =>
+    openEditModuleModal(moduleType, moduleId)
 
   const addRemoveText = module ? 'remove' : 'add'
 
@@ -46,7 +47,7 @@ export default function ModuleRow(props: Props) {
   const enableEditModules = useSelector(
     featureFlagSelectors.getDisableModuleRestrictions
   )
-  const handleEditModule = setCurrentModule(type, id)
+  const handleEditModule = module && setCurrentModule(type, module.id)
 
   return (
     <div>
@@ -64,7 +65,7 @@ export default function ModuleRow(props: Props) {
           {slot && <LabeledValue label="Slot" value={slotDisplayName} />}
         </div>
         <div className={styles.modules_button_group}>
-          {id && (
+          {module && (
             <OutlineButton
               className={styles.module_button}
               onClick={handleEditModule}

--- a/protocol-designer/src/components/modules/ModuleRow.js
+++ b/protocol-designer/src/components/modules/ModuleRow.js
@@ -24,11 +24,20 @@ export default function ModuleRow(props: Props) {
   const id = module?.id
   const slot = module?.slot
 
+  let slotDisplayName = null
+  if (slot) {
+    slotDisplayName = `Slot ${slot}`
+  } else if (slot === 'span7_8_10_11') {
+    slotDisplayName = 'Slot 7'
+  }
+
   const setCurrentModule = (type: ModuleType, id?: string) => () =>
     openEditModuleModal(type, id)
-  const addRemoveText = id ? 'remove' : 'add'
-  const handleAddOrRemove = id
-    ? () => console.log('remove ' + id)
+
+  const addRemoveText = module ? 'remove' : 'add'
+
+  const handleAddOrRemove = module
+    ? () => console.log('remove ' + module.id)
     : setCurrentModule(type)
 
   const enableEditModules = useSelector(
@@ -49,7 +58,7 @@ export default function ModuleRow(props: Props) {
           {model && <LabeledValue label="Model" value={model} />}
         </div>
         <div className={styles.module_col}>
-          {slot && <LabeledValue label="Slot" value={`Slot ${slot}`} />}
+          {slot && <LabeledValue label="Slot" value={slotDisplayName} />}
         </div>
         <div className={styles.modules_button_group}>
           {id && (

--- a/protocol-designer/src/components/modules/ModuleRow.js
+++ b/protocol-designer/src/components/modules/ModuleRow.js
@@ -1,7 +1,8 @@
 // @flow
 import * as React from 'react'
 import i18n from '../../localization'
-import { useSelector } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
+import { actions as stepFormActions } from '../../step-forms'
 import { selectors as featureFlagSelectors } from '../../feature-flags'
 import { LabeledValue, OutlineButton } from '@opentrons/components'
 import ModuleDiagram from './ModuleDiagram'
@@ -36,8 +37,10 @@ export default function ModuleRow(props: Props) {
 
   const addRemoveText = module ? 'remove' : 'add'
 
+  const dispatch = useDispatch()
+
   const handleAddOrRemove = module
-    ? () => console.log('remove ' + module.id)
+    ? () => dispatch(stepFormActions.deleteModule(module.id))
     : setCurrentModule(type)
 
   const enableEditModules = useSelector(

--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -20,12 +20,14 @@ type SP = {|
   formValues: $PropertyType<Props, 'formValues'>,
   _initialDeckSetup: InitialDeckSetup,
   modulesEnabled: ?boolean,
+  modules: $PropertyType<Props, 'modules'>,
 |}
 
 const mapStateToProps = (state: BaseState): SP => {
   return {
     formValues: fileSelectors.getFileMetadata(state),
     instruments: stepFormSelectors.getPipettesForInstrumentGroup(state),
+    modules: stepFormSelectors.getModulesForEditModulesCard(state),
     _initialDeckSetup: stepFormSelectors.getInitialDeckSetup(state),
     modulesEnabled: featureFlagSelectors.getEnableModules(state),
   }

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -297,14 +297,9 @@ export const getModulesForEditModulesCard: Selector<ModulesForEditModulesCard> =
         moduleOnDeck: ModuleOnDeck,
         id
       ): ModulesForEditModulesCard => {
-        const moduleId = moduleOnDeck.id
-        const moduleSlot = moduleOnDeck.slot
-
-        if (!moduleId || !moduleSlot) return acc
-
         return {
           ...acc,
-          [moduleOnDeck.type]: { ...moduleOnDeck },
+          [moduleOnDeck.type]: moduleOnDeck,
         }
       },
       {

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -50,6 +50,7 @@ import type {
   LabwareEntities,
   ModuleOnDeck,
   ModuleEntities,
+  ModulesForEditModulesCard,
   PipetteEntities,
   PipetteOnDeck,
   FormPipettesByMount,
@@ -282,6 +283,36 @@ export const getPipettesForEditPipetteForm: Selector<FormPipettesByMount> = crea
       {
         left: { pipetteName: null, tiprackDefURI: null },
         right: { pipetteName: null, tiprackDefURI: null },
+      }
+    )
+)
+
+export const getModulesForEditModulesCard: Selector<ModulesForEditModulesCard> = createSelector(
+  getInitialDeckSetup,
+  initialDeckSetup =>
+    reduce(
+      initialDeckSetup.modules,
+      (
+        acc: ModulesForEditModulesCard,
+        moduleOnDeck: ModuleOnDeck,
+        id
+      ): ModulesForEditModulesCard => {
+        const moduleId = moduleOnDeck.id
+        const moduleSlot = moduleOnDeck.slot
+
+        if (!moduleId || !moduleSlot) return acc
+
+        return {
+          ...acc,
+          [moduleOnDeck.type]: { ...moduleOnDeck },
+        }
+      },
+      {
+        magdeck: { type: 'magdeck' },
+        tempdeck: { type: 'tempdeck' },
+        thermocycler: {
+          type: 'thermocycler',
+        },
       }
     )
 )

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -308,11 +308,9 @@ export const getModulesForEditModulesCard: Selector<ModulesForEditModulesCard> =
         }
       },
       {
-        magdeck: { type: 'magdeck' },
-        tempdeck: { type: 'tempdeck' },
-        thermocycler: {
-          type: 'thermocycler',
-        },
+        magdeck: null,
+        tempdeck: null,
+        thermocycler: null,
       }
     )
 )

--- a/protocol-designer/src/step-forms/types.js
+++ b/protocol-designer/src/step-forms/types.js
@@ -48,15 +48,17 @@ export type ModuleEntities = { [moduleId: string]: ModuleEntity }
 
 export type ModuleTemporalProperties = {| slot: DeckSlot |}
 export type ModuleOnDeck = {| ...ModuleEntity, ...ModuleTemporalProperties |}
+export type MaybeModuleOnDeck = {|
+  type: ModuleType,
+  slot?: DeckSlot,
+  model?: string,
+  id?: string,
+|}
 
 // TODO IMMEDIATELY: repace ModulesForEditModulesCard with ModuleOnDeck, oops!
 // They're the same except id instead of moduleId.
 export type ModulesForEditModulesCard = {
-  [type: ModuleType]: {
-    moduleId: string,
-    slot: DeckSlot,
-    model: string,
-  },
+  [type: ModuleType]: ?MaybeModuleOnDeck,
 }
 
 // =========== LABWARE ========

--- a/protocol-designer/src/step-forms/types.js
+++ b/protocol-designer/src/step-forms/types.js
@@ -48,17 +48,9 @@ export type ModuleEntities = { [moduleId: string]: ModuleEntity }
 
 export type ModuleTemporalProperties = {| slot: DeckSlot |}
 export type ModuleOnDeck = {| ...ModuleEntity, ...ModuleTemporalProperties |}
-export type MaybeModuleOnDeck = {|
-  type: ModuleType,
-  slot?: DeckSlot,
-  model?: string,
-  id?: string,
-|}
 
-// TODO IMMEDIATELY: repace ModulesForEditModulesCard with ModuleOnDeck, oops!
-// They're the same except id instead of moduleId.
 export type ModulesForEditModulesCard = {
-  [type: ModuleType]: ?MaybeModuleOnDeck,
+  [type: ModuleType]: ?ModuleOnDeck,
 }
 
 // =========== LABWARE ========


### PR DESCRIPTION
## overview

Addresses #4317 by adding `getModulesForEditModulesCard` selector for populating the Modules card with module on deck data from state.

## changelog

- Add selector `getModulesForEditModulesCard`
- Wire up ModulesCard with `ModulesForEditModulesCard`
- Wire up Remove button with `deleteModule`

## review requests
- [ ] Added modules render correctly
- [ ] TC module slot renders as `Slot 7` not `span7_8_10_11`
- [ ] remove button removes module removes module
- [ ] Add/Edit buttons still open EditModulesModal