### PR TITLE
feat(api): raise an error when uploading a v2 protocol on v1 server

### DIFF
--- a/api/src/opentrons/protocols/types.py
+++ b/api/src/opentrons/protocols/types.py
@@ -1,6 +1,12 @@
+import enum
 from typing import Any, Dict, NamedTuple, Optional, Union
 
 Metadata = Dict[str, Union[str, int]]
+
+
+class VersionSource(enum.Enum):
+    METADATA = enum.auto()
+    INFERRED_FROM_IMPORTS = enum.auto()
 
 
 class APIVersion(NamedTuple):
@@ -24,6 +30,7 @@ class PythonProtocol(NamedTuple):
     contents: Any  # This is the output of compile() which we can't type
     metadata: Metadata
     api_level: APIVersion
+    version_from: VersionSource
     # these 'bundled_' attrs should only be included when the protocol is a zip
     bundled_labware: Optional[Dict[str, Dict[str, Any]]]
     bundled_data: Optional[Dict[str, bytes]]

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -204,6 +204,20 @@ async def test_load_and_run(
     assert session.protocol_text == protocol.text
 
 
+@pytest.mark.api1_only
+@pytest.mark.parametrize('protocol_file', ['testosaur_v2.py'])
+async def test_v2_in_v1_error(
+        main_router,
+        protocol,
+        protocol_file,
+        loop):
+    with pytest.raises(
+            RuntimeError, match='protocol targets Protocol API V2.0'):
+        main_router.session_manager.create(
+            name='<blank>',
+            contents=protocol.text)
+
+
 def test_init(run_session):
     assert run_session.state == 'loaded'
     assert run_session.name == 'dino'


### PR DESCRIPTION
In the general case, since V1 doesn't have explicit versioning information, we
want to allow people to upload whatever they want to a V1 server. However, if
somebody uploads a protocol that has its apiLevel key in the metadata set to 2.0
or higher, we can be pretty certain they just forgot (or didn't know) to flip
the v2 feature flag, so let's tell them about it.

## Tests
- With the server set to V1, uploading a protocol with 'apiLevel': '2.0' in the metadata should get you a nice explanatory error

(there was previously text here about uploading a protocol where the version couldn't be inferred but actually that doesn't work right now anyway)