### PR TITLE
fix(api): allow pipette to move to deck slot

### DIFF
--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -1118,7 +1118,6 @@ class Pipette(CommandPublisher):
             if 'rack' in location.get_parent().get_type():
                 half_tip_length = self._tip_length * self._return_tip_height
                 location = location.top(-half_tip_length)
-                print(f'v1 location: {location}')
             elif 'trash' in location.get_parent().get_type():
                 loc, coords = location.top()
                 location = (loc, coords + (0, self.model_offset[1], 0))

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -628,7 +628,6 @@ class Robot(CommandPublisher):
 
             ``direct`` : move to the point in a straight line.
         """
-
         placeable, coordinates = containers.unpack_location(location)
 
         # because the top position is what is tracked,

--- a/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
@@ -891,7 +891,6 @@ class LegacyDeckItem(DeckItem):
         self._highest_z = 0.0
         self._labware: Deque = deque()
         self._type = share_type
-        self._origin = None
 
     @property
     def highest_z(self):
@@ -918,17 +917,6 @@ class LegacyDeckItem(DeckItem):
             self.highest_z = max([lw.highest_z for lw in self._labware])
         else:
             self.highest_z = self._labware[0].highest_z
-
-    @property
-    def origin(self):
-        return self._origin
-
-    def update_origin(self, location):
-        self._origin = location
-
-    def top(self, z: float = 0.0) -> Location:
-        return Location(
-            self.origin.point + Point(0, 0, z), self.origin.labware)
 
 
 class Containers:

--- a/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
@@ -891,7 +891,7 @@ class LegacyDeckItem(DeckItem):
         self._highest_z = 0.0
         self._labware: Deque = deque()
         self._type = share_type
-        self._origins = None
+        self._origin = None
 
     @property
     def highest_z(self):
@@ -920,15 +920,15 @@ class LegacyDeckItem(DeckItem):
             self.highest_z = self._labware[0].highest_z
 
     @property
-    def origins(self):
-        return self._origins
+    def origin(self):
+        return self._origin
 
-    def update_origins(self, location):
-        self._origins = location
+    def update_origin(self, location):
+        self._origin = location
 
     def top(self, z: float = 0.0) -> Location:
         return Location(
-            self.origins.point + Point(0, 0, z), self.origins.labware)
+            self.origin.point + Point(0, 0, z), self.origin.labware)
 
 
 class Containers:

--- a/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
@@ -891,6 +891,7 @@ class LegacyDeckItem(DeckItem):
         self._highest_z = 0.0
         self._labware: Deque = deque()
         self._type = share_type
+        self._origins = None
 
     @property
     def highest_z(self):
@@ -917,6 +918,17 @@ class LegacyDeckItem(DeckItem):
             self.highest_z = max([lw.highest_z for lw in self._labware])
         else:
             self.highest_z = self._labware[0].highest_z
+
+    @property
+    def origins(self):
+        return self._origins
+
+    def update_origins(self, location):
+        self._origins = location
+
+    def top(self, z: float = 0.0) -> Location:
+        return Location(
+            self.origins.point + Point(0, 0, z), self.origins.labware)
 
 
 class Containers:

--- a/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
@@ -11,8 +11,7 @@ from ..util import Clearances, clamp_value
 
 from .types import LegacyLocation
 
-from .containers_wrapper import (LegacyLabware, LegacyWell,
-                                 WellSeries, LegacyDeckItem)
+from .containers_wrapper import LegacyLabware, LegacyWell, WellSeries
 
 if TYPE_CHECKING:
     from ..contexts import InstrumentContext # noqa(F401)

--- a/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
@@ -56,10 +56,13 @@ def _absolute_motion_target(
         real_loc: Union['Labware', 'Well'] = target_loc.labware.lw_obj
     else:
         real_loc = target_loc.labware
-    return Location(
-        labware=real_loc,
-        point=(target_loc.labware._from_center_cartesian(-1, -1, -1)
-               + target_loc.offset))
+    if isinstance(target_loc.labware, str):  # for deck objects
+        return Location(labware=real_loc, point=target_loc.offset)
+    else:
+        return Location(
+            labware=real_loc,
+            point=(target_loc.labware._from_center_cartesian(-1, -1, -1)
+                   + target_loc.offset))
 
 
 class Pipette:
@@ -268,7 +271,7 @@ class Pipette:
         return self
 
     def move_to(self,
-                location: Union[MotionTarget, LegacyDeckItem],
+                location: MotionTarget,
                 strategy: str = None):
         """
         Move this :any:`Pipette` to a location.
