### PR TITLE
feat(protocol-designer): add temperature step form validation

### DIFF
--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -78,6 +78,9 @@ export const DEFAULT_WELL_ORDER_SECOND_OPTION: 'l2r' = 'l2r'
 export const MIN_ENGAGE_HEIGHT = -4
 export const MAX_ENGAGE_HEIGHT = 16
 
+export const MIN_TEMP_MODULE_TEMP = 0
+export const MAX_TEMP_MODULE_TEMP = 95
+
 // TODO: IL 2019-12-03 migrate the ModuleType '___deck' strings to '___ module' forms.
 // We don't call modules 'deck' anymore, but the old code is entrenched
 export const FILE_MODULE_TYPE_TO_MODULE_TYPE: { [string]: ModuleType } = {

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -17,7 +17,12 @@ import {
   type ValueMasker,
   type ValueCaster,
 } from './processing'
-import { MIN_ENGAGE_HEIGHT, MAX_ENGAGE_HEIGHT } from '../../constants'
+import {
+  MIN_ENGAGE_HEIGHT,
+  MAX_ENGAGE_HEIGHT,
+  MIN_TEMP_MODULE_TEMP,
+  MAX_TEMP_MODULE_TEMP,
+} from '../../constants'
 import type { StepFieldName } from '../../form-types'
 import type { LabwareEntity, PipetteEntity } from '../../step-forms'
 import type { InvariantContext } from '../../step-generation'
@@ -144,6 +149,16 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
       maxFieldValue(MAX_ENGAGE_HEIGHT)
     ),
     maskValue: composeMaskers(maskToFloat),
+    castValue: Number,
+  },
+  setTemperature: { getErrors: composeErrors(requiredField) },
+  targetTemperature: {
+    getErrors: composeErrors(
+      minFieldValue(MIN_TEMP_MODULE_TEMP),
+      maxFieldValue(MAX_TEMP_MODULE_TEMP)
+    ),
+    // TODO (sa 2019-12-11): investigate maskToNumber not allowing 0
+    maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
     castValue: Number,
   },
 }

--- a/protocol-designer/src/steplist/formLevel/errors.js
+++ b/protocol-designer/src/steplist/formLevel/errors.js
@@ -16,6 +16,7 @@ export type FormErrorKey =
   | 'TIME_PARAM_REQUIRED'
   | 'MAGNET_ACTION_TYPE_REQUIRED'
   | 'ENGAGE_HEIGHT_REQUIRED'
+  | 'TARGET_TEMPERATURE_REQUIRED'
 
 export type FormError = {
   title: string,
@@ -60,6 +61,10 @@ const FORM_ERRORS: { [FormErrorKey]: FormError } = {
   ENGAGE_HEIGHT_REQUIRED: {
     title: 'Engage height is required',
     dependentFields: ['magnetAction', 'engageHeight'],
+  },
+  TARGET_TEMPERATURE_REQUIRED: {
+    title: 'Temperature is required',
+    dependentFields: ['setTemperature', 'targetTemperature'],
   },
 }
 export type FormErrorChecker = mixed => ?FormError
@@ -138,6 +143,15 @@ export const engageHeightRequired = (fields: HydratedFormData): ?FormError => {
   const { magnetAction, engageHeight } = fields
   return magnetAction === 'engage' && !engageHeight
     ? FORM_ERRORS.ENGAGE_HEIGHT_REQUIRED
+    : null
+}
+
+export const targetTemperatureRequired = (
+  fields: HydratedFormData
+): ?FormError => {
+  const { setTemperature, targetTemperature } = fields
+  return setTemperature === 'true' && !targetTemperature
+    ? FORM_ERRORS.TARGET_TEMPERATURE_REQUIRED
     : null
 }
 

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -83,6 +83,11 @@ export default function getDefaultsForStepType(
         magnetAction: null,
         engageHeight: null,
       }
+    case 'temperature':
+      return {
+        setTemperature: null,
+        targetTemperature: null,
+      }
     default:
       return {}
   }

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateTemperature.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateTemperature.js
@@ -1,0 +1,33 @@
+// @flow
+import pick from 'lodash/pick'
+import { chainPatchUpdaters, fieldHasChanged } from './utils'
+import getDefaultsForStepType from '../getDefaultsForStepType'
+import type { FormData, StepFieldName } from '../../../form-types'
+import type { FormPatch } from '../../actions/types'
+
+// TODO: Ian 2019-02-21 import this from a more central place - see #2926
+const getDefaultFields = (...fields: Array<StepFieldName>): FormPatch =>
+  pick(getDefaultsForStepType('temperature'), fields)
+
+const updatePatchOnSetTemperatureChange = (
+  patch: FormPatch,
+  rawForm: FormData
+) => {
+  if (fieldHasChanged(rawForm, patch, 'setTemperature')) {
+    return {
+      ...patch,
+      ...getDefaultFields('targetTemperature'),
+    }
+  }
+  return patch
+}
+
+export default function dependentFieldsUpdateTemperature(
+  originalPatch: FormPatch,
+  rawForm: FormData // raw = NOT hydrated
+): FormPatch {
+  // sequentially modify parts of the patch until it's fully updated
+  return chainPatchUpdaters(originalPatch, [
+    chainPatch => updatePatchOnSetTemperatureChange(chainPatch, rawForm),
+  ])
+}

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/index.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/index.js
@@ -8,6 +8,7 @@ import type {
   LabwareEntities,
   PipetteEntities,
 } from '../../../step-forms/types'
