### PR TITLE
feat(api): apiv2: Limit protocols to max supported version

### DIFF
--- a/api/docs/v2/new_advanced_running.rst
+++ b/api/docs/v2/new_advanced_running.rst
@@ -20,12 +20,12 @@ Here, you can select a notebook and develop protocols that will be saved on the 
 Protocol Structure
 ++++++++++++++++++
 
-To take advantage of Jupyter's ability to run only parts of your protocol, you have to restructure it slightly - turn it inside out. Rather than writing a single ``run`` function that contains all your protocol logic, you can use the function :py:meth:`opentrons.execute.get_protocol_api`:
+To take advantage of Jupyter's ability to run only parts of your protocol, you have to restructure it slightly - turn it inside out. Rather than writing a single ``run`` function that contains all your protocol logic, you can use the function :py:meth:`opentrons.execute.get_protocol_api`, into which you pass the same API version (see :ref:`v2-versioning`) that you would specify in your protocol's metadata:
 
 .. code-block:: python
 
    >>> import opentrons.execute
-   >>> protocol = opentrons.execute.get_protocol_api()
+   >>> protocol = opentrons.execute.get_protocol_api('2.0')
 
 
 This returns the same kind of object - a :py:class:`.ProtocolContext` - that is passed into your protocol's ``run`` function when you upload your protocol in the Opentrons App. Full documentation on the capabilities and use of the :py:class:`.ProtocolContext` object is available in the other sections of this guide - :ref:`protocol-api-robot`, :ref:`new-pipette`, :ref:`v2-atomic-commands`, :ref:`v2-complex-commands`, :ref:`new-labware`, and :ref:`new_modules`; a full list of all available attributes and methods is available in :ref:`protocol-api-reference`.
@@ -46,7 +46,7 @@ If you have a protocol that you have already written, that is defined in a ``run
    >>> def run(protocol: protocol_api.ProtocolContext):
    ...     # the contents of your protocol are here...
    ...
-   >>> protocol = opentrons.execute.get_protocol_api()
+   >>> protocol = opentrons.execute.get_protocol_api('2.0')
    >>> run(protocol)  # your protocol will now run
 
 

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -120,8 +120,8 @@ class Session(object):
         self.name = name
         self._protocol = protocol
         self._hardware = hardware
-        self._simulating_ctx = ProtocolContext(
-            loop=self._loop, broker=self._broker)
+        self._simulating_ctx = ProtocolContext.build_using(
+            self._protocol, loop=self._loop, broker=self._broker)
         self.state = None
         self.commands = []
         self.command_log = {}
@@ -240,7 +240,6 @@ class Session(object):
                     hardware=sim,
                     broker=self._broker)
                 run_protocol(self._protocol,
-                             simulate=True,
                              context=self._simulating_ctx)
             else:
                 self._hardware.broker = self._broker
@@ -368,16 +367,11 @@ class Session(object):
             self.resume()
             self._pre_run_hooks()
             if ff.use_protocol_api_v2():
-                bundled_data = None
-                bundled_labware = None
-                if isinstance(self._protocol, PythonProtocol):
-                    bundled_data = self._protocol.bundled_data
-                    bundled_labware = self._protocol.bundled_labware
                 self._hardware.cache_instruments()
-                ctx = ProtocolContext(loop=self._loop,
-                                      broker=self._broker,
-                                      bundled_labware=bundled_labware,
-                                      bundled_data=bundled_data)
+                ctx = ProtocolContext.build_using(
+                    self._protocol,
+                    loop=self._loop,
+                    broker=self._broker)
                 ctx.connect(self._hardware)
                 ctx.home()
                 run_protocol(self._protocol, context=ctx)

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -11,14 +11,15 @@ import asyncio
 import logging
 import sys
 import threading
-from typing import Any, Callable, Dict, Optional, TextIO
+from typing import Any, Callable, Dict, Optional, TextIO, Union
 
 from opentrons import protocol_api, __version__
-from opentrons.protocol_api import execute as execute_apiv2
 from opentrons.protocol_api.legacy_wrapper import api
+from opentrons.protocol_api import (execute as execute_apiv2,
+                                    MAX_SUPPORTED_VERSION)
 from opentrons import commands
 from opentrons.config import feature_flags as ff
-from opentrons.protocols.parse import parse
+from opentrons.protocols.parse import parse, version_from_string
 from opentrons.protocols.types import JsonProtocol, APIVersion
 from opentrons.hardware_control import API
 
@@ -28,6 +29,7 @@ _HWCONTROL: Optional[API] = None
 
 
 def get_protocol_api(
+        version: Union[str, APIVersion],
         bundled_labware: Dict[str, Dict[str, Any]] = None,
         bundled_data: Dict[str, bytes] = None
 ) -> protocol_api.ProtocolContext:
