### PR TITLE
fix(api): Suppress error log during check for pipettes

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -948,7 +948,7 @@ class SmoothieDriver_3_0_0:
             # is locking at a higher level like in APIv2.
             self._reset_from_error()
             error_axis = se.ret_code.strip()[-1]
-            log.warning(
+            log.debug(
                     f"alarm/error: command={command}, resp={se.ret_code}")
             if GCODES['MOVE'] in command or GCODES['PROBE'] in command:
                 if error_axis not in 'XYZABC':

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -916,7 +916,11 @@ class SmoothieDriver_3_0_0:
         self.update_homed_flags()
 
     # Potential place for command optimization (buffering, flushing, etc)
-    def _send_command(self, command, timeout=DEFAULT_SMOOTHIE_TIMEOUT):
+    def _send_command(
+            self,
+            command,
+            timeout=DEFAULT_SMOOTHIE_TIMEOUT,
+            suppress_error_msg=False):
         """
         Submit a GCODE command to the robot, followed by M400 to block until
         done. This method also ensures that any command on the B or C axis
@@ -932,9 +936,16 @@ class SmoothieDriver_3_0_0:
         switch was hit unexpectedly. This is usually due to an undetected
         collision in a previous move command.
 
+        SmoothieErrors are also raised when a command is sent to a pipette that
+        is not present, such as when identifying which pipettes are on a robot.
+        In this case, the message should not be logged, so the caller of this
+        function should specify `supress_error_msg=True`.
+
         :param command: the GCODE to submit to the robot
         :param timeout: the time to wait before returning (indefinite wait if
             this is set to none
+        :param suppress_error_msg: flag for indicating that smoothie errors
+            should not be logged
         """
         if self.simulating:
             return
@@ -948,8 +959,9 @@ class SmoothieDriver_3_0_0:
             # is locking at a higher level like in APIv2.
             self._reset_from_error()
             error_axis = se.ret_code.strip()[-1]
-            log.debug(
-                    f"alarm/error: command={command}, resp={se.ret_code}")
+            if not suppress_error_msg:
+                log.warning(
+                        f"alarm/error: command={command}, resp={se.ret_code}")
             if GCODES['MOVE'] in command or GCODES['PROBE'] in command:
                 if error_axis not in 'XYZABC':
                     error_axis = AXES
@@ -1183,7 +1195,7 @@ class SmoothieDriver_3_0_0:
             self.disengage_axis('ZABC')
             self.delay(PIPETTE_READ_DELAY)
             # request from Smoothieware the information from that pipette
-            res = self._send_command(gcode + mount)
+            res = self._send_command(gcode + mount, suppress_error_msg=True)
             if res:
                 res = _parse_instrument_data(res)
                 assert mount in res

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -545,7 +545,8 @@ def test_read_and_write_pipettes(smoothie):
     written_model = ''
     mount = 'L'
 
-    def _new_send_message(self, command, timeout=None):
+    def _new_send_message(
+            self, command, timeout=None, suppress_error_msg=True):
         nonlocal written_id, written_model, mount
         if GCODES['READ_INSTRUMENT_ID'] in command:
             return mount + ': ' + written_id
@@ -584,7 +585,8 @@ def test_read_pipette_v13(smoothie):
     _old_send_command = driver._send_command
     driver.simulating = False
 
-    def _new_send_message(self, command, timeout=None):
+    def _new_send_message(
+            self, command, timeout=None, suppress_error_msg=True):
         return 'L:' + _byte_array_to_hex_string(b'p300_single_v13')
 
     driver._send_command = types.MethodType(_new_send_message, driver)


### PR DESCRIPTION
This log statement was confusing to users, as it seemed to report an error (which are assumed to be a failure or otherwise fatal action that needs to be corrected) when it was in fact not a problem.  The message might still be relevant to a developer working on this module, so suppressing it specifically when checking if a pipette is present or not.

Closes #4096 

## review requests

Here's the new behavior (prior behavior was an error message after `robot.connect()`--see ticket)

![Screen Shot 2019-11-05 at 2 05 28 PM](https://user-images.githubusercontent.com/5034659/68239020-4066ab80-ffd8-11e9-99be-5c67d48ce679.png)
