### PR TITLE
fix(api): allow labeling and versioning for module labware

### DIFF
--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -314,7 +314,7 @@ class ProtocolContext(CommandPublisher):
             location: types.DeckLocation,
             label: str = None,
             namespace: str = None,
-            version: int = 1,
+            version: int = None,
     ) -> Labware:
         """ Load a labware onto the deck given its name.
 
@@ -1975,15 +1975,24 @@ class ModuleContext(CommandPublisher):
                           specified, this is the name the labware will appear
                           as in the run log and the calibration view in the
                           Opentrons app.
+        .. versionadded:: 2.1
         :param str namespace: The namespace the labware definition belongs to.
             If unspecified, will search 'opentrons' then 'custom_beta'
+        .. versionadded:: 2.1
         :param int version: The version of the labware definition. If
             unspecified, will use version 1.
+        .. versionadded:: 2.1
         :returns: The initialized and loaded labware object.
         """
-        lw = load(
-            name, self._geometry.location, label, namespace, version,
-            bundled_defs=self._ctx._bundled_labware)
+        if self._ctx.api_version < APIVersion(2, 1) and\
+                (label or namespace or version):
+            MODULE_LOG.warning(
+                f'You have specified API {self._ctx.api_version}, but you '
+                'are trying to utilize new load_labware parameters in 2.1')
+        lw = load(name, self._geometry.location,
+                    label, namespace, version,
+                    bundled_defs=self._ctx._bundled_labware,
+                    extra_defs=self._ctx._extra_labware)
         return self.load_labware_object(lw)
 
     @requires_version(2, 0)
@@ -2006,12 +2015,16 @@ class ModuleContext(CommandPublisher):
             definition, self._geometry.location, label)
         return self.load_labware_object(lw)
 
-    @requires_version(2, 0)
-    def load_labware_by_name(self, name: str) -> Labware:
+    @requires_version(2, 1)
+    def load_labware_by_name(self,
+                             name: str,
+                             label: str = None,
+                             namespace: str = None,
+                             version: int = 1,) -> Labware:
         MODULE_LOG.warning(
             'load_labware_by_name is deprecated and will be removed in '
             'version 3.12.0. please use load_labware')
-        return self.load_labware(name)
+        return self.load_labware(name, label, namespace, version)
 
     @property  # type: ignore
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1990,9 +1990,9 @@ class ModuleContext(CommandPublisher):
                 f'You have specified API {self._ctx.api_version}, but you '
                 'are trying to utilize new load_labware parameters in 2.1')
         lw = load(name, self._geometry.location,
-                    label, namespace, version,
-                    bundled_defs=self._ctx._bundled_labware,
-                    extra_defs=self._ctx._extra_labware)
+                  label, namespace, version,
+                  bundled_defs=self._ctx._bundled_labware,
+                  extra_defs=self._ctx._extra_labware)
         return self.load_labware_object(lw)
 
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -297,6 +297,10 @@ class ProtocolContext(CommandPublisher):
         :param location: The slot into which to load the labware such as
                          1 or '1'
         :type location: int or str
+        :param str label: An optional special name to give the labware. If
+                          specified, this is the name the labware will appear
+                          as in the run log and the calibration view in the
+                          Opentrons app.
         """
         parent = self.deck.position_for(location)
         labware_obj = load_from_definition(labware_def, parent, label)
@@ -310,7 +314,7 @@ class ProtocolContext(CommandPublisher):
             location: types.DeckLocation,
             label: str = None,
             namespace: str = None,
-            version: int = None,
+            version: int = 1,
     ) -> Labware:
         """ Load a labware onto the deck given its name.
 
@@ -1957,29 +1961,49 @@ class ModuleContext(CommandPublisher):
         return mod_labware
 
     @requires_version(2, 0)
