### PR TITLE
feat(api): apiv2: v1-backcompat: implement modules

### DIFF
--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -21,6 +21,10 @@ class SimulatingDriver:
         self._target_temp = celsius
         self._active = True
 
+    def legacy_set_temperature(self, celsius):
+        self._target_temp = celsius
+        self._active = True
+
     def deactivate(self):
         self._target_temp = 0
         self._active = False

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1974,6 +1974,20 @@ class ModuleContext(CommandPublisher):
         return self.load_labware_object(lw)
 
     @requires_version(2, 0)
+    def load_labware_from_definition(
+            self, definition: Dict[str, Any]) -> Labware:
+        """
+        Specify the presence of a labware on the module, using an
+        inline definition.
+
+        :param definition: The labware definition.
+        :returns: The initialized and loaded labware object.
+        """
+        lw = load_from_definition(
+            definition, self._geometry.location)
+        return self.load_labware_object(lw)
+
+    @requires_version(2, 0)
     def load_labware_by_name(self, name: str) -> Labware:
         MODULE_LOG.warning(
             'load_labware_by_name is deprecated and will be removed in '

--- a/api/src/opentrons/protocol_api/legacy_wrapper/api.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/api.py
@@ -15,6 +15,7 @@ from opentrons.types import Mount
 from .containers_wrapper import Containers, perform_migration, LegacyLabware
 from .robot_wrapper import Robot
 from .instrument_wrapper import Pipette
+from . import modules_wrapper
 
 if TYPE_CHECKING:
     from ..contexts import ProtocolContext
@@ -138,8 +139,8 @@ class BCModules:
     def __init__(self, ctx: 'ProtocolContext') -> None:
         self._ctx = ctx
 
-    def load(self, *args, **wargs):
-        pass
+    def load(self, name: str, slot: str):
+        return modules_wrapper.load(self._ctx, name, slot)
 
 
 def build_globals(context: 'ProtocolContext'):

--- a/api/tests/opentrons/protocol_api/test_legacy_labware.py
+++ b/api/tests/opentrons/protocol_api/test_legacy_labware.py
@@ -109,7 +109,7 @@ def test_load_func(labware, container_create):
         labware.load('96-flat', slot=1, label='plate 1')
         labware.load('96-flat', slot=1, label='plate 2')
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(RuntimeError):
         labware.load('tempdeck', slot=3)
 
     lw1 = labware.load('3x8-chip', slot=2)
@@ -262,3 +262,14 @@ def test_legacy_wells(minimal_labware):
         Point(well_def['x'], well_def['y'], well_def['depth']/2)
     assert well.bottom().point ==\
         Point(well_def['x'], well_def['y'], 0)
+
+
+@pytest.mark.api2_only
+def test_load_labware_on_module(labware, modules):
+    td = modules.load('tempdeck', 1)
+    plate = labware.load('96-flat', 1, share=True)
+    assert td._ctx.labware is plate.lw_obj
+
+    md = modules.load('magdeck', 2)
+    plate2 = labware.load('96-flat', 2, share=True)
+    assert md._ctx.labware is plate2.lw_obj

--- a/api/tests/opentrons/protocol_api/test_legacy_modules.py
+++ b/api/tests/opentrons/protocol_api/test_legacy_modules.py
@@ -1,0 +1,76 @@
+from unittest import mock
+import threading
+import time
+
+import pytest
+
+from opentrons.protocol_api.contexts import (MagneticModuleContext,
+                                             TemperatureModuleContext)
+from opentrons.protocol_api.legacy_wrapper.modules_wrapper import (
+    TempDeckV1, MagDeckV1)
+
+
+@pytest.mark.parametrize(
+    'which_module,new_mod,old_mod',
+    [('tempdeck', TemperatureModuleContext, TempDeckV1),
+     ('magdeck', MagneticModuleContext, MagDeckV1)])
+@pytest.mark.api2_only
+def test_load_module(modules, which_module, new_mod, old_mod):
+    mod = modules.load(which_module, '1')
+    assert isinstance(mod, old_mod)
+    assert isinstance(mod._ctx, new_mod)
+
+
+@pytest.mark.api2_only
+def test_tempdeck_settemp_returns_immediately(modules, monkeypatch):
+    mod = modules.load('tempdeck', '1')
+
+    def _raise(c):
+        raise RuntimeError('wrong one!')
+
+    monkeypatch.setattr(mod._ctx._module._driver, 'set_temperature',
+                        _raise)
+    lst_mock = mock.Mock()
+    monkeypatch.setattr(
+        mod._ctx._module._driver, 'legacy_set_temperature', lst_mock)
+    assert mod.target is None
+    mod.set_temperature(50)
+    lst_mock.assert_called_once_with(50)
+
+
+@pytest.mark.api2_only
+def test_tempdeck_attributes(modules):
+    mod = modules.load('tempdeck', '1')
+    assert mod.temperature == 0
+    assert mod.target is None
+    assert mod.status == 'idle'
+    mod.set_temperature(50)
+    assert mod.temperature == 50
+    assert mod.target == 50
+    assert mod.status == 'holding at target'
+
+
+@pytest.mark.api2_only
+def test_tempdeck_wait(modules, monkeypatch):
+    mod = modules.load('tempdeck', '1')
+
+    monkeypatch.setattr(
+        mod._ctx._module._driver, '_active', False)
+    assert mod.status == 'idle'
+    th = threading.Thread(target=lambda: mod.wait_for_temp())
+    th.start()
+    assert th.is_alive()
+    monkeypatch.setattr(
+        mod._ctx._module._driver, '_active', True)
+    time.sleep(0.25)
+    th.join()
+
+
+@pytest.mark.api2_only
+def test_magdeck(modules):
+    md = modules.load('magdeck', '1')
+    assert md.status == 'disengaged'
+    md.engage(height=10)
+    assert md.status == 'engaged'
+    md.disengage()
+    assert md.status == 'disengaged'


### PR DESCRIPTION
Implement backcompat shims for modules. This includes the special case of
loading labware with share=true for loading labware onto modules. Most
functionality is a straight passthrough to the underlying module context, but
some things have special implementations (mostly due to the previous change of
having tempdeck.set_temp also wait until the temperature is reached in v2).

Closes #3655
