### PR TITLE
fix(api): fix calibration issues in backcompat

### DIFF
--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1206,7 +1206,7 @@ class InstrumentContext(CommandPublisher):
     def pick_up_tip(  # noqa(C901)
             self, location: Union[types.Location, Well] = None,
             presses: int = None,
-            increment: float = 1.0) -> 'InstrumentContext':
+            increment: float = None) -> 'InstrumentContext':
         """
         Pick up a tip for the pipette to run liquid-handling commands with
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 from enum import Enum, auto
 from hashlib import sha256
 from itertools import takewhile, dropwhile
-from typing import Any, AnyStr, List, Dict, Optional, Union, Tuple
+from typing import Any, AnyStr, List, Dict, Optional, Union, Sequence, Tuple
 
 import jsonschema  # type: ignore
 
@@ -179,6 +179,10 @@ class Well:
                  slot 1 as (0,0,0)). If z is specified, returns a point
                  offset by z mm from bottom-center
         """
+        return self._bottom(z)
+
+    def _bottom(self, z: float = 0.0) -> Location:
+        # inheritance and version check workaround
         top = self._top()
         bottom_z = top.point.z - self._depth + z
         return Location(Point(x=top.point.x, y=top.point.y, z=bottom_z), self)
@@ -316,7 +320,7 @@ class Labware(DeckItem):
             self._name = definition['parameters']['loadName']
         self._display_name = "{} on {}".format(dn, str(parent.labware))
         self._calibrated_offset: Point = Point(0, 0, 0)
-        self._wells: List[Well] = []
+        self._wells: Sequence[Well] = []
         # Directly from definition
         self._well_definition = definition['wells']
         self._parameters = definition['parameters']
@@ -392,7 +396,7 @@ class Labware(DeckItem):
         else:
             return self._parameters['magneticModuleEngageHeight']
 
