### PR TITLE
fix(api): clear running module tasks on cancel

### DIFF
--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -450,8 +450,6 @@ class API(HardwareAPILike):
         """
         self._log.info("Halting")
         self._backend.hard_halt()
-        # call on attached modules "halt" func that cancels any waits etc.
-        # and probably cancels any ongoing actions, hold onto the task in tc hwc and cancel it
 
     async def stop(self):
         """

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -450,6 +450,8 @@ class API(HardwareAPILike):
         """
         self._log.info("Halting")
         self._backend.hard_halt()
+        # call on attached modules "halt" func that cancels any waits etc.
+        # and probably cancels any ongoing actions, hold onto the task in tc hwc and cancel it
 
     async def stop(self):
         """


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

@TaylorGoodman was able to reproduce a bug in which cancelling a protocol run during a thermocycler hold led to the api server hanging. This manifested itself as an unresettable protoco, which needed to be power cycled.  

This adds cancel support for the ongoing long running tasks created by the Temperature Module and the Thermocycler Module. 

## review requests

- Cancelling a run while a Temperature Module is heating to temp should be recoverable 
- Cancelling a run while a Thermocycler Module is heating to temp should be recoverable
- Cancelling a run while a Thermocycler Module is holding at temp should be recoverable