### PR TITLE
feat(api): enable v2 internals by default

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -96,10 +96,10 @@ test: local-install test-apiv2 test-apiv1
 	$(python)	-m twine check $(wheel_file)
 
 test-apiv2: local-install
-	OT_API_FF_useProtocolApi2=1 $(pytest) $(tests) $(test_opts) -m "not apiv1 and not api1_only"
+	OT_API_FF_useLegacyInternals=0 $(pytest) $(tests) $(test_opts) -m "not apiv1 and not api1_only"
 
 test-apiv1: local-install
-	OT_API_FF_useProtocolApi2=0 $(pytest) $(tests) $(test_opts) -m "not apiv2 and not api2_only"
+	OT_API_FF_useLegacyInternals=1 $(pytest) $(tests) $(test_opts) -m "not apiv2 and not api2_only"
 
 .PHONY: lint
 lint: $(ot_py_sources)

--- a/api/docs/v2/new_advanced_running.rst
+++ b/api/docs/v2/new_advanced_running.rst
@@ -92,7 +92,7 @@ Bundled protocols have all their labware definitions available to them inside th
 
 Bundled protocols also have any data files they may need available to them inside the bundle. Similarly to labware, if you change what data files you read inside the protocol you should rebundle it.
 
-Bundled protocols are created using ``opentrons_simulate``. The protocol must be an APIv2 protocol, and ``opentrons_simulate`` must be running in APIv2 mode. The easiest way to do this is to specify it with the environment variable ``OT_API_FF_useProtocolApi2=1``. You can specify this every time you run ``opentrons_simulate`` on Linux or Mac, or put it in your shell rc file; on Windows, you can set it in the environment variables dialog.
+Bundled protocols are created using ``opentrons_simulate``. The protocol must be an APIv2 protocol, and ``opentrons_simulate`` must be running in APIv2 mode. This is now the default (unless you have passed ``-i v1``).
 
 To bundle, use the ``-b`` option to ``opentrons_simulate``. **If the ``-b`` option is not available, it is because you have not set the APIv2 feature flag**. This will simulate the protocol, then (if successful) bundle the protocol file, all required labware definitions, and any specified data file into a zip suitable for use with the Opentrons app or the ``opentrons_execute`` script. If you are using custom data files or custom labware definitions, you must ensure that these files and definitions are available to ``opentrons_simulate``.
 

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -80,10 +80,12 @@ settings = [
     ),
     Setting(
         _id='useLegacyInternals',
-        title='Use Protocol API V1 Internals',
-        description='Enable to go back to the Protocol API V1 internals in '
-        'the robot server. This allows protocols that relied on those '
-        'internals to work properly.',
+        title='Downgrade to Version 1 Server',
+        description='Turning on this feature flag will allow you to run APIv1 '
+        'protocols on the original Version 1 Server and Protocol API. This '
+        'downgrade option should only be used if your APIv1 protocols do not '
+        'function as expected on the Version 2 Server. If you notice this '
+        'happening, please contact us at support@opentrons.com.',
         restart_required=True
     )
 ]

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -70,14 +70,6 @@ settings = [
         description='Prevent robot from homing motors on boot'
     ),
     Setting(
-        _id='useProtocolApi2',
-        title='Use Protocol API version 2',
-        description='Enable to use the Protocol API V2 Beta. With this flag '
-                    'set, only Protocol API v2 protocols can be executed by '
-                    'the robot. A restart of the robot is required.',
-        restart_required=True
-    ),
-    Setting(
         _id='useOldAspirationFunctions',
         title='Use older pipette calibrations',
         description='Use the older pipette calibrations for P10S, P10M, P50S,'
@@ -85,6 +77,14 @@ settings = [
                     ' default aspirate behavior (ul to mm conversion) to '
                     ' function as it did prior to version 3.7.0. '
                     ' NOTE: this does not impact GEN2 pipettes'
+    ),
+    Setting(
+        _id='useLegacyInternals',
+        title='Use Protocol API V1 Internals',
+        description='Enable to go back to the Protocol API V1 internals in '
+        'the robot server. This allows protocols that relied on those '
+        'internals to work properly.',
+        restart_required=True
     )
 ]
 
@@ -228,7 +228,21 @@ def _migrate2to3(previous: SettingsMap) -> SettingsMap:
     return newmap
 
 
