### PR TITLE
refactor(api): Add sharing and stacking for backcompat

### DIFF
--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -118,6 +118,7 @@ def _run_python(
 def _run_python_legacy(proto: PythonProtocol, context: ProtocolContext):
     new_locs = locals()
     new_globs = globals()
+    context._api_version = APIVersion(2, 0)
     namespace_mapping = legacy_wrapper.api.build_globals(context)
     for key, value in namespace_mapping.items():
         setattr(opentrons, key, value)

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -1,5 +1,6 @@
-from collections import UserDict
+from collections import UserDict, UserList
 import functools
+import abc
 import logging
 import pkgutil
 import json
@@ -117,7 +118,15 @@ def plan_moves(
             (to_point, dest_cp_override)]
 
 
-DeckItem = Union[Labware, ModuleGeometry, ThermocyclerGeometry]
+# DeckItem = Union[Labware, ModuleGeometry, ThermocyclerGeometry]
+
+class DeckItem(abc.ABC):
+
+    @property
+    @abc.abstractmethod
+    def highest_z(self):
+        pass
+
 
 
 class Deck(UserDict):

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -8,7 +8,6 @@ from typing import Any, List, Optional, Tuple, Dict
 from opentrons import types
 from .labware import (Labware, Well,
                       quirks_from_any_parent, ThermocyclerGeometry, DeckItem)
-# from .util import DeckItem
 from opentrons.hardware_control.types import CriticalPoint
 
 
@@ -118,7 +117,6 @@ def plan_moves(
             (to_point, dest_cp_override)]
 
 
-# DeckItem = Union[Labware, ModuleGeometry, ThermocyclerGeometry]
 class Deck(UserDict):
     def __init__(self):
         super().__init__()

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -1,14 +1,14 @@
-from collections import UserDict, UserList
+from collections import UserDict
 import functools
-import abc
 import logging
 import pkgutil
 import json
-from typing import Any, List, Optional, Tuple, Union, Dict
+from typing import Any, List, Optional, Tuple, Dict
 
 from opentrons import types
-from .labware import (Labware, Well, ModuleGeometry,
-                      quirks_from_any_parent, ThermocyclerGeometry)
+from .labware import (Labware, Well,
+                      quirks_from_any_parent, ThermocyclerGeometry, DeckItem)
+# from .util import DeckItem
 from opentrons.hardware_control.types import CriticalPoint
 
 
@@ -119,16 +119,6 @@ def plan_moves(
 
 
 # DeckItem = Union[Labware, ModuleGeometry, ThermocyclerGeometry]
-
-class DeckItem(abc.ABC):
-
-    @property
-    @abc.abstractmethod
-    def highest_z(self):
-        pass
-
-
-
 class Deck(UserDict):
     def __init__(self):
         super().__init__()

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -318,6 +318,7 @@ class Labware:
 
         self._pattern = re.compile(r'^([A-Z]+)([1-9][0-9]*)$', re.X)
         self._definition = definition
+        self._highest_z = self._dimensions['zDimension']
 
     @property  # type: ignore
     @requires_version(2, 0)
@@ -585,7 +586,16 @@ class Labware:
         This is drawn from the 'dimensions'/'zDimension' elements of the
         labware definition and takes into account the calibration offset.
         """
-        return self._dimensions['zDimension'] + self._calibrated_offset.z
+        return self._highest_z + self._calibrated_offset.z
+
+    @highest_z.setter
+    def highest_z(self, new_height: float):
+        """
+        The z-coordinate of the tallest single point anywhere on the labware.
+        This is drawn from the 'dimensions'/'zDimension' elements of the
+        labware definition and takes into account the calibration offset.
+        """
+        self._highest_z = new_height
 
     @property
     def _is_tiprack(self) -> bool:

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -15,6 +15,7 @@ import os
 import pkgutil
 import shutil
 import sys
+import abc
 from pathlib import Path
 from collections import defaultdict
 from enum import Enum, auto
@@ -57,6 +58,19 @@ well_shapes = {
     'rectangular': WellShape.RECTANGULAR,
     'circular': WellShape.CIRCULAR
 }
+
+
+class DeckItem(abc.ABC):
+
+    @property  # type: ignore
+    @abc.abstractmethod
+    def highest_z(self):
+        pass
+
+    @highest_z.setter  # type: ignore
+    @abc.abstractmethod
+    def highest_z(self, new_z: float):
+        pass
 
 
 class Well:
@@ -235,7 +249,6 @@ class Well:
         return hash(self.top().point)
 
 
-@requires_version(2, 0)
 class Labware(DeckItem):
     """
     This class represents a labware, such as a PCR plate, a tube rack, trough,
@@ -297,8 +310,10 @@ class Labware(DeckItem):
         self._api_version = api_level
         if label:
             dn = label
+            self._name = dn
         else:
             dn = definition['metadata']['displayName']
+            self._name = definition['parameters']['loadName']
         self._display_name = "{} on {}".format(dn, str(parent.labware))
         self._calibrated_offset: Point = Point(0, 0, 0)
         self._wells: List[Well] = []
@@ -349,7 +364,12 @@ class Labware(DeckItem):
     @requires_version(2, 0)
     def name(self) -> str:
         """ The canonical name of the labware, which is used to load it """
-        return self._definition['parameters']['loadName']
+        return self._name
+
+    @name.setter  # type: ignore
+    def name(self, new_name):
+        """ The canonical name of the labware, which is used to load it """
+        self._name = new_name
 
     @property  # type: ignore
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -235,7 +235,8 @@ class Well:
         return hash(self.top().point)
 
 
-class Labware:
+@requires_version(2, 0)
+class Labware(DeckItem):
     """
     This class represents a labware, such as a PCR plate, a tube rack, trough,
     tip rack, etc. It defines the physical geometry of the labware, and
@@ -776,7 +777,7 @@ class Labware:
                 well.has_tip = True
 
 
-class ModuleGeometry:
+class ModuleGeometry(DeckItem):
     """
     This class represents an active peripheral, such as an Opentrons Magnetic
     Module, Temperature Module or Thermocycler Module. It defines the physical

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -363,12 +363,13 @@ class Labware(DeckItem):
     @property  # type: ignore
     @requires_version(2, 0)
     def name(self) -> str:
-        """ The canonical name of the labware, which is used to load it """
+        """ Can either be the canonical name of the labware, which is used to
+        load it, or the label of the labware specified by a user. """
         return self._name
 
     @name.setter  # type: ignore
     def name(self, new_name):
-        """ The canonical name of the labware, which is used to load it """
+        """ Set the labware name"""
         self._name = new_name
 
     @property  # type: ignore

--- a/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
@@ -931,7 +931,6 @@ class Containers:
                 f'Slot {slot} has child. Use "containers.load(\''
                 f'{container_name}\', \'{slot}\', share=True)"')
         elif container_name in MODULE_BLACKLIST:
-<<<<<<< HEAD
             raise RuntimeError(
                 "load modules using modules.load()")
         defn = self._get_labware_def_with_fallback(container_name)
@@ -949,14 +948,6 @@ class Containers:
 
     def _get_labware_def_with_fallback(
             self, container_name: str) -> Dict[str, Any]:
-=======
-            raise NotImplementedError(
-                "Module load not yet implemented")
-        # if self._sharing[str(slot)] and not share:
-        #     raise ValueError(f'Cannot place')
-        if share:
-            return self._determine_share_logic(container_name, slot, label)
->>>>>>> Add stacking support
         try:
             return get_labware_definition(container_name)
         except FileNotFoundError:

--- a/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
@@ -879,6 +879,35 @@ class Containers:
 
     def __init__(self, ctx: 'ProtocolContext') -> None:
         self._ctx = ctx
+        self._sharing = {}
+
+    def _determine_share_logic(self, labware_name, location, label):
+        slot_key_int = self._ctx._deck_layout._check_name(location)
+        item = self._ctx._deck_layout.get(slot_key_int)
+        if not item:
+            raise ValueError(f'There is no other labware in slot {location}',
+                             'please add a labware, then specify share=True')
+        parent = self.deck.position_for(location)
+        labware_definition = get_labware_definition(labware_name)
+        labware_object = load_from_definition(labware_definition, parent, label)
+        _size_of_slot(labware_object)
+        return labware_object
+
+    def _share_slot(self, labware_object):
+
+        return None
+
+    def _stack_labware(self, labware_object):
+
+
+        labware.highest_z = labware.highest_z + item.highest_z
+        del self._ctx._deck_layout[slot_key_int]
+        return LegacyLabware(
+            self._ctx.load_labware(container_name, slot, label, legacy=True))
+
+
+    def _size_of_slot():
+        return None
 
     @log_call(log)
     def load(
@@ -902,6 +931,7 @@ class Containers:
                 f'Slot {slot} has child. Use "containers.load(\''
                 f'{container_name}\', \'{slot}\', share=True)"')
         elif container_name in MODULE_BLACKLIST:
+<<<<<<< HEAD
             raise RuntimeError(
                 "load modules using modules.load()")
         defn = self._get_labware_def_with_fallback(container_name)
@@ -919,6 +949,14 @@ class Containers:
 
     def _get_labware_def_with_fallback(
             self, container_name: str) -> Dict[str, Any]:
+=======
+            raise NotImplementedError(
+                "Module load not yet implemented")
+        # if self._sharing[str(slot)] and not share:
+        #     raise ValueError(f'Cannot place')
+        if share:
+            return self._determine_share_logic(container_name, slot, label)
+>>>>>>> Add stacking support
         try:
             return get_labware_definition(container_name)
         except FileNotFoundError:

--- a/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
@@ -13,7 +13,6 @@ from ..labware import (
     ModuleGeometry,
     LabwareDefinition,
     DeckItem)
-# from ..util import DeckItem
 from .util import log_call
 from .types import LegacyLocation
 from typing import Dict, List, Any, Union, Optional, TYPE_CHECKING
@@ -937,20 +936,7 @@ class Containers:
             new_labware: Labware, old_labware: LegacyDeckItem):
 
         leg_deck_item = self._size_of_slot(old_labware)
