### PR TITLE
fix(app): disable tip probe for unused pipettes

### DIFF
--- a/app/src/components/CalibratePanel/PipetteList.js
+++ b/app/src/components/CalibratePanel/PipetteList.js
@@ -1,48 +1,39 @@
 // @flow
 import * as React from 'react'
-import { connect } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 
-import {
-  constants as robotConstants,
-  selectors as robotSelectors,
-  type Pipette,
-} from '../../robot'
-
+import { selectors as robotSelectors } from '../../robot'
+import { PIPETTE_MOUNTS } from '../../pipettes'
+import { getCalibratePipettesLocations } from '../../nav'
 import { TitledList } from '@opentrons/components'
 import PipetteListItem from './PipetteListItem'
 
-type Props = {
-  pipettes: Array<Pipette>,
-  isRunning: boolean,
-}
+// TODO(mc, 2019-12-10): i18n
+const PIPETTE_CALIBRATION = 'Pipette Calibration'
 
-const TITLE = 'Pipette Calibration'
+export default withRouter(PipetteList)
 
-export default withRouter<{||}, _>(
-  connect<Props, _, _, _, _, _>(mapStateToProps)(PipetteList)
-)
-
-function PipetteList(props: Props) {
-  const { pipettes, isRunning } = props
+function PipetteList() {
+  const pipettes = useSelector(robotSelectors.getPipettes)
+  const urlsByMount = useSelector(getCalibratePipettesLocations)
 
   return (
-    <TitledList title={TITLE}>
-      {robotConstants.PIPETTE_MOUNTS.map(mount => (
-        <PipetteListItem
-          key={mount}
-          mount={mount}
-          isRunning={isRunning}
-          pipette={pipettes.find(i => i.mount === mount)}
-        />
-      ))}
+    <TitledList title={PIPETTE_CALIBRATION}>
+      {PIPETTE_MOUNTS.map(mount => {
+        const pipette = pipettes.find(i => i.mount === mount) || null
+        const { path, disabledReason = null } = urlsByMount[mount]
+
+        return (
+          <PipetteListItem
+            key={mount}
+            mount={mount}
+            pipette={pipette}
+            calibrateUrl={path}
+            disabledReason={disabledReason}
+          />
+        )
+      })}
     </TitledList>
   )
-}
-
-function mapStateToProps(state): $Exact<Props> {
-  return {
-    pipettes: robotSelectors.getPipettes(state),
-    isRunning: robotSelectors.getIsRunning(state),
-  }
 }

--- a/app/src/components/CalibratePanel/PipetteListItem.js
+++ b/app/src/components/CalibratePanel/PipetteListItem.js
@@ -2,40 +2,48 @@
 import React from 'react'
 import capitalize from 'lodash/capitalize'
 
-import { ListItem, type IconName } from '@opentrons/components'
-
-import type { Mount, Pipette } from '../../robot'
+import { ListItem, HoverTooltip } from '@opentrons/components'
 import styles from './styles.css'
 
-type Props = {
-  isRunning: boolean,
+import type { IconName } from '@opentrons/components'
+import type { Pipette as ProtocolPipette } from '../../robot/types'
+import type { Mount } from '../../pipettes/types'
+
+type Props = {|
   mount: Mount,
-  pipette: ?Pipette,
-}
+  pipette: ProtocolPipette | null,
+  calibrateUrl: string | null,
+  disabledReason: string | null,
+|}
 
 export default function PipetteListItem(props: Props) {
-  const { isRunning, mount, pipette } = props
-  const confirmed = pipette && pipette.probed
-  const isDisabled = !pipette || isRunning
-  const url = !isDisabled ? `/calibrate/pipettes/${mount}` : '#'
-
+  const { mount, pipette, calibrateUrl, disabledReason } = props
+  const confirmed = pipette?.probed
+  const displayName = pipette?.modelSpecs?.displayName || 'N/A'
   const iconName: IconName = confirmed
     ? 'check-circle'
     : 'checkbox-blank-circle-outline'
 
-  const description = pipette?.modelSpecs?.displayName || 'N/A'
   return (
-    <ListItem
-      isDisabled={isDisabled}
-      url={url}
-      confirmed={confirmed}
-      iconName={iconName}
-      activeClassName={styles.active}
-    >
-      <div className={styles.item_info}>
-        <span className={styles.item_info_location}>{capitalize(mount)}</span>
-        <span>{description}</span>
-      </div>
-    </ListItem>
+    <HoverTooltip placement="bottom" tooltipComponent={disabledReason}>
+      {tooltipHandlers => (
+        <ListItem
+          ref={tooltipHandlers?.ref}
+          onMouseEnter={tooltipHandlers?.onMouseEnter}
+          onMouseLeave={tooltipHandlers?.onMouseLeave}
+          isDisabled={disabledReason !== null}
+          url={disabledReason === null ? calibrateUrl : null}
+          iconName={iconName}
+          activeClassName={styles.active}
+        >
+          <div className={styles.item_info}>
+            <span className={styles.item_info_location}>
+              {capitalize(mount)}
+            </span>
+            <span>{displayName}</span>
+          </div>
+        </ListItem>
+      )}
+    </HoverTooltip>
   )
 }

--- a/app/src/components/calibrate-pipettes/PipetteTabs.js
+++ b/app/src/components/calibrate-pipettes/PipetteTabs.js
@@ -2,25 +2,25 @@
 // instrument tabs bar container
 // used for left/right pipette selection during pipette calibration
 import * as React from 'react'
+import { useSelector } from 'react-redux'
 
-import type { Pipette } from '../../robot'
-import { constants as robotConstants } from '../../robot'
-
+import { getCalibratePipettesLocations } from '../../nav'
+import { PIPETTE_MOUNTS } from '../../pipettes'
 import { PageTabs } from '@opentrons/components'
 
-type Props = {
-  pipettes: Array<Pipette>,
-  currentPipette: ?Pipette,
-}
+type Props = {|
+  currentMount: ?string,
+|}
 
 export default function PipetteTabs(props: Props) {
-  const { pipettes, currentPipette } = props
+  const { currentMount } = props
+  const pagesByMount = useSelector(getCalibratePipettesLocations)
 
-  const pages = robotConstants.PIPETTE_MOUNTS.map(mount => ({
+  const pages = PIPETTE_MOUNTS.map(mount => ({
     title: mount,
-    href: `./${mount}`,
-    isActive: currentPipette != null && mount === currentPipette.mount,
-    isDisabled: !pipettes.some(pipette => pipette.mount === mount),
+    href: pagesByMount[mount].path,
+    isActive: mount === currentMount,
+    isDisabled: pagesByMount[mount].disabledReason !== null,
   }))
 
   return <PageTabs pages={pages} />

--- a/app/src/components/calibrate-pipettes/Pipettes.js
+++ b/app/src/components/calibrate-pipettes/Pipettes.js
@@ -1,44 +1,30 @@
 // @flow
 import * as React from 'react'
-import { Link } from 'react-router-dom'
 import cx from 'classnames'
 
-import { constants as robotConstants } from '../../robot'
-import { InstrumentGroup, AlertItem } from '@opentrons/components'
+import { PIPETTE_MOUNTS } from '../../pipettes'
+import { InstrumentGroup } from '@opentrons/components'
 import styles from './styles.css'
 
 import type { Pipette, TiprackByMountMap } from '../../robot/types'
-import type { AttachedPipettesByMount } from '../../pipettes/types'
+import type { Mount } from '../../pipettes/types'
 
 type Props = {|
+  currentMount: Mount | null,
   pipettes: Array<Pipette>,
   tipracksByMount: TiprackByMountMap,
-  currentPipette: ?Pipette,
-  actualPipettes: ?AttachedPipettesByMount,
   changePipetteUrl: string,
 |}
 
-const { PIPETTE_MOUNTS } = robotConstants
-const ATTACH_ALERT = 'Pipette missing'
-const CHANGE_ALERT = 'Incorrect pipette attached'
-
 export default function Pipettes(props: Props) {
-  const {
-    currentPipette,
-    pipettes,
-    tipracksByMount,
-    actualPipettes,
-    changePipetteUrl,
-  } = props
-  const currentMount = currentPipette && currentPipette.mount
+  const { currentMount, pipettes, tipracksByMount } = props
 
   const infoByMount = PIPETTE_MOUNTS.reduce((result, mount) => {
     const pipette = pipettes.find(p => p.mount === mount)
     const tiprack = tipracksByMount[mount]
     const pipetteConfig = pipette?.modelSpecs
-    const actualPipetteConfig = actualPipettes?.[mount]?.modelSpecs
-
     const isDisabled = !pipette || mount !== currentMount
+
     const details = !pipetteConfig
       ? { description: 'N/A', tiprackModel: 'N/A' }
       : {
@@ -48,44 +34,11 @@ export default function Pipettes(props: Props) {
           pipetteSpecs: pipetteConfig,
         }
 
-    let showAlert = false
-    let alertType = ''
-
-    // only show alert if a pipette is on this mount in the protocol
-    if (pipetteConfig) {
-      if (!actualPipetteConfig) {
-        showAlert = true
-        alertType = 'attach'
-      } else if (
-        actualPipetteConfig &&
-        actualPipetteConfig.name !== pipetteConfig.name
-      ) {
-        showAlert = true
-        alertType = 'change'
-      }
-    }
-
-    const children = showAlert && (
-      <div>
-        <AlertItem
-          type="warning"
-          className={styles.alert}
-          title={alertType === 'attach' ? ATTACH_ALERT : CHANGE_ALERT}
-        />
-        <p className={styles.wrong_pipette_message}>
-          {'Go to the '}
-          <Link to={changePipetteUrl}>robot settings</Link>
-          {` panel to ${alertType} pipette.`}
-        </p>
-      </div>
-    )
-
     return {
       ...result,
       [mount]: {
         mount,
         isDisabled,
-        children,
         className: cx(styles.instrument, styles[mount]),
         infoClassName: styles.instrument_info,
         ...details,

--- a/app/src/nav/__tests__/calibrate-selectors.test.js
+++ b/app/src/nav/__tests__/calibrate-selectors.test.js
@@ -1,0 +1,133 @@
+// @flow
+import noop from 'lodash/noop'
+
+import * as RobotSelectors from '../../robot/selectors'
+import * as NavSelectors from '../selectors'
+import * as CalibrateSelectors from '../calibrate-selectors'
+
+import type { State } from '../../types'
+
+type SelectorSpec = {|
+  name: string,
+  selector: State => mixed,
+  before?: () => mixed,
+  after?: () => mixed,
+  expected: mixed,
+|}
+
+jest.mock('../selectors')
+jest.mock('../../robot/selectors')
+
+const mockGetCalibrateLocation: JestMockFn<
+  [State],
+  $Call<typeof NavSelectors.getCalibrateLocation, State>
+> = NavSelectors.getCalibrateLocation
+
+const mockGetPipettes: JestMockFn<
+  [State],
+  $Call<typeof RobotSelectors.getPipettes, State>
+> = RobotSelectors.getPipettes
+
+const ENABLED_CALIBRATE = {
+  id: 'calibrate',
+  path: '/calibrate',
+  title: 'Calibrate',
+  iconName: 'ot-calibrate',
+  disabledReason: null,
+}
+
+const DISABLED_CALIBRATE = {
+  ...ENABLED_CALIBRATE,
+  disabledReason: 'AH',
+}
+
+describe('calibrate nav selectors', () => {
+  const mockState: State = ({ mockState: true }: any)
+
+  beforeEach(() => {
+    mockGetCalibrateLocation.mockReturnValue(DISABLED_CALIBRATE)
+    mockGetPipettes.mockReturnValue([])
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  const SPECS: Array<SelectorSpec> = [
+    {
+      name:
+        'getCalibratePipettesLocations returns disabled if /calibrate disabled',
+      selector: CalibrateSelectors.getCalibratePipettesLocations,
+      expected: {
+        left: { path: '/calibrate/pipettes/left', disabledReason: 'AH' },
+        right: { path: '/calibrate/pipettes/right', disabledReason: 'AH' },
+      },
+    },
+    {
+      name: 'getCalibratePipettesLocations returns disabled if no pipettes',
+      selector: CalibrateSelectors.getCalibratePipettesLocations,
+      before: () => mockGetCalibrateLocation.mockReturnValue(ENABLED_CALIBRATE),
+      expected: {
+        left: {
+          path: '/calibrate/pipettes/left',
+          disabledReason: expect.stringMatching(/No pipette specified/),
+        },
+        right: {
+          path: '/calibrate/pipettes/right',
+          disabledReason: expect.stringMatching(/No pipette specified/),
+        },
+      },
+    },
+    {
+      name: 'getCalibratePipettesLocations returns disabled if pipette unused',
+      selector: CalibrateSelectors.getCalibratePipettesLocations,
+      before: () => {
+        mockGetCalibrateLocation.mockReturnValue(ENABLED_CALIBRATE)
+        mockGetPipettes.mockReturnValue([
+          ({ _id: 0, mount: 'right', tipRacks: [] }: any),
+        ])
+      },
+      expected: {
+        left: {
+          path: '/calibrate/pipettes/left',
+          disabledReason: expect.stringMatching(/No pipette specified/),
+        },
+        right: {
+          path: '/calibrate/pipettes/right',
+          disabledReason: expect.stringMatching(/not used/),
+        },
+      },
+    },
+    {
+      name: 'getCalibratePipettesLocations returns enabled if pipette used',
+      selector: CalibrateSelectors.getCalibratePipettesLocations,
+      before: () => {
+        mockGetCalibrateLocation.mockReturnValue(ENABLED_CALIBRATE)
+        mockGetPipettes.mockReturnValue([
+          ({ _id: 0, mount: 'right', tipRacks: [1, 2] }: any),
+        ])
+      },
+      expected: {
+        left: {
+          path: '/calibrate/pipettes/left',
+          disabledReason: expect.stringMatching(/No pipette specified/),
+        },
+        right: {
+          path: '/calibrate/pipettes/right',
+          disabledReason: null,
+        },
+      },
+    },
+  ]
+
+  SPECS.forEach(spec => {
+    const { name, selector, expected, before = noop, after = noop } = spec
+    const state = { ...mockState }
+
+    test(name, () => {
+      before()
+      expect(selector(state)).toEqual(expected)
+      after()
+    })
+  })
+})

--- a/app/src/nav/calibrate-selectors.js
+++ b/app/src/nav/calibrate-selectors.js
@@ -1,0 +1,46 @@
+// @flow
+// calibrate sublocations
+import { createSelector } from 'reselect'
+
+import { LEFT, RIGHT } from '../pipettes'
+import { selectors as RobotSelectors } from '../robot'
+import { getCalibrateLocation } from './selectors'
+
+import type { State } from '../types'
+import type { SubnavLocation } from './types'
+
+// TODO(mc, 2019-12-10): i18n
+const NO_PIPETTE_SPECIFIED_FOR_THIS_MOUNT =
+  'No pipette specified for this mount'
+const PIPETTE_IS_NOT_USED_IN_THIS_PROTOCOL =
+  'This pipette is not used in this protocol'
+
+export const getCalibratePipettesLocations: State => {|
+  left: SubnavLocation,
+  right: SubnavLocation,
+|} = createSelector(
+  getCalibrateLocation,
+  RobotSelectors.getPipettes,
+  (parentLocation, pipettes) => {
+    const makePath = mount => `${parentLocation.path}/pipettes/${mount}`
+    const makeDisReason = mount => {
+      const pipette = pipettes.find(p => p.mount === mount)
+      let disabledReason = null
+
+      if (parentLocation.disabledReason != null) {
+        disabledReason = parentLocation.disabledReason
+      } else if (!pipette) {
+        disabledReason = NO_PIPETTE_SPECIFIED_FOR_THIS_MOUNT
+      } else if (pipette.tipRacks.length === 0) {
+        disabledReason = PIPETTE_IS_NOT_USED_IN_THIS_PROTOCOL
+      }
+
+      return disabledReason
+    }
+
+    return {
+      left: { path: makePath(LEFT), disabledReason: makeDisReason(LEFT) },
+      right: { path: makePath(RIGHT), disabledReason: makeDisReason(RIGHT) },
+    }
+  }
+)

--- a/app/src/nav/index.js
+++ b/app/src/nav/index.js
@@ -1,3 +1,4 @@
 // @flow
 
 export * from './selectors'
+export * from './calibrate-selectors'

--- a/app/src/nav/types.js
+++ b/app/src/nav/types.js
@@ -10,3 +10,8 @@ export type NavLocation = {|
   disabledReason?: string | null,
   notificationReason?: string | null,
 |}
+
+export type SubnavLocation = {|
+  path: string,
+  disabledReason?: string | null,
+|}

--- a/app/src/pages/Calibrate/index.js
+++ b/app/src/pages/Calibrate/index.js
@@ -14,7 +14,7 @@ import CalibrateLabware from './Labware'
 type OP = {| match: Match |}
 
 type SP = {|
-  nextPipette: Pipette,
+  nextPipette: Pipette | null,
   labware: Array<Labware>,
   nextLabware: Labware,
   isTipsProbed: boolean,

--- a/app/src/pipettes/constants.js
+++ b/app/src/pipettes/constants.js
@@ -1,5 +1,7 @@
 // @flow
 
+import type { Mount } from './types'
+
 // action types
 
 // fetch pipettes
@@ -44,7 +46,7 @@ export const PIPETTE_SETTINGS_PATH: '/settings/pipettes' = '/settings/pipettes'
 
 export const LEFT: 'left' = 'left'
 export const RIGHT: 'right' = 'right'
-export const PIPETTE_MOUNTS: ['left', 'right'] = [LEFT, RIGHT]
+export const PIPETTE_MOUNTS: Array<Mount> = [LEFT, RIGHT]
 export const MATCH: 'match' = 'match'
 export const INCOMPATIBLE: 'incompatible' = 'incompatible'
 export const INEXACT_MATCH: 'inexact_match' = 'inexact_match'

--- a/app/src/pipettes/selectors.js
+++ b/app/src/pipettes/selectors.js
@@ -16,9 +16,10 @@ import type { State } from '../types'
 
 export const getAttachedPipettes: (
   state: State,
-  robotName: string
+  robotName: string | null
 ) => Types.AttachedPipettesByMount = createSelector(
-  (state, robotName) => state.pipettes[robotName]?.attachedByMount,
+  (state, robotName) =>
+    robotName ? state.pipettes[robotName]?.attachedByMount : null,
   attachedByMount => {
     return Constants.PIPETTE_MOUNTS.reduce<Types.AttachedPipettesByMount>(
       (result, mount) => {
@@ -39,10 +40,11 @@ export const getAttachedPipettes: (
 
 export const getAttachedPipetteSettings: (
   state: State,
-  robotName: string
+  robotName: string | null
 ) => Types.PipetteSettingsByMount = createSelector(
   getAttachedPipettes,
-  (state, robotName) => state.pipettes[robotName]?.settingsById,
+  (state, robotName) =>
+    robotName ? state.pipettes[robotName]?.settingsById : null,
   (attachedByMount, settingsById) => {
     return Constants.PIPETTE_MOUNTS.reduce<Types.PipetteSettingsByMount>(
       (result, mount) => {
@@ -71,12 +73,13 @@ const pipettesAreInexactMatch = (
   return backCompatNames && backCompatNames.includes(protocolInstrName)
 }
 
+// TODO(mc, 2019-12-10): possibly use getConnectedRobot selector rather than robotName
 export const getProtocolPipettesInfo: (
   state: State,
-  robotName: string
+  robotName: string | null
 ) => Types.ProtocolPipetteInfoByMount = createSelector<
   State,
-  string,
+  string | null,
   Types.ProtocolPipetteInfoByMount,
   _,
   _

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -22,7 +22,6 @@ import { getCustomLabwareDefinitions } from '../../custom-labware/selectors'
 
 const RUN_TIME_TICK_INTERVAL_MS = 1000
 const NO_INTERVAL = -1
-const RE_VOLUME = /.*?(\d+).*?/
 const RE_TIPRACK = /tip ?rack/i
 
 const THIS_ROBOT_DOES_NOT_SUPPORT_BUNDLES =
@@ -549,17 +548,21 @@ export default function client(dispatch) {
     }
 
     function addApiInstrumentToPipettes(apiInstrument) {
-      const { _id, mount, name, channels, requested_as } = apiInstrument
-      // TODO(mc, 2018-01-17): pull this somehow from tiprack the instrument
-      //  interacts with
-      const volume = Number(name.match(RE_VOLUME)[1])
+      const {
+        _id,
+        mount,
+        name,
+        channels,
+        requested_as,
+        tip_racks,
+      } = apiInstrument
 
       update.pipettesByMount[mount] = {
         _id,
         mount,
         name,
         channels,
-        volume,
+        tipRacks: tip_racks.map(t => t._id),
         requestedAs: requested_as,
       }
     }

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -253,13 +253,13 @@ export function getApiLevel(state: State) {
   return session(state).apiLevel
 }
 
-// $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
-export const getNextPipette = createSelector(
+export const getNextPipette: State => Pipette | null = createSelector(
   getPipettes,
-  (pipettes): ?Pipette => {
-    const nextPipette = pipettes.find(i => !i.probed)
+  (pipettes): Pipette | null => {
+    const usedPipettes = pipettes.filter(p => p.tipRacks.length > 0)
+    const nextPipette = usedPipettes.find(i => !i.probed)
 
-    return nextPipette || pipettes[0]
+    return nextPipette || usedPipettes[0] || null
   }
 )
 

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -436,14 +436,16 @@ describe('api client', () => {
               mount: 'left',
               name: 'p200',
               channels: 1,
-              volume: 200,
+              tipRacks: [4, 5],
+              requestedAs: 'bar',
             },
             right: {
               _id: 1,
               mount: 'right',
               name: 'p50',
               channels: 8,
-              volume: 50,
+              tipRacks: [3, 4],
+              requestedAs: 'foo',
             },
           },
         }),
@@ -451,8 +453,22 @@ describe('api client', () => {
       )
 
       session.instruments = [
-        { _id: 1, mount: 'right', name: 'p50', channels: 8 },
-        { _id: 2, mount: 'left', name: 'p200', channels: 1 },
+        {
+          _id: 1,
+          mount: 'right',
+          name: 'p50',
+          channels: 8,
+          tip_racks: [{ _id: 3 }, { _id: 4 }],
+          requested_as: 'foo',
+        },
+        {
+          _id: 2,
+          mount: 'left',
+          name: 'p200',
+          channels: 1,
+          tip_racks: [{ _id: 4 }, { _id: 5 }],
+          requested_as: 'bar',
+        },
       ]
 
       return sendConnect().then(() =>

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -83,10 +83,9 @@ export type StatePipette = {
   // Python Pipette's `name` field by the pipette factory functions.
   // TLDR: this `name` needs to be renamed in a future PR to `model`
   name: string,
-  // volume of the instrument
-  // TODO(mc, 2018-01-17): this is used to drive tip probe setup
-  // instructions which is incorrect and needs to be rethought
-  volume: number,
+  // tipracks the pipette uses during the protocol
+  // array of RPC object IDs corresponding to `_id` field in StateLabware
+  tipRacks: Array<number>,
   // string specified in protocol to load pipette
   requestedAs?: ?string,
 }

--- a/components/src/lists/ListItem.js
+++ b/components/src/lists/ListItem.js
@@ -7,11 +7,15 @@ import classnames from 'classnames'
 import styles from './lists.css'
 import { type IconName, Icon } from '../icons'
 
-type ListItemProps = {
+type ListItemProps = {|
   /** click handler */
   onClick?: (event: SyntheticEvent<>) => mixed,
+  /** mouse enter handler */
+  onMouseEnter?: (event: SyntheticMouseEvent<>) => mixed,
+  /** mouse leave handler */
+  onMouseLeave?: (event: SyntheticMouseEvent<>) => mixed,
   /** if URL is specified, ListItem is wrapped in a React Router NavLink */
-  url?: string,
+  url?: string | null,
   /** if URL is specified NavLink can receive an active class name */
   activeClassName?: string,
   /** if URL is specified NavLink can receive an exact property for matching routes */
@@ -23,13 +27,15 @@ type ListItemProps = {
   /** name constant of the icon to display */
   iconName?: IconName,
   children: React.Node,
-}
+|}
 
 /**
  * A styled `<li>` with an optional icon, and an optional url for a React Router `NavLink`
  *
  */
-export default function ListItem(props: ListItemProps) {
+export default React.forwardRef<ListItemProps, _>(ListItem)
+
+function ListItem(props: ListItemProps, ref) {
   const { url, isDisabled, iconName, activeClassName, exact } = props
   const onClick = props.onClick && !isDisabled ? props.onClick : undefined
 
@@ -42,9 +48,13 @@ export default function ListItem(props: ListItemProps) {
     <Icon className={styles.item_icon} name={iconName} />
   )
 
-  if (url) {
+  if (url != null) {
     return (
-      <li>
+      <li
+        onMouseEnter={props.onMouseEnter}
+        onMouseLeave={props.onMouseLeave}
+        ref={ref}
+      >
         <NavLink
           to={url}
           onClick={onClick}
@@ -61,7 +71,13 @@ export default function ListItem(props: ListItemProps) {
   }
 
   return (
-    <li onClick={onClick} className={className}>
+    <li
+      ref={ref}
+      onClick={onClick}
+      onMouseEnter={props.onMouseEnter}
+      onMouseLeave={props.onMouseLeave}
+      className={className}
+    >
       {itemIcon}
       {props.children}
     </li>


### PR DESCRIPTION
## overview

This PR disables tip-probe calibration for pipettes that are "unused" in a given protocol. "unused" is taken to mean "RPC reports this pipette interacts with 0 tip racks"

Closes #4570

## changelog

- fix(app): disable tip probe for unused pipettes
    - Also removed the no-longer-used alert banner on the /calibrate/pipettes page that now never shows up because you're not allowed to proceed to calibration if your pipettes don't match

## review requests

- [ ] Is "RPC reports this pipette interacts with 0 tip racks" actually a good proxy for pipette is unused?
- [ ] Tip probe continues to function
- [ ] No way to initiate tip probe for an unused pipette
- [ ] Optional `ListItem` prop additions don't mess with anything