### PR TITLE
chore(protocol-designer): expose gen2 multi pipettes behind ff

### DIFF
--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.js
@@ -40,6 +40,7 @@ type PipetteSelectProps = {| mount: Mount, tabIndex: number |}
 
 export default function ChangePipetteFields(props: Props) {
   const { values, onFieldChange } = props
+  const enableMultiGEN2 = useSelector(getEnableMultiGEN2Pipettes)
 
   const tiprackOptions = useMemo(() => {
     const defs = getOnlyLatestDefs()
@@ -68,7 +69,6 @@ export default function ChangePipetteFields(props: Props) {
   const renderPipetteSelect = (props: PipetteSelectProps) => {
     const { tabIndex, mount } = props
     const pipetteName = values[mount].pipetteName
-    const enableMultiGEN2 = useSelector(getEnableMultiGEN2Pipettes)
     const nameBlacklist = enableMultiGEN2
       ? []
       : ['p20_multi_gen2', 'p300_multi_gen2']

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.js
@@ -68,8 +68,8 @@ export default function ChangePipetteFields(props: Props) {
   const renderPipetteSelect = (props: PipetteSelectProps) => {
     const { tabIndex, mount } = props
     const pipetteName = values[mount].pipetteName
-
-    const nameBlacklist = useSelector(getEnableMultiGEN2Pipettes)
+    const enableMultiGEN2 = useSelector(getEnableMultiGEN2Pipettes)
+    const nameBlacklist = enableMultiGEN2
       ? []
       : ['p20_multi_gen2', 'p300_multi_gen2']
     return (

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.js
@@ -1,5 +1,6 @@
 // @flow
 import React, { useMemo } from 'react'
+import { useSelector } from 'react-redux'
 import {
   DropdownField,
   FormGroup,
@@ -22,6 +23,7 @@ import formStyles from '../../forms/forms.css'
 import { getOnlyLatestDefs } from '../../../labware-defs/utils'
 
 import type { FormPipette, FormPipettesByMount } from '../../../step-forms'
+import { getEnableMultiGEN2Pipettes } from '../../../feature-flags/selectors'
 
 type Props = {|
   initialTabIndex?: number,
@@ -66,11 +68,15 @@ export default function ChangePipetteFields(props: Props) {
   const renderPipetteSelect = (props: PipetteSelectProps) => {
     const { tabIndex, mount } = props
     const pipetteName = values[mount].pipetteName
+
+    const nameBlacklist = useSelector(getEnableMultiGEN2Pipettes)
+      ? []
+      : ['p20_multi_gen2', 'p300_multi_gen2']
     return (
       <PipetteSelect
         enableNoneOption
         tabIndex={tabIndex}
-        nameBlacklist={['p20_multi_gen2', 'p300_multi_gen2']}
+        nameBlacklist={nameBlacklist}
         value={pipetteName != null ? getPipetteNameSpecs(pipetteName) : null}
         onPipetteChange={value => {
           const name = value !== null ? value.name : null

--- a/protocol-designer/src/feature-flags/reducers.js
+++ b/protocol-designer/src/feature-flags/reducers.js
@@ -15,6 +15,7 @@ const initialFlags: Flags = {
   PRERELEASE_MODE: false,
   OT_PD_ENABLE_MODULES: false,
   OT_PD_DISABLE_MODULE_RESTRICTIONS: false,
+  OT_PD_ENABLE_MULTI_GEN2_PIPETTES: false,
 }
 
 const flags = handleActions<Flags, any>(

--- a/protocol-designer/src/feature-flags/selectors.js
+++ b/protocol-designer/src/feature-flags/selectors.js
@@ -18,3 +18,8 @@ export const getDisableModuleRestrictions: Selector<?boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_DISABLE_MODULE_RESTRICTIONS
 )
+
+export const getEnableMultiGEN2Pipettes: Selector<?boolean> = createSelector(
+  getFeatureFlagData,
+  flags => flags.OT_PD_ENABLE_MULTI_GEN2_PIPETTES
+)

--- a/protocol-designer/src/feature-flags/types.js
+++ b/protocol-designer/src/feature-flags/types.js
@@ -14,6 +14,7 @@ export type FlagTypes =
   | 'PRERELEASE_MODE'
   | 'OT_PD_ENABLE_MODULES'
   | 'OT_PD_DISABLE_MODULE_RESTRICTIONS'
+  | 'OT_PD_ENABLE_MULTI_GEN2_PIPETTES'
 
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: Array<FlagTypes> = []

--- a/protocol-designer/src/feature-flags/types.js
+++ b/protocol-designer/src/feature-flags/types.js
@@ -17,7 +17,9 @@ export type FlagTypes =
   | 'OT_PD_ENABLE_MULTI_GEN2_PIPETTES'
 
 // flags that are not in this list only show in prerelease mode
-export const userFacingFlags: Array<FlagTypes> = []
+export const userFacingFlags: Array<FlagTypes> = [
+  'OT_PD_ENABLE_MULTI_GEN2_PIPETTES',
+]
 
 export type Flags = $Shape<{|
   [flag: FlagTypes]: ?boolean,

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -11,5 +11,9 @@
     "title": "Disable module restrictions",
     "description_1": "Turn off all restrictions on module placement, labware placement on modules, and related pipette crash guidance.",
     "description_2": "NOT recommended! Switching from default positions may cause crashes and the Protocol Designer cannot yet give guidance on what to expect. Use at your own discretion. "
+  },
+  "OT_PD_ENABLE_MULTI_GEN2_PIPETTES": {
+    "title": "Enable multi GEN2 pipettes in PD",
+    "description": "Allow multi GEN2 pipettes to be specified from Pipette Selection"
   }
 }


### PR DESCRIPTION
Add feature flag that enables the selection of GEN2 multi pipettes in the File tab.

Closes #4396