### PR TITLE
fix(app): prevent user from proceeding if uploaded protocol has no steps

### DIFF
--- a/app/src/components/FileInfo/InstrumentItem.js
+++ b/app/src/components/FileInfo/InstrumentItem.js
@@ -4,14 +4,14 @@ import { Icon } from '@opentrons/components'
 import styles from './styles.css'
 import type { PipetteCompatibility } from './useInstrumentMountInfo'
 
-type Props = {
+type Props = {|
   compatibility?: PipetteCompatibility,
   mount?: string,
   children: React.Node,
   hidden?: boolean,
-}
+|}
 
-export default function ModuleItem(props: Props) {
+export default function InstrumentItem(props: Props) {
   if (props.hidden) return null
   return (
     <div className={styles.instrument_item}>
@@ -26,7 +26,7 @@ export default function ModuleItem(props: Props) {
   )
 }
 
-function StatusIcon(props: { match: boolean }) {
+function StatusIcon(props: {| match: boolean |}) {
   const { match } = props
 
   const iconName = match ? 'check-circle' : 'checkbox-blank-circle-outline'

--- a/app/src/components/FileInfo/index.js
+++ b/app/src/components/FileInfo/index.js
@@ -12,14 +12,20 @@ import styles from './styles.css'
 
 import type { Robot } from '../../discovery'
 
-type Props = {
+const NO_STEPS_MESSAGE = `This protocol has no steps in it - there's nothing for your robot to do! Your protocol needs at least one aspirate/dispense to import properly`
+
+type Props = {|
   robot: Robot,
-  sessionLoaded: ?boolean,
+  sessionLoaded: boolean,
+  sessionHasSteps: boolean,
   uploadError: ?{ message: string },
-}
+|}
 
 export default function FileInfo(props: Props) {
-  const { robot, sessionLoaded, uploadError } = props
+  const { robot, sessionLoaded, sessionHasSteps } = props
+  const uploadError = sessionHasSteps
+    ? props.uploadError
+    : { message: NO_STEPS_MESSAGE }
 
   return (
     <div className={styles.file_info_container}>
@@ -27,8 +33,10 @@ export default function FileInfo(props: Props) {
       <ProtocolPipettesCard robot={robot} />
       <ProtocolModulesCard robot={robot} />
       <ProtocolLabwareCard />
-      {uploadError && <UploadError uploadError={uploadError} />}
-      {sessionLoaded && <Continue />}
+      {sessionLoaded && uploadError && (
+        <UploadError uploadError={uploadError} />
+      )}
+      {sessionLoaded && !uploadError && <Continue />}
     </div>
   )
 }

--- a/app/src/components/nav-bar/NavButton.js
+++ b/app/src/components/nav-bar/NavButton.js
@@ -23,6 +23,7 @@ type Props = {| ...ContextRouter, name: string |}
 function NavButton(props: Props) {
   const { name } = props
   const isProtocolLoaded = useSelector(robotSelectors.getSessionIsLoaded)
+  const isProtocolRunnable = useSelector(robotSelectors.getCommands).length > 0
   const isProtocolRunning = useSelector(robotSelectors.getIsRunning)
   const isProtocolDone = useSelector(robotSelectors.getIsDone)
   const connectedRobot = useSelector(getConnectedRobot)
@@ -70,6 +71,7 @@ function NavButton(props: Props) {
         <GenericNavButton
           disabled={
             !isProtocolLoaded ||
+            !isProtocolRunnable ||
             isProtocolRunning ||
             isProtocolDone ||
             incompatiblePipettes
@@ -85,7 +87,9 @@ function NavButton(props: Props) {
     case 'run':
       return (
         <GenericNavButton
-          disabled={!isProtocolLoaded || incompatiblePipettes}
+          disabled={
+            !isProtocolLoaded || !isProtocolRunnable || incompatiblePipettes
+          }
           tooltipComponent={
             incompatiblePipettes ? incompatPipetteTooltip : null
           }

--- a/app/src/pages/Upload/FileInfo.js
+++ b/app/src/pages/Upload/FileInfo.js
@@ -7,13 +7,14 @@ import FileInfo from '../../components/FileInfo'
 
 import type { Robot } from '../../discovery'
 
-type Props = {
+type Props = {|
   robot: Robot,
   filename: string,
   uploadInProgress: boolean,
   uploadError: ?{ message: string },
   sessionLoaded: boolean,
-}
+  sessionHasSteps: boolean,
+|}
 
 export default function FileInfoPage(props: Props) {
   const {
@@ -22,6 +23,7 @@ export default function FileInfoPage(props: Props) {
     uploadInProgress,
     uploadError,
     sessionLoaded,
+    sessionHasSteps,
   } = props
 
   return (
@@ -34,6 +36,7 @@ export default function FileInfoPage(props: Props) {
       <FileInfo
         robot={robot}
         sessionLoaded={sessionLoaded}
+        sessionHasSteps={sessionHasSteps}
         uploadError={uploadError}
       />
       {uploadInProgress && <SpinnerModal message="Upload in Progress" />}

--- a/app/src/pages/Upload/index.js
+++ b/app/src/pages/Upload/index.js
@@ -24,6 +24,7 @@ type SP = {|
   uploadInProgress: boolean,
   uploadError: ?{ message: string },
   sessionLoaded: boolean,
+  sessionHasSteps: boolean,
 |}
 
 type Props = {| ...OP, ...SP, dispatch: Dispatch |}
@@ -39,6 +40,7 @@ function mapStateToProps(state: State): SP {
     uploadInProgress: robotSelectors.getSessionLoadInProgress(state),
     uploadError: robotSelectors.getUploadError(state),
     sessionLoaded: robotSelectors.getSessionIsLoaded(state),
+    sessionHasSteps: robotSelectors.getCommands(state).length > 0,
   }
 }
 
@@ -49,6 +51,7 @@ function UploadPage(props: Props) {
     uploadInProgress,
     uploadError,
     sessionLoaded,
+    sessionHasSteps,
     match: { path },
   } = props
 
@@ -75,6 +78,7 @@ function UploadPage(props: Props) {
             uploadInProgress={uploadInProgress}
             uploadError={uploadError}
             sessionLoaded={sessionLoaded}
+            sessionHasSteps={sessionHasSteps}
           />
         )}
       />


### PR DESCRIPTION
## overview

If a protocol has no errors, the app will now display an error message in the FileInfo page and disable the calibration and run pages

Closes #3121

![2019-11-06 12 01 03](https://user-images.githubusercontent.com/2963448/68319993-3357c400-008d-11ea-8a6d-dd4947be980f.gif)

## changelog

- fix(app): prevent user from proceeding if uploaded protocol has no steps

## review requests

1. Upload a protocol with no aspirates and dispenses

- [ ] An error is show in the FileInfo page
- [ ] Calibrate and Run nav buttons are disabled