@@ -45,7 +47,11 @@ def get_protocol_api(
         >>> instr.home()
 
     When this function is called, modules and instruments will be recached.
-
+    :param version: The API version to use. This must be lower than
+                    :py:attr:`opentrons.protocol_api.MAX_SUPPORTED_VERSION`.
+                    It may be specified either as a string (``'2.0'``) or
+                    as a :py:class:`.protocols.types.APIVersion`
+                    (``APIVersion(2, 0)``).
     :param bundled_labware: If specified, a mapping from labware names to
                             labware definitions for labware to consider in the
                             protocol. Note that if you specify this, _only_
@@ -78,10 +84,16 @@ def get_protocol_api(
             name='Hardware-controller-builder')
         thread.start()
         thread.join()
-
+    if isinstance(version, str):
+        checked_version = version_from_string(version)
+    elif not isinstance(version, APIVersion):
+        raise TypeError('version must be either a string or an APIVersion')
+    else:
+        checked_version = version
     context = protocol_api.ProtocolContext(hardware=_HWCONTROL,
                                            bundled_labware=bundled_labware,
-                                           bundled_data=bundled_data)
+                                           bundled_data=bundled_data,
+                                           api_version=checked_version)
     context._hw_manager.hardware.cache_instruments()
     context._hw_manager.hardware.discover_modules()
     return context
@@ -183,15 +195,14 @@ def execute(protocol_file: TextIO,
             or protocol.api_level >= APIVersion(2, 0)\
             or (ff.enable_back_compat() and ff.use_protocol_api_v2()):
         context = get_protocol_api(
+            getattr(protocol, 'api_level', MAX_SUPPORTED_VERSION),
             bundled_labware=getattr(protocol, 'bundled_labware', None),
             bundled_data=getattr(protocol, 'bundled_data', None))
         if emit_runlog:
             context.broker.subscribe(
                 commands.command_types.COMMAND, emit_runlog)
         context.home()
-        execute_apiv2.run_protocol(protocol,
-                                   simulate=False,
-                                   context=context)
+        execute_apiv2.run_protocol(protocol, context)
     else:
         from opentrons import robot
         from opentrons.legacy_api import protocols

--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -4,17 +4,17 @@ This package defines classes and functions for access through a protocol to
 control the OT2.
 
 """
-from . import labware
-from .contexts import (ProtocolContext,
-                       InstrumentContext,
-                       TemperatureModuleContext,
-                       MagneticModuleContext,
-                       ThermocyclerContext)
 from ..protocols import types
 
 MAX_SUPPORTED_VERSION = types.APIVersion(2, 0)
 #: The maximum supported protocol API version in this release
 
+from . import labware  # noqa(E402)
+from .contexts import (ProtocolContext,  # noqa(E402)
+                       InstrumentContext,
+                       TemperatureModuleContext,
+                       MagneticModuleContext,
+                       ThermocyclerContext)
 
 __all__ = ['ProtocolContext',
            'InstrumentContext',

--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -8,7 +8,6 @@ import opentrons
 from .contexts import ProtocolContext
 from . import execute_v3, legacy_wrapper
 
-from opentrons import config
 from opentrons.protocols.types import PythonProtocol, Protocol, APIVersion
 
 MODULE_LOG = logging.getLogger(__name__)
@@ -89,8 +88,6 @@ def _find_protocol_error(tb, proto_name):
 
 def _run_python(
         proto: PythonProtocol, context: ProtocolContext):
-    context.set_bundle_contents(
-        proto.bundled_labware, proto.bundled_data, proto.extra_labware)
     new_locs = locals()
     new_globs = globals()
     exec(proto.contents, new_globs, new_locs)
@@ -140,39 +137,17 @@ def _run_python_legacy(proto: PythonProtocol, context: ProtocolContext):
 
 
 def run_protocol(protocol: Protocol,
-                 simulate: bool = False,
-                 context: ProtocolContext = None):
-    """ Create a ProtocolRunner instance from one of a variety of protocol
-    sources.
+                 context: ProtocolContext):
+    """ Run a protocol.
 
     :param protocol: The :py:class:`.protocols.types.Protocol` to execute
-    :param simulate: True to simulate; False to execute. If this is not an
-                     OT2, ``simulate`` will be forced ``True``.
-    :param context: The context to use. If ``None``, create a new
-                    :py:class:`.ProtocolContext`.
-
-    .. note ::
-
-        The :py:class:`.ProtocolContext` has the bundle contents (if any)
-        inserted in it by this method.
-
+    :param context: The context to use.
     """
