### PR TITLE
refactor(app): wire up Add Labware button without error handling

### DIFF
--- a/app-shell/src/labware/__tests__/definitions.test.js
+++ b/app-shell/src/labware/__tests__/definitions.test.js
@@ -4,7 +4,11 @@
 import path from 'path'
 import fs from 'fs-extra'
 import tempy from 'tempy'
-import { readLabwareDirectory, parseLabwareFiles } from '../definitions'
+import {
+  readLabwareDirectory,
+  parseLabwareFiles,
+  addLabwareFile,
+} from '../definitions'
 
 describe('labware directory utilities', () => {
   const tempDirs: Array<string> = []
@@ -131,5 +135,56 @@ describe('labware directory utilities', () => {
         ])
       })
     })
+  })
+
+  describe('addLabwareFile', () => {
+    test('writes a labware file to the directory', () => {
+      const sourceDir = makeEmptyDir()
+      const destDir = makeEmptyDir()
+      const sourceName = path.join(sourceDir, 'source.json')
+      const expectedName = path.join(destDir, 'source.json')
+
+      return fs
+        .writeJson(sourceName, { name: 'a' })
+        .then(() => addLabwareFile(sourceName, destDir))
+        .then(() => readLabwareDirectory(destDir))
+        .then(parseLabwareFiles)
+        .then(files => {
+          expect(files).toEqual([
+            {
+              filename: expectedName,
+              data: { name: 'a' },
+              created: expect.any(Number),
+            },
+          ])
+        })
+    })
+  })
+
+  test('increments filename to avoid collisions', () => {
+    const sourceDir = makeEmptyDir()
+    const destDir = makeEmptyDir()
+    const sourceName = path.join(sourceDir, 'source.json')
+    const collision1 = path.join(destDir, 'source.json')
+    const collision2 = path.join(destDir, 'source1.json')
+    const expectedName = path.join(destDir, 'source2.json')
+
+    const setup = Promise.all([
+      fs.writeJson(sourceName, { name: 'a' }),
+      fs.writeJson(collision1, { name: 'b' }),
+      fs.writeJson(collision2, { name: 'c' }),
+    ])
+
+    return setup
+      .then(() => addLabwareFile(sourceName, destDir))
+      .then(() => readLabwareDirectory(destDir))
+      .then(parseLabwareFiles)
+      .then(files => {
+        expect(files).toContainEqual({
+          filename: expectedName,
+          data: { name: 'a' },
+          created: expect.any(Number),
+        })
+      })
   })
 })

--- a/app-shell/src/labware/definitions.js
+++ b/app-shell/src/labware/definitions.js
@@ -46,3 +46,29 @@ export function parseLabwareFiles(
 
   return Promise.all(tasks)
 }
+
+// get a filename, adding an incrementor to avoid collisions
+const getFileName = (
+  dir: string,
+  base: string,
+  ext: string,
+  count = 0
+): Promise<string> => {
+  const basename = `${base}${count || ''}${ext}`
+  const name = path.join(dir, basename)
+
+  return fs
+    .pathExists(name)
+    .then((exists: boolean) =>
+      exists ? getFileName(dir, base, ext, count + 1) : name
+    )
+}
+
+export function addLabwareFile(file: string, dir: string): Promise<void> {
+  const extname = path.extname(file)
+  const basename = path.basename(file, extname)
+
+  return getFileName(dir, basename, extname).then(destName =>
+    fs.readJson(file).then(data => fs.outputJson(destName, data))
+  )
+}

--- a/app-shell/src/labware/index.js
+++ b/app-shell/src/labware/index.js
@@ -1,40 +1,50 @@
 // @flow
 import fse from 'fs-extra'
-import { dialog } from 'electron'
+import { app, dialog } from 'electron'
 import { getFullConfig, handleConfigChange } from '../config'
-import { readLabwareDirectory, parseLabwareFiles } from './definitions'
-import { validateLabwareFiles } from './validation'
-import * as LabwareActions from '@opentrons/app/src/custom-labware'
+import {
+  readLabwareDirectory,
+  parseLabwareFiles,
+  addLabwareFile,
+} from './definitions'
+import { validateLabwareFiles, validateNewLabwareFile } from './validation'
+import * as CustomLabware from '@opentrons/app/src/custom-labware'
 import * as ConfigActions from '@opentrons/app/src/config'
 
+import type { UncheckedLabwareFile } from '@opentrons/app/src/custom-labware/types'
 import type { Action, Dispatch } from '../types'
 
 const ensureDir: (dir: string) => Promise<void> = fse.ensureDir
 
