### PR TITLE
feat(api): check papi version on method call

### DIFF
--- a/api/docs/static/pygments.css
+++ b/api/docs/static/pygments.css
@@ -7,7 +7,12 @@ table {
     padding-top: 20px;
     padding-bottom: 20px;
     border-left: 10px solid #006FFF;
-    width: 65vw;
+    margin-bottom: 2rem;
+}
+
+table.align-default {
+    margin-left: 0;
+    margin-right: 0;
 }
 
 td.linenos {

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -694,7 +694,7 @@ class Pipette(CommandPublisher):
             location = self.previous_placeable
 
         do_publish(self.broker, commands.mix, self.mix, 'before',
-                   self, None, None, repetitions, volume, location, rate)
+                   None, None, self, repetitions, volume, location, rate)
 
         self.aspirate(location=location, volume=volume, rate=rate)
         for i in range(repetitions - 1):

--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -4,11 +4,7 @@ This package defines classes and functions for access through a protocol to
 control the OT2.
 
 """
-from ..protocols import types
-
-MAX_SUPPORTED_VERSION = types.APIVersion(2, 0)
-#: The maximum supported protocol API version in this release
-
+from .definitions import MAX_SUPPORTED_VERSION  # noqa(F401)
 from . import labware  # noqa(E402)
 from .contexts import (ProtocolContext,  # noqa(E402)
                        InstrumentContext,

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1258,7 +1258,7 @@ class InstrumentContext(CommandPublisher):
 
         assert tiprack.is_tiprack, "{} is not a tiprack".format(str(tiprack))
         cmds.do_publish(self.broker, cmds.pick_up_tip, self.pick_up_tip,
-                        'before', None, None, instrument=self, location=target)
+                        'before', None, None, self, location=target)
         self.move_to(target.top())
 
         self._hw_manager.hardware.set_current_tiprack_diameter(
@@ -1267,7 +1267,7 @@ class InstrumentContext(CommandPublisher):
             self._mount, self._tip_length_for(tiprack), presses, increment)
         # Note that the hardware API pick_up_tip action includes homing z after
         cmds.do_publish(self.broker, cmds.pick_up_tip, self.pick_up_tip,
-                        'after', self, None, instrument=self, location=target)
+                        'after', self, None, self, location=target)
         self._hw_manager.hardware.set_working_volume(
             self._mount, target.max_volume)
         tiprack.use_tips(target, self.channels)
@@ -1345,11 +1345,11 @@ class InstrumentContext(CommandPublisher):
                 "tiprack.wells()[0].top()) or a Well (e.g. tiprack.wells()[0]."
                 " However, it is a {}".format(location))
         cmds.do_publish(self.broker, cmds.drop_tip, self.drop_tip,
-                        'before', None, None, instrument=self, location=target)
+                        'before', None, None, self, location=target)
         self.move_to(target)
         self._hw_manager.hardware.drop_tip(self._mount, home_after=home_after)
         cmds.do_publish(self.broker, cmds.drop_tip, self.drop_tip,
-                        'after', self, None, instrument=self, location=target)
+                        'after', self, None, self, location=target)
         if isinstance(target.labware, Well)\
            and target.labware.parent.is_tiprack:
             # If this is a tiprack we can try and add the tip back to the

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -120,11 +120,10 @@ class ProtocolContext(CommandPublisher):
             trash_name = 'opentrons_1_trash_850ml_fixed'
         else:
             trash_name = 'opentrons_1_trash_1100ml_fixed'
-        if self.deck['12']:
-            del self.deck['12']
+        if self._deck_layout['12']:
+            del self._deck_layout['12']
         self.load_labware(trash_name, '12')
 
-    @requires_version(2, 0)
     @classmethod
     def build_using(cls,
                     protocol: Protocol,

--- a/api/src/opentrons/protocol_api/definitions.py
+++ b/api/src/opentrons/protocol_api/definitions.py
@@ -1,0 +1,4 @@
+from ..protocols import types
+
+MAX_SUPPORTED_VERSION = types.APIVersion(2, 0)
+#: The maximum supported protocol API version in this release

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1246,7 +1246,6 @@ def get_labware_definition(
         load_name, namespace, version)
 
 
-@requires_version(2, 0)
 def get_all_labware_definitions() -> List[str]:
     """
     Return a list of standard and custom labware definitions with load_name +

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -27,6 +27,8 @@ import jsonschema  # type: ignore
 from .util import ModifiedList
 from opentrons.types import Location, Point
 from opentrons.config import CONFIG
