### PR TITLE
fix(api): prevent liquid handling without a tip

### DIFF
--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -990,6 +990,13 @@ class API(HardwareAPILike):
             raise top_types.PipetteNotAttachedError(
                 "No pipette attached to {} mount".format(mount.name))
 
+        if not this_pipette.has_tip:
+            raise NoTipAttachedError(
+                f'Aspirate commands not allowed if there is not tip attached '
+                f'to the pipette. Please make sure that a tip is attached on '
+                f'the {mount.name.lower()} pipette before using '
+                f'liquid-handling commands')
+
         if this_pipette.current_volume == 0\
            and not this_pipette.ready_to_aspirate:
             raise RuntimeError('Pipette not ready to aspirate')
@@ -1042,6 +1049,14 @@ class API(HardwareAPILike):
         if not this_pipette:
             raise top_types.PipetteNotAttachedError(
                 "No pipette attached to {} mount".format(mount.name))
+
+        if not this_pipette.has_tip:
+            raise NoTipAttachedError(
+                f'Dispense commands not allowed if there is not tip attached '
+                f'to the pipette. Please make sure that a tip is attached on '
+                f'the {mount.name} pipette before using liquid-handling '
+                f'commands')
+
         if volume is None:
             disp_vol = this_pipette.current_volume
             mod_log.debug("No dispense volume specified. Dispensing all "

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -992,10 +992,10 @@ class API(HardwareAPILike):
 
         if not this_pipette.has_tip:
             raise NoTipAttachedError(
-                f'Aspirate commands not allowed if there is not tip attached '
-                f'to the pipette. Please make sure that a tip is attached on '
-                f'the {mount.name.lower()} pipette before using '
-                f'liquid-handling commands')
+                f'Aspirate is not allowed if there is no tip attached to the '
+                f'pipette. Please make sure that a tip is attached on the'
+                f'{mount.name.lower()} pipette before using liquid-handling '
+                f'commands')
 
         if this_pipette.current_volume == 0\
            and not this_pipette.ready_to_aspirate:
@@ -1052,9 +1052,9 @@ class API(HardwareAPILike):
 
         if not this_pipette.has_tip:
             raise NoTipAttachedError(
-                f'Dispense commands not allowed if there is not tip attached '
-                f'to the pipette. Please make sure that a tip is attached on '
-                f'the {mount.name} pipette before using liquid-handling '
+                f'Dispense is not allowed if there is no tip attached to the '
+                f'pipette. Please make sure that a tip is attached on the '
+                f'{mount.name.lower()} pipette before using liquid-handling '
                 f'commands')
 
         if volume is None:

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -48,6 +48,10 @@ def _sleep(seconds):
     time.sleep(seconds)
 
 
+class NoTipAttachedError(RuntimeError):
+    pass
+
+
 class PipetteTip:
     def __init__(self, length):
         self.length = length
@@ -432,7 +436,11 @@ class Pipette(CommandPublisher):
         >>> p300.aspirate(plate[2]) # doctest: +SKIP
         """
         if not self.tip_attached:
-            log.warning("Cannot aspirate without a tip attached.")
+            raise NoTipAttachedError(
+                f'Aspirate commands not allowed if there is not tip attached '
+                f'to the pipette. Please make sure that a tip is attached on '
+                f'the {self.mount} pipette before using liquid-handling '
+                f'commands')
 
         # Note: volume positional argument may not be passed. if it isn't then
         # assume the first positional argument is the location
@@ -532,7 +540,11 @@ class Pipette(CommandPublisher):
         >>> p300.dispense(plate[2]) # doctest: +SKIP
         """
         if not self.tip_attached:
-            log.warning("Cannot dispense without a tip attached.")
+            raise NoTipAttachedError(
+                f'Dispense commands not allowed if there is not tip attached '
+                f'to the pipette. Please make sure that a tip is attached on '
+                f'the {self.mount} pipette before using liquid-handling '
+                f'commands')
 
         # Note: volume positional argument may not be passed. if it isn't then
         # assume the first positional argument is the location

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -229,14 +229,18 @@ async def test_prep_aspirate(dummy_instruments, loop):
         attached_instruments=dummy_instruments, loop=loop)
     await hw_api.home()
     await hw_api.cache_instruments()
+
+    mount = types.Mount.LEFT
+    await hw_api.pick_up_tip(mount, 20.0)
+
     # If we're empty and haven't prepared, we should get an error
     with pytest.raises(RuntimeError):
-        await hw_api.aspirate(types.Mount.LEFT, 1, 1.0)
+        await hw_api.aspirate(mount, 1, 1.0)
     # If we're empty and have prepared, we should be fine
-    await hw_api.prepare_for_aspirate(types.Mount.LEFT)
-    await hw_api.aspirate(types.Mount.LEFT, 1)
+    await hw_api.prepare_for_aspirate(mount)
+    await hw_api.aspirate(mount, 1)
     # If we're not empty, we should be fine
-    await hw_api.aspirate(types.Mount.LEFT, 1)
+    await hw_api.aspirate(mount, 1)
 
 
 async def test_aspirate_new(dummy_instruments, loop):
@@ -244,12 +248,16 @@ async def test_aspirate_new(dummy_instruments, loop):
         attached_instruments=dummy_instruments, loop=loop)
     await hw_api.home()
     await hw_api.cache_instruments()
