### PR TITLE
fix(api): fix homing timeouts

### DIFF
--- a/api/src/opentrons/drivers/serial_communication.py
+++ b/api/src/opentrons/drivers/serial_communication.py
@@ -69,6 +69,7 @@ def _write_to_device_and_return(cmd, ack, device_connection, tag=None):
     response = device_connection.read_until(encoded_ack)
     log.debug(f'{tag}: Read <- {response}')
     if encoded_ack not in response:
+        log.warning(f'{tag}: timed out after {device_connection.timeout}')
         raise SerialNoResponse(
             'No response from serial port after {} second(s)'.format(
                 device_connection.timeout))

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -106,7 +106,7 @@ SMOOTHIE_ACK = 'ok\r\nok\r\n'
 
 class SmoothieError(Exception):
     def __init__(self, ret_code: str = None, command: str = None) -> None:
-        self.ret_code = ret_code
+        self.ret_code = ret_code or ''
         self.command = command
         super().__init__()
 

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -63,6 +63,8 @@ DISABLE_AXES = ''
 MOVEMENT_ERROR_MARGIN = 1/160  # Largest movement in mm for any step
 SEC_PER_MIN = 60
 
+DEFAULT_ACK_TIMEOUT = 5
+DEFAULT_EXECUTE_TIMEOUT = 12000
 DEFAULT_SMOOTHIE_TIMEOUT = 1
 DEFAULT_MOVEMENT_TIMEOUT = 30
 SMOOTHIE_BOOT_TIMEOUT = 3
@@ -918,9 +920,10 @@ class SmoothieDriver_3_0_0:
     # Potential place for command optimization (buffering, flushing, etc)
     def _send_command(
             self,
-            command,
-            timeout=DEFAULT_SMOOTHIE_TIMEOUT,
-            suppress_error_msg=False):
+            command: str,
+            timeout: float = DEFAULT_EXECUTE_TIMEOUT,
+            suppress_error_msg: bool = False,
+            ack_timeout: float = DEFAULT_ACK_TIMEOUT):
         """
         Submit a GCODE command to the robot, followed by M400 to block until
         done. This method also ensures that any command on the B or C axis
@@ -942,16 +945,27 @@ class SmoothieDriver_3_0_0:
         function should specify `supress_error_msg=True`.
 
         :param command: the GCODE to submit to the robot
-        :param timeout: the time to wait before returning (indefinite wait if
-            this is set to none
+        :param timeout: the time to wait for the smoothie to execute the
+            command (after an m400). this should be long enough to allow the
+            command to execute. If this is None, the timeout will be infinite.
+            This is almost certainly not what you want.
         :param suppress_error_msg: flag for indicating that smoothie errors
             should not be logged
+        :param ack_timeout: The time to wait for the smoothie to ack a
+            command. For commands that queue (like move) or are short (like
+            pipette interrogation) this should be a small number, and is the
+            default. For commands the smoothie only acks after execution,
+            like home, it should be long enough to allow the command to
+            complete in the worst case. If this is None, the timeout will
+            be infinite. This is almost certainly not what you want.
         """
         if self.simulating:
             return
         try:
             with self._serial_lock:
-                return self._send_command_unsynchronized(command, timeout)
+                return self._send_command_unsynchronized(command,
+                                                         ack_timeout,
+                                                         timeout)
         except SmoothieError as se:
             # XXX: This is a reentrancy error because another command could
             # swoop in here. We're already resetting though and errors (should
@@ -970,16 +984,17 @@ class SmoothieDriver_3_0_0:
             raise SmoothieError(se.ret_code, command)
 
     def _send_command_unsynchronized(self,
-                                     command,
-                                     timeout=DEFAULT_SMOOTHIE_TIMEOUT):
+                                     command: str,
+                                     ack_timeout: float,
+                                     execute_timeout: float):
         cmd_ret = self._write_with_retries(
             command + SMOOTHIE_COMMAND_TERMINATOR,
-            5.0, DEFAULT_COMMAND_RETRIES)
+            ack_timeout, DEFAULT_COMMAND_RETRIES)
         cmd_ret = self._remove_unwanted_characters(command, cmd_ret)
         self._handle_return(cmd_ret)
         wait_ret = serial_communication.write_and_return(
             GCODES['WAIT'] + SMOOTHIE_COMMAND_TERMINATOR,
-            SMOOTHIE_ACK, self._connection, timeout=12000,
+            SMOOTHIE_ACK, self._connection, timeout=execute_timeout,
             tag='smoothie')
         wait_ret = self._remove_unwanted_characters(
             GCODES['WAIT'], wait_ret)
@@ -1073,7 +1088,7 @@ class SmoothieDriver_3_0_0:
 
         command = '{0} {1}'.format(
             self._generate_current_command(), relative_retract_command)
-        self._send_command(command, timeout=DEFAULT_MOVEMENT_TIMEOUT)
+        self._send_command(command)
         self.dwell_axes('Y')
 
         # now it is safe to home the X axis
@@ -1085,7 +1100,11 @@ class SmoothieDriver_3_0_0:
                 self._generate_current_command(),
                 GCODES['HOME'] + 'X'
             )
-            self._send_command(command, timeout=DEFAULT_MOVEMENT_TIMEOUT)
+            # home commands are acked after execution rather than queueing, so
+            # we want a long ack timeout and a short execution timeout
+            home_timeout = (HOMED_POSITION['X'] / XY_HOMING_SPEED) * 2
+            self._send_command(command, ack_timeout=home_timeout,
+                               timeout=5)
             self.update_homed_flags(flags={'X': True})
         finally:
             self.pop_axis_max_speed()