+from opentrons.protocols.types import APIVersion
+from .definitions import MAX_SUPPORTED_VERSION
 
 from .util import requires_version
 
@@ -57,7 +59,6 @@ well_shapes = {
 }
 
 
-@requires_version(2, 0)
 class Well:
     """
     The Well class represents a  single well in a :py:class:`Labware`
@@ -68,7 +69,8 @@ class Well:
     def __init__(self, well_props: dict,
                  parent: Location,
                  display_name: str,
-                 has_tip: bool) -> None:
+                 has_tip: bool,
+                 api_level: APIVersion) -> None:
         """
         Create a well, and track the Point corresponding to the top-center of
         the well (this Point is in absolute deck coordinates)
@@ -84,6 +86,7 @@ class Well:
                        position of the parent of the Well (usually the
                        front-left corner of a labware)
         """
+        self._api_version = api_level
         self._display_name = display_name
         self._position\
             = Point(well_props['x'],
@@ -109,6 +112,11 @@ class Well:
                     well_props['shape']))
         self.max_volume = well_props['totalLiquidVolume']
         self._depth = well_props['depth']
+
+    @property  # type: ignore
+    @requires_version(2, 0)
+    def api_version(self) -> APIVersion:
+        return self._api_version
 
     @property  # type: ignore
     @requires_version(2, 0)
@@ -219,7 +227,6 @@ class Well:
         return hash(self.top().point)
 
 
-@requires_version(2, 0)
 class Labware:
     """
     This class represents a labware, such as a PCR plate, a tube rack, trough,
@@ -249,7 +256,8 @@ class Labware:
     """
     def __init__(
             self, definition: dict,
-            parent: Location, label: str = None) -> None:
+            parent: Location, label: str = None,
+            api_level: APIVersion = None) -> None:
         """
         :param definition: A dict representing all required data for a labware,
                            including metadata such as the display name of the
@@ -264,7 +272,20 @@ class Labware:
                        deck).
         :param str label: An optional label to use instead of the displayName
                           from the definition's metadata element
+        :param APIVersion api_level: the API version to set for the instance.
+                                     The :py:class:`.Labware` will
+                                     conform to this level. If not specified,
+                                     defaults to
+                                     :py:attr:`.MAX_SUPPORTED_VERSION`.
         """
+        if not api_level:
+            api_level = MAX_SUPPORTED_VERSION
+        if api_level > MAX_SUPPORTED_VERSION:
+            raise RuntimeError(
+                f'API version {api_level} is not supported by this '
+                f'robot software. Please either reduce your requested API '
+                f'version or update your robot.')
+        self._api_version = api_level
         if label:
             dn = label
         else:
@@ -289,6 +310,11 @@ class Labware:
 
         self._pattern = re.compile(r'^([A-Z]+)([1-9][0-9]*)$', re.X)
         self._definition = definition
+
+    @property  # type: ignore
+    @requires_version(2, 0)
+    def api_version(self) -> APIVersion:
+        return self._api_version
 
     def __getitem__(self, key: str) -> Well:
         return self.wells_by_name()[key]
@@ -346,7 +372,8 @@ class Labware:
                 self._well_definition[well],
                 Location(self._calibrated_offset, self),
                 "{} of {}".format(well, self._display_name),
-                self.is_tiprack)
+                self._is_tiprack,
+                self._api_version)
             for well in self._ordering]
 
     def _create_indexed_dictionary(self, group=0):
@@ -552,10 +579,15 @@ class Labware:
         """
         return self._dimensions['zDimension'] + self._calibrated_offset.z
 
+    @property
+    def _is_tiprack(self) -> bool:
+        """ as is_tiprack but not subject to version checking for speed """
+        return self._parameters['isTiprack']
+
     @property  # type: ignore
     @requires_version(2, 0)
     def is_tiprack(self) -> bool:
-        return self._parameters['isTiprack']
+        return self._is_tiprack
 
     @property  # type: ignore
     @requires_version(2, 0)
@@ -721,7 +753,7 @@ class Labware:
     def reset(self):
         """Reset all tips in a tiprack
         """