+
+    mount = types.Mount.LEFT
+    await hw_api.pick_up_tip(mount, 20.0)
+
     aspirate_ul = 3.0
     aspirate_rate = 2
-    await hw_api.prepare_for_aspirate(types.Mount.LEFT)
-    await hw_api.aspirate(types.Mount.LEFT, aspirate_ul, aspirate_rate)
+    await hw_api.prepare_for_aspirate(mount)
+    await hw_api.aspirate(mount, aspirate_ul, aspirate_rate)
     new_plunger_pos = 6.05285
-    pos = await hw_api.current_position(types.Mount.LEFT)
+    pos = await hw_api.current_position(mount)
     assert pos[Axis.B] == new_plunger_pos
 
 
@@ -258,12 +266,16 @@ async def test_aspirate_old(dummy_instruments, loop, old_aspiration):
         attached_instruments=dummy_instruments, loop=loop)
     await hw_api.home()
     await hw_api.cache_instruments()
+
+    mount = types.Mount.LEFT
+    await hw_api.pick_up_tip(mount, 20.0)
+
     aspirate_ul = 3.0
     aspirate_rate = 2
-    await hw_api.prepare_for_aspirate(types.Mount.LEFT)
-    await hw_api.aspirate(types.Mount.LEFT, aspirate_ul, aspirate_rate)
+    await hw_api.prepare_for_aspirate(mount)
+    await hw_api.aspirate(mount, aspirate_ul, aspirate_rate)
     new_plunger_pos = 5.660769
-    pos = await hw_api.current_position(types.Mount.LEFT)
+    pos = await hw_api.current_position(mount)
     assert pos[Axis.B] == new_plunger_pos
 
 
@@ -273,20 +285,24 @@ async def test_dispense(dummy_instruments, loop):
     await hw_api.home()
 
     await hw_api.cache_instruments()
+
+    mount = types.Mount.LEFT
+    await hw_api.pick_up_tip(mount, 20.0)
+
     aspirate_ul = 10.0
     aspirate_rate = 2
-    await hw_api.prepare_for_aspirate(types.Mount.LEFT)
-    await hw_api.aspirate(types.Mount.LEFT, aspirate_ul, aspirate_rate)
+    await hw_api.prepare_for_aspirate(mount)
+    await hw_api.aspirate(mount, aspirate_ul, aspirate_rate)
 
     dispense_1 = 3.0
-    await hw_api.dispense(types.Mount.LEFT, dispense_1)
+    await hw_api.dispense(mount, dispense_1)
     plunger_pos_1 = 10.810573
-    assert (await hw_api.current_position(types.Mount.LEFT))[Axis.B]\
+    assert (await hw_api.current_position(mount))[Axis.B]\
         == plunger_pos_1
 
-    await hw_api.dispense(types.Mount.LEFT, rate=2)
+    await hw_api.dispense(mount, rate=2)
     plunger_pos_2 = 2
-    assert (await hw_api.current_position(types.Mount.LEFT))[Axis.B]\
+    assert (await hw_api.current_position(mount))[Axis.B]\
         == plunger_pos_2
 
 
@@ -332,6 +348,9 @@ async def test_aspirate_flow_rate(dummy_instruments, loop, monkeypatch):
     mount = types.Mount.LEFT
     await hw_api.home()
     await hw_api.cache_instruments()
+
+    await hw_api.pick_up_tip(mount, 20.0)
+
     mock_move_plunger = mock.Mock()
 
     def instant_future(mount, distance, speed):
@@ -401,6 +420,9 @@ async def test_dispense_flow_rate(dummy_instruments, loop, monkeypatch):
     mount = types.Mount.LEFT
     await hw_api.home()
     await hw_api.cache_instruments()
+
+    await hw_api.pick_up_tip(mount, 20.0)
+
     await hw_api.prepare_for_aspirate(types.Mount.LEFT)
     await hw_api.aspirate(mount, 10)
     mock_move_plunger = mock.Mock()
@@ -466,6 +488,8 @@ async def test_blowout_flow_rate(dummy_instruments, loop, monkeypatch):
     mount = types.Mount.LEFT
     await hw_api.home()
     await hw_api.cache_instruments()
+
+    await hw_api.pick_up_tip(mount, 20.0)
 
     mock_move_plunger = mock.Mock()
 


### PR DESCRIPTION
## overview

Prevent liquid handling actions (aspirate/dispense) if the pipette does not have a tip. Fixes #4219 

## review requests

Example protocol (the basic protocol from the v2 docs) with the pick_up_tip call commented out:

```
from opentrons import protocol_api

# metadata
metadata = {
    'protocolName': 'My Protocol',
    'author': 'Name <email@address.com>',
    'description': 'Simple protocol to get started using OT2',
    'apiLevel': '2.0'
}

# protocol run function. the part after the colon lets your editor know
# where to look for autocomplete suggestions
def run(protocol: protocol_api.ProtocolContext):

    # labware
    plate = protocol.load_labware('corning_96_wellplate_360ul_flat', '2')
    tiprack = protocol.load_labware('opentrons_96_tiprack_300ul', '1')

    # pipettes
    left_pipette = protocol.load_instrument(
         'p300_single', 'left', tip_racks=[tiprack])

    # commands
    # left_pipette.pick_up_tip()
    left_pipette.aspirate(100, plate['A1'])
    left_pipette.dispense(100, plate['B2'])
    left_pipette.drop_tip()
```