### PR TITLE
refactor(api): look for smoothie firmware in /usr/lib/firmware

### DIFF
--- a/api/tests/opentrons/test_main.py
+++ b/api/tests/opentrons/test_main.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+from opentrons import main
+
+
+def test_find_smoothie_file(monkeypatch, tmpdir):
+    monkeypatch.setattr(main, 'IS_ROBOT', True)
+    tdpath = Path(tmpdir)
+    dummy_file = tdpath / 'smoothie-edge-2cac98asda.hex'
+    dummy_file.write_text("hello")
+    monkeypatch.setattr(main, 'ROBOT_FIRMWARE_DIR', tdpath)
+
+    assert main._find_smoothie_file() == (dummy_file, 'edge-2cac98asda')


### PR DESCRIPTION
That is the standard path for runtime-loaded firmware for attached hardware in
linux. It's a better way to update the smoothie than packing it in the api
wheel. In the future, we may even want to use a separate systemd task to update
the smoothie. Requires https://github.com/Opentrons/buildroot/pull/57

## Testing
- Make sure that if you change the name of the file in `/usr/lib/firmware` on the robot, the api server detects it as the right smoothie firmware to use and does an update on boot.

