### PR TITLE
feat(protocol-designer): add compatibility info to LabwarePreview

### DIFF
--- a/protocol-designer/src/components/LabwareSelectionModal/LabwarePreview.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwarePreview.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import reduce from 'lodash/reduce'
 import {
+  Icon,
   LabwareRender,
   LabeledValue,
   RobotWorkSpace,
@@ -16,10 +17,15 @@ import styles from './styles.css'
 
 type Props = {
   labwareDef: ?LabwareDefinition2,
+  moduleCompatibility?:
+    | 'recommended'
+    | 'potentiallyCompatible'
+    | 'notCompatible'
+    | null,
 }
 
 const LabwarePreview = (props: Props) => {
-  const { labwareDef } = props
+  const { labwareDef, moduleCompatibility } = props
   if (!labwareDef) return null
   const maxVolumes = reduce(
     labwareDef.wells,
@@ -41,6 +47,16 @@ const LabwarePreview = (props: Props) => {
         <h3 className={styles.labware_preview_header}>
           {props.labwareDef ? getLabwareDisplayName(props.labwareDef) : ''}
         </h3>
+        {moduleCompatibility != null ? (
+          <div className={styles.labware_preview_module_compat}>
+            {moduleCompatibility === 'recommended' ? (
+              <Icon className={styles.icon} name="check-decagram" />
+            ) : null}
+            {i18n.t(
+              `modal.labware_selection.module_compatibility.${moduleCompatibility}`
+            )}
+          </div>
+        ) : null}
         <div className={styles.labware_detail_row}>
           <div className={styles.labware_render_wrapper}>
             <RobotWorkSpace

--- a/protocol-designer/src/components/LabwareSelectionModal/styles.css
+++ b/protocol-designer/src/components/LabwareSelectionModal/styles.css
@@ -83,6 +83,13 @@
   @apply --font-header-dark;
 }
 
+.labware_preview_module_compat {
+  @apply --font-body-2-dark;
+
+  display: flex;
+  align-items: center;
+}
+
 .labware_render_wrapper {
   height: 7.125rem;
   width: 10.75rem;

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -9,7 +9,12 @@
     "see_details": "See detail page",
     "view_measurements": "view measurements",
     "creating_labware_defs": "Access the Labware Creator",
-    "recommended_labware_filter": "Show only recommended labware. Read more"
+    "recommended_labware_filter": "Show only recommended labware. Read more",
+    "module_compatibility": {
+      "recommended": "Recommended for use on this module",
+      "potentiallyCompatible": "Potentially compatible with this module",
+      "notCompatible": "Not compatible with this module"
+    }
   },
   "tip_position": {
     "title": "Tip Positioning",


### PR DESCRIPTION
## overview

Closes #4135

Also fixes issue where LabwareSelectionModal did not close when you click outside

## review requests

This adds some text to LabwarePreview (the component you see when you mouse over a labware item in the LabwareSelectionModal -- see issue for design

Make sure rogue mode is OFF

When you're adding labware to a module...
- [ ] Custom labware's LabwarePreview should always say "Potentially compatible with this module"
- [ ] Labware that is potentially compatible (everything that gets enabled when you uncheck "Show only recommended labware) should show "Potentially compatible with this module"
- [ ] Recommended labware show "Recommended for use on this module"
 - [ ] Labware that is incompatible (disabled even when you uncheck "Show only recommended labware") shows "Not compatible with this module"

When you're adding labware to the deck...
- [ ] No extra copy or spacing, should look the same as it did before this PR

- [ ] Clicking outside of LabwareSelectionModal should close it (like it has been doing up until recently!)
- [ ] Custom labware hint modal when adding CUSTOM labware to a module for the first time should work as before