### PR TITLE
feat(protocol-designer): Add magnet step UI

### DIFF
--- a/components/src/__tests__/__snapshots__/icons.test.js.snap
+++ b/components/src/__tests__/__snapshots__/icons.test.js.snap
@@ -676,6 +676,21 @@ exports[`icons ot-logo renders correctly 1`] = `
 </svg>
 `;
 
+exports[`icons ot-magnet renders correctly 1`] = `
+<svg
+  aria-hidden="true"
+  className="foo"
+  fill="currentColor"
+  version="1.1"
+  viewBox="0 0 24 24"
+>
+  <path
+    d="M17 3h-6c-5 0-9 4-9 9s4 9 9 9h6v-4h-6c-2.8 0-5-2.2-5-5s2.2-5 5-5h6m2 10v4h3v-4M19 3v4h3V3"
+    fillRule="evenodd"
+  />
+</svg>
+`;
+
 exports[`icons ot-mix renders correctly 1`] = `
 <svg
   aria-hidden="true"
@@ -716,6 +731,36 @@ exports[`icons ot-spinner renders correctly 1`] = `
 >
   <path
     d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z"
+    fillRule="evenodd"
+  />
+</svg>
+`;
+
+exports[`icons ot-temperature renders correctly 1`] = `
+<svg
+  aria-hidden="true"
+  className="foo"
+  fill="currentColor"
+  version="1.1"
+  viewBox="0 0 24 24"
+>
+  <path
+    d="M15 13V5a3 3 0 00-6 0v8a5 5 0 106 0m-3-9a1 1 0 011 1v3h-2V5a1 1 0 011-1z"
+    fillRule="evenodd"
+  />
+</svg>
+`;
+
+exports[`icons ot-thermocycler renders correctly 1`] = `
+<svg
+  aria-hidden="true"
+  className="foo"
+  fill="currentColor"
+  version="1.1"
+  viewBox="0 0 24 24"
+>
+  <path
+    d="M12 6v3l4-4-4-4v3a8 8 0 00-8 8c0 1.57.46 3.03 1.24 4.26L6.7 14.8A5.9 5.9 0 016 12a6 6 0 016-6m6.76 1.74L17.3 9.2c.44.84.7 1.8.7 2.8a6 6 0 01-6 6v-3l-4 4 4 4v-3a8 8 0 008-8c0-1.57-.46-3.03-1.24-4.26z"
     fillRule="evenodd"
   />
 </svg>

--- a/components/src/icons/icon-data.js
+++ b/components/src/icons/icon-data.js
@@ -333,6 +333,21 @@ const ICON_DATA_BY_NAME = {
     path:
       'M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z',
   },
+  'ot-magnet': {
+    viewBox: '0 0 24 24',
+    path:
+      'M17 3h-6c-5 0-9 4-9 9s4 9 9 9h6v-4h-6c-2.8 0-5-2.2-5-5s2.2-5 5-5h6m2 10v4h3v-4M19 3v4h3V3',
+  },
+  'ot-temperature': {
+    viewBox: '0 0 24 24',
+    path:
+      'M15 13V5a3 3 0 00-6 0v8a5 5 0 106 0m-3-9a1 1 0 011 1v3h-2V5a1 1 0 011-1z',
+  },
+  'ot-thermocycler': {
+    viewBox: '0 0 24 24',
+    path:
+      'M12 6v3l4-4-4-4v3a8 8 0 00-8 8c0 1.57.46 3.03 1.24 4.26L6.7 14.8A5.9 5.9 0 016 12a6 6 0 016-6m6.76 1.74L17.3 9.2c.44.84.7 1.8.7 2.8a6 6 0 01-6 6v-3l-4 4 4 4v-3a8 8 0 008-8c0-1.57-.46-3.03-1.24-4.26z',
+  },
 }
 
 export type IconName = $Keys<typeof ICON_DATA_BY_NAME>

--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -208,3 +208,7 @@
   display: flex;
   justify-content: space-between;
 }
+
+.magnet_form_group {
+  margin: 1rem 4.25rem 2rem 0;
+}