@@ -1104,7 +1123,10 @@ class SmoothieDriver_3_0_0:
             self._generate_current_command(),
             GCODES['HOME'] + 'Y'
         )
-        self._send_command(command, timeout=DEFAULT_MOVEMENT_TIMEOUT)
+        fast_home_timeout = (HOMED_POSITION['Y'] / XY_HOMING_SPEED) * 2
+        # home commands are executed before ack, set a long ack timeout
+        self._send_command(command, ack_timeout=fast_home_timeout,
+                           timeout=5)
 
         # slow the maximum allowed speed on Y axis
         self.set_axis_max_speed({'Y': Y_RETRACT_SPEED})
@@ -1117,13 +1139,15 @@ class SmoothieDriver_3_0_0:
             GCODES['ABSOLUTE_COORDS']   # set back to abs coordinate system
         )
         try:
+            self._send_command(relative_retract_command)
+            # home commands are executed before ack, use a long ack timeout
+            slow_timeout = (Y_RETRACT_DISTANCE / Y_RETRACT_SPEED) * 2
             self._send_command(
-                relative_retract_command, timeout=DEFAULT_MOVEMENT_TIMEOUT)
-            self._send_command(
-                GCODES['HOME'] + 'Y', timeout=DEFAULT_MOVEMENT_TIMEOUT)
+                GCODES['HOME'] + 'Y', ack_timeout=slow_timeout,
+                timeout=5)
             self.update_homed_flags(flags={'Y': True})
             self._send_command(
-                relative_retract_command, timeout=DEFAULT_MOVEMENT_TIMEOUT)
+                relative_retract_command)
         finally:
             self.pop_axis_max_speed()  # bring max speeds back to normal
             self.dwell_axes('Y')
@@ -1379,8 +1403,11 @@ class SmoothieDriver_3_0_0:
                 command += ' ' + GCODES['HOME'] + ''.join(sorted(axes))
                 try:
                     log.debug("home: {}".format(command))
+                    # home commands are executed before ack, use a long ack
+                    # timeout and short execute timeout
                     self._send_command(
-                        command, timeout=DEFAULT_MOVEMENT_TIMEOUT)
+                        command, ack_timeout=DEFAULT_EXECUTE_TIMEOUT,
+                        timeout=DEFAULT_ACK_TIMEOUT)
                     self.update_homed_flags(flags={ax: True for ax in axes})
                 finally:
                     # always dwell an axis after it has been homed

--- a/api/src/opentrons/server/endpoints/control.py
+++ b/api/src/opentrons/server/endpoints/control.py
@@ -465,28 +465,16 @@ async def home(request):
     data = json.loads(req)
     target = data.get('target')
     if target == 'robot':
-        if ff.use_protocol_api_v2():
-            await hw.home()
-        else:
-            hw.home()
+        await hw.home()
         status = 200
         message = "Homing robot."
     elif target == 'pipette':
         mount = data.get('mount')
         if mount in ['left', 'right']:
-            if ff.use_protocol_api_v2():
-                await hw.home([Axis.by_mount(Mount[mount.upper()])])
-                await hw.home_plunger(Mount[mount.upper()])
-                status = 200
-                message = 'Pipette on {} homed successfuly'.format(mount)
-            else:
-                pipette, should_remove = _fetch_or_create_pipette(hw,
-                                                                  mount)
-                pipette.home()
-                if should_remove:
-                    hw.remove_instrument(mount)
-                status = 200
-                message = "Pipette on {} homed successfully.".format(mount)
+            await hw.home([Axis.by_mount(Mount[mount.upper()])])
+            await hw.home_plunger(Mount[mount.upper()])
+            status = 200
+            message = 'Pipette on {} homed successfuly'.format(mount)
         else:
             status = 400
             message = "Expected 'left' or 'right' as values for mount" \

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -866,7 +866,7 @@ def test_unstick_axes(robot, smoothie):
 
     current_log = []
 
-    def send_command_mock(self, command, timeout=None):
+    def send_command_mock(self, command, timeout=12000.0, ack_timeout=5.0):
         nonlocal current_log
         current_log.append(command)
         if 'M119' in command:
@@ -903,7 +903,7 @@ def test_unstick_axes(robot, smoothie):
 
     assert current_log == expected
 
-    def send_command_mock(self, command, timeout=None):
+    def send_command_mock(self, command, timeout=12000.0, ack_timeout=5.0):
         nonlocal current_log
         current_log.append(command)
         if 'M119' in command:
@@ -930,7 +930,7 @@ def test_unstick_axes(robot, smoothie):
     ]
     assert current_log == expected
 
-    def send_command_mock(self, command, timeout=None):
+    def send_command_mock(self, command, timeout=12000.0, ack_timeout=5.0):
         nonlocal current_log
         current_log.append(command)
         if 'M119' in command:


### PR DESCRIPTION
After a recent refactor the smoothie driver has a short timeout for sending
commands to be acked and a longer timeout after sending an M400 to wait for the
command to execute. This works for most long-running commands like move, but
some commands - specifically G28.2, home - are executed before they ack rather
than being queued, and can take a long time. That means that if the gantry is in
the front left of the robot, as far as it can be from home, the x home will
frequently hit its short ack timeout and retry, which leads to two successive x
homes. This can also happen with plunger homes, especially on gen2 pipettes,
when the plunger is at the bottom.

Testing:
- Run a long protocol with a lot of motion and make sure there aren't any smoothie errors.
