### PR TITLE
refactor(app): add dialog to change custom labware directory

### DIFF
--- a/__mocks__/electron.js
+++ b/__mocks__/electron.js
@@ -11,4 +11,9 @@ module.exports = {
     on: jest.fn(),
     send: jest.fn(),
   },
+
+  dialog: {
+    // https://electronjs.org/docs/api/dialog#dialogshowopendialogbrowserwindow-options
+    showOpenDialog: jest.fn(),
+  },
 }

--- a/app-shell/src/labware/__tests__/dispatch.test.js
+++ b/app-shell/src/labware/__tests__/dispatch.test.js
@@ -1,6 +1,7 @@
 // @flow
 
 import fse from 'fs-extra'
+import Electron from 'electron'
 import * as Cfg from '../../config'
 import * as Defs from '../definitions'
 import * as Val from '../validation'
@@ -15,12 +16,22 @@ import type {
 } from '@opentrons/app/src/custom-labware/types'
 
 jest.mock('fs-extra')
+jest.mock('electron')
 jest.mock('../../config')
 jest.mock('../definitions')
 jest.mock('../validation')
 
 const ensureDir: JestMockFn<[string], void> = fse.ensureDir
+
 const getFullConfig: JestMockFn<[], $Shape<Config>> = Cfg.getFullConfig
+
+const handleConfigChange: JestMockFn<[string, (any, any) => mixed], mixed> =
+  Cfg.handleConfigChange
+
+const showOpenDialog: JestMockFn<
+  Array<any>,
+  {| canceled: boolean, filePaths: Array<string> |}
+> = Electron.dialog.showOpenDialog
 
 const readLabwareDirectory: JestMockFn<
   [string],
@@ -39,6 +50,7 @@ const validateLabwareFiles: JestMockFn<
 
 describe('labware module dispatches', () => {
   const labwareDir = '/path/to/somewhere'
+  const mockMainWindow = { browserWindow: true }
   let dispatch
   let handleAction
 
@@ -50,7 +62,7 @@ describe('labware module dispatches', () => {
     validateLabwareFiles.mockReturnValue([])
 
     dispatch = jest.fn()
-    handleAction = registerLabware(dispatch)
+    handleAction = registerLabware(dispatch, mockMainWindow)
   })
 
   afterEach(() => {
@@ -146,5 +158,60 @@ describe('labware module dispatches', () => {
           payload: mockValidatedFiles,
         })
       })
+  })
+
+  test('opens file picker on CHANGE_CUSTOM_LABWARE_DIRECTORY', () => {
+    showOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] })
+
+    handleAction({
+      type: 'labware:CHANGE_CUSTOM_LABWARE_DIRECTORY',
+      meta: { shell: true },
+    })
+
+    return Promise.resolve()
+      .then(() => showOpenDialog.mock.results[0].value)
+      .then(() => {
+        expect(showOpenDialog).toHaveBeenCalledWith(mockMainWindow, {
+          defaultPath: labwareDir,
+          properties: ['openDirectory', 'createDirectory'],
+        })
+        expect(dispatch).not.toHaveBeenCalled()
+      })
+  })
+
+  test('dispatches config:UPDATE on labware dir selection', () => {
+    showOpenDialog.mockResolvedValue({
+      canceled: false,
+      filePaths: ['/path/to/labware'],
+    })
+
+    handleAction({
+      type: 'labware:CHANGE_CUSTOM_LABWARE_DIRECTORY',
+      meta: { shell: true },
+    })
+
+    return Promise.resolve()
+      .then(() => showOpenDialog.mock.results[0].value)
+      .then(() => {
+        expect(dispatch).toHaveBeenCalledWith({
+          type: 'config:UPDATE',
+          payload: { path: 'labware.directory', value: '/path/to/labware' },
+          meta: { shell: true },
+        })
+      })
+  })
+
+  test('reads labware directory on config change', () => {
+    expect(handleConfigChange).toHaveBeenCalledWith(
+      'labware.directory',
+      expect.any(Function)
+    )
+    const changeHandler = handleConfigChange.mock.calls[0][1]
+
+    changeHandler()
+
+    return Promise.resolve()
+      .then(() => ensureDir.mock.results[0].value)
+      .then(() => expect(readLabwareDirectory).toHaveBeenCalledWith(labwareDir))
   })
 })

--- a/app-shell/src/labware/index.js
+++ b/app-shell/src/labware/index.js
@@ -1,27 +1,55 @@
 // @flow
 import fse from 'fs-extra'