-    def _build_wells(self) -> List[Well]:
+    def _build_wells(self) -> Sequence[Well]:
         """
         This function is used to create one instance of wells to be used by all
         accessor functions. It is only called again if a new offset needs
@@ -472,7 +476,7 @@ class Labware(DeckItem):
             res = [self.wells_by_name()[idx] for idx in args]
         else:
             raise TypeError
-        return res
+        return list(res)
 
     @requires_version(2, 0)
     def wells_by_name(self) -> Dict[str, Well]:

--- a/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
@@ -506,7 +506,6 @@ class LegacyLabware():
     def __init__(self, labware: Labware) -> None:
         self.lw_obj = labware
         setattr(labware, '_build_wells', self._build_wells)
-        self.set_calibration(Point(0, 0, 0))
         self._definition = self.lw_obj._definition
         self._wells_by_index = self.lw_obj.wells
         self._wells_by_name = self.lw_obj.wells_by_name
@@ -539,6 +538,7 @@ class LegacyLabware():
             'rows': {
                 'list': self._rows, 'dict': self._rows_by_name}
             }
+        self.lw_obj._wells = self.lw_obj._build_wells()
 
     def __getattr__(self, attr):
         # For the use-case of methods `well` or `cols`

--- a/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
@@ -13,7 +13,6 @@ from ..labware import (
     ModuleGeometry,
     LabwareDefinition,
     DeckItem)
-from .util import log_call
 from .types import LegacyLocation
 from typing import (
     Dict, List, Any, Union, Optional, Sequence, TYPE_CHECKING, Deque)
@@ -975,7 +974,6 @@ class Containers:
 
         old_labware.add_item(new_labware)
 
-    @log_call(log)
     def load(
             self,
             container_name: str,
@@ -1050,7 +1048,6 @@ class Containers:
 
         return labware_object
 
-    @log_call(log)
     def create(
             self,
             name,
@@ -1107,6 +1104,5 @@ class Containers:
         self.labware_mappings[lw] = legacy
         return legacy
 
-    @log_call(log)
     def list(self, *args, **kwargs):
         return get_all_labware_definitions()

--- a/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
@@ -506,6 +506,7 @@ class LegacyLabware():
     def __init__(self, labware: Labware) -> None:
         self.lw_obj = labware
         setattr(labware, '_build_wells', self._build_wells)
+        self.lw_obj._wells = self.lw_obj._build_wells()
         self._definition = self.lw_obj._definition
         self._wells_by_index = self.lw_obj.wells
         self._wells_by_name = self.lw_obj.wells_by_name
@@ -538,7 +539,6 @@ class LegacyLabware():
             'rows': {
                 'list': self._rows, 'dict': self._rows_by_name}
             }
-        self.lw_obj._wells = self.lw_obj._build_wells()
 
     def __getattr__(self, attr):
         # For the use-case of methods `well` or `cols`

--- a/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/containers_wrapper.py
@@ -15,7 +15,7 @@ from ..labware import (
     DeckItem)
 from .types import LegacyLocation
 from typing import (
-    Dict, List, Any, Union, Optional, Sequence, TYPE_CHECKING, Deque)
+    Dict, List, Any, Union, Optional, Sequence, TYPE_CHECKING, Deque, Tuple)
 
 import jsonschema  # type: ignore
 

--- a/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
@@ -837,8 +837,10 @@ class Pipette:
         cmds.do_publish(self._instr_ctx.broker, cmds.pick_up_tip,
                         self.pick_up_tip, 'after', self, None, self,
                         location=new_loc)
+        working_volume = new_loc.labware.max_volume or \
+            self.max_volume
         self._hw_manager.hardware.set_working_volume(
-            self._mount, new_loc.labware.max_volume)
+            self._mount, working_volume)
         self._instr_ctx._last_tip_picked_up_from = \
             self.current_tip()  # type: ignore
 

--- a/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
@@ -823,7 +823,6 @@ class Pipette:
 
         self.current_tip(display_loc)
 
-        self._log.info(f"publishing {type(new_loc[0])}")
         cmds.do_publish(self._instr_ctx.broker, cmds.pick_up_tip,
                         self.pick_up_tip, 'before', None, None, self,
                         location=new_loc)
@@ -905,7 +904,6 @@ class Pipette:
             checked_location = _unpack_motion_target(
                 self.trash_container.wells()[0].top())
         self.move_to(checked_location)
-        self._log.info(f"publishing {type(checked_location[0])}")
         cmds.do_publish(
             self._ctx.broker, cmds.drop_tip, self.drop_tip,
             'before', None, None, self, location=checked_location.labware)

--- a/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
@@ -1,6 +1,6 @@
 from numbers import Number
 import logging
-from typing import Dict, List, Optional, Sequence, TYPE_CHECKING, Union
+from typing import Any, Dict, List, Optional, Sequence, TYPE_CHECKING, Union
 from opentrons import commands as cmds
 from opentrons.types import Point, Location
 from opentrons.config import pipette_config
@@ -42,7 +42,8 @@ def _unpack_motion_target(
         else:
             target_loc = motiontarget.bottom()
     else:
-        raise TypeError('A Well or tuple(well, point) is needed')
+        raise TypeError(
+            'A Well or tuple(well, point) is needed')
     return target_loc
 
 
@@ -75,14 +76,15 @@ class Pipette:
         self._instr_ctx = instrument_context
         self._ctx = self._instr_ctx._ctx
         self._mount = self._instr_ctx._mount
-        self._hw = self._instr_ctx._hw_manager.hardware
-        self._hw_pipette = self._hw._attached_instruments[self._mount]
+        self._hw_manager = self._instr_ctx._hw_manager
+        self._hw_pipette\
+            = self._hw_manager.hardware._attached_instruments[self._mount]
 
         self._log = self._instr_ctx._log
         self._default_speed = self._instr_ctx.default_speed
         self._max_plunger_speed: Optional[float] = None
 
-        self._trash_container = self._instr_ctx.trash_container
+        self._trash_container = LegacyLabware(self._instr_ctx.trash_container)
         self._tip_racks = self._instr_ctx.tip_racks\
             if self._instr_ctx.tip_racks else []
 
@@ -116,7 +118,7 @@ class Pipette:
 
     @property
     def _pipette_status(self):
-        return self._hw.attached_instruments[self._mount]
+        return self._hw_manager.hardware.attached_instruments[self._mount]
 
     @property
     def _working_volume(self) -> float:
@@ -203,7 +205,7 @@ class Pipette:
         Resets the state of this pipette, removing associated placeables,
         setting current volume to zero, and resetting tip tracking
         """
