### PR TITLE
feat(protocol-designer): save/load protocols with modules in prepro PD

### DIFF
--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -12,15 +12,22 @@ import type { BaseState, Selector } from '../../types'
 import type { StepIdType } from '../../form-types'
 import type {
   LabwareOnDeck,
+  ModuleOnDeck,
   PipetteOnDeck,
   LabwareTemporalProperties,
+  ModuleTemporalProperties,
   PipetteTemporalProperties,
 } from '../../step-forms'
 
 const getInvariantContext: Selector<StepGeneration.InvariantContext> = createSelector(
   stepFormSelectors.getLabwareEntities,
+  stepFormSelectors.getModuleEntities,
   stepFormSelectors.getPipetteEntities,
-  (labwareEntities, pipetteEntities) => ({ labwareEntities, pipetteEntities })
+  (labwareEntities, moduleEntities, pipetteEntities) => ({
+    labwareEntities,
+    moduleEntities,
+    pipetteEntities,
+  })
 )
 
 // NOTE this just adds missing well keys to the labware-ingred 'deck setup' liquid state
@@ -79,9 +86,19 @@ export const getInitialRobotState: BaseState => StepGeneration.RobotState = crea
       })
     )
 
+    const modules: {
+      [moduleId: string]: ModuleTemporalProperties,
+    } = mapValues(
+      initialDeckSetup.modules,
+      (m: ModuleOnDeck): ModuleTemporalProperties => ({
+        slot: m.slot,
+      })
+    )
+
     const robotState = StepGeneration.makeInitialRobotState({
       invariantContext,
       labwareLocations: labware,
+      moduleLocations: modules,
       pipetteLocations: pipettes,
     })
     robotState.liquidState.labware = labwareLiquidState

--- a/protocol-designer/src/file-types.js
+++ b/protocol-designer/src/file-types.js
@@ -2,7 +2,7 @@
 import type { RootState as IngredRoot } from './labware-ingred/reducers'
 import type { RootState as StepformRoot } from './step-forms'
 import type { RootState as DismissRoot } from './dismiss'
