### PR TITLE
feat(protocol-designer): fix labware duplication bug

### DIFF
--- a/protocol-designer/src/labware-ingred/utils.js
+++ b/protocol-designer/src/labware-ingred/utils.js
@@ -1,31 +1,13 @@
 // @flow
 import { sortedSlotnames } from '@opentrons/components'
-import { PSEUDO_DECK_SLOTS } from '../constants'
-import type {
-  InitialDeckSetup,
-  LabwareOnDeck,
-  ModuleOnDeck,
-} from '../step-forms/types'
+import { getSlotIsEmpty } from '../step-forms/utils'
+import type { InitialDeckSetup } from '../step-forms/types'
 import type { DeckSlot } from '../types'
 
 export function getNextAvailableDeckSlot(
   initialDeckSetup: InitialDeckSetup
 ): ?DeckSlot {
-  const moduleIds = Object.keys(initialDeckSetup.modules)
-  const pseudoSlots = Object.keys(PSEUDO_DECK_SLOTS)
-  // deck slots only, exclude moduleId-keyed slots & pseudo-slots
-  const filledLocations = [
-    ...(Object.values(initialDeckSetup.labware): Array<any>).map(
-      (labware: LabwareOnDeck) => labware.slot
-    ),
-    ...(Object.values(initialDeckSetup.modules): Array<any>).map(
-      (module: ModuleOnDeck) => module.slot
-    ),
-  ].filter(slot => !moduleIds.includes(slot) && !pseudoSlots.includes(slot))
-
-  return sortedSlotnames.find(
-    slot => !filledLocations.some(filledSlot => filledSlot === slot)
-  )
+  return sortedSlotnames.find(slot => getSlotIsEmpty(initialDeckSetup, slot))
 }
 
 const getMatchOrNull = (pattern: RegExp, s: string): ?string => {

--- a/protocol-designer/src/step-forms/utils.js
+++ b/protocol-designer/src/step-forms/utils.js
@@ -104,8 +104,16 @@ export const getSlotIsEmpty = (
   initialDeckSetup: InitialDeckSetup,
   slot: string
 ): boolean => {
-  if (slot === SPAN7_8_10_11_SLOT) {
-    return TC_SPAN_SLOTS.every(slot => getSlotIsEmpty(initialDeckSetup, slot))
+  if (
+    slot === SPAN7_8_10_11_SLOT &&
+    TC_SPAN_SLOTS.some(slot => !getSlotIsEmpty(initialDeckSetup, slot))
+  ) {
+    // special "spanning slot" is not empty if there's anything in the slots that it spans,
+    // even when there's no spanning labware/module (eg thermocycler) on the deck
+    return false
+  } else if (getSlotsBlockedBySpanning(initialDeckSetup).includes(slot)) {
+    // if a slot is being blocked by a spanning labware/module (eg thermocycler), it's not empty
+    return false
   }
 
   // NOTE: should work for both deck slots and module slots


### PR DESCRIPTION
## overview

closes #4407

## changelog


## review requests

- [ ] Add some modules (esp thermocycler) to the deck. Duplicate a labware until it fills all the slots. It shouldn't fill any slots already taken by modules
- [ ] Check for possible regressions about module placement (eg, you shouldn't be able to add a thermocycler from the Modules card if any of its slots are filled - same for adding mag/temp to a slot occupied by labware)