-    if not config.IS_ROBOT:
-        simulate = True  # noqa - will be used later
-    if None is context and simulate:
-        true_context = ProtocolContext()
-        true_context.home()
-        MODULE_LOG.info("Generating blank protocol context for simulate")
-    elif context:
-        true_context = context
-    else:
-        raise RuntimeError(
-            'Will not automatically generate hardware controller')
     if isinstance(protocol, PythonProtocol):
         if protocol.api_level >= APIVersion(2, 0):
-            _run_python(protocol, true_context)
+            _run_python(protocol, context)
         elif protocol.api_level == APIVersion(1, 0):
-            _run_python_legacy(protocol, true_context)
+            _run_python_legacy(protocol, context)
         else:
             raise RuntimeError(
                 f'Unsupported python API version: {protocol.api_level}'
@@ -180,7 +155,10 @@ def run_protocol(protocol: Protocol,
     else:
         if protocol.schema_version == 3:
             ins = execute_v3.load_pipettes_from_json(
-                true_context, protocol.contents)
+                context, protocol.contents)
             lw = execute_v3.load_labware_from_json_defs(
-                true_context, protocol.contents)
-            execute_v3.dispatch_json(true_context, protocol.contents, ins, lw)
+                context, protocol.contents)
+            execute_v3.dispatch_json(context, protocol.contents, ins, lw)
+        else:
+            raise RuntimeError(
+                f'Unsupported JSON protocol schema: {protocol.schema_version}')

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -21,6 +21,22 @@ from .bundle import extract_bundle
 API_VERSION_RE = re.compile(r'^(\d+)\.(\d+)$')
 
 
+def version_from_string(vstr: str) -> APIVersion:
+    """ Parse an API version from a string
+
+    :param str vstr: The version string to parse
+    :returns APIVersion: The parsed version
+    :raises ValueError: if the version string is the wrong format
+    """
+    matches = API_VERSION_RE.match(vstr)
+    if not matches:
+        raise ValueError(
+            f'apiLevel {vstr} is incorrectly formatted. It should '
+            'major.minor, where both major and minor are numbers.')
+    return APIVersion(
+        major=int(matches.group(1)), minor=int(matches.group(2)))
+
+
 def _parse_json(
         protocol_contents: str, filename: str = None) -> JsonProtocol:
     """ Parse a protocol known or at least suspected to be json """
@@ -202,12 +218,8 @@ def version_from_metadata(metadata: Metadata) -> APIVersion:
     requested_level = str(metadata['apiLevel'])
     if requested_level == '1':
         return APIVersion(1, 0)
-    matches = API_VERSION_RE.match(requested_level)
-    if not matches:
-        raise ValueError(
-            f'apiLevel {requested_level} is incorrectly formatted. It should '
-            'major.minor, where both major and minor are numbers.')
-    return APIVersion(major=int(matches.group(1)), minor=int(matches.group(2)))
+
+    return version_from_string(requested_level)
 
 
 def get_version(metadata: Metadata, parsed: ast.Module) -> APIVersion:

--- a/api/tests/opentrons/protocol_api/test_execute.py
+++ b/api/tests/opentrons/protocol_api/test_execute.py
@@ -1,6 +1,7 @@
 import pytest
 from opentrons.protocol_api import execute, ProtocolContext
 from opentrons.protocols.parse import parse
+from opentrons.protocols.types import APIVersion
 
 v1_protocol_testcases = [
     ("""from opentrons import labware, instruments, robot"""),
@@ -55,7 +56,8 @@ def test_execute_ok(protocol, protocol_file, ensure_api2, loop):
 @pytest.mark.parametrize('protocol', v1_protocol_testcases)
 def test_execute_v1_imports(protocol, ensure_api2):
     proto = parse(protocol)
-    execute.run_protocol(proto)
+    ctx = ProtocolContext(api_version=APIVersion(1, 0))
+    execute.run_protocol(proto, ctx)
 
 
 def test_bad_protocol(ensure_api2, loop):

--- a/api/tests/opentrons/protocol_api/test_execute_v3.py
+++ b/api/tests/opentrons/protocol_api/test_execute_v3.py
@@ -157,4 +157,4 @@ def test_papi_execute_json_v3(monkeypatch, loop, get_json_protocol_fixture):
     ctx = ProtocolContext(loop=loop)
     ctx.home()
     # Check that we end up executing the protocol ok
-    execute.run_protocol(protocol, True, ctx)
+    execute.run_protocol(protocol, ctx)


### PR DESCRIPTION
When we create a protocol context, give it the requested protocol API version.
Do not allow the simulation or execution of protocols that request a version
above the highest version this release of the software supports.

This behavior should be consistent across all entry points: rpc protocol
session, opentrons_execute/get_protocol_api,
opentrons_simulate/get_protocol_api. The get_protocol_api functions now take an
optional argument to limit the protocol api version to user specifications (with
a default of the max supported version)

Closes #4342
