### PR TITLE
chore(docs): apiv2: Document the version all ifaces were added

### DIFF
--- a/api/docs/v1/conf.py
+++ b/api/docs/v1/conf.py
@@ -300,6 +300,8 @@ latex_elements = {
      # Latex figure (float) alignment
      #
      'figure_align': 'H',
+
+     'maxlistdepth': '10',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/api/docs/v2/conf.py
+++ b/api/docs/v2/conf.py
@@ -207,6 +207,7 @@ html_static_path = ['../static']
 
 # Custom sidebar templates, maps document names to template names.
 # Use separate sidebar nav overrides to force (for apiv2) or ignore
+
 # (apiv1) the apiv2 hidden toctree elements (our sphinx overrides css
 # forces the body toctrees hidden using css)
 html_sidebars = {
@@ -290,7 +291,7 @@ latex_elements = {
      # 'pointsize': '10pt',
      # Additional stuff for the LaTeX preamble.
      #
-     # 'preamble': '',
+     # 'preamble': r'\setlistdepth{15}',
 
      # Enable Greek symbol encoding for our sweet mus
      #
@@ -299,6 +300,7 @@ latex_elements = {
      # Latex figure (float) alignment
      #
      'figure_align': 'H',
+    'maxlistdepth': '10',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -48,6 +48,9 @@ If you have associated a tiprack with your pipette such as in the :ref:`new-pipe
 
     pipette.pick_up_tip()
 
+
+.. versionadded:: 2.0
+
 Drop Tip
 ========
 
@@ -65,6 +68,9 @@ Instead of returning a tip to the tip rack, we can also drop it in an alternativ
     trash = protocol.load_labware('trash-box', 4)
     pipette.pick_up_tip()
     pipette.drop_tip(trash)
+
+
+.. versionadded:: 2.0
 
 Return Tip
 ===========
@@ -99,6 +105,10 @@ For the purposes of this section we can assume that we already have the followin
 
 This loads a `Corning 96 Well Plate <https://labware.opentrons.com/corning_96_wellplate_360ul_flat>`_ in slot 2 and two `Opentrons 300ul Tiprack <https://labware.opentrons.com/opentrons_96_tiprack_300ul>`_ in slots 3 and 4 respectively, and uses a P300 Single pipette.
 
+
+.. versionadded:: 2.0
+
+
 Iterating Through Tips
 ----------------------
 
@@ -127,6 +137,9 @@ If we try to :py:meth:`.InstrumentContext.pick_up_tip()` again when all the tips
 
     # this will raise an exception if run after the previous code block
     # pipette.pick_up_tip()
+
+
+.. versionadded:: 2.0
 
 ****************
 Liquid Control
@@ -180,6 +193,8 @@ Now our pipette's tip is holding 100uL.
     the default throughout your protocol - you can change the default offset with
     :py:attr:`.InstrumentContext.well_bottom_clearance` (see :ref:`new-default-op-positions`).
 
+.. versionadded:: 2.0
+
 .. _new-dispense:
 
 Dispense
@@ -200,6 +215,8 @@ To dispense is to push out liquid from the pipette's tip. The usage of :py:meth:
     the default throughout your protocol - you can change the default offset with
     :py:attr:`.InstrumentContext.well_bottom_clearance` (see :ref:`new-default-op-positions`).
 
+.. versionadded:: 2.0
+
 .. _new-blow-out:
 
 .. _blow-out:
@@ -215,6 +232,9 @@ When calling :py:meth:`.InstrumentContext.blow_out`, we have the option to speci
 
     pipette.blow_out()            # blow out in current location
     pipette.blow_out(plate['B3']) # blow out in current plate:B3
+
+
+.. versionadded:: 2.0
 
 .. _touch-tip:
 
@@ -236,6 +256,9 @@ Touch tip can take up to 4 arguments: ``touch_tip(location, radius, v_offset, sp
                       radius=0.75,
                       v_offset=-2)
 
+
+.. versionadded:: 2.0
+
 .. _mix:
 
 Mix
@@ -255,6 +278,9 @@ The mix command takes three arguments: ``mix(repetitions, volume, location)``
 
     Mixes consist of aspirates and then immediate dispenses. In between these actions, the pipette moves up and out of the target well. This is normal, and is done to avoid incorrect aspirate and dispense actions when the plunger does small motions necessary to set it up for its next action.
 
+
+.. versionadded:: 2.0
+
 .. _air-gap:
 
 Air Gap
@@ -267,6 +293,8 @@ Some liquids need an extra amount of air in the pipette's tip to prevent it from
     pipette.aspirate(100, plate['B4'])
     pipette.air_gap(20)
     pipette.drop_tip()
+
+.. versionadded:: 2.0
 
 ******
 Moving
@@ -315,6 +343,8 @@ Usually the above option is useful when moving inside of a well. Take a look at 
     pipette.move_to(plate['A1'].top(-2), force_direct=True)
     pipette.move_to(plate['A2'].top())
 
+.. versionadded:: 2.0
+
 ****************
 Utility Commands
 ****************
@@ -351,6 +381,8 @@ will be displayed in the Opentrons app when protocol execution pauses.
         # more clear.
         protocol.pause('Time to take a break')
 
+.. versionadded:: 2.0
+
 Homing
 ======
 
@@ -379,6 +411,8 @@ None of these functions take any arguments:
         pipette.home()  # Homes the right z axis and plunger
         pipette.home_plunger() # Homes the right plunger
 
+.. versionadded:: 2.0
+
 Comment
 =======
 
@@ -395,4 +429,4 @@ during protocol execution:
     def run(protocol: protocol_api.ProtocolContext):
         protocol.comment('Hello, world!')
 
-
+.. versionadded:: 2.0

--- a/api/docs/v2/new_complex_commands.rst
+++ b/api/docs/v2/new_complex_commands.rst
@@ -118,6 +118,7 @@ Transfer
 The most versatile of the complex liquid handling functions is :py:meth:`.InstrumentContext.transfer`. For a majority of use-cases you will most likely want to use this complex command.
 Below you will find a few scenarios utilizing the :py:meth:`.InstrumentContext.transfer` command.
 
+.. versionadded:: 2.0
 
 Basic
 -----
@@ -188,6 +189,8 @@ will have the steps...
     Dispensing 100.0 uL into well H2 in "1"
     Dropping tip well A1 in "12"
 
+.. versionadded:: 2.0
+
 One to Many
 ------------
 
@@ -222,6 +225,8 @@ will have the steps...
     Dispensing 100.0 uL into well H2 in "1"
     Dropping tip well A1 in "12"
 
+.. versionadded:: 2.0
+
 List of Volumes
 ---------------
 
@@ -248,6 +253,10 @@ will have the steps...
     Aspirating 60.0 uL from well A1 in "1" at 1 speed
     Dispensing 60.0 uL into well B3 in "1"
     Dropping tip well A1 in "12"
+
+
+
+.. versionadded:: 2.0
 
 **********************
 
@@ -311,6 +320,9 @@ will have the steps...
     Aspirating 30.0 uL from well H1 in "1" at 1 speed
     Dispensing 120.0 uL into well A2 in "1"
     Dropping tip well A1 in "12"
+
+
+.. versionadded:: 2.0
 
 Distribute
 -----------
@@ -383,6 +395,8 @@ will have the steps...
     Dispensing 30.0 uL into well A12 in "1"
     Blowing out at well A1 in "12"
     Dropping tip well A1 in "12"
+
+.. versionadded:: 2.0
 
 Re-Visiting Order of Operations
 ===============================
@@ -470,6 +484,8 @@ This parameter handles tip logic. You have options of ``always``, ``once`` and `
 
 If you want to avoid cross-contamination and increase accuracy, you should set this parameter to ``always``.
 
+.. versionadded:: 2.0
+
 Always Get a New Tip
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -503,6 +519,7 @@ will have the steps...
     Aspirating 100.0 uL from well A3 in "1" at 1 speed
     Dispensing 100.0 uL into well B3 in "1"
     Dropping tip well A1 in "12"
+
 
 Never Get a New Tip
 ^^^^^^^^^^^^^^^^^^^
@@ -563,6 +580,8 @@ will have the steps...
     Returning tip
     Dropping tip well A1 in "2"
 
+.. versionadded:: 2.0
+
 touch_tip
 ---------
 
@@ -589,6 +608,8 @@ will have the steps...
     Touching tip
     Dropping tip well A1 in "12"
 
+.. versionadded:: 2.0
+
 blow_out
 --------
 
@@ -613,6 +634,8 @@ will have the steps...
     Dispensing 100.0 uL into well A2 in "1"
     Blowing out
     Dropping tip well A1 in "12"
+
+.. versionadded:: 2.0
 
 mix_before, mix_after
 ---------------------
@@ -651,6 +674,8 @@ will have the steps...
     Dispensing 75.0 uL into well A2 in "1"
     Dropping tip well A1 in "12"
 
+.. versionadded:: 2.0
+
 air_gap
 -------
 
@@ -676,6 +701,8 @@ will have the steps...
     Aspirating 20 uL from well A1 in "1" at 1.0 speed
     Dispensing 120.0 uL into well A2 in "1"
     Dropping tip well A1 in "12"
+
+.. versionadded:: 2.0
 
 disposal_volume
 ---------------
@@ -720,3 +747,5 @@ See this image for example,
 .. image:: ../img/complex_commands/distribute_illustration_tip.png
    :scale: 50 %
    :align: center
+
+.. versionadded:: 2.0

--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -76,6 +76,9 @@ The ending well will be in the bottom right, see the diagram below for further e
         plate = protocol.load_labware('corning_24_wellplate_3.4ml_flat', slot='1')
 
 
+.. versionadded:: 2.0
+
+
 Accessor Methods
 ^^^^^^^^^^^^^^^^
 As part of API Version 2, we wanted to allow users to utilize python's data structures more easily and as intended.
@@ -114,6 +117,8 @@ you will receive a ``KeyError``. This is equivalent to using the return value of
     a1 = plate['A1']
     d6 = plate.wells_by_name()['D6']
 
+.. versionadded:: 2.0
+
 List Access From ``wells``
 --------------------------
 Wells can be referenced by their "string" name, as demonstrated above.
@@ -133,6 +138,8 @@ a labware being at position 0.
     (`Labware Library <https://labware.opentrons.com/opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical>`_).
     Whichever well access method you use, your protocol will be most maintainable
     if you pick one method and don't use the other one.
+
+.. versionadded:: 2.0
 
 Accessing Groups of Wells
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -190,6 +197,8 @@ or,
 
 and it will return the individual well objects in row A.
 
+.. versionadded:: 2.0
+
 
 .. _v2-location-within-wells:
 
@@ -231,6 +240,8 @@ vertically (positive numbers move up, and negative numbers move down):
    plate['A1'].top(z=1)  # This is 1mm above the top center of the well
    plate['A1'].top(z=-1) # This is 1mm below the top center of the well
 
+.. versionadded:: 2.0
+
 Bottom
 ------
 
@@ -265,6 +276,8 @@ numbers move down):
    :py:attr:`.InstrumentContext.well_bottom_clearance`
    (see :ref:`new-default-op-positions`).
 
+.. versionadded:: 2.0
+
 Center
 ------
 
@@ -275,6 +288,8 @@ control of positions within the well for unusual or custom labware.
 .. code-block:: python
 
    plate['A1'].center() # This is the vertical and horizontal center of the well
+
+.. versionadded:: 2.0
 
 Manipulating Positions
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -307,3 +322,4 @@ To move a location, you create a :py:class:`.types.Point` representing a
            types.Point(x=1, y=1, z=1)) # 1mm up, to the right, and towards the
                                        # back of the robot
 
+.. versionadded:: 2.0

--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -8,10 +8,6 @@ Modules are peripherals that attach to the OT-2 to extend its capabilities.
 
 Modules currently supported are the Temperature, Magnetic and Thermocycler Module.
 
-This is not an exhaustive list of functionality for modules. Check :ref:`protocol-api-modules` or on
-our github for full explanations of methods.
-
-
 Loading your Module onto a deck
 ===============================
 Just like labware, you will also need to load in your module in order to use it
@@ -39,6 +35,8 @@ You can reference your module in a few different ways. The valid names can be fo
 | ``Thermocycler Module``  | ``'Thermocycler Module'``, ``'thermocycler'`` |
 +--------------------------+-----------------------------------------------+
 
+.. versionadded:: 2.0
+
 Loading Labware onto your Module
 ================================
 If you want to interact with labware on top of your Module, you must load labware
@@ -55,6 +53,8 @@ onto the module. You can do this via:
          my_labware = module.load_labware('labware_definition_name')
 
 Where ``module`` is the variable name you saved your module to. You do not need to specify the slot.
+
+.. versionadded:: 2.0
 
 Checking the status of your Module
 ==================================
@@ -73,6 +73,8 @@ All modules have the ability to check what state they are currently in. To do th
 For the temperature module this will return a string stating whether it's ``'heating'``, ``'cooling'``, ``'holding at target'`` or ``'idle'``.
 For the magnetic module this will return a string stating whether it's ``'engaged'`` or ``'disengaged'``.
 For the Thermocycler Module this will return ``'holding at target'`` or ``'idle'``. There are more detailed status checks which can be found in at :ref:`thermocycler-section`
+
+.. versionadded:: 2.0
 
 ******************
 Temperature Module
@@ -95,6 +97,8 @@ section, assume we have the following already:
         plate = temp_mod.load_labware('corning_96_wellplate_360ul_flat')
         # The code from the rest of the examples in this section goes here
 
+.. versionadded:: 2.0
+
 Set Temperature
 ^^^^^^^^^^^^^^^
 To set the temperature module to 4 degrees celsius do the following:
@@ -105,6 +109,8 @@ To set the temperature module to 4 degrees celsius do the following:
 
 This function will pause your protocol until your target temperature is reached.
 
+.. versionadded:: 2.0
+
 Read the Current Temperature
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 You can read the current real-time temperature of the module by the following:
@@ -113,6 +119,8 @@ You can read the current real-time temperature of the module by the following:
 
     temp_mod.temperature
 
+.. versionadded:: 2.0
+
 Read the Target Temperature
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 We can read the target temperature of the module by the following:
@@ -120,6 +128,8 @@ We can read the target temperature of the module by the following:
 .. code-block:: python
 
     temp_mod.target
+
+.. versionadded:: 2.0
 
 Deactivate
 ^^^^^^^^^^
@@ -131,12 +141,14 @@ or cooling phase again.
 
     temp_mod.deactivate()
 
-** Note**
-You can also deactivate your temperature module through our Run App by
-clicking on the ``Pipettes & Modules`` tab. Your temperature module will automatically
-deactivate if another protocol is uploaded to the app. Your temperature module will
-not deactivate automatically upon protocol end, cancel or re-setting a protocol.
+.. note::
 
+    You can also deactivate your temperature module through our Run App by
+    clicking on the ``Pipettes & Modules`` tab. Your temperature module will automatically
+    deactivate if another protocol is uploaded to the app. Your temperature module will
+    not deactivate automatically upon protocol end, cancel or re-setting a protocol.
+
+.. versionadded:: 2.0
 
 ***************
 Magnetic Module
@@ -164,6 +176,8 @@ section, assume we have the following already:
         plate = mag_mod.load_labware('nest_96_wellplate_100ul_pcr_full_skirt')
         # The code from the rest of the examples in this section goes here
 
+.. versionadded:: 2.0
+
 Engage
 ^^^^^^
 
@@ -185,10 +199,14 @@ ways, based on internally stored default heights for labware:
 
         mag_mod.engage(height=18.5)
 
-**Note** Only certain labwares have defined engage heights for the Magnetic
-Module. If a labware that does not have a defined engage height is
-loaded on the Magnetic Module (or if no labware is loaded), then
-``height`` must be specified.
+.. note::
+
+    Only certain labwares have defined engage heights for the Magnetic
+    Module. If a labware that does not have a defined engage height is
+    loaded on the Magnetic Module (or if no labware is loaded), then
+    ``height`` must be specified.
+
+.. versionadded:: 2.0
 
 Disengage
 ^^^^^^^^^
@@ -199,6 +217,7 @@ Disengage
 The magnetic modules will disengage on power cycle of the device. It will not auto-disengage otherwise
 unless you specify in your protocol.
 
+.. versionadded:: 2.0
 
 .. _thermocycler-section:
 
@@ -231,6 +250,8 @@ For the purposes of this section, assume we have the following already:
     When loading the Thermocycler Module, it is not necessary to specify a slot.
     This is because the Thermocycler Module has a default position that covers Slots 7, 8, 10, and 11.
     This is the only valid location for the Thermocycler Module on the OT2 deck.
+
+.. versionadded:: 2.0
 
 Run App Control
 ^^^^^^^^^^^^^^^
@@ -274,12 +295,17 @@ Open Lid
 
     tc_mod.open_lid()
 
+
+.. versionadded:: 2.0
+
 Close Lid
 +++++++++
 
 .. code-block:: python
 
     tc_mod.close_lid()
+
+.. versionadded:: 2.0
 
 Lid Temperature Control
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -296,6 +322,8 @@ once the lid temperature has been reached.
 
     tc_mod.set_lid_temperature(temperature)
 
+.. versionadded:: 2.0
+
 Block Temperature Control
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 To set the aluminum block temperature inside the Thermocycler Module, you can use the method :py:meth:`.ThermocyclerContext.set_block_temperature`. It takes in four parameters
@@ -311,6 +339,8 @@ If you only specify a temperature in celsius, the Thermocycler Module will hold 
 
         tc_mod.set_block_temperature(4)
 
+.. versionadded:: 2.0
+
 Hold Time
 +++++++++
 
@@ -321,6 +351,8 @@ proceed once the temperature specified is reached.
 .. code-block:: python
 
         tc_mod.set_block_temperature(4, hold_time_seconds=15, hold_time_minutes=45)
+
+.. versionadded:: 2.0
 
 Ramp Rate
 +++++++++
@@ -334,6 +366,8 @@ Lastly, you can modify the ramp rate in degC/sec for a given temperature.
 .. warning::
 
   Do not change this parameter unless you know what you're doing.
+
+.. versionadded:: 2.0
 
 Thermocycler Module Profiles
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -351,6 +385,9 @@ minutes with ``hold_time_seconds`` and ``hold_time_minutes``. **Note** This is *
 
         tc_mod.execute_profile(steps=profile, repetitions=30)
 
+
+.. versionadded:: 2.0
+
 Thermocycler Module Status
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Throughout your protocol, you may want particular information on the current status of your Thermocycler Module. Below are
@@ -364,6 +401,8 @@ Returns the current status of the lid position. It can be one of the strings ``'
 
     tc_mod.lid_position
 
+.. versionadded:: 2.0
+
 Heated Lid Temperature Status
 +++++++++++++++++++++++++++++
 Returns the current status of the heated lid temperature. It can be one of the strings ``'holding at target'``, ``'heating'``, ``'idle'``,  or ``'error'``.
@@ -372,6 +411,8 @@ Returns the current status of the heated lid temperature. It can be one of the s
 
     tc_mod.lid_temperature_status
 
+.. versionadded:: 2.0
+
 Block Temperature Status
 ++++++++++++++++++++++++
 Returns the current status of the well block temperature controller. It can be one of the strings ``'holding at target'``, ``'cooling'``, ``'heating'``, ``'idle'``, or ``'error'``.
@@ -379,6 +420,8 @@ Returns the current status of the well block temperature controller. It can be o
 .. code-block:: python
 
     tc_mod.block_temperature_status
+
+.. versionadded:: 2.0
 
 Thermocycler Module Deactivate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -402,6 +445,8 @@ This deactivates only the heated lid of the Thermocycler Module.
 
   tc_mod.deactivate_lid()
 
+.. versionadded:: 2.0
+
 Deactivate Block
 ++++++++++++++++
 This deactivates only the well block of the Thermocycler Module.
@@ -409,3 +454,5 @@ This deactivates only the well block of the Thermocycler Module.
 .. code-block:: python
 
   tc_mod.deactivate_block()
+
+.. versionadded:: 2.0

--- a/api/docs/v2/new_pipette.rst
+++ b/api/docs/v2/new_pipette.rst
@@ -34,6 +34,7 @@ a list of associated tipracks:
         right = protocol.load_instrument('p1000_single', 'right',
                                          tip_racks=[tiprack1, tiprack2])
 
+.. versionadded:: 2.0
 .. _new-pipette-models:
 
 Pipette Model(s)
@@ -138,6 +139,8 @@ For instance, in this protocol you can see the effects of specifying tipracks:
 This is further discussed in :ref:`v2-atomic-commands`
 and :ref:`v2-complex-commands`.
 
+.. versionadded:: 2.0
+
 Modifying Pipette Behaviors
 ---------------------------
 
@@ -200,6 +203,7 @@ Each of these attributes can be altered without affecting the others.
 units of mm/s of plunger speed. This does not have a linear transfer to flow rate and
 should only be used if you have a specific need.
 
+.. versionadded:: 2.0
 
 .. _new-default-op-positions:
 
@@ -249,6 +253,7 @@ executed as part of a transfer.
         pipette.well_bottom_clearance.dispense = 10
         pipette.dispense(50, plate['A1'])
 
+.. versionadded:: 2.0
 
 Gantry Speed
 ============
@@ -282,6 +287,7 @@ the overall speed of the gantry. Its default is 400 mm/s.
         # Move to 50mm above the front left of slot 9, much more slowly
         pipette.move_to(protocol.deck.position_for('9').move(types.Point(z=50)))
 
+.. versionadded:: 2.0
 
 Per-Axis Speed Limits
 =====================
@@ -308,6 +314,8 @@ resets that axis's limit to the default:
 
 You cannot set limits for the pipette plunger axes with this mechanism; instead, set the
 flow rates or plunger speeds as described in :ref:`new-plunger-flow-rates`.
+
+.. versionadded:: 2.0
 
 .. _defaults:
 

--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -11,6 +11,7 @@ Protocols and Instruments
 
 .. autoclass:: opentrons.protocol_api.contexts.ProtocolContext
    :members:
+   :exclude-members: location_cache
 
 .. autoclass:: opentrons.protocol_api.contexts.InstrumentContext
    :members:

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -74,7 +74,12 @@ This maximum supported API level is the highest API level you can specify in a p
 Determining What Features Are In What Version
 ---------------------------------------------
 
-As you read the documentation on this site, you will notice that all documentation on features, function calls, available properties, and everything else about the Protocol API notes which API version it was introduced in. Keep this information in mind when specifying your protocol's API version.
+As you read the documentation on this site, you will notice that all documentation on features, function calls, available properties, and everything else about the Protocol API notes which API version it was introduced in. Keep this information in mind when specifying your protocol's API version. The version statement will look like this:
+
+.. versionadded:: 2.0
+
+
+If a behavior or function is annotated with a version, then it is available if your protocol specifies that version or a higher minor version.
 
 
 .. _version-table:

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -5,7 +5,6 @@ from typing import (Any, Dict, Iterator, List,
                     Optional, Sequence, Set, Tuple, Union)
 from opentrons import types, hardware_control as hc, commands as cmds
 from opentrons.commands import CommandPublisher
-import opentrons.config.robot_configs as rc
 from opentrons.config import feature_flags as fflags
 from opentrons.hardware_control import adapters, modules
 from opentrons.hardware_control.simulator import Simulator
@@ -550,19 +549,6 @@ class ProtocolContext(CommandPublisher):
                 in self._instruments.items()
                 if instr}
 
-    def reset(self):
-        """ Reset the state of the context and the hardware.
-
-        For instance, this call will
-        - reset all cached knowledge about attached tips
-        - unload all labware
-        - unload all instruments
-        - clear all location and instrument caches
-
-        The only state that will be kept is the position of the robot.
-        """
-        raise NotImplementedError
-
     @cmds.publish.both(command=cmds.pause)
     @requires_version(2, 0)
     def pause(self, msg=None):
@@ -585,8 +571,10 @@ class ProtocolContext(CommandPublisher):
     @cmds.publish.both(command=cmds.comment)
     @requires_version(2, 0)
     def comment(self, msg):
-        """ Add a user-readable comment string that will be echoed to the
-        Opentrons app. """
+        """
+        Add a user-readable comment string that will be echoed to the Opentrons
+        app.
+        """
         pass
 
     @cmds.publish.both(command=cmds.delay)
@@ -601,27 +589,6 @@ class ProtocolContext(CommandPublisher):
         """
         delay_time = seconds + minutes * 60
         self._hw_manager.hardware.delay(delay_time)
-
-    @property  # type: ignore
-    @requires_version(2, 0)
-    def config(self) -> rc.robot_config:
-        """ Get the robot's configuration object.
-
-        :returns .robot_config: The loaded configuration.
-        """
-        return self._hw_manager.hardware.config
-
-    @requires_version(2, 0)
-    def update_config(self, **kwargs):
-        """ Update values of the robot's configuration.
-
-        `kwargs` should contain keys of the robot's configuration. For instace,
-        `update_config(name='Grace Hopper')` would change the name of the robot
-
-        Documentation on keys can be found in the documentation for
-        :py:class:`.robot_config`.
-        """
-        self._hw_manager.hardware.update_config(**kwargs)
 
     @requires_version(2, 0)
     def home(self):

--- a/api/src/opentrons/protocol_api/legacy_wrapper/robot_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/robot_wrapper.py
@@ -70,7 +70,7 @@ class Robot():
         :func:`__init__` the same instance will be returned. There's
         only once instance of a robot.
         """
-        self.config = protocol_ctx.config
+        self.config = protocol_ctx._hw_manager.hardware.config
         self._ctx = protocol_ctx
         self._head_speed_override: Optional[float] = None
         self._plunger_max_speed_overrides: Dict[str, float] = {}

--- a/api/src/opentrons/protocol_api/util.py
+++ b/api/src/opentrons/protocol_api/util.py
@@ -245,8 +245,18 @@ def requires_version(
     the first version in which the method or attribute was present.
     """
     def _set_version(decorated_obj: DecoratedObj) -> DecoratedObj:
+        version = APIVersion(major, minor)
         setattr(decorated_obj, '__opentrons_version_added',
-                APIVersion(major, minor))
+                version)
+        if hasattr(decorated_obj, '__doc__'):
+            # Add the versionadded stanza to everything decorated if we can
+            docstr = decorated_obj.__doc__ or ''
+            # this newline and initial space has to be there for sphinx to
+            # parse this correctly and not add it into for instance a
+            # previous code-block
+            docstr += f'\n\n    .. versionadded:: {version}\n\n'
+            decorated_obj.__doc__ = docstr
+
         return decorated_obj
 
     return _set_version


### PR DESCRIPTION
The requires_version decorator now adds a sphinx version-added role to the
docstring of whatever it decorates (with some odd spacing to make it parse
correctly). This causes a nice little "New in version x.y" line to show up in
the autogenerated docs.

In addition, manually add versionadded stanzas to all the docs that mention
specific methods or attributes.

Closes #4340
