### PR TITLE
feat(api): Add locks on direct data access for mag and temp module

### DIFF
--- a/api/src/opentrons/drivers/mag_deck/driver.py
+++ b/api/src/opentrons/drivers/mag_deck/driver.py
@@ -181,7 +181,6 @@ class MagDeck:
             self._wait_for_ack()    # verify the device is there
             self._port = port
 
-
         except (SerialException, SerialNoResponse) as e:
             return str(e)
         return ''

--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -68,10 +68,8 @@ class TempDeck:
             self.disconnect(port)
             self._connect_to_port(port)
             if temp_locks.get(port):
-                print("in here")
                 self._lock = temp_locks[port][0]
             else:
-                print("setting up lock")
                 self._lock = Lock()
                 temp_locks[port] = (self._lock, self)
             self._wait_for_ack()  # verify the device is there

--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -68,8 +68,10 @@ class TempDeck:
             self.disconnect(port)
             self._connect_to_port(port)
             if temp_locks.get(port):
+                print("in here")
                 self._lock = temp_locks[port][0]
             else:
+                print("setting up lock")
                 self._lock = Lock()
                 temp_locks[port] = (self._lock, self)
             self._wait_for_ack()  # verify the device is there

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -1373,6 +1373,8 @@ class API(HardwareAPILike):
                     port,
                     name,
                     self.pause_with_message)
+            self._log.info(f"{port}")
+            self._log.info(f"{name}")
             self._attached_modules.append(new_instance)
             self._log.info(f"Module {name} discovered and attached"
                            f" at port {port}")

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -48,6 +48,9 @@ class SimulatingDriver:
     def mag_position(self):
         return self._height
 
+    def is_connected(self):
+        return True
+
 
 class MagDeck(mod_abc.AbstractModule):
     """

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -1,5 +1,4 @@
 import asyncio
-from threading import Lock
 from typing import Union
 from opentrons.drivers.mag_deck import MagDeck as MagDeckDriver
 from . import update, mod_abc
@@ -34,7 +33,7 @@ class SimulatingDriver:
     def connect(self, port):
         pass
 
-    def disconnect(self):
+    def disconnect(self, port=None):
         pass
 
     def enter_programming_mode(self):
@@ -98,7 +97,6 @@ class MagDeck(mod_abc.AbstractModule):
             self._loop = loop
 
         self._device_info = None
-        self._lock = Lock()
 
     def calibrate(self):
         """
@@ -109,8 +107,7 @@ class MagDeck(mod_abc.AbstractModule):
 
     @property
     def current_height(self):
-        with self._lock:
-            return self._driver.mag_position
+        return self._driver.mag_position
 
     def engage(self, height):
         """
@@ -193,7 +190,7 @@ class MagDeck(mod_abc.AbstractModule):
         Disconnect from the serial port
         """
         if self._driver:
-            self._driver.disconnect()
+            self._driver.disconnect(port=self._port)
 
     def __del__(self):
         self._disconnect()

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -2,6 +2,7 @@ import asyncio
 from threading import Thread, Event
 from typing import Union, Optional
 from opentrons.drivers.temp_deck import TempDeck as TempDeckDriver
+from opentrons.drivers.temp_deck.driver import temp_locks
 from . import update, mod_abc
 
 TEMP_POLL_INTERVAL_SECS = 1
@@ -117,8 +118,10 @@ class TempDeck(mod_abc.AbstractModule):
                  port,
                  simulating,
                  loop: asyncio.AbstractEventLoop = None) -> None:
-
-        self._driver = self._build_driver(simulating)
+        if temp_locks.get(port):
+            self._driver = temp_locks[port][1]
+        else:
+            self._driver = self._build_driver(simulating)  # type: ignore
         if None is loop:
             self._loop = asyncio.get_event_loop()
         else:
