### PR TITLE
feat(api): add the maximum supported protocol api version

### DIFF
--- a/api/docs/v2/index.rst
+++ b/api/docs/v2/index.rst
@@ -36,7 +36,7 @@ Overview
 --------
 
 How it Looks
-+++++++++++
+++++++++++++
 
 The design goal of the Opentrons API is to make code readable and easy to understand. For example, below is a short set of instructions to transfer from well ``'A1'`` to well ``'B1'`` that even a computer could understand:
 
@@ -104,15 +104,11 @@ Metadata is a dictionary of data that is read by the server and returned to clie
 
 The required element of the metadata is ``"apiLevel"``. This must contain a string specifying the major and minor version of the Python Protocol API that your protocol is designed for. For instance, a protocol written for the launch version of Protocol API v2 should have in its metadata ``"apiLevel": "2.0"``.
 
-The number before the dot is the **major version**. This is always ``2`` for protocol API version 2.
-
-The number after the dot is the **minor version**. At launch (and during the beta) only minor version ``0`` exists.
-
-As the Protocol API is developed, whenever Opentrons adds a new feature or makes a small behavior change, we will increase the minor version. When you specify a major and minor version in your protocol, it ensures that the protocol will run as you intended on any robot software version that supports your selected protocol version. For instance, a protocol written for API Version 2.0 will work on any robot software version that supports at least API version 2.0.
-
 .. note::
 
     In the API V2 beta, the only available version is 2.0. It is not yet required to specify versions. However, when we fully release API V2, the version will be required.
+
+For more information on Protocol API versioning, see :ref:`v2-versioning`.
 
 The Run Function and the Protocol Context
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -200,6 +196,7 @@ __ https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md
 .. toctree::
 
     writing
+    versioning
     new_pipette
     new_labware
     new_modules

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -1,0 +1,93 @@
+.. _v2-versioning:
+
+Versioning
+==========
+
+The Python Protocol API has its own versioning system, which is disconnected from the version of the robot software or of the Opentrons App. This disconnection allows you to specify the protocol api version your protocol requires without being concerned with what robot software versions it will work with, and allows Opentrons to version the protocol API based only on changes that affect protocols.
+
+The Protocol API is versioned with a major and minor version, expressed like this: ``major.minor``. For instance, major version 2 and minor version 0 is written as ``2.0``. This is not a decimal number; major version 2 and minor version 10 would be written as ``2.10``, which is different from major version 2 and minor version 1 (``2.1``).
+
+Major and Minor Version
+-----------------------
+
+The major version of the protocol API is increased whenever there are signficant structural or behavioral changes to protocols. For instance, major version 2 of the protocol API was introduced because protocols must now have a ``run`` function that takes a ``protocol`` argument rather than importing the ``robot``, ``instruments``, and ``labware`` modules. A similar level of structural change would require a major version 3. Another major version bump would be if all of the default units switched to nanoliters instead of microliters (we won't do this, it's just an example). This major behavioral change would also require a major version 3.
+
+The minor version of the protocol API is increased whenever we add new functionality that might change the way a protocol is written, or when we want to make a behavior change to an aspect of the API but not the whole thing. For instance, if we added support for a new module, added an option for specifying volume units in the ``aspirate`` and ``dispense`` functions, or added a way to queue up actions from multiple different modules and execute them at the same time, we would increase the minor version of the API. Another minor version bump would be if we added automatic liquid level tracking, and the position at which the OT-2 aspirated from wells was now dynamic - some people might not want that change appearing suddenly in their well-tested protocol, so we would increase the minor version.
+
+
+
+Expressing Versions
+-------------------
+
+You must specify the API version you target at the top of your python protocol. This is done in the ``metadata`` block, using the key ``'apiLevel'``:
+
+.. code-block:: python
+
+   from opentrons import protocol_api
+
+   metadata = {
+       'apiLevel': '2.0',
+       'author': 'A. Biologist'}
+
+   def run(protocol: protocol_api.ProtocolContext):
+       pass
+
+
+This key exists alongside the other elements of the metadata.
+
+Version specification is required by the system. If you do not specify your target API version, you will not be able to simulate or run your protocol.
+
+The version you specify determines the features and behaviors available to your protocol. For instance, if Opentrons adds the ability to set the volume units in a call to ``aspirate`` in version 2.1, then you must specify version 2.1 in your metadata. A protocol like this:
+
+
+.. code-block:: python
+
+    
+   from opentrons import protocol_api
+
+   metadata = {
+       'apiLevel': '2.0',
+       'author': 'A. Biologist'}
+
+   def run(protocol: protocol_api.ProtocolContext):
+       tiprack = protocol.load_labware('opentrons_96_tiprack_300ul', '1')
+       plate = protocol.load_labware('corning_96_wellplate_380ul', '2')
+       left = protocol.load_instrument('p300_single', 'left', tip_racks=[tiprack])
+
+       left.pick_up_tip()
+       left.aspirate(volume=50000, location=plate['A1'], units='nanoliters')
+
+
+would cause an error, because the ``units`` argument is not present in API version 2.0. This protects you from accidentally using features not present in your specified API version, and keeps your protocol portable between API versions.
+
+In general, you should closely consider what features you need in your protocol, and keep your specified API level as low as possible. This makes your protocol work on more robot software versions.
+
+
+Determining What Version Is Available
+-------------------------------------
+
+Since robot software and Opentrons App version 3.15.0, the maximum supported API level of your robot is visible in the Information card in the Opentrons App for your robot.
+
+This maximum supported API level is the highest API level you can specify in a protocol. If you upload a protocol that specifies a higher API level than the robot software supports, the robot cannot simulate or run your protocol.
+
+
+Determining What Features Are In What Version
+---------------------------------------------
+
+As you read the documentation on this site, you will notice that all documentation on features, function calls, available properties, and everything else about the Protocol API notes which API version it was introduced in. Keep this information in mind when specifying your protocol's API version.
+
+
+.. _version-table:
+
+API and Robot Software Versions
+-------------------------------
+
+This table lists the correspondence between Protocol API versions and robot software versions.
+
++-------------+-----------------------------+
+| API Version | Introduced In Robot Version |
++=============+=============================+
+|     1.0     |           3.0.0             |
++-------------+-----------------------------+
+|     2.0     |          3.14.0             |
++-------------+-----------------------------+

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -60,7 +60,7 @@ The version you specify determines the features and behaviors available to your 
 
 would cause an error, because the ``units`` argument is not present in API version 2.0. This protects you from accidentally using features not present in your specified API version, and keeps your protocol portable between API versions.
 
