### PR TITLE
refactor(api): add robot globals in backcompat mode

### DIFF
--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -23,7 +23,15 @@ if not config.feature_flags.use_protocol_api_v2():
     names_list = [
         'containers', 'instruments', 'robot', 'reset', 'modules', 'labware']
 else:
-    names_list = []
+    from .protocol_api.legacy_wrapper import api
+    from .protocol_api import ProtocolContext
+    globs = api.build_globals(ProtocolContext())
+    robot = globs['robot']
+    containers = globs['labware']
+    instruments = globs['instruments']
+    labware = globs['labware']
+    modules = globs['modules']
+    names_list = ['containers', 'instruments', 'robot', 'modules', 'labware']
 
 try:
     with open(os.path.join(HERE, 'package.json')) as pkg:


### PR DESCRIPTION
This is necessary for jupyter compatibility