-        if self.is_tiprack:
+        if self._is_tiprack:
             for well in self.wells():
                 well.has_tip = True
 
@@ -752,7 +784,8 @@ class ModuleGeometry:
 
     def __init__(self,
                  definition: dict,
-                 parent: Location) -> None:
+                 parent: Location,
+                 api_level: APIVersion = None) -> None:
         """
         Create a Module for tracking the position of a module.
 
@@ -771,7 +804,21 @@ class ModuleGeometry:
                        the outside of the module (usually the front-left corner
                        of a slot on the deck).
         :type parent: :py:class:`.Location`
+        :param APIVersion api_level: the API version to set for the loaded
+                                     :py:class:`ModuleGeometry` instance. The
+                                     :py:class:`ModuleGeometry` will
+                                     conform to this level. If not specified,
+                                     defaults to
+                                     :py:attr:`.MAX_SUPPORTED_VERSION`.
         """
+        if not api_level:
+            api_level = MAX_SUPPORTED_VERSION
+        if api_level > MAX_SUPPORTED_VERSION:
+            raise RuntimeError(
+                f'API version {api_level} is not supported by this '
+                f'robot software. Please either reduce your requested API '
+                f'version or update your robot.')
+        self._api_version = api_level
         self._parent = parent
         self._display_name = "{} on {}".format(definition["displayName"],
                                                str(parent.labware))
@@ -786,6 +833,10 @@ class ModuleGeometry:
         self._location = Location(
             point=self._offset + self._parent.point,
             labware=self)
+
+    @property
+    def api_version(self) -> APIVersion:
+        return self._api_version
 
     def add_labware(self, labware: Labware) -> Labware:
         assert not self._labware,\
@@ -836,8 +887,9 @@ class ModuleGeometry:
 
 
 class ThermocyclerGeometry(ModuleGeometry):
-    def __init__(self, definition: dict, parent: Location) -> None:
-        super().__init__(definition, parent)
+    def __init__(self, definition: Dict[str, Any], parent: Location,
+                 api_level: APIVersion = None) -> None:
+        super().__init__(definition, parent, api_level)
         self._lid_height = definition["dimensions"]["lidHeight"]
         self._lid_status = 'open'   # Needs to reflect true status
         # TODO: BC 2019-07-25 add affordance for "semi" configuration offset
@@ -870,7 +922,8 @@ class ThermocyclerGeometry(ModuleGeometry):
         # Block first three columns from being accessed
         definition = labware._definition
         definition['ordering'] = definition['ordering'][3::]
-        return Labware(definition, super().location)
+        return Labware(
+            definition, super().location, api_level=self._api_version)
 
     def add_labware(self, labware: Labware) -> Labware:
         assert not self._labware,\
@@ -1232,7 +1285,9 @@ def clear_calibrations():
 
 
 def load_module_from_definition(
-        definition: dict, parent: Location) -> ModuleGeometry:
+        definition: Dict[str, Any],
+        parent: Location,
+        api_level: APIVersion = None) -> ModuleGeometry:
     """
     Return a :py:class:`ModuleGeometry` object from a specified definition
 
@@ -1241,18 +1296,26 @@ def load_module_from_definition(
     :param parent: A :py:class:`.Location` representing the location where
                    the front and left most point of the outside of the module
                    is (often the front-left corner of a slot on the deck).
+    :param APIVersion api_level: the API version to set for the loaded
+                                 :py:class:`ModuleGeometry` instance. The
+                                 :py:class:`ModuleGeometry` will
+                                 conform to this level. If not specified,
+                                 defaults to :py:attr:`.MAX_SUPPORTED_VERSION`.
     """
     mod_name = definition['loadName']
     if mod_name == 'thermocycler':
         mod: ModuleGeometry = \
-                ThermocyclerGeometry(definition, parent)
+                ThermocyclerGeometry(definition, parent, api_level)
     else:
-        mod = ModuleGeometry(definition, parent)
+        mod = ModuleGeometry(definition, parent, api_level)
     # TODO: calibration
     return mod
 
 
