### PR TITLE
feat(protocol-designer): show special-case warning for north/south

### DIFF
--- a/app/src/components/DeckMap/index.js
+++ b/app/src/components/DeckMap/index.js
@@ -74,8 +74,8 @@ function DeckMap(props: Props) {
       viewBox={`-46 -10 ${488} ${390}`} // TODO: put these in variables
       className={className}
     >
-      {({ slots }) =>
-        map(slots, (slot: $Values<typeof slots>, slotId) => {
+      {({ deckSlotsById }) =>
+        map(deckSlotsById, (slot: $Values<typeof deckSlotsById>, slotId) => {
           if (!slot.matingSurfaceUnitVector) return null // if slot has no mating surface, don't render anything in it
           const moduleInSlot = modulesBySlot && modulesBySlot[slotId]
           const allLabwareInSlot = labwareBySlot && labwareBySlot[slotId]

--- a/components/src/deck/RobotWorkSpace.js
+++ b/components/src/deck/RobotWorkSpace.js
@@ -14,6 +14,11 @@ type Props = {
   deckLayerBlacklist?: Array<string>,
 }
 
+type GetRobotCoordsFromDOMCoords = $PropertyType<
+  RobotWorkSpaceRenderProps,
+  'getRobotCoordsFromDOMCoords'
+>
+
 function RobotWorkSpace(props: Props) {
   const { children, deckDef, deckLayerBlacklist = [], viewBox } = props
   const wrapperRef: ElementRef<*> = useRef(null)
@@ -23,10 +28,7 @@ function RobotWorkSpace(props: Props) {
   // Until Firefox fixes this and conforms to SVG2 draft,
   // it will suffer from inverted y behavior (ignores css transform)
   // $FlowFixMe(bc, 2019-05-31): flow type svg ref
-  const getRobotCoordsFromDOMCoords = (
-    x: number,
-    y: number
-  ): { x: number, y: number } => {
+  const getRobotCoordsFromDOMCoords: GetRobotCoordsFromDOMCoords = (x, y) => {
     if (!wrapperRef.current) return { x: 0, y: 0 }
     const cursorPoint = wrapperRef.current.createSVGPoint()
 
@@ -40,12 +42,12 @@ function RobotWorkSpace(props: Props) {
   if (!deckDef && !viewBox) return null
 
   let wholeDeckViewBox = null
-  let slots = {}
+  let deckSlotsById = {}
   if (deckDef) {
     const [viewBoxOriginX, viewBoxOriginY] = deckDef.cornerOffsetFromOrigin
     const [deckXDimension, deckYDimension] = deckDef.dimensions
 
-    slots = deckDef.locations.orderedSlots.reduce(
+    deckSlotsById = deckDef.locations.orderedSlots.reduce(
       (acc, deckSlot) => ({ ...acc, [deckSlot.id]: deckSlot }),
       {}
     )
@@ -61,7 +63,7 @@ function RobotWorkSpace(props: Props) {
       {deckDef && (
         <DeckFromData def={deckDef} layerBlacklist={deckLayerBlacklist} />
       )}
-      {children && children({ slots, getRobotCoordsFromDOMCoords })}
+      {children && children({ deckSlotsById, getRobotCoordsFromDOMCoords })}
     </svg>
   )
 }

--- a/components/src/deck/RobotWorkSpace.md
+++ b/components/src/deck/RobotWorkSpace.md
@@ -6,27 +6,27 @@ const deckDef = getDeckDefinitions()['ot2_standard']
 const slotName = '5'
 const divSlot = '3'
 ;<RobotWorkSpace deckDef={deckDef}>
-  {({ slots }) => (
+  {({ deckSlotsById }) => (
     <>
       <rect
-        x={slots[slotName].position[0]}
-        y={slots[slotName].position[1]}
-        width={slots[slotName].boundingBox.xDimension}
-        height={slots[slotName].boundingBox.yDimension}
+        x={deckSlotsById[slotName].position[0]}
+        y={deckSlotsById[slotName].position[1]}
+        width={deckSlotsById[slotName].boundingBox.xDimension}
+        height={deckSlotsById[slotName].boundingBox.yDimension}
         fill="#0075ff33"
       />
       <RobotCoordsText
-        x={slots[slotName].position[0] + 10}
-        y={slots[slotName].position[1] + 10}
+        x={deckSlotsById[slotName].position[0] + 10}
+        y={deckSlotsById[slotName].position[1] + 10}
         fill="gray"
       >
         Some Text
       </RobotCoordsText>
       <RobotCoordsForeignDiv
-        x={slots[divSlot].position[0]}
-        y={slots[divSlot].position[1]}
-        width={slots[divSlot].boundingBox.xDimension}
-        height={slots[divSlot].boundingBox.yDimension}
+        x={deckSlotsById[divSlot].position[0]}
+        y={deckSlotsById[divSlot].position[1]}
+        width={deckSlotsById[divSlot].boundingBox.xDimension}
+        height={deckSlotsById[divSlot].boundingBox.yDimension}
       >
         <input
           style={{ backgroundColor: 'lightgray', margin: '1rem' }}

--- a/components/src/deck/types.js
+++ b/components/src/deck/types.js
@@ -1,7 +1,7 @@
 // @flow
 import type { DeckSlot } from '@opentrons/shared-data'
 
-export type RobotWorkSpaceRenderProps = {
-  slots: { [string]: DeckSlot },
-  getRobotCoordsFromDOMCoords: (number, number) => { x: number, y: number },
-}
+export type RobotWorkSpaceRenderProps = {|
+  deckSlotsById: { [string]: DeckSlot },
+  getRobotCoordsFromDOMCoords: (number, number) => {| x: number, y: number |},
+|}

--- a/protocol-designer/src/components/DeckSetup/SlotWarning.css
+++ b/protocol-designer/src/components/DeckSetup/SlotWarning.css
@@ -1,0 +1,16 @@
+@import '@opentrons/components';
+
+.slot_warning {
+  rx: 6;
+  fill: transparent;
+  stroke: var(--c-plate-bg);
+  stroke-width: 2;
+  stroke-dasharray: 8 4;
+}
+
+.warning_text {
+  padding: 1.3rem 0.5rem 0 0.5rem;
+  font-size: var(--fs-caption);
+  font-weight: var(--fw-regular);
+  color: var(--c-med-gray);
+}

--- a/protocol-designer/src/components/DeckSetup/SlotWarning.js
+++ b/protocol-designer/src/components/DeckSetup/SlotWarning.js
@@ -1,0 +1,46 @@
+// @flow
+import * as React from 'react'
+import i18n from '../../localization'
+import { RobotCoordsForeignDiv } from '@opentrons/components'
+import styles from './SlotWarning.css'
+import type { ModuleOrientation } from '../../types'
+
+type Props = {|
+  x: number,
+  y: number,
+  xDimension: number,
+  yDimension: number,
+  orientation: ModuleOrientation,
+  warningType: 'gen1multichannel', // NOTE: Ian 2019-10-31 if we want more on-deck warnings, expand the type here
+|}
+
+const OVERHANG = 60
+
+const SlotWarning = (props: Props) => {
+  const { x, y, xDimension, yDimension, orientation, warningType } = props
+  const rectXOffset = orientation === 'left' ? -OVERHANG : 0
+  const textXOffset = orientation === 'left' ? -1 * OVERHANG : xDimension
+
+  return (
+    <g>
+      <rect
+        x={x + rectXOffset}
+        y={y}
+        width={xDimension + OVERHANG}
+        height={yDimension}
+        className={styles.slot_warning}
+      />
+      <RobotCoordsForeignDiv
+        x={x + textXOffset}
+        y={y}
+        className={styles.warning_text}
+        width={OVERHANG}
+        height={yDimension}
+      >
+        {i18n.t(`deck.warning.${warningType}`)}
+      </RobotCoordsForeignDiv>
+    </g>
+  )
+}
+
+export default SlotWarning

--- a/protocol-designer/src/localization/en/deck.json
+++ b/protocol-designer/src/localization/en/deck.json
@@ -1,4 +1,7 @@
 {
+  "warning": {
+    "gen1multichannel": "No 8-Channel GEN1 access"
+  },
   "header": {
     "start": "Tell the robot where labware and liquids start on the deck",
     "end": "Click on labware to inspect the result of your protocol"


### PR DESCRIPTION
## overview

closes #4332

## changelog

- refactor `DeckSetup`
- show "No 8-Channel GEN1 access" warning where appropriate
- rename `RobotWorkSpace`'s `slot` arg to `deckSlotsById`

## review requests

Start with "disable module restriction" setting OFF.

- [ ] If you have at least one GEN1 multichannel pipette in your protocol, show the on-deck warning in slot 4 if there's any module in slot 1, and in slot 6 if there's any module in slot 3
- [ ] If you don't have any GEN1 multichannel pipettes in your protocol, this warning does not show on the deck
- [ ] If the experimental setting "disable module restrictions" is on, don't ever show this warning
- [ ] Refactor of `RobotWorkSpace` child props should not mess up anything deck-related in component library (compare to `edge`, because component library has some upside-down stuff that's been upside-down for a while 🤣 )
- [ ] Refactor of `RobotWorkSpace` child props should not mess up anything in Run App