### PR TITLE
feat(api): warn tc-lid/gantry collision in simulation

### DIFF
--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -36,7 +36,7 @@ Modules
 
 .. autoclass:: opentrons.protocol_api.contexts.ThermocyclerContext
    :members:
-   :exclude-members: total_step_count, current_cycle_index, total_cycle_count, hold_time, ramp_rate, current_step_index
+   :exclude-members: total_step_count, current_cycle_index, total_cycle_count, hold_time, ramp_rate, current_step_index, flag_unsafe_move
    :inherited-members:
 
 

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1653,10 +1653,9 @@ class InstrumentContext(CommandPublisher):
                 self._mount, critical_point=cp_override),
             from_lw)
 
-        tc = next(m for m in self._ctx._modules
-                  if isinstance(m, ThermocyclerContext))
-        if tc:
-            tc.flag_unsafe_move(to_loc=location, from_loc=from_loc)
+        for mod in self._ctx._modules:
+            if isinstance(mod, ThermocyclerContext):
+                mod.flag_unsafe_move(to_loc=location, from_loc=from_loc)
 
         moves = geometry.plan_moves(from_loc, location, self._ctx.deck,
                                     force_direct=force_direct,
@@ -2126,8 +2125,8 @@ class ThermocyclerContext(ModuleContext):
             instr.move_to(types.Location(safe_point, None), force_direct=True)
 
     def flag_unsafe_move(self,
-                          to_loc: types.Location,
-                          from_loc: types.Location):
+                         to_loc: types.Location,
+                         from_loc: types.Location):
         to_lw, to_well = geometry.split_loc_labware(to_loc)
         from_lw, from_well = geometry.split_loc_labware(from_loc)
         if (self.labware is to_lw or self.labware is from_lw) and \

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1659,8 +1659,12 @@ class InstrumentContext(CommandPublisher):
         self._log.debug(f"ctx modules: {self._ctx._modules}")
 
         to_lw, to_well = geometry.split_loc_labware(location)
-        if isinstance(to_lw, Labware) and \
-                isinstance(to_lw.parent, ThermocyclerGeometry):
+        from_lw, from_well = geometry.split_loc_labware(from_loc)
+
+        if (isinstance(to_lw, Labware) and \
+                isinstance(to_lw.parent, ThermocyclerGeometry)) or \
+                (isinstance(from_lw, Labware) and \
+                isinstance(from_lw.parent, ThermocyclerGeometry)):
             tc_context = next(m for m in self._ctx._modules \
                               if isinstance(m._module, modules.thermocycler.Thermocycler))
             if tc_context and tc_context.lid_position == 'closed':

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1656,7 +1656,7 @@ class InstrumentContext(CommandPublisher):
         tc = next(m for m in self._ctx._modules
                   if isinstance(m, ThermocyclerContext))
         if tc:
-            tc._flag_unsafe_move(to_loc=location, from_loc=from_loc)
+            tc.flag_unsafe_move(to_loc=location, from_loc=from_loc)
 
         moves = geometry.plan_moves(from_loc, location, self._ctx.deck,
                                     force_direct=force_direct,
@@ -2125,7 +2125,7 @@ class ThermocyclerContext(ModuleContext):
                     z=high_point[Axis.by_mount(instr._mount)])
             instr.move_to(types.Location(safe_point, None), force_direct=True)
 
-    def _flag_unsafe_move(self,
+    def flag_unsafe_move(self,
                           to_loc: types.Location,
                           from_loc: types.Location):
         to_lw, to_well = geometry.split_loc_labware(to_loc)

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1653,6 +1653,21 @@ class InstrumentContext(CommandPublisher):
                 self._mount, critical_point=cp_override),
             from_lw)
 
