### PR TITLE
fix(app,api): display session error messages in SessionAlert

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -452,6 +452,7 @@ class Session(object):
             payload = {
                 'state': self.state,
                 'startTime': self.startTime,
+                'errors': self.errors,
                 'lastCommand': last_command
             }
         return {

--- a/app/src/components/RunLog/SessionAlert.js
+++ b/app/src/components/RunLog/SessionAlert.js
@@ -1,6 +1,8 @@
 // @flow
 import * as React from 'react'
+import { useSelector } from 'react-redux'
 import { AlertItem } from '@opentrons/components'
+import { getSessionError } from '../../robot/selectors'
 import type { SessionStatus } from '../../robot'
 
 type Props = {
@@ -11,6 +13,7 @@ type Props = {
 
 export default function SessionAlert(props: Props) {
   const { sessionStatus, className, onResetClick } = props
+  const sessionError = useSelector(getSessionError)
 
   switch (sessionStatus) {
     case 'finished':
@@ -63,7 +66,9 @@ export default function SessionAlert(props: Props) {
               resolving this issue.
             </p>
           }
-        />
+        >
+          {sessionError !== null && <p>{sessionError}</p>}
+        </AlertItem>
       )
 
     default:

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -409,6 +409,15 @@ export default function client(dispatch) {
       clearRunTimerInterval()
     }
 
+    // both light and full updates may have the errors list
+    if (apiSession.errors) {
+      update.errors = apiSession.errors.map(e => ({
+        timestamp: e.timestamp,
+        message: e.error.message,
+        line: e.error.line,
+      }))
+    }
+
     // if lastCommand key is present, we're dealing with a light update
     if ('lastCommand' in apiSession) {
       const lastCommand = apiSession.lastCommand && {

--- a/app/src/robot/reducer/session.js
+++ b/app/src/robot/reducer/session.js
@@ -24,7 +24,11 @@ type Request = {
 export type SessionState = {
   sessionRequest: Request,
   state: SessionStatus,
-  errors: Array<{}>,
+  errors: Array<{|
+    timestamp: number,
+    line: number,
+    message: string,
+  |}>,
   // TODO(mc, 2018-01-11): command IDs should be strings
   protocolCommands: Array<number>,
   protocolCommandsById: {

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -172,6 +172,16 @@ export const getRunProgress = createSelector(
   }
 )
 
+export const getSessionError: State => string | null = createSelector(
+  (state: State) => session(state).runRequest.error,
+  (state: State) => session(state).errors,
+  (runError, sessionErrors) => {
+    if (runError) return runError.message
+    if (sessionErrors.length > 0) return sessionErrors[0].message
+    return null
+  }
+)
+
 export function getStartTime(state: State): number | null {
   const { startTime, remoteTimeCompensation } = session(state)
 


### PR DESCRIPTION
##  overview

This PR:

- Adds `session_manager.session.errors` to the redux state
- Uses the errors in redux state or from the protocol run request to populate the message of the `SessionAlert` banner in the run page

Closes #4367

## changelog

- fix(app): display session error messages in SessionAlert

## review requests

1. Load a protocol that will result in a runtime error
    - For example: a protocol that loads a module but does not use it (see #4368)
2. Run the protocol
3. When the protocol errors:
  - [ ] Error banner shows up
  - [ ] Error message is in the body of the banner
4. Disconnect from the robot and reconnect
5. Go to "Run" page
  - [ ] Error banner should still be there
  - [ ] Error message should still be there

**Note**: Due to RPC weirdness, the error message that displays if you remain connected vs the error message if you reconnect will be slightly different. This is because the RPC API is awful, and fixing it is not worth the effort.

Also, if you...

1. Start a run
2. Disconnect
3. Reconnect
4. The run errors 

...there will be no error message in the UI. Fixing _this_ issue requires a little API change, which is included in this PR but won't be on your robot unless you put it on there.
