### PR TITLE
fix(api): update settings reset copy to avoid confusion

### DIFF
--- a/api/src/opentrons/server/endpoints/settings.py
+++ b/api/src/opentrons/server/endpoints/settings.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 _common_settings_reset_options = [
     {
         'id': 'tipProbe',
-        'name': 'Instrument Offset',
+        'name': 'Pipette Calibration',
         'description':
         'Clear pipette offset and tip length calibration'
     },

--- a/api/src/opentrons/server/endpoints/settings.py
+++ b/api/src/opentrons/server/endpoints/settings.py
@@ -21,9 +21,16 @@ log = logging.getLogger(__name__)
 
 _common_settings_reset_options = [
     {
+        'id': 'tipProbe',
+        'name': 'Instrument Offset',
+        'description':
+        'Clear instrument offset calibration, tip probe data, and tip length calibration'  # noqa(E501)
+    },
+    {
         'id': 'labwareCalibration',
         'name': 'Labware Calibration',
-        'description': 'Clear labware calibration'
+        'description':
+        'Clear labware calibration and Protocol API v1 custom labware (created with labware.create())'  # noqa(E501)
     },
     {
         'id': 'bootScripts',
@@ -31,19 +38,6 @@ _common_settings_reset_options = [
         'description': 'Clear custom boot scripts'
     },
 ]
-
-_apiv2_settings_reset_options = [
-    {
-        'id': 'customLabware',
-        'name': 'Custom Labware',
-        'description': 'Clear custom labware definitions'
-    },
-    {
-        'id': 'tipProbe',
-        'name': 'Instrument Offset',
-        'description': 'Clear instrument offset calibration and tip probe data'
-    },
-] + _common_settings_reset_options
 
 
 _SETTINGS_RESTART_REQUIRED = False
@@ -55,7 +49,7 @@ _SETTINGS_RESTART_REQUIRED = False
 
 
 def reset_options() -> List[Dict[str, str]]:
-    return _apiv2_settings_reset_options
+    return _common_settings_reset_options
 
 
 async def get_advanced_settings(request: web.Request) -> web.Response:

--- a/api/src/opentrons/server/endpoints/settings.py
+++ b/api/src/opentrons/server/endpoints/settings.py
@@ -24,7 +24,7 @@ _common_settings_reset_options = [
         'id': 'tipProbe',
         'name': 'Instrument Offset',
         'description':
-        'Clear instrument offset calibration, tip probe data, and tip length calibration'  # noqa(E501)
+        'Clear pipette offset and tip length calibration'
     },
     {
         'id': 'labwareCalibration',

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -88,22 +88,8 @@ async def test_available_resets(async_client):
     body = await resp.json()
     options_list = body.get('options')
     assert resp.status == 200
-    options = [
-        {'id': 'customLabware',
-         'name': 'Custom Labware',
-         'description': 'Clear custom labware definitions'},
-        {'id': 'tipProbe',
-         'name': 'Instrument Offset',
-         'description':
-         'Clear instrument offset calibration and tip probe data'},
-        {'id': 'labwareCalibration',
-         'name': 'Labware Calibration',
-         'description': 'Clear labware calibration'},
-        {'id': 'bootScripts',
-         'name': 'Boot Scripts',
-         'description': 'Clear custom boot scripts'}]
-    assert sorted(options_list, key=lambda el: el['id'])\
-        == sorted(options, key=lambda el: el['id'])
+    assert sorted(['tipProbe', 'labwareCalibration', 'bootScripts'])\
+        == sorted([item['id'] for item in options_list])
 
 
 @pytest.mark.api1_only


### PR DESCRIPTION
When fusing v1 and v2, we accidentally stopped exposing v1 settings resets. When exposing them again, we bundled them with the v2 options. Those options now need to have their copy updated to indicate the changes.

Closes #4568