-    def load_labware(self, name: str) -> Labware:
+    def load_labware(
+            self,
+            name: str,
+            label: str = None,
+            namespace: str = None,
+            version: int = 1,
+            ) -> Labware:
         """ Specify the presence of a piece of labware on the module.
 
         :param name: The name of the labware object.
+        :param str label: An optional special name to give the labware. If
+                          specified, this is the name the labware will appear
+                          as in the run log and the calibration view in the
+                          Opentrons app.
+        :param str namespace: The namespace the labware definition belongs to.
+            If unspecified, will search 'opentrons' then 'custom_beta'
+        :param int version: The version of the labware definition. If
+            unspecified, will use version 1.
         :returns: The initialized and loaded labware object.
         """
         lw = load(
-            name, self._geometry.location,
+            name, self._geometry.location, label, namespace, version,
             bundled_defs=self._ctx._bundled_labware)
         return self.load_labware_object(lw)
 
     @requires_version(2, 0)
     def load_labware_from_definition(
-            self, definition: Dict[str, Any]) -> Labware:
+            self,
+            definition: Dict[str, Any],
+            label: str = None) -> Labware:
         """
         Specify the presence of a labware on the module, using an
         inline definition.
 
         :param definition: The labware definition.
+        :param str label: An optional special name to give the labware. If
+                          specified, this is the name the labware will appear
+                          as in the run log and the calibration view in the
+                          Opentrons app.
         :returns: The initialized and loaded labware object.
         """
         lw = load_from_definition(
-            definition, self._geometry.location)
+            definition, self._geometry.location, label)
         return self.load_labware_object(lw)
 
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/definitions.py
+++ b/api/src/opentrons/protocol_api/definitions.py
@@ -1,4 +1,4 @@
 from ..protocols import types
 
-MAX_SUPPORTED_VERSION = types.APIVersion(2, 0)
+MAX_SUPPORTED_VERSION = types.APIVersion(2, 1)
 #: The maximum supported protocol API version in this release

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -2,6 +2,7 @@ import json
 import pkgutil
 from unittest import mock
 import opentrons.protocol_api as papi
+from opentrons.protocols.types import APIVersion
 from opentrons.types import Point
 
 import pytest

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -289,7 +289,32 @@ def test_module_load_labware(loop):
     mod2 = ctx.load_module('tempdeck', 2)
     lw2 = mod2.load_labware(labware_name)
     assert lw2._offset == lw_offset + mod2._geometry.location.point
-    assert lw2.name == labware_name
+
+
+def test_module_load_labware_with_label(loop):
+    ctx = papi.ProtocolContext(loop)
+    labware_name = 'corning_96_wellplate_360ul_flat'
+    ctx._hw_manager.hardware._backend._attached_modules = [
+        ('mod0', 'tempdeck')]
+    mod = ctx.load_module('Temperature Module', 1)
+    lw = mod.load_labware(labware_name, label='my cool labware')
+    assert lw.name == 'my cool labware'
+
+
+def test_module_load_invalid_labware(loop):
+    ctx = papi.ProtocolContext(loop)
+    labware_name = 'corning_96_wellplate_360ul_flat'
+    ctx._hw_manager.hardware._backend._attached_modules = [
+        ('mod0', 'tempdeck')]
+    mod = ctx.load_module('Temperature Module', 1)
+    # wrong version number
+    with pytest.raises(FileNotFoundError):
+        mod.load_labware(labware_name, namespace='opentrons', version=100)
+    # wrong namespace
+    with pytest.raises(FileNotFoundError):
+        mod.load_labware(labware_name, namespace='fake namespace', version=1)
+    # valid info
+    assert mod.load_labware(labware_name, namespace='opentrons', version=1)
 
 
 def test_deprecated_module_load_labware(loop):

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -2,7 +2,6 @@ import json
 import pkgutil
 from unittest import mock
 import opentrons.protocol_api as papi
-from opentrons.protocols.types import APIVersion
 from opentrons.types import Point
 
 import pytest


### PR DESCRIPTION
## overview
Currently, `ModuleContext.load_labware` is missing a few important parameters, such as `label`, `namespace`, and `version`. Also, `_extra_labware` should also be passed into the `load` function in `ModuleContext.load_labware`, as pointed out in #4612.

This PR adds:
- `label`, `namespace`, and `version` to `ModuleContext.load_labware`
- `_extra_labware`to be passed to the load function in `ModuleContext.load_labware`
- `label` to `ModuleContext.load_labware_from_definition`
- bump the max supported API version!
- docstring fixup for `ProtocolContext.load_labware_from_definition`
- more tests!

closes #4595, closes #4612