-def load_module(name: str, parent: Location) -> ModuleGeometry:
+def load_module(
+        name: str,
+        parent: Location,
+        api_level: APIVersion = None) -> ModuleGeometry:
     """
     Return a :py:class:`ModuleGeometry` object from a definition looked up
     by name.
@@ -1263,12 +1326,17 @@ def load_module(name: str, parent: Location) -> ModuleGeometry:
     :param parent: A :py:class:`.Location` representing the location where
                    the front and left most point of the outside of the module
                    is (often the front-left corner of a slot on the deck).
+    :param APIVersion api_level: the API version to set for the loaded
+                                 :py:class:`ModuleGeometry` instance. The
+                                 :py:class:`ModuleGeometry` will
+                                 conform to this level. If not specified,
+                                 defaults to :py:attr:`.MAX_SUPPORTED_VERSION`.
     """
     def_path = 'shared_data/module/definitions/1.json'
     module_def = json.loads(
         pkgutil.get_data(  # type: ignore
             'opentrons', def_path).decode('utf-8'))  # type: ignore
-    return load_module_from_definition(module_def[name], parent)
+    return load_module_from_definition(module_def[name], parent, api_level)
 
 
 def quirks_from_any_parent(
@@ -1345,10 +1413,10 @@ def uri_from_definition(definition: LabwareDefinition, delimiter='/') -> str:
 
 
 def load_from_definition(
-        definition: dict,
+        definition: Dict[str, Any],
         parent: Location,
         label: str = None,
-        legacy: bool = False) -> Labware:
+        api_level: APIVersion = None) -> Labware:
     """
     Return a labware object constructed from a provided labware definition dict
 
@@ -1363,9 +1431,13 @@ def load_from_definition(
                    (often the front-left corner of a slot on the deck).
     :param str label: An optional label that will override the labware's
                       display name from its definition
+    :param APIVersion api_level: the API version to set for the loaded labware
+                                 instance. The :py:class:`.Labware` will
+                                 conform to this level. If not specified,
+                                 defaults to :py:attr:`.MAX_SUPPORTED_VERSION`.
     """
-    labware = Labware(definition, parent, label)
-    load_calibration(labware)  # type: ignore
+    labware = Labware(definition, parent, label, api_level)
+    load_calibration(labware)
     return labware
 
 
@@ -1376,8 +1448,9 @@ def load(
     namespace: str = None,
     version: int = 1,
     bundled_defs: Dict[str, LabwareDefinition] = None,
-    extra_defs: Dict[str, LabwareDefinition] = None
-) -> Labware:  # type: ignore
+    extra_defs: Dict[str, LabwareDefinition] = None,
+    api_level: APIVersion = None
+) -> Labware:
     """
     Return a labware object constructed from a labware definition dict looked
     up by name (definition must have been previously stored locally on the
@@ -1400,9 +1473,13 @@ def load(
     :param extra_defs: If specified, a mapping of labware names to labware
         definitions. If no bundle is passed, these definitions will also be
         searched.
+    :param APIVersion api_level: the API version to set for the loaded labware
+                                 instance. The :py:class:`.Labware` will
+                                 conform to this level. If not specified,
+                                 defaults to :py:attr:`.MAX_SUPPORTED_VERSION`.
     """
     definition = get_labware_definition(
         load_name, namespace, version,
         bundled_defs=bundled_defs,
         extra_defs=extra_defs)
-    return load_from_definition(definition, parent, label)
+    return load_from_definition(definition, parent, label, api_level)

--- a/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
@@ -16,6 +16,7 @@ from opentrons.data_storage import database as db_cmds
 from opentrons.config import CONFIG
 from opentrons.legacy_api.containers.placeable import (
     Container, Well as oldWell)
+from opentrons.protocols.types import APIVersion
 
 if TYPE_CHECKING:
     from ..contexts import ProtocolContext
