### PR TITLE
fix(app): display robot ip not robot ip subnet base

### DIFF
--- a/app/src/http-api-client/networking.js
+++ b/app/src/http-api-client/networking.js
@@ -219,7 +219,7 @@ export const makeGetRobotNetworkingStatus = (): GetNetworkingStatusCall =>
             if (iface.ipAddress != null) {
               try {
                 const block = new Netmask(iface.ipAddress)
-                ipAddress = iface.ipAddress.split("/")[0]
+                ipAddress = iface.ipAddress.split('/')[0]
                 subnetMask = block.mask
               } catch (e) {
                 // just use what was passed if unable to parse

--- a/app/src/http-api-client/networking.js
+++ b/app/src/http-api-client/networking.js
@@ -219,7 +219,7 @@ export const makeGetRobotNetworkingStatus = (): GetNetworkingStatusCall =>
             if (iface.ipAddress != null) {
               try {
                 const block = new Netmask(iface.ipAddress)
-                ipAddress = block.base
+                ipAddress = iface.ipAddress.split("/")[0]
                 subnetMask = block.mask
               } catch (e) {
                 // just use what was passed if unable to parse


### PR DESCRIPTION
pr #4372 (ac74c122e) added the netmask
package (https://www.npmjs.com/package/netmask) to parse the robot's networking
response of CIDR-format ip/subnetbits into a separate ip and subnet mask.
Unfortunately, that PR was building a Netmask object and then using its base
member to represent the IP address. However, a Netmask object only represents
information _about the subnet_, not about a specific ip; the base attribute is
the base address of the subnet, e.g. `ip & subnetmask`.

Instead, split off the CIDR suffix and use the result as the IP address.

Before: 
<img width="260" alt="Screen Shot 2019-11-08 at 2 10 11 PM" src="https://user-images.githubusercontent.com/3091648/68504150-625b6a80-0232-11ea-8fdb-5e39a5f956ad.png">

Note the IP is displayed as 10.10.0.0, the subnet base

After:
<img width="255" alt="Screen Shot 2019-11-08 at 2 11 07 PM" src="https://user-images.githubusercontent.com/3091648/68504162-67b8b500-0232-11ea-96e0-5cc6a04ce353.png">

Correct IP shown
