### PR TITLE
fix(api): Fix critical points and gantry config backup in http deck cal

### DIFF
--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -283,7 +283,7 @@ def test_pipette_max_deck_height(robot, instruments):
 
 @pytest.mark.api1_only
 def test_retract(robot, instruments):
-    # robot.reset()
+    robot.reset()
     plate = containers_load(robot, '96-flat', '1')
     p300 = instruments.P300_Single(mount='left')
     from opentrons.drivers.smoothie_drivers.driver_3_0 import HOMED_POSITION

--- a/api/tests/opentrons/robot/test_robot.py
+++ b/api/tests/opentrons/robot/test_robot.py
@@ -47,9 +47,9 @@ def test_configurable_mount_offsets(robot, instruments):
         robot.home()
         left_pos = pose_tracker.absolute(robot.poses, left)
         right_pos = pose_tracker.absolute(robot.poses, right)
-        assert left_pos[0] == right_pos[0] + x
-        assert left_pos[1] == right_pos[1] + y
-        assert left_pos[2] == right_pos[2] + z
+        assert left_pos[0] == (right_pos[0] + x)
+        assert left_pos[1] == (right_pos[1] + y)
+        assert left_pos[2] == (right_pos[2] + z)
 
     robot.config = robot.config._replace(
         instrument_offset={

--- a/api/tests/opentrons/server/test_calibration_endpoints.py
+++ b/api/tests/opentrons/server/test_calibration_endpoints.py
@@ -152,10 +152,8 @@ async def test_save_calibration_file(dc_session, monkeypatch):
     await endpoints.save_transform({})
 
     in_memory = hardware.config.gantry_calibration
-    assert len(persisted_data) == 2
+    assert len(persisted_data) == 1  # back up now happens at beginning of sess
     assert persisted_data[0][0].gantry_calibration == in_memory
-    assert persisted_data[1][0].gantry_calibration == in_memory
-    assert persisted_data[1][-1] is not None
 
     expected = [[1.0, 0.0, 0.0, 0.0],
                 [0.0, 1.0, 0.0, 0.3],


### PR DESCRIPTION
## overview

The http deck calibration would back up the most recent gantry calibration, rather than the one it had started with. While I was trying to figure this out, I also noticed that critical points were not being handled correctly for API v2 which resulted in a z difference for gen2 pipettes.

## changelog
- Backup the config at the beginning of a session
- Modify how we handle critical points for positioning.

## review requests
1. Run a deck calibration with a gen2 pipette, see that the Z value is reasonable
2. Run a deck calibration with a gen1 multi pipette and see that the config values are reasonable
3. Check the most recently backed up file to ensure that it is different from the current `deck_calibration.json`
