### PR TITLE
chore(protocol-designer): bump to 3.0.7

### DIFF
--- a/protocol-designer/webpack.config.js
+++ b/protocol-designer/webpack.config.js
@@ -16,7 +16,7 @@ const PROTOCOL_DESIGNER_ENV_VAR_PREFIX = 'OT_PD_'
 // Also remove all OT_PD_VERSION env vars, the version should always
 // be gleaned from the package.json
 
-const OT_PD_VERSION = '3.0.6'
+const OT_PD_VERSION = '3.0.7'
 const OT_PD_BUILD_DATE = new Date().toUTCString()
 
 const JS_ENTRY = path.join(__dirname, 'src/index.js')


### PR DESCRIPTION
## overview

Bump to 3.0.7 to kick off QA.

Major changes to NEST labware that was formerly unusably broken and so the defs have been mutated without version bump.

Also new quirk `touchTipDisabled` in the defs. PD doesn't look at that, API will ignore touch tips on trough-likes. That's existing behavior.

Also many latent changes for modules on deck work in progress; we'll have to check these are truly latent.

## changelog

### User-facing changes
- expose GEN2 pipettes in pipette select (#4351)
- updates to LabwareSelectionModal (#4325) -- only color change should be user-facing

### Labware changes
- do not touch tip on troughs (#4271) -- added `touchTipDisabled` quirk to multiple labware
- swap X/Y spacing for 24-well nest tuberacks (#4240)

### Latent changes (requires preproduction mode to see)
- show special-case warning for north/south (#4361)
- add module slot visualization (#4355)
- fix never-released bug in manualIntervention step (#4350)
- Enable slot selection for modules when FF enabled (#4347)
- Add edit modules modal (#4320)
- hook up module creation in NewFileModal (#4319)
- render modules on deck (#4309) -- refactor tests & reducers to put labware on modules instead of sharing deck slots
- implement prerelease mode + settings (#4242)

### Refactor
- remove enum from protocol schema pipette type (#4292)
- remove spacing variables from components library (#4345)
- update FS snippet; enable linting/flow (#4184)

## review requests

- Sanity check the sandbox build if you want but this is going to go thru QA so quick glance review would be OK
