### PR TITLE
refactor(app): handle "Add Labware" errors and allow overwrites

### DIFF
--- a/__mocks__/electron.js
+++ b/__mocks__/electron.js
@@ -16,4 +16,8 @@ module.exports = {
     // https://electronjs.org/docs/api/dialog#dialogshowopendialogbrowserwindow-options
     showOpenDialog: jest.fn(),
   },
+
+  shell: {
+    moveItemToTrash: jest.fn(),
+  },
 }

--- a/app-shell/src/dialogs/__tests__/dialogs.test.js
+++ b/app-shell/src/dialogs/__tests__/dialogs.test.js
@@ -1,0 +1,123 @@
+// @flow
+
+import Electron from 'electron'
+
+import * as Dialogs from '..'
+
+jest.mock('electron')
+
+const mockShowOpenDialog: JestMockFn<
+  Array<any>,
+  {| canceled: boolean, filePaths: Array<string> |}
+> = Electron.dialog.showOpenDialog
+
+const mockMainWindow = { mainWindow: true }
+
+describe('dialog boxes', () => {
+  describe('showOpenDirectoryDialog', () => {
+    test('directory select with cancel', () => {
+      mockShowOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] })
+
+      return Dialogs.showOpenDirectoryDialog(mockMainWindow).then(filePaths => {
+        expect(mockShowOpenDialog).toHaveBeenCalledWith(mockMainWindow, {
+          properties: ['openDirectory', 'createDirectory'],
+        })
+        expect(filePaths).toEqual([])
+      })
+    })
+
+    test('directory select with files', () => {
+      mockShowOpenDialog.mockResolvedValue({
+        canceled: false,
+        filePaths: ['/path/to/dir'],
+      })
+
+      return Dialogs.showOpenDirectoryDialog(mockMainWindow).then(filePaths => {
+        expect(mockShowOpenDialog).toHaveBeenCalledWith(mockMainWindow, {
+          properties: ['openDirectory', 'createDirectory'],
+        })
+        expect(filePaths).toEqual(['/path/to/dir'])
+      })
+    })
+
+    test('directory select with default location', () => {
+      mockShowOpenDialog.mockResolvedValue({
+        canceled: false,
+        filePaths: ['/path/to/dir'],
+      })
+
+      return Dialogs.showOpenDirectoryDialog(mockMainWindow, {
+        defaultPath: '/foo',
+      }).then(filePaths => {
+        expect(mockShowOpenDialog).toHaveBeenCalledWith(mockMainWindow, {
+          properties: ['openDirectory', 'createDirectory'],
+          defaultPath: '/foo',
+        })
+        expect(filePaths).toEqual(['/path/to/dir'])
+      })
+    })
+  })
+
+  describe('showOpenFileDialog', () => {
+    test('file select with cancel', () => {
+      mockShowOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] })
+
+      return Dialogs.showOpenFileDialog(mockMainWindow).then(filePaths => {
+        expect(mockShowOpenDialog).toHaveBeenCalledWith(mockMainWindow, {
+          properties: ['openFile'],
+        })
+        expect(filePaths).toEqual([])
+      })
+    })
+
+    test('file select with files', () => {
+      mockShowOpenDialog.mockResolvedValue({
+        canceled: false,
+        filePaths: ['/path/to/file.json'],
+      })
+
+      return Dialogs.showOpenFileDialog(mockMainWindow).then(filePaths => {
+        expect(mockShowOpenDialog).toHaveBeenCalledWith(mockMainWindow, {
+          properties: ['openFile'],
+        })
+        expect(filePaths).toEqual(['/path/to/file.json'])
+      })
+    })
+
+    test('file select with filters', () => {
+      mockShowOpenDialog.mockResolvedValue({
+        canceled: false,
+        filePaths: ['/path/to/file.json'],
+      })
+
+      const options = { filters: [{ name: 'JSON', extensions: ['json'] }] }
+
+      return Dialogs.showOpenFileDialog(mockMainWindow, options).then(
+        filePaths => {
+          expect(mockShowOpenDialog).toHaveBeenCalledWith(mockMainWindow, {
+            properties: ['openFile'],
+            filters: [{ name: 'JSON', extensions: ['json'] }],
+          })
+          expect(filePaths).toEqual(['/path/to/file.json'])
+        }
+      )
+    })
+
+    test('file select with default location', () => {
+      mockShowOpenDialog.mockResolvedValue({
+        canceled: false,
+        filePaths: ['/path/to/file.json'],
+      })
+
+      return Dialogs.showOpenFileDialog(mockMainWindow, {
+        defaultPath: '/foo',
+      }).then(filePaths => {
+        expect(mockShowOpenDialog).toHaveBeenCalledWith(mockMainWindow, {
+          properties: ['openFile'],
+          defaultPath: '/foo',
+        })
+        expect(filePaths).toEqual(['/path/to/file.json'])
+      })
+    })
+  })
+})

--- a/app-shell/src/dialogs/index.js
+++ b/app-shell/src/dialogs/index.js
@@ -1,0 +1,59 @@
+// @flow
+import { dialog } from 'electron'
+
+type DialogResult = {| canceled: boolean, filePaths: Array<string> |}
+
+type BaseDialogOptions = $Shape<{|
+  defaultPath: string,
+|}>
+
+type FileDialogOptions = $Shape<{|
+  ...BaseDialogOptions,
+  filters: Array<{| name: string, extensions: Array<string> |}>,
+|}>
+
+const BASE_DIRECTORY_OPTS = {
+  properties: ['openDirectory', 'createDirectory'],
+}
+
+const BASE_FILE_OPTS = {
+  properties: ['openFile'],
+}
+
+export function showOpenDirectoryDialog(
+  browserWindow: mixed,
+  options: BaseDialogOptions = {}
+): Promise<Array<String>> {
+  let openDialogOpts = BASE_DIRECTORY_OPTS
+
+  if (options.defaultPath) {
+    openDialogOpts = { ...openDialogOpts, defaultPath: options.defaultPath }
+  }
+
+  return dialog
+    .showOpenDialog(browserWindow, openDialogOpts)
+    .then((result: DialogResult) => {
+      return result.canceled ? [] : result.filePaths
+    })
+}
+
+export function showOpenFileDialog(
+  browserWindow: mixed,
+  options: FileDialogOptions = {}
+): Promise<Array<string>> {
+  let openDialogOpts = BASE_FILE_OPTS
+
+  if (options.defaultPath) {
+    openDialogOpts = { ...openDialogOpts, defaultPath: options.defaultPath }
+  }
+
+  if (options.filters) {
+    openDialogOpts = { ...openDialogOpts, filters: options.filters }
+  }
+
+  return dialog
+    .showOpenDialog(browserWindow, openDialogOpts)
+    .then((result: DialogResult) => {
+      return result.canceled ? [] : result.filePaths
+    })
+}

