### PR TITLE
fix(rpc): ensure load name is attached to RPC "containers"

### DIFF
--- a/api/src/opentrons/api/models.py
+++ b/api/src/opentrons/api/models.py
@@ -32,12 +32,15 @@ class Container:
             self.is_legacy = container.properties.get(
                 'labware_hash') is None
         else:
+            # will be labware's load name or label
             self.name = container.name
-            self.type = container.name
+            # type must be load_name so client can load correct definition
+            self.type = container.load_name
             slot, position = _get_parent_slot_and_position(container)
             self.slot = slot
             self.position = position
             self.is_legacy = False
+            self.is_tiprack = container.is_tiprack
         self.instruments = [
             Instrument(instrument)
             for instrument in instruments]

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -378,6 +378,12 @@ class Labware(DeckItem):
 
     @property  # type: ignore
     @requires_version(2, 0)
+    def load_name(self) -> str:
+        """ The API load name of the labware definition """
+        return self._parameters['loadName']
+
+    @property  # type: ignore
+    @requires_version(2, 0)
     def parameters(self) -> Dict[str, Any]:
         """Internal properties of a labware including type and quirks"""
         return self._parameters

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -23,7 +23,7 @@ import { getCustomLabwareDefinitions } from '../../custom-labware/selectors'
 const RUN_TIME_TICK_INTERVAL_MS = 1000
 const NO_INTERVAL = -1
 const RE_VOLUME = /.*?(\d+).*?/
-const RE_TIPRACK = /tiprack/i
+const RE_TIPRACK = /tip ?rack/i
 
 const THIS_ROBOT_DOES_NOT_SUPPORT_BUNDLES =
   'This robot does not support ZIP protocol bundles. Please update its software to the latest version and upload this protocol again'
@@ -573,7 +573,11 @@ export default function client(dispatch) {
         position,
         is_legacy: isLegacy,
       } = apiContainer
-      const isTiprack = RE_TIPRACK.test(type)
+      const isTiprack =
+        apiContainer.is_tiprack != null
+          ? apiContainer.is_tiprack
+          : RE_TIPRACK.test(type)
+
       const labware = { _id, name, slot, position, type, isTiprack, isLegacy }
 
       if (isTiprack && apiContainer.instruments.length > 0) {


### PR DESCRIPTION
## overview

Prior to this PR,

- The app determined that a given RPC labware is a tiprack by running a regex for `/tiprack/i` against the `type` field of the RPC `Container`
- `Container.type` was set to the `name` of the v2 `Labware` class
- `Labware.name` was always set to the load name of the labware

#4452 introduced a change that set `Labware.name` to the passed-in `label` parameter of the labware if it was used. This broke tiprack detection in the client anytime label was set to a string that didn't contain the exact case-insensitive string "tiprack".

The Protocol Designer always passes in the display name of the labware as label by default, which means tiprack detection was automatically broken for all PD protocols.

This PR adds a new getter method to `Labware` for `load_name`, which is now used to set `Container.type`. Additionally, it adds a `Container.is_tiprack` property, which the RPC client will use in favor of the regex if available. Finally, it changes the regex (now only used as a back-compat backup) to `/tip ?rack/i` to match on our tiprack display names as well as load names.

## changelog

- fix(rpc): ensure load name is attached to RPC "containers"

## review requests

Exhaustive QA sheet. This is a pretty small PR codewise, so I'd be ok giving this PR some smoke tests and then using the list below to invalidate the necessary entries in the 3.15 master QA

- [ ] JSON protocol has its tipracks recognized on 3.15 robot
- [ ] JSON protocol has its tipracks recognized on 3.14 robot
- [ ] PAPIv2 protocol has its tipracks recognized on 3.15 robot
- [ ] PAPIv2 protocol has its tipracks recognized on 3.14 robot
- [ ] PAPIv1 protocol using Labware v2 has its tipracks recognized on 3.15 robot
- [ ] PAPIv1 protocol has using Labware v2 has its tipracks recognized on 3.14 robot
- [ ] PAPIv1 protocol using Labware v1 has its tipracks recognized on 3.15 robot
- [ ] PAPIv1 protocol has using Labware v1 has its tipracks recognized on 3.14 robot