### PR TITLE
feat(api): add extra labware in session

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -4,7 +4,7 @@ from copy import copy
 from functools import reduce, wraps
 import logging
 from time import time
-from typing import List
+from typing import List, Dict, Any
 from uuid import uuid4
 from opentrons import robot
 from opentrons.broker import Broker
@@ -64,7 +64,40 @@ class SessionManager(object):
                       adapters.SynchronousAdapter):
             self._hardware.join()
 
-    def create(self, name, contents, is_binary=False):
+    def create(
+            self,
+            name: str,
+            contents: str,
+            is_binary: bool = False) -> 'Session':
+        """ Create a protocol session from either
+
+        - a json protocol
+        - a python protocol file
+        - a zipped protocol bundle (deprecated, for back compat)
+
+        No new code should be written that calls this function with
+        ``is_binary=True`` and a base64'd zip in ``contents``; instead,
+        use :py:meth:`.create_from_bundle`.
+
+        :param str name: The name of the protocol
+        :param str contents: The contents of the protocol; this should be
+                             either the contents of the file if it can be
+                             parsed directly or a base64d version of the
+                             contents if it is a zip. If it is base64,
+                             ``is_binary`` must be true. Do not write new
+                             code that uses this.
+        :param bool is_binary: ``True`` if ``contents`` is a base64'd zip.
+                               Do not write new code that uses this.
+        :returns Session: The created session.
+        :raises Exception: If another session is simulating at the time
+
+        .. note::
+
+            This function is mostly (only) intended to be called via rpc.
+        """
+        if is_binary:
+            log.warning("session.create: called with bundle")
+
         if self._session_lock:
             raise Exception(
                 'Cannot create session while simulation in progress')
@@ -81,11 +114,88 @@ class SessionManager(object):
                 hardware=self._hardware,
                 loop=self._loop,
                 broker=self._broker,
-                motion_lock=self._motion_lock)
+                motion_lock=self._motion_lock,
+                extra_labware=[])
+            return self.session
         finally:
             self._session_lock = False
 
-        return self.session
+    def create_from_bundle(self, name: str, contents: str) -> 'Session':
+        """ Create a protocol session from a base64'd zip file.
+
+        :param str name: The name of the protocol
+        :param str contents: The contents of the zip file, base64
+                             encoded
+        :returns Session: The created session
+        :raises Exception: If another session is simulating at the time
+
+        .. note::
+
+            This function is mostly (only) intended to be called via rpc.
+        """
+        if self._session_lock:
+            raise Exception(
+                'Cannot create session while simulation in progress')
+
+        self._session_lock = True
+        try:
+            _contents = base64.b64decode(contents)
+            session_short_id = hex(uuid4().fields[0])
+            session_logger = self._command_logger.getChild(session_short_id)
+            self._broker.set_logger(session_logger)
+            self.session = Session.build_and_prep(
+                name=name,
+                contents=_contents,
+                hardware=self._hardware,
+                loop=self._loop,
+                broker=self._broker,
+                motion_lock=self._motion_lock,
+                extra_labware=[])
+            return self.session
+        finally:
+            self._session_lock = False
+
+    def create_with_extra_labware(
+            self,
+            name: str,
+            contents: str,
+            extra_labware: List[Dict[str, Any]]) -> 'Session':
+        """
+        Create a protocol session from a python protocol string with a list
+        of extra custom labware to make available.
+
+        :param str name: The name of the protocol
+        :param str contents: The contents of the protocol file
+        :param extra_labware: A list of labware definitions to make available
+                              to protocol executions. This should be a list
+                              of directly serialized definitions.
+        :returns Session: The created session
+        :raises Exception: If another session is simulating at the time
+
+        .. note::
+
+            This function is mostly (only) intended to be called via rpc.
+        """
+        if self._session_lock:
+            raise Exception(
+                "Cannot create session while simulation in progress")
+
+        self._session_lock = True
+        try:
+            session_short_id = hex(uuid4().fields[0])
+            session_logger = self._command_logger.getChild(session_short_id)
+            self._broker.set_logger(session_logger)
+            self.session = Session.build_and_prep(
+                name=name,
+                contents=contents,
+                hardware=self._hardware,
+                loop=self._loop,
+                broker=self._broker,
+                motion_lock=self._motion_lock,
+                extra_labware=extra_labware)
+            return self.session
+        finally:
+            self._session_lock = False
 
     def clear(self):
         if self._session_lock:
@@ -106,9 +216,11 @@ class Session(object):
 
     @classmethod
     def build_and_prep(
-        cls, name, contents, hardware, loop, broker, motion_lock
+        cls, name, contents, hardware, loop, broker, motion_lock, extra_labware
     ):
-        protocol = parse(contents, filename=name)
+        protocol = parse(contents, filename=name,
+                         extra_labware={labware.uri_from_definition(defn): defn
+                                        for defn in extra_labware})
         sess = cls(name, protocol, hardware, loop, broker, motion_lock)
         sess.prepare()
         return sess
@@ -255,7 +367,13 @@ class Session(object):
                 self._simulating_ctx = ProtocolContext(
                     loop=self._loop,
                     hardware=sim,
-                    broker=self._broker)
+                    broker=self._broker,
+                    bundled_labware=getattr(
+                        self._protocol, 'bundled_labware', None),
+                    bundled_data=getattr(
+                        self._protocol, 'bundled_data', None),
+                    extra_labware=getattr(
+                        self._protocol, 'extra_labware', {}))
                 run_protocol(self._protocol,
                              context=self._simulating_ctx)
             else:
