### PR TITLE
fix(api): make sure the robot is connected before querying instrs

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -376,6 +376,8 @@ class Session(object):
                              context=self._simulating_ctx)
             else:
                 robot.broker = self._broker
+                # we don't rely on being connected anymore so make sure we are
+                robot.connect()
                 robot.cache_instrument_models()
                 robot.disconnect()
 
@@ -506,6 +508,10 @@ class Session(object):
                 robot.broker = self._broker
                 assert isinstance(self._protocol, PythonProtocol),\
                     'Internal error: v1 should only be used for python'
+                if not robot.is_connected():
+                    robot.connect()
+                robot.cache_instrument_models()
+                robot.discover_modules()
                 exec(self._protocol.contents, {})
 
             # If the last command in a protocol was a pause, the protocol


### PR DESCRIPTION
Since the robot singleton is now not the thing the rest of the api runs on, it
may not be connected the first time the system tries to detect attached pipettes
before a run. This means that requested pipettes get built as v1, which means
that their settings stand a good chance of being wrong - and that can lead to
failed drop tips.

Closes #4590

## Testing

Upload v1 protocols under the following circumstances and check the app redux state path /robot/session/pipettesByMount/{mount}/name. The name should usually (with some noted exceptions be the actual full model number of the pipette:

- With the correct pipette already attached, the name should be the full model number (e.g. v1.5)
- With an incorrect pipette, it should be v1 of the pipette specified in the protocol.