### PR TITLE
fix(api): fix backcompat tip tracking logic

### DIFF
--- a/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
@@ -812,6 +812,9 @@ class Pipette:
             if isinstance(location, (List)):
                 location = location[0]
             new_loc = _unpack_motion_target(location, 'top')
+            # always allow pick up tip if location is passed
+            tip = new_loc.labware
+            tip.has_tip = True
         else:
             tiprack, new_tip = self._instr_ctx._next_available_tip()
             legacy_labware = self._lw_mappings[tiprack]
@@ -837,6 +840,7 @@ class Pipette:
         self._hw.set_working_volume(self._mount, new_loc.labware.max_volume)
         self._instr_ctx._last_tip_picked_up_from = \
             self.current_tip()  # type: ignore
+        tip.parent.use_tips(tip, self.channels)
 
         return self
 

--- a/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
+++ b/api/src/opentrons/protocol_api/legacy_wrapper/instrument_wrapper.py
@@ -242,8 +242,11 @@ class Pipette:
         return self.current_tip_home_well
 
     @log_call(log)
-    def start_at_tip(self, _tip: LegacyWell = None):
+    def start_at_tip(self, _tip: Union[LegacyWell, WellSeries, List] = None):
         """ Change the first tip that will be picked up """
+        if isinstance(_tip, (List, WellSeries)):
+            _tip = _tip[0]
+        self._instr_ctx.reset_tipracks()
         self._instr_ctx.starting_tip = _tip
 
     @log_call(log)
@@ -805,6 +808,7 @@ class Pipette:
             p300.return_tip()
         """
         display_loc: Union[LegacyLocation, LegacyWell, Well]
+        tip: Union[LegacyLabware, LegacyWell, Well]
         if location:
             display_loc = location
             if isinstance(location, (List, WellSeries)):
@@ -814,7 +818,7 @@ class Pipette:
             new_loc = _unpack_motion_target(location, 'top')
             # always allow pick up tip if location is passed
             tip = new_loc.labware
-            tip.has_tip = True
+            tip.has_tip = True  # type: ignore
         else:
             tiprack, new_tip = self._instr_ctx._next_available_tip()
             legacy_labware = self._lw_mappings[tiprack]


### PR DESCRIPTION
## overview
Tip logic in backcompat is broken, in which that unless a tip is specified during pick up tip, the pipette would always pick up from `well A1` of the associated tip rack.

## changelog
- add `use_tips` within pick up tip so the tip tracker can work properly
- add some logic to handle multi-channel tip pick up

## review requests
- check that the if a location is specified in `pick_up_tip()`, the pipette would pick up a tip regardless of whether or not the tip has been previously picked up
- check that using `start_at_tip` would reset the tip tracker and the pipette would actually start picking up the tips from the specified loc
- make sure the above is true for both single and multi pipettes