-In general, you should closely consider what features you need in your protocol, and keep your specified API level as low as possible. This makes your protocol work on more robot software versions.
+In general, you should closely consider what features you need in your protocol, and keep your specified API level as low as possible. This makes your protocol work on a wider range of robot software versions.
 
 
 Determining What Version Is Available

--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -10,6 +10,10 @@ from .contexts import (ProtocolContext,
                        TemperatureModuleContext,
                        MagneticModuleContext,
                        ThermocyclerContext)
+from ..protocols import types
+
+MAX_SUPPORTED_VERSION = types.APIVersion(2, 0)
+#: The maximum supported protocol API version in this release
 
 
 __all__ = ['ProtocolContext',

--- a/api/tests/opentrons/server/test_health_endpoints.py
+++ b/api/tests/opentrons/server/test_health_endpoints.py
@@ -1,5 +1,6 @@
 import json
-from opentrons import __version__
+from opentrons import __version__, protocol_api
+from opentrons.config import feature_flags as ff
 
 
 async def test_health(virtual_smoothie_env, loop, async_client):
@@ -9,7 +10,11 @@ async def test_health(virtual_smoothie_env, loop, async_client):
         'api_version': __version__,
         'fw_version': 'Virtual Smoothie',
         'logs': ['/logs/serial.log', '/logs/api.log'],
-        'system_version': '0.0.0'
+        'system_version': '0.0.0',
+        'protocol_api_version':
+        list(protocol_api.MAX_SUPPORTED_VERSION)
+        if ff.use_protocol_api_v2() else
+        [1, 0]
     })
     resp = await async_client.get('/health')
     text = await resp.text()


### PR DESCRIPTION
As well as adding more docs about protocol API versioning.

The max supported version is exposed in the /health endpoint as
'protocol_api_version': [major, minor].

Closes #4341 