### PR TITLE
feat(api): surface protocol apiv1 backcompat in apiv2

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -281,17 +281,6 @@ class Session(object):
         if isinstance(self._protocol, PythonProtocol):
             self.api_level = self._protocol.api_level
             self.metadata = self._protocol.metadata
-            if ff.use_protocol_api_v2()\
-               and self._protocol.api_level == APIVersion(1, 0)\
-               and not ff.enable_back_compat():
-                raise RuntimeError(
-                    'This protocol targets Protocol API V1, but the robot is '
-                    'set to Protocol API V2. If this is actually a V2 '
-                    'protocol, please set the \'apiLevel\' to \'2\' in the '
-                    'metadata. If you do not want to be on API V2, please '
-                    'disable the \'Use Protocol API version 2\' toggle in the '
-                    'robot\'s Advanced Settings and restart the robot.')
-
             log.info(f"Protocol API version: {self._protocol.api_level}")
         else:
             if ff.use_protocol_api_v2():

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -85,15 +85,6 @@ settings = [
                     ' default aspirate behavior (ul to mm conversion) to '
                     ' function as it did prior to version 3.7.0. '
                     ' NOTE: this does not impact GEN2 pipettes'
-    ),
-    Setting(
-        _id='enableApi1BackCompat',
-        title='Enable APIv1 Back-Compat Execution',
-        description='Use the under-development capability to execute APIv1 '
-                    'protocols using the APIv2 server. Do not set this unless '
-                    'you are a developer or testing; it is not yet feature '
-                    'complete.',
-        show_if=('useProtocolApi2', True)
     )
 ]
 

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -23,7 +23,3 @@ def use_protocol_api_v2():
 
 def use_old_aspiration_functions():
     return advs.get_setting_with_env_overload('useOldAspirationFunctions')
-
-
-def enable_back_compat():
-    return advs.get_setting_with_env_overload('enableApi1BackCompat')

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -18,7 +18,6 @@ from opentrons.protocol_api.legacy_wrapper import api
 from opentrons.protocol_api import (execute as execute_apiv2,
                                     MAX_SUPPORTED_VERSION)
 from opentrons import commands
-from opentrons.config import feature_flags as ff
 from opentrons.protocols.parse import parse, version_from_string
 from opentrons.protocols.types import JsonProtocol, APIVersion
 from opentrons.hardware_control import API
@@ -123,13 +122,25 @@ def get_arguments(
         help='The protocol file to execute. If you pass \'-\', you can pipe '
         'the protocol via stdin; this could be useful if you want to use this '
         'utility as part of an automated workflow.')