@@ -213,13 +214,15 @@ class LegacyWell(Well):
     """
     def __init__(
             self,
-            well_props: dict,
+            well_props: Dict[str, Any],
             parent: Location,
             display_name: str,
             has_tip: bool,
+            api_version: APIVersion,
             labware_height: float = None,
             well_name: str = None):
-        super().__init__(well_props, parent, display_name, has_tip)
+        super().__init__(
+            well_props, parent, display_name, has_tip, api_version)
         self._well_name = well_name
         self._parent_height = labware_height
 
@@ -608,6 +611,7 @@ class LegacyLabware():
                 Location(self.lw_obj._calibrated_offset, self.lw_obj),
                 "{} of {}".format(well, self.lw_obj._display_name),
                 self.lw_obj.is_tiprack,
+                self.lw_obj.api_version,
                 self.lw_obj._dimensions['zDimension'],
                 well_name=well)
             for well in self.lw_obj._ordering]

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -3,7 +3,7 @@ import pkgutil
 
 import pytest
 
-from opentrons.protocol_api import labware
+from opentrons.protocol_api import labware, MAX_SUPPORTED_VERSION
 from opentrons.types import Point, Location
 
 test_data = {
@@ -33,13 +33,15 @@ def test_well_init():
     slot = Location(Point(1, 2, 3), 1)
     well_name = 'circular_well_json'
     has_tip = False
-    well1 = labware.Well(test_data[well_name], slot, well_name, has_tip)
+    well1 = labware.Well(test_data[well_name], slot, well_name, has_tip,
+                         MAX_SUPPORTED_VERSION)
     assert well1._diameter == test_data[well_name]['diameter']
     assert well1._length is None
     assert well1._width is None
 
     well2_name = 'rectangular_well_json'
-    well2 = labware.Well(test_data[well2_name], slot, well2_name, has_tip)
+    well2 = labware.Well(test_data[well2_name], slot, well2_name, has_tip,
+                         MAX_SUPPORTED_VERSION)
     assert well2._diameter is None
     assert well2._length == test_data[well2_name]['xDimension']
     assert well2._width == test_data[well2_name]['yDimension']
@@ -49,7 +51,8 @@ def test_top():
     slot = Location(Point(4, 5, 6), 1)
     well_name = 'circular_well_json'
     has_tip = False
-    well = labware.Well(test_data[well_name], slot, well_name, has_tip)
+    well = labware.Well(test_data[well_name], slot, well_name, has_tip,
+                        MAX_SUPPORTED_VERSION)
     well_data = test_data[well_name]
     expected_x = well_data['x'] + slot.point.x
     expected_y = well_data['y'] + slot.point.y
@@ -62,7 +65,8 @@ def test_bottom():
     slot = Location(Point(7, 8, 9), 1)
     well_name = 'rectangular_well_json'
     has_tip = False
-    well = labware.Well(test_data[well_name], slot, well_name, has_tip)
+    well = labware.Well(test_data[well_name], slot, well_name, has_tip,
+                        MAX_SUPPORTED_VERSION)
     well_data = test_data[well_name]
     expected_x = well_data['x'] + slot.point.x
     expected_y = well_data['y'] + slot.point.y
@@ -75,7 +79,8 @@ def test_from_center_cartesian():
     slot1 = Location(Point(10, 11, 12), 1)
     well_name = 'circular_well_json'
     has_tip = False
-    well1 = labware.Well(test_data[well_name], slot1, well_name, has_tip)
+    well1 = labware.Well(test_data[well_name], slot1, well_name, has_tip,
+                         MAX_SUPPORTED_VERSION)
 
     percent1_x = 1
     percent1_y = 1
@@ -96,7 +101,8 @@ def test_from_center_cartesian():
     slot2 = Location(Point(13, 14, 15), 1)
     well2_name = 'rectangular_well_json'
     has_tip = False
-    well2 = labware.Well(test_data[well2_name], slot2, well2_name, has_tip)
+    well2 = labware.Well(test_data[well2_name], slot2, well2_name, has_tip,
+                         MAX_SUPPORTED_VERSION)
     percent2_x = -0.25
     percent2_y = 0.1
     percent2_z = 0.9
@@ -169,7 +175,8 @@ def test_well_parent():
     well = labware.Well(test_data[well_name],
                         parent,
                         well_name,
-                        has_tip)
+                        has_tip,
+                        MAX_SUPPORTED_VERSION)
     assert well.parent is lw
     assert well.top().labware is well
     assert well.top().labware.parent is lw


### PR DESCRIPTION
## overview

Use the API version specified by the protocol at init to check access to all API functions and methods and make sure the version is appropriate.

## changelog

- Pass the requested version through to dependent instances of ModuleContext, InstrumentContext, Labware, etc
- Rework the `requires_version` decorator to inject a version check

## review requests

- See if the code makes sense at all
- Poke holes
- is the error well worded?

## test requests
- make sure we don't break v1 protocols or v2 protocols
- make a local mod or something and check that it actually works (although the tests should catch it)