+        self._log.debug(f"\n\n\n\nlocation.labware: {location.labware}")
+        if location.labware:
+            self._log.debug(f"location.labware.parent: {location.labware.parent}")
+        self._log.debug(f"ctx modules: {self._ctx._modules}")
+
+        to_lw, to_well = geometry.split_loc_labware(location)
+        if isinstance(to_lw, Labware) and \
+                isinstance(to_lw.parent, ThermocyclerGeometry):
+            tc_context = next(m for m in self._ctx._modules \
+                              if isinstance(m._module, modules.thermocycler.Thermocycler))
+            if tc_context and tc_context.lid_position == 'closed':
+                raise RuntimeError(
+                    "Cannot move to labware loaded in Thermocycler"\
+                    " when lid is closed")
+
         moves = geometry.plan_moves(from_loc, location, self._ctx.deck,
                                     force_direct=force_direct,
                                     minimum_z_height=minimum_z_height)

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1653,23 +1653,18 @@ class InstrumentContext(CommandPublisher):
                 self._mount, critical_point=cp_override),
             from_lw)
 
-        self._log.debug(f"\n\n\n\nlocation.labware: {location.labware}")
-        if location.labware:
-            self._log.debug(f"location.labware.parent: {location.labware.parent}")
-        self._log.debug(f"ctx modules: {self._ctx._modules}")
-
         to_lw, to_well = geometry.split_loc_labware(location)
         from_lw, from_well = geometry.split_loc_labware(from_loc)
 
-        if (isinstance(to_lw, Labware) and \
+        if (isinstance(to_lw, Labware) and
                 isinstance(to_lw.parent, ThermocyclerGeometry)) or \
-                (isinstance(from_lw, Labware) and \
-                isinstance(from_lw.parent, ThermocyclerGeometry)):
-            tc_context = next(m for m in self._ctx._modules \
-                              if isinstance(m._module, modules.thermocycler.Thermocycler))
+                (isinstance(from_lw, Labware) and
+                    isinstance(from_lw.parent, ThermocyclerGeometry)):
+            tc_context = next(m for m in self._ctx._modules
+                              if isinstance(m, ThermocyclerContext))
             if tc_context and tc_context.lid_position == 'closed':
                 raise RuntimeError(
-                    "Cannot move to labware loaded in Thermocycler"\
+                    "Cannot move to labware loaded in Thermocycler"
                     " when lid is closed")
 
         moves = geometry.plan_moves(from_loc, location, self._ctx.deck,

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -18,6 +18,16 @@ def max_many(*args):
     return functools.reduce(max, args[1:], args[0])
 
 
+def split_loc_labware(
+        loc: types.Location) -> Tuple[Optional[Labware], Optional[Well]]:
+    if isinstance(loc.labware, Labware):
+        return loc.labware, None
+    elif isinstance(loc.labware, Well):
+        return loc.labware.parent, loc.labware
+    else:
+        return None, None
+
+
 def plan_moves(
         from_loc: types.Location,
         to_loc: types.Location,
@@ -54,19 +64,10 @@ def plan_moves(
 
     assert minimum_z_height is None or minimum_z_height >= 0.0
 
-    def _split_loc_labware(
-            loc: types.Location) -> Tuple[Optional[Labware], Optional[Well]]:
-        if isinstance(loc.labware, Labware):
-            return loc.labware, None
-        elif isinstance(loc.labware, Well):
-            return loc.labware.parent, loc.labware
-        else:
-            return None, None
-
     to_point = to_loc.point
-    to_lw, to_well = _split_loc_labware(to_loc)
+    to_lw, to_well = split_loc_labware(to_loc)
     from_point = from_loc.point
-    from_lw, from_well = _split_loc_labware(from_loc)
+    from_lw, from_well = split_loc_labware(from_loc)
     dest_quirks = quirks_from_any_parent(to_lw)
     from_quirks = quirks_from_any_parent(from_lw)
     from_center = 'centerMultichannelOnWells' in from_quirks


### PR DESCRIPTION
If a given protocol would target the labware loaded into a thermocycler module, while that module is known to be closed, simulation will fail with a helpful message.

Closes #4044

## review requests

Attempt to upload a protocol in which you:

- [ ] close the TC lid and then pipette into it (should raise)
- [ ] close the TC lid and then pipette from it (should raise)
- [ ]  pipette into it with lid open (should simulate)