### PR TITLE
feat(protocol-designer): blocking hint on adding custom labware to modal

### DIFF
--- a/components/src/modals/ContinueModal.js
+++ b/components/src/modals/ContinueModal.js
@@ -3,16 +3,12 @@ import * as React from 'react'
 
 import AlertModal from './AlertModal'
 
-type ContinueModalProps = {
-  /** optional classes to apply */
-  className?: string,
-  /** cancellation handler (also passed to `Modal`'s `onCloseClick`) */
+type AlertModalProps = React.ElementProps<typeof AlertModal>
+type ContinueModalProps = {|
+  ...$Diff<$Exact<AlertModalProps>, { buttons: any }>,
   onCancelClick: () => mixed,
-  /** continuation handler */
   onContinueClick: () => mixed,
-  /** modal contents */
-  children: React.Node,
-}
+|}
 
 const CANCEL = 'Cancel'
 const CONTINUE = 'Continue'
@@ -21,7 +17,7 @@ const CONTINUE = 'Continue'
  * AlertModal variant to prompt user to "Cancel" or "Continue" a given action
  */
 export default function ContinueModal(props: ContinueModalProps) {
-  const { className, onCancelClick, onContinueClick } = props
+  const { onCancelClick, onContinueClick, ...passThruProps } = props
   const buttons = [
     { title: CANCEL, children: CANCEL, onClick: onCancelClick },
     { title: CONTINUE, children: CONTINUE, onClick: onContinueClick },
@@ -29,12 +25,9 @@ export default function ContinueModal(props: ContinueModalProps) {
 
   return (
     <AlertModal
-      className={className}
-      buttons={buttons}
-      onCloseClick={onCancelClick}
       restrictOuterScroll={false}
-    >
-      {props.children}
-    </AlertModal>
+      {...passThruProps}
+      buttons={buttons}
+    />
   )
 }

--- a/components/src/modals/ContinueModal.js
+++ b/components/src/modals/ContinueModal.js
@@ -26,6 +26,7 @@ export default function ContinueModal(props: ContinueModalProps) {
   return (
     <AlertModal
       restrictOuterScroll={false}
+      onCloseClick={onCancelClick}
       {...passThruProps}
       buttons={buttons}
     />

--- a/protocol-designer/src/components/Hints/index.js
+++ b/protocol-designer/src/components/Hints/index.js
@@ -13,7 +13,7 @@ import EXAMPLE_WATCH_LIQUIDS_MOVE_IMAGE from '../../images/example_watch_liquids
 import type { HintKey } from '../../tutorial'
 import type { BaseState, ThunkDispatch } from '../../types'
 
-type SP = {| hint: ?HintKey |}
+type SP = {| hintKey: ?HintKey |}
 type DP = {|
   removeHint: (HintKey, boolean) => mixed,
   selectTerminalItem: TerminalItemId => mixed,
@@ -32,13 +32,15 @@ class Hints extends React.Component<Props, State> {
     this.setState({ rememberDismissal: !this.state.rememberDismissal })
   }
 
-  makeHandleCloseClick = (hint: HintKey) => {
+  makeHandleCloseClick = (hintKey: HintKey) => {
     const { rememberDismissal } = this.state
-    return () => this.props.removeHint(hint, rememberDismissal)
+    return () => this.props.removeHint(hintKey, rememberDismissal)
   }
 
-  renderHintContents = (hint: HintKey) => {
-    switch (hint) {
+  renderHintContents = (hintKey: HintKey) => {
+    // Only hints that have no outside effects should go here.
+    // For hints that have an effect, use BlockingHint.
+    switch (hintKey) {
       case 'add_liquids_and_labware':
         return (
           <React.Fragment>
@@ -75,15 +77,15 @@ class Hints extends React.Component<Props, State> {
   }
 
   render() {
-    const { hint } = this.props
-    return hint ? (
+    const { hintKey } = this.props
+    return hintKey ? (
       <Portal>
         <AlertModal
           type="warning"
           alertOverlay
-          heading={i18n.t(`alert.hint.${hint}.title`)}
+          heading={i18n.t(`alert.hint.${hintKey}.title`)}
         >
-          {this.renderHintContents(hint)}
+          {this.renderHintContents(hintKey)}
           <div>
             <CheckboxField
               className={styles.dont_show_again}
@@ -93,7 +95,7 @@ class Hints extends React.Component<Props, State> {
             />
             <OutlineButton
               className={styles.ok_button}
-              onClick={this.makeHandleCloseClick(hint)}
+              onClick={this.makeHandleCloseClick(hintKey)}
             >
               {i18n.t('button.ok')}
             </OutlineButton>
@@ -105,11 +107,11 @@ class Hints extends React.Component<Props, State> {
 }
 
 const mapStateToProps = (state: BaseState): SP => ({
-  hint: selectors.getHint(state),
+  hintKey: selectors.getHint(state),
 })
 const mapDispatchToProps = (dispatch: ThunkDispatch<*>): DP => ({
-  removeHint: (hint, rememberDismissal) =>
-    dispatch(actions.removeHint(hint, rememberDismissal)),
+  removeHint: (hintKey, rememberDismissal) =>
+    dispatch(actions.removeHint(hintKey, rememberDismissal)),
   selectTerminalItem: terminalId =>
     dispatch(stepsActions.selectTerminalItem(terminalId)),
 })

--- a/protocol-designer/src/components/Hints/useBlockingHint.js
+++ b/protocol-designer/src/components/Hints/useBlockingHint.js
@@ -1,0 +1,99 @@
+// @flow
+// BlockingHint is an "are you sure" modal that can be dismissed.
+// Instances of BlockingHint need to be individually placed by whatever component
+// is controlling the flow that this modal will block, via useBlockingHint.
+import React, { useState, useCallback, type Node } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { actions, selectors } from '../../tutorial'
+import { ContinueModal, CheckboxField } from '@opentrons/components'
+import { Portal } from '../portals/MainPageModalPortal'
+import i18n from '../../localization'
+import styles from './hints.css'
+import type { HintKey } from '../../tutorial'
+
+type Props = {|
+  hintKey: HintKey,
+  handleCancel: () => mixed,
+  handleContinue: () => mixed,
+|}
+
+const BlockingHint = (props: Props) => {
+  const { hintKey, handleCancel, handleContinue } = props
+  const dispatch = useDispatch()
+
+  const [rememberDismissal, setRememberDismissal] = useState<boolean>(false)
+
+  const toggleRememberDismissal = useCallback(() => {
+    setRememberDismissal(prevDismissal => !prevDismissal)
+  }, [])
+
+  const onCancelClick = useCallback(() => {
+    dispatch(actions.removeHint(hintKey, rememberDismissal))
+    handleCancel()
+  }, [rememberDismissal, handleCancel, dispatch, hintKey])
+
+  const onContinueClick = useCallback(() => {
+    dispatch(actions.removeHint(hintKey, rememberDismissal))
+    handleContinue()
+  }, [rememberDismissal, handleContinue, dispatch, hintKey])
+
+  return (
+    <Portal>
+      <ContinueModal
+        alertOverlay
+        heading={i18n.t(`alert.hint.${hintKey}.title`)}
+        onCancelClick={onCancelClick}
+        onContinueClick={onContinueClick}
+      >
+        {i18n.t(`alert.hint.${hintKey}.body`)}
+        <div>
+          <CheckboxField
+            className={styles.dont_show_again}
+            label={i18n.t('alert.hint.dont_show_again')}
+            onChange={toggleRememberDismissal}
+            value={rememberDismissal}
+          />
+        </div>
+      </ContinueModal>
+    </Portal>
+  )
+}
+
+export const useBlockingHint = (args: {|
+  /** Do nothing, return `null`. Useful when a hint is not relevant under certain conditions */
+  disable: boolean,
+  /** Block BlockingHints from calling handleContinue when dismissed.
+   ** Unlike `disable`, this will show non-dismissed hints normally.
+   **/
+  skipWithAutoContinue: boolean,
+  hintKey: HintKey,
+  handleCancel: () => mixed,
+  handleContinue: () => mixed,
+|}): ?Node => {
+  const {
+    disable,
+    skipWithAutoContinue,
+    hintKey,
+    handleCancel,
+    handleContinue,
+  } = args
+  const isDismissed = useSelector(selectors.getDismissedHints).includes(hintKey)
+
+  if (disable) return null
+
+  if (skipWithAutoContinue && isDismissed) {
+    // continue automatically (as if there is no modal)
+    console.log('leeeroooy', { skipWithAutoContinue, isDismissed })
+    handleContinue()
+  }
+
+  return (
+    <BlockingHint
+      hintKey={hintKey}
+      handleCancel={handleCancel}
+      handleContinue={handleContinue}
+    />
+  )
+}
+
+export default useBlockingHint

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
@@ -84,16 +84,16 @@ const LabwareSelectionModal = (props: Props) => {
     moduleRestrictionsDisabled,
   } = props
 
-  const [selectedCategory, setSelectedCategory] = useState<?string>(null)
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
   const [previewedLabware, setPreviewedLabware] = useState<?LabwareDefinition2>(
     null
   )
   const [filterRecommended, setFilterRecommended] = useState<boolean>(false)
-  const [enqueuedLabwareType, setEnqueuedLabwareType] = useState<?string>(null)
+  const [enqueuedLabwareType, setEnqueuedLabwareType] = useState<string | null>(
+    null
+  )
   const blockingCustomLabwareHint = useBlockingHint({
-    disable: enqueuedLabwareType == null,
-    skipWithAutoContinue: true,
-    // moduleType == null || !enqueuedLabwareType || moduleRestrictionsDisabled,
+    enabled: enqueuedLabwareType !== null,
     hintKey: 'custom_labware_with_modules',
     handleCancel: () => setEnqueuedLabwareType(null),
     handleContinue: () => {
@@ -268,7 +268,6 @@ const LabwareSelectionModal = (props: Props) => {
               collapsed={selectedCategory !== CUSTOM_CATEGORY}
               onCollapseToggle={makeToggleCategory(CUSTOM_CATEGORY)}
               onClick={makeToggleCategory(CUSTOM_CATEGORY)}
-              inert={filterRecommended}
             >
               {customLabwareURIs.map((labwareURI, index) => (
                 <LabwareItem
@@ -279,7 +278,6 @@ const LabwareSelectionModal = (props: Props) => {
                     setPreviewedLabware(customLabwareDefs[labwareURI])
                   }
                   onMouseLeave={() => setPreviewedLabware()}
-                  disabled={filterRecommended}
                 />
               ))}
             </PDTitledList>

--- a/protocol-designer/src/containers/ConnectedMainPanel.js
+++ b/protocol-designer/src/containers/ConnectedMainPanel.js
@@ -2,7 +2,6 @@
 import * as React from 'react'
 import { connect } from 'react-redux'
 import { Splash } from '@opentrons/components'
-
 import { START_TERMINAL_ITEM_ID, type TerminalItemId } from '../steplist'
 import { Portal as MainPageModalPortal } from '../components/portals/MainPageModalPortal'
 import DeckSetup from '../components/DeckSetup'

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -13,6 +13,10 @@
       "summary": "In {{deck_setup_step}}, hover on labware to add liquids.",
       "step1": "Add liquids",
       "step2": "Watch liquids move as you build your protocol"
+    },
+    "custom_labware_with_modules": {
+      "title": "Cannot verify compatibility of custom labware",
+      "body": "The Protocol Designer cannot confirm whether or not custom labware is compatible with any module. Proceed if you are confident your custom labware will fit."
     }
   },
   "timeline": {

--- a/protocol-designer/src/tutorial/index.js
+++ b/protocol-designer/src/tutorial/index.js
@@ -3,7 +3,7 @@ import * as actions from './actions'
 import { rootReducer, type RootState } from './reducers'
 import * as selectors from './selectors'
 
-type HintKey = 'add_liquids_and_labware'
+type HintKey = 'add_liquids_and_labware' | 'custom_labware_with_modules'
 
 export { actions, rootReducer, selectors }
 

--- a/protocol-designer/src/tutorial/selectors.js
+++ b/protocol-designer/src/tutorial/selectors.js
@@ -20,6 +20,14 @@ export const getHint: Selector<?HintKey> = createSelector(
   }
 )
 
+export const getDismissedHints: Selector<Array<HintKey>> = createSelector(
+  rootSelector,
+  tutorial => {
+    const dismissedKeys = Object.keys(tutorial.dismissedHints)
+    return dismissedKeys
+  }
+)
+
 export const getCanClearHintDismissals: Selector<boolean> = createSelector(
   rootSelector,
   tutorial => !isEmpty(tutorial.dismissedHints)


### PR DESCRIPTION
## overview

Closes #4329 

## changelog

Add new "blocking hint" functionality, previously PD's Hints did not have any effects except on their own dismissed state

## review requests

- [ ] When adding custom labware to any module, this modal appears
- [ ] When adding custom labware to a deck slot, no modal (make sure it's a fresh session with all hints restored or it could be a false positive)
- [ ] When adding standard labware to a module, no modal (make sure it's a fresh session with all hints restored or it could be a false positive)
- [ ] This modal will only appear once per session, so if you add another custom labware to a module. If you select "Don't show me again", it will not show up in new sessions. You can restore it via `Settings > Hints > Restore all hints`
- [ ] Behavior of `ContinueModal` shouldn't change -- I wanted to allow passing props like `header` and `alertOverlay` to the `AlertModal` which it wraps.