### PR TITLE
fix(api): do not allow robot.connect() in rpc protocols

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -382,8 +382,8 @@ class Session(object):
                 def robot_connect_error(port=None, options=None):
                     raise RuntimeError(
                         'Protocols executed through the Opentrons App may not '
-                        'robot.connect(). Allowing this call would cause the '
-                        'robot to execute commands during simulation, and '
+                        'use robot.connect(). Allowing this call would cause '
+                        'the robot to execute commands during simulation, and '
                         'then raise an error on execution.')
                 robot.connect = robot_connect_error
                 exec(self._protocol.contents, {})

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -344,6 +344,7 @@ class Session(object):
             else:
                 stack.pop()
         unsubscribe = self._broker.subscribe(command_types.COMMAND, on_command)
+        old_robot_connect = robot.connect
 
         try:
             # ensure actual pipettes are cached before driver is disconnected
@@ -377,13 +378,23 @@ class Session(object):
                 robot.broker = self._broker
                 robot.cache_instrument_models()
                 robot.disconnect()
+
+                def robot_connect_error(port=None, options=None):
+                    raise RuntimeError(
+                        'Protocols executed through the Opentrons App may not '
+                        'robot.connect(). Allowing this call would cause the '
+                        'robot to execute commands during simulation, and '
+                        'then raise an error on execution.')
+                robot.connect = robot_connect_error
                 exec(self._protocol.contents, {})
         finally:
             # physically attached pipettes are re-cached during robot.connect()
             # which is important, because during a simulation, the robot could
             # think that it holds a pipette model that it actually does not
             if not self._use_v2:
+                robot.connect = old_robot_connect
                 robot.connect()
+
             unsubscribe()
 
             instruments, containers, modules, interactions = _accumulate(

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -387,3 +387,14 @@ left.drop_tip()
                                                   v1proto)
     assert ['p300_single_v1'] == [pip.name for pip in session3.instruments]
     assert ['tempdeck'] == [mod.name for mod in session3.modules]
+
+
+async def test_session_robot_connect_not_allowed(main_router,
+                                                 virtual_smoothie_env):
+    proto = """
+from opentrons import robot
+robot.connect()
+"""
+
+    with pytest.raises(RuntimeError, match='.*robot.connect.*'):
+        main_router.session_manager.create('calls-connect', proto)


### PR DESCRIPTION
If you have a robot.connect() in your protocol, and upload it through the
opentrons app, then the robot will move and execute the commands in the protocol
during simulation. It will also behave badly when run. Make the protocol raise
an error if it calls robot.connect when run through the rpc session.

Closes #4252

## Testing
This pokes around at global state in the session and thus makes me a little nervous. We should make sure that
1. If you upload a protocol that calls robot.connect(), you get the new error
2. If you then upload another v1 protocol, that actually executes
3. If you upload a protocol that does _not_ call robot.connect(), everything works as normal.