### PR TITLE
refactor(app): refactor /modules state into first-class state subtree

### DIFF
--- a/app/src/epic.js
+++ b/app/src/epic.js
@@ -8,6 +8,7 @@ import { robotApiEpic } from './robot-api'
 import { robotAdminEpic } from './robot-admin/epic'
 import { robotSettingsEpic } from './robot-settings/epic'
 import { pipettesEpic } from './pipettes/epic'
+import { modulesEpic } from './modules/epic'
 import { shellEpic } from './shell'
 
 export default combineEpics(
@@ -17,5 +18,6 @@ export default combineEpics(
   robotAdminEpic,
   robotSettingsEpic,
   pipettesEpic,
+  modulesEpic,
   shellEpic
 )

--- a/app/src/modules/__fixtures__/index.js
+++ b/app/src/modules/__fixtures__/index.js
@@ -1,0 +1,117 @@
+// @flow
+
+import * as Types from '../types'
+
+export const mockRobot = { name: 'robot', ip: '127.0.0.1', port: 31950 }
+
+export const mockTemperatureModule: Types.TemperatureModule = {
+  name: 'tempdeck',
+  displayName: 'Temperature Deck',
+  port: '/dev/ot_module_tempdeck0',
+  serial: 'abc123',
+  model: 'temp_deck_v4.0',
+  fwVersion: 'v2.0.0',
+  status: 'idle',
+  data: {
+    currentTemp: 25,
+    targetTemp: null,
+  },
+}
+
+export const mockMagneticModule: Types.MagneticModule = {
+  name: 'magdeck',
+  displayName: 'Magnetic Deck',
+  port: '/dev/ot_module_magdeck0',
+  serial: 'def456',
+  model: 'mag_deck_v4.0',
+  fwVersion: 'v2.0.0',
+  status: 'disengaged',
+  data: {
+    engaged: false,
+    height: 42,
+  },
+}
+
+export const mockThermocycler: Types.ThermocyclerModule = {
+  name: 'thermocycler',
+  displayName: 'Thermocycler',
+  port: '/dev/ot_module_thermocycler0',
+  serial: 'ghi789',
+  model: 'thermocycler_v4.0',
+  fwVersion: 'v2.0.0',
+  status: 'idle',
+  data: {
+    lid: 'open',
+    lidTarget: null,
+    lidTemp: null,
+    currentTemp: null,
+    targetTemp: null,
+    holdTime: null,
+    rampRate: null,
+    currentCycleIndex: null,
+    totalCycleCount: null,
+    currentStepIndex: null,
+    totalStepCount: null,
+  },
+}
+
+// fetch modules fixtures
+
+export const mockFetchModulesSuccessMeta = {
+  method: 'GET',
+  path: '/modules',
+  ok: true,
+  status: 200,
+}
+
+export const mockFetchModulesSuccess = {
+  ...mockFetchModulesSuccessMeta,
+  host: mockRobot,
+  body: {
+    modules: [mockTemperatureModule],
+  },
+}
+
+export const mockFetchModulesFailureMeta = {
+  method: 'GET',
+  path: '/modules',
+  ok: false,
+  status: 500,
+}
+
+export const mockFetchModulesFailure = {
+  ...mockFetchModulesFailureMeta,
+  host: mockRobot,
+  body: { message: 'AH' },
+}
+
+// send module command fixtures
+
+export const mockSendModuleCommandSuccessMeta = {
+  method: 'POST',
+  path: '/modules/abc123',
+  ok: true,
+  status: 200,
+}
+
+export const mockSendModuleCommandSuccess = {
+  ...mockSendModuleCommandSuccessMeta,
+  host: mockRobot,
+  body: {
+    message: 'Success',
+    returnValue: 42,
+  },
+}
+
+export const mockSendModuleCommandFailureMeta = {
+  method: 'POST',
+  path: '/modules/abc123',
+  ok: false,
+  status: 500,
+}
+
+export const mockSendModuleCommandFailure = {
+  ...mockSendModuleCommandFailureMeta,
+  host: mockRobot,
+  body: { message: 'AH' },
+}

--- a/app/src/modules/__tests__/actions.test.js
+++ b/app/src/modules/__tests__/actions.test.js
@@ -1,0 +1,120 @@
+// @flow
+
+import * as Actions from '../actions'
+import * as Fixtures from '../__fixtures__'
+
+import type { ModulesAction } from '../types'
+
+type ActionSpec = {|
+  name: string,
+  creator: (...Array<any>) => mixed,
+  args: Array<mixed>,
+  expected: ModulesAction,
+|}
+
+describe('robot modules actions', () => {
+  const SPECS: Array<ActionSpec> = [
+    {
+      name: 'modules:FETCH_MODULES',
+      creator: Actions.fetchModules,
+      args: ['robot-name'],
+      expected: {
+        type: 'modules:FETCH_MODULES',
+        payload: { robotName: 'robot-name' },
+        meta: {},
+      },
+    },
+    {
+      name: 'modules:FETCH_MODULES_SUCCESS',
+      creator: Actions.fetchModulesSuccess,
+      args: [
+        'robot-name',
+        Fixtures.mockFetchModulesSuccess.body.modules,
+        { requestId: 'abc' },
+      ],
+      expected: {
+        type: 'modules:FETCH_MODULES_SUCCESS',
+        payload: {
+          robotName: 'robot-name',
+          modules: Fixtures.mockFetchModulesSuccess.body.modules,
+        },
+        meta: { requestId: 'abc' },
+      },
+    },
+    {
+      name: 'modules:FETCH_MODULES_FAILURE',
+      creator: Actions.fetchModulesFailure,
+      args: ['robot-name', { message: 'AH' }, { requestId: 'abc' }],
+      expected: {
+        type: 'modules:FETCH_MODULES_FAILURE',
+        payload: {
+          robotName: 'robot-name',
+          error: { message: 'AH' },
+        },
+        meta: { requestId: 'abc' },
+      },
+    },
+    {
+      name: 'modules:SEND_MODULE_COMMAND',
+      creator: Actions.sendModuleCommand,
+      args: ['robot-name', 'abc123', 'set_temperature', [1, 2, 3]],
+      expected: {
+        type: 'modules:SEND_MODULE_COMMAND',
+        payload: {
+          robotName: 'robot-name',
+          moduleId: 'abc123',
+          command: 'set_temperature',
+          args: [1, 2, 3],
+        },
+        meta: {},
+      },
+    },
+    {
+      name: 'modules:SEND_MODULE_COMMAND_SUCCESS',
+      creator: Actions.sendModuleCommandSuccess,
+      args: [
+        'robot-name',
+        'abc123',
+        'set_temperature',
+        Fixtures.mockSendModuleCommandSuccess.body.returnValue,
+        { requestId: 'abc' },
+      ],
+      expected: {
+        type: 'modules:SEND_MODULE_COMMAND_SUCCESS',
+        payload: {
+          robotName: 'robot-name',
+          moduleId: 'abc123',
+          command: 'set_temperature',
+          returnValue: Fixtures.mockSendModuleCommandSuccess.body.returnValue,
+        },
+        meta: { requestId: 'abc' },
+      },
+    },
+    {
+      name: 'modules:SEND_MODULE_COMMAND_FAILURE',
+      creator: Actions.sendModuleCommandFailure,
+      args: [
+        'robot-name',
+        'abc123',
+        'set_temperature',
+        { message: 'AH' },
+        { requestId: 'abc' },
+      ],
+      expected: {
+        type: 'modules:SEND_MODULE_COMMAND_FAILURE',
+        payload: {
+          robotName: 'robot-name',
+          moduleId: 'abc123',
+          command: 'set_temperature',
+          error: { message: 'AH' },
+        },
+        meta: { requestId: 'abc' },
+      },
+    },
+  ]
+
+  SPECS.forEach(spec => {
+    const { name, creator, args, expected } = spec
+    test(name, () => expect(creator(...args)).toEqual(expected))
+  })
+})

--- a/app/src/modules/__tests__/reducer.test.js
+++ b/app/src/modules/__tests__/reducer.test.js
@@ -1,0 +1,47 @@
+// @flow
+import * as Fixtures from '../__fixtures__'
+import { modulesReducer } from '../reducer'
+
+import type { Action } from '../../types'
+import type { ModulesState } from '../types'
+
+type ReducerSpec = {|
+  name: string,
+  state: ModulesState,
+  action: Action,
+  expected: ModulesState,
+|}
+
+const SPECS: Array<ReducerSpec> = [
+  {
+    name: 'handles pipettes:FETCH_MODULES_SUCCESS',
+    action: {
+      type: 'modules:FETCH_MODULES_SUCCESS',
+      payload: {
+        robotName: 'robotName',
+        modules: [Fixtures.mockTemperatureModule],
+      },
+      meta: {},
+    },
+    state: {
+      robotName: {
+        modulesById: null,
+      },
+    },
+    expected: {
+      robotName: {
+        modulesById: {
+          [Fixtures.mockTemperatureModule.serial]:
+            Fixtures.mockTemperatureModule,
+        },
+      },
+    },
+  },
+]
+
+describe('pipettesReducer', () => {
+  SPECS.forEach(spec => {
+    const { name, state, action, expected } = spec
+    test(name, () => expect(modulesReducer(state, action)).toEqual(expected))
+  })
+})

--- a/app/src/modules/__tests__/selectors.test.js
+++ b/app/src/modules/__tests__/selectors.test.js
@@ -1,0 +1,134 @@
+// @flow
+import noop from 'lodash/noop'
+import * as Fixtures from '../__fixtures__'
+import * as Selectors from '../selectors'
+import * as RobotSelectors from '../../robot/selectors'
+import * as Types from '../types'
+
+import type { State } from '../../types'
+
+jest.mock('../../robot/selectors')
+
+const mockGetConnectedRobotName: JestMockFn<
+  [State],
+  $Call<typeof RobotSelectors.getConnectedRobotName, State>
+> = RobotSelectors.getConnectedRobotName
+
+const mockGetProtocolModules: JestMockFn<
+  [State],
+  $Call<typeof RobotSelectors.getModules, State>
+> = RobotSelectors.getModules
+
+type SelectorSpec = {|
+  name: string,
+  selector: (State, ...Array<any>) => mixed,
+  state: $Shape<State>,
+  args?: Array<any>,
+  before?: () => mixed,
+  expected: mixed,
+|}
+
+const SPECS: Array<SelectorSpec> = [
+  {
+    name: 'getAttachedModules returns no attached modules by default',
+    selector: Selectors.getAttachedModules,
+    state: { modules: {} },
+    args: ['robotName'],
+    expected: [],
+  },
+  {
+    name: 'getAttachedModules returns attached modules sorted by serial',
+    selector: Selectors.getAttachedModules,
+    state: {
+      modules: {
+        robotName: {
+          modulesById: {
+            def456: Fixtures.mockMagneticModule,
+            ghi789: Fixtures.mockThermocycler,
+            abc123: Fixtures.mockTemperatureModule,
+          },
+        },
+      },
+    },
+    args: ['robotName'],
+    expected: [
+      Fixtures.mockTemperatureModule,
+      Fixtures.mockMagneticModule,
+      Fixtures.mockThermocycler,
+    ],
+  },
+  {
+    name:
+      'getUnpreparedModules returns thermocyclers in protocol with lid closed',
+    selector: Selectors.getUnpreparedModules,
+    state: {
+      modules: {
+        robotName: {
+          modulesById: {
+            abc123: Fixtures.mockTemperatureModule,
+            def456: Fixtures.mockMagneticModule,
+            ghi789: ({
+              ...Fixtures.mockThermocycler,
+              data: {
+                ...Fixtures.mockThermocycler.data,
+                lid: 'closed',
+              },
+            }: Types.ThermocyclerModule),
+          },
+        },
+      },
+    },
+    args: [],
+    before: () => {
+      mockGetConnectedRobotName.mockReturnValue('robotName')
+      mockGetProtocolModules.mockReturnValue([
+        { _id: 0, slot: '1', name: 'thermocycler' },
+      ])
+    },
+    expected: [
+      {
+        ...Fixtures.mockThermocycler,
+        data: {
+          ...Fixtures.mockThermocycler.data,
+          lid: 'closed',
+        },
+      },
+    ],
+  },
+  {
+    name: 'getMissingModules returns protocol modules without attached modules',
+    selector: Selectors.getMissingModules,
+    state: {
+      modules: {
+        robotName: {
+          modulesById: {
+            abc123: Fixtures.mockTemperatureModule,
+          },
+        },
+      },
+    },
+    args: [],
+    before: () => {
+      mockGetConnectedRobotName.mockReturnValue('robotName')
+      mockGetProtocolModules.mockReturnValue([
+        { _id: 0, slot: '1', name: 'thermocycler' },
+        { _id: 1, slot: '2', name: 'tempdeck' },
+        { _id: 2, slot: '3', name: 'magdeck' },
+      ])
+    },
+    expected: [
+      { _id: 0, slot: '1', name: 'thermocycler' },
+      { _id: 2, slot: '3', name: 'magdeck' },
+    ],
+  },
+]
+
+describe('robot api selectors', () => {
+  SPECS.forEach(spec => {
+    const { name, selector, state, args = [], before = noop, expected } = spec
+    test(name, () => {
+      before()
+      expect(selector(state, ...args)).toEqual(expected)
+    })
+  })
+})

--- a/app/src/modules/actions.js
+++ b/app/src/modules/actions.js
@@ -1,0 +1,71 @@
+// @flow
+
+import * as Constants from './constants'
+import * as Types from './types'
+
+import type { RobotApiRequestMeta } from '../robot-api/types'
+
+// fetch modules
+
+export const fetchModules = (robotName: string): Types.FetchModulesAction => ({
+  type: Constants.FETCH_MODULES,
+  payload: { robotName },
+  meta: {},
+})
+
+export const fetchModulesSuccess = (
+  robotName: string,
+  modules: Array<Types.AttachedModule>,
+  meta: RobotApiRequestMeta
+): Types.FetchModulesSuccessAction => ({
+  type: Constants.FETCH_MODULES_SUCCESS,
+  payload: { robotName, modules },
+  meta,
+})
+
+export const fetchModulesFailure = (
+  robotName: string,
+  error: {},
+  meta: RobotApiRequestMeta
+): Types.FetchModulesFailureAction => ({
+  type: Constants.FETCH_MODULES_FAILURE,
+  payload: { robotName, error },
+  meta,
+})
+
+// send module command
+
+export const sendModuleCommand = (
+  robotName: string,
+  moduleId: string,
+  command: Types.ModuleCommand,
+  args: Array<mixed>
+): Types.SendModuleCommandAction => ({
+  type: Constants.SEND_MODULE_COMMAND,
+  payload: { robotName, moduleId, command, args },
+  meta: {},
+})
+
+export const sendModuleCommandSuccess = (
+  robotName: string,
+  moduleId: string,
+  command: Types.ModuleCommand,
+  returnValue: mixed,
+  meta: RobotApiRequestMeta
+): Types.SendModuleCommandSuccessAction => ({
+  type: Constants.SEND_MODULE_COMMAND_SUCCESS,
+  payload: { robotName, moduleId, command, returnValue },
+  meta,
+})
+
+export const sendModuleCommandFailure = (
+  robotName: string,
+  moduleId: string,
+  command: Types.ModuleCommand,
+  error: {},
+  meta: RobotApiRequestMeta
+): Types.SendModuleCommandFailureAction => ({
+  type: Constants.SEND_MODULE_COMMAND_FAILURE,
+  payload: { robotName, moduleId, command, error },
+  meta,
+})

--- a/app/src/modules/constants.js
+++ b/app/src/modules/constants.js
@@ -4,7 +4,7 @@
 
 export const THERMOCYCLER: 'thermocycler' = 'thermocycler'
 
-export const PREPARABLE_MODULES = ['thermocycler']
+export const PREPARABLE_MODULES = [THERMOCYCLER]
 
 // http paths
 

--- a/app/src/modules/constants.js
+++ b/app/src/modules/constants.js
@@ -1,0 +1,34 @@
+// @flow
+
+// common constants
+
+export const THERMOCYCLER: 'thermocycler' = 'thermocycler'
+
+export const PREPARABLE_MODULES = ['thermocycler']
+
+// http paths
+
+export const MODULES_PATH: '/modules' = '/modules'
+
+// action type strings
+
+// fetch modules
+
+export const FETCH_MODULES: 'modules:FETCH_MODULES' = 'modules:FETCH_MODULES'
+
+export const FETCH_MODULES_SUCCESS: 'modules:FETCH_MODULES_SUCCESS' =
+  'modules:FETCH_MODULES_SUCCESS'
+
+export const FETCH_MODULES_FAILURE: 'modules:FETCH_MODULES_FAILURE' =
+  'modules:FETCH_MODULES_FAILURE'
+
+// send module command
+
+export const SEND_MODULE_COMMAND: 'modules:SEND_MODULE_COMMAND' =
+  'modules:SEND_MODULE_COMMAND'
+
+export const SEND_MODULE_COMMAND_SUCCESS: 'modules:SEND_MODULE_COMMAND_SUCCESS' =
+  'modules:SEND_MODULE_COMMAND_SUCCESS'
+
+export const SEND_MODULE_COMMAND_FAILURE: 'modules:SEND_MODULE_COMMAND_FAILURE' =
+  'modules:SEND_MODULE_COMMAND_FAILURE'

--- a/app/src/modules/epic/__tests__/fetchModulesEpic.test.js
+++ b/app/src/modules/epic/__tests__/fetchModulesEpic.test.js
@@ -92,7 +92,7 @@ describe('fetchModulesEpic', () => {
     })
   })
 
