### PR TITLE
fix(shared-data): increase GEN2 pipette plunger & drop tip current

### DIFF
--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -3068,14 +3068,14 @@
       "plungerCurrent": {
         "value": 1.0,
         "min": 0.1,
-        "max": 0.5,
+        "max": 1.0,
         "units": "amps",
         "type": "float"
       },
       "dropTipCurrent": {
         "value": 1.25,
         "min": 0.1,
-        "max": 0.8,
+        "max": 1.25,
         "units": "amps",
         "type": "float"
       },
@@ -3236,14 +3236,14 @@
       "plungerCurrent": {
         "value": 1.0,
         "min": 0.1,
-        "max": 0.5,
+        "max": 1.0,
         "units": "amps",
         "type": "float"
       },
       "dropTipCurrent": {
         "value": 1.25,
         "min": 0.1,
-        "max": 0.8,
+        "max": 1.25,
         "units": "amps",
         "type": "float"
       },
@@ -4481,14 +4481,14 @@
       "plungerCurrent": {
         "value": 1.0,
         "min": 0.1,
-        "max": 0.5,
+        "max": 1.0,
         "units": "amps",
         "type": "float"
       },
       "dropTipCurrent": {
         "value": 1.25,
         "min": 0.1,
-        "max": 0.8,
+        "max": 1.25,
         "units": "amps",
         "type": "float"
       },
@@ -4651,14 +4651,14 @@
       "plungerCurrent": {
         "value": 1.0,
         "min": 0.1,
-        "max": 0.5,
+        "max": 1.0,
         "units": "amps",
         "type": "float"
       },
       "dropTipCurrent": {
         "value": 1.25,
         "min": 0.1,
-        "max": 0.8,
+        "max": 1.25,
         "units": "amps",
         "type": "float"
       },


### PR DESCRIPTION
## overview
Previously, the defaults of the plunger current and drop tip current of the following pipettes exceed their maxes. 
- `p300_single_v2.0`
- `p300_single_v2.1`
- `p1000_single_v2.0`
- `p1000_sinlge_v2.1`

This PR fixes them by setting the maxes to be the same as the defaults.
