### PR TITLE
feat(protocol-designer): Enable adding and editing modules in file page

### DIFF
--- a/api/tests/opentrons/data/testosaur.py
+++ b/api/tests/opentrons/data/testosaur.py
@@ -14,7 +14,7 @@ p300 = instruments.P300_Single(
     mount="right",
     tip_racks=[p200rack])
 
-p300.pick_up_tip()
+#p300.pick_up_tip()
 
 containers = [
     containers.load('96-PCR-flat', slot)
@@ -23,10 +23,10 @@ containers = [
 ]
 
 # Uncomment these to test precision
-p300.move_to(robot.deck['11'])
-p300.move_to(robot.deck['6'])
+# p300.move_to(robot.deck['11'])
+# p300.move_to(robot.deck['6'])
 
-for container in containers:
-    p300.aspirate(10, container[0]).dispense(10, container[-1].top(5))
+# for container in containers:
+#     p300.aspirate(10, container[0]).dispense(10, container[-1].top(5))
 
-p300.drop_tip()
+# p300.drop_tip()

--- a/api/tests/opentrons/data/testosaur.py
+++ b/api/tests/opentrons/data/testosaur.py
@@ -14,7 +14,7 @@ p300 = instruments.P300_Single(
     mount="right",
     tip_racks=[p200rack])
 
-#p300.pick_up_tip()
+p300.pick_up_tip()
 
 containers = [
     containers.load('96-PCR-flat', slot)
@@ -23,10 +23,10 @@ containers = [
 ]
 
 # Uncomment these to test precision
-# p300.move_to(robot.deck['11'])
-# p300.move_to(robot.deck['6'])
+p300.move_to(robot.deck['11'])
+p300.move_to(robot.deck['6'])
 
-# for container in containers:
-#     p300.aspirate(10, container[0]).dispense(10, container[-1].top(5))
+for container in containers:
+    p300.aspirate(10, container[0]).dispense(10, container[-1].top(5))
 
-# p300.drop_tip()
+p300.drop_tip()

--- a/protocol-designer/src/components/DeckSetup/DeckSetup.js
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.js
@@ -15,7 +15,7 @@ import {
 } from '@opentrons/shared-data'
 import { getDeckDefinitions } from '@opentrons/components/src/deck/getDeckDefinitions'
 import i18n from '../../localization'
-import { PSEUDO_DECK_SLOTS, SPAN7_8_10_11_SLOT } from '../../constants'
+import { PSEUDO_DECK_SLOTS } from '../../constants'
 import { START_TERMINAL_ITEM_ID, type TerminalItemId } from '../../steplist'
 import {
   getModuleVizDims,
@@ -23,7 +23,7 @@ import {
 } from './getModuleVizDims'
 
 import { selectors as featureFlagSelectors } from '../../feature-flags'
-
+import { getSlotsBlockedBySpanning, getSlotIsEmpty } from '../../step-forms'
 import { BrowseLabwareModal } from '../labware'
 import ModuleViz from './ModuleViz'
 import ModuleTag from './ModuleTag'
@@ -36,7 +36,6 @@ import type {
   LabwareOnDeck as LabwareOnDeckType,
   ModuleOnDeck,
 } from '../../step-forms'
-import type { DeckSlot } from '../../types'
 
 import styles from './DeckSetup.css'
 
@@ -68,38 +67,6 @@ const VIEWBOX_MIN_X = -64
 const VIEWBOX_MIN_Y = -10
 const VIEWBOX_WIDTH = 520
 const VIEWBOX_HEIGHT = 414
-
-const getSlotsBlockedBySpanning = (
-  initialDeckSetup: InitialDeckSetup
-): Array<DeckSlot> => {
-  // NOTE: Ian 2019-10-25 dumb heuristic since there's only one case this can happen now
-  if (
-    values(initialDeckSetup.modules).some(
-      (module: ModuleOnDeck) =>
-        module.type === 'thermocycler' && module.slot === SPAN7_8_10_11_SLOT
-    )
-  ) {
-    return ['7', '8', '10', '11']
-  }
-  return []
-}
-
-const getSlotIsEmpty = (
-  initialDeckSetup: InitialDeckSetup,
-  slot: string
-): boolean => {
-  // NOTE: should work for both deck slots and module slots
-  return (
-    [
-      ...values(initialDeckSetup.modules).filter(
-        (module: ModuleOnDeck) => module.slot === slot
-      ),
-      ...values(initialDeckSetup.labware).filter(
-        (labware: LabwareOnDeckType) => labware.slot === slot
-      ),
-    ].length === 0
-  )
-}
 
 const getSlotDefForModuleSlot = (
   module: ModuleOnDeck,

--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -55,7 +55,8 @@ export default function EditModulesModal(props: EditModulesProps) {
 
   const slotsBlockedBySpanning = getSlotsBlockedBySpanning(_initialDeckSetup)
   const previousModuleSlot = module && module.slot
-  const slotIsEmpty =
+
+  let slotIsEmpty =
     !slotsBlockedBySpanning.includes(selectedSlot) &&
     (getSlotIsEmpty(_initialDeckSetup, selectedSlot) ||
       previousModuleSlot === selectedSlot)

--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -2,10 +2,11 @@
 import * as React from 'react'
 import cx from 'classnames'
 import { useSelector, useDispatch } from 'react-redux'
-import values from 'lodash/values'
 import {
   selectors as stepFormSelectors,
   actions as stepFormActions,
+  getSlotIsEmpty,
+  getSlotsBlockedBySpanning,
 } from '../../../step-forms'
 import { moveDeckItem } from '../../../labware-ingred/actions'
 import { selectors as featureFlagSelectors } from '../../../feature-flags'
@@ -27,11 +28,7 @@ import styles from './EditModules.css'
 import modalStyles from '../modal.css'
 
 import type { ModuleType } from '@opentrons/shared-data'
-import type {
-  InitialDeckSetup,
-  LabwareOnDeck as LabwareOnDeckType,
-  ModuleOnDeck,
-} from '../../../step-forms'
+
 type EditModulesProps = {
   moduleType: ModuleType,
   moduleId: ?string,
@@ -56,30 +53,13 @@ export default function EditModulesModal(props: EditModulesProps) {
     (module && module.model) || 'GEN1'
   )
 
-  const getSlotIsEmpty = (
-    initialDeckSetup: InitialDeckSetup,
-    slot: string,
-    moduleType: ModuleType
-  ): boolean => {
-    // NOTE: should work for both deck slots and module slots
-    return (
-      [
-        ...values(initialDeckSetup.modules).filter(
-          (module: ModuleOnDeck) =>
-            module.type !== moduleType && module.slot === slot
-        ),
-        ...values(initialDeckSetup.labware).filter(
-          (labware: LabwareOnDeckType) => labware.slot === slot
-        ),
-      ].length === 0
-    )
-  }
+  const slotsBlockedBySpanning = getSlotsBlockedBySpanning(_initialDeckSetup)
+  const previousModuleSlot = module && module.slot
+  const slotIsEmpty =
+    !slotsBlockedBySpanning.includes(selectedSlot) &&
+    (getSlotIsEmpty(_initialDeckSetup, selectedSlot) ||
+      previousModuleSlot === selectedSlot)
 
-  const slotIsEmpty = getSlotIsEmpty(
-    _initialDeckSetup,
-    selectedSlot,
-    moduleType
-  )
   const dispatch = useDispatch()
 
   const handleSlotChange = (e: SyntheticInputEvent<*>) =>

--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -1,7 +1,13 @@
 // @flow
 import * as React from 'react'
 import cx from 'classnames'
-import { useSelector } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
+import values from 'lodash/values'
+import {
+  selectors as stepFormSelectors,
+  actions as stepFormActions,
+} from '../../../step-forms'
+import { moveDeckItem } from '../../../labware-ingred/actions'
 import { selectors as featureFlagSelectors } from '../../../feature-flags'
 import {
   SUPPORTED_MODULE_SLOTS,
@@ -15,37 +21,96 @@ import {
   FormGroup,
   DropdownField,
   HoverTooltip,
+  AlertItem,
 } from '@opentrons/components'
 import styles from './EditModules.css'
 import modalStyles from '../modal.css'
 
 import type { ModuleType } from '@opentrons/shared-data'
-
+import type {
+  InitialDeckSetup,
+  LabwareOnDeck as LabwareOnDeckType,
+  ModuleOnDeck,
+} from '../../../step-forms'
 type EditModulesProps = {
   moduleType: ModuleType,
   moduleId: ?string,
   onCloseClick: () => mixed,
 }
 
+// TODO (ka 2019-11-6): Move this to i18n
+const MODULE_PLACEMENT_ERROR =
+  'Modules can only be placed in slots that are (a) empty or (b) occupied by compatible labware.'
+
 export default function EditModulesModal(props: EditModulesProps) {
-  const { moduleType, moduleId, onCloseClick } = props
-  /* TODO (ka 2019-10-31): This is a temporary hook workaround so the slot selection 'works'
-  Once selectors are in place for modules we can get the previously assigned slot from state
-  and have supported slot as fallback for new modules or failure to get slot from module by id */
-  const [selectedSlot, setSelectedSlot] = React.useState<string | null>(
-    SUPPORTED_MODULE_SLOTS[moduleType][0].value || null
+  const { moduleType, onCloseClick } = props
+  const _initialDeckSetup = useSelector(stepFormSelectors.getInitialDeckSetup)
+
+  const module = props.moduleId && _initialDeckSetup.modules[props.moduleId]
+
+  const [selectedSlot, setSelectedSlot] = React.useState<string>(
+    (module && module.slot) || SUPPORTED_MODULE_SLOTS[moduleType][0].value
   )
+
+  const [selectedModel, setSelectedModel] = React.useState<string>(
+    (module && module.model) || 'GEN1'
+  )
+
+  const getSlotIsEmpty = (
+    initialDeckSetup: InitialDeckSetup,
+    slot: string,
+    moduleType: ModuleType
+  ): boolean => {
+    // NOTE: should work for both deck slots and module slots
+    return (
+      [
+        ...values(initialDeckSetup.modules).filter(
+          (module: ModuleOnDeck) =>
+            module.type !== moduleType && module.slot === slot
+        ),
+        ...values(initialDeckSetup.labware).filter(
+          (labware: LabwareOnDeckType) => labware.slot === slot
+        ),
+      ].length === 0
+    )
+  }
+
+  const slotIsEmpty = getSlotIsEmpty(
+    _initialDeckSetup,
+    selectedSlot,
+    moduleType
+  )
+  const dispatch = useDispatch()
 
   const handleSlotChange = (e: SyntheticInputEvent<*>) =>
     setSelectedSlot(e.target.value)
+  const handleModelChange = (e: SyntheticInputEvent<*>) =>
+    setSelectedModel(e.target.value)
 
   let onSaveClick = () => {
-    moduleType && console.log('add module ' + moduleType)
+    dispatch(
+      stepFormActions.createModule({
+        slot: selectedSlot,
+        type: moduleType,
+        model: selectedModel,
+      })
+    )
     onCloseClick()
   }
-  if (moduleId) {
+  if (module) {
     onSaveClick = () => {
-      console.log('update module ' + moduleId)
+      // disabled if something lives in the slot selected in local state
+      // if previous module.model is different, edit module
+      if (module.model !== selectedModel) {
+        module.id &&
+          dispatch(
+            stepFormActions.editModule({ id: module.id, model: selectedModel })
+          )
+      }
+      // if previous module.slot is different than satate, move deck item
+      if (selectedSlot && module.slot !== selectedSlot) {
+        module.slot && dispatch(moveDeckItem(module.slot, selectedSlot))
+      }
       onCloseClick()
     }
   }
@@ -68,24 +133,20 @@ export default function EditModulesModal(props: EditModulesProps) {
       className={cx(modalStyles.modal, styles.edit_module_modal)}
       contentsClassName={styles.modal_contents}
     >
+      {!slotIsEmpty && (
+        <AlertItem type="error" title={`Cannot place ${heading}`}>
+          <p>{MODULE_PLACEMENT_ERROR}</p>
+        </AlertItem>
+      )}
       <div className={styles.form_row}>
-        {/*
-      TODO (ka 2019-10-29): This field is enabled, but only GEN1 available for now
-      - onChange returns null because onChange is required by DropdownFields
-      */}
         <FormGroup label="Model" className={styles.option_model}>
           <DropdownField
             tabIndex={0}
             options={[{ name: 'GEN1', value: 'GEN1' }]}
-            value={'GEN1'}
-            onChange={() => null}
+            value={selectedModel}
+            onChange={handleModelChange}
           />
         </FormGroup>
-        {/*
-      TODO (ka 2019-10-30):
-      - This is an initial first pass, since nothings coming from state yet,
-      the slot will always default to the supported slot
-      */}
         {showSlotOption && (
           <HoverTooltip
             placement="bottom"
@@ -110,7 +171,9 @@ export default function EditModulesModal(props: EditModulesProps) {
 
       <div className={styles.button_row}>
         <OutlineButton onClick={onCloseClick}>Cancel</OutlineButton>
-        <OutlineButton onClick={onSaveClick}>Save</OutlineButton>
+        <OutlineButton disabled={!slotIsEmpty} onClick={onSaveClick}>
+          Save
+        </OutlineButton>
       </div>
     </Modal>
   )

--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -56,7 +56,7 @@ export default function EditModulesModal(props: EditModulesProps) {
   const slotsBlockedBySpanning = getSlotsBlockedBySpanning(_initialDeckSetup)
   const previousModuleSlot = module && module.slot
 
-  let slotIsEmpty =
+  const slotIsEmpty =
     !slotsBlockedBySpanning.includes(selectedSlot) &&
     (getSlotIsEmpty(_initialDeckSetup, selectedSlot) ||
       previousModuleSlot === selectedSlot)

--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -38,6 +38,7 @@ export const STD_SLOT_DIVIDER_WIDTH = 4
 // These have no visual representation on the deck themselves,
 // but may contain certain specific items that span (eg thermocycler)
 export const SPAN7_8_10_11_SLOT: 'span7_8_10_11' = 'span7_8_10_11'
+export const TC_SPAN_SLOTS: Array<DeckSlot> = ['7', '8', '10', '11']
 export const PSEUDO_DECK_SLOTS: { [DeckSlot]: DeckDefSlot } = {
   [SPAN7_8_10_11_SLOT]: {
     displayName: 'Spanning slot',

--- a/protocol-designer/src/step-forms/utils.js
+++ b/protocol-designer/src/step-forms/utils.js
@@ -98,6 +98,15 @@ export const getSlotIsEmpty = (
   initialDeckSetup: InitialDeckSetup,
   slot: string
 ): boolean => {
+  if (
+    slot === SPAN7_8_10_11_SLOT &&
+    getSlotsBlockedBySpanning(initialDeckSetup).every(slot =>
+      getSlotIsEmpty(initialDeckSetup, slot)
+    )
+  ) {
+    return false
+  }
+
   // NOTE: should work for both deck slots and module slots
   return (
     [

--- a/protocol-designer/src/step-forms/utils.js
+++ b/protocol-designer/src/step-forms/utils.js
@@ -3,7 +3,7 @@ import assert from 'assert'
 import reduce from 'lodash/reduce'
 import values from 'lodash/values'
 import { getPipetteNameSpecs, type DeckSlotId } from '@opentrons/shared-data'
-import { SPAN7_8_10_11_SLOT } from '../constants'
+import { SPAN7_8_10_11_SLOT, TC_SPAN_SLOTS } from '../constants'
 import type { LabwareDefByDefURI } from '../labware-defs'
 import type {
   NormalizedPipette,
@@ -98,13 +98,8 @@ export const getSlotIsEmpty = (
   initialDeckSetup: InitialDeckSetup,
   slot: string
 ): boolean => {
-  if (
-    slot === SPAN7_8_10_11_SLOT &&
-    getSlotsBlockedBySpanning(initialDeckSetup).every(slot =>
-      getSlotIsEmpty(initialDeckSetup, slot)
-    )
-  ) {
-    return false
+  if (slot === SPAN7_8_10_11_SLOT) {
+    return TC_SPAN_SLOTS.every(slot => getSlotIsEmpty(initialDeckSetup, slot))
   }
 
   // NOTE: should work for both deck slots and module slots


### PR DESCRIPTION
## overview

This PR closes #4317 and addresses #4137 by adding Add/Edit capabilities to the `EditModulesModal`. 

It also does a first pass at validation (slot occupied) which requires some UX input. That will be handled in a follow up PR.

## changelog

- feat(protocol-designer): Enable adding and editing modules in file page
- refactor: Move `getSlotIsEmpty` to utils

## review requests

- [ ] Add module is blocked when slot is occupied by anything (not worrying about compat yet)
- [ ] Edit module is blocked when selecting an occupied slot (please test with a TC taking up a span)
- [ ] Works with FF on and off as expected
- [ ] DeckSetup is unaffected by the utils refactor 
