### PR TITLE
fix(api): connect context to real thermocycler during calibration

### DIFF
--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -247,8 +247,8 @@ class ProtocolContext(CommandPublisher):
                 if isinstance(mod_ctx, ThermocyclerContext):
                     tc_context = mod_ctx
                     hw_tc = next(hw_mod for hw_mod in
-                                hardware.attached_modules.values()
-                                if hw_mod.name() == 'thermocycler')
+                                 hardware.attached_modules.values()
+                                 if hw_mod.name() == 'thermocycler')
                     if hw_tc:
                         old_tc = mod_ctx._module
                         mod_ctx._module = hw_tc

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -239,11 +239,24 @@ class ProtocolContext(CommandPublisher):
 
         """
         old_hw = self._hw_manager.hardware
+        old_tc = None
+        tc_context = None
         try:
             self._hw_manager.set_hw(hardware)
+            for mod_ctx in self._modules:
+                if isinstance(mod_ctx, ThermocyclerContext):
+                    tc_context = mod_ctx
+                    hw_tc = next(hw_mod for hw_mod in
+                                hardware.attached_modules.values()
+                                if hw_mod.name() == 'thermocycler')
+                    if hw_tc:
+                        old_tc = mod_ctx._module
+                        mod_ctx._module = hw_tc
             yield self
         finally:
             self._hw_manager.set_hw(old_hw)
+            if tc_context is not None and old_tc is not None:
+                tc_context._module = old_tc
 
     @requires_version(2, 0)
     def connect(self, hardware: hc.API):


### PR DESCRIPTION
The calibration session currently picks up the simulated context from the beginning of the session.
This means that the simulated modules are also usedduring labware calibration. This temporarily
connect the thermocycler during calibration so the session is aware of the lid's open/close state.
This is a short term patch that will be removed in place of better session management to replace the
current RPC over HTTP session communication.


## review requests

Please ensure that you are able to proceed to calibrating the labware loaded onto the Thermocycler in these 2 cases (via the run app):

- Your last protocol step is a call to  `thermocycler.open_lid()`
- Your last protocol step is a call to  `thermocycler.close_lid()`

stub protocol:
```

metadata = {"apiLevel": "2.0"}


def run(protocol):
    # Labware Setup
    reagents = protocol.load_labware('usascientific_12_reservoir_22ml', '1')
    p300rack = protocol.load_labware('opentrons_96_tiprack_300ul', '2')

    p300 = protocol.load_instrument(
        'p20_single_gen2', 'right', tip_racks=[p300rack])
    thermocycler = protocol.load_module('thermocycler')

    reaction_plate = thermocycler.load_labware('biorad_96_wellplate_200ul_pcr')

    thermocycler.set_block_temperature(4)
    p300.pick_up_tip()
    p300.aspirate(10, reagents.wells_by_name()['A1'])
    p300.dispense(10, reaction_plate.wells_by_name()['A1'])
    thermocycler.set_lid_temperature(50)
    thermocycler.deactivate_lid()
    thermocycler.set_lid_temperature(90)

    thermocycler.set_block_temperature(40, hold_time_seconds=10)
    thermocycler.deactivate_block()
    thermocycler.set_block_temperature(80, hold_time_minutes=0.5)
    thermocycler.deactivate()
    thermocycler.set_block_temperature(
        60, hold_time_seconds=30, hold_time_minutes=0.5)
    thermocycler.set_lid_temperature(30)

    thermocycler.close_lid()
    #thermocycler.open_lid()
```