### PR TITLE
fix(api): fix bad adv settings crash

### DIFF
--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -1,4 +1,4 @@
-from opentrons.config.advanced_settings import _migrate
+from opentrons.config.advanced_settings import _migrate, _ensure
 
 
 good_file_version = 4
@@ -91,6 +91,7 @@ def test_migrates_v1_config():
         'useOldAspirationFunctions': True,
         'disableLogAggregation': None,
         'useLegacyInternals': None,
+        'useProtocolApi2': False,
     }
 
 
@@ -115,6 +116,7 @@ def test_migrates_v2_config():
         'useOldAspirationFunctions': True,
         'disableLogAggregation': False,
         'useLegacyInternals': None,
+        'useProtocolApi2': True,
     }
 
 
@@ -139,4 +141,23 @@ def test_migrates_v3_config():
         'useOldAspirationFunctions': True,
         'disableLogAggregation': False,
         'useLegacyInternals': None,
+        'enableApi1BackCompat': False,
+        'useProtocolApi2': True,
     }
+
+
+def test_ensures_config():
+    assert _ensure(
+        {'_version': 3,
+         'shortFixedTrash': False,
+         'disableLogAggregation': True})\
+         == {
+             '_version': 3,
+             'shortFixedTrash': False,
+             'calibrateToBottom': None,
+             'deckCalibrationDots': None,
+             'disableHomeOnBoot': None,
+             'useOldAspirationFunctions': None,
+             'disableLogAggregation': True,
+             'useLegacyInternals': None,
+         }

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -9,7 +9,8 @@ good_file_settings = {
     'disableHomeOnBoot': None,
     'useOldAspirationFunctions': None,
     'disableLogAggregation': None,
-    'useLegacyInternals': None
+    'useLegacyInternals': None,
+    'enableApi1BackCompat': None,
 }
 
 
@@ -38,7 +39,8 @@ def test_migrates_versionless_new_config():
       'disableHomeOnBoot': True,
       'useOldAspirationFunctions': True,
       'disableLogAggregation': None,
-      'useLegacyInternals': None
+      'useLegacyInternals': None,
+      'enableApi1BackCompat': None,
     }
 
 
@@ -58,7 +60,8 @@ def test_migrates_versionless_old_config():
       'disableHomeOnBoot': None,
       'useOldAspirationFunctions': None,
       'disableLogAggregation': None,
-      'useLegacyInternals': None
+      'useLegacyInternals': None,
+      'enableApi1BackCompat': None,
     }
 
 
@@ -92,6 +95,7 @@ def test_migrates_v1_config():
         'disableLogAggregation': None,
         'useLegacyInternals': None,
         'useProtocolApi2': False,
+        'enableApi1BackCompat': None,
     }
 
 
@@ -116,7 +120,8 @@ def test_migrates_v2_config():
         'useOldAspirationFunctions': True,
         'disableLogAggregation': False,
         'useLegacyInternals': None,
-        'useProtocolApi2': True,
+        'useProtocolApi2': False,
+        'enableApi1BackCompat': None,
     }
 
 


### PR DESCRIPTION
Keep around the useProtocolApi2 and enableApi1BackCompat feature flags if they are present so downgrades don't end with the server crashing afterwards. 

You should also now be able to delete things from the feature flags file and the server will be able to start up (it will crash when you edit it at the same time that it's running, though).