### PR TITLE
fix(APIV2): Make tipracks always calibrate from top

### DIFF
--- a/api/src/opentrons/api/calibration.py
+++ b/api/src/opentrons/api/calibration.py
@@ -249,7 +249,8 @@ class CalibrationManager:
             # Reset calibration so we don’t actually calibrate the offset
             # relative to the old calibration
             container._container.set_calibration(Point(0, 0, 0))
-            if ff.calibrate_to_bottom() and not container._container.is_tiprack:
+            if ff.calibrate_to_bottom() and not (
+                                            container._container.is_tiprack):
                 orig = _well0(container._container).bottom().point
             else:
                 orig = _well0(container._container).top().point

--- a/api/src/opentrons/api/calibration.py
+++ b/api/src/opentrons/api/calibration.py
@@ -249,7 +249,7 @@ class CalibrationManager:
             # Reset calibration so we don’t actually calibrate the offset
             # relative to the old calibration
             container._container.set_calibration(Point(0, 0, 0))
-            if ff.calibrate_to_bottom():
+            if ff.calibrate_to_bottom() and not container._container.is_tiprack:
                 orig = _well0(container._container).bottom().point
             else:
                 orig = _well0(container._container).top().point


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

"Calibrate to bottom" when enabled prevents tiprack calibration working as described in #4417. This should fix that.

Fixes  #4417.

## changelog
Prevents calibration to bottom having any effect for tipracks.

## review requests
Haven't tested this as I don't have a dev environment setup yet, but can confirm things are broken at present and logically this should work.