-        # leg_deck_item.add_item(old_labware)
         leg_deck_item.add_item(new_labware)
-
-    # def _share_slot(self, labware_object):
-    #
-    #     return None
-    #
-    # def _stack_labware(self, labware_object):
-    #
-    #
-    #     labware.highest_z = labware.highest_z + item.highest_z
-    #     del self._ctx._deck_layout[slot_key_int]
-    #     return LegacyLabware(
-    #         self._ctx.load_labware(container_name, slot, label, legacy=True))
 
     def _size_of_slot(
             self,

--- a/api/tests/opentrons/protocol_api/test_accessor_fn.py
+++ b/api/tests/opentrons/protocol_api/test_accessor_fn.py
@@ -12,6 +12,7 @@ minimalLabwareDef = {
     },
     "parameters": {
         "isTiprack": False,
+        "loadName": "minimal_labware_def"
     },
     "ordering": [["A1"], ["A2"]],
     "wells": {
@@ -52,6 +53,7 @@ minimalLabwareDef2 = {
     },
     "parameters": {
         "isTiprack": False,
+        "loadName": "minimal_labware_def"
     },
     "ordering": [["A1", "B1", "C1"], ["A2", "B2", "C2"]],
     "wells": {

--- a/api/tests/opentrons/protocol_api/test_legacy_labware.py
+++ b/api/tests/opentrons/protocol_api/test_legacy_labware.py
@@ -103,17 +103,33 @@ def container_create(monkeypatch, config_tempdir):
     shutil.rmtree(CONFIG['labware_user_definitions_dir_v2']/'legacy_api')
     CONFIG['labware_database_file'] = tempdb
 
-# @pytest.mark.api2_only
-# def test_stacking(loop):
-#     ctx = papi.ProtocolContext(loop=loop)
-#     with pytest.raises(ValueError):
-#         ctx.load_labware(labware_name, '1', stacking=True)
-#     older_labware = ctx.load_labware(labware_name, '1')
-#     stacked_labware = ctx.load_labware(labware_name, '1', stacking=True)
-#     assert stacked_labware.highest_z == older_labware.highest_z * 2
-#     del ctx._deck_layout['12']
-#     assert ctx._deck_layout.highest_z == stacked_labware.highest_z
-#     assert ctx._deck_layout['1'] == stacked_labware
+@pytest.mark.api2_only
+def test_stacking(labware):
+    labware_name = 'corning_96_wellplate_360ul_flat'
+    with pytest.raises(ValueError):
+        labware.load(labware_name, '1', share=True)
+    older_labware = labware.load(labware_name, '1')
+    stacked_labware = labware.load(labware_name, '1', share=True)
+    assert stacked_labware.highest_z == older_labware.highest_z * 2
+    del labware._ctx._deck_layout['12']
+    assert labware._ctx._deck_layout.highest_z == stacked_labware.highest_z
+    assert labware._ctx._deck_layout['1'] == stacked_labware
+
+
+@pytest.mark.api2_only
+def test_sharing(labware, container_create):
+    labware_name = '3x8-chip'
+    older_labware = labware.load(labware_name, '1')
+    stacked_labware_1 = labware.load(labware_name, '1', share=True)
+    stacked_labware_2 = labware.load(labware_name, '1', share=True)
+    stacked_labware_3 = labware.load(labware_name, '1', share=True)
+    assert older_labware.parent == slot
+    assert stacked_labware_1.parent == slot
+    assert stacked_labware_2.parent == slot
+    assert stacked_labware_3.parent == slot
+    del labware._ctx._deck_layout['12']
+    # sharing a slot shouldn't combine labwares
+    assert labware._ctx._deck_layout.highest_z == older_labware.highest_z
 
 
 @pytest.mark.api2_only

--- a/api/tests/opentrons/protocol_api/test_legacy_labware.py
+++ b/api/tests/opentrons/protocol_api/test_legacy_labware.py
@@ -103,6 +103,18 @@ def container_create(monkeypatch, config_tempdir):
     shutil.rmtree(CONFIG['labware_user_definitions_dir_v2']/'legacy_api')
     CONFIG['labware_database_file'] = tempdb
 
+# @pytest.mark.api2_only
+# def test_stacking(loop):
+#     ctx = papi.ProtocolContext(loop=loop)
+#     with pytest.raises(ValueError):
+#         ctx.load_labware(labware_name, '1', stacking=True)
+#     older_labware = ctx.load_labware(labware_name, '1')
+#     stacked_labware = ctx.load_labware(labware_name, '1', stacking=True)
+#     assert stacked_labware.highest_z == older_labware.highest_z * 2
+#     del ctx._deck_layout['12']
+#     assert ctx._deck_layout.highest_z == stacked_labware.highest_z
+#     assert ctx._deck_layout['1'] == stacked_labware
+
 
 @pytest.mark.api2_only
 def test_load_func(labware, container_create):

--- a/api/tests/opentrons/protocol_api/test_offsets.py
+++ b/api/tests/opentrons/protocol_api/test_offsets.py
@@ -22,7 +22,8 @@ minimalLabwareDef = {
     "parameters": {
         "isTiprack": True,
         "tipLength": 55.3,
-        "tipOverlap": 2.8
+        "tipOverlap": 2.8,
+        "loadName": "minimal_labware_def"
     },
     "ordering": [["A1"], ["A2"]],
     "wells": {


### PR DESCRIPTION
## overview

The keyword for `sharing` in API v1 could either be used for stacking or sharing scenarios. This PR attempts to cover both use-cases when loading api v1 definitions for 

## changelog

- Add DeckItem abstract base class
- Add LegacyDeckItem which adds some functionality around determining slot height based off of whether a labware is stacking, sharing or other
- Use LegacyDeckItem whenever you aren't adding a module to the deck
~- Determine whether stacking or sharing based off of the size of the initially added labware.~

## review requests

Logic seem OK? More tests to add? Anything else?