### PR TITLE
fix(api): flag move to tc with in-between lid as unsafe

### DIFF
--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -2236,10 +2236,10 @@ class ThermocyclerContext(ModuleContext):
         to_lw, to_well = geometry.split_loc_labware(to_loc)
         from_lw, from_well = geometry.split_loc_labware(from_loc)
         if (self.labware is to_lw or self.labware is from_lw) and \
-                self.lid_position == 'closed':
+                self.lid_position != 'open':
             raise RuntimeError(
                 "Cannot move to labware loaded in Thermocycler"
-                " when lid is closed")
+                " when lid is not fully open.")
 
     @cmds.publish.both(command=cmds.thermocycler_open)
     @requires_version(2, 0)


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

Previously we only raised an  exception if the lid was 'closed', now we'll catch the edge case where the lid is partially open, but still unsafe to pipette to or from.

Behavior identified by @ChrisYarka 
## review requests

- manually close a TC lid part way before a run, and then attempt to pipette from it, an exception should be raised
