### PR TITLE
feat(app): parse subnet out of CIDR-notation IP address

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -34,6 +34,7 @@
     "lodash": "^4.17.4",
     "mixpanel-browser": "^2.22.1",
     "moment": "^2.19.1",
+    "netmask": "^1.0.6",
     "path-to-regexp": "^3.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/app/src/components/RobotSettings/connection.js
+++ b/app/src/components/RobotSettings/connection.js
@@ -77,8 +77,9 @@ type NetworkAddressProps = {
 
 function NetworkAddresses(props: NetworkAddressProps) {
   const type = props.wired ? 'Wired' : 'Wireless'
-  const ip = (props.connection && props.connection.ipAddress) || 'Unknown'
-  const mac = (props.connection && props.connection.macAddress) || 'Unknown'
+  const ip = props.connection?.ipAddress || 'Unknown'
+  const subnet = props.connection?.subnetMask || 'Unknown'
+  const mac = props.connection?.macAddress || 'Unknown'
   const labelStyles = cx(styles.connection_label, {
     [styles.disabled]: props.disabled,
   })
@@ -90,7 +91,11 @@ function NetworkAddresses(props: NetworkAddressProps) {
         {ip}
       </p>
       <p>
-        <span className={labelStyles}>{type} MAC address: </span>
+        <span className={labelStyles}>{type} Subnet Mask: </span>
+        {subnet}
+      </p>
+      <p>
+        <span className={labelStyles}>{type} MAC Address: </span>
         {mac}
       </p>
     </div>

--- a/app/src/http-api-client/__tests__/networking.test.js
+++ b/app/src/http-api-client/__tests__/networking.test.js
@@ -22,13 +22,15 @@ describe('networking', () => {
           api: {
             api: {
               someName: {
-                'networking/status': { response: { status: 'full' } },
+                'networking/status': {
+                  response: { status: 'full', interfaces: {} },
+                },
               },
             },
           },
         },
         props: { name: 'someName' },
-        expected: { response: { status: 'full' } },
+        expected: { response: { status: 'full', interfaces: {} } },
       },
       {
         name: 'makeGetRobotWifiList',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11493,6 +11493,11 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
+netmask@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/netmask/-/netmask-1.0.6.tgz#20297e89d86f6f6400f250d9f4f6b4c1945fcd35"
+  integrity sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=
+
 nice-try@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"


### PR DESCRIPTION
## overview

This PR adds CIDR-notation string parsing to the IP address display of the robots page. Closes #4075

## changelog

- feat(app): parse subnet out of CIDR-notation IP address

## review requests

A couple things to note:

- The `networking` subtree needs a lot of work. This API-client-state refactor work is ongoing anyway, so this PR makes the smallest change possible to enable this functionality
- I pulled in one dependency for CIDR-notation parsing
    - I didn't want to write my own
    - I used the smallest one most widely used one I could find, and it's dependency-free
    - https://github.com/rs/node-netmask/

Anyway, open up the app and click on a robot. It should:

- [ ] List IP address **without a trailing `/24`** (or whatever number)
- [ ] List a subnet mask in X.X.X.X notation