@@ -204,7 +207,8 @@ class TempDeck(mod_abc.AbstractModule):
         """
         if self._poller:
             self._poller.join()
-        self._driver.connect(self._port)
+        if not self._driver.is_connected():
+            self._driver.connect(self._port)
         self._device_info = self._driver.get_device_info()
         self._poller = Poller(self._driver)
         self._poller.start()

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -128,7 +128,6 @@ class TempDeck(mod_abc.AbstractModule):
         self._port = port
         self._device_info = None
         self._poller = None
-        self._lock = asyncio.Lock(loop=self._loop)
 
     async def set_temperature(self, celsius):
         """
@@ -207,14 +206,12 @@ class TempDeck(mod_abc.AbstractModule):
             self._poller.join()
         self._driver.connect(self._port)
         self._device_info = self._driver.get_device_info()
-        async with self._lock:
-            self._poller = Poller(self._driver)
-            self._poller.start()
+        self._poller = Poller(self._driver)
+        self._poller.start()
 
     def __del__(self):
         if hasattr(self, '_poller') and self._poller:
             self._poller.join()
-            # self._lock.release()
 
     async def prep_for_update(self) -> str:
         if self._poller:

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -36,6 +36,9 @@ class SimulatingDriver:
     def connect(self, port):
         self._port = port
 
+    def is_connected(self):
+        return True
+
     def disconnect(self):
         pass
 

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -128,6 +128,7 @@ class TempDeck(mod_abc.AbstractModule):
         self._port = port
         self._device_info = None
         self._poller = None
+        self._lock = asyncio.Lock(loop=self._loop)
 
     async def set_temperature(self, celsius):
         """
@@ -206,12 +207,14 @@ class TempDeck(mod_abc.AbstractModule):
             self._poller.join()
         self._driver.connect(self._port)
         self._device_info = self._driver.get_device_info()
-        self._poller = Poller(self._driver)
-        self._poller.start()
+        async with self._lock:
+            self._poller = Poller(self._driver)
+            self._poller.start()
 
     def __del__(self):
         if hasattr(self, '_poller') and self._poller:
             self._poller.join()
+            # self._lock.release()
 
     async def prep_for_update(self) -> str:
         if self._poller:

--- a/api/src/opentrons/legacy_api/modules/magdeck.py
+++ b/api/src/opentrons/legacy_api/modules/magdeck.py
@@ -1,4 +1,3 @@
-import threading
 from opentrons.drivers.mag_deck import MagDeck as MagDeckDriver
 from opentrons import commands
 
@@ -24,7 +23,7 @@ class MagDeck(commands.CommandPublisher):
         self._port = port
         self._driver = None
         self._device_info = None
-        self._lock = threading.Lock()
+        self._lock = None
 
     @commands.publish.both(command=commands.magdeck_calibrate)
     def calibrate(self):
@@ -78,8 +77,7 @@ class MagDeck(commands.CommandPublisher):
 
     @property
     def current_height(self):
-        with self._lock:
-            return self._driver.mag_position
+        return self._driver.mag_position
 
     @property
     def engaged(self):
@@ -161,4 +159,4 @@ class MagDeck(commands.CommandPublisher):
         Disconnect from the serial port
         '''
         if self._driver:
-            self._driver.disconnect()
+            self._driver.disconnect(port=self._port)

--- a/api/src/opentrons/legacy_api/modules/tempdeck.py
+++ b/api/src/opentrons/legacy_api/modules/tempdeck.py
@@ -136,7 +136,7 @@ class TempDeck(commands.CommandPublisher):
                 self._driver = temp_locks[self._port][1]
             else:
                 self._driver = TempDeckDriver()
-            if self._driver.is_connected():
+            if not self._driver.is_connected():
                 self._driver.connect(self._port)
             self._device_info = self._driver.get_device_info()
             self._poll_stop_event = Event()

--- a/api/src/opentrons/legacy_api/modules/tempdeck.py
+++ b/api/src/opentrons/legacy_api/modules/tempdeck.py
@@ -1,4 +1,4 @@
-from threading import Thread, Event, Lock
+from threading import Thread, Event
 from opentrons.drivers.temp_deck import TempDeck as TempDeckDriver
 from opentrons import commands
 
@@ -25,7 +25,6 @@ class TempDeck(commands.CommandPublisher):
         self._driver = None
         self._device_info = None
         self._poll_stop_event = None
-        self._lock = Lock()
 
     @commands.publish.both(command=commands.tempdeck_set_temp)
     def set_temperature(self, celsius):
@@ -136,8 +135,7 @@ class TempDeck(commands.CommandPublisher):
             self._driver.connect(self._port)
             self._device_info = self._driver.get_device_info()
             self._poll_stop_event = Event()
-            with self._lock:
-                Thread(target=self._poll_temperature).start()
+            Thread(target=self._poll_temperature).start()
         else:
             # Sanity check Should never happen, because connect should never
             # be called without a port on Module
@@ -154,4 +152,4 @@ class TempDeck(commands.CommandPublisher):
         if self._driver:
             if self.status != 'idle':
                 self.deactivate()
-            self._driver.disconnect()
+            self._driver.disconnect(port=self._port)

--- a/api/src/opentrons/legacy_api/modules/tempdeck.py
+++ b/api/src/opentrons/legacy_api/modules/tempdeck.py
@@ -1,5 +1,6 @@
 from threading import Thread, Event
 from opentrons.drivers.temp_deck import TempDeck as TempDeckDriver
+from opentrons.drivers.temp_deck.driver import temp_locks
 from opentrons import commands
 
 
@@ -131,8 +132,12 @@ class TempDeck(commands.CommandPublisher):
         TempDecks
         """
         if self._port:
