### PR TITLE
docs(api): fix transfer example to use new_tip='once'

### DIFF
--- a/api/docs/v1/complex_commands.rst
+++ b/api/docs/v1/complex_commands.rst
@@ -460,6 +460,34 @@ will have the steps...
     ...
     Dropping tip well A1 in "12"
 
+
+Use One Tip
+------------------------
+
+The default behavior of complex commands is to use one tip:
+
+.. code-block:: python
+
+    pipette.transfer(
+        100,
+        plate.wells('A1', 'A2', 'A3'),
+        plate.wells('B1', 'B2', 'B3'),
+        new_tip='once')    # use one tip (default behavior)
+
+will have the steps...
+
+.. code-block:: python
+
+    Transferring 100 from wells A1...A3 in "1" to wells B1...B3 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 100.0 uL from well A1 in "1" at 1 speed
+    Dispensing 100.0 uL into well B1 in "1"
+    Aspirating 100.0 uL from well A2 in "1" at 1 speed
+    Dispensing 100.0 uL into well B2 in "1"
+    Aspirating 100.0 uL from well A3 in "1" at 1 speed
+    Dispensing 100.0 uL into well B3 in "1"
+    Dropping tip well A1 in "12"
+
 Trash or Return Tip
 ------------------------
 

--- a/api/docs/v2/new_complex_commands.rst
+++ b/api/docs/v2/new_complex_commands.rst
@@ -517,7 +517,7 @@ The default behavior of complex commands is to use one tip:
         100,
         [plate.wells_by_name()[well_name] for well_name in ['A1', 'A2', 'A3']],
         [plate.wells_by_name()[well_name] for well_name in ['B1', 'B2', 'B3']],
-        new_tip='single')    # use one tip
+        new_tip='once')    # use one tip
 
 will have the steps...
 

--- a/api/docs/v2/new_complex_commands.rst
+++ b/api/docs/v2/new_complex_commands.rst
@@ -517,7 +517,7 @@ The default behavior of complex commands is to use one tip:
         100,
         [plate.wells_by_name()[well_name] for well_name in ['A1', 'A2', 'A3']],
         [plate.wells_by_name()[well_name] for well_name in ['B1', 'B2', 'B3']],
-        new_tip='once')    # use one tip
+        new_tip='once')    # use one tip (default behavior)
 
 will have the steps...
 


### PR DESCRIPTION
## overview

We had a errant `new_tip='single'` in the API example docs. This PR fixes that line to use the correct `new_tip='once'`.

This PR also adds a `new_tip='once'` section to the PAPIv1 docs to close #357

## changelog

- docs(api): fix transfer example to use new_tip='once'

## review requests

- Did I miss any other places where this sort of typo slipped in?