### PR TITLE
fix(labware): "retire" eppendorf tiprack definitions

### DIFF
--- a/shared-data/js/getLabware.js
+++ b/shared-data/js/getLabware.js
@@ -17,6 +17,8 @@ assert(
 
 // labware definitions only used for back-compat with legacy v1 defs.
 // do not list in any "available labware" UI.
+// TODO(mc, 2019-12-3): how should this correspond to RETIRED_LABWARE?
+// see shared-data/js/helpers/index.js
 export const LABWAREV2_DO_NOT_LIST = [
   'opentrons_40_aluminumblock_eppendorf_24x2ml_safelock_snapcap_generic_16x0.2ml_pcr_strip',
   'opentrons_24_tuberack_eppendorf_2ml_safelock_snapcap_acrylic',

--- a/shared-data/js/getLabware.js
+++ b/shared-data/js/getLabware.js
@@ -25,6 +25,8 @@ export const LABWAREV2_DO_NOT_LIST = [
   'tipone_96_tiprack_200ul',
   'opentrons_1_trash_850ml_fixed',
   'opentrons_1_trash_1100ml_fixed',
+  'eppendorf_96_tiprack_1000ul_eptips',
+  'eppendorf_96_tiprack_10ul_eptips',
 ]
 
 export function getLabwareV1Def(labwareName: string): ?LabwareDefinition1 {

--- a/shared-data/js/helpers/index.js
+++ b/shared-data/js/helpers/index.js
@@ -17,6 +17,8 @@ export const getLabwareDefURI = (def: LabwareDefinition2): string =>
   `${def.namespace}/${def.parameters.loadName}/${def.version}`
 
 // Load names of "retired" labware
+// TODO(mc, 2019-12-3): how should this correspond to LABWAREV2_DO_NOT_LIST?
+// see shared-data/js/getLabware.js
 const RETIRED_LABWARE = [
   'geb_96_tiprack_10ul',
   'geb_96_tiprack_1000ul',
@@ -27,6 +29,8 @@ const RETIRED_LABWARE = [
   'opentrons_40_aluminumblock_eppendorf_24x2ml_safelock_snapcap_generic_16x0.2ml_pcr_strip',
   'opentrons_96_aluminumblock_biorad_wellplate_200ul',
   'tipone_96_tiprack_200ul',
+  'eppendorf_96_tiprack_1000ul_eptips',
+  'eppendorf_96_tiprack_10ul_eptips',
 ]
 
 export const getLabwareDisplayName = (labwareDef: LabwareDefinition2) => {


### PR DESCRIPTION
## overview

This PR marks the Eppendorf EPTips definitions as "Retired" in PD and removes them from the Labware Library. Closes #4518, see ticket for additional details and removal reasoning

## changelog

- fix(labware): "retire" eppendorf tiprack definitions

## review requests

- [ ] EPTips racks do not show up in Labware Library
    - <http://sandbox.labware.opentrons.com/labware_remove-eppendorf-tipracks>
- [ ] EPTips racks show up as "Retired" in PD tiprack selection
    - <http://sandbox.designer.opentrons.com/labware_remove-eppendorf-tipracks>