### PR TITLE
feat(protocol-designer): enforce labware<>module compat

### DIFF
--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
@@ -47,8 +47,6 @@ type Props = {|
   moduleType: ?ModuleType,
   /** tipracks that may be added to deck (depends on pipette<>tiprack assignment) */
   permittedTipracks: Array<string>,
-  /** user has opted out of module restriction guidance */
-  moduleRestrictionsDisabled?: ?boolean,
 |}
 
 const LABWARE_CREATOR_URL = 'https://labware.opentrons.com/create'
@@ -88,7 +86,6 @@ const LabwareSelectionModal = (props: Props) => {
     parentSlot,
     moduleType,
     selectLabware,
-    moduleRestrictionsDisabled,
   } = props
 
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
@@ -113,19 +110,14 @@ const LabwareSelectionModal = (props: Props) => {
 
   const handleSelectCustomLabware = useCallback(
     (containerType: string) => {
-      if (moduleType == null || moduleRestrictionsDisabled) {
+      if (moduleType == null) {
         selectLabware(containerType)
       } else {
         // show the BlockingHint
         setEnqueuedLabwareType(containerType)
       }
     },
-    [
-      moduleType,
-      moduleRestrictionsDisabled,
-      selectLabware,
-      setEnqueuedLabwareType,
-    ]
+    [moduleType, selectLabware, setEnqueuedLabwareType]
   )
 
   // if you're adding labware to a module, check the recommended filter by default
@@ -157,23 +149,10 @@ const LabwareSelectionModal = (props: Props) => {
   )
 
   const getLabwareDisabled = useCallback(
-    (labwareDef: LabwareDefinition2) => {
-      if (moduleRestrictionsDisabled) {
-        // if you disable module restrictions, all labware is enabled
-        // no matter what filterRecommended is set to
-        return false
-      }
-      return (
-        (filterRecommended && !getLabwareRecommended(labwareDef)) ||
-        !getLabwareCompatible(labwareDef)
-      )
-    },
-    [
-      filterRecommended,
-      getLabwareCompatible,
-      getLabwareRecommended,
-      moduleRestrictionsDisabled,
-    ]
+    (labwareDef: LabwareDefinition2) =>
+      (filterRecommended && !getLabwareRecommended(labwareDef)) ||
+      !getLabwareCompatible(labwareDef),
+    [filterRecommended, getLabwareCompatible, getLabwareRecommended]
   )
 
   const customLabwareURIs: Array<string> = useMemo(

--- a/protocol-designer/src/components/LabwareSelectionModal/index.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/index.js
@@ -8,7 +8,6 @@ import {
   createContainer,
 } from '../../labware-ingred/actions'
 import { selectors as labwareIngredSelectors } from '../../labware-ingred/selectors'
-import { selectors as featureFlagSelectors } from '../../feature-flags'
 import {
   actions as labwareDefActions,
   selectors as labwareDefSelectors,
@@ -27,10 +26,6 @@ type SP = {|
   parentSlot: $PropertyType<Props, 'parentSlot'>,
   moduleType: $PropertyType<Props, 'moduleType'>,
   permittedTipracks: $PropertyType<Props, 'permittedTipracks'>,
-  moduleRestrictionsDisabled: $PropertyType<
-    Props,
-    'moduleRestrictionsDisabled'
-  >,
 |}
 
 function mapStateToProps(state: BaseState): SP {
@@ -42,9 +37,6 @@ function mapStateToProps(state: BaseState): SP {
   )
   const parentModule =
     (slot != null && initialModules.find(module => module.id === slot)) || null
-  const moduleRestrictionsDisabled = featureFlagSelectors.getDisableModuleRestrictions(
-    state
-  )
 
   return {
     customLabwareDefs: labwareDefSelectors.getCustomLabwareDefsByURI(state),
@@ -52,7 +44,6 @@ function mapStateToProps(state: BaseState): SP {
     parentSlot: parentModule != null ? parentModule.slot : null,
     moduleType: parentModule != null ? parentModule.type : null,
     permittedTipracks: stepFormSelectors.getPermittedTipracks(state),
-    moduleRestrictionsDisabled,
   }
 }
 

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -8,8 +8,8 @@
     "description": "!"
   },
   "OT_PD_DISABLE_MODULE_RESTRICTIONS": {
-    "title": "Disable module restrictions",
-    "description_1": "Turn off all restrictions on module placement, labware placement on modules, and related pipette crash guidance.",
+    "title": "Disable module placement restrictions",
+    "description_1": "Turn off all restrictions on module placement and related pipette crash guidance.",
     "description_2": "NOT recommended! Switching from default positions may cause crashes and the Protocol Designer cannot yet give guidance on what to expect. Use at your own discretion. "
   },
   "OT_PD_ENABLE_MULTI_GEN2_PIPETTES": {


### PR DESCRIPTION
## overview

Result of the recent Slack convo -- the "Disable module restrictions" experimental setting is now confined to disabling module placement. Labware<>module compat is enforced no matter what this setting is toggled to.

Closes #4136 (kinda indirectly)

## changelog

- Update copy for "disable module restrictions" setting

## review requests

- [ ] Code review
- [ ] With or without "disabled modules restrictions" setting enabled, you're not allowed to add incompatible labware to a module.
- Shouldn't affect other uses of the setting (slot placement stuff)