### PR TITLE
feat(protocol-designer): Add module placement warning and validation

### DIFF
--- a/protocol-designer/src/components/modules/styles.css
+++ b/protocol-designer/src/components/modules/styles.css
@@ -66,6 +66,9 @@
 .crash_info_box {
   @apply --font-body-1-dark;
 
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
   padding: 1rem;
   background-color: var(--c-light-gray);
 

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -46,5 +46,11 @@
     "confirm_delete_step": "Are you sure you want to delete this step?",
     "confirm_import": "Are you sure you want to import this file? You will lose any current unsaved changes.",
     "confirm_leave": "Are you sure you want to leave? You will lose any unsaved changes."
+  },
+  "module_placement": {
+    "SLOT_OCCUPIED": {
+      "title": "Cannot place module",
+      "body": "Modules can only be placed in slots that are empty"
+    }
   }
 }


### PR DESCRIPTION
## overview

This PR closes #4137 by adding updated module placement warning alert banner + dropdown validation error when unrestricted module placement FF is enabled.

## changelog

- feat(protocol-designer): Add module placement warning and validation

## review requests

With unrestricted module placement FF OFF:
- [ ] Warning banner displays when trying to place a module in an already occupied slot
- [ ] Slot dropdown is disabled, no form level error shows, tooltip explaining FF renders on hover

With unrestricted module placement FF ON:
- [ ] Warning banner displays when trying to place a module in an already occupied slot
- [ ] Slot dropdown is enabled
- [ ] Slot dropdown renders orange with error caption when selecting already occupied slot
- [ ] No tooltip on hover

Misc
- [ ] Can still add modules to unoccupied slots
