### PR TITLE
chore(docs): put a banner in ot1 docs

### DIFF
--- a/api/docs/ot1/_static/banners.css
+++ b/api/docs/ot1/_static/banners.css
@@ -1,0 +1,45 @@
+.banner_wrapper {
+  border: 1px solid #d8d8d8;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  width: auto;
+}
+
+.banner_wrapper a {
+  text-decoration: none;
+}
+
+.banner_v1 {
+  display: flex;
+  justify-content: space-between;
+  align-items:center;
+}
+
+@media only screen and (min-width: 1024px) {
+  .banner_wrapper {
+    width: 105%;
+  }
+}
+
+#heading_2 {
+  color: black;
+  font-weight: 600;
+  font-size: 18px;
+  margin: 0 0 0.25rem;
+}
+
+#heading_4 {
+  color: black;
+  font-size: 14px;
+  margin: 0;
+}
+
+#heading_v2 {
+  color: black;
+  font-size: 24px;
+  margin: 0 0 0.25rem;
+}
+
+.banner_list li {
+  margin: 0.25rem 0;
+}

--- a/api/docs/ot1/api.html
+++ b/api/docs/ot1/api.html
@@ -13,15 +13,16 @@
     <link rel="stylesheet" href="_static/override_sphinx.css" type="text/css" />
     <link rel="stylesheet" href="_static/nav.css" type="text/css" />
     <link rel="stylesheet" href="_static/new-nav.css" type="text/css" />
+    <link rel="stylesheet" href="_static/banners.css" type="text/css" />
 
     <script type="text/javascript">
-      var DOCUMENTATION_OPTIONS = {
-        URL_ROOT:    './',
-        VERSION:     '2.0',
-        COLLAPSE_INDEX: false,
-        FILE_SUFFIX: '.html',
-        HAS_SOURCE:  true
-      };
+     var DOCUMENTATION_OPTIONS = {
+         URL_ROOT:    './',
+         VERSION:     '2.0',
+         COLLAPSE_INDEX: false,
+         FILE_SUFFIX: '.html',
+         HAS_SOURCE:  true
+     };
     </script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
