### PR TITLE
feat(protocol-designer): Add magnet step form field validation

### DIFF
--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -209,6 +209,13 @@
   justify-content: space-between;
 }
 
+.magnet_section_wrapper {
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: 0.5rem;
+  min-height: 4rem;
+}
+
 .magnet_form_group {
-  margin-top: 1rem;
+  margin: 1rem 4.25rem 2rem 0;
 }

--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -210,5 +210,5 @@
 }
 
 .magnet_form_group {
-  margin: 1rem 4.25rem 2rem 0;
+  margin-top: 1rem;
 }

--- a/protocol-designer/src/components/StepEditForm/forms/MagnetForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MagnetForm.js
@@ -1,10 +1,10 @@
 // @flow
 import * as React from 'react'
-import { FormGroup, DropdownField } from '@opentrons/components'
+import { FormGroup } from '@opentrons/components'
 import i18n from '../../../localization'
 
-import StepField from '../fields/FieldConnector'
-import { ConditionalOnField, TextField } from '../fields'
+// import StepField from '../fields/FieldConnector'
+import { ConditionalOnField, TextField, RadioGroupField } from '../fields'
 import styles from '../StepEditForm.css'
 
 import type { FocusHandlers } from '../types'
@@ -22,67 +22,64 @@ function MagnetForm(props: MagnetFormProps): React.Element<'div'> {
       </div>
 
       <div className={styles.section_wrapper}>
-        <div className={styles.wrap_group}>
-          <div className={styles.section_column}>
+        <div className={styles.section_column}>
+          <FormGroup
+            label={i18n.t(
+              'form.step_edit_form.field.magnetActionLabware.label'
+            )}
+            className={styles.magnet_form_group}
+          >
+            TODO: labware dropdown
+          </FormGroup>
+        </div>
+        <div className={styles.section_column}>
+          <FormGroup
+            label={i18n.t('form.step_edit_form.field.magnetAction.label')}
+            className={styles.magnet_form_group}
+          >
+            <RadioGroupField
+              name="magnetAction"
+              options={[
+                {
+                  name: i18n.t(
+                    'form.step_edit_form.field.magnetAction.options.engage'
+                  ),
+                  value: 'engage',
+                },
+              ]}
+              {...focusHandlers}
+            />
+            <RadioGroupField
+              name="magnetAction"
+              options={[
+                {
+                  name: i18n.t(
+                    'form.step_edit_form.field.magnetAction.options.disengage'
+                  ),
+                  value: 'disengage',
+                },
+              ]}
+              {...focusHandlers}
+            />
+          </FormGroup>
+        </div>
+        <div className={styles.section_column}>
+          <ConditionalOnField
+            name={'magnetAction'}
+            condition={val => val === 'engage'}
+          >
             <FormGroup
-              label={i18n.t('form.step_edit_form.field.magnetAction.label')}
+              label={i18n.t('form.step_edit_form.field.engageHeight.label')}
               className={styles.magnet_form_group}
             >
-              <StepField
-                dirtyFields={focusHandlers.dirtyFields}
-                focusedField={focusHandlers.focusedField}
-                name="magnetAction"
-                render={({ value, updateValue, errorToShow }) => {
-                  const fieldValue = String(value) || null
-                  return (
-                    <DropdownField
-                      name="magnetAction"
-                      className={styles.large_field}
-                      onChange={(e: SyntheticEvent<HTMLSelectElement>) => {
-                        updateValue(e.currentTarget.value)
-                      }}
-                      value={fieldValue}
-                      options={[
-                        {
-                          name: i18n.t(
-                            'form.step_edit_form.field.magnetAction.options.engage'
-                          ),
-                          value: 'engage',
-                        },
-                        {
-                          name: i18n.t(
-                            'form.step_edit_form.field.magnetAction.options.disengage'
-                          ),
-                          value: 'disengage',
-                        },
-                      ]}
-                    />
-                  )
-                }}
+              <TextField
+                name="engageHeight"
+                className={styles.small_field}
+                units={i18n.t('application.units.millimeter')}
+                {...focusHandlers}
               />
             </FormGroup>
-          </div>
-          <div className={styles.section_column}>
-            <ConditionalOnField
-              name={'magnetAction'}
-              condition={val => val === 'engage'}
-            >
-              <FormGroup
-                label={i18n.t('form.step_edit_form.field.engageHeight.label')}
-                className={styles.magnet_form_group}
-              >
-                <TextField
-                  name="engageHeight"
-                  caption={i18n.t(
-                    'form.step_edit_form.field.engageHeight.caption'
-                  )}
-                  className={styles.small_field}
-                  units={i18n.t('application.units.millimeter')}
-                  {...focusHandlers}
-                />
-              </FormGroup>
-            </ConditionalOnField>
-          </div>
+          </ConditionalOnField>
         </div>
       </div>
     </div>

--- a/protocol-designer/src/components/StepEditForm/forms/MagnetForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MagnetForm.js
@@ -3,7 +3,6 @@ import * as React from 'react'
 import { FormGroup } from '@opentrons/components'
 import i18n from '../../../localization'
 
-// import StepField from '../fields/FieldConnector'
 import { ConditionalOnField, TextField, RadioGroupField } from '../fields'
 import styles from '../StepEditForm.css'
 
@@ -21,68 +20,52 @@ function MagnetForm(props: MagnetFormProps): React.Element<'div'> {
         </span>
       </div>
 
-      <div className={styles.section_wrapper}>
-        <div className={styles.section_column}>
-          {/*
-            <FormGroup
-            label={i18n.t(
-              'form.step_edit_form.field.magnetActionLabware.label'
-            )}
-            className={styles.magnet_form_group}
-          >
-            TODO: labware dropdown
-          </FormGroup>
-        */}
-        </div>
-        <div className={styles.section_column}>
+      <div className={styles.magnet_section_wrapper}>
+        <FormGroup
+          label={i18n.t('form.step_edit_form.field.magnetAction.label')}
+          className={styles.magnet_form_group}
+        >
+          <RadioGroupField
+            name="magnetAction"
+            options={[
+              {
+                name: i18n.t(
+                  'form.step_edit_form.field.magnetAction.options.engage'
+                ),
+                value: 'engage',
+              },
+            ]}
+            {...focusHandlers}
+          />
+          <RadioGroupField
+            name="magnetAction"
+            options={[
+              {
+                name: i18n.t(
+                  'form.step_edit_form.field.magnetAction.options.disengage'
+                ),
+                value: 'disengage',
+              },
+            ]}
+            {...focusHandlers}
+          />
+        </FormGroup>
+        <ConditionalOnField
+          name={'magnetAction'}
+          condition={val => val === 'engage'}
+        >
           <FormGroup
-            label={i18n.t('form.step_edit_form.field.magnetAction.label')}
+            label={i18n.t('form.step_edit_form.field.engageHeight.label')}
             className={styles.magnet_form_group}
           >
-            <RadioGroupField
-              name="magnetAction"
-              options={[
-                {
-                  name: i18n.t(
-                    'form.step_edit_form.field.magnetAction.options.engage'
-                  ),
-                  value: 'engage',
-                },
-              ]}
-              {...focusHandlers}
-            />
-            <RadioGroupField
-              name="magnetAction"
-              options={[
-                {
-                  name: i18n.t(
-                    'form.step_edit_form.field.magnetAction.options.disengage'
-                  ),
-                  value: 'disengage',
-                },
-              ]}
+            <TextField
+              name="engageHeight"
+              className={styles.small_field}
+              units={i18n.t('application.units.millimeter')}
               {...focusHandlers}
             />
           </FormGroup>
-        </div>
-        <div className={styles.section_column}>
-          <ConditionalOnField
-            name={'magnetAction'}
-            condition={val => val === 'engage'}
-          >
-            <FormGroup
-              label={i18n.t('form.step_edit_form.field.engageHeight.label')}
-              className={styles.magnet_form_group}
-            >
-              <TextField
-                name="engageHeight"
-                className={styles.small_field}
-                units={i18n.t('application.units.millimeter')}
-                {...focusHandlers}
-              />
-            </FormGroup>
-          </ConditionalOnField>
-        </div>
+        </ConditionalOnField>
       </div>
     </div>
   )

--- a/protocol-designer/src/components/StepEditForm/forms/MagnetForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MagnetForm.js
@@ -73,6 +73,9 @@ function MagnetForm(props: MagnetFormProps): React.Element<'div'> {
               >
                 <TextField
                   name="engageHeight"
+                  caption={i18n.t(
+                    'form.step_edit_form.field.engageHeight.caption'
+                  )}
                   className={styles.small_field}
                   units={i18n.t('application.units.millimeter')}
                   {...focusHandlers}

--- a/protocol-designer/src/components/StepEditForm/forms/MagnetForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MagnetForm.js
@@ -23,7 +23,8 @@ function MagnetForm(props: MagnetFormProps): React.Element<'div'> {
 
       <div className={styles.section_wrapper}>
         <div className={styles.section_column}>
-          <FormGroup
+          {/*
+            <FormGroup
             label={i18n.t(
               'form.step_edit_form.field.magnetActionLabware.label'
             )}
@@ -31,6 +32,7 @@ function MagnetForm(props: MagnetFormProps): React.Element<'div'> {
           >
             TODO: labware dropdown
           </FormGroup>
+        */}
         </div>
         <div className={styles.section_column}>
           <FormGroup

--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -73,3 +73,6 @@ export const DEFAULT_MM_BLOWOUT_OFFSET_FROM_TOP = 0
 
 export const DEFAULT_WELL_ORDER_FIRST_OPTION: 't2b' = 't2b'
 export const DEFAULT_WELL_ORDER_SECOND_OPTION: 'l2r' = 'l2r'
+
+export const MIN_ENGAGE_HEIGHT = -4
+export const MAX_ENGAGE_HEIGHT = 16

--- a/protocol-designer/src/localization/en/form.json
+++ b/protocol-designer/src/localization/en/form.json
@@ -96,7 +96,7 @@
       "pipette": { "label": "pipette" },
       "preWetTip": { "label": "pre-wet tip" },
       "touchTip": { "label": "touch tip" },
-      "magnetActionLabware":{ "label": "labware" },
+      "magnetActionLabware": { "label": "labware" },
       "magnetAction": {
         "label": "Magnet action",
         "options": {

--- a/protocol-designer/src/localization/en/form.json
+++ b/protocol-designer/src/localization/en/form.json
@@ -104,7 +104,8 @@
         }
       },
       "engageHeight": {
-        "label": "Distance from labware bottom"
+        "label": "Distance from labware bottom",
+        "caption": "Recommended: 4mm"
       }
     }
   }

--- a/protocol-designer/src/localization/en/form.json
+++ b/protocol-designer/src/localization/en/form.json
@@ -96,6 +96,7 @@
       "pipette": { "label": "pipette" },
       "preWetTip": { "label": "pre-wet tip" },
       "touchTip": { "label": "touch tip" },
+      "magnetActionLabware":{ "label": "labware" },
       "magnetAction": {
         "label": "Magnet action",
         "options": {

--- a/protocol-designer/src/steplist/fieldLevel/errors.js
+++ b/protocol-designer/src/steplist/fieldLevel/errors.js
@@ -38,18 +38,20 @@ export const minimumWellCount = (minimum: number): ErrorChecker => (
   isArray(wells) && wells.length < minimum
     ? `${minimum} ${FIELD_ERRORS.UNDER_WELL_MINIMUM}`
     : null
+
 export const minFieldValue = (minimum: number): ErrorChecker => (
   value: mixed
 ): ?string =>
-  value && Number(value) < minimum
-    ? `${FIELD_ERRORS.UNDER_RANGE_MINIMUM} ${minimum}`
-    : null
+  Number(value) > minimum
+    ? null
+    : `${FIELD_ERRORS.UNDER_RANGE_MINIMUM} ${minimum}`
+
 export const maxFieldValue = (maximum: number): ErrorChecker => (
   value: mixed
 ): ?string =>
-  value && Number(value) > maximum
-    ? `${FIELD_ERRORS.OVER_RANGE_MAXIMUM} ${maximum}`
-    : null
+  Number(value) < maximum
+    ? null
+    : `${FIELD_ERRORS.OVER_RANGE_MAXIMUM} ${maximum}`
 
 /*******************
  **     Helpers    **

--- a/protocol-designer/src/steplist/fieldLevel/errors.js
+++ b/protocol-designer/src/steplist/fieldLevel/errors.js
@@ -42,14 +42,14 @@ export const minimumWellCount = (minimum: number): ErrorChecker => (
 export const minFieldValue = (minimum: number): ErrorChecker => (
   value: mixed
 ): ?string =>
-  Number(value) > minimum
+  Number(value) >= minimum
     ? null
     : `${FIELD_ERRORS.UNDER_RANGE_MINIMUM} ${minimum}`
 
 export const maxFieldValue = (maximum: number): ErrorChecker => (
   value: mixed
 ): ?string =>
-  Number(value) < maximum
+  Number(value) <= maximum
     ? null
     : `${FIELD_ERRORS.OVER_RANGE_MAXIMUM} ${maximum}`
 

--- a/protocol-designer/src/steplist/fieldLevel/errors.js
+++ b/protocol-designer/src/steplist/fieldLevel/errors.js
@@ -31,6 +31,16 @@ export const minimumWellCount = (minimum: number): ErrorChecker => (
   isArray(wells) && wells.length < minimum
     ? `${minimum} ${FIELD_ERRORS.UNDER_WELL_MINIMUM}`
     : null
+export const minFieldValue = (minimum: number): ErrorChecker => (
+  value: mixed
+): ?string =>
+  value && Number(value) < minimum ? `Must be greater than ${minimum}` : null
+export const maxFieldValue = (maximum: number): ErrorChecker => (
+  value: mixed
+): ?string =>
+  value && Number(value) > maximum ? `Must be greater than ${maximum}` : null
+
+// ^ like above... && Number(value)
 
 /*******************
  **     Helpers    **

--- a/protocol-designer/src/steplist/fieldLevel/errors.js
+++ b/protocol-designer/src/steplist/fieldLevel/errors.js
@@ -7,12 +7,19 @@ import isArray from 'lodash/isArray'
 
 // TODO: reconcile difference between returning error string and key
 
-export type FieldError = 'REQUIRED' | 'UNDER_WELL_MINIMUM' | 'NON_ZERO'
+export type FieldError =
+  | 'REQUIRED'
+  | 'UNDER_WELL_MINIMUM'
+  | 'NON_ZERO'
+  | 'UNDER_RANGE_MINIMUM'
+  | 'OVER_RANGE_MAXIMUM'
 
 const FIELD_ERRORS: { [FieldError]: string } = {
   REQUIRED: 'This field is required',
   UNDER_WELL_MINIMUM: 'or more wells are required',
   NON_ZERO: 'Must be greater than zero',
+  UNDER_RANGE_MINIMUM: 'Must be greater than',
+  OVER_RANGE_MAXIMUM: 'Must be less than',
 }
 
 // TODO: test these
@@ -34,11 +41,15 @@ export const minimumWellCount = (minimum: number): ErrorChecker => (
 export const minFieldValue = (minimum: number): ErrorChecker => (
   value: mixed
 ): ?string =>
-  value && Number(value) < minimum ? `Must be greater than ${minimum}` : null
+  value && Number(value) < minimum
+    ? `${FIELD_ERRORS.UNDER_RANGE_MINIMUM} ${minimum}`
+    : null
 export const maxFieldValue = (maximum: number): ErrorChecker => (
   value: mixed
 ): ?string =>
-  value && Number(value) > maximum ? `Must be greater than ${maximum}` : null
+  value && Number(value) > maximum
+    ? `${FIELD_ERRORS.OVER_RANGE_MAXIMUM} ${maximum}`
+    : null
 
 /*******************
  **     Helpers    **

--- a/protocol-designer/src/steplist/fieldLevel/errors.js
+++ b/protocol-designer/src/steplist/fieldLevel/errors.js
@@ -40,8 +40,6 @@ export const maxFieldValue = (maximum: number): ErrorChecker => (
 ): ?string =>
   value && Number(value) > maximum ? `Must be greater than ${maximum}` : null
 
-// ^ like above... && Number(value)
-
 /*******************
  **     Helpers    **
  ********************/

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -140,7 +140,6 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
   magnetAction: { getErrors: composeErrors(requiredField) },
   engageHeight: {
     getErrors: composeErrors(
-      requiredField,
       minFieldValue(MIN_ENGAGE_HEIGHT),
       maxFieldValue(MAX_ENGAGE_HEIGHT)
     ),

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -17,6 +17,7 @@ import {
   type ValueMasker,
   type ValueCaster,
 } from './processing'
+import { MIN_ENGAGE_HEIGHT, MAX_ENGAGE_HEIGHT } from '../../constants'
 import type { StepFieldName } from '../../form-types'
 import type { LabwareEntity, PipetteEntity } from '../../step-forms'
 import type { InvariantContext } from '../../step-generation'
@@ -140,8 +141,8 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
   engageHeight: {
     getErrors: composeErrors(
       requiredField,
-      minFieldValue(-4.0),
-      maxFieldValue(16)
+      minFieldValue(MIN_ENGAGE_HEIGHT),
+      maxFieldValue(MAX_ENGAGE_HEIGHT)
     ),
     maskValue: composeMaskers(maskToFloat),
     castValue: Number,

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -4,6 +4,8 @@ import {
   minimumWellCount,
   nonZero,
   composeErrors,
+  minFieldValue,
+  maxFieldValue,
 } from './errors'
 import {
   maskToNumber,
@@ -133,6 +135,13 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
   wells: {
     getErrors: composeErrors(requiredField, minimumWellCount(1)),
     maskValue: defaultTo([]),
+  },
+  engageHeight: {
+    getErrors: composeErrors(
+      requiredField,
+      minFieldValue(-4.0),
+      maxFieldValue(16)
+    ),
   },
 }
 

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -136,13 +136,14 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
     getErrors: composeErrors(requiredField, minimumWellCount(1)),
     maskValue: defaultTo([]),
   },
+  magnetAction: { getErrors: composeErrors(requiredField) },
   engageHeight: {
     getErrors: composeErrors(
       requiredField,
       minFieldValue(-4.0),
       maxFieldValue(16)
     ),
-    maskValue: composeMaskers(maskToFloat, defaultTo(4)),
+    maskValue: composeMaskers(maskToFloat),
     castValue: Number,
   },
 }

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -142,6 +142,8 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
       minFieldValue(-4.0),
       maxFieldValue(16)
     ),
+    maskValue: composeMaskers(maskToFloat, defaultTo(4)),
+    castValue: Number,
   },
 }
 

--- a/protocol-designer/src/steplist/fieldLevel/processing.js
+++ b/protocol-designer/src/steplist/fieldLevel/processing.js
@@ -23,7 +23,7 @@ export const maskToFloat = (rawValue: mixed): ?mixed => {
   if (!rawValue) return Number(rawValue)
   const rawNumericValue =
     typeof rawValue === 'string'
-      ? rawValue.replace(/[^.0-9]/, '')
+      ? rawValue.replace(/[^-/.0-9]/, '')
       : String(rawValue)
   const trimRegex = new RegExp(
     `(\\d*[.]{1}\\d{${DEFAULT_DECIMAL_PLACES}})(\\d*)`

--- a/protocol-designer/src/steplist/formLevel/errors.js
+++ b/protocol-designer/src/steplist/formLevel/errors.js
@@ -14,6 +14,10 @@ export type FormErrorKey =
   | 'WELL_RATIO_MOVE_LIQUID'
   | 'PAUSE_TYPE_REQUIRED'
   | 'TIME_PARAM_REQUIRED'
+  | 'MAGNET_ACTION_TYPE_REQUIRED'
+  | 'ENGAGE_HEIGHT_REQUIRED'
+  | 'ENGAGE_HEIGHT_MIN_EXCEEDED'
+  | 'ENGAGE_HEIGHT_MAX_EXCEEDED'
 
 export type FormError = {
   title: string,
@@ -50,6 +54,22 @@ const FORM_ERRORS: { [FormErrorKey]: FormError } = {
   WELL_RATIO_MOVE_LIQUID: {
     title: 'Well selection must be 1 to many, many to 1, or N to N',
     dependentFields: ['aspirate_wells', 'dispense_wells'],
+  },
+  MAGNET_ACTION_TYPE_REQUIRED: {
+    title: 'Action type must be either engage or disengage',
+    dependentFields: ['magnetAction'],
+  },
+  ENGAGE_HEIGHT_REQUIRED: {
+    title: 'Engage height is required',
+    dependentFields: ['magnetAction', 'engageHeight'],
+  },
+  ENGAGE_HEIGHT_MIN_EXCEEDED: {
+    title: 'Specified distance is below module minimum',
+    dependentFields: ['magnetAction', 'engageHeight'],
+  },
+  ENGAGE_HEIGHT_MAX_EXCEEDED: {
+    title: 'Specified distance is above module maximum',
+    dependentFields: ['magnetAction', 'engageHeight'],
   },
 }
 export type FormErrorChecker = mixed => ?FormError
@@ -116,6 +136,27 @@ export const wellRatioMoveLiquid = (fields: HydratedFormData): ?FormError => {
   return getWellRatio(aspirate_wells, dispense_wells)
     ? null
     : FORM_ERRORS.WELL_RATIO_MOVE_LIQUID
+}
+
+export const magnetActionRequired = (fields: HydratedFormData): ?FormError => {
+  const { magnetAction } = fields
+  if (!magnetAction) return FORM_ERRORS.MAGNET_ACTION_TYPE_REQUIRED
+}
+
+// TODO (ka 2019-11-19): Should Min/Max be blocking for save?
+// Investigate changing to form level warning
+export const engageHeight = (fields: HydratedFormData): ?FormError => {
+  const { magnetAction, engageHeight } = fields
+  if (magnetAction === 'engage') {
+    if (!engageHeight) {
+      return FORM_ERRORS.ENGAGE_HEIGHT_REQUIRED
+    } else if (engageHeight < -4.0) {
+      return FORM_ERRORS.ENGAGE_HEIGHT_MIN_EXCEEDED
+    } else if (engageHeight > 16) {
+      return FORM_ERRORS.ENGAGE_HEIGHT_MAX_EXCEEDED
+    }
+  }
+  return null
 }
 
 /*******************

--- a/protocol-designer/src/steplist/formLevel/errors.js
+++ b/protocol-designer/src/steplist/formLevel/errors.js
@@ -16,8 +16,6 @@ export type FormErrorKey =
   | 'TIME_PARAM_REQUIRED'
   | 'MAGNET_ACTION_TYPE_REQUIRED'
   | 'ENGAGE_HEIGHT_REQUIRED'
-  | 'ENGAGE_HEIGHT_MIN_EXCEEDED'
-  | 'ENGAGE_HEIGHT_MAX_EXCEEDED'
 
 export type FormError = {
   title: string,
@@ -61,14 +59,6 @@ const FORM_ERRORS: { [FormErrorKey]: FormError } = {
   },
   ENGAGE_HEIGHT_REQUIRED: {
     title: 'Engage height is required',
-    dependentFields: ['magnetAction', 'engageHeight'],
-  },
-  ENGAGE_HEIGHT_MIN_EXCEEDED: {
-    title: 'Specified distance is below module minimum',
-    dependentFields: ['magnetAction', 'engageHeight'],
-  },
-  ENGAGE_HEIGHT_MAX_EXCEEDED: {
-    title: 'Specified distance is above module maximum',
     dependentFields: ['magnetAction', 'engageHeight'],
   },
 }
@@ -141,22 +131,14 @@ export const wellRatioMoveLiquid = (fields: HydratedFormData): ?FormError => {
 export const magnetActionRequired = (fields: HydratedFormData): ?FormError => {
   const { magnetAction } = fields
   if (!magnetAction) return FORM_ERRORS.MAGNET_ACTION_TYPE_REQUIRED
+  return null
 }
 
-// TODO (ka 2019-11-19): Should Min/Max be blocking for save?
-// Investigate changing to form level warning
-export const engageHeight = (fields: HydratedFormData): ?FormError => {
+export const engageHeightRequired = (fields: HydratedFormData): ?FormError => {
   const { magnetAction, engageHeight } = fields
-  if (magnetAction === 'engage') {
-    if (!engageHeight) {
-      return FORM_ERRORS.ENGAGE_HEIGHT_REQUIRED
-    } else if (engageHeight < -4.0) {
-      return FORM_ERRORS.ENGAGE_HEIGHT_MIN_EXCEEDED
-    } else if (engageHeight > 16) {
-      return FORM_ERRORS.ENGAGE_HEIGHT_MAX_EXCEEDED
-    }
-  }
-  return null
+  return magnetAction === 'engage' && !engageHeight
+    ? FORM_ERRORS.ENGAGE_HEIGHT_REQUIRED
+    : null
 }
 
 /*******************

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -78,6 +78,11 @@ export default function getDefaultsForStepType(
         pipetteLocationUpdate: {},
         moduleLocationUpdate: {},
       }
+    case 'magnet':
+      return {
+        magnetAction: null,
+        engageHeight: null,
+      }
     default:
       return {}
   }

--- a/protocol-designer/src/steplist/formLevel/getDisabledFields/index.js
+++ b/protocol-designer/src/steplist/formLevel/getDisabledFields/index.js
@@ -11,7 +11,9 @@ function _getDisabledFields(rawForm: FormData): Set<string> {
     case 'mix':
       return getDisabledFieldsMixForm(rawForm)
     case 'pause':
-      return new Set() // nothing to disable
+      return new Set() // nothing to disabled
+    case 'magnet':
+      return new Set()
     default: {
       console.warn(
         `disabled fields for step type ${rawForm.stepType} not yet implemented!`

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMagnet.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMagnet.js
@@ -1,0 +1,33 @@
+// @flow
+import pick from 'lodash/pick'
+import { chainPatchUpdaters, fieldHasChanged } from './utils'
+import getDefaultsForStepType from '../getDefaultsForStepType'
+import type { FormData, StepFieldName } from '../../../form-types'
+import type { FormPatch } from '../../actions/types'
+
+// TODO: Ian 2019-02-21 import this from a more central place - see #2926
+const getDefaultFields = (...fields: Array<StepFieldName>): FormPatch =>
+  pick(getDefaultsForStepType('mix'), fields)
+
+const updatePatchOnMagnetActionChange = (
+  patch: FormPatch,
+  rawForm: FormData
+) => {
+  if (fieldHasChanged(rawForm, patch, 'magnetAction')) {
+    return {
+      ...patch,
+      ...getDefaultFields('engageHeight'),
+    }
+  }
+  return patch
+}
+
+export default function dependentFieldsUpdateMagnet(
+  originalPatch: FormPatch,
+  rawForm: FormData // raw = NOT hydrated
+): FormPatch {
+  // sequentially modify parts of the patch until it's fully updated
+  return chainPatchUpdaters(originalPatch, [
+    chainPatch => updatePatchOnMagnetActionChange(chainPatch, rawForm),
+  ])
+}

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMagnet.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMagnet.js
@@ -7,7 +7,7 @@ import type { FormPatch } from '../../actions/types'
 
 // TODO: Ian 2019-02-21 import this from a more central place - see #2926
 const getDefaultFields = (...fields: Array<StepFieldName>): FormPatch =>
-  pick(getDefaultsForStepType('mix'), fields)
+  pick(getDefaultsForStepType('magnet'), fields)
 
 const updatePatchOnMagnetActionChange = (
   patch: FormPatch,

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/index.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/index.js
@@ -1,6 +1,7 @@
 // @flow
 import dependentFieldsUpdateMoveLiquid from './dependentFieldsUpdateMoveLiquid'
 import dependentFieldsUpdateMix from './dependentFieldsUpdateMix'
+import dependentFieldsUpdateMagnet from './dependentFieldsUpdateMagnet'
 import type { FormData } from '../../../form-types'
 import type { FormPatch } from '../../actions/types'
 import type {
@@ -34,6 +35,10 @@ function handleFormChange(
       pipetteEntities,
       labwareEntities
     )
+    return { ...patch, ...dependentFieldsPatch }
+  }
+  if (rawForm.stepType === 'magnet') {
+    const dependentFieldsPatch = dependentFieldsUpdateMagnet(patch, rawForm)
     return { ...patch, ...dependentFieldsPatch }
   }
 

--- a/protocol-designer/src/steplist/formLevel/index.js
+++ b/protocol-designer/src/steplist/formLevel/index.js
@@ -6,6 +6,8 @@ import {
   incompatibleLabware,
   pauseForTimeOrUntilTold,
   wellRatioMoveLiquid,
+  magnetActionRequired,
+  engageHeight,
   type FormError,
 } from './errors'
 import {
@@ -47,6 +49,7 @@ const stepFormHelperMap: { [StepType]: FormHelpers } = {
       minDisposalVolume
     ),
   },
+  magnet: { getErrors: composeErrors(magnetActionRequired, engageHeight) },
 }
 
 export type { FormError, FormWarning, FormWarningType }

--- a/protocol-designer/src/steplist/formLevel/index.js
+++ b/protocol-designer/src/steplist/formLevel/index.js
@@ -7,7 +7,7 @@ import {
   pauseForTimeOrUntilTold,
   wellRatioMoveLiquid,
   magnetActionRequired,
-  engageHeight,
+  engageHeightRequired,
   type FormError,
 } from './errors'
 import {
@@ -15,6 +15,7 @@ import {
   belowPipetteMinimumVolume,
   maxDispenseWellVolume,
   minDisposalVolume,
+  engageHeightRangeExceeded,
   type FormWarning,
   type FormWarningType,
 } from './warnings'
@@ -49,7 +50,10 @@ const stepFormHelperMap: { [StepType]: FormHelpers } = {
       minDisposalVolume
     ),
   },
-  magnet: { getErrors: composeErrors(magnetActionRequired, engageHeight) },
+  magnet: {
+    getErrors: composeErrors(magnetActionRequired, engageHeightRequired),
+    getWarnings: composeWarnings(engageHeightRangeExceeded),
+  },
 }
 
 export type { FormError, FormWarning, FormWarningType }

--- a/protocol-designer/src/steplist/formLevel/warnings.js
+++ b/protocol-designer/src/steplist/formLevel/warnings.js
@@ -11,6 +11,8 @@ export type FormWarningType =
   | 'BELOW_PIPETTE_MINIMUM_VOLUME'
   | 'OVER_MAX_WELL_VOLUME'
   | 'BELOW_MIN_DISPOSAL_VOLUME'
+  | 'ENGAGE_HEIGHT_MIN_EXCEEDED'
+  | 'ENGAGE_HEIGHT_MAX_EXCEEDED'
 
 export type FormWarning = {
   ...$Exact<FormError>,
@@ -39,6 +41,16 @@ const FORM_WARNINGS: { [FormWarningType]: FormWarning } = {
       </React.Fragment>
     ),
     dependentFields: ['disposalVolume_volume', 'pipette'],
+  },
+  ENGAGE_HEIGHT_MIN_EXCEEDED: {
+    type: 'ENGAGE_HEIGHT_MIN_EXCEEDED',
+    title: 'Specified distance is below module minimum',
+    dependentFields: ['magnetAction', 'engageHeight'],
+  },
+  ENGAGE_HEIGHT_MAX_EXCEEDED: {
+    type: 'ENGAGE_HEIGHT_MAX_EXCEEDED',
+    title: 'Specified distance is above module maximum',
+    dependentFields: ['magnetAction', 'engageHeight'],
   },
 }
 export type WarningChecker = mixed => ?FormWarning
@@ -84,6 +96,18 @@ export const minDisposalVolume = (fields: HydratedFormData): ?FormWarning => {
   if (isUnselected) return FORM_WARNINGS.BELOW_MIN_DISPOSAL_VOLUME
   const isBelowMin = disposalVolume_volume < pipette.spec.minVolume
   return isBelowMin ? FORM_WARNINGS.BELOW_MIN_DISPOSAL_VOLUME : null
+}
+
+export const engageHeightRangeExceeded = (
+  fields: HydratedFormData
+): ?FormWarning => {
+  const { magnetAction, engageHeight } = fields
+  if (magnetAction === 'engage' && engageHeight < -4.0) {
+    return FORM_WARNINGS.ENGAGE_HEIGHT_MIN_EXCEEDED
+  } else if (magnetAction === 'engage' && engageHeight > 16) {
+    return FORM_WARNINGS.ENGAGE_HEIGHT_MAX_EXCEEDED
+  }
+  return null
 }
 
 /*******************

--- a/protocol-designer/src/steplist/formLevel/warnings.js
+++ b/protocol-designer/src/steplist/formLevel/warnings.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
 import { getWellTotalVolume } from '@opentrons/shared-data'
+import { MIN_ENGAGE_HEIGHT, MAX_ENGAGE_HEIGHT } from '../../constants'
 import KnowledgeBaseLink from '../../components/KnowledgeBaseLink'
 import type { FormError } from './errors'
 /*******************
@@ -102,9 +103,9 @@ export const engageHeightRangeExceeded = (
   fields: HydratedFormData
 ): ?FormWarning => {
   const { magnetAction, engageHeight } = fields
-  if (magnetAction === 'engage' && engageHeight < -4.0) {
+  if (magnetAction === 'engage' && engageHeight < MIN_ENGAGE_HEIGHT) {
     return FORM_WARNINGS.ENGAGE_HEIGHT_MIN_EXCEEDED
-  } else if (magnetAction === 'engage' && engageHeight > 16) {
+  } else if (magnetAction === 'engage' && engageHeight > MAX_ENGAGE_HEIGHT) {
     return FORM_WARNINGS.ENGAGE_HEIGHT_MAX_EXCEEDED
   }
   return null


### PR DESCRIPTION
## overview

This PR closes #4300 by adding form and field level validation. Addresses #4303 by changing the magnetAction field from a dropdown to a radio group.

## changelog

- feat(protocol-designer): Add magnet step form field validation. It also updates magnet action field to be a radio group instead of a dropdown. Punting on labware selection until ticket is finalized. 

## review requests

http://sandbox.designer.opentrons.com/pd_magnet-form-field-validation/ (currently building... not up to date yet)

- [ ] Magnet form disengage - no validation
- [ ] Magnet form engage min error renders
- [ ] Magnet form engage max error renders
- [ ] Magnet form engage required error renders (returned the default this field is required text here)
- [ ] If either magnet action or engage height is left blank - save button is disabled