### PR TITLE
refactor(app): add warning if robot doesn't support custom labware

### DIFF
--- a/app/src/components/UploadPanel/UploadMenu.js
+++ b/app/src/components/UploadPanel/UploadMenu.js
@@ -1,16 +1,18 @@
+// @flow
 import * as React from 'react'
 import { ListItem, Icon } from '@opentrons/components'
 import styles from './upload-panel.css'
+
 export default function UploadMenu() {
   return (
     <ol className={styles.menu_list}>
       <ListItem
+        url="/upload/file-info"
         className={styles.menu_item}
-        url={'/upload/file-info'}
         activeClassName={styles.active}
       >
         <span>File Overview</span>
-        <Icon name={'chevron-right'} className={styles.menu_icon} />
+        <Icon name="chevron-right" className={styles.menu_icon} />
       </ListItem>
     </ol>
   )

--- a/app/src/pages/Upload/FileInfo.js
+++ b/app/src/pages/Upload/FileInfo.js
@@ -1,19 +1,31 @@
 // @flow
 import * as React from 'react'
 
-import { SpinnerModal } from '@opentrons/components'
+import { Splash, SpinnerModal, AlertItem } from '@opentrons/components'
 import Page from '../../components/Page'
 import FileInfo from '../../components/FileInfo'
 
 import type { Robot } from '../../discovery/types'
 
+// TODO(mc, 2019-11-25): i18n
+const UPLOAD_AND_SIMULATE_PROTOCOL = 'Upload and Simulate Protocol'
+
+const SIMULATION_IN_PROGRESS = 'Simulation in Progress'
+
+const ROBOT_DOESNT_SUPPORT_CUSTOM_LABWARE =
+  "Robot doesn't support custom labware"
+
+const YOU_HAVE_CUSTOM_LABWARE_BUT_THIS_ROBOT_NEEDS_UPDATE =
+  'You have custom labware definitions saved to your app, but this robot needs to be updated before you can use these definitions with Python protocols'
+
 type Props = {|
   robot: Robot,
-  filename: string,
+  filename: ?string,
   uploadInProgress: boolean,
   uploadError: ?{ message: string },
   sessionLoaded: boolean,
   sessionHasSteps: boolean,
+  showCustomLabwareWarning: boolean,
 |}
 
 export default function FileInfoPage(props: Props) {
@@ -24,22 +36,33 @@ export default function FileInfoPage(props: Props) {
     uploadError,
     sessionLoaded,
     sessionHasSteps,
+    showCustomLabwareWarning,
   } = props
 
+  const titleBarProps = filename
+    ? { title: filename, subtitle: 'overview' }
+    : { title: UPLOAD_AND_SIMULATE_PROTOCOL }
+
+  const sessionLoadedSuccessfully = sessionLoaded && !uploadError
+
   return (
-    <Page
-      titleBarProps={{
-        title: filename,
-        subtitle: 'overview',
-      }}
-    >
-      <FileInfo
-        robot={robot}
-        sessionLoaded={sessionLoaded}
-        sessionHasSteps={sessionHasSteps}
-        uploadError={uploadError}
-      />
-      {uploadInProgress && <SpinnerModal message="Upload in Progress" />}
+    <Page titleBarProps={titleBarProps}>
+      {showCustomLabwareWarning && !sessionLoadedSuccessfully && (
+        <AlertItem type="warning" title={ROBOT_DOESNT_SUPPORT_CUSTOM_LABWARE}>
+          {YOU_HAVE_CUSTOM_LABWARE_BUT_THIS_ROBOT_NEEDS_UPDATE}
+        </AlertItem>
+      )}
+      {filename ? (
+        <FileInfo
+          robot={robot}
+          sessionLoaded={sessionLoaded}
+          sessionHasSteps={sessionHasSteps}
+          uploadError={uploadError}
+        />
+      ) : (
+        <Splash />
+      )}
+      {uploadInProgress && <SpinnerModal message={SIMULATION_IN_PROGRESS} />}
     </Page>
   )
 }

--- a/app/src/pages/Upload/index.js
+++ b/app/src/pages/Upload/index.js
@@ -7,9 +7,8 @@ import { withRouter, Route, Switch, Redirect } from 'react-router-dom'
 import { selectors as robotSelectors } from '../../robot'
 import { getProtocolFilename } from '../../protocol'
 import { getConnectedRobot } from '../../discovery'
+import { getCustomLabware } from '../../custom-labware'
 
-import { Splash } from '@opentrons/components'
-import Page from '../../components/Page'
 import FileInfo from './FileInfo'
 
 import type { ContextRouter } from 'react-router-dom'
@@ -25,6 +24,7 @@ type SP = {|
   uploadError: ?{ message: string },
   sessionLoaded: boolean,
   sessionHasSteps: boolean,
+  showCustomLabwareWarning: boolean,
 |}
 
 type Props = {| ...OP, ...SP, dispatch: Dispatch |}
@@ -41,6 +41,11 @@ function mapStateToProps(state: State): SP {
     uploadError: robotSelectors.getUploadError(state),
     sessionLoaded: robotSelectors.getSessionIsLoaded(state),
     sessionHasSteps: robotSelectors.getCommands(state).length > 0,
+    showCustomLabwareWarning:
+      getCustomLabware(state).length > 0 &&
+      !robotSelectors
+        .getSessionCapabilities(state)
+        .includes('create_with_extra_labware'),
   }
 }
 
