### PR TITLE
refactor(api): remove some very chatty logs in pipette config

### DIFF
--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -158,10 +158,9 @@ def load(pipette_model: str, pipette_id: str = None) -> pipette_config:
     # future, we’ll have to change this code to select items more
     # intelligently
     if ff.use_old_aspiration_functions():
-        log.info("Using old aspiration functions")
+        log.debug("Using old aspiration functions")
         ul_per_mm = cfg['ulPerMm'][0]
     else:
-        log.info("Using new aspiration functions")
         ul_per_mm = cfg['ulPerMm'][-1]
 
     smoothie_configs = cfg['smoothieConfigs']


### PR DESCRIPTION
The logging around the feature flag to use the old bad aspiration functions for
p10 singles was getting extremely chatty in the expected case of using the new
functions. Remove the expected case logs and bump the unexpected case logs down
to debug.
