### PR TITLE
docs(api): remove protocolContext references from PAPIv1 docs

### DIFF
--- a/api/docs/v1/api.rst
+++ b/api/docs/v1/api.rst
@@ -37,5 +37,5 @@ Simulation
 ----------
 
 .. automodule:: opentrons.simulate
-   :exclude-members: CommandScraper, AccumulatingHandler, main
+   :exclude-members: CommandScraper, AccumulatingHandler, get_protocol_api, bundle_from_sim, main
    :members:


### PR DESCRIPTION
## overview
Remove `get_protocol_api` and `bundle_from_sim` from API Reference section in APIv1 docs.

## review requests
Make sure they do not show up here:
http://sandbox.docs.opentrons.com/docs_remove-v2-in-v1-docs/v1/api.html