### PR TITLE
refactor(app): clarify module behavior in cancel modal

### DIFF
--- a/app/src/components/RunLog/ConfirmCancelModal.js
+++ b/app/src/components/RunLog/ConfirmCancelModal.js
@@ -35,9 +35,8 @@ export default function ExitAlertModal() {
     >
       <p>Doing so will terminate this run and home your robot.</p>
       <p>
-        Your modules will remain in their current states. They can be controlled
-        via their card on the "Run" page, or the "Pipettes &amp; Modules" page
-        for this robot.
+        Additionally, any hardware modules used within the protocol will remain
+        active and maintain their current states until deactivated
       </p>
     </AlertModal>
   )

--- a/app/src/components/RunLog/ConfirmCancelModal.js
+++ b/app/src/components/RunLog/ConfirmCancelModal.js
@@ -36,7 +36,7 @@ export default function ExitAlertModal() {
       <p>Doing so will terminate this run and home your robot.</p>
       <p>
         Additionally, any hardware modules used within the protocol will remain
-        active and maintain their current states until deactivated
+        active and maintain their current states until deactivated.
       </p>
     </AlertModal>
   )

--- a/app/src/components/RunLog/ConfirmCancelModal.js
+++ b/app/src/components/RunLog/ConfirmCancelModal.js
@@ -34,6 +34,11 @@ export default function ExitAlertModal() {
       alertOverlay
     >
       <p>Doing so will terminate this run and home your robot.</p>
+      <p>
+        Your modules will remain in their current states. They can be controlled
+        via their card on the "Run" page, or the "Pipettes &amp; Modules" page
+        for this robot.
+      </p>
     </AlertModal>
   )
 }


### PR DESCRIPTION
## Overview

Following @sfoster1 's comments on #4464. This adds clarifying copy to the cancel modal that better forecasts how your modules will behave.

