### PR TITLE
fix(app): Call correct create method depending on protocol

### DIFF
--- a/app-shell/src/labware/__tests__/dispatch.test.js
+++ b/app-shell/src/labware/__tests__/dispatch.test.js
@@ -113,6 +113,15 @@ describe('labware module dispatches', () => {
     )
   })
 
+  // TODO(mc, 2019-11-25): refactor this action to be shell:INITIALIZE
+  test('reads labware directory on shell:CHECK_UPDATE', () => {
+    handleAction({ type: 'shell:CHECK_UPDATE', meta: { shell: true } })
+
+    return flush().then(() =>
+      expect(readLabwareDirectory).toHaveBeenCalledWith(labwareDir)
+    )
+  })
+
   test('reads and parses definition files', () => {
     const mockDirectoryListing = ['a.json', 'b.json', 'c.json', 'd.json']
     const mockParsedFiles = [

--- a/app-shell/src/labware/index.js
+++ b/app-shell/src/labware/index.js
@@ -86,7 +86,8 @@ export function registerLabware(dispatch: Dispatch, mainWindow: {}) {
 
   return function handleActionForLabware(action: Action) {
     switch (action.type) {
-      case CustomLabware.FETCH_CUSTOM_LABWARE: {
+      case CustomLabware.FETCH_CUSTOM_LABWARE:
+      case 'shell:CHECK_UPDATE': {
         fetchAndValidateCustomLabware(dispatch)
         break
       }

--- a/app-shell/src/main.js
+++ b/app-shell/src/main.js
@@ -54,11 +54,15 @@ function startUp() {
   const actionHandlers = [
     registerConfig(dispatch),
     registerDiscovery(dispatch),
-    registerLabware(dispatch, mainWindow),
     registerRobotLogs(dispatch, mainWindow),
     registerUpdate(dispatch),
     registerBuildrootUpdate(dispatch),
   ]
+
+  // TODO(mc, 2019-11-25): remove this feature flag and move handler into `actionHandlers`
+  if (config.devInternal?.customLabware) {
+    actionHandlers.push(registerLabware(dispatch, mainWindow))
+  }
 
   ipcMain.on('dispatch', (_, action) => {
     log.debug('Received action via IPC from renderer', { action })

--- a/app/src/protocol/protocol-data.js
+++ b/app/src/protocol/protocol-data.js
@@ -43,6 +43,10 @@ export function parseProtocolData(
   return null
 }
 
+export function fileIsPython(file: ProtocolFile): boolean {
+  return file.type === 'python' || file.type == null
+}
+
 export function fileIsJson(file: ProtocolFile): boolean {
   return file.type === 'json'
 }

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -24,7 +24,7 @@ export type ConnectResponseAction = {|
   type: 'robot:CONNECT_RESPONSE',
   payload: {|
     error: ?{ message: string },
-    pollHealth: ?boolean,
+    sessionCapabilities: Array<string>,
   |},
 |}
 
@@ -229,10 +229,13 @@ export const actions = {
     }
   },
 
-  connectResponse(error: ?Error, pollHealth: ?boolean): ConnectResponseAction {
+  connectResponse(
+    error: Error,
+    sessionCapabilities: Array<string> = []
+  ): ConnectResponseAction {
     return {
       type: 'robot:CONNECT_RESPONSE',
-      payload: { error, pollHealth },
+      payload: { error, sessionCapabilities },
     }
   },
 

--- a/app/src/robot/api-client/__tests__/create-sessions.test.js
+++ b/app/src/robot/api-client/__tests__/create-sessions.test.js
@@ -1,0 +1,246 @@
+// session creation tests for the RPC API client
+import EventEmitter from 'events'
+import client from '../client'
+import RpcClient from '../../../rpc/client'
+import { actions as RobotActions } from '../../actions'
+import * as ProtocolSelectors from '../../../protocol/selectors'
+import * as DiscoverySelectors from '../../../discovery/selectors'
+import * as LabwareSelectors from '../../../custom-labware/selectors'
+import MockSession from '../../test/__mocks__/session'
+
+jest.mock('../../../rpc/client')
+jest.mock('../../../protocol/selectors')
+jest.mock('../../../discovery/selectors')
+jest.mock('../../../custom-labware/selectors')
+
+const mockState = { state: true }
+const mockRobot = { name: 'robot-name', ip: '127.0.0.1', port: 31950 }
+
+describe('RPC API client - session creation', () => {
+  let mockRpcClient
+  let mockSessionManager
+  let mockDispatch
+  let sendToClient
+
+  beforeEach(() => {
+    mockSessionManager = {
+      session: null,
+      clear: jest.fn(),
+      create: jest.fn(),
+      // added in API v3.15
+      create_from_bundle: jest.fn(),
+      // added in API v3.15
+      create_with_extra_labware: jest.fn(),
+    }
+
+    mockRpcClient = Object.assign(new EventEmitter(), {
+      close: jest.fn(),
+      remote: { session_manager: mockSessionManager },
+    })
+
+    mockDispatch = jest.fn()
+
+    RpcClient.mockResolvedValue(mockRpcClient)
+    DiscoverySelectors.getConnectableRobots.mockReturnValue([mockRobot])
+    LabwareSelectors.getCustomLabwareDefinitions.mockReturnValue([])
+
+    const _receive = client(mockDispatch)
+    const _flush = () => new Promise(resolve => setTimeout(resolve, 0))
+
+    sendToClient = action => {
+      _receive(mockState, action)
+      return _flush()
+    }
+
+    return sendToClient(RobotActions.connect(mockRobot.name))
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  test('calls session_manager.create on protocol:UPLOAD', () => {
+    const mockProtocolFile = { name: 'protocol.py' }
+    const mockSession = MockSession()
+
+    ProtocolSelectors.getProtocolFile.mockReturnValue(mockProtocolFile)
+    mockSessionManager.create.mockResolvedValue(mockSession)
+
+    return sendToClient({
+      type: 'protocol:UPLOAD',
+      payload: { contents: '# protocol', data: null },
+      meta: { robot: true },
+    }).then(() => {
+      expect(ProtocolSelectors.getProtocolFile).toHaveBeenCalledWith(mockState)
+      expect(mockSessionManager.create).toHaveBeenCalledWith(
+        mockProtocolFile.name,
+        '# protocol'
+      )
+    })
+  })
+
+  test('calls session_manager.create_from_bundle if zip protocol', () => {
+    const mockProtocolFile = { name: 'protocol.zip', type: 'zip' }
+    const mockSession = MockSession()
+
+    ProtocolSelectors.getProtocolFile.mockReturnValue(mockProtocolFile)
+    mockSessionManager.create_from_bundle.mockResolvedValue(mockSession)
+
+    return sendToClient({
+      type: 'protocol:UPLOAD',
+      payload: { contents: 'binary-data', data: null },
+      meta: { robot: true },
+    }).then(() => {
+      expect(mockSessionManager.create_from_bundle).toHaveBeenCalledWith(
+        mockProtocolFile.name,
+        'binary-data'
+      )
+    })
+  })
+
+  test('calls create with third param if zip and create_from_bundle not available', () => {
+    const mockProtocolFile = { name: 'protocol.zip', type: 'zip' }
+    const mockSession = MockSession()
+
+    delete mockSessionManager.create_from_bundle
+
+    ProtocolSelectors.getProtocolFile.mockReturnValue(mockProtocolFile)
+    mockSessionManager.create.mockResolvedValue(mockSession)
+
+    return sendToClient({
+      type: 'protocol:UPLOAD',
+      payload: { contents: 'binary-data', data: null },
+      meta: { robot: true },
+    }).then(() => {
+      expect(mockSessionManager.create).toHaveBeenCalledWith(
+        mockProtocolFile.name,
+        'binary-data',
+        true
+      )
+    })
+  })
+
+  test('calls create_with_extra_labware if python protocol and custom labware exist', () => {
+    const mockProtocolFile = { name: 'protocol.py', type: 'python' }
+    const mockSession = MockSession()
+
+    ProtocolSelectors.getProtocolFile.mockReturnValue(mockProtocolFile)
+    LabwareSelectors.getCustomLabwareDefinitions.mockReturnValue([
+      { mockLabware: 1 },
+      { mockLabware: 2 },
+    ])
+    mockSessionManager.create_with_extra_labware.mockResolvedValue(mockSession)
+
+    return sendToClient({
+      type: 'protocol:UPLOAD',
+      payload: { contents: '# protocol', data: null },
+      meta: { robot: true },
+    }).then(() => {
+      expect(mockSessionManager.create_with_extra_labware).toHaveBeenCalledWith(
+        mockProtocolFile.name,
+        '# protocol',
+        [{ v: { mockLabware: 1 } }, { v: { mockLabware: 2 } }]
+      )
+    })
+  })
+
+  test('calls create if custom labware but create_with_extra_labware not available', () => {
+    const mockProtocolFile = { name: 'protocol.py', type: 'python' }
+    const mockSession = MockSession()
+
+    delete mockSessionManager.create_with_extra_labware
+
+    ProtocolSelectors.getProtocolFile.mockReturnValue(mockProtocolFile)
+    LabwareSelectors.getCustomLabwareDefinitions.mockReturnValue([
+      { mockLabware: 1 },
+      { mockLabware: 2 },
+    ])
+    mockSessionManager.create.mockResolvedValue(mockSession)
+
+    return sendToClient({
+      type: 'protocol:UPLOAD',
+      payload: { contents: '# protocol', data: null },
+      meta: { robot: true },
+    }).then(() => {
+      expect(mockSessionManager.create).toHaveBeenCalledWith(
+        mockProtocolFile.name,
+        '# protocol'
+      )
+    })
+  })
+
+  test('calls create if custom labware but protocol is JSON', () => {
+    const mockProtocolFile = { name: 'protocol.json', type: 'json' }
+    const mockSession = MockSession()
+
+    ProtocolSelectors.getProtocolFile.mockReturnValue(mockProtocolFile)
+    LabwareSelectors.getCustomLabwareDefinitions.mockReturnValue([
+      { mockLabware: 1 },
+      { mockLabware: 2 },
+    ])
+    mockSessionManager.create.mockResolvedValue(mockSession)
+
+    return sendToClient({
+      type: 'protocol:UPLOAD',
+      payload: { contents: '{}', data: {} },
+      meta: { robot: true },
+    }).then(() => {
+      expect(mockSessionManager.create).toHaveBeenCalledWith(
+        mockProtocolFile.name,
+        '{}'
+      )
+    })
+  })
+
+  test('dispatches session response with error if create throws', () => {
+    const mockProtocolFile = { name: 'protocol.py', type: 'python' }
+
+    ProtocolSelectors.getProtocolFile.mockReturnValue(mockProtocolFile)
+    mockSessionManager.create.mockRejectedValue(new Error('AH'))
+
+    return sendToClient({
+      type: 'protocol:UPLOAD',
+      payload: { contents: '{}', data: {} },
+      meta: { robot: true },
+    }).then(() => {
+      expect(mockDispatch).toHaveBeenCalledWith(
+        RobotActions.sessionResponse(new Error('AH'), null, true)
+      )
+    })
+  })
+
+  test('dispatches helpful error response with if create throws with bundle', () => {
+    const mockProtocolFile = { name: 'protocol.zip', type: 'zip' }
+    const mockError = Object.assign(
+      new Error(
+        'TypeError: create() takes 3 positional arguments but 4 were given'
+      ),
+      {
+        methodName: 'create',
+      }
+    )
+
+    delete mockSessionManager.create_from_bundle
+
+    ProtocolSelectors.getProtocolFile.mockReturnValue(mockProtocolFile)
+    mockSessionManager.create.mockRejectedValue(mockError)
+
+    return sendToClient({
+      type: 'protocol:UPLOAD',
+      payload: { contents: 'binary-data', data: null },
+      meta: { robot: true },
+    }).then(() => {
+      expect(mockDispatch).toHaveBeenCalledWith(
+        RobotActions.sessionResponse(
+          expect.objectContaining({
+            message: expect.stringMatching(
+              /does not support ZIP protocol bundles/
+            ),
+          }),
+          null,
+          true
+        )
+      )
+    })
+  })
+})

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -6,6 +6,7 @@ import find from 'lodash/find'
 import kebabCase from 'lodash/kebabCase'
 import mapKeys from 'lodash/mapKeys'
 import pick from 'lodash/pick'
+import functionsIn from 'lodash/functionsIn'
 
 import RpcClient from '../../rpc/client'
 import { actions, actionTypes } from '../actions'
@@ -128,8 +129,9 @@ export default function client(dispatch) {
           }
         }
 
-        // only poll health if RPC is not monitoring itself with ping/pong
-        dispatch(actions.connectResponse(null, !rpcClient.monitoring))
+        dispatch(
+          actions.connectResponse(null, functionsIn(remote.session_manager))
+        )
       })
       .catch(e => dispatch(actions.connectResponse(e)))
   }

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -15,13 +15,17 @@ import * as selectors from '../selectors'
 // bypass the robot entry point here to avoid shell module
 import { RESTART as ROBOT_RESTART_ACTION } from '../../robot-admin'
 import { getConnectableRobots } from '../../discovery/selectors'
-
-import { fileIsBinary } from '../../protocol/protocol-data'
+import { getProtocolFile } from '../../protocol/selectors'
+import { fileIsBundle, fileIsPython } from '../../protocol/protocol-data'
+import { getCustomLabwareDefinitions } from '../../custom-labware/selectors'
 
 const RUN_TIME_TICK_INTERVAL_MS = 1000
 const NO_INTERVAL = -1
 const RE_VOLUME = /.*?(\d+).*?/
 const RE_TIPRACK = /tiprack/i
+
+const THIS_ROBOT_DOES_NOT_SUPPORT_BUNDLES =
+  'This robot does not support ZIP protocol bundles. Please update its software to the latest version and upload this protocol again'
 
 export default function client(dispatch) {
   let freshUpload = false
@@ -149,25 +153,47 @@ export default function client(dispatch) {
   }
 
   function uploadProtocol(state, action) {
-    const { name } = state.protocol.file
+    const { session_manager } = remote
+    const file = getProtocolFile(state)
     const { contents } = action.payload
+    const isBundle = fileIsBundle(file)
+    const isPython = fileIsPython(file)
+    const customLabware = getCustomLabwareDefinitions(state)
 
     freshUpload = true
-    remote.session_manager
-      .create(name, contents, fileIsBinary(state.protocol.file))
-      .catch(error => {
-        // back compat: for robot versions before 3.13, Session.create fn takes only 3 args (self, name, contents)
-        // not 4 (self, name, contents, is_binary)
-        if (
-          error.name === 'RemoteError' &&
-          error.methodName === 'create' &&
-          /takes 3 positional arguments/.test(error.message)
-        ) {
-          return remote.session_manager.create(name, contents)
-        }
+    let createTask
 
-        throw error
-      })
+    if (isBundle && 'create_from_bundle' in session_manager) {
+      createTask = session_manager.create_from_bundle(file.name, contents)
+    } else if (isBundle) {
+      createTask = session_manager
+        .create(file.name, contents, true)
+        .catch(error => {
+          if (
+            error.methodName === 'create' &&
+            /takes 3 positional arguments/.test(error.message)
+          ) {
+            throw new Error(THIS_ROBOT_DOES_NOT_SUPPORT_BUNDLES)
+          }
+
+          throw error
+        })
+    } else if (
+      isPython &&
+      customLabware.length > 0 &&
+      'create_with_extra_labware' in session_manager
+    ) {
+      createTask = session_manager.create_with_extra_labware(
+        file.name,
+        contents,
+        // map JS objects to RPC objects (where "value" is under the key `v`)
+        customLabware.map(lw => ({ v: lw }))
+      )
+    } else {
+      createTask = session_manager.create(file.name, contents)
+    }
+
+    createTask
       .then(apiSession => {
         remote.session_manager.session = apiSession
         // state change will trigger a session notification, which will

--- a/app/src/robot/reducer/session.js
+++ b/app/src/robot/reducer/session.js
@@ -51,6 +51,7 @@ export type SessionState = {
   startTime: ?number,
   runTime: number,
   apiLevel: [number, number],
+  capabilities: Array<string>,
 }
 
 // TODO(mc, 2018-01-11): replace actionType constants with Flow types
@@ -73,6 +74,7 @@ const INITIAL_STATE: SessionState = {
   errors: [],
   protocolCommands: [],
   protocolCommandsById: {},
+  capabilities: [],
 
   // deck setup from protocol
   pipettesByMount: {},
@@ -95,6 +97,14 @@ export default function sessionReducer(
   action: Action
 ): SessionState {
   switch (action.type) {
+    case 'robot:CONNECT_RESPONSE': {
+      if (action.payload.error) return state
+      return {
+        ...state,
+        capabilities: action.payload.sessionCapabilities,
+      }
+    }
+
     case 'robot:DISCONNECT_RESPONSE':
       return INITIAL_STATE
 

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -70,6 +70,10 @@ export const getConnectionStatus: OutputSelector<
   }
 )
 
+export function getSessionCapabilities(state: State): Array<string> {
+  return session(state).capabilities
+}
+
 export function getSessionLoadInProgress(state: State): boolean {
   return sessionRequest(state).inProgress
 }

--- a/app/src/robot/test/actions.test.js
+++ b/app/src/robot/test/actions.test.js
@@ -15,14 +15,14 @@ describe('robot actions', () => {
   test('CONNECT_RESPONSE action', () => {
     const success = {
       type: 'robot:CONNECT_RESPONSE',
-      payload: {},
+      payload: { error: null, sessionCapabilities: ['create'] },
     }
     const failure = {
       type: 'robot:CONNECT_RESPONSE',
-      payload: { error: new Error('AH') },
+      payload: { error: new Error('AH'), sessionCapabilities: [] },
     }
 
-    expect(actions.connectResponse()).toEqual(success)
+    expect(actions.connectResponse(null, ['create'])).toEqual(success)
     expect(actions.connectResponse(new Error('AH'))).toEqual(failure)
   })
 

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -3,14 +3,17 @@ import { setIn } from '@thi.ng/paths'
 import { NAME, selectors, constants } from '../'
 
 import { getLabwareDefBySlot } from '../../protocol/selectors'
+import { getCustomLabwareDefinitions } from '../../custom-labware/selectors'
 
 jest.mock('../../protocol/selectors')
+jest.mock('../../custom-labware/selectors')
 
 const makeState = state => ({ [NAME]: state })
 
 const {
   getConnectedRobotName,
   getConnectionStatus,
+  getSessionCapabilities,
   getSessionLoadInProgress,
   getUploadError,
   getSessionIsLoaded,
@@ -38,7 +41,9 @@ const {
 describe('robot selectors', () => {
   beforeEach(() => {
     getLabwareDefBySlot.mockReturnValue({})
+    getCustomLabwareDefinitions.mockReturnValue([])
   })
+
   afterEach(() => {
     jest.resetAllMocks()
   })
@@ -87,6 +92,16 @@ describe('robot selectors', () => {
       })
       expect(getConnectionStatus(state)).toBe(constants.DISCONNECTING)
     })
+  })
+
+  test('getSessionCapabilities', () => {
+    const state = makeState({
+      session: { capabilities: ['create', 'create_from_bundle'] },
+    })
+    expect(getSessionCapabilities(state)).toEqual([
+      'create',
+      'create_from_bundle',
+    ])
   })
 
   test('getSessionLoadInProgress', () => {

--- a/app/src/robot/test/session-reducer.test.js
+++ b/app/src/robot/test/session-reducer.test.js
@@ -19,6 +19,7 @@ describe('robot reducer - session', () => {
       errors: [],
       protocolCommands: [],
       protocolCommandsById: {},
+      capabilities: [],
 
       // deck setup from protocol
       pipettesByMount: {},
@@ -35,6 +36,28 @@ describe('robot reducer - session', () => {
       runTime: 0,
       apiLevel: [1, 0],
     })
+  })
+
+  test('handles CONNECT_RESPONSE success', () => {
+    const expected = { capabilities: ['create'] }
+    const state = { session: { capabilities: [] } }
+    const action = {
+      type: 'robot:CONNECT_RESPONSE',
+      payload: { sessionCapabilities: ['create'] },
+    }
+
+    expect(reducer(state, action).session).toEqual(expected)
+  })
+
+  test('handles CONNECT_RESPONSE failure', () => {
+    const expected = { capabilities: ['create'] }
+    const state = { session: { capabilities: ['create'] } }
+    const action = {
+      type: 'robot:CONNECT_RESPONSE',
+      payload: { error: new Error('AH'), sessionCapabilities: [] },
+    }
+
+    expect(reducer(state, action).session).toEqual(expected)
   })
 
   test('handles DISCONNECT_RESPONSE success', () => {

--- a/app/src/rpc/remote-error.js
+++ b/app/src/rpc/remote-error.js
@@ -2,7 +2,7 @@
 export default class RemoteError extends Error {
   constructor(message, methodName, args, traceback) {
     super(message)
-    this.name = this.constructor.name
+    this.name = 'RemoteError'
     this.methodName = methodName
     this.args = args
     this.traceback = traceback

--- a/app/src/shell/update.js
+++ b/app/src/shell/update.js
@@ -34,6 +34,8 @@ export type ShellUpdateAction =
   | {| type: 'shell:SET_UPDATE_SEEN' |}
 
 // command sent to app-shell via meta.shell === true
+// TODO(mc, 2019-11-25): refactor this action to be shell:INITIALIZE
+// it is used for more than just initial update checking
 export function checkShellUpdate(): ShellUpdateAction {
   return { type: 'shell:CHECK_UPDATE', meta: { shell: true } }
 }


### PR DESCRIPTION
## overview

This PR refactors how the RPC API client calls `session_manager.create` in order to:

- Support using custom labware in Python protocols (see #4490)
- Fix #4202 for real this time

## changelog

- Call the correct `session_manager.create...` method depending on the protocol and what methods the remote `session_manager` has available
    - If ZIP, call `session_manager.create_from_bundle` if available, else `create(..., true)`
    - If Python, call `create_with_extra_labware` or `create` depending on if the user has custom labware or not
    - Else, call `create`

## review requests

With the app's "Custom Labware" feature flag enabled:

1. Add a custom labware to the app
2. Upload a Python protocol using that labware to a robot with #4490 installed

- [ ] Happy path works
- [ ] Fails appropriately if custom labware isn't in the app
- [ ] Fails appropriately if robot doesn't support custom labware in Python (e.g. if the robot _doesn't_ have 4490 installed
- [ ] Doesn't mess with JSON protocols
- [ ] Doesn't mess with ZIP protocols