-import { getFullConfig } from '../config'
+import { dialog } from 'electron'
+import { getFullConfig, handleConfigChange } from '../config'
 import { readLabwareDirectory, parseLabwareFiles } from './definitions'
 import { validateLabwareFiles } from './validation'
-import * as labwareActions from '@opentrons/app/src/custom-labware/actions'
+import * as LabwareActions from '@opentrons/app/src/custom-labware'
+import * as ConfigActions from '@opentrons/app/src/config'
 
 import type { Action, Dispatch } from '../types'
 
 const ensureDir: (dir: string) => Promise<void> = fse.ensureDir
 
-export function registerLabware(dispatch: Dispatch) {
+const fetchCustomLabware = (dispatch: Dispatch): void => {
   const { labware: config } = getFullConfig()
+
+  // TODO(mc, 2019-11-18): catch errors and tell the UI
+  ensureDir(config.directory)
+    .then(() => readLabwareDirectory(config.directory))
+    .then(parseLabwareFiles)
+    .then(files => {
+      const payload = validateLabwareFiles(files)
+      dispatch(LabwareActions.customLabware(payload))
+    })
+}
+
+export function registerLabware(dispatch: Dispatch, mainWindow: {}) {
+  handleConfigChange('labware.directory', () => fetchCustomLabware(dispatch))
 
   return function handleActionForLabware(action: Action) {
     switch (action.type) {
-      case labwareActions.FETCH_CUSTOM_LABWARE: {
-        ensureDir(config.directory)
-          .then(() => readLabwareDirectory(config.directory))
-          .then(parseLabwareFiles)
-          .then(files => {
-            const payload = validateLabwareFiles(files)
-            dispatch(labwareActions.customLabware(payload))
-          })
+      case LabwareActions.FETCH_CUSTOM_LABWARE: {
+        fetchCustomLabware(dispatch)
+        break
+      }
+
+      case LabwareActions.CHANGE_CUSTOM_LABWARE_DIRECTORY: {
+        const { labware: config } = getFullConfig()
+        const dialogOptions = {
+          defaultPath: config.directory,
+          properties: ['openDirectory', 'createDirectory'],
+        }
+
+        dialog.showOpenDialog(mainWindow, dialogOptions).then(result => {
+          const { canceled, filePaths } = result
+
+          if (!canceled && filePaths.length > 0) {
+            const dir = filePaths[0]
+            dispatch(ConfigActions.updateConfig('labware.directory', dir))
+          }
+        })
+        break
       }
     }
   }

--- a/app/src/components/AddLabwareCard/ChangePathButton.js
+++ b/app/src/components/AddLabwareCard/ChangePathButton.js
@@ -1,0 +1,24 @@
+// @flow
+
+import * as React from 'react'
+import { OutlineButton } from '@opentrons/components'
+
+import styles from './styles.css'
+
+// TODO(mc, 2019-11-18): i18n
+const CHANGE_SOURCE = 'Change Source'
+
+export type ChangePathButtonProps = {|
+  onChangePath: () => mixed,
+|}
+
+export function ChangePathButton(props: ChangePathButtonProps) {
+  return (
+    <OutlineButton
+      className={styles.change_path_button}
+      onClick={props.onChangePath}
+    >
+      {CHANGE_SOURCE}
+    </OutlineButton>
+  )
+}

--- a/app/src/components/AddLabwareCard/PathDetail.js
+++ b/app/src/components/AddLabwareCard/PathDetail.js
@@ -1,0 +1,31 @@
+// @flow
+
+import * as React from 'react'
+
+import { InputField } from '@opentrons/components'
+import styles from './styles.css'
+
+// TODO(mc, 2019-11-18): i18n
+const CUSTOM_LABWARE_DEFINITIONS_FOLDER = 'Custom Labware Definitions Folder'
+
+export type PathDetailProps = {|
+  path: string,
+|}
+
+export function PathDetail(props: PathDetailProps) {
+  return (
+    <div className={styles.path_detail}>
+      <h4 className={styles.path_detail_title}>
+        {CUSTOM_LABWARE_DEFINITIONS_FOLDER}
+      </h4>
+      <InputField
+        readOnly
+        value={props.path}
+        type="text"
+        onFocus={(e: SyntheticFocusEvent<HTMLInputElement>) => {
+          e.currentTarget.select()
+        }}
+      />
+    </div>
+  )
+}

--- a/app/src/components/AddLabwareCard/__tests__/AddLabwareCard.test.js
+++ b/app/src/components/AddLabwareCard/__tests__/AddLabwareCard.test.js
@@ -1,13 +1,64 @@
 // @flow
 import * as React from 'react'
-import { shallow } from 'enzyme'
+import { Provider } from 'react-redux'
+import { mount } from 'enzyme'
 
-import AddLabwareCard from '..'
+import * as Cfg from '../../../config'
+
+import { changeCustomLabwareDirectory } from '../../../custom-labware'
+import { AddLabwareCard } from '..'
+import { PathDetail } from '../PathDetail'
+import { ChangePathButton } from '../ChangePathButton'
+
+import type { State } from '../../../types'
+import type { Config } from '../../../config/types'
+
+jest.mock('../../../config')
+
+const mockGetConfig: JestMockFn<[State], $Shape<Config>> = Cfg.getConfig
+const mockLabwarePath = '/path/to/labware'
+const mockConfig = { labware: { directory: mockLabwarePath } }
 
 describe('AddLabwareCard', () => {
-  test('component renders', () => {
-    const tree = shallow(<AddLabwareCard />)
+  let mockStore
+  let render
 
-    expect(tree).toMatchSnapshot()
+  beforeEach(() => {
+    mockGetConfig.mockReturnValue(mockConfig)
+
+    mockStore = {
+      subscribe: () => {},
+      getState: () => ({ state: true }),
+      dispatch: jest.fn(),
+    }
+
+    render = () =>
+      mount(
+        <Provider store={mockStore}>
+          <AddLabwareCard />
+        </Provider>
+      )
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  test('passes labware directory to PathDetail', () => {
+    const wrapper = render()
+    const detail = wrapper.find(PathDetail)
+
+    expect(mockGetConfig).toHaveBeenCalledWith({ state: true })
+    expect(detail.prop('path')).toEqual(mockLabwarePath)
+  })
+
+  test('passes dispatch function to ChangePathButton', () => {
+    const wrapper = render()
+    const button = wrapper.find(ChangePathButton)
+    const expectedAction = changeCustomLabwareDirectory()
+
+    expect(mockStore.dispatch).toHaveBeenCalledTimes(0)
+    button.invoke('onChangePath')()
+    expect(mockStore.dispatch).toHaveBeenCalledWith(expectedAction)
   })
 })

--- a/app/src/components/AddLabwareCard/__tests__/ChangePathButton.test.js
+++ b/app/src/components/AddLabwareCard/__tests__/ChangePathButton.test.js
@@ -1,0 +1,30 @@
+// @flow
+
+import * as React from 'react'
+import { shallow, mount } from 'enzyme'
+
+import { ChangePathButton } from '../ChangePathButton'
+
+describe('AddLabwareCard', () => {
+  const mockOnChangePath = jest.fn()
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  test('clicking the button calls onChangePath', () => {
+    const wrapper = mount(<ChangePathButton onChangePath={mockOnChangePath} />)
+
+    expect(mockOnChangePath).toHaveBeenCalledTimes(0)
+    wrapper.find('button').invoke('onClick')()
+    expect(mockOnChangePath).toHaveBeenCalledTimes(1)
+  })
+
+  test('component renders', () => {
+    const wrapper = shallow(
+      <ChangePathButton onChangePath={mockOnChangePath} />
+    )
+
+    expect(wrapper).toMatchSnapshot()
+  })
+})

--- a/app/src/components/AddLabwareCard/__tests__/PathDetail.test.js
+++ b/app/src/components/AddLabwareCard/__tests__/PathDetail.test.js
@@ -1,0 +1,21 @@
+// @flow
+import * as React from 'react'
+import { shallow } from 'enzyme'
+
+import { PathDetail } from '../PathDetail'
+
+describe('AddLabwareCard', () => {
+  const mockPath = '/path/to/a/place'
+
+  test('component displays path', () => {
+    const wrapper = shallow(<PathDetail path={mockPath} />)
+
+    expect(wrapper.html()).toContain(mockPath)
+  })
+
+  test('component renders', () => {
+    const wrapper = shallow(<PathDetail path={mockPath} />)
+
+    expect(wrapper).toMatchSnapshot()
+  })
+})

--- a/app/src/components/AddLabwareCard/__tests__/__snapshots__/AddLabwareCard.test.js.snap
+++ b/app/src/components/AddLabwareCard/__tests__/__snapshots__/AddLabwareCard.test.js.snap
@@ -1,7 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`AddLabwareCard component renders 1`] = `
-<Card
-  title="Labware Management"
-/>
-`;

--- a/app/src/components/AddLabwareCard/__tests__/__snapshots__/ChangePathButton.test.js.snap
+++ b/app/src/components/AddLabwareCard/__tests__/__snapshots__/ChangePathButton.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddLabwareCard component renders 1`] = `
+<OutlineButton
+  className="change_path_button"
+  onClick={[MockFunction]}
+>
+  Change Source
+</OutlineButton>
+`;

--- a/app/src/components/AddLabwareCard/__tests__/__snapshots__/PathDetail.test.js.snap
+++ b/app/src/components/AddLabwareCard/__tests__/__snapshots__/PathDetail.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddLabwareCard component renders 1`] = `
+<div
+  className="path_detail"
+>
+  <h4
+    className="path_detail_title"
+  >
+    Custom Labware Definitions Folder
+  </h4>
+  <InputField
+    onFocus={[Function]}
+    readOnly={true}
+    type="text"
+    value="/path/to/a/place"
+  />
+</div>
+`;

--- a/app/src/components/AddLabwareCard/index.js
+++ b/app/src/components/AddLabwareCard/index.js
@@ -1,12 +1,31 @@
 // @flow
 import * as React from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 import { Card } from '@opentrons/components'
+
+import { getConfig } from '../../config'
+import { changeCustomLabwareDirectory } from '../../custom-labware'
+import { CardContentFlex } from '../layout'
+import { PathDetail } from './PathDetail'
+import { ChangePathButton } from './ChangePathButton'
+
+import type { Dispatch } from '../../types'
 
 // TODO(mc, 2019-10-17): i18n
 const ADD_LABWARE_CARD_TITLE = 'Labware Management'
 
-function AddLabwareCard() {
-  return <Card title={ADD_LABWARE_CARD_TITLE}></Card>
-}
+export function AddLabwareCard() {
+  const dispatch = useDispatch<Dispatch>()
+  const config = useSelector(getConfig)
+  const labwarePath = config.labware.directory
+  const handleChangePath = () => dispatch(changeCustomLabwareDirectory())
 
-export default AddLabwareCard
+  return (
+    <Card title={ADD_LABWARE_CARD_TITLE}>
+      <CardContentFlex>
+        <PathDetail path={labwarePath} />
+        <ChangePathButton onChangePath={handleChangePath} />
+      </CardContentFlex>
+    </Card>
+  )
+}

--- a/app/src/components/AddLabwareCard/styles.css
+++ b/app/src/components/AddLabwareCard/styles.css
@@ -1,0 +1,18 @@
+@import '@opentrons/components';
+
+.path_detail {
+  width: 100%;
+}
+
+.path_detail_title {
+  @apply --font-body-2-dark;
+
+  font-weight: var(--fw-semibold);
+  margin-bottom: 0.25rem;
+}
+
+.change_path_button {
+  flex: none;
+  align-self: flex-end;
+  margin-left: 2rem;
+}

--- a/app/src/components/ListLabwareCard/__tests__/ListLabwareCard.test.js
+++ b/app/src/components/ListLabwareCard/__tests__/ListLabwareCard.test.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { Provider } from 'react-redux'
 import { mount } from 'enzyme'
 
-import ListLabwareCard from '..'
+import { ListLabwareCard } from '..'
 import ListCard from '../ListCard'
 import LabwareItem from '../LabwareItem'
 import * as LabwareSelectors from '../../../custom-labware/selectors'

--- a/app/src/components/ListLabwareCard/index.js
+++ b/app/src/components/ListLabwareCard/index.js
@@ -5,14 +5,13 @@ import { useInterval } from '@opentrons/components'
 
 import ListCard from './ListCard'
 import LabwareItem from './LabwareItem'
-import { fetchCustomLabware } from '../../custom-labware/actions'
-import { getValidCustomLabware } from '../../custom-labware/selectors'
+import { fetchCustomLabware, getValidCustomLabware } from '../../custom-labware'
 
 import type { Dispatch } from '../../types'
 
 const LABWARE_REFRESH_INTERVAL_MS = 5000
 
-function ListLabwareCard() {
+export function ListLabwareCard() {
   const dispatch = useDispatch<Dispatch>()
   const validLabware = useSelector(getValidCustomLabware)
   const fetchLabware = React.useCallback(() => dispatch(fetchCustomLabware()), [
@@ -36,5 +35,3 @@ function ListLabwareCard() {
     </ListCard>
   )
 }
-
-export default ListLabwareCard

--- a/app/src/custom-labware/__tests__/actions.test.js
+++ b/app/src/custom-labware/__tests__/actions.test.js
@@ -33,6 +33,15 @@ describe('custom labware actions', () => {
         ],
       },
     },
+    {
+      name: 'changeLabwareDirectory',
+      creator: actions.changeCustomLabwareDirectory,
+      args: [],
+      expected: {
+        type: 'labware:CHANGE_CUSTOM_LABWARE_DIRECTORY',
+        meta: { shell: true },
+      },
+    },
   ]
 
   SPECS.forEach(spec => {

--- a/app/src/custom-labware/actions.js
+++ b/app/src/custom-labware/actions.js
@@ -7,6 +7,9 @@ export const FETCH_CUSTOM_LABWARE: 'labware:FETCH_CUSTOM_LABWARE' =
 
 export const CUSTOM_LABWARE: 'labware:CUSTOM_LABWARE' = 'labware:CUSTOM_LABWARE'
 
+export const CHANGE_CUSTOM_LABWARE_DIRECTORY: 'labware:CHANGE_CUSTOM_LABWARE_DIRECTORY' =
+  'labware:CHANGE_CUSTOM_LABWARE_DIRECTORY'
+
 export const fetchCustomLabware = (): CustomLabwareAction => ({
   type: FETCH_CUSTOM_LABWARE,
   meta: { shell: true },
@@ -15,3 +18,8 @@ export const fetchCustomLabware = (): CustomLabwareAction => ({
 export const customLabware = (
   payload: Array<CheckedLabwareFile>
 ): CustomLabwareAction => ({ type: CUSTOM_LABWARE, payload })
+
+export const changeCustomLabwareDirectory = (): CustomLabwareAction => ({
+  type: CHANGE_CUSTOM_LABWARE_DIRECTORY,
+  meta: { shell: true },
+})

--- a/app/src/custom-labware/index.js
+++ b/app/src/custom-labware/index.js
@@ -1,0 +1,4 @@
+// @flow
+
+export * from './actions'
+export * from './selectors'

--- a/app/src/custom-labware/types.js
+++ b/app/src/custom-labware/types.js
@@ -64,3 +64,7 @@ export type CustomLabwareState = $ReadOnly<{|
 export type CustomLabwareAction =
   | {| type: 'labware:FETCH_CUSTOM_LABWARE', meta: {| shell: true |} |}
   | {| type: 'labware:CUSTOM_LABWARE', payload: Array<CheckedLabwareFile> |}
+  | {|
+      type: 'labware:CHANGE_CUSTOM_LABWARE_DIRECTORY',
+      meta: {| shell: true |},
+    |}

--- a/app/src/pages/More/CustomLabware.js
+++ b/app/src/pages/More/CustomLabware.js
@@ -5,8 +5,8 @@ import type { ContextRouter } from 'react-router-dom'
 
 import Page from '../../components/Page'
 import { CardContainer, CardRow } from '../../components/layout'
-import AddLabwareCard from '../../components/AddLabwareCard'
-import ListLabwareCard from '../../components/ListLabwareCard'
+import { AddLabwareCard } from '../../components/AddLabwareCard'
+import { ListLabwareCard } from '../../components/ListLabwareCard'
 
 // TODO(mc, 2019-10-17): i18n
 const CUSTOM_LABWARE_PAGE_TITLE = 'Custom Labware'


### PR DESCRIPTION
## overview

This PR adds UI and a selection dialog to set the user's custom labware directory. Closes #4246.

![2019-11-18 23 54 46](https://user-images.githubusercontent.com/2963448/69117803-ed243c80-0a5e-11ea-8df9-6a149812b8d4.gif)


## changelog

- refactor(app): add dialog to change custom labware directory

### walkthrough

The location of the custom labware directory was already stored in config as of #4268. Now:

- Clicking "Change Source" dispatches a `labware:CHANGE_CUSTOM_LABWARE_DIRECTORY` action that gets sent to the main process via `meta.shell: true`
- Main process catches that action and opens a directory selection dialog via `electron::dialog.showOpenDialog`
- Once the user selects a directory, a `config:UPDATE` action is dispatched to update the labware directory entry
- Changes to the labware directory entry in config trigger a refresh of the labware list

## review requests

Reference screen: https://zpl.io/bo6RmzW (option 3)

Note: The ticket mentions that clicking the text opens the finder folder, but in the interest of scope, instead we allow the full path to be copied as text for pasting into Finder / Explorer

0. Ensure devtools and custom labware feature flag are enabled
1. Go to App's "More" page and click "Custom Labware"
2. Click "Change Source"

- [ ] Clicking cancel does nothing
- [ ] Selecting a directory changes the directory
- [ ] Selecting a directory refreshes the labware list
    - This is easier to test if you have some custom labware in a few different folders
