### PR TITLE
fix(api): tools: fix `write_pipette_memory` on host

### DIFF
--- a/api/src/opentrons/tools/__init__.py
+++ b/api/src/opentrons/tools/__init__.py
@@ -18,7 +18,7 @@ def connect_to_port(hardware):
 
 driver = opentrons.drivers.smoothie_drivers.SimulatingDriver()
 
-if opentrons.config.IS_ROBOT:
+try:
     if opentrons.config.feature_flags.use_protocol_api_v2():
         api = opentrons.hardware_control.API
         adapter = opentrons.hardware_control.adapters
@@ -29,3 +29,5 @@ if opentrons.config.IS_ROBOT:
         hardware = opentrons.robot
         connect_to_port(hardware)
         driver = hardware._driver
+except AttributeError:
+    hardware = None

--- a/api/src/opentrons/tools/write_pipette_memory.py
+++ b/api/src/opentrons/tools/write_pipette_memory.py
@@ -111,7 +111,7 @@ def _parse_model_from_barcode(barcode):
     raise Exception(BAD_BARCODE_MESSAGE.format(barcode))
 
 
-def main():
+def _do_wpm():
     try:
         barcode = _user_submitted_barcode(32)
         model = _parse_model_from_barcode(barcode)
@@ -122,6 +122,11 @@ def main():
         exit()
     except Exception as e:
         print('FAIL: {}'.format(e))
+
+
+def main():
+    while True:
+        _do_wpm()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The Shenzhen and hardware teams usually run the utils in api/src/opentrons/tools
from a laptop connected to a smoothie with a serial cable, and the changes to
have the tools.driver object work were gated behind config.IS_ROBOT. Now they
are not.