### PR TITLE
refactor(api): make labware migration non-destructive

### DIFF
--- a/api/src/opentrons/protocol_api/legacy_wrapper/api.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/api.py
@@ -167,22 +167,18 @@ def build_globals(context: 'ProtocolContext'):
 
 def maybe_migrate_containers():
     result = False
-    if not os.environ.get('MIGRATE_V1_LABWARE'):
-        return result
-    if not os.path.exists(CONFIG['labware_database_file']):
-        return result
-    if os.environ.get('MIGRATE_V1_LABWARE') and\
-            os.path.exists(CONFIG['labware_database_file']):
+    if os.path.exists(CONFIG['labware_database_file']):
+        log.info("Checking for labware to migrate from database")
         try:
             result, validation_failure = perform_migration()
-            log.warning("The following labwares failed labware migration",
-                        f"{validation_failure}")
+            if validation_failure:
+                log.warning(
+                    "The following labwares failed labware migration: "
+                    f"{validation_failure}")
         except (IndexError, ValueError, KeyError):
             delete_dir = CONFIG['labware_user_definitions_dir_v2']/'legacy_api'
             if os.path.exists(delete_dir):
                 shutil.rmtree(delete_dir)
-            log.warning('Failed to perform database migration,',
+            log.warning('Failed to perform database migration,  '
                         'please try again.')
-    if result:
-        os.remove(CONFIG['labware_database_file'])
     return result


### PR DESCRIPTION
Since we're going to spend a while with the ability to switch back and forth
between v1 and v2, we should make the v1->v2 labware migration not delete the
labware database when it's done. Instead, we just skip any labware we've already
migrated.

This also means we don't have to gate this functionality behind an environment
variable anymore and we can just do it all the time (even if we're on v1
internals).