@@ -52,19 +57,13 @@ function UploadPage(props: Props) {
     uploadError,
     sessionLoaded,
     sessionHasSteps,
+    showCustomLabwareWarning,
     match: { path },
   } = props
 
   const fileInfoPath = `${path}/file-info`
 
   if (!robot) return <Redirect to="/robots" />
-  if (!filename) {
-    return (
-      <Page>
-        <Splash />
-      </Page>
-    )
-  }
 
   return (
     <Switch>
@@ -79,6 +78,7 @@ function UploadPage(props: Props) {
             uploadError={uploadError}
             sessionLoaded={sessionLoaded}
             sessionHasSteps={sessionHasSteps}
+            showCustomLabwareWarning={showCustomLabwareWarning}
           />
         )}
       />

--- a/app/src/robot/reducer/session.js
+++ b/app/src/robot/reducer/session.js
@@ -112,7 +112,10 @@ export default function sessionReducer(
       return handleSessionUpdate(state, action)
 
     case 'protocol:UPLOAD':
-      return handleSessionInProgress(INITIAL_STATE)
+      return handleSessionInProgress({
+        ...INITIAL_STATE,
+        capabilities: state.capabilities,
+      })
 
     case 'robot:REFRESH_SESSION':
       return handleSessionInProgress(state)

--- a/app/src/robot/test/session-reducer.test.js
+++ b/app/src/robot/test/session-reducer.test.js
@@ -72,6 +72,7 @@ describe('robot reducer - session', () => {
     const initialState = reducer(undefined, {}).session
     const state = {
       session: {
+        capabilities: ['create'],
         sessionRequest: { inProgress: false, error: new Error('AH') },
         startTime: 40,
         runTime: 42,
@@ -84,6 +85,7 @@ describe('robot reducer - session', () => {
 
     expect(reducer(state, action).session).toEqual({
       ...initialState,
+      capabilities: ['create'],
       sessionRequest: { inProgress: true, error: null },
     })
   })


### PR DESCRIPTION
## overview

If the user has custom labware present in the app, and they navigate to the protocol upload page, a warning will display if the robot hasn't yet been updated to the version needed to support custom labware in Python protocols

## changelog

- refactor(app): add warning if robot doesn't support custom labware

## review requests

Ensure your app's "Custom Labware" feature flag is enabled

**Empty folder**
- [ ] Warning does not show

**Folder has labware, robot has support**
- [ ] Warning does not show

**Folder has labware, robot does not have support**
- [ ] Warning does shows if not protocol was uploaded
- [ ] Warning shows if protocol was uploaded and simulation errored
- [ ] Warning does not show if protocol simulates successfully