### PR TITLE
feat(api): Assume OT_SMOOTHIE_ID is AMA if environmental variable is unset.

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -528,7 +528,7 @@ class SmoothieDriver_3_0_0:
 
     def _connect_to_port(self, port=None):
         try:
-            smoothie_id = environ.get('OT_SMOOTHIE_ID', 'FT232R')
+            smoothie_id = environ.get('OT_SMOOTHIE_ID', 'AMA')
             self._connection = serial_communication.connect(
                 device_name=smoothie_id,
                 port=port,


### PR DESCRIPTION
## overview

All(?) standard OT2 robots set an environmental variable `OT_SMOOTHIE_ID` to "AMA". This is used to match the comports and identify /dev/ttyAMA0. However if this environmental variable is unset (e.g. on a custom install) the assumed value is `FT232R`. I do not see what purpose this serves, and it requires an extra step of setting this environmental variable.

This PR changes that default which should allow graceful handling where OT_SMOOTHIE_ID is unset. I'm not clear of any situation where the current default (FT232R) would be useful and I presume it is vestigial but I may be unaware of a situation in for example old robots.

An alternative would be to raise an exception if this variable is unset but the current behaviour seems to be suboptimal as you get the obscure error:
```
File "/home/pi/bare/lib/python3.6/site-packages/opentrons/drivers/serial_communication.py", line 126, in connect
    port = get_ports_by_name(device_name=device_name)[0]
IndexError: list index out of range
```

## changelog
Changes default pattern match if OT_SMOOTHIE_ID is unset from FT232R to AMA.

Related to #4397.