### PR TITLE
feat(api): Add ability to stack labware in api v2

### DIFF
--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -273,7 +273,8 @@ class ProtocolContext(CommandPublisher):
             self,
             labware_def: LabwareDefinition,
             location: types.DeckLocation,
-            label: str = None
+            label: str = None,
+            stacking: bool = False,
     ) -> Labware:
         """ Specify the presence of a piece of labware on the OT2 deck.
 
@@ -287,7 +288,10 @@ class ProtocolContext(CommandPublisher):
         """
         parent = self.deck.position_for(location)
         labware_obj = load_from_definition(labware_def, parent, label)
-        self._deck_layout[location] = labware_obj
+        if stacking:
+            self._deck_layout.resolve_stacking_labware(labware_obj, location)
+        else:
+            self._deck_layout[location] = labware_obj
         return labware_obj
 
     @requires_version(2, 0)
@@ -297,7 +301,8 @@ class ProtocolContext(CommandPublisher):
             location: types.DeckLocation,
             label: str = None,
             namespace: str = None,
-            version: int = None
+            version: int = None,
+            stacking: bool = False,
     ) -> Labware:
         """ Load a labware onto the deck given its name.
 
@@ -325,7 +330,11 @@ class ProtocolContext(CommandPublisher):
             load_name, namespace, version,
             bundled_defs=self._bundled_labware,
             extra_defs=self._extra_labware)
-        return self.load_labware_from_definition(labware_def, location, label)
+        return self.load_labware_from_definition(
+            labware_def,
+            location,
+            label,
+            stacking)
 
     @requires_version(2, 0)
     def load_labware_by_name(

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -243,6 +243,20 @@ class Deck(UserDict):
                     f'module {module_name} does not have a default'
                     ' location, you must specify a slot')
 
+    def resolve_stacking_labware(self, labware, location: types.DeckLocation):
+        slot_key_int = self._check_name(location)
+        item = self.data.get(slot_key_int)
+        print(f"Current item {item}")
+        if not item:
+            raise ValueError(f'There is no other labware in slot {location}',
+                             'please add a labware, then specify the labware',
+                             'to stack.')
+
+        labware.highest_z = labware.highest_z + item.highest_z
+        del self.data[slot_key_int]
+        self.data[slot_key_int] = labware
+        self.recalculate_high_z()
+
     @property
     def highest_z(self) -> float:
         """ Return the tallest known point on the deck. """

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -284,6 +284,7 @@ class Labware:
 
         self._pattern = re.compile(r'^([A-Z]+)([1-9][0-9]*)$', re.X)
         self._definition = definition
+        self._highest_z = self._dimensions['zDimension']
 
     def __getitem__(self, key: str) -> Well:
         return self.wells_by_name()[key]
@@ -545,7 +546,17 @@ class Labware:
         This is drawn from the 'dimensions'/'zDimension' elements of the
         labware definition and takes into account the calibration offset.
         """
-        return self._dimensions['zDimension'] + self._calibrated_offset.z
+        return self._highest_z + self._calibrated_offset.z
+
+    @highest_z.setter
+    def highest_z(self, new_height: float):
+        """
+        The z-coordinate of the tallest single point anywhere on the labware.
+
+        This is drawn from the 'dimensions'/'zDimension' elements of the
+        labware definition and takes into account the calibration offset.
+        """
+        self._highest_z = new_height
 
     @property  # type: ignore
     @requires_version(2, 0)

--- a/api/tests/opentrons/protocol_api/test_labware_load.py
+++ b/api/tests/opentrons/protocol_api/test_labware_load.py
@@ -13,6 +13,18 @@ def test_load_to_slot(loop):
     assert other._offset == types.Point(132.5, 0, 0)
 
 
+def test_stacking(loop):
+    ctx = papi.ProtocolContext(loop=loop)
+    with pytest.raises(ValueError):
+        ctx.load_labware(labware_name, '1', stacking=True)
+    older_labware = ctx.load_labware(labware_name, '1')
+    stacked_labware = ctx.load_labware(labware_name, '1', stacking=True)
+    assert stacked_labware.highest_z == older_labware.highest_z * 2
+    del ctx._deck_layout['12']
+    assert ctx._deck_layout.highest_z == stacked_labware.highest_z
+    assert ctx._deck_layout['1'] == stacked_labware
+
+
 def test_loaded(loop):
     ctx = papi.ProtocolContext(loop=loop)
     labware = ctx.load_labware(labware_name, '1')


### PR DESCRIPTION
## overview

As a result of the on-going backwards compatibility project, there is a need to be able to stack labware in API v2 to accommodate part of the `sharing` behavior in API v1. There will be a follow-up PR that allows for sharing the slot with different labwares.

## changelog
- Add `stacking` key to `load_labware` in contexts.py
- Add logic in geometry.py which will add up the height of all labwares in a given slot and only use the most recently 'stacked' labware.

## review requests
Test on robot, any other errors you think might be useful to raise?
