### PR TITLE
feat(shared-data): add 20uL filter tiprack

### DIFF
--- a/labware-library/src/components/labware-ui/labware-images.js
+++ b/labware-library/src/components/labware-ui/labware-images.js
@@ -179,6 +179,9 @@ export default {
   opentrons_96_filtertiprack_10ul: [
     require('../../images/opentrons_96_tiprack_10ul_side_view.jpg'),
   ],
+  opentrons_96_filtertiprack_20ul: [
+    require('../../images/opentrons_96_tiprack_10ul_side_view.jpg'),
+  ],
   opentrons_96_filtertiprack_200ul: [
     require('../../images/opentrons_96_tiprack_300ul_side_view.jpg'),
   ],

--- a/shared-data/labware/definitions/2/opentrons_96_filtertiprack_20ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_filtertiprack_20ul/1.json
@@ -34,7 +34,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 14.36,
       "y": 74.26,
       "z": 25.49
@@ -43,7 +43,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 14.36,
       "y": 65.26,
       "z": 25.49
@@ -52,7 +52,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 14.36,
       "y": 56.26,
       "z": 25.49
@@ -61,7 +61,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 14.36,
       "y": 47.26,
       "z": 25.49
@@ -70,7 +70,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 14.36,
       "y": 38.26,
       "z": 25.49
@@ -79,7 +79,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 14.36,
       "y": 29.26,
       "z": 25.49
@@ -88,7 +88,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 14.36,
       "y": 20.26,
       "z": 25.49
@@ -97,7 +97,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 14.36,
       "y": 11.26,
       "z": 25.49
@@ -106,7 +106,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 23.36,
       "y": 74.26,
       "z": 25.49
@@ -115,7 +115,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 23.36,
       "y": 65.26,
       "z": 25.49
@@ -124,7 +124,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 23.36,
       "y": 56.26,
       "z": 25.49
@@ -133,7 +133,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 23.36,
       "y": 47.26,
       "z": 25.49
@@ -142,7 +142,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 23.36,
       "y": 38.26,
       "z": 25.49
@@ -151,7 +151,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 23.36,
       "y": 29.26,
       "z": 25.49
@@ -160,7 +160,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 23.36,
       "y": 20.26,
       "z": 25.49
@@ -169,7 +169,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 23.36,
       "y": 11.26,
       "z": 25.49
@@ -178,7 +178,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 32.36,
       "y": 74.26,
       "z": 25.49
@@ -187,7 +187,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 32.36,
       "y": 65.26,
       "z": 25.49
@@ -196,7 +196,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 32.36,
       "y": 56.26,
       "z": 25.49
@@ -205,7 +205,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 32.36,
       "y": 47.26,
       "z": 25.49
@@ -214,7 +214,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 32.36,
       "y": 38.26,
       "z": 25.49
@@ -223,7 +223,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 32.36,
       "y": 29.26,
       "z": 25.49
@@ -232,7 +232,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 32.36,
       "y": 20.26,
       "z": 25.49
@@ -241,7 +241,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 32.36,
       "y": 11.26,
       "z": 25.49
@@ -250,7 +250,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 41.36,
       "y": 74.26,
       "z": 25.49
@@ -259,7 +259,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 41.36,
       "y": 65.26,
       "z": 25.49
@@ -268,7 +268,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 41.36,
       "y": 56.26,
       "z": 25.49
@@ -277,7 +277,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 41.36,
       "y": 47.26,
       "z": 25.49
@@ -286,7 +286,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 41.36,
       "y": 38.26,
       "z": 25.49
@@ -295,7 +295,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 41.36,
       "y": 29.26,
       "z": 25.49
@@ -304,7 +304,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 41.36,
       "y": 20.26,
       "z": 25.49
@@ -313,7 +313,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 41.36,
       "y": 11.26,
       "z": 25.49
@@ -322,7 +322,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 50.36,
       "y": 74.26,
       "z": 25.49
@@ -331,7 +331,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 50.36,
       "y": 65.26,
       "z": 25.49
@@ -340,7 +340,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 50.36,
       "y": 56.26,
       "z": 25.49
@@ -349,7 +349,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 50.36,
       "y": 47.26,
       "z": 25.49
@@ -358,7 +358,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 50.36,
       "y": 38.26,
       "z": 25.49
@@ -367,7 +367,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 50.36,
       "y": 29.26,
       "z": 25.49
@@ -376,7 +376,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 50.36,
       "y": 20.26,
       "z": 25.49
@@ -385,7 +385,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 50.36,
       "y": 11.26,
       "z": 25.49
@@ -394,7 +394,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 59.36,
       "y": 74.26,
       "z": 25.49
@@ -403,7 +403,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 59.36,
       "y": 65.26,
       "z": 25.49
@@ -412,7 +412,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 59.36,
       "y": 56.26,
       "z": 25.49
@@ -421,7 +421,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 59.36,
       "y": 47.26,
       "z": 25.49
@@ -430,7 +430,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 59.36,
       "y": 38.26,
       "z": 25.49
@@ -439,7 +439,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 59.36,
       "y": 29.26,
       "z": 25.49
@@ -448,7 +448,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 59.36,
       "y": 20.26,
       "z": 25.49
@@ -457,7 +457,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 59.36,
       "y": 11.26,
       "z": 25.49
@@ -466,7 +466,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 68.36,
       "y": 74.26,
       "z": 25.49
@@ -475,7 +475,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 68.36,
       "y": 65.26,
       "z": 25.49
@@ -484,7 +484,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 68.36,
       "y": 56.26,
       "z": 25.49
@@ -493,7 +493,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 68.36,
       "y": 47.26,
       "z": 25.49
@@ -502,7 +502,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 68.36,
       "y": 38.26,
       "z": 25.49
@@ -511,7 +511,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 68.36,
       "y": 29.26,
       "z": 25.49
@@ -520,7 +520,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 68.36,
       "y": 20.26,
       "z": 25.49
@@ -529,7 +529,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 68.36,
       "y": 11.26,
       "z": 25.49
@@ -538,7 +538,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 77.36,
       "y": 74.26,
       "z": 25.49
@@ -547,7 +547,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 77.36,
       "y": 65.26,
       "z": 25.49
@@ -556,7 +556,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 77.36,
       "y": 56.26,
       "z": 25.49
@@ -565,7 +565,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 77.36,
       "y": 47.26,
       "z": 25.49
@@ -574,7 +574,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 77.36,
       "y": 38.26,
       "z": 25.49
@@ -583,7 +583,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 77.36,
       "y": 29.26,
       "z": 25.49
@@ -592,7 +592,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 77.36,
       "y": 20.26,
       "z": 25.49
@@ -601,7 +601,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 77.36,
       "y": 11.26,
       "z": 25.49
@@ -610,7 +610,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 86.36,
       "y": 74.26,
       "z": 25.49
@@ -619,7 +619,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 86.36,
       "y": 65.26,
       "z": 25.49
@@ -628,7 +628,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 86.36,
       "y": 56.26,
       "z": 25.49
@@ -637,7 +637,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 86.36,
       "y": 47.26,
       "z": 25.49
@@ -646,7 +646,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 86.36,
       "y": 38.26,
       "z": 25.49
@@ -655,7 +655,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 86.36,
       "y": 29.26,
       "z": 25.49
@@ -664,7 +664,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 86.36,
       "y": 20.26,
       "z": 25.49
@@ -673,7 +673,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 86.36,
       "y": 11.26,
       "z": 25.49
@@ -682,7 +682,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 95.36,
       "y": 74.26,
       "z": 25.49
@@ -691,7 +691,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 95.36,
       "y": 65.26,
       "z": 25.49
@@ -700,7 +700,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 95.36,
       "y": 56.26,
       "z": 25.49
@@ -709,7 +709,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 95.36,
       "y": 47.26,
       "z": 25.49
@@ -718,7 +718,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 95.36,
       "y": 38.26,
       "z": 25.49
@@ -727,7 +727,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 95.36,
       "y": 29.26,
       "z": 25.49
@@ -736,7 +736,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 95.36,
       "y": 20.26,
       "z": 25.49
@@ -745,7 +745,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 95.36,
       "y": 11.26,
       "z": 25.49
@@ -754,7 +754,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 104.36,
       "y": 74.26,
       "z": 25.49
@@ -763,7 +763,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 104.36,
       "y": 65.26,
       "z": 25.49
@@ -772,7 +772,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 104.36,
       "y": 56.26,
       "z": 25.49
@@ -781,7 +781,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 104.36,
       "y": 47.26,
       "z": 25.49
@@ -790,7 +790,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 104.36,
       "y": 38.26,
       "z": 25.49
@@ -799,7 +799,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 104.36,
       "y": 29.26,
       "z": 25.49
@@ -808,7 +808,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 104.36,
       "y": 20.26,
       "z": 25.49
@@ -817,7 +817,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 104.36,
       "y": 11.26,
       "z": 25.49
@@ -826,7 +826,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 113.36,
       "y": 74.26,
       "z": 25.49
@@ -835,7 +835,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 113.36,
       "y": 65.26,
       "z": 25.49
@@ -844,7 +844,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 113.36,
       "y": 56.26,
       "z": 25.49
@@ -853,7 +853,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 113.36,
       "y": 47.26,
       "z": 25.49
@@ -862,7 +862,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 113.36,
       "y": 38.26,
       "z": 25.49
@@ -871,7 +871,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 113.36,
       "y": 29.26,
       "z": 25.49
@@ -880,7 +880,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 113.36,
       "y": 20.26,
       "z": 25.49
@@ -889,7 +889,7 @@
       "depth": 39.2,
       "shape": "circular",
       "diameter": 3.27,
-      "totalLiquidVolume": 10,
+      "totalLiquidVolume": 20,
       "x": 113.36,
       "y": 11.26,
       "z": 25.49

--- a/shared-data/labware/definitions/2/opentrons_96_filtertiprack_20ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_filtertiprack_20ul/1.json
@@ -1,0 +1,1017 @@
+{
+  "ordering": [
+    ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+    ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+    ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+    ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+    ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+    ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+    ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+    ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+    ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+    ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+    ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+    ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+  ],
+  "brand": {
+    "brand": "Opentrons",
+    "brandId": [],
+    "links": []
+  },
+  "metadata": {
+    "displayName": "Opentrons 96 Filter Tip Rack 20 µL",
+    "displayCategory": "tipRack",
+    "displayVolumeUnits": "µL",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.76,
+    "yDimension": 85.48,
+    "zDimension": 64.69
+  },
+  "wells": {
+    "A1": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 14.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B1": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 14.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C1": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 14.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D1": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 14.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E1": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 14.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F1": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 14.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G1": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 14.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H1": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 14.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A2": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 23.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B2": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 23.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C2": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 23.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D2": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 23.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E2": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 23.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F2": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 23.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G2": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 23.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H2": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 23.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A3": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 32.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B3": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 32.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C3": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 32.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D3": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 32.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E3": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 32.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F3": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 32.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G3": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 32.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H3": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 32.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A4": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 41.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B4": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 41.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C4": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 41.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D4": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 41.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E4": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 41.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F4": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 41.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G4": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 41.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H4": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 41.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A5": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 50.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B5": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 50.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C5": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 50.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D5": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 50.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E5": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 50.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F5": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 50.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G5": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 50.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H5": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 50.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A6": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 59.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B6": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 59.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C6": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 59.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D6": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 59.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E6": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 59.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F6": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 59.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G6": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 59.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H6": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 59.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A7": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 68.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B7": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 68.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C7": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 68.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D7": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 68.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E7": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 68.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F7": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 68.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G7": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 68.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H7": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 68.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A8": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 77.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B8": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 77.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C8": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 77.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D8": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 77.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E8": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 77.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F8": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 77.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G8": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 77.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H8": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 77.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A9": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 86.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B9": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 86.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C9": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 86.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D9": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 86.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E9": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 86.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F9": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 86.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G9": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 86.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H9": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 86.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A10": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 95.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B10": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 95.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C10": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 95.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D10": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 95.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E10": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 95.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F10": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 95.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G10": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 95.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H10": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 95.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A11": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 104.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B11": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 104.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C11": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 104.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D11": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 104.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E11": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 104.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F11": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 104.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G11": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 104.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H11": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 104.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A12": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 113.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B12": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 113.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C12": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 113.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D12": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 113.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E12": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 113.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F12": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 113.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G12": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 113.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H12": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 113.36,
+      "y": 11.26,
+      "z": 25.49
+    }
+  },
+  "groups": [
+    {
+      "metadata": {},
+      "wells": [
+        "A1",
+        "B1",
+        "C1",
+        "D1",
+        "E1",
+        "F1",
+        "G1",
+        "H1",
+        "A2",
+        "B2",
+        "C2",
+        "D2",
+        "E2",
+        "F2",
+        "G2",
+        "H2",
+        "A3",
+        "B3",
+        "C3",
+        "D3",
+        "E3",
+        "F3",
+        "G3",
+        "H3",
+        "A4",
+        "B4",
+        "C4",
+        "D4",
+        "E4",
+        "F4",
+        "G4",
+        "H4",
+        "A5",
+        "B5",
+        "C5",
+        "D5",
+        "E5",
+        "F5",
+        "G5",
+        "H5",
+        "A6",
+        "B6",
+        "C6",
+        "D6",
+        "E6",
+        "F6",
+        "G6",
+        "H6",
+        "A7",
+        "B7",
+        "C7",
+        "D7",
+        "E7",
+        "F7",
+        "G7",
+        "H7",
+        "A8",
+        "B8",
+        "C8",
+        "D8",
+        "E8",
+        "F8",
+        "G8",
+        "H8",
+        "A9",
+        "B9",
+        "C9",
+        "D9",
+        "E9",
+        "F9",
+        "G9",
+        "H9",
+        "A10",
+        "B10",
+        "C10",
+        "D10",
+        "E10",
+        "F10",
+        "G10",
+        "H10",
+        "A11",
+        "B11",
+        "C11",
+        "D11",
+        "E11",
+        "F11",
+        "G11",
+        "H11",
+        "A12",
+        "B12",
+        "C12",
+        "D12",
+        "E12",
+        "F12",
+        "G12",
+        "H12"
+      ]
+    }
+  ],
+  "parameters": {
+    "format": "96Standard",
+    "isTiprack": true,
+    "tipLength": 39.2,
+    "tipOverlap": 3.29,
+    "isMagneticModuleCompatible": false,
+    "loadName": "opentrons_96_filtertiprack_20ul"
+  },
+  "namespace": "opentrons",
+  "version": 1,
+  "schemaVersion": 2,
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  }
+}