+import dependentFieldsUpdateTemperature from './dependentFieldsUpdateTemperature'
 
 function handleFormChange(
   patch: FormPatch,
@@ -39,6 +40,13 @@ function handleFormChange(
   }
   if (rawForm.stepType === 'magnet') {
     const dependentFieldsPatch = dependentFieldsUpdateMagnet(patch, rawForm)
+    return { ...patch, ...dependentFieldsPatch }
+  }
+  if (rawForm.stepType === 'temperature') {
+    const dependentFieldsPatch = dependentFieldsUpdateTemperature(
+      patch,
+      rawForm
+    )
     return { ...patch, ...dependentFieldsPatch }
   }
 

--- a/protocol-designer/src/steplist/formLevel/index.js
+++ b/protocol-designer/src/steplist/formLevel/index.js
@@ -9,6 +9,7 @@ import {
   magnetActionRequired,
   engageHeightRequired,
   type FormError,
+  targetTemperatureRequired,
 } from './errors'
 import {
   composeWarnings,
@@ -16,6 +17,7 @@ import {
   maxDispenseWellVolume,
   minDisposalVolume,
   engageHeightRangeExceeded,
+  temperatureRangeExceeded,
   type FormWarning,
   type FormWarningType,
 } from './warnings'
@@ -53,6 +55,10 @@ const stepFormHelperMap: { [StepType]: FormHelpers } = {
   magnet: {
     getErrors: composeErrors(magnetActionRequired, engageHeightRequired),
     getWarnings: composeWarnings(engageHeightRangeExceeded),
+  },
+  temperature: {
+    getErrors: composeErrors(targetTemperatureRequired),
+    getWarnings: composeWarnings(temperatureRangeExceeded),
   },
 }
 

--- a/protocol-designer/src/steplist/formLevel/warnings.js
+++ b/protocol-designer/src/steplist/formLevel/warnings.js
@@ -1,7 +1,12 @@
 // @flow
 import * as React from 'react'
 import { getWellTotalVolume } from '@opentrons/shared-data'
-import { MIN_ENGAGE_HEIGHT, MAX_ENGAGE_HEIGHT } from '../../constants'
+import {
+  MIN_ENGAGE_HEIGHT,
+  MAX_ENGAGE_HEIGHT,
+  MIN_TEMP_MODULE_TEMP,
+  MAX_TEMP_MODULE_TEMP,
+} from '../../constants'
 import KnowledgeBaseLink from '../../components/KnowledgeBaseLink'
 import type { FormError } from './errors'
 /*******************
@@ -14,6 +19,8 @@ export type FormWarningType =
   | 'BELOW_MIN_DISPOSAL_VOLUME'
   | 'ENGAGE_HEIGHT_MIN_EXCEEDED'
   | 'ENGAGE_HEIGHT_MAX_EXCEEDED'
+  | 'TEMPERATURE_MIN_EXCEEDED'
+  | 'TEMPERATURE_MAX_EXCEEDED'
 
 export type FormWarning = {
   ...$Exact<FormError>,
@@ -52,6 +59,16 @@ const FORM_WARNINGS: { [FormWarningType]: FormWarning } = {
     type: 'ENGAGE_HEIGHT_MAX_EXCEEDED',
     title: 'Specified distance is above module maximum',
     dependentFields: ['magnetAction', 'engageHeight'],
+  },
+  TEMPERATURE_MIN_EXCEEDED: {
+    type: 'TEMPERATURE_MIN_EXCEEDED',
+    title: 'Specified temperature is below module minimum',
+    dependentFields: ['setTemperature', 'targetTemperature'],
+  },
+  TEMPERATURE_MAX_EXCEEDED: {
+    type: 'TEMPERATURE_MAX_EXCEEDED',
+    title: 'Specified temperature is above module maximum',
+    dependentFields: ['setTemperature', 'targetTemperature'],
   },
 }
 export type WarningChecker = mixed => ?FormWarning
@@ -107,6 +124,21 @@ export const engageHeightRangeExceeded = (
     return FORM_WARNINGS.ENGAGE_HEIGHT_MIN_EXCEEDED
   } else if (magnetAction === 'engage' && engageHeight > MAX_ENGAGE_HEIGHT) {
     return FORM_WARNINGS.ENGAGE_HEIGHT_MAX_EXCEEDED
+  }
+  return null
+}
+
+export const temperatureRangeExceeded = (
+  fields: HydratedFormData
+): ?FormWarning => {
+  const { setTemperature, targetTemperature } = fields
+  if (setTemperature === 'true' && targetTemperature < MIN_TEMP_MODULE_TEMP) {
+    return FORM_WARNINGS.TEMPERATURE_MIN_EXCEEDED
+  } else if (
+    setTemperature === 'true' &&
+    targetTemperature > MAX_TEMP_MODULE_TEMP
+  ) {
+    return FORM_WARNINGS.TEMPERATURE_MAX_EXCEEDED
   }
   return null
 }


### PR DESCRIPTION
closes #4578 

## overview
This PR adds both form and field validation for temperature step for the temperature module only.

## changelog
- feat(protocol-designer): add temperature step form validation

## review requests

- Create protocol with temp module
- Add temperature step
- Select change temperature
- [ ] Enter a number above 95 (you should see appropriate warning)
- [ ] Enter a number below 0 (you should not be able to enter at all)
- [ ] Enter a number non number (you should not be able to enter at all)

- Create protocol with temp module
- Add temperature step
- Select change temperature
- [ ] You should not be able to save form if temp is empty or invalid

- Create protocol with temp module
- Add temperature step
- Select change temperature
- [ ] Selecting deactivate button clears our any previous target temp + possible errors/warnings