-_MIGRATIONS = [_migrate0to1, _migrate1to2, _migrate2to3]
+def _migrate3to4(previous: SettingsMap) -> SettingsMap:
+    """
+    Migration to version 4 of the feature flags file. Removes
+    the enableApi1BackCompat and useProtocolApi2 config elements
+    and adds a useLegacyInternals config element, which has the
+    opposite sense to useProtocolApi2.
+    """
+    newmap = {k: v for k, v in previous.items()
+              if k not in [
+                      'enableApi1BackCompat', 'useProtocolApi2']}
+    newmap['useLegacyInternals'] = None
+    return newmap
+
+
+_MIGRATIONS = [_migrate0to1, _migrate1to2, _migrate2to3, _migrate3to4]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below
 for how the migration functions are applied. Each migration function should

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -18,7 +18,7 @@ def disable_home_on_boot():
 
 
 def use_protocol_api_v2():
-    return advs.get_setting_with_env_overload('useProtocolApi2')
+    return not advs.get_setting_with_env_overload('useLegacyInternals')
 
 
 def use_old_aspiration_functions():

--- a/api/src/opentrons/tools/__init__.py
+++ b/api/src/opentrons/tools/__init__.py
@@ -1,5 +1,6 @@
 import opentrons
 import optparse
+import sys
 
 
 def connect_to_port(hardware):
@@ -9,7 +10,7 @@ def connect_to_port(hardware):
         type='str', help='serial port of the smoothie'
     )
 
-    options, _ = parser.parse_args(args=None, values=None)
+    options, _ = parser.parse_args(args=sys.argv, values=None)
     if options.port:
         hardware.connect(options.port)
     else:

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -1,16 +1,15 @@
 from opentrons.config.advanced_settings import _migrate
 
 
-good_file_version = 3
+good_file_version = 4
 good_file_settings = {
     'shortFixedTrash': None,
     'calibrateToBottom': None,
     'deckCalibrationDots': None,
     'disableHomeOnBoot': None,
-    'useProtocolApi2': None,
     'useOldAspirationFunctions': None,
     'disableLogAggregation': None,
-    'enableApi1BackCompat': None
+    'useLegacyInternals': None
 }
 
 
@@ -37,10 +36,9 @@ def test_migrates_versionless_new_config():
       'calibrateToBottom': True,
       'deckCalibrationDots': None,
       'disableHomeOnBoot': True,
-      'useProtocolApi2': None,
       'useOldAspirationFunctions': True,
       'disableLogAggregation': None,
-      'enableApi1BackCompat': None
+      'useLegacyInternals': None
     }
 
 
@@ -58,10 +56,9 @@ def test_migrates_versionless_old_config():
       'calibrateToBottom': None,
       'deckCalibrationDots': True,
       'disableHomeOnBoot': None,
-      'useProtocolApi2': None,
       'useOldAspirationFunctions': None,
       'disableLogAggregation': None,
-      'enableApi1BackCompat': None
+      'useLegacyInternals': None
     }
 
 
@@ -72,16 +69,7 @@ def test_ignores_invalid_keys():
     })
 
     assert version == good_file_version
-    assert settings == {
-      'shortFixedTrash': None,
-      'calibrateToBottom': None,
-      'deckCalibrationDots': None,
-      'disableHomeOnBoot': None,
-      'useProtocolApi2': None,
-      'useOldAspirationFunctions': None,
-      'disableLogAggregation': None,
-      'enableApi1BackCompat': None
-    }
+    assert settings == good_file_settings
 
 
 def test_migrates_v1_config():
@@ -94,16 +82,15 @@ def test_migrates_v1_config():
       'useProtocolApi2': False,
       'useOldAspirationFunctions': True,
     })
-    assert version == 3
+    assert version == good_file_version
     assert settings == {
         'shortFixedTrash': True,
         'calibrateToBottom': True,
         'deckCalibrationDots': False,
         'disableHomeOnBoot': True,
-        'useProtocolApi2': False,
         'useOldAspirationFunctions': True,
         'disableLogAggregation': None,
-        'enableApi1BackCompat': None
+        'useLegacyInternals': None,
     }
 
 
@@ -119,14 +106,37 @@ def test_migrates_v2_config():
         'disableLogAggregation': False,
     })
 
