### PR TITLE
chore: refactor startup sequence logic from blinkenlights to API

### DIFF
--- a/api/src/opentrons/drivers/rpi_drivers/gpio.py
+++ b/api/src/opentrons/drivers/rpi_drivers/gpio.py
@@ -22,7 +22,7 @@ to set up all pins correctly, and then providing `set_low` and `set_high`
 functions that accept a pin number. The OUTPUT_PINS and INPUT_PINS dicts
 provide pin-mappings so calling code does not need to use raw integers.
 """
-
+import time
 
 IN = "in"
 OUT = "out"
@@ -153,6 +153,24 @@ def initialize():
     for pin in sorted(INPUT_PINS.values()):
         _enable_pin(pin, IN)
 
+  def activate_robot():
+    """
+    Gets the robot ready for operation by initializing GPIO pins, resetting
+    the Smoothie and enabling the audio pin.
+    """
+    initialize()
+
+    # audio-enable pin can stay HIGH always, unless there is noise coming
+    # from the amplifier, then we can set to LOW to disable the amplifier
+    set_high(OUTPUT_PINS['AUDIO_ENABLE'])
+
+    # smoothieware programming pins, must be in a known state (HIGH)
+    set_high(OUTPUT_PINS['HALT'])
+    set_high(OUTPUT_PINS['ISP'])
+    set_low(OUTPUT_PINS['RESET'])
+    time.sleep(0.25)
+    set_high(OUTPUT_PINS['RESET'])
+    time.sleep(0.25)
 
 def turn_on_blue_button_light():
     set_button_light(blue=True)

--- a/api/src/opentrons/drivers/rpi_drivers/gpio.py
+++ b/api/src/opentrons/drivers/rpi_drivers/gpio.py
@@ -51,7 +51,6 @@ INPUT_PINS = {
 
 _path_prefix = "/sys/class/gpio"
 
-
 def _enable_pin(pin, direction):
     """
     In order to enable a GPIO pin, the pin number must be written into
@@ -153,10 +152,11 @@ def initialize():
     for pin in sorted(INPUT_PINS.values()):
         _enable_pin(pin, IN)
 
-  def activate_robot():
+def robot_startup_sequence():
     """
     Gets the robot ready for operation by initializing GPIO pins, resetting
-    the Smoothie and enabling the audio pin.
+    the Smoothie and enabling the audio pin. This only needs to be done
+    after power cycling the machine.
     """
     initialize()
 

--- a/api/src/opentrons/drivers/rpi_drivers/gpio.py
+++ b/api/src/opentrons/drivers/rpi_drivers/gpio.py
@@ -51,6 +51,7 @@ INPUT_PINS = {
 
 _path_prefix = "/sys/class/gpio"
 
+
 def _enable_pin(pin, direction):
     """
     In order to enable a GPIO pin, the pin number must be written into
@@ -152,6 +153,7 @@ def initialize():
     for pin in sorted(INPUT_PINS.values()):
         _enable_pin(pin, IN)
 
+
 def robot_startup_sequence():
     """
     Gets the robot ready for operation by initializing GPIO pins, resetting
@@ -171,6 +173,7 @@ def robot_startup_sequence():
     time.sleep(0.25)
     set_high(OUTPUT_PINS['RESET'])
     time.sleep(0.25)
+
 
 def turn_on_blue_button_light():
     set_button_light(blue=True)


### PR DESCRIPTION
## overview

A number of pins need to be set at power-on before the robot can work correctly. Previously some of these were defined only in the [ot-blinkenlights](https://github.com/Opentrons/buildroot/blob/opentrons-develop/board/opentrons/ot2/rootfs-overlay/usr/bin/ot-blinkenlights) script in the buildroot repo. This was confusing to newcomers: in some sense it was the only logic needed for the robot to pipette not to be found in the opentrons repo. This PR places that logic in a new function, `robot_startup_sequence` in `gpio` which can then be invoked from `ot-blinkenlights`. 

In #4397, @sfoster1 said there might be issues about ensuring this is only run once. I can't think of a nice way to achieve this that would work even if the modules were re-imported in a new Python process. But I think that there are lots of functions that should only be called in specific circumstances and this is just another of them. 

A subsequent PR in buildroot will refactor ot-blinkenlights to invoke this function.


Closes #4397.

## review requests

@sfoster1 