### PR TITLE
refactor(protocol-designer): factor out PDAlert

### DIFF
--- a/protocol-designer/src/components/StepEditForm/FormAlerts.js
+++ b/protocol-designer/src/components/StepEditForm/FormAlerts.js
@@ -1,7 +1,6 @@
 // @flow
-import * as React from 'react'
 import { connect } from 'react-redux'
-import Alerts from '../alerts/Alerts'
+import Alerts, { type Props } from '../alerts/Alerts'
 import {
   actions as dismissActions,
   selectors as dismissSelectors,
@@ -17,8 +16,6 @@ import type { BaseState } from '../../types'
 /* TODO:  BC 2018-09-13 move to src/components/alerts and adapt and use src/components/alerts/Alerts
  * see #1814 for reference
  */
-
-type Props = React.ElementProps<typeof Alerts>
 
 type SP = {|
   errors: $PropertyType<Props, 'errors'>,

--- a/protocol-designer/src/components/alerts/Alerts.js
+++ b/protocol-designer/src/components/alerts/Alerts.js
@@ -1,12 +1,8 @@
 // @flow
 import * as React from 'react'
 import assert from 'assert'
-import { AlertItem, OutlineButton } from '@opentrons/components'
-import i18n from '../../localization'
-// TODO: Ian 2019-03-27 the use of Component Library `Alert` is being
-// stretched beyond its intentions here, we should reconcile PD + Run App uses of Alert later
-import styles from './alerts.css'
-import type { AlertData } from './types'
+import { PDAlert } from './PDAlert'
+import type { AlertData, AlertType } from './types'
 
 /* TODO:  BC 2018-09-13 this component is an abstraction that is meant to be shared for timeline
  * and form level alerts. Currently it is being used in TimelineAlerts, but it should be used in
@@ -14,70 +10,44 @@ import type { AlertData } from './types'
  * see #1814 for reference
  */
 
-type Props = {
+export type Props = {
   errors: Array<AlertData>,
   warnings: Array<AlertData>,
   dismissWarning: string => mixed,
 }
 
 type MakeAlert = (
-  alertType: 'error' | 'warning',
+  alertType: AlertType,
   data: AlertData,
   key: number | string
 ) => React.Node
 
-class Alerts extends React.Component<Props> {
-  makeHandleCloseWarning = (dismissId: ?string) => () => {
+const Alerts = (props: Props) => {
+  const makeHandleCloseWarning = (dismissId: ?string) => () => {
     assert(dismissId, 'expected dismissId, Alert cannot dismiss warning')
     if (dismissId) {
-      this.props.dismissWarning(dismissId)
+      props.dismissWarning(dismissId)
     }
   }
 
-  makeAlert: MakeAlert = (alertType, data, key) => {
-    return (
-      <AlertItem
-        type={alertType}
-        key={`${alertType}:${key}`}
-        title={
-          <div className={styles.alert_inner_wrapper}>
-            <div className={styles.icon_label}>
-              {i18n.t(`alert.type.${alertType}`)}
-            </div>
-            <div className={styles.alert_body}>
-              <div className={styles.alert_title}>
-                {data.title}
-                {/* i18n.t(`alert.${level}.${alertType}.${data.type}.title`) */}
-              </div>
-              <div className={styles.alert_description}>{data.description}</div>
-            </div>
-            {alertType === 'warning' && (
-              <OutlineButton
-                className={styles.dismiss_button}
-                onClick={this.makeHandleCloseWarning(data.dismissId)}
-              >
-                {i18n.t('alert.dismiss')}
-              </OutlineButton>
-            )}
-          </div>
-        }
-        onCloseClick={undefined}
-      />
-    )
-  }
+  const makeAlert: MakeAlert = (alertType, data, key) => (
+    <PDAlert
+      alertType={alertType}
+      title={data.title}
+      description={data.description}
+      key={`${alertType}:${key}`}
+      onDismiss={
+        alertType === 'warning' ? makeHandleCloseWarning(data.dismissId) : null
+      }
+    />
+  )
 
-  render() {
-    return (
-      <React.Fragment>
-        {this.props.errors.map((error, key) =>
-          this.makeAlert('error', error, key)
-        )}
-        {this.props.warnings.map((warning, key) =>
-          this.makeAlert('warning', warning, key)
-        )}
-      </React.Fragment>
-    )
-  }
+  return (
+    <>
+      {props.errors.map((error, key) => makeAlert('error', error, key))}
+      {props.warnings.map((warning, key) => makeAlert('warning', warning, key))}
+    </>
+  )
 }
 
-export default Alerts
+export default React.memo<Props>(Alerts)

--- a/protocol-designer/src/components/alerts/PDAlert.js
+++ b/protocol-designer/src/components/alerts/PDAlert.js
@@ -1,0 +1,43 @@
+// @flow
+import * as React from 'react'
+import { AlertItem, OutlineButton } from '@opentrons/components'
+import i18n from '../../localization'
+// TODO: Ian 2019-03-27 the use of Component Library `Alert` is being
+// stretched beyond its intentions here, we should reconcile PD + Run App uses of Alert later
+import styles from './alerts.css'
+import type { AlertType } from './types'
+
+type PDAlertProps = {|
+  alertType: AlertType,
+  title: string,
+  description: React.Node,
+  onDismiss?: ?() => mixed,
+|}
+
+export const PDAlert = (props: PDAlertProps) => {
+  const { alertType, title, description, onDismiss } = props
+  return (
+    <AlertItem
+      type={alertType}
+      title={
+        <div className={styles.alert_inner_wrapper}>
+          <div className={styles.icon_label}>
+            {i18n.t(`alert.type.${alertType}`)}
+          </div>
+          <div className={styles.alert_body}>
+            <div className={styles.alert_title}>{title}</div>
+            <div className={styles.alert_description}>{description}</div>
+          </div>
+          {onDismiss != null && (
+            <OutlineButton
+              className={styles.dismiss_button}
+              onClick={onDismiss}
+            >
+              {i18n.t('alert.dismiss')}
+            </OutlineButton>
+          )}
+        </div>
+      }
+    />
+  )
+}

--- a/protocol-designer/src/components/alerts/TimelineAlerts.js
+++ b/protocol-designer/src/components/alerts/TimelineAlerts.js
@@ -13,9 +13,7 @@ import { selectors as stepsSelectors } from '../../ui/steps'
 import { selectors as fileDataSelectors } from '../../file-data'
 import type { BaseState } from '../../types'
 import type { StepIdType } from '../../form-types'
-import Alerts from './Alerts'
-
-type Props = React.ElementProps<typeof Alerts>
+import Alerts, { type Props } from './Alerts'
 
 type SP = {|
   errors: $PropertyType<Props, 'errors'>,

--- a/protocol-designer/src/components/alerts/types.js
+++ b/protocol-designer/src/components/alerts/types.js
@@ -1,6 +1,7 @@
 // @flow
 import type { Node } from 'react'
-export type AlertLevel = 'timeline' | 'form' // TODO IMMEDIATELY
+export type AlertLevel = 'timeline' | 'form'
+export type AlertType = 'error' | 'warning'
 
 // generic alert (warning or error) formatted for rendering
 export type AlertData = {


### PR DESCRIPTION
## overview

PD doesn't use the component library Alert component, which is really only for Run App. This PR makes the existing PD-specific alert presentational component more reusable as `PDAlert` instead of being nested inside a fn inside of PD's `Alerts` connected component.

## changelog

## review requests

All existing behavior around alerts in PD should be unaffected

- [ ] Timeline warnings should be yellow & dismissable (eg multichannel incompatible with tube rack, or over-aspirate from a well with low liquid)
- [ ] Timeline errors should be red & not dismissable (eg labware deleted, or not enough tips)

- Code review sanity check -- existing behavior should not be changed