### PR TITLE
feat(protocol-designer): ignore labware<>module collision error in rogue mode

### DIFF
--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -6,8 +6,9 @@ import takeWhile from 'lodash/takeWhile'
 import uniqBy from 'lodash/uniqBy'
 import { getAllWellsForLabware } from '../../constants'
 import * as StepGeneration from '../../step-generation'
-import { selectors as stepFormSelectors } from '../../step-forms'
+import { selectors as featureFlagSelectors } from '../../feature-flags'
 import { selectors as labwareIngredSelectors } from '../../labware-ingred/selectors'
+import { selectors as stepFormSelectors } from '../../step-forms'
 import type { BaseState, Selector } from '../../types'
 import type { StepIdType } from '../../form-types'
 import type {
@@ -143,11 +144,16 @@ export const getRobotStateTimeline: Selector<StepGeneration.Timeline> = createSe
   stepFormSelectors.getOrderedStepIds,
   getInitialRobotState,
   getInvariantContext,
+  featureFlagSelectors.getFeatureFlagData,
   (
     allStepArgsAndErrors,
     orderedStepIds,
     initialRobotState,
-    invariantContext
+    invariantContext,
+    featureFlagMemoizationBust // HACK Ian 2019-11-12: this isn't used directly,
+    // it's only included to bust this selector's memoization. Required b/c step-generation's `getFeatureFlag` util
+    // must read directly from localStorage. Once getDisableModuleRestrictions aka "rogue mode"
+    // is removed, we can remove this arg to this selector.
   ) => {
     const allStepArgs: Array<StepGeneration.CommandCreatorArgs | null> = orderedStepIds.map(
       stepId => {

--- a/protocol-designer/src/step-generation/utils.js
+++ b/protocol-designer/src/step-generation/utils.js
@@ -397,12 +397,42 @@ export function makeInitialRobotState(args: {|
   }
 }
 
+// HACK Ian 2019-11-12: this is a temporary solution to pass PD runtime feature flags
+// down into step-generation, which is meant to be relatively independent of PD.
+// WARNING: Unless you're careful to bust any caches (eg of selectors that use step-generation),
+// there could be delayed-sync issues when toggling a flag with this solution, because
+// we're directly accessing localStorage without an ability to.
+// A long-term solution might be to either restart PD upon setting flags that are used here,
+// or pass flags as "config options" into step-generation via a factory that stands in front of all step-generation imports,
+// or just avoid this complexity for non-experimental features.
+const getFeatureFlag = (flagName: string): boolean => {
+  if (!global.localStorage) {
+    let value = false
+    try {
+      value = process.env[flagName] === 'true'
+    } catch (e) {
+      console.error(
+        `appear to be in node environment, but cannot access ${flagName} in process.env. ${e}`
+      )
+    }
+    return value
+  }
+  const allFlags = JSON.parse(
+    global.localStorage.getItem('root.featureFlags.flags') || '{}'
+  )
+  return (allFlags && allFlags[flagName]) || false
+}
+
 export const modulePipetteCollision = (args: {|
   pipette: ?string,
   labware: ?string,
   invariantContext: InvariantContext,
   prevRobotState: RobotState,
 |}): boolean => {
+  if (getFeatureFlag('OT_PD_DISABLE_MODULE_RESTRICTIONS')) {
+    // always ignore collision hazard
+    return false
+  }
   const { pipette, labware, invariantContext, prevRobotState } = args
   const pipetteEntity: ?* = pipette && invariantContext.pipetteEntities[pipette]
   const labwareSlot: ?* = labware && prevRobotState.labware[labware]?.slot


### PR DESCRIPTION
## overview

Closes #4130

Morgan thought it would give users a false sense of security if we show collision errors for slot 1<>4 and 3<>6 situations but not everything. This PR hides the new error if you have module restrictions disabled.

This implementation is hacky but by definition it's only for experimental settings.

## changelog


## review requests

- [ ] When the "Pipette cannot access labware" error is showing, toggling "Disable module placement restrictions" will toggle the existence of the error