### PR TITLE
feat(api): apiv2: implement instruments backcompat

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -4,6 +4,7 @@ from copy import copy
 from functools import reduce, wraps
 import logging
 from time import time
+from typing import List
 from uuid import uuid4
 from opentrons.broker import Broker
 from opentrons.commands import tree, types as command_types
@@ -492,6 +493,8 @@ def _get_parent_module(placeable):
     elif isinstance(placeable,
                     (ModulePlaceable, labware.ModuleGeometry)):
         res = placeable
+    elif isinstance(placeable, List):
+        res = _get_parent_module(placeable[0].parent)
     else:
         res = _get_parent_module(placeable.parent)
     return res

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -11,6 +11,8 @@ from opentrons.legacy_api.containers import (Well as OldWell,
                                              Slot as OldSlot,
                                              location_to_list)
 from opentrons.protocol_api.labware import Well, Labware, ModuleGeometry
+from opentrons.protocol_api.legacy_wrapper.containers_wrapper import (
+    LegacyWell, LegacyLabware)
 from opentrons.types import Location
 from opentrons.drivers import utils
 
@@ -59,17 +61,23 @@ def _stringify_new_loc(loc: Union[Location, Well]) -> str:
 
 
 def _stringify_legacy_loc(loc: Union[OldWell, OldContainer,
-                                     OldSlot, None]) -> str:
+                                     OldSlot, LegacyLabware, LegacyWell,
+                                     None]) -> str:
     def get_slot(location):
         trace = location.get_trace()
         for item in trace:
             if isinstance(item, OldSlot):
+                return item.get_name()
+            elif isinstance(item, str):
                 return item
+        return '?'
 
     type_to_text = {
         OldSlot: 'slot',
         OldContainer: 'container',
         OldWell: 'well',
+        LegacyLabware: 'container',
+        LegacyWell: 'well'
     }
 
     # Coordinates only
