### PR TITLE
feat(protocol-designer): add warning when using expt features

### DIFF
--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -54,7 +54,7 @@ class FilePage extends React.Component<Props, State> {
     },
   }
 
-  // TODO (ka 2019-10-28): This is a workaround,
+  // TODO (ka 2019-10-28): This is a workaround, see #4446
   // but it solves the modal positioning problem caused by main page wrapper
   // being positioned absolute until we can figure out something better
   scrollToTop = () => {

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -88,5 +88,10 @@
     "failed_verification": "Something Went Wrong",
     "sign_up_success": "Please confirm your email address to continue",
     "check_email": "We've sent a confirmation URL to your email that will take you to the Protocol Designer. Keep an eye out for a follow up email which contains links to resources such as our help documents."
+  },
+  "experimental_feature_warning": {
+    "title": "Switching on an experimental feature",
+    "body1": "Warning: At this time Opentrons does not provide support for protocols with experimental settings turned on.",
+    "body2": "We encourage you to report any bugs you find, however note that at this time we are unable to prioritize fixes as they are a result of experimental features. "
   }
 }


### PR DESCRIPTION
## overview

Closes #4129

Credit to @shlokamin for being a code pairing partner! 💻 

## changelog

- add experimental settings warning modal

## review requests

For both user-exposed Experimental Settings and for preproduction settings...
- [ ] Toggling any setting should trigger the modal as described in #4129
- [ ] Clicking "cancel" should close the modal and have no other effect
- [ ] Clicking "continue" should close the modal and toggle the setting that was clicked

- You should be blocked by this modal both when you're toggling ON and when you're toggling OFF a setting (ie, on/off direction doesn't matter).

- Displaying the modal should scroll to the top of the window and lock the scrollbar. This is existing PD funky modal behavior, newly ticketed as #4446 