-const fetchCustomLabware = (dispatch: Dispatch): void => {
+const fetchCustomLabware = (): Promise<Array<UncheckedLabwareFile>> => {
   const { labware: config } = getFullConfig()
 
-  // TODO(mc, 2019-11-18): catch errors and tell the UI
-  ensureDir(config.directory)
+  return ensureDir(config.directory)
     .then(() => readLabwareDirectory(config.directory))
     .then(parseLabwareFiles)
-    .then(files => {
-      const payload = validateLabwareFiles(files)
-      dispatch(LabwareActions.customLabware(payload))
-    })
+}
+
+const fetchAndValidateCustomLabware = (dispatch: Dispatch): void => {
+  // TODO(mc, 2019-11-18): catch errors and tell the UI
+  fetchCustomLabware().then(files => {
+    const payload = validateLabwareFiles(files)
+    dispatch(CustomLabware.customLabware(payload))
+  })
 }
 
 export function registerLabware(dispatch: Dispatch, mainWindow: {}) {
-  handleConfigChange('labware.directory', () => fetchCustomLabware(dispatch))
+  handleConfigChange('labware.directory', () => {
+    fetchAndValidateCustomLabware(dispatch)
+  })
 
   return function handleActionForLabware(action: Action) {
     switch (action.type) {
-      case LabwareActions.FETCH_CUSTOM_LABWARE: {
-        fetchCustomLabware(dispatch)
+      case CustomLabware.FETCH_CUSTOM_LABWARE: {
+        fetchAndValidateCustomLabware(dispatch)
         break
       }
 
-      case LabwareActions.CHANGE_CUSTOM_LABWARE_DIRECTORY: {
+      case CustomLabware.CHANGE_CUSTOM_LABWARE_DIRECTORY: {
         const { labware: config } = getFullConfig()
         const dialogOptions = {
           defaultPath: config.directory,
@@ -49,6 +59,42 @@ export function registerLabware(dispatch: Dispatch, mainWindow: {}) {
             dispatch(ConfigActions.updateConfig('labware.directory', dir))
           }
         })
+        break
+      }
+
+      case CustomLabware.ADD_CUSTOM_LABWARE: {
+        const dialogOptions = {
+          defaultPath: app.getPath('downloads'),
+          properties: ['openFile'],
+          filters: [{ name: 'JSON Labware Definitions', extensions: ['json'] }],
+        }
+
+        dialog.showOpenDialog(mainWindow, dialogOptions).then(result => {
+          const { canceled, filePaths } = result
+
+          if (!canceled && filePaths.length > 0) {
+            return Promise.all([
+              fetchCustomLabware(),
+              parseLabwareFiles(filePaths),
+            ]).then(([existingFiles, [newFile]]) => {
+              const checkedExisting = validateLabwareFiles(existingFiles)
+              const checkedNewFile = validateNewLabwareFile(
+                checkedExisting,
+                newFile
+              )
+
+              if (checkedNewFile.type === CustomLabware.VALID_LABWARE_FILE) {
+                return addLabwareFile(
+                  checkedNewFile.filename,
+                  getFullConfig().labware.directory
+                ).then(() => fetchAndValidateCustomLabware(dispatch))
+              } else {
+                dispatch(CustomLabware.addCustomLabwareFailure(checkedNewFile))
+              }
+            })
+          }
+        })
+
         break
       }
     }

--- a/app/src/custom-labware/__tests__/actions.test.js
+++ b/app/src/custom-labware/__tests__/actions.test.js
@@ -51,6 +51,27 @@ describe('custom labware actions', () => {
         meta: { shell: true },
       },
     },
+    {
+      name: 'addCustomLabwareFailure',
+      creator: actions.addCustomLabwareFailure,
+      args: [{ type: 'INVALID_LABWARE_FILE', filename: 'a.json', created: 0 }],
+      expected: {
+        type: 'labware:ADD_CUSTOM_LABWARE_FAILURE',
+        payload: {
+          labware: {
+            type: 'INVALID_LABWARE_FILE',
+            filename: 'a.json',
+            created: 0,
+          },
+        },
+      },
+    },
+    {
+      name: 'clearAddCustomLabwareFailure',
+      creator: actions.clearAddCustomLabwareFailure,
+      args: [],
+      expected: { type: 'labware:CLEAR_ADD_CUSTOM_LABWARE_FAILURE' },
+    },
   ]
 
   SPECS.forEach(spec => {

--- a/app/src/custom-labware/__tests__/reducer.test.js
+++ b/app/src/custom-labware/__tests__/reducer.test.js
@@ -24,6 +24,7 @@ describe('customLabwareReducer', () => {
         ],
       },
       expected: {
+        addFileFailure: null,
         filenames: ['a.json', 'b.json'],
         filesByName: {
           'a.json': {
@@ -42,6 +43,7 @@ describe('customLabwareReducer', () => {
     {
       name: 'handles CUSTOM_LABWARE with removed files',
       state: {
+        addFileFailure: null,
         filenames: ['a.json', 'b.json'],
         filesByName: {
           'a.json': {
@@ -63,6 +65,7 @@ describe('customLabwareReducer', () => {
         ],
       },
       expected: {
+        addFileFailure: null,
         filenames: ['b.json'],
         filesByName: {
           'b.json': {
@@ -71,6 +74,72 @@ describe('customLabwareReducer', () => {
             created: 2,
           },
         },
+      },
+    },
+    {
+      name: 'handles ADD_CUSTOM_LABWARE',
+      state: {
+        addFileFailure: {
+          type: 'INVALID_LABWARE_FILE',
+          filename: 'b.json',
+          created: 2,
+        },
+        filenames: [],
+        filesByName: {},
+      },
+      action: {
+        type: 'labware:ADD_CUSTOM_LABWARE',
+        meta: { shell: true },
+      },
+      expected: {
+        addFileFailure: null,
+        filenames: [],
+        filesByName: {},
+      },
+    },
+    {
+      name: 'handles ADD_CUSTOM_LABWARE_FAILURE',
+      state: {
+        addFileFailure: null,
+        filenames: [],
+        filesByName: {},
+      },
+      action: {
+        type: 'labware:ADD_CUSTOM_LABWARE_FAILURE',
+        payload: {
+          labware: {
+            type: 'INVALID_LABWARE_FILE',
+            filename: 'b.json',
+            created: 2,
+          },
+        },
+      },
+      expected: {
+        addFileFailure: {
+          type: 'INVALID_LABWARE_FILE',
+          filename: 'b.json',
+          created: 2,
+        },
+        filenames: [],
+        filesByName: {},
+      },
+    },
+    {
+      name: 'handles CLEAR_ADD_CUSTOM_LABWARE_FAILURE',
+      state: {
+        addFileFailure: {
+          type: 'INVALID_LABWARE_FILE',
+          filename: 'b.json',
+          created: 2,
+        },
+        filenames: [],
+        filesByName: {},
+      },
+      action: { type: 'labware:CLEAR_ADD_CUSTOM_LABWARE_FAILURE' },
+      expected: {
+        addFileFailure: null,
+        filenames: [],
+        filesByName: {},
       },
     },
   ]

--- a/app/src/custom-labware/__tests__/selectors.test.js
+++ b/app/src/custom-labware/__tests__/selectors.test.js
@@ -18,6 +18,7 @@ describe('custom labware selectors', () => {
       selector: selectors.getCustomLabware,
       state: {
         labware: {
+          addFileFailure: null,
           filenames: ['a.json', 'b.json'],
           filesByName: {
             'a.json': {
@@ -43,6 +44,7 @@ describe('custom labware selectors', () => {
       selector: selectors.getValidCustomLabware,
       state: {
         labware: {
+          addFileFailure: null,
           filenames: ['a.json', 'b.json', 'c.json', 'd.json', 'e.json'],
           filesByName: {
             'a.json': {

--- a/app/src/custom-labware/actions.js
+++ b/app/src/custom-labware/actions.js
@@ -1,6 +1,12 @@
 // @flow
 
-import type { CustomLabwareAction, CheckedLabwareFile } from './types'
+import type {
+  CustomLabwareAction,
+  CheckedLabwareFile,
+  FailedLabwareFile,
+} from './types'
+
+// action type literals
 
 export const FETCH_CUSTOM_LABWARE: 'labware:FETCH_CUSTOM_LABWARE' =
   'labware:FETCH_CUSTOM_LABWARE'
@@ -12,6 +18,14 @@ export const CHANGE_CUSTOM_LABWARE_DIRECTORY: 'labware:CHANGE_CUSTOM_LABWARE_DIR
 
 export const ADD_CUSTOM_LABWARE: 'labware:ADD_CUSTOM_LABWARE' =
   'labware:ADD_CUSTOM_LABWARE'
+
+export const ADD_CUSTOM_LABWARE_FAILURE: 'labware:ADD_CUSTOM_LABWARE_FAILURE' =
+  'labware:ADD_CUSTOM_LABWARE_FAILURE'
+
+export const CLEAR_ADD_CUSTOM_LABWARE_FAILURE: 'labware:CLEAR_ADD_CUSTOM_LABWARE_FAILURE' =
+  'labware:CLEAR_ADD_CUSTOM_LABWARE_FAILURE'
+
+// action creators
 
 export const fetchCustomLabware = (): CustomLabwareAction => ({
   type: FETCH_CUSTOM_LABWARE,
@@ -30,4 +44,15 @@ export const changeCustomLabwareDirectory = (): CustomLabwareAction => ({
 export const addCustomLabware = (): CustomLabwareAction => ({
   type: ADD_CUSTOM_LABWARE,
   meta: { shell: true },
+})
+
+export const addCustomLabwareFailure = (
+  labware: FailedLabwareFile
+): CustomLabwareAction => ({
+  type: ADD_CUSTOM_LABWARE_FAILURE,
+  payload: { labware },
+})
+
+export const clearAddCustomLabwareFailure = (): CustomLabwareAction => ({
+  type: CLEAR_ADD_CUSTOM_LABWARE_FAILURE,
 })

--- a/app/src/custom-labware/reducer.js
+++ b/app/src/custom-labware/reducer.js
@@ -8,6 +8,7 @@ import type { CustomLabwareState } from './types'
 export const INITIAL_STATE: CustomLabwareState = {
   filenames: [],
   filesByName: {},
+  addFileFailure: null,
 }
 
 export function customLabwareReducer(
@@ -26,6 +27,15 @@ export function customLabwareReducer(
       )
 
       return { ...state, filenames, filesByName }
+    }
+
+    case ActionTypes.ADD_CUSTOM_LABWARE:
+    case ActionTypes.CLEAR_ADD_CUSTOM_LABWARE_FAILURE: {
+      return { ...state, addFileFailure: null }
+    }
+
+    case ActionTypes.ADD_CUSTOM_LABWARE_FAILURE: {
+      return { ...state, addFileFailure: action.payload.labware }
     }
   }
 

--- a/app/src/custom-labware/types.js
+++ b/app/src/custom-labware/types.js
@@ -56,9 +56,16 @@ export type CheckedLabwareFile =
   | OpentronsLabwareFile
   | ValidLabwareFile
 
+export type FailedLabwareFile =
+  | BadJsonLabwareFile
+  | InvalidLabwareFile
+  | DuplicateLabwareFile
+  | OpentronsLabwareFile
+
 export type CustomLabwareState = $ReadOnly<{|
   filenames: Array<string>,
   filesByName: $Shape<{| [filename: string]: CheckedLabwareFile |}>,
+  addFileFailure: FailedLabwareFile | null,
 |}>
 
 export type CustomLabwareAction =
@@ -69,3 +76,8 @@ export type CustomLabwareAction =
       meta: {| shell: true |},
     |}
   | {| type: 'labware:ADD_CUSTOM_LABWARE', meta: {| shell: true |} |}
+  | {|
+      type: 'labware:ADD_CUSTOM_LABWARE_FAILURE',
+      payload: {| labware: FailedLabwareFile |},
+    |}
+  | {| type: 'labware:CLEAR_ADD_CUSTOM_LABWARE_FAILURE' |}


### PR DESCRIPTION
## overview

Continuing work on #4247. This PR follows up on #4475 by wiring the "Add Labware" button to a file picker and a copy action.

- Valid files will be copied into the labware directory and shown in the list
- Invalid / duplicate files reported into state, but no error UI is wired to that state yet
- Unexpected filesystem errors are not yet caught

## changelog

- refactor(app): wire up Add Labware button without error handling

## review requests

With the "Custom Labware" feature flag enabled in the app, navigate to "More" > "Custom Labware"

- [ ] Clicking "Add Labware" in the custom labware page opens a filepicker dialog
    - Dialog is a single-file picker
    - Dialog is limited to JSON files
- [ ] Clicking cancel does nothing
- [ ] Selecting a valid custom labware file adds it to the list
- [ ] Selecting an invalid labware file adds it to `state.labware.addLabwareFailure`

If you are in need of valid custom labware files, either create one with labware creator, or:

- Grab any labware file from `shared-data/labware/definitions/2/`
- Open it up and change its `namespace` field to something other that `opentrons`

If you need an invalid custom labware file, use:

- Any standard Opentrons labware
- Any JSON file that isn't labware
- Any custom labware file that you've already added
- Any JSON file that isn't actually JSON