@@ -362,7 +480,12 @@ class Session(object):
                 ctx = ProtocolContext.build_using(
                     self._protocol,
                     loop=self._loop,
-                    broker=self._broker)
+                    broker=self._broker,
+                    bundled_labware=getattr(
+                        self._protocol, 'bundled_labware', None),
+                    bundled_data=getattr(
+                        self._protocol, 'bundled_data', None),
+                    extra_labware=getattr(self._protocol, 'extra_labware', {}))
                 ctx.connect(self._hardware)
                 ctx.home()
                 run_protocol(self._protocol, context=ctx)

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -32,22 +32,6 @@ log = logging.getLogger(__name__)
 VALID_STATES = {'loaded', 'running', 'finished', 'stopped', 'paused', 'error'}
 
 
-def rpc_invisible(cond):
-    """ Decorate a function with this to hide it from rpc
-
-    cond is a callable that returns bool that is assigned to the added
-    attribute. The callable is called when evaluated for rpc reflection,
-    not when this function is interpreted
-
-    This shouldn't be defined here but it's a bit of a hack anyway and
-    rpc will be gone soon and it avoids a circular import problem
-    """
-    def _make_invisible(func):
-        setattr(func, '__ot_rpc_invisible', cond)
-        return func
-    return _make_invisible
-
-
 def _motion_lock(func):
     """ Decorator to make a function require a lock. Only works for instance
     methods of Session (or SessionManager) """
@@ -136,7 +120,6 @@ class SessionManager(object):
         finally:
             self._session_lock = False
 
-    @rpc_invisible(lambda: ff.use_protocol_api_v2())
     def create_from_bundle(self, name: str, contents: str) -> 'Session':
         """ Create a protocol session from a base64'd zip file.
 
@@ -172,7 +155,6 @@ class SessionManager(object):
         finally:
             self._session_lock = False
 
-    @rpc_invisible(lambda: ff.use_protocol_api_v2())
     def create_with_extra_labware(
             self,
             name: str,

--- a/api/src/opentrons/server/serialize.py
+++ b/api/src/opentrons/server/serialize.py
@@ -24,10 +24,6 @@ def _get_object_tree(max_depth, path, refs, depth, obj):  # noqa C901
     object_tree = functools.partial(
         _get_object_tree, max_depth, path, refs, depth + 1)
 
-    def hide(check):
-        return hasattr(check, '__ot_rpc_invisible')\
-            and getattr(check, '__ot_rpc_invisible')()
-
     path += [id(obj)]
 
     # Cut-off at max_depth
@@ -39,8 +35,7 @@ def _get_object_tree(max_depth, path, refs, depth, obj):  # noqa C901
         return [object_tree(o) for o in obj]
 
     def iterate(kv):
-        return {str(k): object_tree(v) for k, v in kv.items()
-                if not hide(v)}
+        return {str(k): object_tree(v) for k, v in kv.items()}
 
     if isinstance(obj, dict):
         return object_container(iterate(obj))
@@ -50,15 +45,15 @@ def _get_object_tree(max_depth, path, refs, depth, obj):  # noqa C901
         # If Type is iterable we will iterate generating numeric keys and
         # and merge with the output
         try:
-            items = [object_tree(o) for o in obj if not hide(o)]
+            items = [object_tree(o) for o in obj]
         except TypeError:
             pass
-        tail = {i: v for i, v in enumerate(items) if not hide(v)}
+        tail = {i: v for i, v in enumerate(items)}
 
         # Filter out private attributes
         attributes = {
             k: v for k, v in obj.__dict__.items()
-            if not k.startswith('_') and not hide(obj)}
+            if not k.startswith('_')}
         return object_container({**iterate(attributes), **tail})
     else:
         return object_container({})

--- a/api/tests/opentrons/server/test_server.py
+++ b/api/tests/opentrons/server/test_server.py
@@ -5,6 +5,7 @@ import time
 
 from opentrons.server import rpc
 from opentrons.protocol_api.execute import ExceptionInProtocolError
+from opentrons.api.session import rpc_invisible
 from threading import Event
 
 from uuid import uuid4 as uuid
@@ -39,6 +40,10 @@ class Foo(object):
         raise ExceptionInProtocolError(v, b,
                                        'This is a test',
                                        10)
+
+    @rpc_invisible(lambda: True)
+    def should_be_hidden(self):
+        raise Exception("This shouldn't be exposed!")
 
 
 class Notifications(object):

--- a/api/tests/opentrons/server/test_server.py
+++ b/api/tests/opentrons/server/test_server.py
@@ -5,7 +5,6 @@ import time
 
 from opentrons.server import rpc
 from opentrons.protocol_api.execute import ExceptionInProtocolError
-from opentrons.api.session import rpc_invisible
 from threading import Event
 
 from uuid import uuid4 as uuid
@@ -40,10 +39,6 @@ class Foo(object):
         raise ExceptionInProtocolError(v, b,
                                        'This is a test',
                                        10)
-
-    @rpc_invisible(lambda: True)
-    def should_be_hidden(self):
-        raise Exception("This shouldn't be exposed!")
 
 
 class Notifications(object):


### PR DESCRIPTION
This lets the run app provide all the custom labware it knows about to an
unbundled protocol execution without having to also provide all the standard
labware it knows about.

There are new session.create methods for bundles and custom labware,
specifically create_from_bundle and create_with_extra_labware:

create_from_bundle(name, contents)
create_with_extra_labware(name, contents, extra_labware)

These operate the same way as session.create. In the bundle case, it is the same
as calling create with binary=True. In the create_with_extra_labware case,
extra_labware should be a list of labware definitions as dicts (aka serialized
directly as json). You can probably call create_with_extra_labware with a json
protocol but it won't do anything different than create.

These new functions are (probably) only exposed over rpc if the robot is running a v2 server.