### PR TITLE
refactor(app): fix no-steps-in-protocol warning clobbering upload errors

### DIFF
--- a/app/src/components/FileInfo/index.js
+++ b/app/src/components/FileInfo/index.js
@@ -23,9 +23,11 @@ type Props = {|
 
 export default function FileInfo(props: Props) {
   const { robot, sessionLoaded, sessionHasSteps } = props
-  const uploadError = sessionHasSteps
-    ? props.uploadError
-    : { message: NO_STEPS_MESSAGE }
+  let uploadError = props.uploadError
+
+  if (sessionLoaded && !uploadError && !sessionHasSteps) {
+    uploadError = { message: NO_STEPS_MESSAGE }
+  }
 
   return (
     <div className={styles.file_info_container}>
@@ -33,9 +35,7 @@ export default function FileInfo(props: Props) {
       <ProtocolPipettesCard robot={robot} />
       <ProtocolModulesCard robot={robot} />
       <ProtocolLabwareCard />
-      {sessionLoaded && uploadError && (
-        <UploadError uploadError={uploadError} />
-      )}
+      {uploadError && <UploadError uploadError={uploadError} />}
       {sessionLoaded && !uploadError && <Continue />}
     </div>
   )


### PR DESCRIPTION
## overview

#4381 inadvertently introduced a bug that allowed the legitimate upload error (i.e. error during simulation) warning to never show

This PR fixes that bug so that we can successfully show errors for both simulation errors and empty protocols (which do not fail simulation, but come back from simulation with an empty commands list)

## changelog

- refactor(app): fix no-steps-in-protocol warning clobbering upload errors
    - Labelled as a refactor for changelog purposes because the bug never hit users

## review requests

- [ ] Uploading a protocol that fails simulation displays an error
- [ ] Uploading a "good" protocol with no aspirates nor dispenses displays an error
- [ ] Uploading a good protocol with steps does not display an error and allows the user to proceed