### PR TITLE
feat(app): enable custom labware management in the app

### DIFF
--- a/app-shell/src/main.js
+++ b/app-shell/src/main.js
@@ -57,12 +57,8 @@ function startUp() {
     registerRobotLogs(dispatch, mainWindow),
     registerUpdate(dispatch),
     registerBuildrootUpdate(dispatch),
+    registerLabware(dispatch, mainWindow),
   ]
-
-  // TODO(mc, 2019-11-25): remove this feature flag and move handler into `actionHandlers`
-  if (config.devInternal?.customLabware) {
-    actionHandlers.push(registerLabware(dispatch, mainWindow))
-  }
 
   ipcMain.on('dispatch', (_, action) => {
     log.debug('Received action via IPC from renderer', { action })

--- a/app/src/components/MenuPanel/index.js
+++ b/app/src/components/MenuPanel/index.js
@@ -1,28 +1,23 @@
 // @flow
 import * as React from 'react'
-import { useSelector } from 'react-redux'
-
-import { getFeatureFlags } from '../../config/selectors'
 import { SidePanel, ListItem, Icon } from '@opentrons/components'
 
 import styles from './styles.css'
 
+// TODO(mc, 2019-12-03): i18n
+const MENU = 'Menu'
+const ITEMS = [
+  { label: 'App', url: '/menu/app' },
+  { label: 'Custom Labware', url: '/menu/custom-labware' },
+  { label: 'Resources', url: '/menu/resources' },
+]
+
 export default function MenuPanel() {
-  const featureFlags = useSelector(getFeatureFlags)
-
-  const items = [
-    { label: 'App', url: '/menu/app' },
-    featureFlags.customLabware
-      ? { label: 'Custom Labware', url: '/menu/custom-labware' }
-      : null,
-    { label: 'Resources', url: '/menu/resources' },
-  ].filter(Boolean)
-
   return (
-    <SidePanel title="Menu">
+    <SidePanel title={MENU}>
       <div className={styles.menu_panel}>
         <ol className={styles.menu_list}>
-          {items.map(item => (
+          {ITEMS.map(item => (
             <ListItem
               key={item.url}
               url={item.url}
@@ -30,7 +25,7 @@ export default function MenuPanel() {
               activeClassName={styles.active}
             >
               <span>{item.label}</span>
-              <Icon name={'chevron-right'} className={styles.menu_icon} />
+              <Icon name="chevron-right" className={styles.menu_icon} />
             </ListItem>
           ))}
         </ol>

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -13,7 +13,6 @@ export * from './selectors'
 
 export const DEV_INTERNAL_FLAGS: Array<DevInternalFlag> = [
   'allPipetteConfig',
-  'customLabware',
   'enableMultiGEN2',
 ]
 

--- a/app/src/config/types.js
+++ b/app/src/config/types.js
@@ -7,10 +7,7 @@ export type UpdateChannel = 'latest' | 'beta' | 'alpha'
 
 export type DiscoveryCandidates = string | Array<string>
 
-export type DevInternalFlag =
-  | 'allPipetteConfig'
-  | 'customLabware'
-  | 'enableMultiGEN2'
+export type DevInternalFlag = 'allPipetteConfig' | 'enableMultiGEN2'
 
 export type FeatureFlags = $Shape<{|
   [DevInternalFlag]: boolean | void,

--- a/app/src/pages/More/Resources.js
+++ b/app/src/pages/More/Resources.js
@@ -1,6 +1,8 @@
+// @flow
 import React from 'react'
 import Page from '../../components/Page'
 import Resources from '../../components/Resources'
+
 export default function ResourcesPage() {
   return (
     <Page titleBarProps={{ title: 'Resources' }}>

--- a/app/src/pages/More/index.js
+++ b/app/src/pages/More/index.js
@@ -1,10 +1,8 @@
 // @flow
 // more nav button routes
 import * as React from 'react'
-import { useSelector } from 'react-redux'
 import { Switch, Route, Redirect } from 'react-router-dom'
 
-import { getFeatureFlags } from '../../config/selectors'
 import AppSettings from './AppSettings'
 import CustomLabware from './CustomLabware'
 import Resources from './Resources'
@@ -12,7 +10,6 @@ import Resources from './Resources'
 import type { ContextRouter } from 'react-router-dom'
 
 export default function More(props: ContextRouter) {
-  const featureFlags = useSelector(getFeatureFlags)
   const { path } = props.match
   const appPath = `${path}/app`
 
@@ -20,9 +17,7 @@ export default function More(props: ContextRouter) {
     <Switch>
       <Redirect exact from={path} to={appPath} />
       <Route path={appPath} component={AppSettings} />
-      {featureFlags.customLabware && (
-        <Route path={`${path}/custom-labware`} component={CustomLabware} />
-      )}
+      <Route path={`${path}/custom-labware`} component={CustomLabware} />
       <Route path={`${path}/resources`} component={Resources} />
     </Switch>
   )


### PR DESCRIPTION
## overview

This PR removes the `customLabware` feature flag to enable the custom labware management feature by default

## changelog

- feat(app): enable custom labware management in the app

## review requests

0. Open your app's config file and remove the `devInternal.customLabware` setting if it exists
1. Open the app
2. Navigate to "More"

- [ ] "Custom Labware" link should appear in sidebar
- [ ] Clicking "Custom Labware" should take you to the custom labware page
- [ ] All actions on the custom labware page should work as expected (smoke test)
