### PR TITLE
fix(protocol-designer): fix labware incompat drag warning

### DIFF
--- a/protocol-designer/src/components/DeckSetup/DeckSetup.js
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useState, type Node } from 'react'
+import React, { useCallback, useState, type Node } from 'react'
 import { useSelector } from 'react-redux'
 import compact from 'lodash/compact'
 import values from 'lodash/values'
@@ -152,6 +152,7 @@ const DeckSetupContents = (props: ContentsProps) => {
     draggedLabware,
     modulesById: initialDeckSetup.modules,
   })
+  const handleHoverEmptySlot = useCallback(() => setHoveredLabware(null), [])
 
   const slotsBlockedBySpanning = getSlotsBlockedBySpanning(
     props.initialDeckSetup
@@ -247,6 +248,7 @@ const DeckSetupContents = (props: ContentsProps) => {
               selectedTerminalItemId={props.selectedTerminalItemId}
               // Module slots' ids reference their parent module
               moduleType={initialDeckSetup.modules[slot.id]?.type || null}
+              handleDragHover={handleHoverEmptySlot}
             />
           )
         })}

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.js
@@ -33,6 +33,7 @@ type OP = {|
   slot: {| ...DeckSlotDefinition, id: DeckSlot |}, // NOTE: Ian 2019-10-22 make slot `id` more restrictive when used in PD
   moduleType: ModuleType | null,
   selectedTerminalItemId: ?TerminalItemId,
+  handleDragHover?: () => mixed,
 |}
 type DP = {|
   addLabware: (e: SyntheticEvent<*>) => mixed,
@@ -108,6 +109,11 @@ const slotTarget = {
     const draggedItem = monitor.getItem()
     if (draggedItem) {
       props.moveDeckItem(draggedItem.labwareOnDeck.slot, props.slot.id)
+    }
+  },
+  hover: (props, monitor) => {
+    if (props.handleDragHover) {
+      props.handleDragHover()
     }
   },
   canDrop: (props, monitor) => {


### PR DESCRIPTION
## overview

Serves as its own ticket. Fixes small UI bug in PD where the "swapping labware not possible" orange warning on top of a labware didn't go away when you dragged over to an empty slot. To reproduce on edge:
1. Add a temperature module in slot 3
2. Put a labware immediately adjacent to that module (eg move the tiprack to slot 2)
3. Click the module and add a compatible labware - let's say a well plate
4. Drag the well plate off the module and over slot 2, the "swapping labware not possible" warning is correctly shown.
5. Without letting go, continue dragging the well plate to an empty slot. The "swapping labware not possible" warning doesn't go away! (You can still drop it into an empty slot though)

## changelog

## review requests

- Reproduce the thing above on `edge` sandbox so you know what it looks like
- This bug should no longer be reproducible in this PR - the warning should go away once you move to an empty slot
