### PR TITLE
docs(api): Fix autodoc formatting to fix rendering

### DIFF
--- a/api/src/opentrons/protocol_api/util.py
+++ b/api/src/opentrons/protocol_api/util.py
@@ -259,7 +259,7 @@ def requires_version(
             # this newline and initial space has to be there for sphinx to
             # parse this correctly and not add it into for instance a
             # previous code-block
-            docstr += f'\n\n    .. versionadded:: {added_version}\n\n'
+            docstr += f'\n\n        .. versionadded:: {added_version}\n\n'
             decorated_obj.__doc__ = docstr
 
         @functools.wraps(decorated_obj)


### PR DESCRIPTION
You love to see it

Makes the autodoc'd apiv2 stuff that has the `requires_version` decorator go from this:
<img width="652" alt="Screen Shot 2019-12-16 at 4 15 37 PM" src="https://user-images.githubusercontent.com/3091648/70943633-51ff9200-201f-11ea-9be6-4adc5a450d9a.png">

to this (which is what we want):
<img width="654" alt="Screen Shot 2019-12-16 at 4 14 31 PM" src="https://user-images.githubusercontent.com/3091648/70943609-4318df80-201f-11ea-8c13-6f827855a823.png">