@@ -84,7 +92,7 @@ def _stringify_legacy_loc(loc: Union[OldWell, OldContainer,
             suffix='s' if multiple else '',
             first=location[0].get_name(),
             last='...'+location[-1].get_name() if multiple else '',
-            slot_text=get_slot(location[0]).get_name()
+            slot_text=get_slot(location[0])
         )
 
 

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -627,7 +627,7 @@ class API(HardwareAPILike):
             if refresh:
                 self._current_position = self._deck_from_smoothie(
                     self._backend.update_position())
-            if mount == mount.RIGHT:
+            if mount == top_types.Mount.RIGHT:
                 offset = top_types.Point(0, 0, 0)
             else:
                 offset = top_types.Point(*self._config.mount_offset)

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -1118,6 +1118,7 @@ class Pipette(CommandPublisher):
             if 'rack' in location.get_parent().get_type():
                 half_tip_length = self._tip_length * self._return_tip_height
                 location = location.top(-half_tip_length)
+                print(f'v1 location: {location}')
             elif 'trash' in location.get_parent().get_type():
                 loc, coords = location.top()
                 location = (loc, coords + (0, self.model_offset[1], 0))

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -583,6 +583,7 @@ class Pipette(CommandPublisher):
             placeable, _ = unpack_location(location)
             # go to top of source, if not already there
             if placeable != self.previous_placeable:
+                print('Move to top of well bc not already there')
                 self.move_to(placeable.top())
         else:
             placeable = self.previous_placeable
@@ -594,6 +595,7 @@ class Pipette(CommandPublisher):
             if pos != self._get_plunger_position('bottom'):
                 # move to top of well to avoid touching liquid
                 if placeable:
+                    print('If plunger not at bottom, move to top to reset')
                     self.move_to(placeable.top())
                 self.instrument_actuator.set_active_current(
                     self._plunger_current)
@@ -606,6 +608,7 @@ class Pipette(CommandPublisher):
         if location:
             if isinstance(location, Placeable):
                 location = location.bottom(min(location.z_size(), clearance))
+            print('Now move to the location directly for aspirate')
             self.move_to(location, strategy='direct')
 
     def _position_for_dispense(self, location=None, clearance=0.5):

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -606,7 +606,6 @@ class Pipette(CommandPublisher):
         if location:
             if isinstance(location, Placeable):
                 location = location.bottom(min(location.z_size(), clearance))
-            print('Now move to the location directly for aspirate')
             self.move_to(location, strategy='direct')
 
     def _position_for_dispense(self, location=None, clearance=0.5):

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -583,7 +583,6 @@ class Pipette(CommandPublisher):
             placeable, _ = unpack_location(location)
             # go to top of source, if not already there
             if placeable != self.previous_placeable:
-                print('Move to top of well bc not already there')
                 self.move_to(placeable.top())
         else:
             placeable = self.previous_placeable
@@ -595,7 +594,6 @@ class Pipette(CommandPublisher):
             if pos != self._get_plunger_position('bottom'):
                 # move to top of well to avoid touching liquid
                 if placeable:
-                    print('If plunger not at bottom, move to top to reset')
                     self.move_to(placeable.top())
                 self.instrument_actuator.set_active_current(
                     self._plunger_current)

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1711,6 +1711,7 @@ class InstrumentContext(CommandPublisher):
             raise
         else:
             self._ctx.location_cache = location
+        print(f'Location cache: {self._ctx.location_cache}')
         return self
 
     @property  # type: ignore

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1154,13 +1154,9 @@ class InstrumentContext(CommandPublisher):
         if height is None:
             height = 5
         loc = self._ctx.location_cache
-        print("location in context air gap")
-        print(loc)
         if not loc or not isinstance(loc.labware, Well):
             raise RuntimeError('No previous Well cached to perform air gap')
         target = loc.labware.top(height)
-        print("new target")
-        print(target)
         self.move_to(target)
         self.aspirate(volume)
         return self

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1711,7 +1711,6 @@ class InstrumentContext(CommandPublisher):
             raise
         else:
             self._ctx.location_cache = location
-        print(f'Location cache: {self._ctx.location_cache}')
         return self
 
     @property  # type: ignore

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1154,9 +1154,13 @@ class InstrumentContext(CommandPublisher):
         if height is None:
             height = 5
         loc = self._ctx.location_cache
+        print("location in context air gap")
+        print(loc)
         if not loc or not isinstance(loc.labware, Well):
             raise RuntimeError('No previous Well cached to perform air gap')
         target = loc.labware.top(height)
+        print("new target")
+        print(target)
         self.move_to(target)
         self.aspirate(volume)
         return self

--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -117,14 +117,13 @@ def _run_python(
 
 
 def _run_python_legacy(proto: PythonProtocol, context: ProtocolContext):
-    new_locs = locals()
     new_globs = globals()
     context._api_version = APIVersion(2, 0)
     namespace_mapping = api.build_globals(context)
     for key, value in namespace_mapping.items():
         setattr(opentrons, key, value)
     try:
-        exec(proto.contents, new_globs, new_locs)
+        exec(proto.contents, new_globs)
     except Exception as e:
         exc_type, exc_value, tb = sys.exc_info()
         try:

--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -6,7 +6,8 @@ from typing import Any, Callable
 
 import opentrons
 from .contexts import ProtocolContext
-from . import execute_v3, legacy_wrapper
+from . import execute_v3
+from .legacy_wrapper import api
 
 from opentrons.protocols.types import PythonProtocol, Protocol, APIVersion
 
@@ -119,7 +120,7 @@ def _run_python_legacy(proto: PythonProtocol, context: ProtocolContext):
     new_locs = locals()
     new_globs = globals()
     context._api_version = APIVersion(2, 0)
-    namespace_mapping = legacy_wrapper.api.build_globals(context)
+    namespace_mapping = api.build_globals(context)
     for key, value in namespace_mapping.items():
         setattr(opentrons, key, value)
     try:

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -89,12 +89,14 @@ def plan_moves(
     if to_lw and to_lw == from_lw:
         # If we know the labwares we’re moving from and to, we can calculate
         # a safe z based on their heights
+        # TODO: Remove these awful Well.top() calls when we eliminate the back
+        #       compat wrapper
         if to_well:
-            to_safety = to_well.top().point.z + well_z_margin
+            to_safety = Well.top(to_well).point.z + well_z_margin
         else:
             to_safety = to_lw.highest_z + well_z_margin
         if from_well:
-            from_safety = from_well.top().point.z + well_z_margin
+            from_safety = Well.top(from_well).point.z + well_z_margin
         else:
             from_safety = from_lw.highest_z + well_z_margin
     else:

--- a/api/src/opentrons/protocol_api/legacy_wrapper/__init__.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/__init__.py
@@ -4,5 +4,3 @@ The functions and modules here implement an API wrapper that looks like the
 old robot singleton based api for python protocols, but in fact rely on the
 protocol api for behavior.
 """
-
-from .api import *  # noqa(F401)

--- a/api/src/opentrons/protocol_api/legacy_wrapper/api.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/api.py
@@ -157,7 +157,12 @@ def build_globals(context: 'ProtocolContext'):
     instr = BCInstruments(rob, lw)
     rob._set_globals(instr, lw, mod)
 
-    return {'robot': rob, 'instruments': instr, 'labware': lw, 'modules': mod}
+    return {
+        'robot': rob,
+        'instruments': instr,
+        'labware': lw,
+        'containers': lw,
+        'modules': mod}
 
 
 def maybe_migrate_containers():

--- a/api/src/opentrons/protocol_api/legacy_wrapper/api.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/api.py
@@ -120,8 +120,10 @@ class BCInstruments(metaclass=AddInstrumentCtors):
 
     def __init__(
             self,
-            robot: Robot) -> None:
+            robot: Robot,
+            containers: Containers) -> None:
         self._robot_wrapper = robot
+        self._containers = containers
 
     def _load_instr(self,
                     name: str,
@@ -130,7 +132,7 @@ class BCInstruments(metaclass=AddInstrumentCtors):
         """
         instr_ctx = self._robot_wrapper._ctx.load_instrument(
             name, Mount[mount.upper()])
-        instr = Pipette(instr_ctx)
+        instr = Pipette(instr_ctx, self._containers.labware_mappings)
         self._robot_wrapper._add_instrument(mount, instr)
         return instr
 
@@ -144,10 +146,10 @@ class BCModules:
 
 
 def build_globals(context: 'ProtocolContext'):
-    rob = Robot(context)
-    instr = BCInstruments(rob)
     lw = Containers(context)
     mod = BCModules(context)
+    rob = Robot(context)
+    instr = BCInstruments(rob, lw)
     rob._set_globals(instr, lw, mod)
 
     return {'robot': rob, 'instruments': instr, 'labware': lw, 'modules': mod}

--- a/api/src/opentrons/protocol_api/legacy_wrapper/api.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/api.py
@@ -86,23 +86,24 @@ class AddInstrumentCtors(type):
     def __new__(cls, name, bases, namespace, **kwds):
         """ Add the pipette initializer functions to the class. """
         res = type.__new__(cls, name, bases, namespace)
-        for config in pipette_config.config_models:
-            # Split the long name with the version
-            comps = config.split('_')
-            # To get the name without the version
-            generic_model = '_'.join(comps[:2])
-            number = comps[0].upper()
-            ptype_0 = comps[1][0].upper()
+        for name in pipette_config.config_names:
+            split = name.split('_')
+            number = split[0].upper()
+            ptype_0 = split[1][0].upper()
             # And a nicely formatted version to name the function
-            ptype = ptype_0 + comps[1][1:]
+            ptype = ptype_0 + split[1][1:]
             proper_name = number + '_' + ptype
+            # if this is a GEN2, it will have another element in the split.
+            # this one needs to be all uppercase
+            if len(split) > 2:
+                proper_name += '_' + split[2].upper()
             if hasattr(res, proper_name):
                 # Only build one initializer function for each versionless
                 # model (i.e. don’t make a P10_Single for both p10_single_v1
                 # and p10_single_v1.3)
                 continue
 
-            initializer = cls._build_initializer(generic_model, proper_name)
+            initializer = cls._build_initializer(name, proper_name)
             setattr(res, proper_name, initializer)
 
         return res

--- a/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
@@ -882,6 +882,9 @@ class WellSeries(LegacyLabware):
         else:
             raise TypeError(f'You cannot call {self.__name__}')
 
+    def __iter__(self):
+        return iter(self.values)
+
 
 class LegacyDeckItem(DeckItem):
     def __init__(self, share_type: str):

--- a/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
@@ -471,7 +471,6 @@ class LegacyWell(Well):
         return LegacyLocation(
                 labware=self,
                 offset=offset)
-        return LegacyLocation(labware=self, offset=Point(0, 0, 0))
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, (LegacyWell, Well)):

--- a/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
@@ -926,6 +926,12 @@ class Containers:
 
     def __init__(self, ctx: 'ProtocolContext') -> None:
         self._ctx = ctx
+        self._labware_mappings: Dict[Labware, LegacyLabware] = {}
+
+    @property
+    def labware_mappings(self) -> Dict[Labware, LegacyLabware]:
+        """ Reverse of LegacyLabware.lw_obj """
+        return self._labware_mappings
 
     def _determine_share_logic(
             self,
@@ -973,7 +979,9 @@ class Containers:
             lw_obj = mod.load_labware_from_definition(defn)
         else:
             lw_obj = self._add_labware_to_deck(defn, slot_int, label, share)
-        return LegacyLabware(lw_obj)
+        legacy = LegacyLabware(lw_obj)
+        self.labware_mappings[lw_obj] = legacy
+        return legacy
 
     def _get_labware_def_with_fallback(
             self, container_name: str) -> Dict[str, Any]:
@@ -1063,8 +1071,10 @@ class Containers:
         path_to_save_defs = CONFIG['labware_user_definitions_dir_v2']
         save_definition(lw_dict, location=path_to_save_defs)
 
-        return LegacyLabware(
-            Labware(lw_dict, Location(Point(0, 0, 0), 'deck')))
+        lw = Labware(lw_dict, Location(Point(0, 0, 0), 'deck'))
+        legacy = LegacyLabware(lw)
+        self.labware_mappings[lw] = legacy
+        return legacy
 
     @log_call(log)
     def list(self, *args, **kwargs):

--- a/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
@@ -205,7 +205,6 @@ def perform_migration():
                 save_definition(labware_def, location=path_to_save_defs)
             except jsonschema.exceptions.ValidationError:
                 validation_failure.append(lw_name)
-                print(f"validation failure on {lw_name}")
         else:
             log.info(f"Skipping migration of {lw_name} because there are no",
                      "wells associated with this labware.")
@@ -229,7 +228,7 @@ class LegacyWell(Well):
             api_version: APIVersion,
             labware_height: float = None,
             well_name: str = None):
-        super().__init__(
+        self._well = super().__init__(
             well_props, parent, display_name, has_tip, api_version)
         self._well_name = well_name
         self._parent_height = labware_height
@@ -258,6 +257,12 @@ class LegacyWell(Well):
     @property
     def depth(self) -> float:
         return self._depth
+
+    def get_trace(self):
+        current_obj = self.parent
+        while current_obj:
+            yield current_obj
+            current_obj = getattr(current_obj, 'parent')
 
     @property
     def width(self) -> float:

--- a/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
@@ -252,7 +252,6 @@ class LegacyWell(Well):
     def parent(self) -> 'LegacyLabware':
         return self._parent  # type: ignore
 
-    @property
     def get_name(self) -> Optional[str]:
         return self._well_name
 

--- a/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
@@ -91,7 +91,7 @@ class Pipette:
         self._pipette_config = pipette_config.load(self._instr_ctx.model)
 
     @property
-    def requested_as(self) -> str:
+    def requested_as(self) -> Optional[str]:
         return self._instr_ctx.requested_as
 
     @property
@@ -107,7 +107,7 @@ class Pipette:
         return self._instr_ctx.channels
 
     @property
-    def _config(self) -> pipette_config:
+    def _config(self) -> pipette_config.pipette_config:
         return self._hw_pipette.config
 
     @property

--- a/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
@@ -800,9 +800,9 @@ class Pipette:
             checked_location = _absolute_motion_target(new_loc)
         else:
             checked_location = location  # type: ignore
-
         self._instr_ctx.drop_tip(
             location=checked_location, home_after=home_after)
+        self.current_tip(None)
         return self
 
     @log_call(log)

--- a/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
@@ -1,8 +1,7 @@
-# pylama:ignore=E731
 from numbers import Number
 import logging
 from typing import Dict, List, Optional, Sequence, TYPE_CHECKING, Union
-from opentrons import commands as cmds, hardware_control as hc
+from opentrons import commands as cmds
 from opentrons.types import Point, Location
 
 from .util import log_call
@@ -13,7 +12,8 @@ from .types import LegacyLocation
 from .containers_wrapper import LegacyLabware, LegacyWell
 
 if TYPE_CHECKING:
-    from ..contexts import InstrumentContext
+    from ..contexts import InstrumentContext # noqa(F401)
+    from ..labware import Labware, Well  # noqa(F401)
 
 log = logging.getLogger(__name__)
 
@@ -263,11 +263,8 @@ class Pipette:
         if not self.placeables or (placeable != self.placeables[-1]):
             self.placeables.append(placeable)
 
-        if isinstance(location, LegacyWell):
-            location = location.top()
-        print(f'Wrapper: Move to: {self.previous_placeable}')
-
-        return self._instr_ctx.move_to(location=location,
+        absolute_location = _absolute_motion_target(location)
+        return self._instr_ctx.move_to(location=absolute_location,
                                        force_direct=force_direct)
 
     def aspirate(self,

--- a/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
@@ -804,6 +804,7 @@ class Pipette:
             p300.pick_up_tip()
             p300.return_tip()
         """
+        display_loc: Union[LegacyLocation, LegacyWell, Well]
         if location:
             display_loc = location
             if isinstance(location, (List, WellSeries)):

--- a/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
@@ -785,6 +785,20 @@ class Pipette:
             # drops the tip back at its tip rack
             p300.drop_tip(tiprack[1])
         """
+        if location:
+            lw, coords = _unpack_motion_target(location, 'top')
+            if 'rack' in str(location.parent):
+                half_tip_length = self._pipette_config.tip_length * \
+                    (self._pipette_config.return_tip_height)
+                new_loc = lw.top(-half_tip_length)
+                print(f'v2 location: {new_loc}')
+            elif 'trash' in str(location.parent):
+                new_loc = (lw, coords +
+                           (0, self._pipette_config.modelOffset[1], 0))
+            else:
+                new_loc = lw.top()
+            new_loc = _absolute_motion_target(new_loc, 'top')
+
         self._instr_ctx.drop_tip(
             location=location, home_after=home_after)
         return self

--- a/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
@@ -787,17 +787,17 @@ class Pipette:
         """
         if location:
             lw, coords = _unpack_motion_target(location, 'top')
-            if 'rack' in str(location.parent):
+            if 'rack' in str(location.parent).lower():
                 half_tip_length = self._pipette_config.tip_length * \
-                    (self._pipette_config.return_tip_height)
+                    (self._pipette_config.return_tip_height or 0.5)
                 new_loc = lw.top(-half_tip_length)
-                print(f'v2 location: {new_loc}')
-            elif 'trash' in str(location.parent):
+                print(f'v2: {new_loc}')
+            elif 'trash' in str(location.parent).lower():
                 new_loc = (lw, coords +
                            (0, self._pipette_config.modelOffset[1], 0))
             else:
                 new_loc = lw.top()
-            new_loc = _absolute_motion_target(new_loc, 'top')
+            location = _absolute_motion_target(new_loc)
 
         self._instr_ctx.drop_tip(
             location=location, home_after=home_after)

--- a/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
@@ -47,7 +47,7 @@ def _absolute_motion_target(motiontarget: MotionTarget) -> Location:
         real_loc = target_loc.labware
     return Location(
         labware=real_loc,
-        point=(target_loc.labware.from_center(-1, -1, -1).offset
+        point=(target_loc.labware._from_center_cartesian(-1, -1, -1)
                + target_loc.offset))
 
 

--- a/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
@@ -91,7 +91,23 @@ class Pipette:
         self._pipette_config = pipette_config.load(self._instr_ctx.model)
 
     @property
-    def _config(self):
+    def requested_as(self) -> str:
+        return self._instr_ctx.requested_as
+
+    @property
+    def model(self) -> str:
+        return self._instr_ctx.model
+
+    @property
+    def name(self) -> str:
+        return self._instr_ctx.name
+
+    @property
+    def channels(self) -> int:
+        return self._instr_ctx.channels
+
+    @property
+    def _config(self) -> pipette_config:
         return self._hw_pipette.config
 
     @property
@@ -230,7 +246,7 @@ class Pipette:
     def get_next_tip(self):
         """ Find the next tip to pick up"""
         tiprack, tip = self._instr_ctx._next_available_tip()
-        tiprack.use_tips(tip, self._instr_ctx.channels)
+        tiprack.use_tips(tip, self.channels)
         return tip
 
     @log_call(log)
@@ -733,7 +749,7 @@ class Pipette:
                         location=new_loc)
         self._hw.set_working_volume(self._mount, new_loc.labware.max_volume)
         new_loc.labware.parent.use_tips(new_loc.labware,  # type: ignore
-                                        self._instr_ctx.channels)
+                                        self.channels)
         self._instr_ctx._last_tip_picked_up_from = \
             new_loc.labware  # type: ignore
 

--- a/api/src/opentrons/protocol_api/legacy_wrapper/modules_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/modules_wrapper.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from .util import log_call
 from .. import contexts
@@ -9,9 +9,12 @@ from opentrons import commands
 
 log = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from ..contexts import ProtocolContext
+
 
 @log_call(log)
-def load(ctx: contexts.ProtocolContext,
+def load(ctx: 'ProtocolContext',
          name: str,
          slot: str):
     new_mod = ctx.load_module(name, slot)

--- a/api/src/opentrons/protocol_api/legacy_wrapper/robot_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/robot_wrapper.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional, TYPE_CHECKING
 
 from opentrons.hardware_control import adapters, API
 from .util import log_call
+from .types import LegacyLocation
 
 
 if TYPE_CHECKING:
@@ -12,7 +13,6 @@ if TYPE_CHECKING:
     from ..labware import Labware
     from .api import BCInstruments, BCModules
     from .containers_wrapper import Containers
-    from opentrons import types
 
 
 log = logging.getLogger(__name__)
@@ -176,7 +176,7 @@ class Robot():
     @log_call(log)
     def move_to(
             self,
-            location: 'types.Location',
+            location: LegacyLocation,
             instrument: 'Pipette',
             strategy: str = 'arc',
             **kwargs):

--- a/api/src/opentrons/protocol_api/legacy_wrapper/robot_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/robot_wrapper.py
@@ -54,7 +54,7 @@ class Robot():
         """ Internal. Register intrument with this wrapper """
         self._instrs[mount] = instr
         if self._head_speed_override:
-            instr._ctx.default_speed = self._head_speed_override
+            instr._instr_ctx.default_speed = self._head_speed_override
         plunger_max = self._plunger_max_speed_overrides.get(mount)
         if plunger_max is not None:
             instr._set_plunger_max_speed_override(plunger_max)
@@ -158,7 +158,7 @@ class Robot():
         if combined_speed:
             self._head_speed_override = combined_speed
             for instr in self._instrs.values():
-                instr._ctx.default_speed = combined_speed
+                instr._instr_ctx.default_speed = combined_speed
 
         maxes = {'x': x, 'y': y, 'z': z, 'a': a}
         for ax, m in maxes.items():

--- a/api/src/opentrons/protocol_api/legacy_wrapper/types.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/types.py
@@ -6,5 +6,5 @@ if TYPE_CHECKING:
 
 
 class LegacyLocation(NamedTuple):
-    labware: Union['LegacyLabware', 'LegacyWell', str]
+    labware: Union['LegacyLabware', 'LegacyWell']
     offset: types.Point

--- a/api/src/opentrons/util/entrypoint_util.py
+++ b/api/src/opentrons/util/entrypoint_util.py
@@ -29,7 +29,6 @@ def labware_from_paths(paths: List[str]) -> Dict[str, Dict[str, Any]]:
                 try:
                     defn = labware.verify_definition(child.read_bytes())
                 except (ValidationError, JSONDecodeError) as e:
-                    print(f'{child}: invalid ({str(e)})')
                     log.info(f"{child}: invalid ({str(e)})")
                 else:
                     uri = labware.uri_from_definition(defn)

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -142,6 +142,13 @@ def old_aspiration(monkeypatch):
     config.advanced_settings.set_adv_setting(
         'useOldAspirationFunctions', False)
 
+
+@pytest.fixture
+def enable_apiv1_backcompat(monkeypatch):
+    config.advanced_settings.set_adv_setting('enableApi1BackCompat', True)
+    yield
+    config.advanced_settings.set_adv_setting('enableApi1BackCompat', False)
+
 # -----end feature flag fixtures-----------
 
 

--- a/api/tests/opentrons/data/multi-single.py
+++ b/api/tests/opentrons/data/multi-single.py
@@ -1,4 +1,4 @@
-from opentrons import containers, instruments
+from opentrons import containers, instruments, robot
 
 metadata = {
     'protocolName': 'Multi/Single',
@@ -19,6 +19,7 @@ plate = containers.load('96-flat', '5')
 single = instruments.P300_Single(mount='right', tip_racks=[tiprack])
 multi = instruments.P300_Multi(mount='left', tip_racks=[tiprack])
 
+robot.home()
 
 for tip in [tiprack[0], tiprack[-1]]:
     single.pick_up_tip(tip)
@@ -29,11 +30,10 @@ for tip in [tiprack[0], tiprack[-1]]:
     single.dispense(100, plate[-1])
     single.drop_tip(tip)
 
-for tips in [tiprack.rows(0), tiprack.rows[-1]]:
+for tips in [tiprack.columns(0), tiprack.columns[-1]]:
     multi.pick_up_tip(tips)
-    multi.aspirate(100, trough.rows[0])
-    multi.aspirate(100, trough.rows[-1])
-
-    multi.dispense(100, plate.rows[0])
-    multi.dispense(100, plate.rows[-1])
+    multi.aspirate(100, trough.columns[0])
+    multi.aspirate(100, trough.columns[-1])
+    multi.dispense(100, plate.columns[0])
+    multi.dispense(100, plate.columns[-1])
     multi.drop_tip(tips)

--- a/api/tests/opentrons/data/testosaur.py
+++ b/api/tests/opentrons/data/testosaur.py
@@ -1,4 +1,4 @@
-from opentrons import instruments, containers, robot
+from opentrons import instruments, containers
 
 metadata = {
     'protocolName': 'Testosaur',
@@ -16,17 +16,17 @@ p300 = instruments.P300_Single(
 
 p300.pick_up_tip()
 
-containers = [
+conts = [
     containers.load('96-PCR-flat', slot)
     for slot
     in ('8', '11')
 ]
 
 # Uncomment these to test precision
-p300.move_to(robot.deck['11'])
-p300.move_to(robot.deck['6'])
+# p300.move_to(robot.deck['11'])
+# p300.move_to(robot.deck['6'])
 
-for container in containers:
+for container in conts:
     p300.aspirate(10, container[0]).dispense(10, container[-1].top(5))
 
 p300.drop_tip()

--- a/api/tests/opentrons/integration/test_api.py
+++ b/api/tests/opentrons/integration/test_api.py
@@ -46,7 +46,8 @@ async def test_multi_single(
 @pytest.mark.api1_only
 @pytest.mark.parametrize('protocol_file', ['multi-single.py'])
 async def test_load_jog_save_run(
-        main_router, protocol, protocol_file, monkeypatch, robot):
+        main_router, protocol, protocol_file, monkeypatch, robot,
+        enable_apiv1_backcompat):
     import tempfile
     temp = tempfile.gettempdir()
     monkeypatch.setenv('USER_DEFN_ROOT', temp)

--- a/api/tests/opentrons/protocol_api/test_back_compat.py
+++ b/api/tests/opentrons/protocol_api/test_back_compat.py
@@ -8,7 +8,7 @@ from opentrons.hardware_control import API
 
 @pytest.mark.api2_only
 def test_add_instrument(loop, monkeypatch, singletons):
-    fake_load = mock.Mock()
+    fake_load = mock.MagicMock()
     instruments = singletons['instruments']
     monkeypatch.setattr(instruments._robot_wrapper._ctx,
                         'load_instrument', fake_load)
@@ -54,12 +54,12 @@ def test_head_speed(singletons):
     assert singletons['robot']._head_speed_override == 10
     # Default speed should be provisioned on pipette create from the cache
     left = singletons['instruments'].P50_Single('left')
-    assert left._ctx._default_speed == 10
+    assert left._instr_ctx._default_speed == 10
     # and so should plunger max
     assert left._max_plunger_speed == 3
     # And setting it with already-created instruments should work
     singletons['robot'].head_speed(combined_speed=20, b=4)
-    assert left._ctx._default_speed == 20
+    assert left._instr_ctx._default_speed == 20
     assert left._max_plunger_speed == 4
 
 

--- a/api/tests/opentrons/protocol_api/test_back_compat.py
+++ b/api/tests/opentrons/protocol_api/test_back_compat.py
@@ -2,35 +2,27 @@ from unittest import mock
 
 import pytest
 
-from opentrons.types import Mount
 from opentrons.hardware_control import API
 
 
+@pytest.mark.parametrize('ctorname,modelname', [
+    ('P1000_Single', 'p1000_single'),
+    ('P1000_Single_GEN2', 'p1000_single_gen2'),
+    ('P300_Single', 'p300_single'),
+    ('P300_Single_GEN2', 'p300_single_gen2'),
+    ('P300_Multi', 'p300_multi'),
+    ('P300_Multi_GEN2', 'p300_multi_gen2'),
+    ('P20_Single_GEN2', 'p20_single_gen2'),
+    ('P20_Multi_GEN2', 'p20_multi_gen2'),
+    ('P10_Single', 'p10_single'),
+    ('P10_Multi', 'p10_multi')
+])
 @pytest.mark.api2_only
-def test_add_instrument(loop, monkeypatch, singletons):
-    fake_load = mock.MagicMock()
+def test_add_instrument(loop, monkeypatch, singletons,
+                        ctorname, modelname):
     instruments = singletons['instruments']
-    monkeypatch.setattr(instruments._robot_wrapper._ctx,
-                        'load_instrument', fake_load)
-
-    instruments.P1000_Single('left')
-    instruments.P10_Single('right')
-    instruments.P10_Multi('left')
-    instruments.P50_Single('right')
-    instruments.P50_Multi('left')
-    instruments.P300_Single('right')
-    instruments.P300_Multi('left')
-    instruments.P1000_Single('right')
-    assert fake_load.call_args_list == [
-        (('p1000_single', Mount.LEFT), {}),
-        (('p10_single', Mount.RIGHT), {}),
-        (('p10_multi', Mount.LEFT), {}),
-        (('p50_single', Mount.RIGHT), {}),
-        (('p50_multi', Mount.LEFT), {}),
-        (('p300_single', Mount.RIGHT), {}),
-        (('p300_multi', Mount.LEFT), {}),
-        (('p1000_single', Mount.RIGHT), {})
-    ]
+    pip = getattr(instruments, ctorname)('left')
+    assert pip.name == modelname
 
 
 @pytest.mark.api2_only

--- a/api/tests/opentrons/protocol_api/test_instrument_wrapper.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_wrapper.py
@@ -3,17 +3,44 @@ from unittest import mock
 import pytest
 
 import opentrons.protocol_api as papi
-import opentrons.protocol_api.legacy_wrapper.
 
-# @pytest.fixture
-# def test_load_instrument(loop):
-#     ctx = papi.ProtocolContext(loop=loop)
-#     robot = Robot(ctx)
+
+@pytest.fixture
+def load_v1_instrument(virtual_smoothie_env):
+    from opentrons.legacy_api import api
+    robot = api.robot
+    robot.connect()
+    robot.reset()
+
+    instr = api.InstrumentsWrapper(robot)
+    lw = api.ContainersWrapper(robot)
+
+    legacy_tr = lw.load('opentrons_96_tiprack_10ul', '2')
+    legacy_instr = instr.P10_Single(mount='left', tip_racks=[legacy_tr])
+    legacy_lw = lw.load('corning_96_wellplate_360ul_flat', '1')
+    return legacy_instr, legacy_lw
+
 
 @pytest.mark.api2_only
 def test_pick_up_tip(instruments, labware):
     lw = labware.load('opentrons_96_tiprack_10ul', '1')
     pip = instruments.P10_Single(mount='left')
 
+    instruments._robot_wrapper.home()
+
     pip.pick_up_tip(lw.wells(0))
-    
+    assert pip.has_tip
+    assert pip.current_tip() == lw.wells(0)
+
+@pytest.mark.api2_only
+def test_aspirate(instruments, labware, load_v1_instrument):
+    tr = labware.load('opentrons_96_tiprack_10ul', '1')
+    pip = instruments.P10_Single(mount='left', tip_racks=[tr])
+    lw = labware.load('corning_96_wellplate_360ul_flat', '2')
+
+    instruments._robot_wrapper.home()
+    fake_move_to = mock.Mock()
+    monkeypatch.setattr(instruments._robot_wrapper._ctx,
+                        'load_instrument', fake_load)
+    pip.aspirate(lw.wells(0))
+    assert pip.current_volume == pip.max_volume

--- a/api/tests/opentrons/protocol_api/test_instrument_wrapper.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_wrapper.py
@@ -1,0 +1,19 @@
+from unittest import mock
+
+import pytest
+
+import opentrons.protocol_api as papi
+import opentrons.protocol_api.legacy_wrapper.
+
+# @pytest.fixture
+# def test_load_instrument(loop):
+#     ctx = papi.ProtocolContext(loop=loop)
+#     robot = Robot(ctx)
+
+@pytest.mark.api2_only
+def test_pick_up_tip(instruments, labware):
+    lw = labware.load('opentrons_96_tiprack_10ul', '1')
+    pip = instruments.P10_Single(mount='left')
+
+    pip.pick_up_tip(lw.wells(0))
+    

--- a/api/tests/opentrons/protocol_api/test_instrument_wrapper.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_wrapper.py
@@ -704,7 +704,8 @@ def common_method_calls(call_list):
 
 def build_kwargs(legacy_instr, new_instr, legacy_lw, new_lw,  # noqa(C901)
                  volume, source, dest, touch_tip, blow_out,
-                 mix_before, mix_after, gradient, air_gap, new_tip):
+                 mix_before, mix_after, gradient, air_gap, new_tip,
+                 disposal_vol):
     new_kwargs = {}
     legacy_kwargs = {}
     if dest[0] == 'single':
@@ -799,6 +800,13 @@ def build_kwargs(legacy_instr, new_instr, legacy_lw, new_lw,  # noqa(C901)
         legacy_kwargs['new_tip'] = new_tip
         new_kwargs['new_tip'] = new_tip
 
+    if disposal_vol is not None:
+        if disposal_vol == 'twice_min_volume':
+            legacy_kwargs['disposal_vol'] = legacy_instr.min_volume * 2
+            new_kwargs['disposal_vol'] = new_instr.min_volume * 2
+        else:
+            raise Exception(f"invalid disposal vol spec {disposal_vol}")
+
     return legacy_kwargs, new_kwargs
 
 @pytest.mark.parametrize(  # noqa(E501,C901)
@@ -848,7 +856,7 @@ def test_basic_transfer(
     legacy_kwargs, new_kwargs = build_kwargs(
         legacy_instr, new_instr, legacy_lw, new_lw,
         volume, source, dest, touch_tip, blow_out,
-        mix_before, mix_after, gradient, air_gap, None)
+        mix_before, mix_after, gradient, air_gap, None, None)
     new_instr._ctx._hw_manager.hardware.home()
     legacy_instr.transfer(**legacy_kwargs)
     new_instr.transfer(**new_kwargs)
@@ -882,7 +890,8 @@ def test_transfer_tips_manipulations(
 
     legacy_kwargs, new_kwargs = build_kwargs(
         legacy_instr, new_instr, legacy_lw, new_lw,
-        volume, source, dest, None, None, None, None, None, None, new_tip)
+        volume, source, dest, None, None, None, None, None, None, new_tip,
+        None)
 
     new_instr._ctx._hw_manager.hardware.home()
 
@@ -893,6 +902,94 @@ def test_transfer_tips_manipulations(
     legacy_instr.transfer(**legacy_kwargs)
     new_instr.transfer(**new_kwargs)
 
+    assert new_mock.method_calls
+    assert legacy_mock.method_calls
+    assert common_method_calls(new_mock.method_calls)\
+        == common_method_calls(legacy_mock.method_calls)
+
+
+@pytest.mark.parametrize(
+    'instrument_ctor,volume,source,dest,touch_tip,blow_out,mix_after,gradient',  # noqa(E501)
+    bind_parameters_to_instruments([
+        ('half_max_volume', ('list', 16), ('single', 'A1'), None, None, None, None),  # noqa(E501)
+        ('gradient', ('list', 8), ('single', 'A1'), None, None, None, None),  # noqa(E501)
+        # mix after
+        ('max_volume', ('list', 8), ('single', 'A2'), None, None, (5, 'half_max_volume'), None),  # noqa(E501)
+        # touch tip
+        ('max_volume', ('list', 8), ('single', 'A3'), True, None, None, None),  # noqa(E501)
+        # blow out
+        ('max_volume', ('list', 8), ('single', 'A3'), None, True, None, None),  # noqa(E501)
+        # free for all
+        ('max_volume', ('list', 8), ('single', 'A4'), True, True, (5, 'half_max_volume'), None),  # noqa(E501)
+    ], instrs=['P300_Single', 'P20_Multi_GEN2'])
+)
+@pytest.mark.api2_only
+def test_consolidate(
+        monkeypatch, instruments, labware, load_v1_instrument,
+        load_bc_instrument,
+        instrument_ctor, volume, source, dest,
+        touch_tip, blow_out, mix_after, gradient):
+    robot, legacy_instr, legacy_lw = load_v1_instrument
+    new_robot, new_instr, new_lw = load_bc_instrument
+    legacy_instr, legacy_mock = mock_atomics(legacy_instr, monkeypatch)
+    new_instr, new_mock = mock_atomics(new_instr, monkeypatch)
+    from opentrons.legacy_api.instruments import pipette
+    monkeypatch.setattr(pipette, 'do_publish', mock.Mock())
+    from opentrons.protocol_api.legacy_wrapper import instrument_wrapper
+    monkeypatch.setattr(instrument_wrapper.cmds, 'do_publish', mock.Mock())
+    legacy_kwargs, new_kwargs = build_kwargs(
+        legacy_instr, new_instr, legacy_lw, new_lw,
+        volume, source, dest, touch_tip, blow_out,
+        None, mix_after, gradient, None, None, None)
+    new_instr._ctx._hw_manager.hardware.home()
+    legacy_instr.consolidate(**legacy_kwargs)
+    new_instr.consolidate(**new_kwargs)
+    assert new_mock.method_calls
+    assert legacy_mock.method_calls
+    assert common_method_calls(new_mock.method_calls)\
+        == common_method_calls(legacy_mock.method_calls)
+
+
+@pytest.mark.parametrize(
+    'instrument_ctor,volume,source,dest,touch_tip,blow_out,mix_before,gradient,air_gap,disposal_vol',  # noqa(E501)
+    bind_parameters_to_instruments([
+        ('half_max_volume', ('single', 'A1'), ('list', 16), None, None, None, None, None, None),  # noqa(E501)
+        # mix after
+        ('max_volume', ('single', 'A2'), ('list', 8), None, None, (5, 'half_max_volume'), None, None, None),  # noqa(E501)
+        # touch tip
+        ('max_volume', ('single', 'A3'), ('list', 8), True, None, None, None, None, None),  # noqa(E501)
+        # blow out
+        ('max_volume', ('single', 'A3'), ('list', 8), None, True, None, None, None, None),  # noqa(E501)
+        # air gap
+        ('max_volume', ('single', 'A4'), ('list', 8), True, True, (5, 'half_max_volume'), None, 'min_volume', None),  # noqa(E501),
+        # disposal vol
+        ('max_volume', ('single', 'A4'), ('list', 8), True, True, (5, 'half_max_volume'), None, None, 'twice_min_volume'),  # noqa(E501),
+        # free for all
+        ('max_volume', ('single', 'A4'), ('list', 8), True, True, (5, 'half_max_volume'), None, 'min_volume', 'twice_min_volume'),  # noqa(E501),
+
+    ], instrs=['P300_Single', 'P20_Multi_GEN2'])
+)
+@pytest.mark.api2_only
+def test_distribute(
+        monkeypatch, instruments, labware, load_v1_instrument,
+        load_bc_instrument,
+        instrument_ctor, volume, source, dest,
+        touch_tip, blow_out, mix_before, gradient, air_gap, disposal_vol):
+    robot, legacy_instr, legacy_lw = load_v1_instrument
+    new_robot, new_instr, new_lw = load_bc_instrument
+    legacy_instr, legacy_mock = mock_atomics(legacy_instr, monkeypatch)
+    new_instr, new_mock = mock_atomics(new_instr, monkeypatch)
+    from opentrons.legacy_api.instruments import pipette
+    monkeypatch.setattr(pipette, 'do_publish', mock.Mock())
+    from opentrons.protocol_api.legacy_wrapper import instrument_wrapper
+    monkeypatch.setattr(instrument_wrapper.cmds, 'do_publish', mock.Mock())
+    legacy_kwargs, new_kwargs = build_kwargs(
+        legacy_instr, new_instr, legacy_lw, new_lw,
+        volume, source, dest, touch_tip, blow_out,
+        mix_before, None, gradient, air_gap, None, disposal_vol)
+    new_instr._ctx._hw_manager.hardware.home()
+    legacy_instr.distribute(**legacy_kwargs)
+    new_instr.distribute(**new_kwargs)
     assert new_mock.method_calls
     assert legacy_mock.method_calls
     assert common_method_calls(new_mock.method_calls)\

--- a/api/tests/opentrons/protocol_api/test_instrument_wrapper.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_wrapper.py
@@ -706,3 +706,30 @@ def test_basic_transfer(
                        new_lw.well('A2'))
     assert method_names(new_mock.method_calls)\
         == method_names(legacy_mock.method_calls)
+
+    legacy_instr.transfer(legacy_instr.max_volume / 2,
+                          legacy_lw[:16],
+                          legacy_lw[16:32])
+    new_instr.transfer(new_instr.max_volume / 2,
+                       new_lw[:16],
+                       new_lw[16:32])
+    assert method_names(new_mock.method_calls)\
+        == method_names(legacy_mock.method_calls)
+
+    legacy_instr.transfer(legacy_instr.max_volume * 2,
+                          legacy_lw[:16],
+                          legacy_lw[16:32])
+    new_instr.transfer(new_instr.max_volume * 2,
+                       new_lw[:16],
+                       new_lw[16:32])
+    assert method_names(new_mock.method_calls)\
+        == method_names(legacy_mock.method_calls)
+
+    legacy_instr.transfer(legacy_instr.max_volume,
+                          legacy_lw[:16],
+                          legacy_lw[16:32])
+    new_instr.transfer(new_instr.max_volume,
+                       new_lw[:16],
+                       new_lw[16:32])
+    assert method_names(new_mock.method_calls)\
+        == method_names(legacy_mock.method_calls)

--- a/api/tests/opentrons/protocol_api/test_instrument_wrapper.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_wrapper.py
@@ -601,7 +601,7 @@ def test_drop_tip(
 
     legacy_instr.drop_tip(**legacy_kwargs)
     pip.drop_tip(**new_kwargs)
-
+    assert not pip.current_tip()
     if loc is None:
         # check retract pipette
         assert legacy_move.call_args_list[0][0][0]['Z'] == \

--- a/api/tests/opentrons/protocol_api/test_instrument_wrapper.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_wrapper.py
@@ -909,18 +909,18 @@ def test_transfer_tips_manipulations(
 
 
 @pytest.mark.parametrize(
-    'instrument_ctor,volume,source,dest,touch_tip,blow_out,mix_after,gradient',  # noqa(E501)
+    'instrument_ctor,volume,source,dest,touch_tip,blow_out,mix_after,gradient,new_tip',  # noqa(E501)
     bind_parameters_to_instruments([
-        ('half_max_volume', ('list', 16), ('single', 'A1'), None, None, None, None),  # noqa(E501)
-        ('gradient', ('list', 8), ('single', 'A1'), None, None, None, None),  # noqa(E501)
+        ('half_max_volume', ('list', 16), ('single', 'A1'), None, None, None, None, None),  # noqa(E501)
+        ('gradient', ('list', 8), ('single', 'A1'), None, None, None, None, None),  # noqa(E501)
         # mix after
-        ('max_volume', ('list', 8), ('single', 'A2'), None, None, (5, 'half_max_volume'), None),  # noqa(E501)
+        ('max_volume', ('list', 8), ('single', 'A2'), None, None, (5, 'half_max_volume'), None, None),  # noqa(E501)
         # touch tip
-        ('max_volume', ('list', 8), ('single', 'A3'), True, None, None, None),  # noqa(E501)
+        ('max_volume', ('list', 8), ('single', 'A3'), True, None, None, None, None),  # noqa(E501)
         # blow out
-        ('max_volume', ('list', 8), ('single', 'A3'), None, True, None, None),  # noqa(E501)
+        ('max_volume', ('list', 8), ('single', 'A3'), None, True, None, None, None),  # noqa(E501)
         # free for all
-        ('max_volume', ('list', 8), ('single', 'A4'), True, True, (5, 'half_max_volume'), None),  # noqa(E501)
+        ('max_volume', ('list', 8), ('single', 'A4'), True, True, (5, 'half_max_volume'), None, None),  # noqa(E501)
     ], instrs=['P300_Single', 'P20_Multi_GEN2'])
 )
 @pytest.mark.api2_only
@@ -928,7 +928,7 @@ def test_consolidate(
         monkeypatch, instruments, labware, load_v1_instrument,
         load_bc_instrument,
         instrument_ctor, volume, source, dest,
-        touch_tip, blow_out, mix_after, gradient):
+        touch_tip, blow_out, mix_after, gradient, new_tip):
     robot, legacy_instr, legacy_lw = load_v1_instrument
     new_robot, new_instr, new_lw = load_bc_instrument
     legacy_instr, legacy_mock = mock_atomics(legacy_instr, monkeypatch)
@@ -940,7 +940,7 @@ def test_consolidate(
     legacy_kwargs, new_kwargs = build_kwargs(
         legacy_instr, new_instr, legacy_lw, new_lw,
         volume, source, dest, touch_tip, blow_out,
-        None, mix_after, gradient, None, None, None)
+        None, mix_after, gradient, None, new_tip, None)
     new_instr._ctx._hw_manager.hardware.home()
     legacy_instr.consolidate(**legacy_kwargs)
     new_instr.consolidate(**new_kwargs)
@@ -951,21 +951,21 @@ def test_consolidate(
 
 
 @pytest.mark.parametrize(
-    'instrument_ctor,volume,source,dest,touch_tip,blow_out,mix_before,gradient,air_gap,disposal_vol',  # noqa(E501)
+    'instrument_ctor,volume,source,dest,touch_tip,blow_out,mix_before,gradient,air_gap,disposal_vol,new_tip',  # noqa(E501)
     bind_parameters_to_instruments([
-        ('half_max_volume', ('single', 'A1'), ('list', 16), None, None, None, None, None, None),  # noqa(E501)
+        ('half_max_volume', ('single', 'A1'), ('list', 16), None, None, None, None, None, None, None),  # noqa(E501)
         # mix after
-        ('max_volume', ('single', 'A2'), ('list', 8), None, None, (5, 'half_max_volume'), None, None, None),  # noqa(E501)
+        ('max_volume', ('single', 'A2'), ('list', 8), None, None, (5, 'half_max_volume'), None, None, None, None),  # noqa(E501)
         # touch tip
-        ('max_volume', ('single', 'A3'), ('list', 8), True, None, None, None, None, None),  # noqa(E501)
+        ('max_volume', ('single', 'A3'), ('list', 8), True, None, None, None, None, None, None),  # noqa(E501)
         # blow out
-        ('max_volume', ('single', 'A3'), ('list', 8), None, True, None, None, None, None),  # noqa(E501)
+        ('max_volume', ('single', 'A3'), ('list', 8), None, True, None, None, None, None, None),  # noqa(E501)
         # air gap
-        ('max_volume', ('single', 'A4'), ('list', 8), True, True, (5, 'half_max_volume'), None, 'min_volume', None),  # noqa(E501),
+        ('max_volume', ('single', 'A4'), ('list', 8), True, True, (5, 'half_max_volume'), None, 'min_volume', None, None),  # noqa(E501),
         # disposal vol
-        ('max_volume', ('single', 'A4'), ('list', 8), True, True, (5, 'half_max_volume'), None, None, 'twice_min_volume'),  # noqa(E501),
+        ('max_volume', ('single', 'A4'), ('list', 8), True, True, (5, 'half_max_volume'), None, None, 'twice_min_volume', None),  # noqa(E501),
         # free for all
-        ('max_volume', ('single', 'A4'), ('list', 8), True, True, (5, 'half_max_volume'), None, 'min_volume', 'twice_min_volume'),  # noqa(E501),
+        ('max_volume', ('single', 'A4'), ('list', 8), True, True, (5, 'half_max_volume'), None, 'min_volume', 'twice_min_volume', 'always'),  # noqa(E501),
 
     ], instrs=['P300_Single', 'P20_Multi_GEN2'])
 )
@@ -974,7 +974,8 @@ def test_distribute(
         monkeypatch, instruments, labware, load_v1_instrument,
         load_bc_instrument,
         instrument_ctor, volume, source, dest,
-        touch_tip, blow_out, mix_before, gradient, air_gap, disposal_vol):
+        touch_tip, blow_out, mix_before, gradient, air_gap, disposal_vol,
+        new_tip):
     robot, legacy_instr, legacy_lw = load_v1_instrument
     new_robot, new_instr, new_lw = load_bc_instrument
     legacy_instr, legacy_mock = mock_atomics(legacy_instr, monkeypatch)
@@ -986,7 +987,7 @@ def test_distribute(
     legacy_kwargs, new_kwargs = build_kwargs(
         legacy_instr, new_instr, legacy_lw, new_lw,
         volume, source, dest, touch_tip, blow_out,
-        mix_before, None, gradient, air_gap, None, disposal_vol)
+        mix_before, None, gradient, air_gap, new_tip, disposal_vol)
     new_instr._ctx._hw_manager.hardware.home()
     legacy_instr.distribute(**legacy_kwargs)
     new_instr.distribute(**new_kwargs)

--- a/api/tests/opentrons/protocol_api/test_instrument_wrapper.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_wrapper.py
@@ -2,6 +2,12 @@ from unittest import mock
 
 import pytest
 
+# import opentrons.protocol_api as papi
+from numpy import add, subtract, isclose
+# from opentrons.legacy_api.containers import unpack_location, Placeable
+from opentrons.legacy_api.containers.placeable import Placeable
+from opentrons.protocol_api.legacy_wrapper.containers_wrapper import LegacyWell
+
 
 @pytest.fixture
 def load_v1_instrument(virtual_smoothie_env):
@@ -13,32 +19,211 @@ def load_v1_instrument(virtual_smoothie_env):
     instr = api.InstrumentsWrapper(robot)
     lw = api.ContainersWrapper(robot)
 
-    legacy_tr = lw.load('opentrons_96_tiprack_10ul', '2')
+    legacy_tr = lw.load('opentrons_96_tiprack_10ul', '1')
     legacy_instr = instr.P10_Single(mount='left', tip_racks=[legacy_tr])
-    legacy_lw = lw.load('corning_96_wellplate_360ul_flat', '1')
-    return legacy_instr, legacy_lw
+    legacy_lw = lw.load('corning_96_wellplate_360ul_flat', '2')
+    return robot, legacy_instr, legacy_lw
 
 
+# @pytest.mark.api2_only
+# def test_pick_up_tip(instruments, labware):
+#     lw = labware.load('opentrons_96_tiprack_10ul', '1')
+#     pip = instruments.P10_Single(mount='left')
+#
+#     instruments._robot_wrapper.home()
+#
+#     pip.pick_up_tip(lw.wells(0))
+#     assert pip.has_tip
+#     assert pip.current_tip() == lw.wells(0)
+
+
+def get_v1_v2_mock_calls(monkeypatch, v1_api, v2_api, function):
+    v1 = mock.Mock()
+    v2 = mock.Mock()
+    monkeypatch.setattr(v1_api, function, v1)
+    monkeypatch.setattr(v2_api, function, v2)
+    return v1, v2
+
+
+def convert_to_deck_coordinates(robot, location, version):
+    from opentrons.legacy_api import containers
+    from opentrons.trackers import pose_tracker
+
+    placeable, coordinates = containers.unpack_location(location)
+    if version == 1:
+        offset = subtract(coordinates, placeable.top()[1])
+    else:
+        offset = subtract(coordinates, placeable.top())
+    print("OFFSET")
+    print(offset)
+    return add(pose_tracker.absolute(robot.poses, placeable),
+               offset.coordinates)
+
+
+@pytest.mark.parametrize('volume,loc,rate', [
+    (10, 0, 1.0),
+    (10, None, 1.0),
+    (None, 0, 1.0),
+    (None, None, 1.0),
+    (10, 0, 1000.0),
+    (10, 0, None)])
 @pytest.mark.api2_only
-def test_pick_up_tip(instruments, labware):
-    lw = labware.load('opentrons_96_tiprack_10ul', '1')
-    pip = instruments.P10_Single(mount='left')
+def test_aspirate_locations(
+        monkeypatch, instruments, labware, load_v1_instrument,
+        volume, loc, rate):
+    robot, legacy_instr, legacy_lw = load_v1_instrument
 
-    instruments._robot_wrapper.home()
-
-    pip.pick_up_tip(lw.wells(0))
-    assert pip.has_tip
-    assert pip.current_tip() == lw.wells(0)
-
-@pytest.mark.api2_only
-def test_aspirate(instruments, labware, load_v1_instrument):
     tr = labware.load('opentrons_96_tiprack_10ul', '1')
     pip = instruments.P10_Single(mount='left', tip_racks=[tr])
     lw = labware.load('corning_96_wellplate_360ul_flat', '2')
 
     instruments._robot_wrapper.home()
-    fake_move_to = mock.Mock()
-    monkeypatch.setattr(instruments._robot_wrapper._ctx,
-                        'load_instrument', fake_load)
-    pip.aspirate(lw.wells(0))
-    assert pip.current_volume == pip.max_volume
+
+    legacy_move_to, move_to = get_v1_v2_mock_calls(
+        monkeypatch, legacy_instr, pip, 'move_to')
+    # import pdb; pdb.set_trace()
+    hw_aspirate = mock.Mock()
+    monkeypatch.setattr(pip._hw._api, 'aspirate', hw_aspirate)
+
+    legacy_call = {}
+    new_call = {}
+    if volume is not None:
+        legacy_call['volume'] = volume
+        new_call['volume'] = volume
+    if loc is not None:
+        if volume is None:
+            kw = 'volume'
+        else:
+            kw = 'location'
+        legacy_call[kw] = legacy_lw.wells(loc)
+        new_call[kw] = lw.wells(loc)
+    if rate is not None:
+        legacy_call['rate'] = rate
+        new_call['rate'] = rate
+
+    pip._set_plunger_max_speed_override(10)
+
+    legacy_instr.aspirate(**legacy_call)
+    pip.aspirate(**new_call)
+    
+    max_speed = pip._clamp_to_max_plunger_speed(
+        pip.speeds['aspirate'] * 1000, 'aspirate rate')
+    max_rate = max_speed / pip.speeds['aspirate']
+
+    assert pip.current_volume == volume or pip.max_volume
+    assert len(legacy_move_to.call_args_list) == len(move_to.call_args_list)
+    for expected_call, call in zip(
+            legacy_move_to.call_args_list, move_to.call_args_list):
+        expected_args, expected_kwargs = expected_call
+        call_args, call_kwargs = call
+        assert all(isclose(list(expected_args[0][1]), list(call_args[0][1])))
+        assert expected_kwargs == call_kwargs
+    hw_aspirate.assert_called_once_with(
+        pip._mount,
+        volume if volume is not None else 10,
+        min(max_rate, rate or 1.0))
+
+
+@pytest.mark.api2_only
+def test_dispense_locations(
+        monkeypatch, instruments, labware, load_v1_instrument):
+    robot, legacy_instr, legacy_lw = load_v1_instrument
+
+    tr = labware.load('opentrons_96_tiprack_10ul', '1')
+    pip = instruments.P10_Single(mount='left', tip_racks=[tr])
+    lw = labware.load('corning_96_wellplate_360ul_flat', '2')
+
+    instruments._robot_wrapper.home()
+
+    legacy_move_to, move_to = get_v1_v2_mock_calls(
+        monkeypatch, legacy_instr, pip, 'move_to')
+
+    legacy_instr.dispense(legacy_lw.wells(1))
+    pip.dispense(lw.wells(1))
+
+    assert pip.current_volume == 0
+    assert len(legacy_move_to.call_args_list) == len(move_to.call_args_list)
+    for expected_call, call in zip(
+            legacy_move_to.call_args_list, move_to.call_args_list):
+        expected_args, _ = expected_call
+        call_args, _ = call
+        assert all(isclose(list(expected_args[0][1]), list(call_args[0][1])))
+
+
+def convert_well_to_name(item):
+    if isinstance(item, Placeable) or isinstance(item, LegacyWell):
+        return item.get_name()
+    else:
+        return item
+
+
+@pytest.mark.parametrize('reps,volume,loc', [
+    (1, 10, 0),
+    (1, None, 0),
+    (1, 10, None),
+    (None, None, None),
+    (5, 10, 0),
+    (5, None, 0),
+    (5, 10, None)])
+@pytest.mark.api2_only
+def test_mix_locations(monkeypatch, instruments, labware, load_v1_instrument,
+                       reps, volume, loc):
+    robot, legacy_instr, legacy_lw = load_v1_instrument
+    tr = labware.load('opentrons_96_tiprack_10ul', '1')
+    pip = instruments.P10_Single(mount='left', tip_racks=[tr])
+    lw = labware.load('corning_96_wellplate_360ul_flat', '2')
+
+    instruments._robot_wrapper.home()
+
+    legacy_aspirate, aspirate = get_v1_v2_mock_calls(
+        monkeypatch, legacy_instr, pip, 'aspirate')
+
+    legacy_dispense, dispense = get_v1_v2_mock_calls(
+        monkeypatch, legacy_instr, pip, 'dispense')
+
+    legacy_call = {}
+    new_call = {}
+    if reps is not None:
+        legacy_call['repetitions'] = reps
+        new_call['repetitions'] = reps
+    if volume is not None:
+        legacy_call['volume'] = volume
+        new_call['volume'] = volume
+    if loc is not None:
+        if volume is None:
+            kw = 'volume'
+        else:
+            kw = 'location'
+        legacy_call[kw] = legacy_lw.wells(loc)
+        new_call[kw] = lw.wells(loc)
+
+    legacy_instr.mix(**legacy_call)
+    pip.mix(**new_call)
+
+    assert len(legacy_aspirate.call_args_list) == len(aspirate.call_args_list)
+
+    _, legacy_kwargs = legacy_aspirate.call_args_list[0]
+    _, call_kwargs = aspirate.call_args_list[0]
+    legacy_aspirate_args_1 = {k: convert_well_to_name(v)
+                              for k, v in legacy_kwargs.items()}
+    aspirate_args_1 = {k: convert_well_to_name(v)
+                       for k, v in call_kwargs.items()}
+    assert legacy_aspirate_args_1 == aspirate_args_1
+
+    for expected_call, call in zip(
+            legacy_aspirate.call_args_list[1:], aspirate.call_args_list[1:]):
+        expected_args, expected_kwargs = expected_call
+        call_args, call_kwargs = call
+        if expected_args:
+            assert len(expected_args) == len(call_args)
+            assert expected_args[0] == call_args[0]
+        assert expected_kwargs == call_kwargs
+
+    assert len(legacy_dispense.call_args_list) == len(dispense.call_args_list)
+    for expected_call, call in zip(
+            legacy_dispense.call_args_list, dispense.call_args_list):
+        expected_args, _ = expected_call
+        call_args, _ = call
+        if expected_args:
+            assert len(expected_args) == len(call_args)
+            assert expected_args[0] == call_args[0]

--- a/api/tests/opentrons/protocol_api/test_instrument_wrapper.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_wrapper.py
@@ -2,8 +2,6 @@ from unittest import mock
 
 import pytest
 
-import opentrons.protocol_api as papi
-
 
 @pytest.fixture
 def load_v1_instrument(virtual_smoothie_env):

--- a/api/tests/opentrons/protocol_api/test_instrument_wrapper.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_wrapper.py
@@ -1,5 +1,4 @@
 from unittest import mock
-import math
 
 import pytest
 
@@ -664,9 +663,11 @@ def mock_atomics(instr, monkeypatch):
     monkeypatch.setattr(instr, 'aspirate', top_mock.aspirate)
     top_mock.dispense.side_effect = instr.dispense
     monkeypatch.setattr(instr, 'dispense', top_mock.dispense)
-    #top_mock.air_gap.side_effect = instr.air_gap
+    # TODO: uncomment when air gap works
+    # top_mock.air_gap.side_effect = instr.air_gap
     monkeypatch.setattr(instr, 'air_gap', top_mock.air_gap)
-    #top_mock.blow_out.side_effect = instr.blow_out
+    # TODO: uncomment when blow out works
+    # top_mock.blow_out.side_effect = instr.blow_out
     monkeypatch.setattr(instr, 'blow_out', top_mock.blow_out)
     top_mock.pick_up_tip.side_effect = instr.pick_up_tip
     monkeypatch.setattr(instr, 'pick_up_tip', top_mock.pick_up_tip)
@@ -674,7 +675,8 @@ def mock_atomics(instr, monkeypatch):
     monkeypatch.setattr(instr, 'drop_tip', top_mock.drop_tip)
     top_mock.return_tip.side_effect = instr.return_tip
     monkeypatch.setattr(instr, 'return_tip', top_mock.return_tip)
-    #top_mock.touch_tip.side_effect = instr.touch_tip
+    # TODO: uncomment when touch tip works
+    # top_mock.touch_tip.side_effect = instr.touch_tip
     monkeypatch.setattr(instr, 'touch_tip', top_mock.touch_tip)
     return instr, top_mock
 
@@ -700,39 +702,40 @@ def common_method_calls(call_list):
     return [common_method_call(call) for call in call_list]
 
 
-@pytest.mark.parametrize(
-    'instrument_ctor,volume,source,dest,touch_tip,blow_out,mix_before,mix_after,gradient,air_gap',
+@pytest.mark.parametrize(  # noqa(E501,C901)
+    'instrument_ctor,volume,source,dest,touch_tip,blow_out,mix_before,mix_after,gradient,air_gap',  # noqa(E501)
     bind_parameters_to_instruments([
-        ('half_max_volume', ('single', 'A1'), ('single', 'A2'), None, None, None, None, None, None),
-        ('half_max_volume', ('wellseries', 16), ('wellseries', 16), None, None, None, None, None, None),
-        ('max_volume', ('single', 'A1'), ('single', 'A2'), None, None, None, None, None, None),
-        ('twice_max_volume', ('wellseries', 16), ('wellseries', 16), None, None, None, None, None, None),
-        ('max_volume', ('wellseries', 16), ('wellseries', 16), None, None, None, None, None, None),
-        ('max_volume', ('list', 8), ('list', 8), None, None, None, None, None, None),
-        ('list of max', ('list', 8), ('list', 8), None, None, None, None, None, None),
-        ('gradient', ('list', 8), ('list', 8), None, None, None, None, None, None),
-        ('gradient', ('list', 8), ('list', 8), None, None, None, None, lambda x: x, None),
+        ('half_max_volume', ('single', 'A1'), ('single', 'A2'), None, None, None, None, None, None),  # noqa(E501)
+        ('half_max_volume', ('wellseries', 16), ('wellseries', 16), None, None, None, None, None, None),  # noqa(E501)
+        ('max_volume', ('single', 'A1'), ('single', 'A2'), None, None, None, None, None, None),  # noqa(E501)
+        ('twice_max_volume', ('wellseries', 16), ('wellseries', 16), None, None, None, None, None, None),  # noqa(E501)
+        ('max_volume', ('wellseries', 16), ('wellseries', 16), None, None, None, None, None, None),  # noqa(E501)
+        ('max_volume', ('list', 8), ('list', 8), None, None, None, None, None, None),  # noqa(E501)
+        ('list of max', ('list', 8), ('list', 8), None, None, None, None, None, None),  # noqa(E501)
+        ('gradient', ('list', 8), ('list', 8), None, None, None, None, None, None),  # noqa(E501)
+        ('gradient', ('list', 8), ('list', 8), None, None, None, None, lambda x: x, None),  # noqa(E501)
         # mix before
-        ('max_volume', ('list', 8), ('list', 8), None, None, (5, 'half_max_volume'), None, None, None),
+        ('max_volume', ('list', 8), ('list', 8), None, None, (5, 'half_max_volume'), None, None, None),  # noqa(E501)
         # mix after
-        ('max_volume', ('list', 8), ('list', 8), None, None, None, (5, 'half_max_volume'), None, None),
+        ('max_volume', ('list', 8), ('list', 8), None, None, None, (5, 'half_max_volume'), None, None),  # noqa(E501)
         # mix after and mix before
-        ('max_volume', ('list', 8), ('list', 8), None, None, (7, 'half_max_volume'), (5, 'half_max_volume'), None, None),
+        ('max_volume', ('list', 8), ('list', 8), None, None, (7, 'half_max_volume'), (5, 'half_max_volume'), None, None),  # noqa(E501)
         # air gap
-        ('max_volume', ('list', 8), ('list', 8), None, None, None, None, None, 'min_volume'),
+        ('max_volume', ('list', 8), ('list', 8), None, None, None, None, None, 'min_volume'),  # noqa(E501)
         # touch tip
-        ('max_volume', ('list', 8), ('list', 8), True, None, None, None, None, None),
+        ('max_volume', ('list', 8), ('list', 8), True, None, None, None, None, None),  # noqa(E501)
         # blow out
-        ('max_volume', ('list', 8), ('list', 8), None, True, None, None, None, None),
+        ('max_volume', ('list', 8), ('list', 8), None, True, None, None, None, None),  # noqa(E501)
         # free for all
-        ('max_volume', ('list', 8), ('list', 8), True, True, (7, 'half_max_volume'), (5, 'half_max_volume'), None, 'min_volume'),
+        ('max_volume', ('list', 8), ('list', 8), True, True, (7, 'half_max_volume'), (5, 'half_max_volume'), None, 'min_volume'),  # noqa(E501)
     ], instrs=['P300_Single', 'P20_Multi_GEN2'])
 )
 @pytest.mark.api2_only
 def test_basic_transfer(
         monkeypatch, instruments, labware, load_v1_instrument,
         load_bc_instrument,
-        instrument_ctor, volume, source, dest, touch_tip, blow_out, mix_before, mix_after, gradient, air_gap):
+        instrument_ctor, volume, source, dest,
+        touch_tip, blow_out, mix_before, mix_after, gradient, air_gap):
     robot, legacy_instr, legacy_lw = load_v1_instrument
     new_robot, new_instr, new_lw = load_bc_instrument
     legacy_instr, legacy_mock = mock_atomics(legacy_instr, monkeypatch)


### PR DESCRIPTION
This is the PR for adding full backwards compatibility for instrument methods (aka just about everything) to APIv2. it is still under development but there is enough basic functionality read to begin testing.

## What Should Work Right Now
- aspirate (all argument forms)
- dispense (all argument forms)
- pick up tip (all argument forms including tipracks specified in instrument constructor)
- drop tip (all argument forms)
- tempdeck and magdeck arguments and labware loading