-    assert version == 3
+    assert version == good_file_version
     assert settings == {
         'shortFixedTrash': True,
         'calibrateToBottom': True,
         'deckCalibrationDots': False,
         'disableHomeOnBoot': True,
-        'useProtocolApi2': False,
         'useOldAspirationFunctions': True,
         'disableLogAggregation': False,
-        'enableApi1BackCompat': None
+        'useLegacyInternals': None,
+    }
+
+
+def test_migrates_v3_config():
+    settings, version = _migrate({
+        '_version': 3,
+        'shortFixedTrash': True,
+        'calibrateToBottom': True,
+        'deckCalibrationDots': False,
+        'disableHomeOnBoot': True,
+        'useProtocolApi2': True,
+        'useOldAspirationFunctions': True,
+        'disableLogAggregation': False,
+        'enableApi1BackCompat': False
+    })
+    assert version == good_file_version
+    assert settings == {
+        'shortFixedTrash': True,
+        'calibrateToBottom': True,
+        'deckCalibrationDots': False,
+        'disableHomeOnBoot': True,
+        'useOldAspirationFunctions': True,
+        'disableLogAggregation': False,
+        'useLegacyInternals': None,
     }

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -152,7 +152,8 @@ def old_aspiration(monkeypatch):
 
 @contextlib.contextmanager
 def using_api2(loop):
-    if not os.environ.get('OT_API_FF_useProtocolApi2'):
+    flag = os.environ.get('OT_API_FF_useLegacyInternals')
+    if flag is not None and flag.lower() in ('1', 'true'):
         pytest.skip('Do not run api v1 tests here')
     hw_manager = adapters.SingletonAdapter(loop)
     old_config = config.robot_configs.load()
@@ -167,8 +168,9 @@ def using_api2(loop):
                     reason="requires inotify (linux only)")
 @contextlib.contextmanager
 def using_sync_api2(loop):
-    if not os.environ.get('OT_API_FF_useProtocolApi2'):
-        pytest.skip('Do not run api v2 tests here')
+    flag = os.environ.get('OT_API_FF_useLegacyInternals')
+    if flag is not None and flag.lower() in ('1', 'true'):
+        pytest.skip('Do not run api v1 tests here')
     hardware = adapters.SynchronousAdapter.build(
         API.build_hardware_controller)
     try:
@@ -193,6 +195,9 @@ def ensure_api1(request, loop):
 @pytest.mark.apiv1
 @contextlib.contextmanager
 def using_api1(loop):
+    flag = os.environ.get('OT_API_FF_useLegacyInternals')
+    if flag is None or flag.lower() not in ('1', 'true'):
+        pytest.skip('Do not run API v2 tests here')
     try:
         yield rb
     finally:

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -100,10 +100,10 @@ async def test_restart_required_persistence(
 
     # Changing the state sets restart required
     cur_apiv2_state = [s['value'] for s in current_body['settings']
-                       if s['id'] == 'useProtocolApi2'][0]
+                       if s['id'] == 'useLegacyInternals'][0]
     new_apiv2_state = not bool(cur_apiv2_state)
     resp = await async_client.post('/settings',
-                                   json={'id': 'useProtocolApi2',
+                                   json={'id': 'useLegacyInternals',
                                          'value': new_apiv2_state})
     assert resp.status == 200
     body = await resp.json()
@@ -115,7 +115,7 @@ async def test_restart_required_persistence(
     assert new_body['links']['restart'] == '/server/restart'
 
     resp = await async_client.post('/settings',
-                                   json={'id': 'useProtocolApi2',
+                                   json={'id': 'useLegacyInternals',
                                          'value': new_apiv2_state})
     assert resp.status == 200
     body = await resp.json()
@@ -127,7 +127,7 @@ async def test_restart_required_persistence(
     assert new_body['links']['restart'] == '/server/restart'
 
     resp = await async_client.post('/settings',
-                                   json={'id': 'useProtocolApi2',
+                                   json={'id': 'useLegacyInternals',
                                          'value': cur_apiv2_state})
     assert resp.status == 200
     body = await resp.json()


### PR DESCRIPTION
This removes the apiv2 feature flag in favor of a new flag, useLegacyInternals,
with the opposite sense: enable to use the v1 internals (default off).

<img width="420" alt="Screen Shot 2019-11-19 at 2 09 42 PM" src="https://user-images.githubusercontent.com/3091648/69177941-8d697800-0ad6-11ea-8ee0-da30742d969f.png">

Closes #2187 