### PR TITLE
fix(api): limit air_gap in transfer to <max volume

### DIFF
--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1572,9 +1572,15 @@ class InstrumentContext(CommandPublisher):
         if disposal is None:
             disposal = default_args.disposal_volume
 
+        air_gap = kwargs.get('air_gap', default_args.air_gap)
+        if air_gap < 0 or air_gap >= max_volume:
+            raise ValueError(
+                "air_gap must be between 0uL and the pipette's expected "
+                f"working volume, {max_volume}uL")
+
         transfer_args = transfers.Transfer(
             new_tip=new_tip or default_args.new_tip,
-            air_gap=kwargs.get('air_gap') or default_args.air_gap,
+            air_gap=air_gap,
             carryover=kwargs.get('carryover') or default_args.carryover,
             gradient_function=(kwargs.get('gradient_function') or
                                default_args.gradient_function),

--- a/api/tests/opentrons/labware/test_pipette_unittest.py
+++ b/api/tests/opentrons/labware/test_pipette_unittest.py
@@ -517,6 +517,16 @@ def test_transfer(local_test_pipette, robot):
     fuzzy_assert(robot.commands(),
                  expected=expected)
     robot.clear_commands()
+    with pytest.raises(ValueError, match='air_gap.*'):
+        p200.transfer(300,
+                      plate[0],
+                      plate[1],
+                      air_gap=300)
+    with pytest.raises(ValueError, match='air_gap.*'):
+        p200.transfer(300,
+                      plate[0],
+                      plate[1],
+                      air_gap=10000)
 
 
 @pytest.mark.api1_only

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -653,6 +653,10 @@ def test_transfer_options(loop, monkeypatch):
         dispense=tf.DispenseOpts()
     )
     assert transfer_options == expected_xfer_options2
+    with pytest.raises(ValueError, match='air_gap.*'):
+        instr.transfer(300, lw1['A1'], lw2['A1'], air_gap=300)
+    with pytest.raises(ValueError, match='air_gap.*'):
+        instr.transfer(300, lw1['A1'], lw2['A1'], air_gap=10000)
 
 
 def test_flow_rate(loop, monkeypatch):


### PR DESCRIPTION
If you pass an air_gap larger than the pipette's working volume to any complex
command, in either v1 or v2, you get an infinite loop because it's subtracted
from the pipette's max volume to figure out how much can be aspirated in any
given transfer step.

Limit air_gap to between 0 and the pipette's expected working volume in transfer
and friends.

Closes #364