-import type { ProtocolFile } from '@opentrons/shared-data/protocol/flowTypes/schemaV3'
+import type { ProtocolFile } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
 
 export type PDMetadata = {
   // pipetteId to tiprackModel

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -38,10 +38,12 @@ import type {
 } from '../../labware-ingred/actions'
 import type { ReplaceCustomLabwareDef } from '../../labware-defs/actions'
 import type { FormData, StepIdType } from '../../form-types'
+import type { ModuleType } from '@opentrons/shared-data'
 import type {
   FileLabware,
   FilePipette,
-} from '@opentrons/shared-data/protocol/flowTypes/schemaV3'
+  FileModule,
+} from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
 import type {
   AddStepAction,
   ChangeFormInputAction,
@@ -638,6 +640,26 @@ export const moduleInvariantProperties = handleActions<ModuleEntities, *>(
       state: ModuleEntities,
       action: DeleteModuleAction
     ): ModuleEntities => omit(state, action.payload.id),
+    LOAD_FILE: (
+      state: ModuleEntities,
+      action: LoadFileAction
+    ): ModuleEntities => {
+      const { file } = action.payload
+      // NOTE: fallback for JSONv3
+      const FILE_MODULE_TYPE_TO_MODULE_TYPE: { [string]: ModuleType } = {
+        'temperature module': 'tempdeck',
+        'magnetic module': 'magdeck',
+        thermocycler: 'thermocycler',
+      }
+      return mapValues(
+        file.modules || {}, // TODO: Ian 2019-11-11 remive this fallback to empty object once JSONv4 is migrated & released
+        (fileModule: FileModule, id: string) => ({
+          id,
+          type: FILE_MODULE_TYPE_TO_MODULE_TYPE[fileModule.moduleType],
+          model: fileModule.model,
+        })
+      )
+    },
   },
   {}
 )

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -374,8 +374,13 @@ const _getFormAndFieldErrorsFromHydratedForm = (
 
 export const getInvariantContext: Selector<InvariantContext> = createSelector(
   getLabwareEntities,
+  getModuleEntities,
   getPipetteEntities,
-  (labwareEntities, pipetteEntities) => ({ labwareEntities, pipetteEntities })
+  (labwareEntities, moduleEntities, pipetteEntities) => ({
+    labwareEntities,
+    moduleEntities,
+    pipetteEntities,
+  })
 )
 
 export const getUnsavedFormErrors: Selector<?StepFormAndFieldErrors> = createSelector(

--- a/protocol-designer/src/step-generation/test-with-flow/__snapshots__/fixtureGeneration.test.js.snap
+++ b/protocol-designer/src/step-generation/test-with-flow/__snapshots__/fixtureGeneration.test.js.snap
@@ -6523,6 +6523,7 @@ Object {
       "labwareDefURI": "fixture/fixture_12_trough/1",
     },
   },
+  "moduleEntities": Object {},
   "pipetteEntities": Object {
     "p10MultiId": Object {
       "id": "p10MultiId",
@@ -11683,6 +11684,7 @@ Object {
       },
     },
   },
+  "modules": Object {},
   "pipettes": Object {
     "p300SingleId": Object {
       "mount": "left",

--- a/protocol-designer/src/step-generation/test-with-flow/__snapshots__/utils.test.js.snap
+++ b/protocol-designer/src/step-generation/test-with-flow/__snapshots__/utils.test.js.snap
@@ -10,7 +10,7 @@ Object {
       "slot": "2",
     },
     "tiprack300Id": Object {
-      "slot": "3",
+      "slot": "4",
     },
     "trashId": Object {
       "slot": "12",
@@ -330,6 +330,11 @@ Object {
         "6": Object {},
         "7": Object {},
       },
+    },
+  },
+  "modules": Object {
+    "someTempModuleId": Object {
+      "slot": "3",
     },
   },
   "pipettes": Object {

--- a/protocol-designer/src/step-generation/test-with-flow/fixtures/robotStateFixtures.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtures/robotStateFixtures.js
@@ -90,6 +90,8 @@ export function makeContext(): InvariantContext {
     },
   }
 
+  const moduleEntities = {}
+
   const pipetteEntities = {
     p10SingleId: {
       name: 'p10_single',
@@ -120,24 +122,27 @@ export function makeContext(): InvariantContext {
       spec: fixtureP300Multi,
     },
   }
-  return { labwareEntities, pipetteEntities }
+  return { labwareEntities, moduleEntities, pipetteEntities }
 }
 
 export const makeState = (args: {|
   invariantContext: InvariantContext,
   labwareLocations: $PropertyType<RobotState, 'labware'>,
+  moduleLocations?: $PropertyType<RobotState, 'modules'>,
   pipetteLocations: $PropertyType<RobotState, 'pipettes'>,
   tiprackSetting: { [labwareId: string]: boolean },
 |}) => {
   const {
     invariantContext,
     labwareLocations,
+    moduleLocations,
     pipetteLocations,
     tiprackSetting,
   } = args
   let robotState = makeInitialRobotState({
     invariantContext,
     labwareLocations,
+    moduleLocations: moduleLocations || {},
     pipetteLocations,
   })
   // overwrite tiprack tip state using tiprackSetting arg
@@ -160,6 +165,7 @@ export const makeStateArgsStandard = () => ({
     destPlateId: { slot: '3' },
     trashId: { slot: '12' },
   },
+  moduleLocations: {},
 })
 export const getInitialRobotStateStandard = (
   invariantContext: InvariantContext

--- a/protocol-designer/src/step-generation/test-with-flow/utils.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/utils.test.js
@@ -81,7 +81,11 @@ const divideCreator: any = (num: number) => (
 }
 
 beforeEach(() => {
-  invariantContext = { pipetteEntities: {}, labwareEntities: {} }
+  invariantContext = {
+    labwareEntities: {},
+    moduleEntities: {},
+    pipetteEntities: {},
+  }
 })
 
 describe('reduceCommandCreators', () => {
@@ -424,6 +428,13 @@ describe('makeInitialRobotState', () => {
             tiprackLabwareDef: fixture_tiprack_300_ul,
           },
         },
+        moduleEntities: {
+          someTempModuleId: {
+            id: 'someTempModuleId',
+            model: 'GEN1',
+            type: 'tempdeck',
+          },
+        },
         labwareEntities: {
           somePlateId: {
             id: 'somePlateId',
@@ -450,8 +461,11 @@ describe('makeInitialRobotState', () => {
       labwareLocations: {
         somePlateId: { slot: '1' },
         tiprack10Id: { slot: '2' },
-        tiprack300Id: { slot: '3' },
+        tiprack300Id: { slot: '4' },
         trashId: { slot: '12' },
+      },
+      moduleLocations: {
+        someTempModuleId: { slot: '3' },
       },
       pipetteLocations: {
         p10SingleId: { mount: 'left' },

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -2,8 +2,10 @@
 import type { Command } from '@opentrons/shared-data/protocol/flowTypes/schemaV3'
 import type {
   LabwareTemporalProperties,
+  ModuleTemporalProperties,
   PipetteTemporalProperties,
   LabwareEntities,
+  ModuleEntities,
   PipetteEntities,
 } from '../step-forms'
 
@@ -188,6 +190,7 @@ export type SourceAndDest = {|
 // Data that never changes across time
 export type InvariantContext = {|
   labwareEntities: LabwareEntities,
+  moduleEntities: ModuleEntities,
   pipetteEntities: PipetteEntities,
 |}
 
@@ -198,6 +201,9 @@ export type RobotState = {|
   },
   labware: {
     [labwareId: string]: LabwareTemporalProperties,
+  },
+  modules: {
+    [moduleId: string]: ModuleTemporalProperties,
   },
   tipState: {
     tipracks: {

--- a/protocol-designer/src/step-generation/utils.js
+++ b/protocol-designer/src/step-generation/utils.js
@@ -361,11 +361,18 @@ export function createTipLiquidState<T>(
 export function makeInitialRobotState(args: {|
   invariantContext: InvariantContext,
   labwareLocations: $PropertyType<RobotState, 'labware'>,
+  moduleLocations: $PropertyType<RobotState, 'modules'>,
   pipetteLocations: $PropertyType<RobotState, 'pipettes'>,
 |}): RobotState {
-  const { invariantContext, labwareLocations, pipetteLocations } = args
+  const {
+    invariantContext,
+    labwareLocations,
+    moduleLocations,
+    pipetteLocations,
+  } = args
   return {
     labware: labwareLocations,
+    modules: moduleLocations,
     pipettes: pipetteLocations,
     liquidState: createEmptyLiquidState(invariantContext),
     tipState: {

--- a/shared-data/protocol/flowTypes/schemaV4.js
+++ b/shared-data/protocol/flowTypes/schemaV4.js
@@ -1,0 +1,20 @@
+// @flow
+import type { DeckSlotId } from '@opentrons/shared-data'
+import type { ProtocolFile as V3ProtocolFile } from './schemaV3'
+export type { Command, FilePipette, FileLabware } from './schemaV3'
+
+export type FileModule = {|
+  slot: DeckSlotId,
+  moduleType: string, // see spec for enum
+  model: string,
+|}
+
+// NOTE: must be kept in sync with '../schemas/4.json'
+export type ProtocolFile<DesignerApplicationData> = {|
+  ...V3ProtocolFile<DesignerApplicationData>,
+  schemaVersion: 4,
+  // TODO: Ian 2019-11-11 make modules a required key when v4 is legit
+  modules?: {
+    [moduleId: string]: FileModule,
+  },
+|}

--- a/shared-data/protocol/schemas/4.json
+++ b/shared-data/protocol/schemas/4.json
@@ -1,0 +1,382 @@
+{
+  "$id": "opentronsProtocolSchemaV4",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+
+  "definitions": {
+    "pipetteName": {
+      "description": "Name of a pipette. Does not contain info about specific model/version. Should match keys in pipetteNameSpecs.json file",
+      "type": "string"
+    },
+
+    "mmOffset": {
+      "description": "Millimeters for pipette location offsets",
+      "type": "number"
+    },
+
+    "offsetFromBottomMm": {
+      "description": "Offset from bottom of well in millimeters",
+      "required": ["offsetFromBottomMm"],
+      "properties": {
+        "offsetFromBottomMm": { "$ref": "#/definitions/mmOffset" }
+      }
+    },
+
+    "pipetteAccessParams": {
+      "required": ["pipette", "labware", "well"],
+      "properties": {
+        "pipette": {
+          "type": "string"
+        },
+        "labware": {
+          "type": "string"
+        },
+        "well": {
+          "type": "string"
+        }
+      }
+    },
+
+    "volumeParams": {
+      "required": ["volume"],
+      "volume": {
+        "type": "number"
+      }
+    },
+
+    "flowRate": {
+      "required": ["flowRate"],
+      "properties": {
+        "flowRate": {
+          "description": "Flow rate in uL/sec. Must be greater than 0",
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+
+    "slot": {
+      "description": "Slot on the deck of an OT-2 robot if 1-12. Else, a module ID",
+      "type": "string"
+    }
+  },
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "metadata",
+    "robot",
+    "pipettes",
+    "labware",
+    "labwareDefinitions",
+    "commands"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "description": "Schema version of a protocol is a single integer",
+      "enum": [4]
+    },
+
+    "metadata": {
+      "description": "Optional metadata about the protocol",
+      "type": "object",
+
+      "properties": {
+        "protocolName": {
+          "description": "A short, human-readable name for the protocol",
+          "type": "string"
+        },
+        "author": {
+          "description": "The author or organization who created the protocol",
+          "type": "string"
+        },
+        "description": {
+          "description": "A text description of the protocol.",
+          "type": ["string", "null"]
+        },
+
+        "created": {
+          "description": "UNIX timestamp when this file was created",
+          "type": "number"
+        },
+        "lastModified": {
+          "description": "UNIX timestamp when this file was last modified",
+          "type": ["number", "null"]
+        },
+
+        "category": {
+          "description": "Category of protocol (eg, \"Basic Pipetting\")",
+          "type": ["string", "null"]
+        },
+        "subcategory": {
+          "description": "Subcategory of protocol (eg, \"Cell Plating\")",
+          "type": ["string", "null"]
+        },
+        "tags": {
+          "description": "Tags to be used in searching for this protocol",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+
+    "designerApplication": {
+      "description": "Optional data & metadata not required to execute the protocol, used by the application that created this protocol",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the application that created the protocol. Should be namespaced under the organization or individual who owns the organization, eg \"opentrons/protocol-designer\"",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version of the application that created the protocol",
+          "type": "string"
+        },
+        "data": {
+          "description": "Any data used by the application that created this protocol",
+          "type": "object"
+        }
+      }
+    },
+
+    "robot": {
+      "required": ["model"],
+      "properties": {
+        "model": {
+          "description": "Model of the robot this protocol is written for (currently only OT-2 Standard is supported)",
+          "type": "string",
+          "enum": ["OT-2 Standard"]
+        }
+      }
+    },
+
+    "pipettes": {
+      "description": "The pipettes used in this protocol, keyed by an arbitrary unique ID",
+      "additionalProperties": false,
+      "patternProperties": {
+        ".+": {
+          "description": "Fields describing an individual pipette",
+          "type": "object",
+          "required": ["mount", "name"],
+          "additionalProperties": false,
+          "properties": {
+            "mount": {
+              "description": "Where the pipette is mounted",
+              "type": "string",
+              "enum": ["left", "right"]
+            },
+            "name": {
+              "$ref": "#/definitions/pipetteName"
+            }
+          }
+        }
+      }
+    },
+
+    "labwareDefinitions": {
+      "description": "All labware definitions used by labware in this protocol, keyed by UUID",
+      "patternProperties": {
+        ".+": {
+          "$ref": "opentronsLabwareSchemaV2"
+        }
+      }
+    },
+
+    "labware": {
+      "description": "All types of labware used in this protocol, and references to their definitions",
+      "patternProperties": {
+        ".+": {
+          "description": "Fields describing a single labware on the deck",
+          "type": "object",
+          "required": ["slot", "definitionId"],
+          "additionalProperties": false,
+          "properties": {
+            "slot": { "$ref": "#/definitions/slot" },
+            "definitionId": {
+              "description": "reference to this labware's ID in \"labwareDefinitions\"",
+              "type": "string"
+            },
+            "displayName": {
+              "description": "An optional human-readable nickname for this labware. Eg \"Buffer Trough\"",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+
+    "modules": {
+      "description": "All modules used in this protocol",
+      "patternProperties": {
+        ".+": {
+          "description": "Fields describing a single module on the deck",
+          "type": "object",
+          "required": ["slot", "moduleType"],
+          "additionalProperties": false,
+          "properties": {
+            "slot": { "$ref": "#/definitions/slot" },
+            "moduleType": {
+              "enum": ["temperature module", "magnetic module", "thermocycler"],
+              "type": "string"
+            },
+            "model": {
+              "description": "module of module. Eg 'GEN1'.",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+
+    "commands": {
+      "description": "An array of command objects representing steps to be executed on the robot",
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "description": "Aspirate / dispense / air gap commands",
+            "type": "object",
+            "required": ["command", "params"],
+            "additionalProperties": false,
+            "properties": {
+              "command": {
+                "enum": ["aspirate", "dispense", "airGap"]
+              },
+              "params": {
+                "allOf": [
+                  { "$ref": "#/definitions/flowRate" },
+                  { "$ref": "#/definitions/pipetteAccessParams" },
+                  { "$ref": "#/definitions/volumeParams" },
+                  { "$ref": "#/definitions/offsetFromBottomMm" }
+                ]
+              }
+            }
+          },
+
+          {
+            "description": "Blowout command",
+            "type": "object",
+            "required": ["command", "params"],
+            "additionalProperties": false,
+            "properties": {
+              "command": {
+                "enum": ["blowout"]
+              },
+              "params": {
+                "allOf": [
+                  { "$ref": "#/definitions/flowRate" },
+                  { "$ref": "#/definitions/pipetteAccessParams" },
+                  { "$ref": "#/definitions/offsetFromBottomMm" }
+                ]
+              }
+            }
+          },
+
+          {
+            "description": "Touch tip commands",
+            "type": "object",
+            "required": ["command", "params"],
+            "additionalProperties": false,
+            "properties": {
+              "command": {
+                "enum": ["touchTip"]
+              },
+              "params": {
+                "allOf": [
+                  { "$ref": "#/definitions/pipetteAccessParams" },
+                  { "$ref": "#/definitions/offsetFromBottomMm" }
+                ]
+              }
+            }
+          },
+
+          {
+            "description": "Pick up tip / drop tip commands",
+            "type": "object",
+            "required": ["command", "params"],
+            "additionalProperties": false,
+            "properties": {
+              "command": {
+                "enum": ["pickUpTip", "dropTip"]
+              },
+              "params": {
+                "allOf": [{ "$ref": "#/definitions/pipetteAccessParams" }]
+              }
+            }
+          },
+
+          {
+            "description": "Move to slot command. NOTE: this is an EXPERIMENTAL command, its behavior is subject to change in future releases.",
+            "type": "object",
+            "required": ["command", "params"],
+            "additionalProperties": false,
+            "properties": {
+              "command": { "enum": ["moveToSlot"] },
+              "params": {
+                "type": "object",
+                "required": ["pipette", "slot"],
+                "additionalProperties": false,
+                "properties": {
+                  "pipette": { "type": "string" },
+                  "slot": { "$ref": "#/definitions/slot" },
+                  "offset": {
+                    "description": "Optional offset from slot bottom left corner, in mm",
+                    "type": "object",
+                    "required": ["x", "y", "z"],
+                    "properties": {
+                      "x": { "type": "number" },
+                      "y": { "type": "number" },
+                      "z": { "type": "number" }
+                    }
+                  },
+                  "minimumZHeight": {
+                    "description": "Optional minimal Z margin in mm. If this is larger than the API's default safe Z margin, it will make the arc higher. If it's smaller, it will have no effect. Specifying this for movements that would not arc (moving within the same well in the same labware) will cause an arc movement instead. This param only supported in API v2, API v1 will ignore it.",
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "forceDirect": {
+                    "description": "Default is false. If true, moving from one labware/well to another will not arc to the default safe z, but instead will move directly to the specified location. This will also force the 'minimumZHeight' param to be ignored. In APIv1, this will use strategy='direct', which moves first in X/Y plane and then in Z. In API v2, a 'direct' movement is in X/Y/Z simultaneously",
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "description": "Delay command",
+            "type": "object",
+            "required": ["command", "params"],
+            "additionalProperties": false,
+            "properties": {
+              "command": {
+                "enum": ["delay"]
+              },
+              "params": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["wait"],
+                "properties": {
+                  "wait": {
+                    "description": "either a number of seconds to wait (fractional values OK), or `true` to wait indefinitely until the user manually resumes the protocol",
+                    "anyOf": [{ "type": "number" }, { "enum": [true] }]
+                  },
+                  "message": {
+                    "description": "optional message describing the delay"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+
+    "commandAnnotations": {
+      "description": "An optional object of annotations associated with commands. Its usage has not yet been defined, so its shape is not enforced by this schema.",
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
## overview

Closes #4404 

Sets up placeholder for v4 JSON protocol schema, but doesn't do a PD migration b/c there is no real v4 yet

## changelog

* adds guard to production PD to not import protocols with modules
* add early draft/placeholder schema for v4 JSON protocols

## review requests

The most important thing to test is that PD without any preproduction settings enabled still works as-is with no changes
- [ ] Load an existing PD file (eg from designer.opentrons.com) that has a variety of steps in it. They should all work OK with no weird errors or console warnings
- [ ] Save a file in normal (non-prepro) PD and load it again -- behaves as expected.
- [ ] Turn on prepro mode, turn on "Enable Modules", make some modules, save the protocol (let's call it `modules_4404_test.json`), load it again - it should fully load everything you had with no errors
- [ ] Still in prepro mode, load an older protocol from production PD or make a new one from designer.opentrons.com -- it should load OK
- [ ] Reset PD back to non-prepro, load that file you made before that contained modules (`modules_4404_test.json`) -- you should get a human-readable load file modal error message that says something like "This protocol appears to contain modules, this isn't supported yet"

- [ ] Code review.