@@ -283,13 +286,9 @@ class Pipette:
                              in a straight line from the current position
         :returns Pipette: This instance.
         """
-        if not isinstance(location, LegacyDeckItem):
-            placeable = location\
-                if isinstance(location, LegacyWell) else location.labware
-            absolute_location = _absolute_motion_target(location, 'top')
-        else:
-            placeable = location.origin.labware
-            absolute_location = location.origin
+        placeable = location\
+            if isinstance(location, LegacyWell) else location.labware
+        absolute_location = _absolute_motion_target(location, 'top')
 
         force_direct = False
         if strategy == 'direct' or (

--- a/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
@@ -288,8 +288,8 @@ class Pipette:
                 if isinstance(location, LegacyWell) else location.labware
             absolute_location = _absolute_motion_target(location, 'top')
         else:
-            placeable = location.origins.labware
-            absolute_location = location.origins
+            placeable = location.origin.labware
+            absolute_location = location.origin
 
         force_direct = False
         if strategy == 'direct' or (

--- a/api/src/opentrons/protocol_api/legacy_wrapper/robot_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/robot_wrapper.py
@@ -80,9 +80,6 @@ class Robot():
         self._bc_lw: Optional['Containers'] = None
         self._bc_mods: Optional['BCModules'] = None
 
-        self._deck = {
-            str(k): LegacyDeckItem('normal') for k in self._ctx.deck.keys()}
-
     def _set_globals(
             self, instr: 'BCInstruments', lw: 'Containers', mod: 'BCModules'):
         self._bc_instr = instr
@@ -212,14 +209,14 @@ class Robot():
         return self._ctx.disconnect()
 
     @property
-    def deck(self) -> Dict[str, LegacyDeckItem]:
-        for k, v in self._ctx.deck.items():
-            if v is not None:
-                self._deck[str(k)].add_item(v)
-            if not self._deck[str(k)].origin:
-                self._deck[str(k)].update_origin(
-                    self._ctx.deck.position_for(k))
-        return self._deck
+    def deck(self) -> Dict[str, LegacyLocation]:
+        deck_dict = {}
+        for slot in range(1, 13):
+            point, lw = self._ctx.deck.position_for(slot)
+            legacy_loc = LegacyLocation(
+                labware=lw, offset=point)
+            deck_dict[str(slot)] = legacy_loc
+        return deck_dict
 
     @property
     def fixed_trash(self) -> 'Labware':

--- a/api/src/opentrons/protocol_api/legacy_wrapper/robot_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/robot_wrapper.py
@@ -10,7 +10,6 @@ from .containers_wrapper import LegacyDeckItem
 if TYPE_CHECKING:
     from .instrument_wrapper import Pipette
     from ..contexts import ProtocolContext
-    from ..geometry import Deck
     from ..labware import Labware
     from .api import BCInstruments, BCModules
     from .containers_wrapper import Containers

--- a/api/src/opentrons/protocol_api/legacy_wrapper/robot_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/robot_wrapper.py
@@ -217,8 +217,8 @@ class Robot():
         for k, v in self._ctx.deck.items():
             if v is not None:
                 self._deck[str(k)].add_item(v)
-            if not self._deck[str(k)].origins:
-                self._deck[str(k)].update_origins(
+            if not self._deck[str(k)].origin:
+                self._deck[str(k)].update_origin(
                     self._ctx.deck.position_for(k))
         return self._deck
 

--- a/api/src/opentrons/protocol_api/legacy_wrapper/robot_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/robot_wrapper.py
@@ -4,8 +4,6 @@ from typing import Any, Dict, Optional, TYPE_CHECKING
 from opentrons.hardware_control import adapters, API
 from .util import log_call
 from .types import LegacyLocation
-from .containers_wrapper import LegacyDeckItem
-
 
 if TYPE_CHECKING:
     from .instrument_wrapper import Pipette

--- a/api/tests/opentrons/data/testosaur.py
+++ b/api/tests/opentrons/data/testosaur.py
@@ -1,4 +1,4 @@
-from opentrons import instruments, containers
+from opentrons import instruments, containers, robot
 
 metadata = {
     'protocolName': 'Testosaur',
@@ -23,8 +23,8 @@ conts = [
 ]
 
 # Uncomment these to test precision
-# p300.move_to(robot.deck['11'])
-# p300.move_to(robot.deck['6'])
+p300.move_to(robot.deck['11'])
+p300.move_to(robot.deck['6'])
 
 for container in conts:
     p300.aspirate(10, container[0]).dispense(10, container[-1].top(5))

--- a/api/tests/opentrons/protocol_api/test_back_compat.py
+++ b/api/tests/opentrons/protocol_api/test_back_compat.py
@@ -125,3 +125,8 @@ def test_robot_reset(singletons):
     assert singletons['robot']._instrs == {}
     assert singletons['robot']._head_speed_override is None
     assert singletons['robot']._ctx.max_speeds == {}
+
+
+@pytest.mark.api2_only
+def test_robot_deck_wrapper(singletons):
+    assert singletons['robot'].deck['12'] == singletons['robot'].deck['12']


### PR DESCRIPTION
## overview
In APIv1, the following is valid:

```PYTHON
pip.move_to(robot.deck['11'])
```
Currently with backcompat, `robot.deck[slot]` returns either `None` or the labware that is loaded in that slot. This means that the pipette cannot differentiate a slot from a labware. Instead of returning the deck layout from ProtocoContext, we have to refactor it so that it returns a dictionary of LegacyDeckItems. 

## changelog
- add `origin` as a LegacyDeckItem property
- add `top` as an attribute
- more tests!
