### PR TITLE
feat(api): Handle extra labware in script entrypoints

### DIFF
--- a/api/docs/v2/new_advanced_running.rst
+++ b/api/docs/v2/new_advanced_running.rst
@@ -50,6 +50,11 @@ If you have a protocol that you have already written you can run it directly in 
    run(protocol)  # your protocol will now run
 
 
+Custom Labware
+++++++++++++++
+
+If you have custom labware definitions you want to use with Jupyter, make a new directory called "labware" in Jupyter and put the definitions there. These definitions will be available when you call ``load_labware``.
+
 
 Command Line
 ------------

--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -73,6 +73,13 @@ if IS_ROBOT:
             ARCHITECTURE = SystemArchitecture.BUILDROOT
         except Exception:
             log.exception("Could not find version file in /etc/VERSION.json")
+    JUPYTER_NOTEBOOK_ROOT_DIR: Optional[Path]\
+        = Path('/var/lib/jupyter/notebooks/')
+    JUPYTER_NOTEBOOK_LABWARE_DIR: Optional[Path]\
+        = JUPYTER_NOTEBOOK_ROOT_DIR/'labware'  # type: ignore
+else:
+    JUPYTER_NOTEBOOK_ROOT_DIR = None
+    JUPYTER_NOTEBOOK_LABWARE_DIR = None
 
 
 def name() -> str:

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -185,6 +185,7 @@ def get_arguments(
 
 
 def execute(protocol_file: TextIO,
+            protocol_name: str,
             propagate_logs: bool = False,
             log_level: str = 'warning',
             emit_runlog: Callable[[Dict[str, Any]], None] = None,
@@ -210,6 +211,9 @@ def execute(protocol_file: TextIO,
     :py:meth:`.Robot.cache_instrument_models`.
 
     :param file-like protocol_file: The protocol file to execute
+    :param str protocol_name: The name of the protocol file. This is required
+                              internally, but it may not be a thing we can get
+                              from the protocol_file argument.
     :param propagate_logs: Whether this function should allow logs from the
                            Opentrons stack to propagate up to the root handler.
                            This can be useful if you're integrating this
@@ -269,7 +273,7 @@ def execute(protocol_file: TextIO,
         extra_data = datafiles_from_paths(custom_data_paths)
     else:
         extra_data = {}
-    protocol = parse(contents, protocol_file.name,
+    protocol = parse(contents, protocol_name,
                      extra_labware=extra_labware,
                      extra_data=extra_data)
     if getattr(protocol, 'api_level', APIVersion(2, 0)) < APIVersion(2, 0):
@@ -350,7 +354,8 @@ def main() -> int:
     else:
         log_level = 'warning'
     # Try to migrate containers from database to v2 format
-    execute(args.protocol, log_level=log_level, emit_runlog=printer)
+    execute(args.protocol, args.protocol.name,
+            log_level=log_level, emit_runlog=printer)
     return 0
 
 

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -9,18 +9,21 @@ protocol from the command line.
 import argparse
 import asyncio
 import logging
+import os
 import sys
 import threading
-from typing import Any, Callable, Dict, Optional, TextIO, Union
+from typing import Any, Callable, Dict, List, Optional, TextIO, Union
 
 import opentrons
 from opentrons import protocol_api, __version__
+from opentrons.config import IS_ROBOT, JUPYTER_NOTEBOOK_LABWARE_DIR
 from opentrons.protocol_api import (execute as execute_apiv2,
                                     MAX_SUPPORTED_VERSION)
 from opentrons import commands
 from opentrons.protocols.parse import parse, version_from_string
 from opentrons.protocols.types import APIVersion, PythonProtocol
 from opentrons.hardware_control import API
+from .util.entrypoint_util import labware_from_paths, datafiles_from_paths
 
 _HWCONTROL: Optional[API] = None
 #: The background global cache that all protocol contexts created by
@@ -30,7 +33,8 @@ _HWCONTROL: Optional[API] = None
 def get_protocol_api(
         version: Union[str, APIVersion],
         bundled_labware: Dict[str, Dict[str, Any]] = None,
-        bundled_data: Dict[str, bytes] = None
+        bundled_data: Dict[str, bytes] = None,
+        extra_labware: Dict[str, Any] = None,
 ) -> protocol_api.ProtocolContext:
     """
     Build and return a :py:class:`ProtocolContext` connected to the robot.
@@ -45,7 +49,12 @@ def get_protocol_api(
         >>> instr = protocol.load_instrument('p300_single', 'right')
         >>> instr.home()
 
+    If ``extra_labware`` is not specified, any labware definitions saved in
+    the ``labware`` directory of the Jupyter notebook directory will be
+    available.
+
     When this function is called, modules and instruments will be recached.
+
     :param version: The API version to use. This must be lower than
                     :py:attr:`opentrons.protocol_api.MAX_SUPPORTED_VERSION`.
                     It may be specified either as a string (``'2.0'``) or
@@ -60,7 +69,13 @@ def get_protocol_api(
     :param bundled_data: If specified, a mapping from filenames to contents
                          for data to be available in the protocol from
                          :py:attr:`.ProtocolContext.bundled_data`.
-
+    :param extra_labware: If specified, a mapping from labware names to
+                          labware definitions for labware to consider in the
+                          protocol in addition to those stored on the robot.
+                          If this is an empty dict, and this function is called
+                          on a robot, it will look in the 'labware'
+                          subdirectory of the Jupyter data directory for
+                          custom labware.
     :returns opentrons.protocol_api.ProtocolContext: The protocol context.
     """
     if not _HWCONTROL:
@@ -89,9 +104,15 @@ def get_protocol_api(
         raise TypeError('version must be either a string or an APIVersion')
     else:
         checked_version = version
+
+    if extra_labware is None and IS_ROBOT:
+        extra_labware = labware_from_paths(
+            [str(JUPYTER_NOTEBOOK_LABWARE_DIR)])
+
     context = protocol_api.ProtocolContext(hardware=_HWCONTROL,
                                            bundled_labware=bundled_labware,
                                            bundled_data=bundled_data,
+                                           extra_labware=extra_labware,
                                            api_version=checked_version)
     context._hw_manager.hardware.cache_instruments()
     return context
@@ -116,6 +137,43 @@ def get_arguments(
         'this option and should be configured in the config file. If '
         '\'none\', do not show logs')
     parser.add_argument(
+        '-L', '--custom-labware-path',
+        action='append', default=[os.getcwd()],
+        help='Specify directories to search for custom labware definitions. '
+             'You can specify this argument multiple times. Once you specify '
+             'a directory in this way, labware definitions in that directory '
+             'will become available in ProtocolContext.load_labware(). '
+             'Only directories specified directly by '
+             'this argument are searched, not their children. JSON files that '
+             'do not define labware will be ignored with a message. '
+             'By default, the current directory (the one in which you are '
+             'invoking this program) will be searched for labware.')
+    parser.add_argument(
+        '-D', '--custom-data-path',
+        action='append', nargs='?', const='.', default=[],
+        help='Specify directories to search for custom data files. '
+             'You can specify this argument multiple times. Once you specify '
+             'a directory in this way, files located in the specified '
+             'directory will be available in ProtocolContext.bundled_data. '
+             'Note that bundle execution will still only allow data files in '
+             'the bundle. If you specify this without a path, it will '
+             'add the current path implicitly. If you do not specify this '
+             'argument at all, no data files will be added. Any file in the '
+             'specified paths will be loaded into memory and included in the '
+             'bundle if --bundle is passed, so be careful that any directory '
+             'you specify has only the files you want. It is usually a '
+             'better idea to use -d so no files are accidentally included. '
+             'Also note that data files are made available as their name, not '
+             'their full path, so name them uniquely.')
+    parser.add_argument(
+        '-d', '--custom-data-file',
+        action='append', default=[],
+        help='Specify data files to be made available in '
+             'ProtocolContext.bundled_data (and possibly bundled if --bundle '
+             'is passed). Can be specified multiple times with different '
+             'files. It is usually a better idea to use this than -D because '
+             'there is less possibility of accidentally including something.')
+    parser.add_argument(
         'protocol', metavar='PROTOCOL',
         type=argparse.FileType('rb'),
         help='The protocol file to execute. If you pass \'-\', you can pipe '
@@ -127,7 +185,9 @@ def get_arguments(
 def execute(protocol_file: TextIO,
             propagate_logs: bool = False,
             log_level: str = 'warning',
-            emit_runlog: Callable[[Dict[str, Any]], None] = None):
+            emit_runlog: Callable[[Dict[str, Any]], None] = None,
+            custom_labware_paths: List[str] = None,
+            custom_data_paths: List[str] = None):
     """
     Run the protocol itself.
 
@@ -165,7 +225,18 @@ def execute(protocol_file: TextIO,
                         estimation. If specified, the callback should take a
                         single argument (the name doesn't matter) which will
                         be a dictionary (see below). Default: ``None``
-
+    :param custom_labware_paths: A list of directories to search for custom
+                                 labware, or None. Ignored if the apiv2 feature
+                                 flag is not set. Loads valid labware from
+                                 these paths and makes them available to the
+                                 protocol context.
+    :param custom_data_paths: A list of directories or files to load custom
+                              data files from. Ignored if the apiv2 feature
+                              flag if not set. Entries may be either files or
+                              directories. Specified files and the
+                              non-recursive contents of specified directories
+                              are presented by the protocol context in
+                              :py:attr:`.ProtocolContext.bundled_data`.
     The format of the runlog entries is as follows:
 
     .. code-block:: python
@@ -188,7 +259,17 @@ def execute(protocol_file: TextIO,
     stack_logger.propagate = propagate_logs
     stack_logger.setLevel(getattr(logging, log_level.upper(), logging.WARNING))
     contents = protocol_file.read()
-    protocol = parse(contents, protocol_file.name)
+    if custom_labware_paths:
+        extra_labware = labware_from_paths(custom_labware_paths)
+    else:
+        extra_labware = {}
+    if custom_data_paths:
+        extra_data = datafiles_from_paths(custom_data_paths)
+    else:
+        extra_data = {}
+    protocol = parse(contents, protocol_file.name,
+                     extra_labware=extra_labware,
+                     extra_data=extra_data)
     if getattr(protocol, 'api_level', APIVersion(2, 0)) < APIVersion(2, 0):
         opentrons.robot.connect()
         opentrons.robot.cache_instrument_models()
@@ -201,10 +282,14 @@ def execute(protocol_file: TextIO,
             'Internal error: Only Python protocols may be executed in v1'
         exec(protocol.contents, {})
     else:
+        bundled_data = getattr(protocol, 'bundled_data', {})
+        bundled_data.update(extra_data)
+        gpa_extras = getattr(protocol, 'extra_labware', None) or None
         context = get_protocol_api(
             getattr(protocol, 'api_level', MAX_SUPPORTED_VERSION),
             bundled_labware=getattr(protocol, 'bundled_labware', None),
-            bundled_data=getattr(protocol, 'bundled_data', None))
+            bundled_data=bundled_data,
+            extra_labware=gpa_extras)
         if emit_runlog:
             context.broker.subscribe(
                 commands.command_types.COMMAND, emit_runlog)

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -105,7 +105,9 @@ def get_protocol_api(
     else:
         checked_version = version
 
-    if extra_labware is None and IS_ROBOT:
+    if extra_labware is None\
+       and IS_ROBOT\
+       and JUPYTER_NOTEBOOK_LABWARE_DIR.is_dir():  # type: ignore
         extra_labware = labware_from_paths(
             [str(JUPYTER_NOTEBOOK_LABWARE_DIR)])
 

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -157,7 +157,9 @@ def get_protocol_api(
         raise TypeError('version must be either a string or an APIVersion')
     else:
         checked_version = version
-    if extra_labware is None and IS_ROBOT:
+    if extra_labware is None\
+       and IS_ROBOT\
+       and JUPYTER_NOTEBOOK_LABWARE_DIR.is_dir():  # type: ignore
         extra_labware = labware_from_paths(
             [str(JUPYTER_NOTEBOOK_LABWARE_DIR)])
     return _build_protocol_context(

--- a/api/src/opentrons/util/entrypoint_util.py
+++ b/api/src/opentrons/util/entrypoint_util.py
@@ -29,7 +29,8 @@ def labware_from_paths(paths: List[str]) -> Dict[str, Dict[str, Any]]:
                 try:
                     defn = labware.verify_definition(child.read_bytes())
                 except (ValidationError, JSONDecodeError) as e:
-                    log.info(f"{child}: invalid ({str(e)})")
+                    log.info(f"{child}: invalid labware, ignoring")
+                    log.debug(f"{child}: labware invalid because: {str(e)}")
                 else:
                     uri = labware.uri_from_definition(defn)
                     labware_defs[uri] = defn

--- a/api/tests/opentrons/data/python_v2_custom_lw.py
+++ b/api/tests/opentrons/data/python_v2_custom_lw.py
@@ -1,0 +1,20 @@
+from opentrons import types
+
+metadata = {
+    'protocolName': 'Testosaur (custom labware)',
+    'author': 'Opentrons <engineering@opentrons.com>',
+    'description': 'A variant on "Dinosaur" for testing custom labware',
+    'source': 'Opentrons Repository',
+    'apiLevel': '2.0'
+}
+
+
+def run(ctx):
+    ctx.home()
+    tr = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
+    right = ctx.load_instrument('p300_single_gen2', types.Mount.RIGHT, [tr])
+    lw = ctx.load_labware('fixture_96_plate', 2, namespace='fixture')
+    right.pick_up_tip()
+    right.aspirate(10, lw.wells()[0].bottom())
+    right.dispense(10, lw.wells()[1].bottom())
+    right.drop_tip(tr.wells()[-1].top())

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -1,7 +1,6 @@
 import ast
 import json
 
-import jsonschema
 import pytest
 
 from opentrons.protocols.parse import (extract_metadata,
@@ -184,7 +183,7 @@ def test_validate_json(get_json_protocol_fixture):
     # valid data that has no schema should fail
     with pytest.raises(RuntimeError, match='deprecated'):
         validate_json({'protocol-schema': '1.0.0'})
-    with pytest.raises(jsonschema.ValidationError):
+    with pytest.raises(RuntimeError):
         validate_json({'schemaVersion': '3'})
     v3 = get_json_protocol_fixture('3', 'testAllAtomicSingleV3')
     assert validate_json(v3) == 3

--- a/api/tests/opentrons/test_execute.py
+++ b/api/tests/opentrons/test_execute.py
@@ -1,0 +1,196 @@
+# coding=utf-8
+import io
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from opentrons import execute, types
+from opentrons.protocol_api.execute import ExceptionInProtocolError
+
+HERE = Path(__file__).parent
+
+
+@pytest.fixture
+def backing_hardware(monkeypatch, virtual_smoothie_env):
+    # make sure the backing hardware controller is up
+    execute.get_protocol_api('2.0')
+    # give it instruments
+    gai_mock = mock.Mock()
+
+    async def dummy_delay(duration_s):
+        pass
+
+    monkeypatch.setattr(execute._HWCONTROL._backend,
+                        'get_attached_instruments',
+                        gai_mock)
+    monkeypatch.setattr(execute._HWCONTROL._backend, 'delay', dummy_delay)
+    gai_mock.return_value = {types.Mount.RIGHT: {'model': None, 'id': None},
+                             types.Mount.LEFT: {'model': None, 'id': None}}
+    return gai_mock
+
+
+@pytest.mark.parametrize('protocol_file', ['testosaur_v2.py'])
+def test_execute_function_apiv2(protocol,
+                                protocol_file,
+                                monkeypatch,
+                                virtual_smoothie_env,
+                                backing_hardware):
+
+    backing_hardware.return_value[types.Mount.LEFT]\
+        = {'model': 'p10_single_v1.5', 'id': 'testid'}
+    backing_hardware.return_value[types.Mount.RIGHT]\
+        = {'model': 'p300_single_v1.5', 'id': 'testid2'}
+    entries = []
+
+    def emit_runlog(entry):
+        nonlocal entries
+        entries.append(entry)
+
+    execute.execute(
+        protocol.filelike, 'testosaur_v2.py', emit_runlog=emit_runlog)
+    assert [item['payload']['text'] for item in entries
+            if item['$'] == 'before'] == [
+        'Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1',
+        'Aspirating 10.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 1.0 speed',  # noqa(E501),
+        'Dispensing 10.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 1.0 speed',  # noqa(E501),
+        'Dropping tip into H12 of Opentrons 96 Tip Rack 300 µL on 1'
+        ]
+
+
+def test_execute_function_json_apiv2(get_json_protocol_fixture,
+                                     virtual_smoothie_env,
+                                     backing_hardware):
+    jp = get_json_protocol_fixture('3', 'simple', False)
+    filelike = io.StringIO(jp)
+    entries = []
+
+    def emit_runlog(entry):
+        nonlocal entries
+        entries.append(entry)
+
+    backing_hardware.return_value[types.Mount.LEFT] = {
+        'model': 'p10_single_v1.5', 'id': 'testid'}
+    execute.execute(filelike, 'simple.json', emit_runlog=emit_runlog)
+    assert [item['payload']['text'] for item in entries
+            if item['$'] == 'before'] == [
+        'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 1',
+        'Aspirating 5.0 uL from A1 of Source Plate on 2 at 1.0 speed',
+        'Delaying for 0 minutes and 42 seconds',
+        'Dispensing 4.5 uL into B1 of Dest Plate on 3 at 1.0 speed',
+        'Touching tip',
+        'Blowing out at B1 of Dest Plate on 3',
+        'Dropping tip into A1 of Trash on 12'
+    ]
+
+
+def test_execute_function_bundle_apiv2(get_bundle_fixture,
+                                       virtual_smoothie_env,
+                                       backing_hardware):
+    bundle = get_bundle_fixture('simple_bundle')
+    entries = []
+
+    def emit_runlog(entry):
+        nonlocal entries
+        entries.append(entry)
+
+    backing_hardware.return_value[types.Mount.LEFT] = {
+        'model': 'p10_single_v1.5', 'id': 'testid'}
+    execute.execute(
+        bundle['filelike'], 'simple_bundle.zip', emit_runlog=emit_runlog)
+    assert [item['payload']['text']
+            for item in entries if item['$'] == 'before'] == [
+        'Transferring 1.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
+        'Picking up tip from A1 of Opentrons 96 Tip Rack 10 µL on 3',
+        'Aspirating 1.0 uL from A1 of FAKE example labware on 1 at 1.0 speed',
+        'Dispensing 1.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
+        'Dropping tip into A1 of Opentrons Fixed Trash on 12',
+        'Transferring 2.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
+        'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 3',
+        'Aspirating 2.0 uL from A1 of FAKE example labware on 1 at 1.0 speed',
+        'Dispensing 2.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
+        'Dropping tip into A1 of Opentrons Fixed Trash on 12',
+        'Transferring 3.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
+        'Picking up tip from C1 of Opentrons 96 Tip Rack 10 µL on 3',
+        'Aspirating 3.0 uL from A1 of FAKE example labware on 1 at 1.0 speed',
+        'Dispensing 3.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
+        'Dropping tip into A1 of Opentrons Fixed Trash on 12'
+        ]
+
+
+@pytest.mark.parametrize('protocol_file', ['testosaur.py'])
+def test_execute_function_v1(protocol, protocol_file,
+                             virtual_smoothie_env,
+                             backing_hardware):
+    entries = []
+
+    def emit_runlog(entry):
+        nonlocal entries
+        entries.append(entry)
+
+    backing_hardware.return_value[types.Mount.RIGHT] = {
+        'model': 'p300_single_v1.5', 'id': 'testid'}
+    execute.execute(protocol.filelike, 'testosaur.py', emit_runlog=emit_runlog)
+    assert [item['payload']['text'] for item in entries
+            if item['$'] == 'before'] == [
+        'Picking up tip from well A1 in "5"',
+        'Aspirating 10.0 uL from well A1 in "8" at 1.0 speed',
+        'Dispensing 10.0 uL into well H12 in "8" at 1.0 speed',
+        'Aspirating 10.0 uL from well A1 in "11" at 1.0 speed',
+        'Dispensing 10.0 uL into well H12 in "11" at 1.0 speed',
+        'Dropping tip into well A1 in "12"'
+    ]
+
+
+@pytest.mark.parametrize('protocol_file', ['python_v2_custom_lw.py'])
+def test_execute_extra_labware(protocol, protocol_file, monkeypatch,
+                               virtual_smoothie_env, backing_hardware):
+    fixturedir = HERE / '..' / '..' / '..' /\
+        'shared-data' / 'labware' / 'fixtures' / '2'
+    entries = []
+
+    def emit_runlog(entry):
+        nonlocal entries
+        entries.append(entry)
+
+    backing_hardware.return_value[types.Mount.RIGHT] = {
+        'model': 'p300_single_v2.0', 'id': 'testid'}
+    # make sure we can load labware explicitly
+    # make sure we don't have an exception from not finding the labware
+    execute.execute(protocol.filelike, 'custom_labware.py',
+                    emit_runlog=emit_runlog,
+                    custom_labware_paths=[str(fixturedir)])
+    # instead of 4 in simulate because we get before and after
+    assert len(entries) == 8
+
+    protocol.filelike.seek(0)
+    # make sure we don't get autoload behavior when not on a robot
+    with pytest.raises(ExceptionInProtocolError,
+                       match='.*FileNotFoundError.*'):
+        execute.execute(protocol.filelike, 'custom_labware.py')
+    no_lw = execute.get_protocol_api('2.0')
+    assert not no_lw._extra_labware
+    protocol.filelike.seek(0)
+    monkeypatch.setattr(execute, 'IS_ROBOT', True)
+    monkeypatch.setattr(execute, 'JUPYTER_NOTEBOOK_LABWARE_DIR',
+                        fixturedir)
+    # make sure we don't have an exception from not finding the labware
+    entries = []
+    execute.execute(protocol.filelike, 'custom_labware.py',
+                    emit_runlog=emit_runlog)
+    # instead of 4 in simulate because we get before and after
+    assert len(entries) == 8
+
+    # make sure the extra labware loaded by default is right
+    ctx = execute.get_protocol_api('2.0')
+    assert len(ctx._extra_labware.keys()) == len(os.listdir(fixturedir))
+
+    assert ctx.load_labware('fixture_12_trough', 1, namespace='fixture')
+
+    # if there is no labware dir, make sure everything still works
+    monkeypatch.setattr(execute, 'JUPYTER_NOTEBOOK_LABWARE_DIR',
+                        HERE / 'nosuchdirectory')
+    ctx = execute.get_protocol_api('2.0')
+    with pytest.raises(FileNotFoundError):
+        ctx.load_labware("fixture_12_trough", 1, namespace='fixture')

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -68,25 +68,6 @@ def test_simulate_function_bundle_apiv2(get_bundle_fixture):
 
 
 @pytest.mark.parametrize('protocol_file', ['testosaur.py'])
-def test_simulate_function_apiv1(protocol, protocol_file):
-    runlog, bundle = simulate.simulate(protocol.filelike, 'testosaur.py')
-    assert bundle is None
-    assert runlog[0]['payload']['text'].startswith('Picking up tip')
-    assert 'A1' in runlog[0]['payload']['text']
-    assert runlog[1]['payload']['text'].startswith('Aspirating 10.0 uL')
-    assert 'A1' in runlog[1]['payload']['text']
-    assert runlog[2]['payload']['text'].startswith('Dispensing 10.0 uL')
-    assert 'H12' in runlog[2]['payload']['text']
-    assert runlog[3]['payload']['text'].startswith('Aspirating 10.0 uL')
-    assert 'A1' in runlog[3]['payload']['text']
-    assert runlog[4]['payload']['text'].startswith('Dispensing 10.0 uL')
-    assert 'H12' in runlog[4]['payload']['text']
-    assert runlog[5]['payload']['text'].startswith('Dropping tip')
-    assert 'A1' in runlog[5]['payload']['text']
-    assert len(runlog) == 6
-
-
-@pytest.mark.parametrize('protocol_file', ['testosaur.py'])
 def test_simulate_function_v1(protocol, protocol_file):
     runlog, bundle = simulate.simulate(protocol.filelike, 'testosaur.py')
     assert bundle is None

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -130,3 +130,10 @@ def test_simulate_extra_labware(protocol, protocol_file, monkeypatch):
     assert len(ctx._extra_labware.keys()) == len(os.listdir(fixturedir))
 
     assert ctx.load_labware('fixture_12_trough', 1, namespace='fixture')
+
+    # if there is no labware dir, make sure everything still works
+    monkeypatch.setattr(simulate, 'JUPYTER_NOTEBOOK_LABWARE_DIR',
+                        HERE / 'nosuchdirectory')
+    ctx = simulate.get_protocol_api('2.0')
+    with pytest.raises(FileNotFoundError):
+        ctx.load_labware("fixture_12_trough", 1, namespace='fixture')


### PR DESCRIPTION
Previously, extra_labware (the mechanism for v2 custom labware) wasn't really
handled in the script entrypoints opentrons_execute and opentrons_simulate. This
adds that handling. Specifically,

- opentrons_execute learned -L, which lets you specify paths to search for
labware definitions (previously only known by opentrons_simulate for building
bundles). This defaults to '.', as in opentrons_simulate
- opentrons.{simulate,execute}.get_protocol_api learned the extra_labware
argument, which should be a dict mapping labware names to labware definitions.
If this is not specified (as in, not as an empty dict), if this is a robot the
software will look in /var/lib/jupyter/notebooks/labware for custom labware.
- Add the jupyter lookup thing to docs. This is the canonical "right place" to
put custom labware defs you want to use in jupyter.
- Add some tests.


## Testing
Use the simulate and execute entrypoints:
- `opentrons_simulate` as a script from a notebook terminal should look in the current directory for custom labware files. You should be able to specify more with `-L`. If there are json files that aren't labware, nothing should break. This should all be true both on a local computer and a robot, including a robot jupyter notebook.
- `opentrons_execute` as a script from a terminal should do the same thing
- if you import `opentrons.simulate.get_protocol_api` or `opentrons.execute.get_protocol_api` in a jupyter terminal or normal python prompt on a robot, it should look in `/var/lib/jupyter/notebooks/labware` for custom labware defs. Nothing should break if there are json files that aren't labware in there. Nothing should break if the directory doesn't exist.