### PR TITLE
fix(app-shell): improve context menu and log handling

### DIFF
--- a/app-shell/README.md
+++ b/app-shell/README.md
@@ -24,10 +24,30 @@ Configuration values will be determined by:
 4.  If no value in `config.json`, default value from code will be used
     - Default value will also be written to `config.json`
 
+#### format
+
+Configuration values may be specified via:
+
+- A CLI argument of the format `--configName.nestedValue`
+- An environment variable of the format `OT_APP_CONFIG_NAME__NESTed_VALUE`
+- The configuration JSON file with the path `configName.nestedValue`
+
 **If overriding boolean values**:
 
 - For CLI arguments, use `--value` for true, and `--disable_value` for false
 - For environment variables, use `OT_APP_VALUE=1` for true, and `OT_APP_VALUE=0` for false
+
+#### feature flags
+
+During development, we develop new features behind "feature flags", so that we can continue to release software while keeping anything that's still a work-in-progress safely disabled.
+
+The feature flags are part of the configuration under the path `devInternal`. To enable a feature flag, set the configuration value to true:
+
+- CLI: `--devInternal.nameOfFlag`
+- Environment variable: `OT_APP_DEV_INTERNAL__NAME_OF_FLAG`
+- Configuration JSON: `devInteral.nameOfFlag`
+
+The app also presents UI for enabling these flags when the [`devtools`](#devtools) setting is enabled.
 
 #### overriding config for end-users
 
@@ -69,30 +89,39 @@ The easiest way to override config on Windows is to modify the Opentrons desktop
 
 ##### devtools
 
-- CLI argument: `--devtools` or `--disable_devtools`
+- CLI argument: `--devtools`
 - Environment variable: `OT_APP_DEVTOOLS`
 - JSON path: `devtools`
 - Default: `false`
 
-Enables and opens the Chrome devtools.
+Enables and opens the Chrome devtools with the React and Redux devtools extensions installed.
 
-##### modules
+##### reinstallDevtools
 
-- CLI argument: `--modules` or `--disable_modules`
-- Environment variable: `OT_APP_MODULES`
-- JSON path: `modules`
+- CLI argument: `--reinstallDevtools`
+- Environment variable: `OT_APP_REINSTALL_DEVTOOLS`
+- JSON path: `reinstallDevtools`
 - Default: `false`
 
-Enables experimental support for [Opentrons Modules](http://opentrons.com/modules).
+Forces the devtools extensions to be re-installed. Make sure you enable **both** `-devtools` and `--reinstallDevtools`
 
 ##### update.channel
 
-- CLI argument: `--channel`
+- CLI argument: `--update.channel`
 - Environment variable: `OT_APP_UPDATE__CHANNEL`
 - JSON path: `update.channel`
 - Default: `"latest"`
 
 Sets the app's self-update channel. Options are `alpha`, `beta`, or `latest`. `alpha` is the least tested/stable, followed by `beta`, followed by `latest`. `alpha` and `beta` get new features earlier than `latest`.
+
+##### buildroot.manifestUrl
+
+- CLI argument: `--buildroot.manifestUrl`
+- Environment variable: `OT_APP_BUILDROOT__MANIFEST_URL`
+- JSON path: `buildroot.manifestUrl`
+- Default: `"https://opentrons-buildroot-ci.s3.us-east-2.amazonaws.com/releases.json"`
+
+Sets the file that the app checks for its corresponding robot update.
 
 ##### log.level.file
 
@@ -224,10 +253,22 @@ Email of app user to populate "Email" in support conversations.
 
 - CLI argument: `--discovery.candidates`
 - Environment variable: `OT_APP_DISCOVERY__CANDIDATES`
-- JSON path: `--discovery.candidates`
+- JSON path: `discovery.candidates`
 - Default: `[]`
 
 `string` or `Array<string>` of extra IP address(es)/hosts for the discovery client to track. For example, to get the discovery client to find an instance of the API server running on your own computer, you could do `--discovery.candidates=localhost`.
+
+##### labware.directory
+
+- CLI argument: `--labware.directory`
+- Environment variable: `OT_APP_LABWARE__DIRECTORY`
+- JSON path: `labware.directory`
+- Default:
+  - `%APPDATA%\Opentrons\labware` on Windows
+  - `~/.config/Opentrons/labware` on Linux
+  - `~/Library/Application Support/Opentrons/labware` on macOS
+
+Folder that the app stores and retrieves custom labware definitions from
 
 ### logging
 
@@ -323,29 +364,29 @@ There are a series of tasks designed to be run in CI to create distributable ver
 
 ```shell
 # Create a macOS distributable of the app
-make dist-osx OT_BUCKET_APP=opentrons-app OT_FOLDER_APP=builds
+make dist-osx OT_APP_DEPLOY_BUCKET=opentrons-app OT_APP_DEPLOY_FOLDER=builds
 
 # Create a Linux distributable of the app
-make dist-linux OT_BUCKET_APP=opentrons-app OT_FOLDER_APP=builds
+make dist-linux OT_APP_DEPLOY_BUCKET=opentrons-app OT_APP_DEPLOY_FOLDER=builds
 
 # Create macOS and Linux apps simultaneously
-make dist-posix OT_BUCKET_APP=opentrons-app OT_FOLDER_APP=builds
+make dist-posix OT_APP_DEPLOY_BUCKET=opentrons-app OT_APP_DEPLOY_FOLDER=builds
 
 # Create a Windows distributable of the app
-make dist-win OT_BUCKET_APP=opentrons-app OT_FOLDER_APP=builds
+make dist-win OT_APP_DEPLOY_BUCKET=opentrons-app OT_APP_DEPLOY_FOLDER=builds
 ```
 
 These tasks use the following environment variables defined:
 
 <!-- TODO(mc, 2018-05-16): update bucket / folder vars to use config prefix -->
 
-| name          | description   | required | description                            |
-| ------------- | ------------- | -------- | -------------------------------------- |
-| OT_BUCKET_APP | AWS S3 bucket | yes      | Artifact deploy bucket                 |
-| OT_FOLDER_APP | AWS S3 folder | yes      | Artifact deploy folder in bucket       |
-| OT_BRANCH     | Branch name   | no       | Sometimes added to the artifact name   |
-| OT_BUILD      | Build number  | no       | Appended to the artifact name          |
-| OT_TAG        | Tag name      | no       | Flags autoupdate files to be published |
+| name                 | description   | required | description                            |
+| -------------------- | ------------- | -------- | -------------------------------------- |
+| OT_APP_DEPLOY_BUCKET | AWS S3 bucket | yes      | Artifact deploy bucket                 |
+| OT_APP_DEPLOY_FOLDER | AWS S3 folder | yes      | Artifact deploy folder in bucket       |
+| OT_BRANCH            | Branch name   | no       | Sometimes added to the artifact name   |
+| OT_BUILD             | Build number  | no       | Appended to the artifact name          |
+| OT_TAG               | Tag name      | no       | Flags autoupdate files to be published |
 
 The release channel is set according to the version string:
 

--- a/app-shell/README.md
+++ b/app-shell/README.md
@@ -29,7 +29,7 @@ Configuration values will be determined by:
 Configuration values may be specified via:
 
 - A CLI argument of the format `--configName.nestedValue`
-- An environment variable of the format `OT_APP_CONFIG_NAME__NESTed_VALUE`
+- An environment variable of the format `OT_APP_CONFIG_NAME__NESTED_VALUE`
 - The configuration JSON file with the path `configName.nestedValue`
 
 **If overriding boolean values**:

--- a/app-shell/package.json
+++ b/app-shell/package.json
@@ -27,6 +27,7 @@
     "@thi.ng/paths": "^1.6.5",
     "ajv": "^6.10.2",
     "dateformat": "^3.0.3",
+    "electron-context-menu": "^0.15.1",
     "electron-debug": "^3.0.1",
     "electron-devtools-installer": "^2.2.4",
     "electron-dl": "^1.14.0",

--- a/app-shell/src/config.js
+++ b/app-shell/src/config.js
@@ -31,6 +31,7 @@ const PARSE_ARGS_OPTS = {
 // TODO(mc, 2018-05-25): future config changes may require migration strategy
 const DEFAULTS: Config = {
   devtools: false,
+  reinstallDevtools: false,
 
   // app update config
   update: {
@@ -109,9 +110,9 @@ export function registerConfig(dispatch: Dispatch) {
       log().debug('Handling config:UPDATE', payload)
 
       if (getIn(overrides(), payload.path) != null) {
-        log().info(`${payload.path} in overrides; not updating`)
+        log().debug(`${payload.path} in overrides; not updating`)
       } else {
-        log().info(`Updating "${payload.path}" to ${payload.value}`)
+        log().debug(`Updating "${payload.path}" to ${payload.value}`)
         store().set(payload.path, payload.value)
         dispatch({ type: 'config:SET', payload })
       }

--- a/app-shell/src/log.js
+++ b/app-shell/src/log.js
@@ -8,7 +8,7 @@ import winston from 'winston'
 
 import { getConfig } from './config'
 
-const LOG_DIR = path.join(app.getPath('userData'), 'logs')
+export const LOG_DIR = path.join(app.getPath('userData'), 'logs')
 const ERROR_LOG = path.join(LOG_DIR, 'error.log')
 const COMBINED_LOG = path.join(LOG_DIR, 'combined.log')
 const FILE_OPTIONS = {

--- a/app-shell/src/menu.js
+++ b/app-shell/src/menu.js
@@ -2,6 +2,7 @@
 import { Menu } from 'electron'
 
 import pkg from '../package.json'
+import { LOG_DIR } from './log'
 
 // file or application menu
 const firstMenu = {
@@ -21,6 +22,12 @@ const helpMenu = {
       label: 'Learn More',
       click: () => {
         require('electron').shell.openExternal('https://opentrons.com/')
+      },
+    },
+    {
+      label: `View ${pkg.productName} App logs`,
+      click: () => {
+        require('electron').shell.openItem(LOG_DIR)
       },
     },
     {

--- a/app-shell/src/menu.js
+++ b/app-shell/src/menu.js
@@ -25,7 +25,7 @@ const helpMenu = {
       },
     },
     {
-      label: `View ${pkg.productName} App logs`,
+      label: `View ${pkg.productName} App Logs`,
       click: () => {
         require('electron').shell.openItem(LOG_DIR)
       },

--- a/app-shell/src/robot-logs.js
+++ b/app-shell/src/robot-logs.js
@@ -13,10 +13,14 @@ export function registerRobotLogs(dispatch, mainWindow) {
       log.debug('Downloading robot logs', { logUrls })
 
       logUrls
-        .reduce(
-          (result, url) => result.then(() => download(mainWindow, url)),
-          Promise.resolve()
-        )
+        .reduce((result, url, index) => {
+          return result.then(() => {
+            return download(mainWindow, url, {
+              saveAs: true,
+              openFolderWhenDone: index === logUrls.length - 1,
+            })
+          })
+        }, Promise.resolve())
         .catch(error => log.error('Error downloading robot logs', { error }))
         .then(() => dispatch({ type: 'shell:DOWNLOAD_LOGS_DONE' }))
     }

--- a/app/src/config/types.js
+++ b/app/src/config/types.js
@@ -18,6 +18,7 @@ export type FeatureFlags = $Shape<{|
 
 export type Config = {
   devtools: boolean,
+  reinstallDevtools: boolean,
 
   // app update config
   update: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4567,6 +4567,14 @@ cli-spinners@^1.1.0:
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.3.1.tgz#002c1990912d0d59580c93bd36c056de99e4259a"
   integrity sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==
 
+cli-truncate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.0.0.tgz#68ff6aaa53b203b52ad89b8b1a80f1f61ad1e1d5"
+  integrity sha512-C4hp+8GCIFVsUUiXcw+ce+7wexVWImw8rQrgMBFsqerx9LvvcGlwm6sMjQYAEmV/Xb87xc1b5Ttx505MSpZVqg==
+  dependencies:
+    slice-ansi "^2.1.0"
+    string-width "^4.1.0"
+
 cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
@@ -6132,6 +6140,15 @@ electron-builder@^21.2.0:
     update-notifier "^3.0.1"
     yargs "^13.3.0"
 
+electron-context-menu@^0.15.1:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/electron-context-menu/-/electron-context-menu-0.15.1.tgz#30d776ff889f220de688bde762870d5fcf9c83c2"
+  integrity sha512-+uiTR8c/GKT1D4jxkV5GGEuAJz+RJGFJmdCXD3yIzhQ6BwpjEC99F9DqJJfTzHK1P3R5sxiZ7qoSNvg/3dBgzw==
+  dependencies:
+    cli-truncate "^2.0.0"
+    electron-dl "^1.2.0"
+    electron-is-dev "^1.0.1"
+
 electron-debug@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/electron-debug/-/electron-debug-3.0.1.tgz#95b43b968ec7dbe96300034143e58b803a1e82dc"
@@ -6149,7 +6166,7 @@ electron-devtools-installer@^2.2.4:
     rimraf "^2.5.2"
     semver "^5.3.0"
 
-electron-dl@^1.14.0:
+electron-dl@^1.14.0, electron-dl@^1.2.0:
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/electron-dl/-/electron-dl-1.14.0.tgz#1466f1b945664ca3d784268307c2b935728177bf"
   integrity sha512-4okyei42a1mLsvLK7hLrIfd20EQzB18nIlLTwBV992aMSmTGLUEFRTmO1MfSslGNrzD8nuPuy1l/VxO8so4lig==
@@ -6176,7 +6193,7 @@ electron-is-accelerator@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/electron-is-accelerator/-/electron-is-accelerator-0.1.2.tgz#509e510c26a56b55e17f863a4b04e111846ab27b"
 
-electron-is-dev@^1.1.0:
+electron-is-dev@^1.0.1, electron-is-dev@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-1.1.0.tgz#b15a2a600bdc48a51a857d460e05f15b19a2522c"
   integrity sha512-Z1qA/1oHNowGtSBIcWk0pcLEqYT/j+13xUw/MYOrBUOL4X7VN0i0KCTf5SqyvMPmW5pSPKbo28wkxMxzZ20YnQ==


### PR DESCRIPTION
## overview

- Separated context menu setup from devtools extensions install
    - Previously, the "Inspect Element" right click could be broken if devtools failed to install
    - Added `--reinstallDevtools` option to force a devtools reinstall if they're not loading for some reason
    - Side-effect: standard context menu options like "Copy" and "Paste" are now available
- Added Help menu entry for opening app's log folder
    - Previously, app's logs were hard to get to
- Restored "Save As..." functionality for robot logs
    - Transparent log saving was inconvenient and confusing for users
    - Fixes #4293

## changelog

- fix(app-shell): improve context menu and log handling

## review requests

Caution: robot logs take a _long_ time to download. This is an API side thing

- [ ] Help > View Opentrons App Logs opens app log folder
- [ ] Robot logs download button gives you a "Save As" for each file
- [ ] Robot logs download location opens when last file is downloaded
- [ ] Opening the app with --reinstallDevtools gets you new devtools
    - This is easiest to see if you haven't got the new React Profiler extension installed (which I didn't have until I was testing this functionality)