### PR TITLE
feat(app,api): allow rich version specification for python protocols

### DIFF
--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -18,7 +18,7 @@ from opentrons.protocol_api import execute as execute_apiv2
 from opentrons import commands
 from opentrons.config import feature_flags as ff
 from opentrons.protocols.parse import parse
-from opentrons.protocols.types import JsonProtocol
+from opentrons.protocols.types import JsonProtocol, APIVersion
 from opentrons.hardware_control import API
 
 _HWCONTROL: Optional[API] = None
@@ -179,7 +179,7 @@ def execute(protocol_file: TextIO,
     contents = protocol_file.read()
     protocol = parse(contents, protocol_file.name)
     if isinstance(protocol, JsonProtocol)\
-            or protocol.api_level == '2'\
+            or protocol.api_level >= APIVersion(2, 0)\
             or (ff.enable_back_compat() and ff.use_protocol_api_v2()):
         context = get_protocol_api(
             bundled_labware=getattr(protocol, 'bundled_labware', None),

--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -9,7 +9,7 @@ from .contexts import ProtocolContext
 from . import execute_v3, legacy_wrapper
 
 from opentrons import config
-from opentrons.protocols.types import PythonProtocol, Protocol
+from opentrons.protocols.types import PythonProtocol, Protocol, APIVersion
 
 MODULE_LOG = logging.getLogger(__name__)
 
@@ -169,9 +169,9 @@ def run_protocol(protocol: Protocol,
         raise RuntimeError(
             'Will not automatically generate hardware controller')
     if isinstance(protocol, PythonProtocol):
-        if protocol.api_level == '2':
+        if protocol.api_level >= APIVersion(2, 0):
             _run_python(protocol, true_context)
-        elif protocol.api_level == '1':
+        elif protocol.api_level == APIVersion(1, 0):
             _run_python_legacy(protocol, true_context)
         else:
             raise RuntimeError(

--- a/api/src/opentrons/protocols/types.py
+++ b/api/src/opentrons/protocols/types.py
@@ -3,6 +3,14 @@ from typing import Any, Dict, NamedTuple, Optional, Union
 Metadata = Dict[str, Union[str, int]]
 
 
+class APIVersion(NamedTuple):
+    major: int
+    minor: int
+
+    def __str__(self):
+        return f'{self.major}.{self.minor}'
+
+
 class JsonProtocol(NamedTuple):
     text: str
     filename: Optional[str]
@@ -15,7 +23,7 @@ class PythonProtocol(NamedTuple):
     filename: Optional[str]
     contents: Any  # This is the output of compile() which we can't type
     metadata: Metadata
-    api_level: str  # For now, should be '1' or '2'
+    api_level: APIVersion
     # these 'bundled_' attrs should only be included when the protocol is a zip
     bundled_labware: Optional[Dict[str, Dict[str, Any]]]
     bundled_data: Optional[Dict[str, bytes]]

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -21,7 +21,7 @@ from opentrons.config import feature_flags as ff
 from opentrons import protocol_api
 from opentrons.protocols import parse, bundle
 from opentrons.protocols.types import (
-    JsonProtocol, PythonProtocol, BundleContents)
+    JsonProtocol, PythonProtocol, BundleContents, APIVersion)
 from opentrons.protocol_api import execute
 from .util.entrypoint_util import labware_from_paths, datafiles_from_paths
 
@@ -249,7 +249,7 @@ def simulate(protocol_file: TextIO,
                            extra_data=extra_data)
 
     if isinstance(protocol, JsonProtocol)\
-            or protocol.api_level == '2'\
+            or protocol.api_level >= APIVersion(2, 0)\
             or (ff.enable_back_compat() and ff.use_protocol_api_v2()):
         context = get_protocol_api(protocol)
         scraper = CommandScraper(stack_logger, log_level, context.broker)

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -646,7 +646,8 @@ def get_bundle_fixture():
             result['bundled_python'] = {}
 
             # NOTE: this is copy-pasted from the .py fixture file
-            result['metadata'] = {'author': 'MISTER FIXTURE'}
+            result['metadata'] = {'author': 'MISTER FIXTURE',
+                                  'apiLevel': '2.0'}
 
             # make binary zipfile
             binary_zipfile = io.BytesIO()

--- a/api/tests/opentrons/data/testosaur-gen2-v2.py
+++ b/api/tests/opentrons/data/testosaur-gen2-v2.py
@@ -4,7 +4,8 @@ metadata = {
     'protocolName': 'Testosaur',
     'author': 'Opentrons <engineering@opentrons.com>',
     'description': 'A variant on "Dinosaur" for testing',
-    'source': 'Opentrons Repository'
+    'source': 'Opentrons Repository',
+    'apiLevel': '2.0'
 }
 
 

--- a/api/tests/opentrons/data/testosaur_v2.py
+++ b/api/tests/opentrons/data/testosaur_v2.py
@@ -4,7 +4,8 @@ metadata = {
     'protocolName': 'Testosaur',
     'author': 'Opentrons <engineering@opentrons.com>',
     'description': 'A variant on "Dinosaur" for testing',
-    'source': 'Opentrons Repository'
+    'source': 'Opentrons Repository',
+    'apiLevel': '2.0',
 }
 
 

--- a/api/tests/opentrons/protocols/fixtures/bundled_protocols/simple_bundle/protocol.py
+++ b/api/tests/opentrons/protocols/fixtures/bundled_protocols/simple_bundle/protocol.py
@@ -1,4 +1,5 @@
-metadata = {'author': 'MISTER FIXTURE'}
+metadata = {'author': 'MISTER FIXTURE',
+            'apiLevel': '2.0'}
 
 
 def run(protocol_context):

--- a/app/src/components/CalibrateLabware/ConfirmModalContents.js
+++ b/app/src/components/CalibrateLabware/ConfirmModalContents.js
@@ -61,6 +61,6 @@ function mapStateToProps(state, ownProps: OP): SP {
   const calibrator =
     pipettes.find(i => i.mount === calibratorMount) ||
     robotSelectors.getCalibrator(state)
-  const useCenteredTroughs = robotSelectors.getApiLevel(state) > 1
+  const useCenteredTroughs = robotSelectors.getApiLevel(state)[0] > 1
   return { calibrator, useCenteredTroughs }
 }

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -133,7 +133,7 @@ export type SessionResponseAction = {|
     name: string,
     protocolText: string,
     metadata?: ?$PropertyType<ProtocolData, 'metadata'>,
-    apiLevel: number,
+    apiLevel: [number, number],
   |},
   meta: {| freshUpload: boolean |},
 |}

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -471,7 +471,13 @@ export default function client(dispatch) {
         )
       }
 
-      update.apiLevel = apiSession.api_level || 1
+      if (Array.isArray(apiSession.api_level)) {
+        update.apiLevel = apiSession.api_level
+      } else if (apiSession.api_level) {
+        update.apiLevel = [apiSession.api_level, 0]
+      } else {
+        update.apiLevel = [1, 0]
+      }
 
       dispatch(actions.sessionResponse(null, update, freshUpload))
     } catch (error) {

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -474,8 +474,12 @@ export default function client(dispatch) {
       if (Array.isArray(apiSession.api_level)) {
         update.apiLevel = apiSession.api_level
       } else if (apiSession.api_level) {
+        // if we're connected to a robot on older software that still expresses
+        // its api level as a single int, it's the major version
         update.apiLevel = [apiSession.api_level, 0]
       } else {
+        // if we're connected to a robot on software sufficiently old that it
+        // doesn't send us its api level at all, it's on API v1
         update.apiLevel = [1, 0]
       }
 

--- a/app/src/robot/reducer/session.js
+++ b/app/src/robot/reducer/session.js
@@ -46,7 +46,7 @@ export type SessionState = {
   remoteTimeCompensation: number | null,
   startTime: ?number,
   runTime: number,
-  apiLevel: number,
+  apiLevel: [number, number],
 }
 
 // TODO(mc, 2018-01-11): replace actionType constants with Flow types
@@ -83,7 +83,7 @@ const INITIAL_STATE: SessionState = {
   remoteTimeCompensation: null,
   startTime: null,
   runTime: 0,
-  apiLevel: 1,
+  apiLevel: [1, 0],
 }
 
 export default function sessionReducer(

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -323,7 +323,7 @@ describe('api client', () => {
           pipettesByMount: {},
           labwareBySlot: {},
           modulesBySlot: {},
-          apiLevel: 1,
+          apiLevel: [1, 0],
         },
         false
       )

--- a/app/src/robot/test/session-reducer.test.js
+++ b/app/src/robot/test/session-reducer.test.js
@@ -33,7 +33,7 @@ describe('robot reducer - session', () => {
       remoteTimeCompensation: null,
       startTime: null,
       runTime: 0,
-      apiLevel: 1,
+      apiLevel: [1, 0],
     })
   })
 


### PR DESCRIPTION
This allows and requires apiv2 users to have

'apiLevel': '2.0'

in their metadata dict.

This is parsed and stored along with the protocol and passed along with RPC.
This allows specification of API minor versions.

Closes #4338
