### PR TITLE
feat(protocol-designer): move deck setup guidance to hint modal

### DIFF
--- a/components/src/modals/AlertModal.js
+++ b/components/src/modals/AlertModal.js
@@ -7,7 +7,7 @@ import { Icon, type IconName } from '../icons'
 import Modal from './Modal'
 import styles from './modals.css'
 
-type Props = {
+type Props = {|
   /** optional handler for overlay click */
   onCloseClick?: () => mixed,
   /** optional modal heading */
@@ -26,7 +26,7 @@ type Props = {
   iconName?: ?IconName,
   /** restricts scroll outside of Modal when open, true by default */
   restrictOuterScroll?: boolean,
-}
+|}
 
 /**
  * Generic alert modal with a heading and a set of buttons at the bottom

--- a/protocol-designer/src/components/DeckSetup/DeckSetup.css
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.css
@@ -19,15 +19,6 @@
   overflow-y: hidden;
 }
 
-.deck_instructions {
-  font-size: var(--fs-caption);
-  font-weight: var(--fw-semibold);
-  color: var(--c-font-dark);
-  background-color: white;
-  height: 2rem;
-  line-height: 1.25;
-}
-
 .robot_workspace {
   width: 100%;
   height: 100%;

--- a/protocol-designer/src/components/DeckSetup/DeckSetup.js
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.js
@@ -1,12 +1,11 @@
 // @flow
-import React, { useCallback, useState, type Node } from 'react'
+import React, { useCallback, useState } from 'react'
 import { useSelector } from 'react-redux'
 import compact from 'lodash/compact'
 import values from 'lodash/values'
 import {
   useOnClickOutside,
   RobotWorkSpace,
-  RobotCoordsForeignDiv,
   type RobotWorkSpaceRenderProps,
 } from '@opentrons/components'
 import {
@@ -15,9 +14,8 @@ import {
   type ModuleType,
 } from '@opentrons/shared-data'
 import { getDeckDefinitions } from '@opentrons/components/src/deck/getDeckDefinitions'
-import i18n from '../../localization'
 import { PSEUDO_DECK_SLOTS, GEN_ONE_MULTI_PIPETTES } from '../../constants'
-import { START_TERMINAL_ITEM_ID, type TerminalItemId } from '../../steplist'
+import type { TerminalItemId } from '../../steplist'
 import { getLabwareIsCompatible } from '../../utils/labwareModuleCompatibility'
 import {
   getModuleVizDims,
@@ -290,20 +288,6 @@ const DeckSetupContents = (props: ContentsProps) => {
   )
 }
 
-const DeckInstructions = (props: {| children: Node |}) => (
-  <RobotCoordsForeignDiv
-    x={0}
-    y={364}
-    height={36}
-    width={200}
-    innerDivProps={{
-      className: styles.deck_instructions,
-    }}
-  >
-    {props.children}
-  </RobotCoordsForeignDiv>
-)
-
 const getHasGen1MultiChannelPipette = (
   pipettes: $PropertyType<InitialDeckSetup, 'pipettes'>
 ) => {
@@ -328,15 +312,6 @@ const DeckSetup = (props: Props) => {
   const wrapperRef = useOnClickOutside({
     onClickOutside: props.handleClickOutside,
   })
-  const headerMessage = props.selectedTerminalItemId
-    ? i18n.t(
-        `deck.header.${
-          props.selectedTerminalItemId === START_TERMINAL_ITEM_ID
-            ? 'start'
-            : 'end'
-        }`
-      )
-    : null
 
   return (
     <React.Fragment>
@@ -351,7 +326,6 @@ const DeckSetup = (props: Props) => {
           >
             {({ deckSlotsById, getRobotCoordsFromDOMCoords }) => (
               <>
-                <DeckInstructions>{headerMessage}</DeckInstructions>
                 <DeckSetupContents
                   initialDeckSetup={props.initialDeckSetup}
                   selectedTerminalItemId={props.selectedTerminalItemId}

--- a/protocol-designer/src/components/Hints/hints.css
+++ b/protocol-designer/src/components/Hints/hints.css
@@ -20,6 +20,22 @@
   }
 }
 
+.hint_contents {
+  @apply --font-body-2-dark;
+
+  line-height: var(--lh-copy);
+
+  & p {
+    margin-bottom: 1rem;
+  }
+}
+
+.heading {
+  @apply --font-header-dark;
+
+  margin-bottom: 1rem;
+}
+
 .column_left {
   width: 35%;
 }

--- a/protocol-designer/src/components/Hints/index.js
+++ b/protocol-designer/src/components/Hints/index.js
@@ -22,6 +22,10 @@ type Props = {| ...SP, ...DP |}
 
 type State = { rememberDismissal: boolean }
 
+// List of hints that should have /!\ gray AlertModal header
+// (versus calmer non-alert header)
+const HINT_IS_ALERT: Array<HintKey> = ['add_liquids_and_labware']
+
 class Hints extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
@@ -43,7 +47,7 @@ class Hints extends React.Component<Props, State> {
     switch (hintKey) {
       case 'add_liquids_and_labware':
         return (
-          <React.Fragment>
+          <>
             <div className={styles.summary}>
               {i18n.t('alert.hint.add_liquids_and_labware.summary', {
                 deck_setup_step: i18n.t('nav.terminal_item.__initial_setup__'),
@@ -69,7 +73,15 @@ class Hints extends React.Component<Props, State> {
               </div>
               <img src={EXAMPLE_WATCH_LIQUIDS_MOVE_IMAGE} />
             </span>
-          </React.Fragment>
+          </>
+        )
+      case 'deck_setup_explanation':
+        return (
+          <>
+            <p>{i18n.t(`alert.hint.${hintKey}.body1`)}</p>
+            <p>{i18n.t(`alert.hint.${hintKey}.body2`)}</p>
+            <p>{i18n.t(`alert.hint.${hintKey}.body3`)}</p>
+          </>
         )
       default:
         return null
@@ -78,14 +90,19 @@ class Hints extends React.Component<Props, State> {
 
   render() {
     const { hintKey } = this.props
-    return hintKey ? (
+    if (!hintKey) return null
+
+    const headingText = i18n.t(`alert.hint.${hintKey}.title`)
+    const hintIsAlert = HINT_IS_ALERT.includes(hintKey)
+    return (
       <Portal>
-        <AlertModal
-          type="warning"
-          alertOverlay
-          heading={i18n.t(`alert.hint.${hintKey}.title`)}
-        >
-          {this.renderHintContents(hintKey)}
+        <AlertModal alertOverlay heading={hintIsAlert ? headingText : null}>
+          {!hintIsAlert ? (
+            <div className={styles.heading}>{headingText}</div>
+          ) : null}
+          <div className={styles.hint_contents}>
+            {this.renderHintContents(hintKey)}
+          </div>
           <div>
             <CheckboxField
               className={styles.dont_show_again}
@@ -102,7 +119,7 @@ class Hints extends React.Component<Props, State> {
           </div>
         </AlertModal>
       </Portal>
-    ) : null
+    )
   }
 }
 

--- a/protocol-designer/src/components/modals/EditPipettesModal/StepChangesConfirmModal.js
+++ b/protocol-designer/src/components/modals/EditPipettesModal/StepChangesConfirmModal.js
@@ -14,7 +14,6 @@ const StepChangesConfirmModal = (props: Props) => {
 
   return (
     <AlertModal
-      type="warning"
       alertOverlay
       className={modalStyles.modal}
       heading={i18n.t('modal.global_step_changes.heading')}

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -14,6 +14,12 @@
       "step1": "Add liquids",
       "step2": "Watch liquids move as you build your protocol"
     },
+    "deck_setup_explanation": {
+      "title": "Setting up your protocol",
+      "body1": "If you look to your left you will see the Protocol Timeline, and that the \"Starting Deck State\" step is blue. The blue means that this is the step you are currently working on.",
+      "body2": "Before you can build a protocol that tell the robot how to move liquid around, you'll need to tell the Protocol Designer where all of your labware is on the deck, and which liquids start in which wells. As you add steps to your protocol the Protocol Designer will move liquid from the starting positions you defined in the Starting Deck State to new positions.",
+      "body3": "Hover on empty slots in the deck to add labware. Hover on labware to add liquid to the wells."
+    },
     "custom_labware_with_modules": {
       "title": "Cannot verify compatibility of custom labware",
       "body": "The Protocol Designer cannot confirm whether or not custom labware is compatible with any module. Proceed if you are confident your custom labware will fit."

--- a/protocol-designer/src/localization/en/deck.json
+++ b/protocol-designer/src/localization/en/deck.json
@@ -7,7 +7,6 @@
     "MODULE_INCOMPATIBLE_LABWARE_SWAP": "Swapping labware not possible due to module incompatibility"
   },
   "header": {
-    "start": "Tell the robot where labware and liquids start on the deck",
     "end": "Click on labware to inspect the result of your protocol"
   },
   "overlay": {

--- a/protocol-designer/src/navigation/actions.js
+++ b/protocol-designer/src/navigation/actions.js
@@ -1,7 +1,9 @@
 // @flow
 import type { Page } from './types'
 
-export const navigateToPage = (payload: Page) => ({
+export type NavigateToPageAction = {| type: 'NAVIGATE_TO_PAGE', payload: Page |}
+
+export const navigateToPage = (payload: Page): NavigateToPageAction => ({
   type: 'NAVIGATE_TO_PAGE',
   payload,
 })

--- a/protocol-designer/src/tutorial/index.js
+++ b/protocol-designer/src/tutorial/index.js
@@ -3,7 +3,12 @@ import * as actions from './actions'
 import { rootReducer, type RootState } from './reducers'
 import * as selectors from './selectors'
 
-type HintKey = 'add_liquids_and_labware' | 'custom_labware_with_modules'
+type HintKey =
+  // normal hints
+  | 'add_liquids_and_labware'
+  | 'deck_setup_explanation'
+  // blocking hints
+  | 'custom_labware_with_modules'
 
 export { actions, rootReducer, selectors }
 

--- a/protocol-designer/src/tutorial/reducers.js
+++ b/protocol-designer/src/tutorial/reducers.js
@@ -8,6 +8,7 @@ import { rehydrate } from '../persist'
 import type { Action } from '../types'
 import type { HintKey } from './index'
 import type { AddHintAction, RemoveHintAction } from './actions'
+import type { NavigateToPageAction } from '../navigation/actions'
 
 type HintReducerState = Array<HintKey>
 const hints = handleActions(
@@ -16,6 +17,15 @@ const hints = handleActions(
       state: HintReducerState,
       action: AddHintAction
     ): HintReducerState => uniq([...state, action.payload.hintKey]),
+
+    // going to the steplist page triggers 'deck_setup_explanation' hint
+    NAVIGATE_TO_PAGE: (
+      state: HintReducerState,
+      action: NavigateToPageAction
+    ): HintReducerState =>
+      action.payload === 'steplist'
+        ? uniq([...state, 'deck_setup_explanation'])
+        : state,
   },
   []
 )


### PR DESCRIPTION
## overview

closes #4328

## changelog

* make AlertModal props exact
* allow Hints to be alert or plain
* remove "Tell the robot where labware and liquids start on the deck" text

## review requests

- [ ] Hint shows up when you first go to Design page (first time after creating or uploading a protocol) and not subsequent times (unless you go and create/upload a new protocol again)
- [ ] The existing "Your labware has no liquids in it" behavior+appearance should not change (you get it when adding a transfer/mix step without liquids on the deck)
- [ ] If you remember dismissal, this hint won't show up next time you create/upload a protocol and go to design page