-  test('maps failed response to FETCH_PIPETTES_FAILURE', () => {
+  test('maps failed response to FETCH_MODULES_FAILURE', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockFetchModulesFailure })

--- a/app/src/modules/epic/__tests__/fetchModulesEpic.test.js
+++ b/app/src/modules/epic/__tests__/fetchModulesEpic.test.js
@@ -72,7 +72,7 @@ describe('fetchModulesEpic', () => {
     })
   })
 
-  test('maps successful response to FETCH_PIPETTES_SUCCESS', () => {
+  test('maps successful response to FETCH_MODULES_SUCCESS', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockFetchModulesSuccess })

--- a/app/src/modules/epic/__tests__/fetchModulesEpic.test.js
+++ b/app/src/modules/epic/__tests__/fetchModulesEpic.test.js
@@ -1,0 +1,119 @@
+// @flow
+import { TestScheduler } from 'rxjs/testing'
+
+import * as RobotApiHttp from '../../../robot-api/http'
+import * as DiscoverySelectors from '../../../discovery/selectors'
+import * as Fixtures from '../../__fixtures__'
+
+import * as Actions from '../../actions'
+import * as Types from '../../types'
+import { modulesEpic } from '../../epic'
+
+import type { Observable } from 'rxjs'
+import type {
+  RobotHost,
+  HostlessRobotApiRequest,
+  RobotApiResponse,
+} from '../../../robot-api/types'
+
+jest.mock('../../../robot-api/http')
+jest.mock('../../../discovery/selectors')
+
+const mockState = { state: true }
+const { mockRobot } = Fixtures
+
+const mockFetchRobotApi: JestMockFn<
+  [RobotHost, HostlessRobotApiRequest],
+  Observable<RobotApiResponse>
+> = RobotApiHttp.fetchRobotApi
+
+const mockGetRobotByName: JestMockFn<[any, string], mixed> =
+  DiscoverySelectors.getRobotByName
+
+describe('fetchModulesEpic', () => {
+  let testScheduler
+
+  beforeEach(() => {
+    mockGetRobotByName.mockReturnValue(mockRobot)
+
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('handles FETCH_MODULES', () => {
+    const meta = { requestId: '1234' }
+    const action: Types.FetchModulesAction = {
+      ...Actions.fetchModules(mockRobot.name),
+      meta,
+    }
+
+    test('calls GET /modules', () => {
+      testScheduler.run(({ hot, cold, expectObservable, flush }) => {
+        mockFetchRobotApi.mockReturnValue(
+          cold('r', { r: Fixtures.mockFetchModulesSuccess })
+        )
+
+        const action$ = hot('--a', { a: action })
+        const state$ = hot('a-a', { a: mockState })
+        const output$ = modulesEpic(action$, state$)
+
+        expectObservable(output$)
+        flush()
+
+        expect(mockGetRobotByName).toHaveBeenCalledWith(
+          mockState,
+          mockRobot.name
+        )
+        expect(mockFetchRobotApi).toHaveBeenCalledWith(mockRobot, {
+          method: 'GET',
+          path: '/modules',
+        })
+      })
+    })
+
+    test('maps successful response to FETCH_PIPETTES_SUCCESS', () => {
+      testScheduler.run(({ hot, cold, expectObservable, flush }) => {
+        mockFetchRobotApi.mockReturnValue(
+          cold('r', { r: Fixtures.mockFetchModulesSuccess })
+        )
+
+        const action$ = hot('--a', { a: action })
+        const state$ = hot('a-a', { a: {} })
+        const output$ = modulesEpic(action$, state$)
+
+        expectObservable(output$).toBe('--a', {
+          a: Actions.fetchModulesSuccess(
+            mockRobot.name,
+            Fixtures.mockFetchModulesSuccess.body.modules,
+            { ...meta, response: Fixtures.mockFetchModulesSuccessMeta }
+          ),
+        })
+      })
+    })
+
+    test('maps failed response to FETCH_PIPETTES_FAILURE', () => {
+      testScheduler.run(({ hot, cold, expectObservable, flush }) => {
+        mockFetchRobotApi.mockReturnValue(
+          cold('r', { r: Fixtures.mockFetchModulesFailure })
+        )
+
+        const action$ = hot('--a', { a: action })
+        const state$ = hot('a-a', { a: {} })
+        const output$ = modulesEpic(action$, state$)
+
+        expectObservable(output$).toBe('--a', {
+          a: Actions.fetchModulesFailure(
+            mockRobot.name,
+            { message: 'AH' },
+            { ...meta, response: Fixtures.mockFetchModulesFailureMeta }
+          ),
+        })
+      })
+    })
+  })
+})

--- a/app/src/modules/epic/__tests__/pollModulesWhileConnectedEpic.test.js
+++ b/app/src/modules/epic/__tests__/pollModulesWhileConnectedEpic.test.js
@@ -1,0 +1,68 @@
+// @flow
+import { TestScheduler } from 'rxjs/testing'
+
+import {
+  actions as RobotActions,
+  selectors as RobotSelectors,
+} from '../../../robot'
+import * as Fixtures from '../../__fixtures__'
+import * as Actions from '../../actions'
+import { modulesEpic } from '../../epic'
+
+import type { State } from '../../../types'
+
+jest.mock('../../../robot/selectors')
+
+const mockState = { state: true }
+const { mockRobot } = Fixtures
+
+const mockGetConnectedRobotName: JestMockFn<
+  [State],
+  $Call<typeof RobotSelectors.getConnectedRobotName, State>
+> = RobotSelectors.getConnectedRobotName
+
+describe('pollModulesWhileConnectedEpic', () => {
+  let testScheduler
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  test('does nothing if connect fails', () => {
+    testScheduler.run(({ hot, expectObservable }) => {
+      const action = RobotActions.connectResponse(new Error('AH'))
+
+      const action$ = hot('--a', { a: action })
+      const state$ = hot('--a', { a: mockState })
+      const output$ = modulesEpic(action$, state$)
+
+      expectObservable(output$).toBe('---')
+    })
+  })
+
+  test('polls connected robot until no longer connected', () => {
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const action = RobotActions.connectResponse(null, ['create'])
+
+      mockGetConnectedRobotName
+        .mockReturnValueOnce(mockRobot.name)
+        .mockReturnValueOnce(mockRobot.name)
+        .mockReturnValueOnce(mockRobot.name)
+        .mockReturnValueOnce(null)
+
+      const action$ = hot('a', { a: action })
+      const state$ = hot('a 15s a', { a: mockState })
+      const output$ = modulesEpic(action$, state$)
+
+      expectObservable(output$).toBe('5s a 4999ms a 4999ms a', {
+        a: Actions.fetchModules(mockRobot.name),
+      })
+    })
+  })
+})

--- a/app/src/modules/epic/__tests__/sendModuleCommandEpic.test.js
+++ b/app/src/modules/epic/__tests__/sendModuleCommandEpic.test.js
@@ -1,0 +1,132 @@
+// @flow
+import { TestScheduler } from 'rxjs/testing'
+
+import * as RobotApiHttp from '../../../robot-api/http'
+import * as DiscoverySelectors from '../../../discovery/selectors'
+import * as Fixtures from '../../__fixtures__'
+
+import * as Actions from '../../actions'
+import * as Types from '../../types'
+import { modulesEpic } from '../../epic'
+
+import type { Observable } from 'rxjs'
+import type {
+  RobotHost,
+  HostlessRobotApiRequest,
+  RobotApiResponse,
+} from '../../../robot-api/types'
+
+jest.mock('../../../robot-api/http')
+jest.mock('../../../discovery/selectors')
+
+const mockState = { state: true }
+const { mockRobot } = Fixtures
+
+const mockFetchRobotApi: JestMockFn<
+  [RobotHost, HostlessRobotApiRequest],
+  Observable<RobotApiResponse>
+> = RobotApiHttp.fetchRobotApi
+
+const mockGetRobotByName: JestMockFn<[any, string], mixed> =
+  DiscoverySelectors.getRobotByName
+
+describe('fetchModulesEpic', () => {
+  let testScheduler
+
+  beforeEach(() => {
+    mockGetRobotByName.mockReturnValue(mockRobot)
+
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('handles SEND_MODULE_COMMAND', () => {
+    const meta = { requestId: '1234' }
+    const action: Types.SendModuleCommandAction = {
+      ...Actions.sendModuleCommand(
+        mockRobot.name,
+        'abc123',
+        'set_temperature',
+        [42]
+      ),
+      meta,
+    }
+
+    test('calls GET /modules', () => {
+      testScheduler.run(({ hot, cold, expectObservable, flush }) => {
+        mockFetchRobotApi.mockReturnValue(
+          cold('r', { r: Fixtures.mockSendModuleCommandSuccess })
+        )
+
+        const action$ = hot('--a', { a: action })
+        const state$ = hot('a-a', { a: mockState })
+        const output$ = modulesEpic(action$, state$)
+
+        expectObservable(output$)
+        flush()
+
+        expect(mockGetRobotByName).toHaveBeenCalledWith(
+          mockState,
+          mockRobot.name
+        )
+        expect(mockFetchRobotApi).toHaveBeenCalledWith(mockRobot, {
+          method: 'POST',
+          path: '/modules/abc123',
+          body: {
+            command_type: 'set_temperature',
+            args: [42],
+          },
+        })
+      })
+    })
+
+    test('maps successful response to SEND_MODULE_COMMAND_SUCCESS', () => {
+      testScheduler.run(({ hot, cold, expectObservable, flush }) => {
+        mockFetchRobotApi.mockReturnValue(
+          cold('r', { r: Fixtures.mockSendModuleCommandSuccess })
+        )
+
+        const action$ = hot('--a', { a: action })
+        const state$ = hot('a-a', { a: {} })
+        const output$ = modulesEpic(action$, state$)
+
+        expectObservable(output$).toBe('--a', {
+          a: Actions.sendModuleCommandSuccess(
+            mockRobot.name,
+            'abc123',
+            'set_temperature',
+            Fixtures.mockSendModuleCommandSuccess.body.returnValue,
+            { ...meta, response: Fixtures.mockSendModuleCommandSuccessMeta }
+          ),
+        })
+      })
+    })
+
+    test('maps failed response to SEND_MODULE_COMMAND_FAILURE', () => {
+      testScheduler.run(({ hot, cold, expectObservable, flush }) => {
+        mockFetchRobotApi.mockReturnValue(
+          cold('r', { r: Fixtures.mockSendModuleCommandFailure })
+        )
+
+        const action$ = hot('--a', { a: action })
+        const state$ = hot('a-a', { a: {} })
+        const output$ = modulesEpic(action$, state$)
+
+        expectObservable(output$).toBe('--a', {
+          a: Actions.sendModuleCommandFailure(
+            mockRobot.name,
+            'abc123',
+            'set_temperature',
+            { message: 'AH' },
+            { ...meta, response: Fixtures.mockSendModuleCommandFailureMeta }
+          ),
+        })
+      })
+    })
+  })
+})

--- a/app/src/modules/epic/fetchModulesEpic.js
+++ b/app/src/modules/epic/fetchModulesEpic.js
@@ -1,0 +1,49 @@
+// @flow
+import { ofType } from 'redux-observable'
+
+import { GET } from '../../robot-api/constants'
+import { mapToRobotApiRequest } from '../../robot-api/operators'
+
+import * as Actions from '../actions'
+import * as Constants from '../constants'
+
+import type { StrictEpic } from '../../types'
+
+import type {
+  ActionToRequestMapper,
+  ResponseToActionMapper,
+} from '../../robot-api/operators'
+
+import type { FetchModulesAction, FetchModulesDoneAction } from '../types'
+
+const mapActionToRequest: ActionToRequestMapper<FetchModulesAction> = action => ({
+  method: GET,
+  path: Constants.MODULES_PATH,
+})
+
+const mapResponseToAction: ResponseToActionMapper<
+  FetchModulesAction,
+  FetchModulesDoneAction
+> = (response, originalAction) => {
+  const { host, body, ...responseMeta } = response
+  const meta = { ...originalAction.meta, response: responseMeta }
+
+  return response.ok
+    ? Actions.fetchModulesSuccess(host.name, body.modules, meta)
+    : Actions.fetchModulesFailure(host.name, body, meta)
+}
+
+export const fetchModulesEpic: StrictEpic<FetchModulesDoneAction> = (
+  action$,
+  state$
+) => {
+  return action$.pipe(
+    ofType(Constants.FETCH_MODULES),
+    mapToRobotApiRequest(
+      state$,
+      a => a.payload.robotName,
+      mapActionToRequest,
+      mapResponseToAction
+    )
+  )
+}

--- a/app/src/modules/epic/index.js
+++ b/app/src/modules/epic/index.js
@@ -1,0 +1,13 @@
+// @flow
+import { combineEpics } from 'redux-observable'
+import { fetchModulesEpic } from './fetchModulesEpic'
+import { sendModuleCommandEpic } from './sendModuleCommandEpic'
+import { pollModulesWhileConnectedEpic } from './pollModulesWhileConnectedEpic'
+
+import type { Epic } from '../../types'
+
+export const modulesEpic: Epic = combineEpics(
+  fetchModulesEpic,
+  sendModuleCommandEpic,
+  pollModulesWhileConnectedEpic
+)

--- a/app/src/modules/epic/pollModulesWhileConnectedEpic.js
+++ b/app/src/modules/epic/pollModulesWhileConnectedEpic.js
@@ -1,0 +1,36 @@
+// @flow
+import { ofType } from 'redux-observable'
+import { interval } from 'rxjs'
+import {
+  mergeMap,
+  withLatestFrom,
+  filter,
+  map,
+  takeWhile,
+} from 'rxjs/operators'
+
+import { getConnectedRobotName } from '../../robot/selectors'
+import { fetchModules } from '../actions'
+
+import * as Types from '../types'
+import type { StrictEpic } from '../../types'
+import type { ConnectResponseAction } from '../../robot/actions'
+
+const POLL_MODULE_INTERVAL_MS = 5000
+
+export const pollModulesWhileConnectedEpic: StrictEpic<Types.FetchModulesAction> = (
+  action$,
+  state$
+) => {
+  return action$.pipe(
+    ofType('robot:CONNECT_RESPONSE'),
+    filter<ConnectResponseAction>(action => !action.payload?.error),
+    mergeMap(() => {
+      return interval(POLL_MODULE_INTERVAL_MS).pipe(
+        withLatestFrom(state$, (_, state) => getConnectedRobotName(state)),
+        takeWhile<string | null, any>(robotName => Boolean(robotName)),
+        map((robotName: string) => fetchModules(robotName))
+      )
+    })
+  )
+}

--- a/app/src/modules/epic/sendModuleCommandEpic.js
+++ b/app/src/modules/epic/sendModuleCommandEpic.js
@@ -1,0 +1,63 @@
+// @flow
+import { ofType } from 'redux-observable'
+
+import { POST } from '../../robot-api/constants'
+import { mapToRobotApiRequest } from '../../robot-api/operators'
+
+import * as Actions from '../actions'
+import * as Constants from '../constants'
+
+import type { StrictEpic } from '../../types'
+
+import type {
+  ActionToRequestMapper,
+  ResponseToActionMapper,
+} from '../../robot-api/operators'
+
+import type {
+  SendModuleCommandAction,
+  SendModuleCommandDoneAction,
+} from '../types'
+
+const mapActionToRequest: ActionToRequestMapper<SendModuleCommandAction> = action => ({
+  method: POST,
+  path: `${Constants.MODULES_PATH}/${action.payload.moduleId}`,
+  body: {
+    command_type: action.payload.command,
+    args: action.payload.args,
+  },
+})
+
+const mapResponseToAction: ResponseToActionMapper<
+  SendModuleCommandAction,
+  SendModuleCommandDoneAction
+> = (response, originalAction) => {
+  const { host, body, ...responseMeta } = response
+  const { moduleId, command } = originalAction.payload
+  const meta = { ...originalAction.meta, response: responseMeta }
+
+  return response.ok
+    ? Actions.sendModuleCommandSuccess(
+        host.name,
+        moduleId,
+        command,
+        body.returnValue,
+        meta
+      )
+    : Actions.sendModuleCommandFailure(host.name, moduleId, command, body, meta)
+}
+
+export const sendModuleCommandEpic: StrictEpic<SendModuleCommandDoneAction> = (
+  action$,
+  state$
+) => {
+  return action$.pipe(
+    ofType(Constants.SEND_MODULE_COMMAND),
+    mapToRobotApiRequest(
+      state$,
+      a => a.payload.robotName,
+      mapActionToRequest,
+      mapResponseToAction
+    )
+  )
+}

--- a/app/src/modules/index.js
+++ b/app/src/modules/index.js
@@ -1,0 +1,5 @@
+// @flow
+
+export * from './actions'
+export * from './constants'
+export * from './selectors'

--- a/app/src/modules/reducer.js
+++ b/app/src/modules/reducer.js
@@ -1,0 +1,29 @@
+// @flow
+import keyBy from 'lodash/keyBy'
+import * as Constants from './constants'
+
+import type { Action } from '../types'
+import type { ModulesState, PerRobotModulesState } from './types'
+
+const INITIAL_STATE: ModulesState = {}
+
+const INITIAL_MODULES_STATE: PerRobotModulesState = {
+  modulesById: null,
+}
+
+export function modulesReducer(
+  state: ModulesState = INITIAL_STATE,
+  action: Action
+): ModulesState {
+  switch (action.type) {
+    case Constants.FETCH_MODULES_SUCCESS: {
+      const { robotName, modules } = action.payload
+      const robotState = state[robotName] || INITIAL_MODULES_STATE
+      const modulesById = keyBy(modules, 'serial')
+
+      return { ...state, [robotName]: { ...robotState, modulesById } }
+    }
+  }
+
+  return state
+}

--- a/app/src/modules/selectors.js
+++ b/app/src/modules/selectors.js
@@ -1,0 +1,72 @@
+// @flow
+import { createSelector } from 'reselect'
+import sortBy from 'lodash/sortBy'
+import countBy from 'lodash/countBy'
+
+import { selectors as RobotSelectors } from '../robot'
+import * as Constants from './constants'
+import * as Types from './types'
+
+import type { State } from '../types'
+import type { SessionModule } from '../robot/types'
+
+export const getAttachedModules: (
+  state: State,
+  robotName: string | null
+) => Array<Types.AttachedModule> = createSelector(
+  (state, robotName) =>
+    robotName !== null ? state.modules[robotName]?.modulesById : {},
+  modulesById => sortBy(modulesById, 'serial')
+)
+
+const getAttachedModulesForConnectedRobot = (
+  state: State
+): Array<Types.AttachedModule> => {
+  const robotName = RobotSelectors.getConnectedRobotName(state)
+  return getAttachedModules(state, robotName)
+}
+
+const isModulePrepared = (module: Types.AttachedModule): boolean => {
+  if (module.name === 'thermocycler') return module.data.lid === 'open'
+  return false
+}
+
+export const getUnpreparedModules: (
+  state: State
+) => Array<Types.AttachedModule> = createSelector(
+  getAttachedModulesForConnectedRobot,
+  RobotSelectors.getModules,
+  (attachedModules, protocolModules) => {
+    const preparableSessionModules = protocolModules
+      .filter(m => Constants.PREPARABLE_MODULES.includes(m.name))
+      .map(m => m.name)
+
+    // return actual modules that are both
+    // a) required to be prepared by the session
+    // b) not prepared according to isModulePrepared
+    return attachedModules.filter(
+      m => preparableSessionModules.includes(m.name) && !isModulePrepared(m)
+    )
+  }
+)
+
+export const getMissingModules: (
+  state: State
+) => Array<SessionModule> = createSelector(
+  getAttachedModulesForConnectedRobot,
+  RobotSelectors.getModules,
+  (attachedModules, protocolModules) => {
+    const requiredCountMap: { [string]: number } = countBy(
+      protocolModules,
+      'name'
+    )
+    const actualCountMap: { [string]: number } = countBy(
+      attachedModules,
+      'name'
+    )
+
+    return protocolModules.filter(
+      m => requiredCountMap[m.name] > (actualCountMap[m.name] || 0)
+    )
+  }
+)

--- a/app/src/modules/types.js
+++ b/app/src/modules/types.js
@@ -23,8 +23,8 @@ export type MagneticData = {|
 |}
 
 export type ThermocyclerData = {|
-  // TODO(mc, 2019-12-12): in_between not yet implemented server side due to
-  // firmware limitations in current hardware revision
+  // TODO(mc, 2019-12-12): in_between comes from the thermocycler firmware and
+  // will be rare in normal operation due to limitations in current revision
   lid: 'open' | 'closed' | 'in_between',
   lidTarget: number | null,
   lidTemp: number | null,

--- a/app/src/modules/types.js
+++ b/app/src/modules/types.js
@@ -12,12 +12,12 @@ type BaseModule = {|
   port: string,
 |}
 
-export type TempDeckData = {|
+export type TemperatureData = {|
   currentTemp: number,
   targetTemp: number | null,
 |}
 
-export type MagDeckData = {|
+export type MagneticData = {|
   engaged: boolean,
   height: number,
 |}
@@ -56,14 +56,14 @@ export type MagneticStatus = 'engaged' | 'disengaged'
 export type TemperatureModule = {|
   ...BaseModule,
   name: 'tempdeck',
-  data: TempDeckData,
+  data: TemperatureData,
   status: TemperatureStatus,
 |}
 
 export type MagneticModule = {|
   ...BaseModule,
   name: 'magdeck',
-  data: MagDeckData,
+  data: MagneticData,
   status: MagneticStatus,
 |}
 

--- a/app/src/modules/types.js
+++ b/app/src/modules/types.js
@@ -1,0 +1,178 @@
+// @flow
+
+import type { RobotApiRequestMeta } from '../robot-api/types'
+
+// common types
+
+type BaseModule = {|
+  displayName: string,
+  model: string,
+  serial: string,
+  fwVersion: string,
+  port: string,
+|}
+
+export type TempDeckData = {|
+  currentTemp: number,
+  targetTemp: number | null,
+|}
+
+export type MagDeckData = {|
+  engaged: boolean,
+  height: number,
+|}
+
+export type ThermocyclerData = {|
+  // TODO(mc, 2019-12-12): in_between not yet implemented server side due to
+  // firmware limitations in current hardware revision
+  lid: 'open' | 'closed' | 'in_between',
+  lidTarget: number | null,
+  lidTemp: number | null,
+  currentTemp: number | null,
+  targetTemp: number | null,
+  holdTime: number | null,
+  rampRate: number | null,
+  totalStepCount: number | null,
+  currentStepIndex: number | null,
+  totalCycleCount: number | null,
+  currentCycleIndex: number | null,
+|}
+
+export type TemperatureStatus =
+  | 'idle'
+  | 'holding at target'
+  | 'cooling'
+  | 'heating'
+
+export type ThermocyclerStatus =
+  | 'idle'
+  | 'holding at target'
+  | 'cooling'
+  | 'heating'
+  | 'error'
+
+export type MagneticStatus = 'engaged' | 'disengaged'
+
+export type TemperatureModule = {|
+  ...BaseModule,
+  name: 'tempdeck',
+  data: TempDeckData,
+  status: TemperatureStatus,
+|}
+
+export type MagneticModule = {|
+  ...BaseModule,
+  name: 'magdeck',
+  data: MagDeckData,
+  status: MagneticStatus,
+|}
+
+export type ThermocyclerModule = {|
+  ...BaseModule,
+  name: 'thermocycler',
+  data: ThermocyclerData,
+  status: ThermocyclerStatus,
+|}
+
+export type AttachedModule =
+  | ThermocyclerModule
+  | MagneticModule
+  | TemperatureModule
+
+export type ModuleCommand =
+  | 'set_temperature'
+  | 'set_block_temperature'
+  | 'set_lid_temperature'
+  | 'deactivate'
+  | 'open'
+
+// action object types
+
+// fetch modules
+
+export type FetchModulesAction = {|
+  type: 'modules:FETCH_MODULES',
+  payload: {| robotName: string |},
+  meta: RobotApiRequestMeta,
+|}
+
+export type FetchModulesSuccessAction = {|
+  type: 'modules:FETCH_MODULES_SUCCESS',
+  payload: {| robotName: string, modules: Array<AttachedModule> |},
+  meta: RobotApiRequestMeta,
+|}
+
+export type FetchModulesFailureAction = {|
+  type: 'modules:FETCH_MODULES_FAILURE',
+  payload: {| robotName: string, error: {} |},
+  meta: RobotApiRequestMeta,
+|}
+
+export type FetchModulesDoneAction =
+  | FetchModulesSuccessAction
+  | FetchModulesFailureAction
+
+// fetch module data
+
+export type SendModuleCommandAction = {|
+  type: 'modules:SEND_MODULE_COMMAND',
+  payload: {|
+    robotName: string,
+    moduleId: string,
+    command: ModuleCommand,
+    args: Array<mixed>,
+  |},
+  meta: RobotApiRequestMeta,
+|}
+
+export type SendModuleCommandSuccessAction = {|
+  type: 'modules:SEND_MODULE_COMMAND_SUCCESS',
+  payload: {|
+    robotName: string,
+    moduleId: string,
+    command: ModuleCommand,
+    returnValue: mixed,
+  |},
+  meta: RobotApiRequestMeta,
+|}
+
+export type SendModuleCommandFailureAction = {|
+  type: 'modules:SEND_MODULE_COMMAND_FAILURE',
+  payload: {|
+    robotName: string,
+    moduleId: string,
+    command: ModuleCommand,
+    error: {},
+  |},
+  meta: RobotApiRequestMeta,
+|}
+
+export type SendModuleCommandDoneAction =
+  | SendModuleCommandSuccessAction
+  | SendModuleCommandFailureAction
+
+// action union
+
+export type ModulesAction =
+  | FetchModulesAction
+  | FetchModulesSuccessAction
+  | FetchModulesFailureAction
+  | SendModuleCommandAction
+  | SendModuleCommandSuccessAction
+  | SendModuleCommandFailureAction
+
+// state types
+
+export type AttachedModulesById = $Shape<
+  $ReadOnly<{| [moduleId: string]: AttachedModule |}>
+>
+
+export type PerRobotModulesState = $ReadOnly<{|
+  modulesById: AttachedModulesById | null,
+|}>
+
+export type ModulesState = $Shape<
+  $ReadOnly<{|
+    [robotName: string]: void | PerRobotModulesState,
+  |}>
+>

--- a/app/src/pipettes/__tests__/actions.test.js
+++ b/app/src/pipettes/__tests__/actions.test.js
@@ -12,7 +12,7 @@ type ActionSpec = {|
   expected: PipettesAction,
 |}
 
-describe('robot settings actions', () => {
+describe('robot pipettes actions', () => {
   const SPECS: Array<ActionSpec> = [
     {
       name: 'pipettes:FETCH_PIPETTES without refresh',

--- a/app/src/reducer.js
+++ b/app/src/reducer.js
@@ -23,6 +23,9 @@ import { robotSettingsReducer } from './robot-settings/reducer'
 // pipettes state
 import { pipettesReducer } from './pipettes/reducer'
 
+// modules state
+import { modulesReducer } from './modules/reducer'
+
 // app shell state
 import { shellReducer } from './shell'
 
@@ -51,6 +54,7 @@ const rootReducer: Reducer<State, Action> = combineReducers<_, Action>({
   robotAdmin: robotAdminReducer,
   robotSettings: robotSettingsReducer,
   pipettes: pipettesReducer,
+  modules: modulesReducer,
   config: configReducer,
   discovery: discoveryReducer,
   labware: customLabwareReducer,

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -230,7 +230,7 @@ export const actions = {
   },
 
   connectResponse(
-    error: Error,
+    error: Error | null,
     sessionCapabilities: Array<string> = []
   ): ConnectResponseAction {
     return {

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -47,8 +47,8 @@ export function getConnectRequest(state: State) {
   return connection(state).connectRequest
 }
 
-export function getConnectedRobotName(state: State): ?string {
-  return connection(state).connectedTo
+export function getConnectedRobotName(state: State): string | null {
+  return connection(state).connectedTo || null
 }
 
 export const getConnectionStatus: OutputSelector<
@@ -290,11 +290,7 @@ export function getModulesBySlot(state: State): { [Slot]: SessionModule } {
   return session(state).modulesBySlot
 }
 
-export const getModules: OutputSelector<
-  State,
-  void,
-  Array<SessionModule>
-> = createSelector(
+export const getModules: State => Array<SessionModule> = createSelector(
   getModulesBySlot,
   // TODO (ka 2019-3-26): can't import getConfig due to circular dependency
   state => state.config,

--- a/app/src/types.js
+++ b/app/src/types.js
@@ -12,6 +12,7 @@ import type {
 } from './robot-api/types'
 import type { RobotAdminState, RobotAdminAction } from './robot-admin/types'
 import type { PipettesState, PipettesAction } from './pipettes/types'
+import type { ModulesState, ModulesAction } from './modules/types'
 import type {
   State as SuperDeprecatedRobotApiState,
   HttpApiAction as SuperDeprecatedRobotApiAction,
@@ -39,6 +40,7 @@ export type State = $ReadOnly<{|
   robotAdmin: RobotAdminState,
   robotSettings: RobotSettingsState,
   pipettes: PipettesState,
+  modules: ModulesState,
   config: Config,
   discovery: DiscoveryState,
   labware: CustomLabwareState,
@@ -54,6 +56,7 @@ export type Action =
   | RobotAdminAction
   | RobotSettingsAction
   | PipettesAction
+  | ModulesAction
   | ShellAction
   | ConfigAction
   | RouterAction


### PR DESCRIPTION
## overview

This PR refactors the code that was in `app/src/robot-api/resources/modules` (and a few other places) into a new, top-level state subtree at `app/src/modules` and `state.modules`.

- Six actions
    - Fetch modules + success + failure
    - Send module command + success + failure
- Three epics
    - Fetch modules epic (makes HTTP call on fetch modules action)
    - Send module command epic (makes HTTP call on send module command action)
    - Poll modules while connected epic (triggers fetch modules actions on an interval while robot is connected)
- Three selectors
    - Get attached modules
    - Get unprepared modules (checks that attached thermocycler lid is open)
    - Get missing modules (compares attached modules to protocol modules)
- One reducer
    - Puts attached modules in state on FETCH_MODULES_SUCCESS

**This PR does not wire most of this stuff up**. Rather than grow this PR any more, I'll do the old code removal + new code wireup in my next PR

## changelog

- refactor(app): refactor /modules state into first-class state subtree

## review requests

- [ ] New actions + epics work
    - To test fetch modules, dispatch a fetch modules from the redux devools
    - The `pollModulesWhileConnectedEpic` is actually wired up, so you should see `modules:FETCH_MODULES` in the log every 5 seconds while connected
    - The response will hit state, so you can check out `state.modules`, but it's not wired to any components
- [ ] Reducer and epic code looks fine
    - These are harder to test without the wireup, so I plan to squash any bugs we miss here in the next PR
    - Otherwise, check out the code and their unit tests for any obvious errors


Example actions for testing

```js
// fetch pipettes
{
  type: 'modules:FETCH_MODULES',
  payload: { robotName: 'YOUR_ROBOT_NAME' },
  meta: {},
}

// send module command pipettes
{
  type: 'modules:SEND_MODULE_COMMAND',
  payload: {
    robotName: 'YOUR_ROBOT_NAME',
    moduleId: 'YOUR_MODULE_SERIAL',
    command: 'some_method_name',
    args: [ 42 ],
  },
  meta: {},
}
```