### PR TITLE
fix(api): allow labels on old magdeck containers in v1

### DIFF
--- a/api/src/opentrons/legacy_api/containers/placeable.py
+++ b/api/src/opentrons/legacy_api/containers/placeable.py
@@ -104,6 +104,9 @@ class Placeable(object):
         # by name and by reference
         self.children_by_name = OrderedDict()
         self.children_by_reference = OrderedDict()
+        # A special stash for original names because the children won't
+        # have them
+        self.child_original_names_by_reference = OrderedDict()
         self._coordinates = Vector(0, 0, 0)
 
         self.parent = parent
@@ -201,6 +204,15 @@ class Placeable(object):
 
         return self.parent.children_by_reference[self]
 
+    def get_original_name(self):
+        """ Returns the placeable's "original name" (i.e. not any
+        user-specified overrides
+        """
+        if self.parent is None:
+            return None
+
+        return self.parent.child_original_names_by_reference[self]
+
     def get_type(self):
         """
         Returns the Placeable's type or class name
@@ -246,7 +258,7 @@ class Placeable(object):
         coordinates = [i._coordinates for i in self.get_trace(reference)]
         return functools.reduce(lambda a, b: a + b, coordinates)
 
-    def add(self, child, name=None, coordinates=None):
+    def add(self, child, name=None, coordinates=None, original_name=None):
         """
         Adds child to the :Placeable:, storing it's :name: and :coordinates:
 
@@ -255,6 +267,9 @@ class Placeable(object):
         """
         if not name:
             name = str(child)
+
+        if not original_name:
+            original_name = name
 
         if name in self.children_by_name:
             raise RuntimeWarning(
@@ -266,6 +281,7 @@ class Placeable(object):
         child.parent = self
         self.children_by_name[name] = child
         self.children_by_reference[child] = name
+        self.child_original_names_by_reference[child] = original_name
 
     def get_deck(self):
         """

--- a/api/src/opentrons/legacy_api/modules/magdeck.py
+++ b/api/src/opentrons/legacy_api/modules/magdeck.py
@@ -54,7 +54,7 @@ class MagDeck(commands.CommandPublisher):
                     magdeck_engage_height()
             except KeyError:
                 height = LABWARE_ENGAGE_HEIGHT.get(
-                    self.labware.get_children_list()[1].get_name())
+                    self.labware.get_children_list()[1].get_original_name())
             if not height:
                 raise ValueError(
                     'No engage height definition found for {}. Provide a'

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -855,7 +855,7 @@ class Robot(CommandPublisher):
             self, container, name, slot, label=None, share=False):
         location = self._get_placement_location(slot)
         if self._is_available_slot(location, share, slot, name):
-            location.add(container, label or name)
+            location.add(container, label or name, original_name=name)
         self.add_container_to_pose_tracker(location, container)
         self.max_deck_height.cache_clear()
         return container


### PR DESCRIPTION
If you used a label to customize the name of the labware on your magdeck in v1,
and you were using the original v1 labware name to load on to the magdeck, you
would have to specify the engage height because the label would be used to look
up the magdeck height.

Closes #2310


Nobody may care about this! But technically it was still a bug.

You can test it with this protocol:
```python
from opentrons import modules, labware
mag_module = modules.load('magdeck', '1')
mag_plate = labware.load('biorad-hardshell-96-PCR', '1', 'mag_plate_custom_name',
                         share=True)

# fails with no height
mag_module.engage()
```

Note that it won't happen if you use a v2 labware because it'll get it from the definition.