### PR TITLE
fix(api,shared-data): fix gen2 multi positioning

### DIFF
--- a/api/src/opentrons/deck_calibration/endpoints.py
+++ b/api/src/opentrons/deck_calibration/endpoints.py
@@ -51,7 +51,7 @@ def safe_points() -> Dict[str, Tuple[float, float, float]]:
         slot_3_lower_right[0] - 5, slot_3_lower_right[1] + 5, 10)
     slot_7_safe_point = (
         slot_7_upper_left[0] + 5, slot_7_upper_left[1] - 5, 10)
-    attach_tip_point = (200, 90, 150)
+    attach_tip_point = (200, 90, 130)
 
     return {
         '1': slot_1_safe_point,

--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -1381,7 +1381,7 @@
         "units": "mm/s",
         "type": "float"
       },
-      "modelOffset": [0.0, 31.5, 5.6],
+      "modelOffset": [0.0, 31.5, -5.6],
       "plungerCurrent": {
         "value": 1.0,
         "min": 0.01,
@@ -3747,7 +3747,7 @@
         "units": "mm/s",
         "type": "float"
       },
-      "modelOffset": [0.0, 31.5, -10.52],
+      "modelOffset": [0.0, 31.5, 10.52],
       "ulPerMm": [
         {
           "aspirate": [

--- a/shared-data/pipette/definitions/pipetteNameSpecs.json
+++ b/shared-data/pipette/definitions/pipetteNameSpecs.json
@@ -103,7 +103,7 @@
     "channels": 8,
     "smoothieConfigs": {
       "stepsPerMM": 3200,
-      "homePosition": 152.25,
+      "homePosition": 155.75,
       "travelDistance": 60
     }
   },
@@ -238,7 +238,7 @@
     "maxVolume": 300,
     "smoothieConfigs": {
       "stepsPerMM": 3200,
-      "homePosition": 152.25,
+      "homePosition": 155.75,
       "travelDistance": 60
     }
   },


### PR DESCRIPTION
Our references for the height (and therefore homing position) of the gen2 multi
was not taking into account that gen1 pipettes home to a bearing, not to the top
of their housing; we have to modify the positions a little bit.

Also, the gen2 multis are tall enough that we need to bump the attach-tip
position for deck calibration down a bit to avoid triggering the z endstop.

# Testing
- deck calibrate in UI and make sure you don't get a hard stop error
- also make sure the positioning is right
- subsequently tip probe and make sure you don't miss by a lot