+    parser.add_argument(
+        '-i', '--internals',
+        choices=['v1', 'v2'],
+        default='v2',
+        help='Specify the internals to use when executing the protocol. v2 '
+        'means execute protocols that request API V2 using V2, and protocols '
+        'that request API V1 using the V1 back-compat shim. If you have a '
+        'protocol that uses undocumented, private, or internal capabilities '
+        'that are not present in the backcompat layer, you can specify v1 to '
+        'use the old internals.'
+    )
     return parser
 
 
 def execute(protocol_file: TextIO,
             propagate_logs: bool = False,
             log_level: str = 'warning',
-            emit_runlog: Callable[[Dict[str, Any]], None] = None):
+            emit_runlog: Callable[[Dict[str, Any]], None] = None,
+            force_v1: bool = False):
     """
     Run the protocol itself.
 
@@ -167,6 +178,11 @@ def execute(protocol_file: TextIO,
                         estimation. If specified, the callback should take a
                         single argument (the name doesn't matter) which will
                         be a dictionary (see below). Default: ``None``
+    :param bool force_v1: If ``True``, use API V1 internals. This prevents
+                          simulation of V2 protocols, but allows the use of
+                          undocumented, private, or internal API V1
+                          interactions. This parameter may be specified on
+                          the command line as ``-i v1``.
 
     The format of the runlog entries is as follows:
 
@@ -191,9 +207,33 @@ def execute(protocol_file: TextIO,
     stack_logger.setLevel(getattr(logging, log_level.upper(), logging.WARNING))
     contents = protocol_file.read()
     protocol = parse(contents, protocol_file.name)
-    if isinstance(protocol, JsonProtocol)\
-            or protocol.api_level >= APIVersion(2, 0)\
-            or (ff.enable_back_compat() and ff.use_protocol_api_v2()):
+    if force_v1:
+        import opentrons.legacy_api.api
+        import opentrons.api
+        from opentrons.legacy_api import protocols
+        if not hasattr(opentrons, 'robot'):
+            setattr(opentrons, 'instruments',
+                    opentrons.legacy_api.api.instruments)
+            setattr(opentrons, 'containers',
+                    opentrons.legacy_api.api.containers)
+            setattr(opentrons, 'labware',
+                    opentrons.legacy_api.api.containers)
+            setattr(opentrons, 'robot',
+                    opentrons.legacy_api.api.robot)
+            setattr(opentrons, 'modules',
+                    opentrons.legacy_api.api.modules)
+        opentrons.robot.connect()
+        opentrons.robot.cache_instrument_models()
+        opentrons.robot.discover_modules()
+        opentrons.robot.home()
+        if emit_runlog:
+            opentrons.robot.broker.subscribe(
+                commands.command_types.COMMAND, emit_runlog)
+        if isinstance(protocol, JsonProtocol):
+            protocols.execute_protocol(protocol)
+        else:
+            exec(protocol.contents, {})
+    else:
         context = get_protocol_api(
             getattr(protocol, 'api_level', MAX_SUPPORTED_VERSION),
             bundled_labware=getattr(protocol, 'bundled_labware', None),
@@ -203,20 +243,6 @@ def execute(protocol_file: TextIO,
                 commands.command_types.COMMAND, emit_runlog)
         context.home()
         execute_apiv2.run_protocol(protocol, context)
-    else:
-        from opentrons import robot
-        from opentrons.legacy_api import protocols
-        robot.connect()
-        robot.cache_instrument_models()
-        robot.discover_modules()
-        robot.home()
-        if emit_runlog:
-            robot.broker.subscribe(
-                commands.command_types.COMMAND, emit_runlog)
-        if isinstance(protocol, JsonProtocol):
-            protocols.execute_protocol(protocol)
-        else:
-            exec(protocol.contents, {})
 
 
 def make_runlog_cb():
@@ -271,7 +297,8 @@ def main() -> int:
         log_level = 'warning'
     # Try to migrate containers from database to v2 format
     api.maybe_migrate_containers()
-    execute(args.protocol, log_level=log_level, emit_runlog=printer)
+    execute(args.protocol, log_level=log_level, emit_runlog=printer,
+            force_v1=(args.internals == 'v1'))
     return 0
 
 

--- a/api/src/opentrons/legacy_api/protocols/execute_v3.py
+++ b/api/src/opentrons/legacy_api/protocols/execute_v3.py
@@ -3,7 +3,7 @@ import datetime
 
 from numpy import add  # type: ignore
 
-from opentrons import instruments, robot
+from ..api import instruments, robot
 
 
 def _sleep(seconds):

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -117,12 +117,10 @@ def test_load_protocol_with_error_v1(session_manager, hardware):
     'protocol_file',
     ['testosaur_v2.py', 'testosaur.py', 'multi-single.py'])
 async def test_load_and_run_v2(
-    main_router,
-    protocol,
-    protocol_file,
-    loop,
-    enable_apiv1_backcompat
-):
+        main_router,
+        protocol,
+        protocol_file,
+        loop):
     session = main_router.session_manager.create(
         name='<blank>',
         contents=protocol.text)

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -143,12 +143,6 @@ def old_aspiration(monkeypatch):
         'useOldAspirationFunctions', False)
 
 
-@pytest.fixture
-def enable_apiv1_backcompat(monkeypatch):
-    config.advanced_settings.set_adv_setting('enableApi1BackCompat', True)
-    yield
-    config.advanced_settings.set_adv_setting('enableApi1BackCompat', False)
-
 # -----end feature flag fixtures-----------
 
 

--- a/api/tests/opentrons/integration/test_api.py
+++ b/api/tests/opentrons/integration/test_api.py
@@ -46,8 +46,7 @@ async def test_multi_single(
 @pytest.mark.api1_only
 @pytest.mark.parametrize('protocol_file', ['multi-single.py'])
 async def test_load_jog_save_run(
-        main_router, protocol, protocol_file, monkeypatch, robot,
-        enable_apiv1_backcompat):
+        main_router, protocol, protocol_file, monkeypatch, robot):
     import tempfile
     temp = tempfile.gettempdir()
     monkeypatch.setenv('USER_DEFN_ROOT', temp)

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -76,11 +76,6 @@ async def test_get(async_client):
     body = await resp.json()
     assert resp.status == 200
     validate_response_body(body)
-    if async_client.app['api_version'] == 2:
-        assert 'enableApi1BackCompat' in [s['id'] for s in body['settings']]
-    else:
-        assert 'enableApi1BackCompat' not in [
-            s['id'] for s in body['settings']]
 
 
 async def test_set(virtual_smoothie_env, loop, async_client):

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -6,9 +6,8 @@ import pytest
 from opentrons import simulate, protocols
 
 
-@pytest.mark.api2_only
 @pytest.mark.parametrize('protocol_file', ['testosaur_v2.py'])
-def test_simulate_function_apiv2(ensure_api2,
+def test_simulate_function_apiv2(singletons,
                                  protocol,
                                  protocol_file):
     runlog, bundle = simulate.simulate(
@@ -22,9 +21,7 @@ def test_simulate_function_apiv2(ensure_api2,
         ]
 
 
-@pytest.mark.api2_only
-def test_simulate_function_json_apiv2(ensure_api2,
-                                      get_json_protocol_fixture):
+def test_simulate_function_json_apiv2(singletons, get_json_protocol_fixture):
     jp = get_json_protocol_fixture('3', 'simple', False)
     filelike = io.StringIO(jp)
     runlog, bundle = simulate.simulate(filelike, 'simple.json')
@@ -41,8 +38,7 @@ def test_simulate_function_json_apiv2(ensure_api2,
 
 
 @pytest.mark.api2_only
-def test_simulate_function_bundle_apiv2(ensure_api2,
-                                        get_bundle_fixture):
+def test_simulate_function_bundle_apiv2(singletons, get_bundle_fixture):
     bundle = get_bundle_fixture('simple_bundle')
     runlog, bundle = simulate.simulate(
         bundle['filelike'], 'simple_bundle.zip')
@@ -66,10 +62,29 @@ def test_simulate_function_bundle_apiv2(ensure_api2,
         ]
 
 
-@pytest.mark.api1_only
 @pytest.mark.parametrize('protocol_file', ['testosaur.py'])
-def test_simulate_function_apiv1(ensure_api1, protocol, protocol_file):
+def test_simulate_function_apiv1(singletons, protocol, protocol_file):
     runlog, bundle = simulate.simulate(protocol.filelike, 'testosaur.py')
+    assert bundle is None
+    assert runlog[0]['payload']['text'].startswith('Picking up tip')
+    assert 'A1' in runlog[0]['payload']['text']
+    assert runlog[1]['payload']['text'].startswith('Aspirating 10 uL')
+    assert 'A1' in runlog[1]['payload']['text']
+    assert runlog[2]['payload']['text'].startswith('Dispensing 10 uL')
+    assert 'H12' in runlog[2]['payload']['text']
+    assert runlog[3]['payload']['text'].startswith('Aspirating 10 uL')
+    assert 'A1' in runlog[3]['payload']['text']
+    assert runlog[4]['payload']['text'].startswith('Dispensing 10 uL')
+    assert 'H12' in runlog[4]['payload']['text']
+    assert runlog[5]['payload']['text'].startswith('Dropping tip')
+    assert 'A1' in runlog[5]['payload']['text']
+    assert len(runlog) == 6
+
+
+@pytest.mark.parametrize('protocol_file', ['testosaur.py'])
+def test_simulate_function_force_v1(singletons, protocol, protocol_file):
+    runlog, bundle = simulate.simulate(protocol.filelike, 'testosaur.py',
+                                       force_v1=True)
     assert bundle is None
     assert [item['payload']['text'] for item in runlog] == [
         'Picking up tip well A1 in "5"',


### PR DESCRIPTION
This removes the back compat feature flag and makes v1 backcompat available by
default in the v2 internals. You can also now select an internals version in the
opentrons_simulate and opentrons_execute scripts.
