### PR TITLE
build: Default OT_PYTHON to python3, not python.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ UPDATE_SERVER_DIR := update-server
 # this may be set as an environment variable to select the version of
 # python to run if pyenv is not available. it should always be set to
 # point to a python3.6.
-OT_PYTHON ?= python
+OT_PYTHON ?= python3
 
 # watch, coverage, and update snapshot variables for tests
 watch ?= false


### PR DESCRIPTION
The documented intent of the OT_PYTHON makefile variable is to point to a Python 3 interpreter.  However, it previously used just `python`, which is Python 2 on most systems.  This caused at least the `python -m pip` done by `make install` to fail.