-            self._driver = TempDeckDriver()
-            self._driver.connect(self._port)
+            if temp_locks.get(self._port):
+                self._driver = temp_locks[self._port][1]
+            else:
+                self._driver = TempDeckDriver()
+            if self._driver.is_connected():
+                self._driver.connect(self._port)
             self._device_info = self._driver.get_device_info()
             self._poll_stop_event = Event()
             Thread(target=self._poll_temperature).start()

--- a/api/tests/opentrons/config/test_pipette_config.py
+++ b/api/tests/opentrons/config/test_pipette_config.py
@@ -149,7 +149,7 @@ def test_override_save(config_tempdir):
 
     old_pconf = pipette_config.load('p300_multi_v1.4', new_id)
 
-    assert old_pconf.quirks == []
+    assert old_pconf.quirks == ['dropTipShake']
 
     pipette_config.save_overrides(new_id, overrides, model)
 

--- a/api/tests/opentrons/config/test_pipette_config.py
+++ b/api/tests/opentrons/config/test_pipette_config.py
@@ -149,7 +149,7 @@ def test_override_save(config_tempdir):
 
     old_pconf = pipette_config.load('p300_multi_v1.4', new_id)
 
-    assert old_pconf.quirks == ['dropTipShake']
+    assert old_pconf.quirks == []
 
     pipette_config.save_overrides(new_id, overrides, model)
 

--- a/api/tests/opentrons/labware/test_modules.py
+++ b/api/tests/opentrons/labware/test_modules.py
@@ -4,6 +4,7 @@
 
 import pytest
 import asyncio
+from threading import Lock
 from opentrons.drivers.mag_deck import MagDeck as MagDeckDriver
 from opentrons.drivers.temp_deck import TempDeck as TempDeckDriver
 from opentrons.drivers import serial_communication
@@ -87,6 +88,7 @@ def test_run_tempdeck_connected(
     def mock_connect(self, port):
         nonlocal connected
         connected = True
+        self._lock = Lock()
 
     def mock_write(command, ack, serial_connection):
         return 'ok\n\rok\n\r'


### PR DESCRIPTION
## overview

Add locks on both the temperature and magnetic modules to prevent multi-access to data from the hardware.

## review requests

**Test Plan**
1. Ensure you can still set/deactivate temperature in the app
2. Run an API v1 protocol with a tempdeck and set temp low (maybe 5C) so that you can cancel before the temperature reaches the target. You should still be able to deactivate the temperature module after in the app, and then set temp again in the app.
3. Repeat #2 with an API v2 protocol.
4. With a magnetic module, ensure that you can plug/unplug and have the robot continue to be able to recognize it.
5. Use a magnetic module in a v1 and v2 protocol