### PR TITLE
refactor(api): Modify the labware load error message

### DIFF
--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1203,6 +1203,18 @@ def _get_standard_labware_definition(
         checked_version = 1
     else:
         checked_version = version
+    error_msg_string = """Unable to find a labware
+        definition for "{0}",
+        version {1}, in the {2} namespace.
+        Please confirm your protocol includes the correct
+        labware spelling and (optionally) the correct version
+        number and namespace.
+
+        If you are referencing a custom labware in your
+        protocol, you must add it to your Custom Labware
+        Definitions Folder from the Opentrons App before
+        uploading your protocol.
+        """
 
     if namespace is None:
         for fallback_namespace in [OPENTRONS_NAMESPACE, CUSTOM_NAMESPACE]:
@@ -1211,16 +1223,9 @@ def _get_standard_labware_definition(
                     load_name, fallback_namespace, checked_version)
             except (FileNotFoundError):
                 pass
-        raise FileNotFoundError(
-            f'Unable to find a labware definition for "{load_name}",'
-            f'version {checked_version}, in the {OPENTRONS_NAMESPACE}'
-            'namespace. Please confirm your protocol includes the correct'
-            'labware spelling and (optionally) the correct version number'
-            'and namespace.'
-            ''
-            'If you are referencing a custom labware in your protocol, you'
-            'must add it to your Custom Labware Definitions Folder from the'
-            'Opentrons App before uploading your protocol.')
+
+        raise FileNotFoundError(error_msg_string.format(
+                load_name, checked_version, OPENTRONS_NAMESPACE))
 
     namespace = namespace.lower()
     def_path = _get_path_to_labware(load_name, namespace, checked_version)

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1212,9 +1212,15 @@ def _get_standard_labware_definition(
             except (FileNotFoundError):
                 pass
         raise FileNotFoundError(
-            f'Labware "{load_name}" not found with version {checked_version}. '
-            f'If you are using a namespace besides {OPENTRONS_NAMESPACE} or '
-            f'{CUSTOM_NAMESPACE}, please specify it')
+            f'Unable to find a labware definition for "{load_name}",'
+            f'version {checked_version}, in the {OPENTRONS_NAMESPACE}'
+            'namespace. Please confirm your protocol includes the correct'
+            'labware spelling and (optionally) the correct version number'
+            'and namespace.'
+            ''
+            'If you are referencing a custom labware in your protocol, you'
+            'must add it to your Custom Labware Definitions Folder from the'
+            'Opentrons App before uploading your protocol.')
 
     namespace = namespace.lower()
     def_path = _get_path_to_labware(load_name, namespace, checked_version)


### PR DESCRIPTION
Okaayyy, let's try it again. Somehow deleted my change with the onto target rebase and thus closed my other PR...

## Overview
Fixing up the labware load error message to be more descriptive for new 'custom labware upload' users. As per this message from design:

```
FileNotFoundError [Line 16]: Unable to find a labware definition for "custom_12_wellplate_6900ul", version 1, in the Opentrons namespace. Please confirm your protocol includes the correct labware spelling and (optionally) the correct version number and namespace.

If you are referencing a custom labware in your protocol, you must add it to your Custom Labware Definitions Folder from the Opentrons App before uploading your protocol.
```