### PR TITLE
perf(api): use math.isclose in hotpaths

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -6,7 +6,7 @@ from time import sleep
 from threading import Event, RLock
 from typing import Any, Dict, Optional
 
-from numpy import isclose  # type: ignore
+from math import isclose
 from serial.serialutil import SerialException  # type: ignore
 
 from opentrons.drivers import serial_communication
@@ -1268,7 +1268,8 @@ class SmoothieDriver_3_0_0:
             return not (
                 (axis in DISABLE_AXES) or
                 (coords is None) or
-                isclose(coords, self.position[axis])
+                isclose(coords, self.position[axis],
+                        rel_tol=1e-05, abs_tol=1e-08)
             )
 
         def create_coords_list(coords_dict):
@@ -1285,7 +1286,9 @@ class SmoothieDriver_3_0_0:
             if axis in 'BC' and self.position[axis] < value
         })
 
-        target_coords = create_coords_list(target)
+        target_coords = create_coords_list(
+            {axis: round(coords, GCODE_ROUNDING_PRECISION)
+             for axis, coords in target.items()})
         backlash_coords = create_coords_list(backlash_target)
 
         if target_coords:

--- a/api/src/opentrons/util/vector.py
+++ b/api/src/opentrons/util/vector.py
@@ -62,11 +62,6 @@ class VectorValue(tuple):
 value_type = VectorValue
 
 
-# To keep Python 3.4 compatibility
-def isclose(a, b, rel_tol):
-    return abs(a - b) < rel_tol
-
-
 class VectorEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, Vector):
@@ -143,7 +138,7 @@ class Vector(object):
     def __eq__(self, other):
         if isinstance(other, Vector):
             return all(
-                [isclose(a, b, rel_tol=1e-5)
+                [math.isclose(a, b, rel_tol=1e-05, abs_tol=1e-08)
                  for a, b in zip(self, other)]
             )
         elif isinstance(other, dict):


### PR DESCRIPTION
@rgatkinson reported in #4482 that per their investigations, APIv1 protocol
simulation (and thus execution) spends an inordinate amount of time in
numpy.isclose - around 13%. They noted that numpy.isclose is intended to be
dynamic across many sizes of array, and the main place that we use it (in the
smoothie driver to elide motion axes that haven't changed their coordinates)
compares scalars.

This fix uses math.isclose, which compares only scalars, in place of
numpy.isclose. It uses math.isclose instead of @rgatkinson's handwritten version
for maintainability and just in case of any odd bugs around floating point
handling. Also, math.isclose is not that much slower than the handrolled:

```
>>> timeit.timeit(lambda: valid_movement(10, 'X'), number=10000)
0.22610970796085894
>>> timeit.timeit(lambda: my_valid(10, 'X'), number=10000)
0.006807674013543874
>>> timeit.timeit(lambda: math_valid(10, 'X'), number=10000)
0.011523746012244374
```

(valid_movement is the default with numpy, my_valid is with the handrolled,
math_valid is with math)

That's a 2X difference between math and handrolled, but still an order of
magnitude better than numpy.

There's probably still gains to be made here by using `round` since we only emit
or receive gcodes up to a specific rounding (or, maybe we shouldn't do that) but
this is a solid start: for a protocol that uses 9 tipracks worth of tips to
pick up tip, aspirate, dispense in another well, and drop the tip in the trash
you get these kinds of time differences:

```
math.isclose:

real	0m24.940s
user	1m26.103s
sys	0m11.654s

numpy.isclose:

real	0m27.530s
user	1m35.323s
sys	0m12.854s

Apiv2 math.isclose:

real	0m9.252s
user	0m29.776s
sys	0m5.756s

APIv2 numpy.isclose:

real	0m9.601s
user	0m30.714s
sys	0m5.977s
```

Closes #4482
