### PR TITLE
refactor(api): clean up command publisher

### DIFF
--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -312,7 +312,7 @@ def return_tip():
 
 def pick_up_tip(instrument, location):
     location_text = stringify_location(location)
-    text = 'Picking up tip {location}'.format(location=location_text)
+    text = 'Picking up tip from {location}'.format(location=location_text)
     return make_command(
         name=command_types.PICK_UP_TIP,
         payload={
@@ -325,7 +325,7 @@ def pick_up_tip(instrument, location):
 
 def drop_tip(instrument, location):
     location_text = stringify_location(location)
-    text = 'Dropping tip {location}'.format(location=location_text)
+    text = 'Dropping tip into {location}'.format(location=location_text)
     return make_command(
         name=command_types.DROP_TIP,
         payload={
@@ -394,7 +394,7 @@ def thermocycler_set_block_temp(temperature,
                                 hold_time_seconds,
                                 hold_time_minutes):
     temp = round(float(temperature), utils.TC_GCODE_ROUNDING_PRECISION)
-    text = f'Setting Thermocycler well block temperature to {temp} °C '
+    text = f'Setting Thermocycler well block temperature to {temp} °C'
     total_seconds = None
     # TODO: BC 2019-09-05 this time resolving logic is partially duplicated
     # in the thermocycler api class definition, with this command logger
@@ -499,7 +499,7 @@ def thermocycler_close():
 
 
 def delay(seconds, minutes, msg=None):
-    text = f"Delaying for {minutes}m {seconds}s"
+    text = f"Delaying for {minutes} minutes and {seconds} seconds"
     if msg:
         text = f"{text}. {msg}"
     return make_command(

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -450,8 +450,8 @@ def thermocycler_wait_for_temp():
 
 
 def thermocycler_set_lid_temperature(temperature):
-    temperature = round(float(temperature), utils.TC_GCODE_ROUNDING_PRECISION)
-    text = f'Setting Thermocycler lid temperature to {temperature} °C '
+    temp = round(float(temperature), utils.TC_GCODE_ROUNDING_PRECISION)
+    text = f'Setting Thermocycler lid temperature to {temp} °C'
     return make_command(
         name=command_types.THERMOCYCLER_SET_LID_TEMP,
         payload={'text': text}

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -120,7 +120,7 @@ def home(mount):
 def aspirate(instrument, volume, location, rate):
     location_text = stringify_location(location)
     text = 'Aspirating {volume} uL from {location} at {rate} speed'.format(
-        volume=volume, location=location_text, rate=rate
+        volume=float(volume), location=location_text, rate=rate
     )
     return make_command(
         name=command_types.ASPIRATE,
@@ -136,8 +136,8 @@ def aspirate(instrument, volume, location, rate):
 
 def dispense(instrument, volume, location, rate):
     location_text = stringify_location(location)
-    text = 'Dispensing {volume} uL into {location}'.format(
-        volume=volume, location=location_text)
+    text = 'Dispensing {volume} uL into {location} at {rate} speed'.format(
+        volume=float(volume), location=location_text, rate=rate)
 
     return make_command(
         name=command_types.DISPENSE,
@@ -153,7 +153,7 @@ def dispense(instrument, volume, location, rate):
 
 def consolidate(instrument, volume, source, dest):
     text = 'Consolidating {volume} from {source} to {dest}'.format(
-        volume=volume,
+        volume=transform_volumes(volume),
         source=stringify_location(source),
         dest=stringify_location(dest)
     )
@@ -179,7 +179,7 @@ def consolidate(instrument, volume, source, dest):
 
 def distribute(instrument, volume, source, dest):
     text = 'Distributing {volume} from {source} to {dest}'.format(
-        volume=volume,
+        volume=transform_volumes(volume),
         source=stringify_location(source),
         dest=stringify_location(dest)
     )
@@ -205,7 +205,7 @@ def distribute(instrument, volume, source, dest):
 
 def transfer(instrument, volume, source, dest):
     text = 'Transferring {volume} from {source} to {dest}'.format(
-        volume=volume,
+        volume=transform_volumes(volume),
         source=stringify_location(source),
         dest=stringify_location(dest)
     )
@@ -239,9 +239,16 @@ def comment(msg):
     )
 
 
+def transform_volumes(volumes):
+    if not isinstance(volumes, list):
+        return float(volumes)
+    else:
+        return [float(vol) for vol in volumes]
+
+
 def mix(instrument, repetitions, volume, location):
-    text = 'Mixing {repetitions} times with a volume of {volume}ul'.format(
-        repetitions=repetitions, volume=volume
+    text = 'Mixing {repetitions} times with a volume of {volume} ul'.format(
+        repetitions=repetitions, volume=float(volume)
     )
     return make_command(
         name=command_types.MIX,
@@ -330,7 +337,7 @@ def drop_tip(instrument, location):
 
 
 def magdeck_engage():
-    text = "Engaging magnetic deck module"
+    text = "Engaging Magnetic Module"
     return make_command(
         name=command_types.MAGDECK_ENGAGE,
         payload={'text': text}
@@ -338,7 +345,7 @@ def magdeck_engage():
 
 
 def magdeck_disengage():
-    text = "Disengaging magnetic deck module"
+    text = "Disengaging Magnetic Module"
     return make_command(
         name=command_types.MAGDECK_DISENGAGE,
         payload={'text': text}
@@ -346,7 +353,7 @@ def magdeck_disengage():
 
 
 def magdeck_calibrate():
-    text = "Calibrating magnetic deck module"
+    text = "Calibrating Magnetic Module"
     return make_command(
         name=command_types.MAGDECK_CALIBRATE,
         payload={'text': text}
@@ -354,7 +361,7 @@ def magdeck_calibrate():
 
 
 def tempdeck_set_temp(celsius):
-    text = "Setting temperature deck module temperature " \
+    text = "Setting Temperature Module temperature " \
            "to {temp} °C (rounded off to nearest integer)".format(
             temp=round(float(celsius),
                        utils.TEMPDECK_GCODE_ROUNDING_PRECISION))
@@ -368,7 +375,7 @@ def tempdeck_set_temp(celsius):
 
 
 def tempdeck_deactivate():
-    text = "Deactivating temperature deck module"
+    text = "Deactivating Temperature Module"
     return make_command(
         name=command_types.TEMPDECK_DEACTIVATE,
         payload={'text': text}
@@ -386,7 +393,8 @@ def thermocycler_open():
 def thermocycler_set_block_temp(temperature,
                                 hold_time_seconds,
                                 hold_time_minutes):
-    text = f'Setting Thermocycler well block temperature to {temperature} °C '
+    temp = round(float(temperature), utils.TC_GCODE_ROUNDING_PRECISION)
+    text = f'Setting Thermocycler well block temperature to {temp} °C '
     total_seconds = None
     # TODO: BC 2019-09-05 this time resolving logic is partially duplicated
     # in the thermocycler api class definition, with this command logger
@@ -442,6 +450,7 @@ def thermocycler_wait_for_temp():
 
 
 def thermocycler_set_lid_temperature(temperature):
+    temperature = round(float(temperature), utils.TC_GCODE_ROUNDING_PRECISION)
     text = f'Setting Thermocycler lid temperature to {temperature} °C '
     return make_command(
         name=command_types.THERMOCYCLER_SET_LID_TEMP,

--- a/api/tests/opentrons/labware/test_pipette_unittest.py
+++ b/api/tests/opentrons/labware/test_pipette_unittest.py
@@ -65,7 +65,7 @@ def test_aspirate_zero_volume(local_test_pipette, robot):
     assert robot.commands() == []
     p200.tip_attached = True
     p200.aspirate(0)
-    assert robot.commands() == ['Aspirating 0 uL from ? at 1.0 speed']  # noqa
+    assert robot.commands() == ['Aspirating 0.0 uL from ? at 1.0 speed']  # noqa
 
 
 @pytest.mark.api1_only

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -13,10 +13,10 @@ def test_simulate_function_apiv2(protocol,
         protocol.filelike, 'testosaur_v2.py')
     assert isinstance(bundle, protocols.types.BundleContents)
     assert [item['payload']['text'] for item in runlog] == [
-        'Picking up tip A1 of Opentrons 96 Tip Rack 300 µL on 1',
+        'Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1',
         'Aspirating 10.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 1.0 speed',  # noqa(E501),
         'Dispensing 10.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 1.0 speed',  # noqa(E501),
-        'Dropping tip H12 of Opentrons 96 Tip Rack 300 µL on 1'
+        'Dropping tip into H12 of Opentrons 96 Tip Rack 300 µL on 1'
         ]
 
 
@@ -26,13 +26,13 @@ def test_simulate_function_json_apiv2(get_json_protocol_fixture):
     runlog, bundle = simulate.simulate(filelike, 'simple.json')
     assert bundle is None
     assert [item['payload']['text'] for item in runlog] == [
-        'Picking up tip B1 of Opentrons 96 Tip Rack 10 µL on 1',
+        'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 1',
         'Aspirating 5.0 uL from A1 of Source Plate on 2 at 1.0 speed',
-        'Delaying for 0m 42s',
+        'Delaying for 0 minutes and 42 seconds',
         'Dispensing 4.5 uL into B1 of Dest Plate on 3 at 1.0 speed',
         'Touching tip',
         'Blowing out at B1 of Dest Plate on 3',
-        'Dropping tip A1 of Trash on 12'
+        'Dropping tip into A1 of Trash on 12'
     ]
 
 
@@ -43,20 +43,20 @@ def test_simulate_function_bundle_apiv2(get_bundle_fixture):
     assert bundle is None
     assert [item['payload']['text'] for item in runlog] == [
         'Transferring 1.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
-        'Picking up tip A1 of Opentrons 96 Tip Rack 10 µL on 3',
+        'Picking up tip from A1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 1.0 uL from A1 of FAKE example labware on 1 at 1.0 speed',
         'Dispensing 1.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
-        'Dropping tip A1 of Opentrons Fixed Trash on 12',
+        'Dropping tip into A1 of Opentrons Fixed Trash on 12',
         'Transferring 2.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
-        'Picking up tip B1 of Opentrons 96 Tip Rack 10 µL on 3',
+        'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 2.0 uL from A1 of FAKE example labware on 1 at 1.0 speed',
         'Dispensing 2.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
-        'Dropping tip A1 of Opentrons Fixed Trash on 12',
+        'Dropping tip into A1 of Opentrons Fixed Trash on 12',
         'Transferring 3.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
-        'Picking up tip C1 of Opentrons 96 Tip Rack 10 µL on 3',
+        'Picking up tip from C1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 3.0 uL from A1 of FAKE example labware on 1 at 1.0 speed',
         'Dispensing 3.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
-        'Dropping tip A1 of Opentrons Fixed Trash on 12'
+        'Dropping tip into A1 of Opentrons Fixed Trash on 12'
         ]
 
 
@@ -84,10 +84,10 @@ def test_simulate_function_v1(protocol, protocol_file):
     runlog, bundle = simulate.simulate(protocol.filelike, 'testosaur.py')
     assert bundle is None
     assert [item['payload']['text'] for item in runlog] == [
-        'Picking up tip well A1 in "5"',
+        'Picking up tip from well A1 in "5"',
         'Aspirating 10.0 uL from well A1 in "8" at 1.0 speed',
         'Dispensing 10.0 uL into well H12 in "8" at 1.0 speed',
         'Aspirating 10.0 uL from well A1 in "11" at 1.0 speed',
         'Dispensing 10.0 uL into well H12 in "11" at 1.0 speed',
-        'Dropping tip well A1 in "12"'
+        'Dropping tip into well A1 in "12"'
     ]

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -14,8 +14,8 @@ def test_simulate_function_apiv2(protocol,
     assert isinstance(bundle, protocols.types.BundleContents)
     assert [item['payload']['text'] for item in runlog] == [
         'Picking up tip A1 of Opentrons 96 Tip Rack 300 µL on 1',
-        'Aspirating 10 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 1.0 speed',  # noqa(E501),
-        'Dispensing 10 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2',
+        'Aspirating 10.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 1.0 speed',  # noqa(E501),
+        'Dispensing 10.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 1.0 speed',  # noqa(E501),
         'Dropping tip H12 of Opentrons 96 Tip Rack 300 µL on 1'
         ]
 
@@ -27,9 +27,9 @@ def test_simulate_function_json_apiv2(get_json_protocol_fixture):
     assert bundle is None
     assert [item['payload']['text'] for item in runlog] == [
         'Picking up tip B1 of Opentrons 96 Tip Rack 10 µL on 1',
-        'Aspirating 5 uL from A1 of Source Plate on 2 at 1.0 speed',
+        'Aspirating 5.0 uL from A1 of Source Plate on 2 at 1.0 speed',
         'Delaying for 0m 42s',
-        'Dispensing 4.5 uL into B1 of Dest Plate on 3',
+        'Dispensing 4.5 uL into B1 of Dest Plate on 3 at 1.0 speed',
         'Touching tip',
         'Blowing out at B1 of Dest Plate on 3',
         'Dropping tip A1 of Trash on 12'
@@ -45,17 +45,17 @@ def test_simulate_function_bundle_apiv2(get_bundle_fixture):
         'Transferring 1.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip A1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 1.0 uL from A1 of FAKE example labware on 1 at 1.0 speed',
-        'Dispensing 1.0 uL into A4 of FAKE example labware on 1',
+        'Dispensing 1.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
         'Dropping tip A1 of Opentrons Fixed Trash on 12',
         'Transferring 2.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip B1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 2.0 uL from A1 of FAKE example labware on 1 at 1.0 speed',
-        'Dispensing 2.0 uL into A4 of FAKE example labware on 1',
+        'Dispensing 2.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
         'Dropping tip A1 of Opentrons Fixed Trash on 12',
         'Transferring 3.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip C1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 3.0 uL from A1 of FAKE example labware on 1 at 1.0 speed',
-        'Dispensing 3.0 uL into A4 of FAKE example labware on 1',
+        'Dispensing 3.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
         'Dropping tip A1 of Opentrons Fixed Trash on 12'
         ]
 
@@ -66,13 +66,13 @@ def test_simulate_function_apiv1(protocol, protocol_file):
     assert bundle is None
     assert runlog[0]['payload']['text'].startswith('Picking up tip')
     assert 'A1' in runlog[0]['payload']['text']
-    assert runlog[1]['payload']['text'].startswith('Aspirating 10 uL')
+    assert runlog[1]['payload']['text'].startswith('Aspirating 10.0 uL')
     assert 'A1' in runlog[1]['payload']['text']
-    assert runlog[2]['payload']['text'].startswith('Dispensing 10 uL')
+    assert runlog[2]['payload']['text'].startswith('Dispensing 10.0 uL')
     assert 'H12' in runlog[2]['payload']['text']
-    assert runlog[3]['payload']['text'].startswith('Aspirating 10 uL')
+    assert runlog[3]['payload']['text'].startswith('Aspirating 10.0 uL')
     assert 'A1' in runlog[3]['payload']['text']
-    assert runlog[4]['payload']['text'].startswith('Dispensing 10 uL')
+    assert runlog[4]['payload']['text'].startswith('Dispensing 10.0 uL')
     assert 'H12' in runlog[4]['payload']['text']
     assert runlog[5]['payload']['text'].startswith('Dropping tip')
     assert 'A1' in runlog[5]['payload']['text']
@@ -85,9 +85,9 @@ def test_simulate_function_v1(protocol, protocol_file):
     assert bundle is None
     assert [item['payload']['text'] for item in runlog] == [
         'Picking up tip well A1 in "5"',
-        'Aspirating 10 uL from well A1 in "8" at 1.0 speed',
-        'Dispensing 10 uL into well H12 in "8"',
-        'Aspirating 10 uL from well A1 in "11" at 1.0 speed',
-        'Dispensing 10 uL into well H12 in "11"',
+        'Aspirating 10.0 uL from well A1 in "8" at 1.0 speed',
+        'Dispensing 10.0 uL into well H12 in "8" at 1.0 speed',
+        'Aspirating 10.0 uL from well A1 in "11" at 1.0 speed',
+        'Dispensing 10.0 uL into well H12 in "11" at 1.0 speed',
         'Dropping tip well A1 in "12"'
     ]


### PR DESCRIPTION
## overview

This PR fixes some inconsistency in the command publisher.

For a quick example:

```
Picking up tip A1 of Opentrons 96 Tip Rack 10 µL on 1
Aspirating 1 uL from A2 of Opentrons 24 Tube Rack with NEST 1.5 mL Snapcap on 6 at 1.0 speed
Dispensing 1.0 uL into A1 of NEST 96 Well Plate 100 µL PCR Full Skirt on Thermocycler Module on 7
Blowing out at A1 of NEST 96 Well Plate 100 µL PCR Full Skirt on Thermocycler Module on 7
Dropping tip A1 of Opentrons Fixed Trash on 12
```

- volume can be both an `int` and a `float`
- the aspirate speed is stated but not the dispense speed

## changelog
- update the volume type for all liquid handling commands
- publish dispense speed
- rename `magnetic deck module` to `Magnetic Module`
- rename `temperature deck module` to `Temperature Module`
- round all Thermocycler temperature to the `TC_GCODE_ROUNDING_PRECISION`
- update the appropriate tests