@@ -1008,7 +1009,9 @@ window.intercomSettings = {
     <div class="documentwrapper">
         <div class="bodywrapper">
             <div class="body" role="main">
-
+                <div class="banner_wrapper">
+                    <p> You are currently viewing the documentation for the Opentrons OT-1. To view documentation for the OT-2, click <a href="../v2/index.html">here</a>.
+                </div>
   <div class="section" id="module-opentrons">
 <span id="api-reference"></span><span id="api"></span><h1>API Reference<a class="headerlink" href="#module-opentrons" title="Permalink to this headline">¶</a></h1>
 <p>If you are reading this, you are probably looking for an in-depth explanation of API classes and methods to fully master your protocol development skills.</p>

--- a/api/docs/ot1/calibration.html
+++ b/api/docs/ot1/calibration.html
@@ -11,15 +11,16 @@
     <link rel="stylesheet" href="_static/override_sphinx.css" type="text/css" />
     <link rel="stylesheet" href="_static/nav.css" type="text/css" />
     <link rel="stylesheet" href="_static/new-nav.css" type="text/css" />
+    <link rel="stylesheet" href="_static/banners.css" type="text/css" />
 
     <script type="text/javascript">
-      var DOCUMENTATION_OPTIONS = {
-        URL_ROOT: './',
-        VERSION: '2.0',
-        COLLAPSE_INDEX: false,
-        FILE_SUFFIX: '.html',
-        HAS_SOURCE: true,
-      }
+     var DOCUMENTATION_OPTIONS = {
+         URL_ROOT: './',
+         VERSION: '2.0',
+         COLLAPSE_INDEX: false,
+         FILE_SUFFIX: '.html',
+         HAS_SOURCE: true,
+     }
     </script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
@@ -1106,7 +1107,10 @@
     <div class="document">
       <div class="documentwrapper">
         <div class="bodywrapper">
-          <div class="body" role="main">
+            <div class="body" role="main">
+                <div class="banner_wrapper">
+                    <p> You are currently viewing the documentation for the Opentrons OT-1. To view documentation for the OT-2, click <a href="../v2/index.html">here</a>.
+                </div>
             <div class="section" id="how-to-calibrate">
               <span id="calibration"></span>
               <h1>

--- a/api/docs/ot1/containers.html
+++ b/api/docs/ot1/containers.html
@@ -11,15 +11,16 @@
     <link rel="stylesheet" href="_static/override_sphinx.css" type="text/css" />
     <link rel="stylesheet" href="_static/nav.css" type="text/css" />
     <link rel="stylesheet" href="_static/new-nav.css" type="text/css" />
+    <link rel="stylesheet" href="_static/banners.css" type="text/css" />
 
     <script type="text/javascript">
-      var DOCUMENTATION_OPTIONS = {
-        URL_ROOT: './',
-        VERSION: '2.0',
-        COLLAPSE_INDEX: false,
-        FILE_SUFFIX: '.html',
-        HAS_SOURCE: true,
-      }
+     var DOCUMENTATION_OPTIONS = {
+         URL_ROOT: './',
+         VERSION: '2.0',
+         COLLAPSE_INDEX: false,
+         FILE_SUFFIX: '.html',
+         HAS_SOURCE: true,
+     }
     </script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
@@ -1106,7 +1107,10 @@
     <div class="document">
       <div class="documentwrapper">
         <div class="bodywrapper">
-          <div class="body" role="main">
+            <div class="body" role="main">
+                <div class="banner_wrapper">
+                    <p> You are currently viewing the documentation for the Opentrons OT-1. To view documentation for the OT-2, click <a href="../v2/index.html">here</a>.
+                </div>
             <div class="section" id="containers">
               <span id="id1"></span>
               <h1>

--- a/api/docs/ot1/examples.html
+++ b/api/docs/ot1/examples.html
@@ -11,15 +11,16 @@
     <link rel="stylesheet" href="_static/override_sphinx.css" type="text/css" />
     <link rel="stylesheet" href="_static/nav.css" type="text/css" />
     <link rel="stylesheet" href="_static/new-nav.css" type="text/css" />
+    <link rel="stylesheet" href="_static/banners.css" type="text/css" />
 
     <script type="text/javascript">
-      var DOCUMENTATION_OPTIONS = {
-        URL_ROOT: './',
-        VERSION: '2.0',
-        COLLAPSE_INDEX: false,
-        FILE_SUFFIX: '.html',
-        HAS_SOURCE: true,
-      }
+     var DOCUMENTATION_OPTIONS = {
+         URL_ROOT: './',
+         VERSION: '2.0',
+         COLLAPSE_INDEX: false,
+         FILE_SUFFIX: '.html',
+         HAS_SOURCE: true,
+     }
     </script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
@@ -1106,7 +1107,10 @@
     <div class="document">
       <div class="documentwrapper">
         <div class="bodywrapper">
-          <div class="body" role="main">
+            <div class="body" role="main">
+                <div class="banner_wrapper">
+                    <p> You are currently viewing the documentation for the Opentrons OT-1. To view documentation for the OT-2, click <a href="../v2/index.html">here</a>.
+                </div>
             <div class="section" id="examples">
               <span id="id1"></span>
               <h1>

--- a/api/docs/ot1/firmware.html
+++ b/api/docs/ot1/firmware.html
@@ -11,14 +11,16 @@
     <link rel="stylesheet" href="_static/override_sphinx.css" type="text/css" />
     <link rel="stylesheet" href="_static/nav.css" type="text/css" />
     <link rel="stylesheet" href="_static/new-nav.css" type="text/css" />
+    <link rel="stylesheet" href="_static/banners.css" type="text/css" />
+    
     <script type="text/javascript">
-      var DOCUMENTATION_OPTIONS = {
-        URL_ROOT: './',
-        VERSION: '2.0',
-        COLLAPSE_INDEX: false,
-        FILE_SUFFIX: '.html',
-        HAS_SOURCE: true,
-      }
+     var DOCUMENTATION_OPTIONS = {
+         URL_ROOT: './',
+         VERSION: '2.0',
+         COLLAPSE_INDEX: false,
+         FILE_SUFFIX: '.html',
+         HAS_SOURCE: true,
+     }
     </script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
@@ -1104,7 +1106,10 @@
     <div class="document">
       <div class="documentwrapper">
         <div class="bodywrapper">
-          <div class="body" role="main">
+            <div class="body" role="main">
+                <div class="banner_wrapper">
+                    <p> You are currently viewing the documentation for the Opentrons OT-1. To view documentation for the OT-2, click <a href="../v2/index.html">here</a>.
+                </div>
             <div class="section" id="firmware-updates">
               <span id="firmware"></span>
               <h1>

--- a/api/docs/ot1/genindex.html
+++ b/api/docs/ot1/genindex.html
@@ -11,15 +11,16 @@
     <link rel="stylesheet" href="_static/override_sphinx.css" type="text/css" />
     <link rel="stylesheet" href="_static/nav.css" type="text/css" />
     <link rel="stylesheet" href="_static/new-nav.css" type="text/css" />
+    <link rel="stylesheet" href="_static/banners.css" type="text/css" />
 
     <script type="text/javascript">
-      var DOCUMENTATION_OPTIONS = {
-        URL_ROOT: './',
-        VERSION: '2.0',
-        COLLAPSE_INDEX: false,
-        FILE_SUFFIX: '.html',
-        HAS_SOURCE: true,
-      }
+     var DOCUMENTATION_OPTIONS = {
+         URL_ROOT: './',
+         VERSION: '2.0',
+         COLLAPSE_INDEX: false,
+         FILE_SUFFIX: '.html',
+         HAS_SOURCE: true,
+     }
     </script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
@@ -1104,7 +1105,10 @@
     <div class="document">
       <div class="documentwrapper">
         <div class="bodywrapper">
-          <div class="body" role="main">
+            <div class="body" role="main">
+                <div class="banner_wrapper">
+                    <p> You are currently viewing the documentation for the Opentrons OT-1. To view documentation for the OT-2, click <a href="../v2/index.html">here</a>.
+                </div>
             <h1 id="index">Index</h1>
 
             <div class="genindex-jumpbox">

--- a/api/docs/ot1/index.html
+++ b/api/docs/ot1/index.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="_static/override_sphinx.css" type="text/css" />
     <link rel="stylesheet" href="_static/nav.css" type="text/css" />
     <link rel="stylesheet" href="_static/new-nav.css" type="text/css" />
+    <link rel="stylesheet" href="_static/banners.css" type="text/css" />
 
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
@@ -1105,7 +1106,11 @@
     <div class="document">
       <div class="documentwrapper">
         <div class="bodywrapper">
-          <div class="body" role="main">
+            <div class="body" role="main">
+                <div class="banner_wrapper">
+                    <h2 id="heading_2">We thought you'd like to know...</h2>
+                    <h4 id="heading_4">The documentation you are viewing is for the Opentrons OT-1. If you have an Opentrons OT-2, please click <a href="../v2/index.html">here</a> for the OT-2 Python Protocol API documentation.
+                </div>
             <div class="section" id="opentrons-api">
               <h1>
                 Opentrons API<a

--- a/api/docs/ot1/modules.html
+++ b/api/docs/ot1/modules.html
@@ -11,15 +11,16 @@
     <link rel="stylesheet" href="_static/override_sphinx.css" type="text/css" />
     <link rel="stylesheet" href="_static/nav.css" type="text/css" />
     <link rel="stylesheet" href="_static/new-nav.css" type="text/css" />
+    <link rel="stylesheet" href="_static/banners.css" type="text/css" />
 
     <script type="text/javascript">
-      var DOCUMENTATION_OPTIONS = {
-        URL_ROOT: './',
-        VERSION: '2.0',
-        COLLAPSE_INDEX: false,
-        FILE_SUFFIX: '.html',
-        HAS_SOURCE: true,
-      }
+     var DOCUMENTATION_OPTIONS = {
+         URL_ROOT: './',
+         VERSION: '2.0',
+         COLLAPSE_INDEX: false,
+         FILE_SUFFIX: '.html',
+         HAS_SOURCE: true,
+     }
     </script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
@@ -1106,7 +1107,10 @@
     <div class="document">
       <div class="documentwrapper">
         <div class="bodywrapper">
-          <div class="body" role="main">
+            <div class="body" role="main">
+                <div class="banner_wrapper">
+                    <p> You are currently viewing the documentation for the Opentrons OT-1. To view documentation for the OT-2, click <a href="../v2/index.html">here</a>.
+                </div>
             <div class="section" id="hardware-modules">
               <span id="modules"></span>
               <h1>

--- a/api/docs/ot1/pipettes.html
+++ b/api/docs/ot1/pipettes.html
@@ -11,15 +11,16 @@
     <link rel="stylesheet" href="_static/override_sphinx.css" type="text/css" />
     <link rel="stylesheet" href="_static/nav.css" type="text/css" />
     <link rel="stylesheet" href="_static/new-nav.css" type="text/css" />
+    <link rel="stylesheet" href="_static/banners.css" type="text/css" />
 
     <script type="text/javascript">
-      var DOCUMENTATION_OPTIONS = {
-        URL_ROOT: './',
-        VERSION: '2.0',
-        COLLAPSE_INDEX: false,
-        FILE_SUFFIX: '.html',
-        HAS_SOURCE: true,
-      }
+     var DOCUMENTATION_OPTIONS = {
+         URL_ROOT: './',
+         VERSION: '2.0',
+         COLLAPSE_INDEX: false,
+         FILE_SUFFIX: '.html',
+         HAS_SOURCE: true,
+     }
     </script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
@@ -1106,7 +1107,10 @@
     <div class="document">
       <div class="documentwrapper">
         <div class="bodywrapper">
-          <div class="body" role="main">
+            <div class="body" role="main">
+                <div class="banner_wrapper">
+                    <p> You are currently viewing the documentation for the Opentrons OT-1. To view documentation for the OT-2, click <a href="../v2/index.html">here</a>.
+                </div>
             <div class="section" id="liquid-handling">
               <span id="pipettes"></span>
               <h1>

--- a/api/docs/ot1/py-modindex.html
+++ b/api/docs/ot1/py-modindex.html
@@ -11,15 +11,16 @@
     <link rel="stylesheet" href="_static/override_sphinx.css" type="text/css" />
     <link rel="stylesheet" href="_static/nav.css" type="text/css" />
     <link rel="stylesheet" href="_static/new-nav.css" type="text/css" />
+    <link rel="stylesheet" href="_static/banners.css" type="text/css" />
 
     <script type="text/javascript">
-      var DOCUMENTATION_OPTIONS = {
-        URL_ROOT: './',
-        VERSION: '2.0',
-        COLLAPSE_INDEX: false,
-        FILE_SUFFIX: '.html',
-        HAS_SOURCE: true,
-      }
+     var DOCUMENTATION_OPTIONS = {
+         URL_ROOT: './',
+         VERSION: '2.0',
+         COLLAPSE_INDEX: false,
+         FILE_SUFFIX: '.html',
+         HAS_SOURCE: true,
+     }
     </script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
@@ -1105,7 +1106,10 @@
     <div class="document">
       <div class="documentwrapper">
         <div class="bodywrapper">
-          <div class="body" role="main">
+            <div class="body" role="main">
+                <div class="banner_wrapper">
+                    <p> You are currently viewing the documentation for the Opentrons OT-1. To view documentation for the OT-2, click <a href="../v2/index.html">here</a>.
+                </div>
             <h1>Python Module Index</h1>
 
             <div class="modindex-jumpbox">

--- a/api/docs/ot1/robot.html
+++ b/api/docs/ot1/robot.html
@@ -11,15 +11,16 @@
     <link rel="stylesheet" href="_static/override_sphinx.css" type="text/css" />
     <link rel="stylesheet" href="_static/nav.css" type="text/css" />
     <link rel="stylesheet" href="_static/new-nav.css" type="text/css" />
+    <link rel="stylesheet" href="_static/banners.css" type="text/css" />
 
     <script type="text/javascript">
-      var DOCUMENTATION_OPTIONS = {
-        URL_ROOT: './',
-        VERSION: '2.0',
-        COLLAPSE_INDEX: false,
-        FILE_SUFFIX: '.html',
-        HAS_SOURCE: true,
-      }
+     var DOCUMENTATION_OPTIONS = {
+         URL_ROOT: './',
+         VERSION: '2.0',
+         COLLAPSE_INDEX: false,
+         FILE_SUFFIX: '.html',
+         HAS_SOURCE: true,
+     }
     </script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
@@ -1106,7 +1107,10 @@
     <div class="document">
       <div class="documentwrapper">
         <div class="bodywrapper">
-          <div class="body" role="main">
+            <div class="body" role="main">
+                <div class="banner_wrapper">
+                    <p> You are currently viewing the documentation for the Opentrons OT-1. To view documentation for the OT-2, click <a href="../v2/index.html">here</a>.
+                </div>
             <span class="target" id="robot"></span>
             <div class="section" id="advanced-control">
               <h1>

--- a/api/docs/ot1/search.html
+++ b/api/docs/ot1/search.html
@@ -11,15 +11,16 @@
     <link rel="stylesheet" href="_static/override_sphinx.css" type="text/css" />
     <link rel="stylesheet" href="_static/nav.css" type="text/css" />
     <link rel="stylesheet" href="_static/new-nav.css" type="text/css" />
+    <link rel="stylesheet" href="_static/banners.css" type="text/css" />
 
     <script type="text/javascript">
-      var DOCUMENTATION_OPTIONS = {
-        URL_ROOT: './',
-        VERSION: '2.0',
-        COLLAPSE_INDEX: false,
-        FILE_SUFFIX: '.html',
-        HAS_SOURCE: true,
-      }
+     var DOCUMENTATION_OPTIONS = {
+         URL_ROOT: './',
+         VERSION: '2.0',
+         COLLAPSE_INDEX: false,
+         FILE_SUFFIX: '.html',
+         HAS_SOURCE: true,
+     }
     </script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
@@ -1113,7 +1114,10 @@
     <div class="document">
       <div class="documentwrapper">
         <div class="bodywrapper">
-          <div class="body" role="main">
+            <div class="body" role="main">
+                <div class="banner_wrapper">
+                    <p> You are currently viewing the documentation for the Opentrons OT-1. To view documentation for the OT-2, click <a href="../v2/index.html">here</a>.
+                </div>
             <h1 id="search-documentation">Search</h1>
             <div id="fallback" class="admonition warning">
               <script type="text/javascript">

--- a/api/docs/ot1/transfer.html
+++ b/api/docs/ot1/transfer.html
@@ -11,15 +11,17 @@
     <link rel="stylesheet" href="_static/override_sphinx.css" type="text/css" />
     <link rel="stylesheet" href="_static/nav.css" type="text/css" />
     <link rel="stylesheet" href="_static/new-nav.css" type="text/css" />
+    <link rel="stylesheet" href="_static/banners.css" type="text/css" />
+    <link rel="stylesheet" href="_static/banners.css" type="text/css" />
 
     <script type="text/javascript">
-      var DOCUMENTATION_OPTIONS = {
-        URL_ROOT: './',
-        VERSION: '2.0',
-        COLLAPSE_INDEX: false,
-        FILE_SUFFIX: '.html',
-        HAS_SOURCE: true,
-      }
+     var DOCUMENTATION_OPTIONS = {
+         URL_ROOT: './',
+         VERSION: '2.0',
+         COLLAPSE_INDEX: false,
+         FILE_SUFFIX: '.html',
+         HAS_SOURCE: true,
+     }
     </script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
@@ -1106,7 +1108,10 @@
     <div class="document">
       <div class="documentwrapper">
         <div class="bodywrapper">
-          <div class="body" role="main">
+            <div class="body" role="main">
+                <div class="banner_wrapper">
+                    <p> You are currently viewing the documentation for the Opentrons OT-1. To view documentation for the OT-2, click <a href="../v2/index.html">here</a>.
+                </div>
             <span class="target" id="transfer"></span>
             <div class="section" id="transfer-shortcuts">
               <h1>

--- a/api/docs/ot1/writing.html
+++ b/api/docs/ot1/writing.html
@@ -11,15 +11,16 @@
     <link rel="stylesheet" href="_static/override_sphinx.css" type="text/css" />
     <link rel="stylesheet" href="_static/nav.css" type="text/css" />
     <link rel="stylesheet" href="_static/new-nav.css" type="text/css" />
+    <link rel="stylesheet" href="_static/banners.css" type="text/css" />
 
     <script type="text/javascript">
-      var DOCUMENTATION_OPTIONS = {
-        URL_ROOT: './',
-        VERSION: '2.0',
-        COLLAPSE_INDEX: false,
-        FILE_SUFFIX: '.html',
-        HAS_SOURCE: true,
-      }
+     var DOCUMENTATION_OPTIONS = {
+         URL_ROOT: './',
+         VERSION: '2.0',
+         COLLAPSE_INDEX: false,
+         FILE_SUFFIX: '.html',
+         HAS_SOURCE: true,
+     }
     </script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
@@ -1106,7 +1107,10 @@
     <div class="document">
       <div class="documentwrapper">
         <div class="bodywrapper">
-          <div class="body" role="main">
+            <div class="body" role="main">
+                <div class="banner_wrapper">
+                    <p> You are currently viewing the documentation for the Opentrons OT-1. To view documentation for the OT-2, click <a href="../v2/index.html">here</a>.
+                </div>
             <div class="section" id="design-with-python">
               <span id="writing"></span>
               <h1>


### PR DESCRIPTION
This lets you know that you're in the ot1 docs. Great!
It's the same style as the v1/v2 redirect banners.

Closes #4403