--- a/protocol-designer/src/components/StepEditForm/forms/MagnetForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MagnetForm.js
@@ -1,0 +1,89 @@
+// @flow
+import * as React from 'react'
+import { FormGroup, DropdownField } from '@opentrons/components'
+import i18n from '../../../localization'
+
+import StepField from '../fields/FieldConnector'
+import { ConditionalOnField, TextField } from '../fields'
+import styles from '../StepEditForm.css'
+
+import type { FocusHandlers } from '../types'
+
+type MagnetFormProps = { focusHandlers: FocusHandlers }
+function MagnetForm(props: MagnetFormProps): React.Element<'div'> {
+  const { focusHandlers } = props
+
+  return (
+    <div className={styles.form_wrapper}>
+      <div className={styles.section_header}>
+        <span className={styles.section_header_text}>
+          {i18n.t('application.stepType.magnet')}
+        </span>
+      </div>
+
+      <div className={styles.section_wrapper}>
+        <div className={styles.wrap_group}>
+          <div className={styles.section_column}>
+            <FormGroup
+              label={i18n.t('form.step_edit_form.field.magnetAction.label')}
+              className={styles.magnet_form_group}
+            >
+              <StepField
+                dirtyFields={focusHandlers.dirtyFields}
+                focusedField={focusHandlers.focusedField}
+                name="magnetAction"
+                render={({ value, updateValue, errorToShow }) => {
+                  const fieldValue = String(value) || null
+                  return (
+                    <DropdownField
+                      name="magnetAction"
+                      className={styles.large_field}
+                      onChange={(e: SyntheticEvent<HTMLSelectElement>) => {
+                        updateValue(e.currentTarget.value)
+                      }}
+                      value={fieldValue}
+                      options={[
+                        {
+                          name: i18n.t(
+                            'form.step_edit_form.field.magnetAction.options.engage'
+                          ),
+                          value: 'engage',
+                        },
+                        {
+                          name: i18n.t(
+                            'form.step_edit_form.field.magnetAction.options.disengage'
+                          ),
+                          value: 'disengage',
+                        },
+                      ]}
+                    />
+                  )
+                }}
+              />
+            </FormGroup>
+          </div>
+          <div className={styles.section_column}>
+            <ConditionalOnField
+              name={'magnetAction'}
+              condition={val => val === 'engage'}
+            >
+              <FormGroup
+                label={i18n.t('form.step_edit_form.field.engageHeight.label')}
+                className={styles.magnet_form_group}
+              >
+                <TextField
+                  name="engageHeight"
+                  className={styles.small_field}
+                  units={i18n.t('application.units.millimeter')}
+                  {...focusHandlers}
+                />
+              </FormGroup>
+            </ConditionalOnField>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default MagnetForm

--- a/protocol-designer/src/components/StepEditForm/forms/index.js
+++ b/protocol-designer/src/components/StepEditForm/forms/index.js
@@ -3,3 +3,4 @@
 export { default as MoveLiquidForm } from './MoveLiquid'
 export { default as MixForm } from './Mix'
 export { default as PauseForm } from './Pause'
+export { default as MagnetForm } from './MagnetForm'

--- a/protocol-designer/src/components/StepEditForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/index.js
@@ -21,7 +21,7 @@ import MoreOptionsModal from '../modals/MoreOptionsModal'
 import ConfirmDeleteStepModal from '../modals/ConfirmDeleteStepModal'
 import styles from './StepEditForm.css'
 
-import { MixForm, MoveLiquidForm, PauseForm } from './forms'
+import { MixForm, MoveLiquidForm, PauseForm, MagnetForm } from './forms'
 import FormAlerts from './FormAlerts'
 import ButtonRow from './ButtonRow'
 
@@ -29,6 +29,7 @@ const STEP_FORM_MAP: { [StepType]: * } = {
   mix: MixForm,
   pause: PauseForm,
   moveLiquid: MoveLiquidForm,
+  magnet: MagnetForm,
 }
 
 type SP = {|

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -73,6 +73,9 @@ export const stepIconsByType: { [string]: IconName } = {
   mix: 'ot-mix',
   pause: 'pause',
   manualIntervention: 'pause', // TODO Ian 2018-12-13 pause icon for this is a placeholder
+  magnet: 'ot-magnet',
+  temperature: 'ot-temperature',
+  thermocycler: 'ot-thermocycler',
 }
 
 export type StepType = $Keys<typeof stepIconsByType>

--- a/protocol-designer/src/localization/en/application.json
+++ b/protocol-designer/src/localization/en/application.json
@@ -2,7 +2,8 @@
   "stepType": {
     "mix": "mix",
     "moveLiquid": "transfer",
-    "pause": "pause"
+    "pause": "pause",
+    "magnet": "magnetic module"
   },
   "units": {
     "millimeter": "mm",

--- a/protocol-designer/src/localization/en/form.json
+++ b/protocol-designer/src/localization/en/form.json
@@ -95,7 +95,17 @@
       },
       "pipette": { "label": "pipette" },
       "preWetTip": { "label": "pre-wet tip" },
-      "touchTip": { "label": "touch tip" }
+      "touchTip": { "label": "touch tip" },
+      "magnetAction": {
+        "label": "Magnet action",
+        "options": {
+          "engage": "engage",
+          "disengage": "disengage"
+        }
+      },
+      "engageHeight": {
+        "label": "Distance from labware bottom"
+      }
     }
   }
 }

--- a/protocol-designer/src/localization/en/form.json
+++ b/protocol-designer/src/localization/en/form.json
@@ -99,8 +99,8 @@
       "magnetAction": {
         "label": "Magnet action",
         "options": {
-          "engage": "engage",
-          "disengage": "disengage"
+          "engage": "Engage",
+          "disengage": "Disengage"
         }
       },
       "engageHeight": {

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -5,7 +5,8 @@
   "step_description": {
     "mix": "Mix content of wells",
     "pause": "OT-2 will pause before proceeding",
-    "moveLiquid": "Move liquid"
+    "moveLiquid": "Move liquid",
+    "magnet": "Engage or disengage magnetic module"
   },
 
   "step_fields": {


### PR DESCRIPTION
## overview

I'm saying addresses #4303 since the issue has WIP and Design tags. (This could potentially close it if design stays as is)

<img width="359" alt="Screen Shot 2019-11-15 at 7 21 53 AM" src="https://user-images.githubusercontent.com/3430313/68943248-a988b480-0778-11ea-84d3-c058f8c06970.png">
<img width="1401" alt="Screen Shot 2019-11-15 at 7 21 39 AM" src="https://user-images.githubusercontent.com/3430313/68943258-adb4d200-0778-11ea-9d44-69617b26c3af.png">

## changelog

This PR:
- Adds module icons to components library
- Updates StepCreationButton to contain module steps (Only magnet is wired)
- Adds MagnetForm

This PR does NOT:
- Generate the step data on save
- Disable the module steps based on InitialDeckSetup

## review requests

- [ ] Code looks sane
- [ ] Magnet form and button behave as expected