--- a/app-shell/src/labware/__tests__/validation.test.js
+++ b/app-shell/src/labware/__tests__/validation.test.js
@@ -5,29 +5,9 @@ import validLabwareA from '@opentrons/shared-data/labware/fixtures/2/fixture_96_
 import validLabwareB from '@opentrons/shared-data/labware/fixtures/2/fixture_12_trough.json'
 
 describe('validateLabwareFiles', () => {
-  test('handles unparseable labware files', () => {
+  test('handles unparseable and invalid labware files', () => {
     const files = [
       { filename: 'a.json', data: null, created: Date.now() },
-      { filename: 'b.json', data: null, created: Date.now() },
-    ]
-
-    expect(validateLabwareFiles(files)).toEqual([
-      {
-        type: 'BAD_JSON_LABWARE_FILE',
-        filename: 'a.json',
-        created: expect.any(Number),
-      },
-      {
-        type: 'BAD_JSON_LABWARE_FILE',
-        filename: 'b.json',
-        created: expect.any(Number),
-      },
-    ])
-  })
-
-  test('handles invalid labware files', () => {
-    const files = [
-      { filename: 'a.json', data: { foo: 'bar' }, created: Date.now() },
       { filename: 'b.json', data: { baz: 'qux' }, created: Date.now() },
     ]
 

--- a/app-shell/src/labware/compare.js
+++ b/app-shell/src/labware/compare.js
@@ -1,0 +1,16 @@
+// @flow
+
+import type { CheckedLabwareFile } from '@opentrons/app/src/custom-labware/types'
+
+export function sameIdentity(
+  a: CheckedLabwareFile,
+  b: CheckedLabwareFile
+): boolean {
+  return (
+    a.identity != null &&
+    b.identity != null &&
+    a.identity.name === b.identity.name &&
+    a.identity.version === b.identity.version &&
+    a.identity.namespace === b.identity.namespace
+  )
+}

--- a/app-shell/src/labware/definitions.js
+++ b/app-shell/src/labware/definitions.js
@@ -1,6 +1,7 @@
 // @flow
 import path from 'path'
 import fs from 'fs-extra'
+import { shell } from 'electron'
 
 import type { Dirent } from '../types'
 import type { UncheckedLabwareFile } from '@opentrons/app/src/custom-labware/types'
@@ -71,4 +72,10 @@ export function addLabwareFile(file: string, dir: string): Promise<void> {
   return getFileName(dir, basename, extname).then(destName =>
     fs.readJson(file).then(data => fs.outputJson(destName, data))
   )
+}
+
+export function removeLabwareFile(file: string): Promise<void> {
+  const result = shell.moveItemToTrash(file)
+
+  return result ? Promise.resolve() : fs.unlink(file)
 }

--- a/app/src/components/AddLabwareCard/AddLabwareFailureModal.js
+++ b/app/src/components/AddLabwareCard/AddLabwareFailureModal.js
@@ -38,6 +38,8 @@ const THIS_LABWARE_DEFINITION_CONFLICTS =
   'This labware definition conflicts with an Opentrons standard definition. If you are trying to create a new labware based on an Opentrons definition, please contact support.'
 const A_LABWARE_DEFINITION_ALREADY_EXISTS =
   'A labware definition with the same API name, version, and namespace already exists in your labware source folder. Would you like to overwrite it?'
+const CLICKING_OVERWRITE_LABWARE_WILL_DELETE_FILES =
+  'Clicking "Overwrite Labware" will delete any existing files that conflict with the new file'
 
 const DISPLAY_NAME = 'Name: '
 const API_NAME = 'API name: '
@@ -124,6 +126,7 @@ export function AddLabwareFailureModal(props: AddLabwareFailureModalProps) {
       <>
         <p>{A_LABWARE_DEFINITION_ALREADY_EXISTS}</p>
         {renderDetails(file)}
+        <p>{CLICKING_OVERWRITE_LABWARE_WILL_DELETE_FILES}</p>
       </>
     )
   }

--- a/app/src/components/AddLabwareCard/AddLabwareFailureModal.js
+++ b/app/src/components/AddLabwareCard/AddLabwareFailureModal.js
@@ -1,0 +1,146 @@
+// @flow
+import * as React from 'react'
+
+import { AlertModal } from '@opentrons/components'
+import { Portal } from '../portal'
+import styles from './styles.css'
+
+import {
+  INVALID_LABWARE_FILE,
+  DUPLICATE_LABWARE_FILE,
+  OPENTRONS_LABWARE_FILE,
+} from '../../custom-labware'
+
+import type {
+  FailedLabwareFile,
+  DuplicateLabwareFile,
+} from '../../custom-labware/types'
+
+// TODO(mc, 2019-11-20): i18n
+// buttons
+const CANCEL = 'cancel'
+const OVERWRITE_LABWARE = 'overwrite labware'
+
+// headings
+const UNABLE_TO_ADD_LABWARE = 'Unable to add labware'
+const INVALID_LABWARE_DEFINITION = 'Invalid labware definition'
+const CONFLICT_WITH_OPENTRONS_LABWARE = 'Conflict with Opentrons labware'
+const OVERWRITE_DUPLICATE_LABWARE = 'Overwrite duplicate labware?'
+
+// copy
+const UNABLE_TO_COPY_LABWARE_FILE_TO = 'Unable to copy labware file to'
+const PLEASE_CHECK_PERMISSIONS =
+  'Please check that you are able to open this file and add files to your labware source folder, or contact Opentrons Support for help.'
+const THE_FILE = 'The file'
+const IS_NOT_A_VALID_LABWARE_DEFINITION =
+  'is not a valid Opentrons labware definition. Please check that you selected to correct file.'
+const THIS_LABWARE_DEFINITION_CONFLICTS =
+  'This labware definition conflicts with an Opentrons standard definition. If you are trying to create a new labware based on an Opentrons definition, please contact support.'
+const A_LABWARE_DEFINITION_ALREADY_EXISTS =
+  'A labware definition with the same API name, version, and namespace already exists in your labware source folder. Would you like to overwrite it?'
+
+const DISPLAY_NAME = 'Name: '
+const API_NAME = 'API name: '
+const FILENAME = 'File name: '
+
+export type AddLabwareFailureModalProps = {|
+  file: FailedLabwareFile | null,
+  errorMessage: string | null,
+  directory: string,
+  onCancel: () => mixed,
+  onOverwrite: (file: DuplicateLabwareFile) => mixed,
+|}
+
+const renderFilename = file => (
+  <span className={styles.code}>{file.filename}</span>
+)
+
+const renderDetails = file => (
+  <>
+    <ul className={styles.details_list}>
+      <li className={styles.list_item}>
+        <span className={styles.list_item_title}>{DISPLAY_NAME}</span>
+        <span>{file.metadata.displayName}</span>
+      </li>
+      <li className={styles.list_item}>
+        <span className={styles.list_item_title}>{API_NAME}</span>
+        <span className={styles.code}>{file.identity.name}</span>
+      </li>
+      <li className={styles.list_item}>
+        <span className={styles.list_item_title}>{FILENAME}</span>
+        <span>{renderFilename(file)}</span>
+      </li>
+    </ul>
+  </>
+)
+
+export function AddLabwareFailureModal(props: AddLabwareFailureModalProps) {
+  const { file, errorMessage, directory, onCancel, onOverwrite } = props
+  let buttons = [
+    { onClick: onCancel, children: CANCEL, className: styles.button },
+  ]
+  let heading = null
+  let children = null
+
+  if (!file || errorMessage) {
+    heading = UNABLE_TO_ADD_LABWARE
+    children = (
+      <>
+        <p>
+          {UNABLE_TO_COPY_LABWARE_FILE_TO}{' '}
+          <span className={styles.code}>{directory}</span>
+          {'. '}
+          {PLEASE_CHECK_PERMISSIONS}
+        </p>
+        {errorMessage && <p className={styles.error}>{errorMessage}</p>}
+      </>
+    )
+  } else if (file.type === INVALID_LABWARE_FILE) {
+    heading = INVALID_LABWARE_DEFINITION
+    children = (
+      <p>
+        {THE_FILE} {renderFilename(file)} {IS_NOT_A_VALID_LABWARE_DEFINITION}
+      </p>
+    )
+  } else if (file.type === OPENTRONS_LABWARE_FILE) {
+    heading = CONFLICT_WITH_OPENTRONS_LABWARE
+    children = (
+      <>
+        <p>{THIS_LABWARE_DEFINITION_CONFLICTS}</p>
+        {renderDetails(file)}
+      </>
+    )
+  } else if (file.type === DUPLICATE_LABWARE_FILE) {
+    buttons = [
+      ...buttons,
+      {
+        className: styles.button,
+        children: OVERWRITE_LABWARE,
+        onClick: () => onOverwrite(file),
+      },
+    ]
+    heading = OVERWRITE_DUPLICATE_LABWARE
+    children = (
+      <>
+        <p>{A_LABWARE_DEFINITION_ALREADY_EXISTS}</p>
+        {renderDetails(file)}
+      </>
+    )
+  }
+
+  return (
+    <AlertModal alertOverlay heading={heading} buttons={buttons}>
+      {children}
+    </AlertModal>
+  )
+}
+
+export function PortaledAddLabwareFailureModal(
+  props: AddLabwareFailureModalProps
+) {
+  return (
+    <Portal>
+      <AddLabwareFailureModal {...props} />
+    </Portal>
+  )
+}

--- a/app/src/components/AddLabwareCard/__tests__/AddLabwareFailureModal.test.js
+++ b/app/src/components/AddLabwareCard/__tests__/AddLabwareFailureModal.test.js
@@ -1,0 +1,131 @@
+// @flow
+import * as React from 'react'
+import { shallow, mount } from 'enzyme'
+
+import { AlertModal } from '@opentrons/components'
+import { Portal } from '../../portal'
+import {
+  PortaledAddLabwareFailureModal,
+  AddLabwareFailureModal,
+} from '../AddLabwareFailureModal'
+
+import * as LabwareFixtures from '../../../custom-labware/__fixtures__'
+
+describe('AddLabwareFailureModal', () => {
+  const mockDirectory = '/path/to/labware'
+  const mockOnCancel = jest.fn()
+  const mockOnOverwrite = jest.fn()
+  const emptyProps = {
+    directory: mockDirectory,
+    file: null,
+    errorMessage: null,
+    onCancel: mockOnCancel,
+    onOverwrite: mockOnOverwrite,
+  }
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  test('component renders', () => {
+    const wrapper = shallow(<AddLabwareFailureModal {...emptyProps} />)
+
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  test('renders inside a Portal', () => {
+    const wrapper = shallow(<PortaledAddLabwareFailureModal {...emptyProps} />)
+    const portal = wrapper.find(Portal)
+    const modal = portal.find(AddLabwareFailureModal)
+
+    expect(modal.props()).toEqual(emptyProps)
+  })
+
+  test('renders an AlertModal', () => {
+    const wrapper = shallow(<AddLabwareFailureModal {...emptyProps} />)
+
+    expect(wrapper.exists(AlertModal)).toBe(true)
+  })
+
+  test('renders a cancel button that calls props.onCancel', () => {
+    const wrapper = mount(<AddLabwareFailureModal {...emptyProps} />)
+    const button = wrapper.findWhere(
+      c => c.type() === 'button' && c.text().toLowerCase() === 'cancel'
+    )
+
+    button.invoke('onClick')()
+    expect(mockOnCancel).toHaveBeenCalled()
+  })
+
+  test('renders proper title for error', () => {
+    const wrapper = mount(
+      <AddLabwareFailureModal {...emptyProps} errorMessage="AHHH!" />
+    )
+    const html = wrapper.html()
+
+    expect(wrapper.find(AlertModal).prop('heading')).toEqual(
+      'Unable to add labware'
+    )
+    expect(html).toMatch(/Unable to copy labware/)
+    expect(html).toContain('AHHH!')
+  })
+
+  describe('invalid files', () => {
+    const render = file => {
+      return mount(<AddLabwareFailureModal {...emptyProps} file={file} />)
+    }
+
+    test('renders proper copy for invalid file', () => {
+      const file = LabwareFixtures.mockInvalidLabware
+      const wrapper = render(file)
+      const html = wrapper.html()
+
+      expect(wrapper.find(AlertModal).prop('heading')).toEqual(
+        'Invalid labware definition'
+      )
+      expect(html).toMatch(/not a valid Opentrons labware definition/)
+      expect(html).toContain(file.filename)
+    })
+
+    test('renders proper copy for an Opentrons conflicting file', () => {
+      const file = LabwareFixtures.mockOpentronsLabware
+      const wrapper = render(file)
+      const html = wrapper.html()
+
+      expect(wrapper.find(AlertModal).prop('heading')).toEqual(
+        'Conflict with Opentrons labware'
+      )
+      expect(wrapper.html()).toMatch(
+        /conflicts with an Opentrons standard definition/
+      )
+      expect(html).toContain(file.metadata.displayName)
+      expect(html).toContain(file.identity.name)
+      expect(html).toContain(file.filename)
+    })
+
+    test('renders proper copy for an duplicate file', () => {
+      const file = LabwareFixtures.mockDuplicateLabware
+      const wrapper = render(file)
+      const html = wrapper.html()
+
+      expect(wrapper.find(AlertModal).prop('heading')).toEqual(
+        'Overwrite duplicate labware?'
+      )
+      expect(html).toMatch(/already exists/)
+      expect(html).toContain(file.metadata.displayName)
+      expect(html).toContain(file.identity.name)
+      expect(html).toContain(file.filename)
+    })
+
+    test('duplicate file adds overwrite button', () => {
+      const file = LabwareFixtures.mockDuplicateLabware
+      const wrapper = render(file)
+      const button = wrapper.findWhere(
+        c => c.type() === 'button' && /overwrite/i.test(c.text())
+      )
+
+      button.invoke('onClick')()
+      expect(mockOnOverwrite).toHaveBeenCalledWith(file)
+    })
+  })
+})

--- a/app/src/components/AddLabwareCard/__tests__/__snapshots__/AddLabwareFailureModal.test.js.snap
+++ b/app/src/components/AddLabwareCard/__tests__/__snapshots__/AddLabwareFailureModal.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddLabwareFailureModal component renders 1`] = `
+<AlertModal
+  alertOverlay={true}
+  buttons={
+    Array [
+      Object {
+        "children": "cancel",
+        "className": "button",
+        "onClick": [MockFunction],
+      },
+    ]
+  }
+  heading="Unable to add labware"
+>
+  <p>
+    Unable to copy labware file to
+     
+    <span
+      className="code"
+    >
+      /path/to/labware
+    </span>
+    . 
+    Please check that you are able to open this file and add files to your labware source folder, or contact Opentrons Support for help.
+  </p>
+</AlertModal>
+`;

--- a/app/src/components/AddLabwareCard/index.js
+++ b/app/src/components/AddLabwareCard/index.js
@@ -7,10 +7,13 @@ import { getConfig } from '../../config'
 import {
   changeCustomLabwareDirectory,
   addCustomLabware,
+  clearAddCustomLabwareFailure,
+  getAddLabwareFailure,
 } from '../../custom-labware'
 
 import { ManagePath } from './ManagePath'
 import { AddLabware } from './AddLabware'
+import { PortaledAddLabwareFailureModal } from './AddLabwareFailureModal'
 
 import type { Dispatch } from '../../types'
 
@@ -20,14 +23,24 @@ const ADD_LABWARE_CARD_TITLE = 'Labware Management'
 export function AddLabwareCard() {
   const dispatch = useDispatch<Dispatch>()
   const config = useSelector(getConfig)
+  const addFailure = useSelector(getAddLabwareFailure)
   const labwarePath = config.labware.directory
   const handleChangePath = () => dispatch(changeCustomLabwareDirectory())
   const handleAddLabware = () => dispatch(addCustomLabware())
+  const showAddFailure = addFailure.file || addFailure.errorMessage !== null
 
   return (
     <Card title={ADD_LABWARE_CARD_TITLE}>
       <ManagePath path={labwarePath} onChangePath={handleChangePath} />
       <AddLabware onAddLabware={handleAddLabware} />
+      {showAddFailure && (
+        <PortaledAddLabwareFailureModal
+          {...addFailure}
+          directory={labwarePath}
+          onCancel={() => dispatch(clearAddCustomLabwareFailure())}
+          onOverwrite={file => dispatch(addCustomLabware(file))}
+        />
+      )}
     </Card>
   )
 }

--- a/app/src/components/AddLabwareCard/styles.css
+++ b/app/src/components/AddLabwareCard/styles.css
@@ -4,3 +4,34 @@
   margin-top: 0.25rem;
   margin-bottom: 0;
 }
+
+.code {
+  @apply --font-code;
+}
+
+.details_list {
+  list-style: none;
+}
+
+.list_item {
+  display: flex;
+  align-items: baseline;
+  margin-top: 0.125rem;
+}
+
+.list_item_title {
+  font-weight: var(--fw-semibold);
+  margin-right: 0.25rem;
+  min-width: 5rem;
+}
+
+.button {
+  width: auto;
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
+.error {
+  font-weight: var(--fw-semibold);
+  color: var(--c-error-dark);
+}

--- a/app/src/custom-labware/__fixtures__/index.js
+++ b/app/src/custom-labware/__fixtures__/index.js
@@ -1,0 +1,45 @@
+// @flow
+
+import * as Types from '../types'
+
+export const mockValidLabware: Types.ValidLabwareFile = {
+  type: 'VALID_LABWARE_FILE',
+  filename: 'a.json',
+  created: 1,
+  identity: { name: 'a', namespace: 'custom', version: 1 },
+  metadata: {
+    displayName: 'A',
+    displayCategory: 'wellPlate',
+    displayVolumeUnits: 'mL',
+  },
+}
+
+export const mockInvalidLabware: Types.InvalidLabwareFile = {
+  type: 'INVALID_LABWARE_FILE',
+  filename: 'b.json',
+  created: 2,
+}
+
+export const mockOpentronsLabware: Types.OpentronsLabwareFile = {
+  type: 'OPENTRONS_LABWARE_FILE',
+  filename: 'c.json',
+  created: 3,
+  identity: { name: 'c', namespace: 'opentrons', version: 1 },
+  metadata: {
+    displayName: 'C',
+    displayCategory: 'wellPlate',
+    displayVolumeUnits: 'mL',
+  },
+}
+
+export const mockDuplicateLabware: Types.DuplicateLabwareFile = {
+  type: 'DUPLICATE_LABWARE_FILE',
+  filename: 'd.json',
+  created: 4,
+  identity: { name: 'd', namespace: 'custom', version: 1 },
+  metadata: {
+    displayName: 'D',
+    displayCategory: 'wellPlate',
+    displayVolumeUnits: 'mL',
+  },
+}

--- a/app/src/custom-labware/__tests__/actions.test.js
+++ b/app/src/custom-labware/__tests__/actions.test.js
@@ -1,5 +1,7 @@
 // @flow
 import * as actions from '../actions'
+import * as Fixtures from '../__fixtures__'
+
 import type { CustomLabwareAction } from '../types'
 
 type ActionSpec = {|
@@ -58,6 +60,16 @@ describe('custom labware actions', () => {
       expected: {
         type: 'labware:ADD_CUSTOM_LABWARE',
         payload: { overwrite: null },
+        meta: { shell: true },
+      },
+    },
+    {
+      name: 'addCustomLabware with overwrite',
+      creator: actions.addCustomLabware,
+      args: [Fixtures.mockDuplicateLabware],
+      expected: {
+        type: 'labware:ADD_CUSTOM_LABWARE',
+        payload: { overwrite: Fixtures.mockDuplicateLabware },
         meta: { shell: true },
       },
     },

--- a/app/src/custom-labware/__tests__/actions.test.js
+++ b/app/src/custom-labware/__tests__/actions.test.js
@@ -1,6 +1,6 @@
 // @flow
-import * as actions from '../actions'
 import * as Fixtures from '../__fixtures__'
+import * as actions from '../actions'
 
 import type { CustomLabwareAction } from '../types'
 

--- a/app/src/custom-labware/__tests__/actions.test.js
+++ b/app/src/custom-labware/__tests__/actions.test.js
@@ -17,8 +17,8 @@ describe('custom labware actions', () => {
       expected: { type: 'labware:FETCH_CUSTOM_LABWARE', meta: { shell: true } },
     },
     {
-      name: 'customLabware',
-      creator: actions.customLabware,
+      name: 'customLabwareList',
+      creator: actions.customLabwareList,
       args: [
         [
           { type: 'INVALID_LABWARE_FILE', filename: 'a.json', created: 0 },
@@ -26,11 +26,20 @@ describe('custom labware actions', () => {
         ],
       ],
       expected: {
-        type: 'labware:CUSTOM_LABWARE',
+        type: 'labware:CUSTOM_LABWARE_LIST',
         payload: [
           { type: 'INVALID_LABWARE_FILE', filename: 'a.json', created: 0 },
           { type: 'INVALID_LABWARE_FILE', filename: 'b.json', created: 1 },
         ],
+      },
+    },
+    {
+      name: 'customLabwareListFailure',
+      creator: actions.customLabwareListFailure,
+      args: ['AH!'],
+      expected: {
+        type: 'labware:CUSTOM_LABWARE_LIST_FAILURE',
+        payload: { message: 'AH!' },
       },
     },
     {
@@ -43,27 +52,38 @@ describe('custom labware actions', () => {
       },
     },
     {
-      name: 'addCustomLabware',
+      name: 'addCustomLabware without overwrite',
       creator: actions.addCustomLabware,
       args: [],
       expected: {
         type: 'labware:ADD_CUSTOM_LABWARE',
+        payload: { overwrite: null },
         meta: { shell: true },
       },
     },
     {
-      name: 'addCustomLabwareFailure',
+      name: 'addCustomLabwareFailure with failed labware',
       creator: actions.addCustomLabwareFailure,
       args: [{ type: 'INVALID_LABWARE_FILE', filename: 'a.json', created: 0 }],
       expected: {
         type: 'labware:ADD_CUSTOM_LABWARE_FAILURE',
         payload: {
+          message: null,
           labware: {
             type: 'INVALID_LABWARE_FILE',
             filename: 'a.json',
             created: 0,
           },
         },
+      },
+    },
+    {
+      name: 'addCustomLabwareFailure with error message',
+      creator: actions.addCustomLabwareFailure,
+      args: [null, 'AH'],
+      expected: {
+        type: 'labware:ADD_CUSTOM_LABWARE_FAILURE',
+        payload: { labware: null, message: 'AH' },
       },
     },
     {

--- a/app/src/custom-labware/__tests__/reducer.test.js
+++ b/app/src/custom-labware/__tests__/reducer.test.js
@@ -6,25 +6,25 @@ import type { CustomLabwareState } from '../types'
 
 type ReducerSpec = {|
   name: string,
-  state: CustomLabwareState,
+  state: $Shape<CustomLabwareState>,
   action: Action,
-  expected: CustomLabwareState,
+  expected: $Shape<CustomLabwareState>,
 |}
 
 describe('customLabwareReducer', () => {
   const SPECS: Array<ReducerSpec> = [
     {
-      name: 'handles CUSTOM_LABWARE with new files',
+      name: 'handles CUSTOM_LABWARE_LIST with new files',
       state: INITIAL_STATE,
       action: {
-        type: 'labware:CUSTOM_LABWARE',
+        type: 'labware:CUSTOM_LABWARE_LIST',
         payload: [
           { type: 'BAD_JSON_LABWARE_FILE', filename: 'a.json', created: 3 },
           { type: 'INVALID_LABWARE_FILE', filename: 'b.json', created: 2 },
         ],
       },
       expected: {
-        addFileFailure: null,
+        ...INITIAL_STATE,
         filenames: ['a.json', 'b.json'],
         filesByName: {
           'a.json': {
@@ -38,12 +38,12 @@ describe('customLabwareReducer', () => {
             created: 2,
           },
         },
+        listFailureMessage: null,
       },
     },
     {
-      name: 'handles CUSTOM_LABWARE with removed files',
+      name: 'handles CUSTOM_LABWARE_LIST with removed files',
       state: {
-        addFileFailure: null,
         filenames: ['a.json', 'b.json'],
         filesByName: {
           'a.json': {
@@ -57,15 +57,15 @@ describe('customLabwareReducer', () => {
             created: 2,
           },
         },
+        listFailureMessage: 'AH',
       },
       action: {
-        type: 'labware:CUSTOM_LABWARE',
+        type: 'labware:CUSTOM_LABWARE_LIST',
         payload: [
           { type: 'INVALID_LABWARE_FILE', filename: 'b.json', created: 2 },
         ],
       },
       expected: {
-        addFileFailure: null,
         filenames: ['b.json'],
         filesByName: {
           'b.json': {
@@ -74,36 +74,41 @@ describe('customLabwareReducer', () => {
             created: 2,
           },
         },
+        listFailureMessage: null,
       },
+    },
+    {
+      name: 'handles CUSTOM_LABWARE_LIST_FAILURE',
+      state: INITIAL_STATE,
+      action: {
+        type: 'labware:CUSTOM_LABWARE_LIST_FAILURE',
+        payload: { message: 'AH' },
+      },
+      expected: { ...INITIAL_STATE, listFailureMessage: 'AH' },
     },
     {
       name: 'handles ADD_CUSTOM_LABWARE',
       state: {
-        addFileFailure: {
+        addFailureFile: {
           type: 'INVALID_LABWARE_FILE',
           filename: 'b.json',
           created: 2,
         },
-        filenames: [],
-        filesByName: {},
+        addFailureMessage: 'AH',
       },
       action: {
         type: 'labware:ADD_CUSTOM_LABWARE',
+        payload: { overwrite: null },
         meta: { shell: true },
       },
       expected: {
-        addFileFailure: null,
-        filenames: [],
-        filesByName: {},
+        addFailureFile: null,
+        addFailureMessage: null,
       },
     },
     {
       name: 'handles ADD_CUSTOM_LABWARE_FAILURE',
-      state: {
-        addFileFailure: null,
-        filenames: [],
-        filesByName: {},
-      },
+      state: INITIAL_STATE,
       action: {
         type: 'labware:ADD_CUSTOM_LABWARE_FAILURE',
         payload: {
@@ -112,34 +117,33 @@ describe('customLabwareReducer', () => {
             filename: 'b.json',
             created: 2,
           },
+          message: 'AH',
         },
       },
       expected: {
-        addFileFailure: {
+        ...INITIAL_STATE,
+        addFailureFile: {
           type: 'INVALID_LABWARE_FILE',
           filename: 'b.json',
           created: 2,
         },
-        filenames: [],
-        filesByName: {},
+        addFailureMessage: 'AH',
       },
     },
     {
       name: 'handles CLEAR_ADD_CUSTOM_LABWARE_FAILURE',
       state: {
-        addFileFailure: {
+        addFailureFile: {
           type: 'INVALID_LABWARE_FILE',
           filename: 'b.json',
           created: 2,
         },
-        filenames: [],
-        filesByName: {},
+        addFailureMessage: 'AH',
       },
       action: { type: 'labware:CLEAR_ADD_CUSTOM_LABWARE_FAILURE' },
       expected: {
-        addFileFailure: null,
-        filenames: [],
-        filesByName: {},
+        addFailureFile: null,
+        addFailureMessage: null,
       },
     },
   ]

--- a/app/src/custom-labware/__tests__/reducer.test.js
+++ b/app/src/custom-labware/__tests__/reducer.test.js
@@ -1,4 +1,5 @@
 // @flow
+import * as Fixtures from '../__fixtures__'
 import { INITIAL_STATE, customLabwareReducer } from '../reducer'
 
 import type { Action } from '../../types'
@@ -18,25 +19,17 @@ describe('customLabwareReducer', () => {
       state: INITIAL_STATE,
       action: {
         type: 'labware:CUSTOM_LABWARE_LIST',
-        payload: [
-          { type: 'BAD_JSON_LABWARE_FILE', filename: 'a.json', created: 3 },
-          { type: 'INVALID_LABWARE_FILE', filename: 'b.json', created: 2 },
-        ],
+        payload: [Fixtures.mockInvalidLabware, Fixtures.mockValidLabware],
       },
       expected: {
         ...INITIAL_STATE,
-        filenames: ['a.json', 'b.json'],
+        filenames: [
+          Fixtures.mockInvalidLabware.filename,
+          Fixtures.mockValidLabware.filename,
+        ],
         filesByName: {
-          'a.json': {
-            type: 'BAD_JSON_LABWARE_FILE',
-            filename: 'a.json',
-            created: 3,
-          },
-          'b.json': {
-            type: 'INVALID_LABWARE_FILE',
-            filename: 'b.json',
-            created: 2,
-          },
+          [Fixtures.mockInvalidLabware.filename]: Fixtures.mockInvalidLabware,
+          [Fixtures.mockValidLabware.filename]: Fixtures.mockValidLabware,
         },
         listFailureMessage: null,
       },
@@ -44,35 +37,24 @@ describe('customLabwareReducer', () => {
     {
       name: 'handles CUSTOM_LABWARE_LIST with removed files',
       state: {
-        filenames: ['a.json', 'b.json'],
+        filenames: [
+          Fixtures.mockInvalidLabware.filename,
+          Fixtures.mockValidLabware.filename,
+        ],
         filesByName: {
-          'a.json': {
-            type: 'BAD_JSON_LABWARE_FILE',
-            filename: 'a.json',
-            created: 3,
-          },
-          'b.json': {
-            type: 'INVALID_LABWARE_FILE',
-            filename: 'b.json',
-            created: 2,
-          },
+          [Fixtures.mockInvalidLabware.filename]: Fixtures.mockInvalidLabware,
+          [Fixtures.mockValidLabware.filename]: Fixtures.mockValidLabware,
         },
         listFailureMessage: 'AH',
       },
       action: {
         type: 'labware:CUSTOM_LABWARE_LIST',
-        payload: [
-          { type: 'INVALID_LABWARE_FILE', filename: 'b.json', created: 2 },
-        ],
+        payload: [Fixtures.mockInvalidLabware],
       },
       expected: {
-        filenames: ['b.json'],
+        filenames: [Fixtures.mockInvalidLabware.filename],
         filesByName: {
-          'b.json': {
-            type: 'INVALID_LABWARE_FILE',
-            filename: 'b.json',
-            created: 2,
-          },
+          [Fixtures.mockInvalidLabware.filename]: Fixtures.mockInvalidLabware,
         },
         listFailureMessage: null,
       },
@@ -89,11 +71,7 @@ describe('customLabwareReducer', () => {
     {
       name: 'handles ADD_CUSTOM_LABWARE',
       state: {
-        addFailureFile: {
-          type: 'INVALID_LABWARE_FILE',
-          filename: 'b.json',
-          created: 2,
-        },
+        addFailureFile: Fixtures.mockInvalidLabware,
         addFailureMessage: 'AH',
       },
       action: {
@@ -112,32 +90,20 @@ describe('customLabwareReducer', () => {
       action: {
         type: 'labware:ADD_CUSTOM_LABWARE_FAILURE',
         payload: {
-          labware: {
-            type: 'INVALID_LABWARE_FILE',
-            filename: 'b.json',
-            created: 2,
-          },
+          labware: Fixtures.mockInvalidLabware,
           message: 'AH',
         },
       },
       expected: {
         ...INITIAL_STATE,
-        addFailureFile: {
-          type: 'INVALID_LABWARE_FILE',
-          filename: 'b.json',
-          created: 2,
-        },
+        addFailureFile: Fixtures.mockInvalidLabware,
         addFailureMessage: 'AH',
       },
     },
     {
       name: 'handles CLEAR_ADD_CUSTOM_LABWARE_FAILURE',
       state: {
-        addFailureFile: {
-          type: 'INVALID_LABWARE_FILE',
-          filename: 'b.json',
-          created: 2,
-        },
+        addFailureFile: Fixtures.mockInvalidLabware,
         addFailureMessage: 'AH',
       },
       action: { type: 'labware:CLEAR_ADD_CUSTOM_LABWARE_FAILURE' },

--- a/app/src/custom-labware/__tests__/selectors.test.js
+++ b/app/src/custom-labware/__tests__/selectors.test.js
@@ -1,8 +1,10 @@
 // @flow
 
+import * as Fixtures from '../__fixtures__'
 import * as selectors from '../selectors'
 
 import type { State } from '../../types'
+import type { ValidLabwareFile } from '../types'
 
 type SelectorSpec = {|
   name: string,
@@ -18,105 +20,62 @@ describe('custom labware selectors', () => {
       selector: selectors.getCustomLabware,
       state: {
         labware: {
-          addFileFailure: null,
-          filenames: ['a.json', 'b.json'],
+          addFailureFile: null,
+          addFailureMessage: null,
+          listFailureMessage: null,
+          filenames: [
+            Fixtures.mockValidLabware.filename,
+            Fixtures.mockInvalidLabware.filename,
+          ],
           filesByName: {
-            'a.json': {
-              type: 'BAD_JSON_LABWARE_FILE',
-              filename: 'a.json',
-              created: 3,
-            },
-            'b.json': {
-              type: 'INVALID_LABWARE_FILE',
-              filename: 'b.json',
-              created: 2,
-            },
+            [Fixtures.mockValidLabware.filename]: Fixtures.mockValidLabware,
+            [Fixtures.mockInvalidLabware.filename]: Fixtures.mockInvalidLabware,
           },
         },
       },
-      expected: [
-        { type: 'BAD_JSON_LABWARE_FILE', filename: 'a.json', created: 3 },
-        { type: 'INVALID_LABWARE_FILE', filename: 'b.json', created: 2 },
-      ],
+      expected: [Fixtures.mockValidLabware, Fixtures.mockInvalidLabware],
     },
     {
       name: 'getValidCustomLabware',
       selector: selectors.getValidCustomLabware,
       state: {
         labware: {
-          addFileFailure: null,
-          filenames: ['a.json', 'b.json', 'c.json', 'd.json', 'e.json'],
+          addFailureFile: null,
+          addFailureMessage: null,
+          listFailureMessage: null,
+          filenames: [
+            Fixtures.mockValidLabware.filename,
+            Fixtures.mockInvalidLabware.filename,
+            'foo.json',
+          ],
           filesByName: {
-            'a.json': {
-              type: 'VALID_LABWARE_FILE',
-              filename: 'a.json',
-              created: 1,
-              identity: { name: 'a', namespace: 'custom', version: 1 },
-              metadata: {
-                displayName: 'A',
-                displayCategory: 'wellPlate',
-                displayVolumeUnits: 'mL',
-              },
-            },
-            'b.json': {
-              type: 'BAD_JSON_LABWARE_FILE',
-              filename: 'b.json',
-              created: 2,
-            },
-            'c.json': {
-              type: 'INVALID_LABWARE_FILE',
-              filename: 'c.json',
-              created: 3,
-            },
-            'd.json': {
-              type: 'DUPLICATE_LABWARE_FILE',
-              filename: 'd.json',
-              created: 4,
-              identity: { name: 'd', namespace: 'custom', version: 1 },
-              metadata: {
-                displayName: 'D',
-                displayCategory: 'wellPlate',
-                displayVolumeUnits: 'mL',
-              },
-            },
-            'e.json': {
-              type: 'VALID_LABWARE_FILE',
-              filename: 'e.json',
-              created: 5,
-              identity: { name: 'e', namespace: 'custom', version: 1 },
-              metadata: {
-                displayName: 'E',
-                displayCategory: 'reservoir',
-                displayVolumeUnits: 'mL',
-              },
-            },
+            [Fixtures.mockValidLabware.filename]: Fixtures.mockValidLabware,
+            [Fixtures.mockInvalidLabware.filename]: Fixtures.mockInvalidLabware,
+            'foo.json': ({
+              ...Fixtures.mockValidLabware,
+              filename: 'foo.json',
+            }: ValidLabwareFile),
           },
         },
       },
       expected: [
-        {
-          type: 'VALID_LABWARE_FILE',
-          filename: 'a.json',
-          created: 1,
-          identity: { name: 'a', namespace: 'custom', version: 1 },
-          metadata: {
-            displayName: 'A',
-            displayCategory: 'wellPlate',
-            displayVolumeUnits: 'mL',
-          },
-        },
-        {
-          type: 'VALID_LABWARE_FILE',
-          filename: 'e.json',
-          created: 5,
-          identity: { name: 'e', namespace: 'custom', version: 1 },
-          metadata: {
-            displayName: 'E',
-            displayCategory: 'reservoir',
-            displayVolumeUnits: 'mL',
-          },
-        },
+        Fixtures.mockValidLabware,
+        { ...Fixtures.mockValidLabware, filename: 'foo.json' },
       ],
+    },
+    {
+      name: 'getAddLabwareFailure',
+      selector: selectors.getAddLabwareFailure,
+      state: {
+        labware: {
+          addFailureFile: Fixtures.mockInvalidLabware,
+          addFailureMessage: 'AH',
+          listFailureMessage: null,
+          filenames: [],
+          filesByName: {},
+        },
+      },
+      expected: { file: Fixtures.mockInvalidLabware, errorMessage: 'AH' },
     },
   ]
 

--- a/app/src/custom-labware/actions.js
+++ b/app/src/custom-labware/actions.js
@@ -1,17 +1,17 @@
 // @flow
 
-import type {
-  CustomLabwareAction,
-  CheckedLabwareFile,
-  FailedLabwareFile,
-} from './types'
+import * as Types from './types'
 
 // action type literals
 
 export const FETCH_CUSTOM_LABWARE: 'labware:FETCH_CUSTOM_LABWARE' =
   'labware:FETCH_CUSTOM_LABWARE'
 
-export const CUSTOM_LABWARE: 'labware:CUSTOM_LABWARE' = 'labware:CUSTOM_LABWARE'
+export const CUSTOM_LABWARE_LIST: 'labware:CUSTOM_LABWARE_LIST' =
+  'labware:CUSTOM_LABWARE_LIST'
+
+export const CUSTOM_LABWARE_LIST_FAILURE: 'labware:CUSTOM_LABWARE_LIST_FAILURE' =
+  'labware:CUSTOM_LABWARE_LIST_FAILURE'
 
 export const CHANGE_CUSTOM_LABWARE_DIRECTORY: 'labware:CHANGE_CUSTOM_LABWARE_DIRECTORY' =
   'labware:CHANGE_CUSTOM_LABWARE_DIRECTORY'
@@ -27,32 +27,43 @@ export const CLEAR_ADD_CUSTOM_LABWARE_FAILURE: 'labware:CLEAR_ADD_CUSTOM_LABWARE
 
 // action creators
 
-export const fetchCustomLabware = (): CustomLabwareAction => ({
+export const fetchCustomLabware = (): Types.FetchCustomLabwareAction => ({
   type: FETCH_CUSTOM_LABWARE,
   meta: { shell: true },
 })
 
-export const customLabware = (
-  payload: Array<CheckedLabwareFile>
-): CustomLabwareAction => ({ type: CUSTOM_LABWARE, payload })
+export const customLabwareList = (
+  payload: Array<Types.CheckedLabwareFile>
+): Types.CustomLabwareListAction => ({ type: CUSTOM_LABWARE_LIST, payload })
 
-export const changeCustomLabwareDirectory = (): CustomLabwareAction => ({
+export const customLabwareListFailure = (
+  message: string
+): Types.CustomLabwareListFailureAction => ({
+  type: CUSTOM_LABWARE_LIST_FAILURE,
+  payload: { message },
+})
+
+export const changeCustomLabwareDirectory = (): Types.ChangeCustomLabwareDirectoryAction => ({
   type: CHANGE_CUSTOM_LABWARE_DIRECTORY,
   meta: { shell: true },
 })
 
-export const addCustomLabware = (): CustomLabwareAction => ({
+export const addCustomLabware = (
+  overwrite: Types.DuplicateLabwareFile | null = null
+): Types.AddCustomLabwareAction => ({
   type: ADD_CUSTOM_LABWARE,
+  payload: { overwrite },
   meta: { shell: true },
 })
 
 export const addCustomLabwareFailure = (
-  labware: FailedLabwareFile
-): CustomLabwareAction => ({
+  labware: Types.FailedLabwareFile | null = null,
+  message: string | null = null
+): Types.AddCustomLabwareFailureAction => ({
   type: ADD_CUSTOM_LABWARE_FAILURE,
-  payload: { labware },
+  payload: { labware, message },
 })
 
-export const clearAddCustomLabwareFailure = (): CustomLabwareAction => ({
+export const clearAddCustomLabwareFailure = (): Types.ClearAddCustomLabwareFailureAction => ({
   type: CLEAR_ADD_CUSTOM_LABWARE_FAILURE,
 })

--- a/app/src/custom-labware/reducer.js
+++ b/app/src/custom-labware/reducer.js
@@ -1,6 +1,7 @@
 // @flow
 // custom labware reducer
-import * as ActionTypes from './actions'
+import keyBy from 'lodash/keyBy'
+import * as Actions from './actions'
 
 import type { Action } from '../types'
 import type { CustomLabwareState } from './types'
@@ -8,7 +9,9 @@ import type { CustomLabwareState } from './types'
 export const INITIAL_STATE: CustomLabwareState = {
   filenames: [],
   filesByName: {},
-  addFileFailure: null,
+  addFailureFile: null,
+  addFailureMessage: null,
+  listFailureMessage: null,
 }
 
 export function customLabwareReducer(
@@ -16,26 +19,30 @@ export function customLabwareReducer(
   action: Action
 ): CustomLabwareState {
   switch (action.type) {
-    case ActionTypes.CUSTOM_LABWARE: {
-      const { filenames, filesByName } = action.payload.reduce(
-        (res, file) => {
-          res.filenames.push(file.filename)
-          res.filesByName[file.filename] = file
-          return res
-        },
-        { filenames: [], filesByName: {} }
-      )
-
-      return { ...state, filenames, filesByName }
+    case Actions.CUSTOM_LABWARE_LIST: {
+      return {
+        ...state,
+        listFailureMessage: null,
+        filenames: action.payload.map(f => f.filename),
+        filesByName: keyBy(action.payload, 'filename'),
+      }
     }
 
-    case ActionTypes.ADD_CUSTOM_LABWARE:
-    case ActionTypes.CLEAR_ADD_CUSTOM_LABWARE_FAILURE: {
-      return { ...state, addFileFailure: null }
+    case Actions.CUSTOM_LABWARE_LIST_FAILURE: {
+      return { ...state, listFailureMessage: action.payload.message }
     }
 
-    case ActionTypes.ADD_CUSTOM_LABWARE_FAILURE: {
-      return { ...state, addFileFailure: action.payload.labware }
+    case Actions.ADD_CUSTOM_LABWARE:
+    case Actions.CLEAR_ADD_CUSTOM_LABWARE_FAILURE: {
+      return { ...state, addFailureFile: null, addFailureMessage: null }
+    }
+
+    case Actions.ADD_CUSTOM_LABWARE_FAILURE: {
+      return {
+        ...state,
+        addFailureFile: action.payload.labware,
+        addFailureMessage: action.payload.message,
+      }
     }
   }
 

--- a/app/src/custom-labware/selectors.js
+++ b/app/src/custom-labware/selectors.js
@@ -3,10 +3,11 @@
 import { createSelector } from 'reselect'
 
 import type { State } from '../types'
-import type { CheckedLabwareFile, ValidLabwareFile } from './types'
-
-export const BAD_JSON_LABWARE_FILE: 'BAD_JSON_LABWARE_FILE' =
-  'BAD_JSON_LABWARE_FILE'
+import type {
+  CheckedLabwareFile,
+  ValidLabwareFile,
+  FailedLabwareFile,
+} from './types'
 
 export const INVALID_LABWARE_FILE: 'INVALID_LABWARE_FILE' =
   'INVALID_LABWARE_FILE'
@@ -29,4 +30,13 @@ export const getValidCustomLabware: State => Array<ValidLabwareFile> = createSel
   getCustomLabware,
   // $FlowFixMe: flow unable to do type refinements via filter
   labware => labware.filter(f => f.type === VALID_LABWARE_FILE)
+)
+
+export const getAddLabwareFailure: State => {|
+  file: FailedLabwareFile | null,
+  errorMessage: string | null,
+|} = createSelector(
+  state => state.labware.addFailureFile,
+  state => state.labware.addFailureMessage,
+  (file, errorMessage) => ({ file, errorMessage })
 )

--- a/app/src/custom-labware/types.js
+++ b/app/src/custom-labware/types.js
@@ -26,11 +26,6 @@ export type UncheckedLabwareFile = {|
   data: { [string]: mixed } | null,
 |}
 
-export type BadJsonLabwareFile = {|
-  type: 'BAD_JSON_LABWARE_FILE',
-  ...LabwareFileProps,
-|}
-
 export type InvalidLabwareFile = {|
   type: 'INVALID_LABWARE_FILE',
   ...LabwareFileProps,
@@ -52,14 +47,12 @@ export type ValidLabwareFile = {|
 |}
 
 export type CheckedLabwareFile =
-  | BadJsonLabwareFile
   | InvalidLabwareFile
   | DuplicateLabwareFile
   | OpentronsLabwareFile
   | ValidLabwareFile
 
 export type FailedLabwareFile =
-  | BadJsonLabwareFile
   | InvalidLabwareFile
   | DuplicateLabwareFile
   | OpentronsLabwareFile

--- a/app/src/custom-labware/types.js
+++ b/app/src/custom-labware/types.js
@@ -2,6 +2,8 @@
 
 import type { LabwareMetadata } from '@opentrons/shared-data'
 
+// common types
+
 export type LabwareIdentity = {|
   name: string,
   namespace: string,
@@ -62,22 +64,58 @@ export type FailedLabwareFile =
   | DuplicateLabwareFile
   | OpentronsLabwareFile
 
+// state types
+
 export type CustomLabwareState = $ReadOnly<{|
   filenames: Array<string>,
   filesByName: $Shape<{| [filename: string]: CheckedLabwareFile |}>,
-  addFileFailure: FailedLabwareFile | null,
+  addFailureFile: FailedLabwareFile | null,
+  addFailureMessage: string | null,
+  listFailureMessage: string | null,
 |}>
 
+// action types
+
+export type FetchCustomLabwareAction = {|
+  type: 'labware:FETCH_CUSTOM_LABWARE',
+  meta: {| shell: true |},
+|}
+
+export type CustomLabwareListAction = {|
+  type: 'labware:CUSTOM_LABWARE_LIST',
+  payload: Array<CheckedLabwareFile>,
+|}
+
+export type CustomLabwareListFailureAction = {|
+  type: 'labware:CUSTOM_LABWARE_LIST_FAILURE',
+  payload: {| message: string |},
+|}
+
+export type ChangeCustomLabwareDirectoryAction = {|
+  type: 'labware:CHANGE_CUSTOM_LABWARE_DIRECTORY',
+  meta: {| shell: true |},
+|}
+
+export type AddCustomLabwareAction = {|
+  type: 'labware:ADD_CUSTOM_LABWARE',
+  payload: {| overwrite: DuplicateLabwareFile | null |},
+  meta: {| shell: true |},
+|}
+
+export type AddCustomLabwareFailureAction = {|
+  type: 'labware:ADD_CUSTOM_LABWARE_FAILURE',
+  payload: {| labware: FailedLabwareFile | null, message: string | null |},
+|}
+
+export type ClearAddCustomLabwareFailureAction = {|
+  type: 'labware:CLEAR_ADD_CUSTOM_LABWARE_FAILURE',
+|}
+
 export type CustomLabwareAction =
-  | {| type: 'labware:FETCH_CUSTOM_LABWARE', meta: {| shell: true |} |}
-  | {| type: 'labware:CUSTOM_LABWARE', payload: Array<CheckedLabwareFile> |}
-  | {|
-      type: 'labware:CHANGE_CUSTOM_LABWARE_DIRECTORY',
-      meta: {| shell: true |},
-    |}
-  | {| type: 'labware:ADD_CUSTOM_LABWARE', meta: {| shell: true |} |}
-  | {|
-      type: 'labware:ADD_CUSTOM_LABWARE_FAILURE',
-      payload: {| labware: FailedLabwareFile |},
-    |}
-  | {| type: 'labware:CLEAR_ADD_CUSTOM_LABWARE_FAILURE' |}
+  | FetchCustomLabwareAction
+  | CustomLabwareListAction
+  | CustomLabwareListFailureAction
+  | ChangeCustomLabwareDirectoryAction
+  | AddCustomLabwareAction
+  | AddCustomLabwareFailureAction
+  | ClearAddCustomLabwareFailureAction

--- a/components/src/styles/typography.css
+++ b/components/src/styles/typography.css
@@ -15,6 +15,7 @@
   --fw-semibold: 600;
   --fw-regular: 400;
   --fw-light: 300;
+  --ff-code: Consolas, monaco, monospace;
   --lh-solid: 1;
   --lh-title: 1.25;
   --lh-copy: 1.5;
@@ -96,6 +97,13 @@
     font-size: var(--fs-caption);
     font-weight: var(--fw-semibold);
     color: var(--c-med-gray);
+  };
+
+  --font-code: {
+    font-family: var(--ff-code);
+    font-size: var(--fs-body-1);
+    font-weight: var(--fw-regular);
+    color: var(--c-font-dark);
   };
 
   --truncate: {


### PR DESCRIPTION
## overview

Closes #4247 

This PR follows up on #4475 and #4487 by adding "Add Labware" error handling to the UI, including allowing the user to overwrite existing labware with a newer duplicate.

## changelog

- refactor(app): handle "Add Labware" errors and allow overwrites

## review requests

With the "Custom Labware" feature flag enabled in the app, navigate to "More" > "Custom Labware"

In lieu of a test plan in this PR, please follow the acceptance criteria in #4247

If you are in need of valid custom labware files, either create one with labware creator, or:

- Grab any labware file from `shared-data/labware/definitions/2/`
- Open it up and change its `namespace` field to something other than `opentrons`

If you need an invalid custom labware file, use:

- Any standard Opentrons labware
- Any JSON file that isn't labware
- Any JSON file that isn't actually JSON