-        instr = self._hw._attached_instruments[self._mount]
+        instr = self._hw_manager.hardware._attached_instruments[self._mount]
         instr.set_current_volume(0)
         instr.current_tiprack_diamater = 0.0
         instr._has_tip = False
@@ -263,7 +265,7 @@ class Pipette:
         :returns Pipette: This instance
         '''
         self._ctx.location_cache = None
-        self._hw.retract(self._mount)
+        self._hw_manager.hardware.retract(self._mount)
         return self
 
     def move_to(self,
@@ -368,7 +370,7 @@ class Pipette:
                 self._instr_ctx.broker, cmds.aspirate, self.aspirate,
                 'before', None, None, self, volume,
                 display_location, rate)
-            self._hw.aspirate(self._mount, volume, rate)
+            self._hw_manager.hardware.aspirate(self._mount, volume, rate)
             cmds.do_publish(
                 self._instr_ctx.broker, cmds.aspirate, self.aspirate,
                 'after', self, None,  self, volume,
@@ -392,7 +394,7 @@ class Pipette:
         if self.current_volume == 0:
             if placeable:
                 self.move_to(placeable.top())
-            self._hw.prepare_for_aspirate(self._mount)
+            self._hw_manager.hardware.prepare_for_aspirate(self._mount)
 
         if location:
             if isinstance(location, LegacyWell):
@@ -477,7 +479,7 @@ class Pipette:
         if volume != 0:
             self._position_for_dispense(location)
 
-            self._hw.dispense(self._mount, volume, rate)
+            self._hw_manager.hardware.dispense(self._mount, volume, rate)
 
         cmds.do_publish(self._instr_ctx.broker, cmds.dispense, self.dispense,
                         'after', self, None, self, volume, display_location,
@@ -593,7 +595,7 @@ class Pipette:
             self.move_to(location)
         # In API v1, a pipette will blow out at any location as long as there
         # is a tip attached
-        self._hw.blow_out(self._mount)
+        self._hw_manager.hardware.blow_out(self._mount)
         return self
 
     @log_call(log)
@@ -763,7 +765,7 @@ class Pipette:
     @log_call(log)
     def pick_up_tip(
             self, location: MotionTarget = None,
-            presses: int = None, increment: float = 1.0)\
+            presses: int = None, increment: float = None)\
             -> 'Pipette':
         """
         Pick up a tip for the Pipette to handle liquids with
@@ -817,28 +819,33 @@ class Pipette:
             legacy_labware = self._lw_mappings[tiprack]
             tip = legacy_labware[new_tip._display_name.split(' of')[0]]
             new_loc = tip.top()
-            display_loc = new_tip
+            display_loc = tip
 
         self.current_tip(display_loc)
 
+        self._log.info(f"publishing {type(new_loc[0])}")
         cmds.do_publish(self._instr_ctx.broker, cmds.pick_up_tip,
                         self.pick_up_tip, 'before', None, None, self,
                         location=new_loc)
         self.move_to(new_loc)
-        self._hw.set_current_tiprack_diameter(
+        self._hw_manager.hardware.set_current_tiprack_diameter(
             self._mount, new_loc.labware.diameter)
-        self._hw.pick_up_tip(
+        self._hw_manager.hardware.pick_up_tip(
             self._mount,
             self._pipette_config.tip_length,
             presses, increment)
         cmds.do_publish(self._instr_ctx.broker, cmds.pick_up_tip,
                         self.pick_up_tip, 'after', self, None, self,
-                        location=display_loc)
-        self._hw.set_working_volume(self._mount, new_loc.labware.max_volume)
+                        location=new_loc)
+        self._hw_manager.hardware.set_working_volume(
+            self._mount, new_loc.labware.max_volume)
         self._instr_ctx._last_tip_picked_up_from = \
             self.current_tip()  # type: ignore
 
         return self
+
+    def _tip_length_for(self, tiprack: Any) -> float:
+        return self._pipette_config.tip_length
 
     def _flatten_well_list(self, well_list: Union[List, WellSeries]):
         if isinstance(well_list[0], (List, WellSeries)):
@@ -891,11 +898,19 @@ class Pipette:
                            (0, self._pipette_config.model_offset[1], 0))
             else:
                 new_loc = lw.top()
-            checked_location = _absolute_motion_target(new_loc)
+            checked_location = _unpack_motion_target(new_loc)
         else:
-            checked_location = location  # type: ignore
-        self._instr_ctx.drop_tip(
-            location=checked_location, home_after=home_after)
+            checked_location = _unpack_motion_target(
+                self.trash_container.wells()[0].top())
+        self.move_to(checked_location)
+        self._log.info(f"publishing {type(checked_location[0])}")
+        cmds.do_publish(
+            self._ctx.broker, cmds.drop_tip, self.drop_tip,
+            'before', None, None, self, location=checked_location.labware)
+        self._hw_manager.hardware.drop_tip(self._mount, home_after=home_after)
+        cmds.do_publish(
+            self._ctx.broker, cmds.drop_tip, self.drop_tip,
+            'after', self, None, self, location=checked_location.labware)
         self.current_tip(None)
         return self
 

--- a/api/tests/opentrons/protocol_api/test_instrument_wrapper.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_wrapper.py
@@ -150,14 +150,14 @@ def test_aspirate_locations(
     legacy_move_to, move_to = get_v1_v2_mock_calls(
         monkeypatch, legacy_instr, pip, 'move_to')
 
-    hw_aspirate_effect = pip._hw._api.aspirate
+    hw_aspirate_effect = pip._hw_manager.hardware._api.aspirate
 
     def run_aspirate(*args, **kwargs):
         return loop.run_until_complete(hw_aspirate_effect(*args, **kwargs))
 
     hw_aspirate = mock.Mock()
     hw_aspirate.side_effect = run_aspirate
-    monkeypatch.setattr(pip._hw._api, 'aspirate', hw_aspirate)
+    monkeypatch.setattr(pip._hw_manager.hardware._api, 'aspirate', hw_aspirate)
 
     legacy_call = {}
     new_call = {}
@@ -234,14 +234,14 @@ def test_dispense_locations(
     legacy_move_to, move_to = get_v1_v2_mock_calls(
         monkeypatch, legacy_instr, pip, 'move_to')
 
-    hw_dispense_effect = pip._hw._api.dispense
+    hw_dispense_effect = pip._hw_manager.hardware._api.dispense
 
     def run_dispense(*args, **kwargs):
         return loop.run_until_complete(hw_dispense_effect(*args, **kwargs))
 
     hw_dispense = mock.Mock()
     hw_dispense.side_effect = run_dispense
-    monkeypatch.setattr(pip._hw._api, 'dispense', hw_dispense)
+    monkeypatch.setattr(pip._hw_manager.hardware._api, 'dispense', hw_dispense)
 
     legacy_call = {}
     new_call = {}

--- a/api/tests/opentrons/protocol_api/test_legacy_labware.py
+++ b/api/tests/opentrons/protocol_api/test_legacy_labware.py
@@ -197,22 +197,24 @@ def test_load_func(labware, container_create):
 @pytest.mark.api2_only
 def test_well_accessor(minimal_labware):
     # Access well by __getitem__ from LegacyLabware
-    assert minimal_labware[0] == minimal_labware._wells_by_index[0]
-    assert minimal_labware['A1'] == minimal_labware._wells_by_index[0]
+    assert minimal_labware[0] == minimal_labware._wells_by_index()[0]
+    assert minimal_labware['A1'] == minimal_labware._wells_by_index()[0]
 
     # Access individual wells within a labware using wells method
-    assert minimal_labware.wells()[0] == minimal_labware._wells_by_index[0]
-    assert minimal_labware.wells()['A1'] == minimal_labware._wells_by_index[0]
-    assert minimal_labware.wells(0) == minimal_labware._wells_by_index[0]
-    assert minimal_labware.wells('A2') == minimal_labware._wells_by_name['A2']
+    assert minimal_labware.wells()[0] == minimal_labware._wells_by_index()[0]
+    assert minimal_labware.wells()['A1']\
+        == minimal_labware._wells_by_index()[0]
+    assert minimal_labware.wells(0) == minimal_labware._wells_by_index()[0]
+    assert minimal_labware.wells('A2')\
+        == minimal_labware._wells_by_name()['A2']
 
-    assert minimal_labware.well(1) == minimal_labware._wells_by_index[1]
-    assert minimal_labware.well('A2') == minimal_labware._wells_by_name['A2']
+    assert minimal_labware.well(1) == minimal_labware._wells_by_index()[1]
+    assert minimal_labware.well('A2') == minimal_labware._wells_by_name()['A2']
 
-    well_1 = minimal_labware._wells_by_index[0]
-    well_2 = minimal_labware._wells_by_index[1]
-    well_3 = minimal_labware._wells_by_name['A2']
-    well_4 = minimal_labware._wells_by_name['B2']
+    well_1 = minimal_labware._wells_by_index()[0]
+    well_2 = minimal_labware._wells_by_index()[1]
+    well_3 = minimal_labware._wells_by_name()['A2']
+    well_4 = minimal_labware._wells_by_name()['B2']
 
     # Generate lists using `wells()` method
     assert minimal_labware.wells(0, 'A2') == [well_1, well_3]
@@ -231,11 +233,11 @@ def test_well_accessor(minimal_labware):
 @pytest.mark.api2_only
 def test_row_accessor(minimal_labware):
     row_1 = [
-        minimal_labware._wells_by_index[0],
-        minimal_labware._wells_by_index[2]]
+        minimal_labware._wells_by_index()[0],
+        minimal_labware._wells_by_index()[2]]
     row_2 = [
-        minimal_labware._wells_by_index[1],
-        minimal_labware._wells_by_index[3]]
+        minimal_labware._wells_by_index()[1],
+        minimal_labware._wells_by_index()[3]]
 
     assert minimal_labware.rows[0] == row_1
     assert minimal_labware.rows['B'] == row_2
@@ -248,17 +250,16 @@ def test_row_accessor(minimal_labware):
 @pytest.mark.api2_only
 def test_column_accessor(minimal_labware):
     col_1 = [
-        minimal_labware._wells_by_name['A1'],
-        minimal_labware._wells_by_name['B1']]
+        minimal_labware._wells_by_name()['A1'],
+        minimal_labware._wells_by_name()['B1']]
     col_2 = [
-        minimal_labware._wells_by_name['A2'],
-        minimal_labware._wells_by_name['B2']]
+        minimal_labware._wells_by_name()['A2'],
+        minimal_labware._wells_by_name()['B2']]
 
     assert minimal_labware.columns[0] == col_1
     assert minimal_labware.cols[0] == col_1
     assert minimal_labware.columns['2'] == col_2
     assert minimal_labware.cols['2'] == col_2
-
     assert minimal_labware.columns(0) == col_1
     assert minimal_labware.columns('1') == col_1
     assert minimal_labware.columns('1', 1) == [col_1, col_2]


### PR DESCRIPTION
There were a couple different issues with pre-protocol labware calibration for the backcompat shim (even on top of getting locations correctly):

- We need to use the underlying context's hardware _manager_ rather than its hardware instance so we can take advantage of the calibration manager connecting to actual hardware (otherwise we won't move anywhere)
- We need to patch the underlying labware object's well builder to build legacy wells or a lot of the advanced constructors will return labware.Well, which doesn't work with the back compat wrapper motion control
- We need to home plungers at some point before calibration. This may actually be a v2 bug in general, it was causing hard stop errors the first time you go to pick up a tip after boot in calibration
- For some reason we were defaulting the tip pickup increment to 1.0mm in both v2 and the backcompat wrapper which is... odd. I don't know when this got introduced but it's very wrong