--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -1134,6 +1134,7 @@
         "opentrons/opentrons_96_tiprack_10ul/1": 8.25,
         "opentrons/opentrons_96_filtertiprack_10ul/1": 8.25,
         "opentrons/opentrons_96_tiprack_20ul/1": 8.25,
+        "opentrons/opentrons_96_filtertiprack_20ul/1": 8.25,
         "opentrons/eppendorf_96_tiprack_10ul_eptips/1": 8.4,
         "opentrons/geb_96_tiprack_10ul/1": 8.3
       },
@@ -1472,6 +1473,7 @@
         "opentrons/opentrons_96_tiprack_10ul/1": 8.25,
         "opentrons/opentrons_96_filtertiprack_10ul/1": 8.25,
         "opentrons/opentrons_96_tiprack_20ul/1": 8.25,
+        "opentrons/opentrons_96_filtertiprack_20ul/1": 8.25,
         "opentrons/eppendorf_96_tiprack_10ul_eptips/1": 8.4,
         "opentrons/geb_96_tiprack_10ul/1": 8.3
       },


### PR DESCRIPTION
## overview
Closes #4524. This PR adds the Opentrons 20 µL filter tip rack definition to Labware Library. It has the same dimensions as the Opentrons 10 µL tip rack. 

## changelog
- add new definition in shared-data
- add image of the 10 uL tip rack to labware library
- update tip overlap values for P20 GEN2 in pipetteModelSpecs

## review requests
- [ ] Labware should be browseable with images in Labware Library: http://sandbox.labware.opentrons.com/sd_filter-tiprack-20ul 
  - [ ] Display Name: Opentrons 96 Filter Tip Rack 20ul
  - [ ] API Name: opentrons_96_filtertiprack_20ul
  - [ ] Labware definition should match manufacturer's technical diagram and the max volume of the tips should be 20ul 
- [ ] Labware should be browseable in Protocol Designer: http://sandbox.designer.opentrons.com/sd_filter-tiprack-20ul/
