### PR TITLE
refactor(app): ensure RPC API client uses correct restart action shape

### DIFF
--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -84,7 +84,7 @@ export default function client(dispatch) {
       // disconnect RPC prior to robot restart
       case ROBOT_RESTART_ACTION: {
         const connectedName = selectors.getConnectedRobotName(state)
-        const { name: restartingName } = action.payload.host
+        const { robotName: restartingName } = action.payload
         if (connectedName === restartingName) disconnect()
         break
       }

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -11,6 +11,7 @@ import { delay } from '../../util'
 import client from '../api-client/client'
 import RpcClient from '../../rpc/client'
 import { NAME, actions, constants } from '../'
+import * as AdminActions from '../../robot-admin/actions'
 
 import MockSession from './__mocks__/session'
 import MockCalibrationMangager from './__mocks__/calibration-manager'
@@ -181,6 +182,19 @@ describe('api client', () => {
 
       return sendConnect()
         .then(() => sendDisconnect())
+        .then(() => expect(rpcClient.close).toHaveBeenCalled())
+        .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
+    })
+
+    test('disconnects RPC client on robotAdmin:RESTART message', () => {
+      const state = {
+        ...STATE,
+        robot: { ...STATE.robot, connection: { connectedTo: ROBOT_NAME } },
+      }
+      const expected = actions.disconnectResponse()
+
+      return sendConnect()
+        .then(() => sendToClient(state, AdminActions.restartRobot(ROBOT_NAME)))
         .then(() => expect(rpcClient.close).toHaveBeenCalled())
         .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
     })


### PR DESCRIPTION
## overview

This PR categorized as a refactor because it finishes something that was missed in #4477 but not yet released.

In the context of the `edge` branch, it fixes a regression where purposeful user-initiated restarts of the robot cause spurious "robot has unexpectedly disconnected" warnings due to the RPC client not properly catching restart trigger actions

## changelog

- refactor(app): ensure RPC API client uses correct restart action shape

## review requests

1. Connect to a robot via the "Connect" button or connect toggle
2. Click "Restart" or trigger a factory reset

- [ ] Robot disconnects and restarts without showing a warning