### PR TITLE
fix(api): apiv1: move instrument in Z-axis prior to touch tip in XY

### DIFF
--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -783,10 +783,8 @@ class Pipette(CommandPublisher):
 
         Parameters
         ----------
-        location : :any:`Placeable` or tuple(:any:`Placeable`, :any:`Vector`)
+        location : :any:`Placeable`
             The :any:`Placeable` (:any:`Well`) to perform the touch_tip.
-            Can also be a tuple with first item :any:`Placeable`,
-            second item relative :any:`Vector`
 
         radius : float
             Radius is a floating point describing the percentage of a well's

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -841,9 +841,8 @@ class Pipette(CommandPublisher):
         do_publish(self.broker, commands.touch_tip, self.touch_tip, 'before',
                    None, None, self, location, radius, v_offset, speed)
 
-        # move to location if we're not already there
-        if location != self.previous_placeable:
-            self.move_to(location)
+        # move to location
+        self.move_to(location.top(v_offset))
 
         v_offset = (0, 0, v_offset)
 

--- a/api/tests/opentrons/labware/test_pipette_unittest.py
+++ b/api/tests/opentrons/labware/test_pipette_unittest.py
@@ -919,9 +919,10 @@ def test_touch_tip(local_test_pipette):
     p200.touch_tip(plate[1], radius=0.5)
 
     expected = [
-        mock.call(plate[0],
-                  instrument=p200,
-                  strategy='arc'),
+        mock.call(
+            (plate[0], (3.20, 3.20, 9.50)),
+            instrument=p200,
+            strategy='arc'),
 
         mock.call(
             (plate[0], (6.40, 3.20, 9.50)),
@@ -940,6 +941,10 @@ def test_touch_tip(local_test_pipette):
             instrument=p200,
             strategy='direct'),
         mock.call(
+            (plate[0], (3.20, 3.20, 7.50)),
+            instrument=p200,
+            strategy='direct'),
+        mock.call(
             (plate[0], (6.40, 3.20, 7.50)),
             instrument=p200,
             strategy='direct'),
@@ -955,9 +960,10 @@ def test_touch_tip(local_test_pipette):
             (plate[0], (3.20, 0.00, 7.50)),
             instrument=p200,
             strategy='direct'),
-        mock.call(plate[1],
-                  instrument=p200,
-                  strategy='arc'),
+        mock.call(
+            (plate[1], (3.20, 3.20, 9.50)),
+            instrument=p200,
+            strategy='arc'),
         mock.call(
             (plate[1], (4.80, 3.20, 9.50)),
             instrument=p200,


### PR DESCRIPTION
## overview
Touch tip in APIv1 moves to the +X direction to touch the first side of the well before moving up to the desired height. This causes collisions with any labware with v-shaped wells, and can potentially dislocate tube racks by dragging the upwards (see behavior [here](https://drive.google.com/file/d/1hSRdIlICRC9edA2o0Bwjdsvk37xzf33v/view?usp=sharing))

This PR fixes this issue by moving the pipette to the correct Z height for touch tip before moving in the XY directions, mimicking the touch tip behavior in APIv2. 

Closes #2712 & closes #3599

## review requests
Already tested on 🍀 but feel free to verify the behavior.
Can this fix possibly break anything?