### PR TITLE
feat(protocol-designer): Disable module step creation when module missing

### DIFF
--- a/protocol-designer/src/components/StepCreationButton.js
+++ b/protocol-designer/src/components/StepCreationButton.js
@@ -13,7 +13,6 @@ import {
 } from '../step-forms'
 import { stepIconsByType, type StepType } from '../form-types'
 import type { BaseState, ThunkDispatch } from '../types'
-// import type { InitialDeckSetup } from '../step-forms'
 import styles from './listButtons.css'
 
 type SP = {|

--- a/protocol-designer/src/components/StepCreationButton.js
+++ b/protocol-designer/src/components/StepCreationButton.js
@@ -1,17 +1,19 @@
 // @flow
 import * as React from 'react'
 import { connect } from 'react-redux'
-import without from 'lodash/without'
 import i18n from '../localization'
 import { HoverTooltip, PrimaryButton } from '@opentrons/components'
 import { actions as steplistActions } from '../steplist'
 import { selectors as featureFlagSelectors } from '../feature-flags'
+import { selectors as stepFormSelectors } from '../step-forms'
 import { stepIconsByType, type StepType } from '../form-types'
 import type { BaseState, ThunkDispatch } from '../types'
+import type { InitialDeckSetup } from '../step-forms'
 import styles from './listButtons.css'
 
 type SP = {|
   modulesEnabled: ?boolean,
+  _initialDeckSetup: InitialDeckSetup,
 |}
 
 type DP = {|
@@ -38,21 +40,8 @@ class StepCreationButton extends React.Component<Props, State> {
 
   render() {
     // TODO: Ian 2019-01-17 move out to centralized step info file - see #2926
-    const supportedSteps = [
-      'moveLiquid',
-      'mix',
-      'pause',
-      'magnet',
-      'temperature',
-      'thermocycler',
-    ]
+    const supportedSteps = ['moveLiquid', 'mix', 'pause']
     const moduleSteps = ['magnet', 'temperature', 'thermocycler']
-    // TODO (ka 11-15-2019): Move module specific steps into thier own group to
-    // conditionally render below and add the disabled logic for steps related
-    // to modules not present on deck
-    const filteredSteps = this.props.modulesEnabled
-      ? supportedSteps
-      : without(supportedSteps, ...moduleSteps)
 
     return (
       <div
@@ -65,7 +54,30 @@ class StepCreationButton extends React.Component<Props, State> {
 
         <div className={styles.buttons_popover}>
           {this.state.expanded &&
-            filteredSteps.map(stepType => (
+            supportedSteps.map(stepType => (
+              <HoverTooltip
+                key={stepType}
+                placement="right"
+                modifiers={{ preventOverflow: { enabled: false } }}
+                positionFixed
+                tooltipComponent={i18n.t(
+                  `tooltip.step_description.${stepType}`
+                )}
+              >
+                {hoverTooltipHandlers => (
+                  <PrimaryButton
+                    hoverTooltipHandlers={hoverTooltipHandlers}
+                    onClick={this.props.makeAddStep(stepType)}
+                    iconName={stepIconsByType[stepType]}
+                  >
+                    {i18n.t(`application.stepType.${stepType}`, stepType)}
+                  </PrimaryButton>
+                )}
+              </HoverTooltip>
+            ))}
+          {this.state.expanded &&
+            this.props.modulesEnabled &&
+            moduleSteps.map(stepType => (
               <HoverTooltip
                 key={stepType}
                 placement="right"
@@ -95,6 +107,7 @@ class StepCreationButton extends React.Component<Props, State> {
 const mapSTP = (state: BaseState): SP => {
   return {
     modulesEnabled: featureFlagSelectors.getEnableModules(state),
+    _initialDeckSetup: stepFormSelectors.getInitialDeckSetup(state),
   }
 }
 

--- a/protocol-designer/src/components/StepCreationButton.js
+++ b/protocol-designer/src/components/StepCreationButton.js
@@ -1,19 +1,26 @@
 // @flow
 import * as React from 'react'
 import { connect } from 'react-redux'
+import cx from 'classnames'
+import without from 'lodash/without'
 import i18n from '../localization'
 import { HoverTooltip, PrimaryButton } from '@opentrons/components'
 import { actions as steplistActions } from '../steplist'
 import { selectors as featureFlagSelectors } from '../feature-flags'
-import { selectors as stepFormSelectors } from '../step-forms'
+import {
+  selectors as stepFormSelectors,
+  getIsModuleOnDeck,
+} from '../step-forms'
 import { stepIconsByType, type StepType } from '../form-types'
 import type { BaseState, ThunkDispatch } from '../types'
-import type { InitialDeckSetup } from '../step-forms'
+// import type { InitialDeckSetup } from '../step-forms'
 import styles from './listButtons.css'
 
 type SP = {|
   modulesEnabled: ?boolean,
-  _initialDeckSetup: InitialDeckSetup,
+  isStepTypeEnabled: {
+    [moduleType: StepType]: boolean,
+  },
 |}
 
 type DP = {|
@@ -40,8 +47,19 @@ class StepCreationButton extends React.Component<Props, State> {
 
   render() {
     // TODO: Ian 2019-01-17 move out to centralized step info file - see #2926
-    const supportedSteps = ['moveLiquid', 'mix', 'pause']
+    const supportedSteps = [
+      'moveLiquid',
+      'mix',
+      'pause',
+      'magnet',
+      'temperature',
+      'thermocycler',
+    ]
     const moduleSteps = ['magnet', 'temperature', 'thermocycler']
+    const filteredSteps = this.props.modulesEnabled
+      ? supportedSteps
+      : without(supportedSteps, ...moduleSteps)
+    const { isStepTypeEnabled } = this.props
 
     return (
       <div
@@ -54,50 +72,37 @@ class StepCreationButton extends React.Component<Props, State> {
 
         <div className={styles.buttons_popover}>
           {this.state.expanded &&
-            supportedSteps.map(stepType => (
-              <HoverTooltip
-                key={stepType}
-                placement="right"
-                modifiers={{ preventOverflow: { enabled: false } }}
-                positionFixed
-                tooltipComponent={i18n.t(
-                  `tooltip.step_description.${stepType}`
-                )}
-              >
-                {hoverTooltipHandlers => (
-                  <PrimaryButton
-                    hoverTooltipHandlers={hoverTooltipHandlers}
-                    onClick={this.props.makeAddStep(stepType)}
-                    iconName={stepIconsByType[stepType]}
-                  >
-                    {i18n.t(`application.stepType.${stepType}`, stepType)}
-                  </PrimaryButton>
-                )}
-              </HoverTooltip>
-            ))}
-          {this.state.expanded &&
-            this.props.modulesEnabled &&
-            moduleSteps.map(stepType => (
-              <HoverTooltip
-                key={stepType}
-                placement="right"
-                modifiers={{ preventOverflow: { enabled: false } }}
-                positionFixed
-                tooltipComponent={i18n.t(
-                  `tooltip.step_description.${stepType}`
-                )}
-              >
-                {hoverTooltipHandlers => (
-                  <PrimaryButton
-                    hoverTooltipHandlers={hoverTooltipHandlers}
-                    onClick={this.props.makeAddStep(stepType)}
-                    iconName={stepIconsByType[stepType]}
-                  >
-                    {i18n.t(`application.stepType.${stepType}`, stepType)}
-                  </PrimaryButton>
-                )}
-              </HoverTooltip>
-            ))}
+            filteredSteps.map(stepType => {
+              const disabled = !isStepTypeEnabled[stepType]
+              const tooltipMessage = disabled
+                ? i18n.t(`tooltip.disabled_module_step`)
+                : i18n.t(`tooltip.step_description.${stepType}`)
+              const onClick = !disabled
+                ? this.props.makeAddStep(stepType)
+                : () => null
+              return (
+                <HoverTooltip
+                  key={stepType}
+                  placement="right"
+                  modifiers={{ preventOverflow: { enabled: false } }}
+                  positionFixed
+                  tooltipComponent={tooltipMessage}
+                >
+                  {hoverTooltipHandlers => (
+                    <PrimaryButton
+                      hoverTooltipHandlers={hoverTooltipHandlers}
+                      onClick={onClick}
+                      iconName={stepIconsByType[stepType]}
+                      className={cx({
+                        [styles.step_button_disabled]: disabled,
+                      })}
+                    >
+                      {i18n.t(`application.stepType.${stepType}`, stepType)}
+                    </PrimaryButton>
+                  )}
+                </HoverTooltip>
+              )
+            })}
         </div>
       </div>
     )
@@ -105,9 +110,19 @@ class StepCreationButton extends React.Component<Props, State> {
 }
 
 const mapSTP = (state: BaseState): SP => {
+  const modules = stepFormSelectors.getInitialDeckSetup(state).modules
   return {
     modulesEnabled: featureFlagSelectors.getEnableModules(state),
-    _initialDeckSetup: stepFormSelectors.getInitialDeckSetup(state),
+    isStepTypeEnabled: {
+      moveLiquid: true,
+      mix: true,
+      pause: true,
+      magnet: getIsModuleOnDeck(modules, 'magdeck'),
+      temperature:
+        getIsModuleOnDeck(modules, 'tempdeck') ||
+        getIsModuleOnDeck(modules, 'thermocycler'),
+      thermocycler: getIsModuleOnDeck(modules, 'thermocycler'),
+    },
   }
 }
 

--- a/protocol-designer/src/components/listButtons.css
+++ b/protocol-designer/src/components/listButtons.css
@@ -1,3 +1,5 @@
+@import '@opentrons/components';
+
 .list_item_button {
   z-index: 5;
   position: relative;
@@ -8,4 +10,15 @@
   position: absolute;
   left: 2rem;
   right: 2rem;
+}
+
+.step_button_disabled {
+  color: var(--c-font-disabled);
+  fill: var(--c-font-disabled);
+  cursor: default;
+
+  &:hover,
+  &.hover {
+    background-color: var(--c-bg-dark);
+  }
 }

--- a/protocol-designer/src/localization/en/application.json
+++ b/protocol-designer/src/localization/en/application.json
@@ -3,7 +3,9 @@
     "mix": "mix",
     "moveLiquid": "transfer",
     "pause": "pause",
-    "magnet": "magnetic module"
+    "magnet": "magnet",
+    "temperature": "temperature",
+    "thermocycler": "thermocycler profile"
   },
   "units": {
     "millimeter": "mm",

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -6,9 +6,9 @@
     "mix": "Mix content of wells",
     "pause": "OT-2 will pause before proceeding",
     "moveLiquid": "Move liquid",
-    "magnet": "Engage or disengage magnetic module",
-    "temperature": "TODO",
-    "thermocycler": "TODO"
+    "magnet": "Engage or disengage the magnetic module",
+    "temperature": "Set a temperature on a temperature module or a thermocycler",
+    "thermocycler": "Begin running a thermocycler profile"
   },
 
   "disabled_module_step": "Add a relevant module to use this step",

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -3,12 +3,12 @@
   "advanced_settings": "Advanced Settings",
 
   "step_description": {
-    "mix": "Mix content of wells",
-    "pause": "OT-2 will pause before proceeding",
-    "moveLiquid": "Move liquid",
-    "magnet": "Engage or disengage the magnetic module",
-    "temperature": "Set a temperature on a temperature module or a thermocycler",
-    "thermocycler": "Begin running a thermocycler profile"
+    "mix": "Mix contents of wells/tubes.",
+    "pause": "Enable pause within protocol.",
+    "moveLiquid": "Move liquid to and from wells/tubes.",
+    "magnet": "Engage or disengage the Magnetic module.",
+    "temperature": "Set temperature command for Temperature and Thermocycler modules.",
+    "thermocycler": "Program a profile for the Thermocycler module."
   },
 
   "disabled_module_step": "Add a relevant module to use this step",

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -6,8 +6,12 @@
     "mix": "Mix content of wells",
     "pause": "OT-2 will pause before proceeding",
     "moveLiquid": "Move liquid",
-    "magnet": "Engage or disengage magnetic module"
+    "magnet": "Engage or disengage magnetic module",
+    "temperature": "TODO",
+    "thermocycler": "TODO"
   },
+
+  "disabled_module_step": "Add a relevant module to use this step",
 
   "step_fields": {
     "defaults": {

--- a/protocol-designer/src/step-forms/utils.js
+++ b/protocol-designer/src/step-forms/utils.js
@@ -2,7 +2,11 @@
 import assert from 'assert'
 import reduce from 'lodash/reduce'
 import values from 'lodash/values'
-import { getPipetteNameSpecs, type DeckSlotId } from '@opentrons/shared-data'
+import {
+  getPipetteNameSpecs,
+  type DeckSlotId,
+  type ModuleType,
+} from '@opentrons/shared-data'
 import {
   SPAN7_8_10_11_SLOT,
   TC_SPAN_SLOTS,
@@ -146,4 +150,12 @@ export const getHasGen1MultiChannelPipette = (
   return pipetteIds.some(pipetteId =>
     GEN_ONE_MULTI_PIPETTES.includes(pipettes[pipetteId]?.name)
   )
+}
+
+export const getIsModuleOnDeck = (
+  modules: $PropertyType<InitialDeckSetup, 'modules'>,
+  moduleType: ModuleType
+) => {
+  const moduleIds = Object.keys(modules)
+  return moduleIds.some(moduleId => modules[moduleId]?.type === moduleType)
 }


### PR DESCRIPTION
## overview

This PR closes #4456 by disabling step creation button when modules required for step are not present on the deck. It also updates ALL step creation button tooltip text.

## changelog

- chore: Add `isModuleOnDeck` util
- feat(protocol-designer): Disable module step creation when module missing

## review requests
http://sandbox.designer.opentrons.com/pd_disable-module-steps/ (currently building... not up to date yet)

- [ ] Module steps do not render at all if modules FF is turned off
- [ ] Module step is disabled if required module is missing
- [ ] Tooltip for disabled module steps reads: `Add a relevant module to use this step`
- [ ] Tooltip for enabled steps read:
  - Transfer:  Move liquid to and from wells/tubes.
  - Mix: Mix contents of wells/tubes.
  - Pause: Enable pause within protocol.
  - Temperature: Set temperature command for Temperature and Thermocycler modules.
  - Magnet: Engage or disengage the Magnetic module.
  - Thermocycler Profile: Program a profile for the Thermocycler module.