### PR TITLE
docs: Document pick_up_tip hardware procedure

### DIFF
--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -1128,8 +1128,8 @@ class API(HardwareAPILike):
         pick up operation is done at a current specified in the pipette config,
         which is experimentally determined to skip steps at a level of force
         sufficient to provide a good seal between the pipette nozzle and tip
-        while also avoiding attaching the tip so firmly that it can't be dropped
-        later.
+        while also avoiding attaching the tip so firmly that it can't be
+        dropped later.
 
         If ``presses`` or ``increment`` is not specified (or is ``None``),
         their value is taken from the pipette configuration.

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -1124,7 +1124,12 @@ class API(HardwareAPILike):
         This is achieved by attempting to move the instrument down by its
         `pick_up_distance`, in a series of presses. This distance is larger
         than the space available in the tip, so the stepper motor will
-        eventually skip steps, which is resolved by homing afterwards.
+        eventually skip steps, which is resolved by homing afterwards. The
+        pick up operation is done at a current specified in the pipette config,
+        which is experimentally determined to skip steps at a level of force
+        sufficient to provide a good seal between the pipette nozzle and tip
+        while also avoiding attaching the tip so firmly that it can't be dropped
+        later.
 
         If ``presses`` or ``increment`` is not specified (or is ``None``),
         their value is taken from the pipette configuration.

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -1121,7 +1121,7 @@ class API(HardwareAPILike):
         """
         Pick up tip from current location.
 
-        This is achieved by attempting to move the instrument down by its 
+        This is achieved by attempting to move the instrument down by its
         `pick_up_distance`, in a series of presses. This distance is larger
         than the space available in the tip, so the stepper motor will
         eventually skip steps, which is resolved by homing afterwards.

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -1120,10 +1120,10 @@ class API(HardwareAPILike):
                           increment: float = None):
         """
         Pick up tip from current location.
-        
+
         This is achieved by attempting to move the instrument down by its 
         `pick_up_distance`, in a series of presses. This distance is larger
-        than the space available in the tip, so the stepper motor will 
+        than the space available in the tip, so the stepper motor will
         eventually skip steps, which is resolved by homing afterwards.
 
         If ``presses`` or ``increment`` is not specified (or is ``None``),

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -1120,9 +1120,14 @@ class API(HardwareAPILike):
                           increment: float = None):
         """
         Pick up tip from current location.
+        
+        This is achieved by attempting to move the instrument down by its 
+        `pick_up_distance`, in a series of presses. This distance is larger
+        than the space available in the tip, so the stepper motor will 
+        eventually skip steps, which is resolved by homing afterwards.
 
         If ``presses`` or ``increment`` is not specified (or is ``None``),
-        their value is taken from the pipette configuration
+        their value is taken from the pipette configuration.
         """
         instr = self._attached_instruments[mount]
         assert instr


### PR DESCRIPTION
Expands docstring to explain how tip pick-up works in hardware terms.

Resolves #4433 (for now).