### PR TITLE
docs(api): remove tiprack-200ul from v1 docs

### DIFF
--- a/api/docs/v1/atomic_commands.rst
+++ b/api/docs/v1/atomic_commands.rst
@@ -22,7 +22,7 @@ This section demonstrates the options available for controlling tips
     '''
     from opentrons import labware, instruments, robot
 
-    tiprack = labware.load('tiprack-200ul', '2')
+    tiprack = labware.load('opentrons_96_tiprack_300ul', '2')
 
     pipette = instruments.P300_Single(mount='left')
 
@@ -81,8 +81,8 @@ If no location is specified, the pipette will move to the next available tip by 
     from opentrons import labware, instruments, robot
 
     trash = labware.load('trash-box', '1')
-    tip_rack_1 = containers.load('tiprack-200ul', '2')
-    tip_rack_2 = containers.load('tiprack-200ul', '3')
+    tip_rack_1 = containers.load('opentrons_96_tiprack_300ul', '2')
+    tip_rack_2 = containers.load('opentrons_96_tiprack_300ul', '3')
 
 Attach Tip Rack to Pipette
 --------------------------
@@ -297,7 +297,7 @@ Some liquids need an extra amount of air in the pipette's tip to prevent it from
     '''
     Examples in this section expect the following
     '''
-    tiprack = labware.load('tiprack-200ul', '1')
+    tiprack = labware.load('opentrons_96_tiprack_300ul', '1')
     plate = labware.load('96-flat', '2')
 
     pipette = instruments.P300_Single(mount='right', tip_racks=[tiprack])
@@ -316,7 +316,7 @@ using our `set_flow_rate` function. This can be called at any time during the pr
     '''
     Examples in this section expect the following
     '''
-    tiprack = labware.load('tiprack-200ul', '1')
+    tiprack = labware.load('opentrons_96_tiprack_300ul', '1')
     plate = labware.load('96-flat', '2')
 
     pipette = instruments.P300_Single(mount='right', tip_racks=[tiprack])

--- a/api/docs/v1/complex_commands.rst
+++ b/api/docs/v1/complex_commands.rst
@@ -14,7 +14,7 @@ The examples below will use the following set-up:
 
     plate = labware.load('96-flat', '1')
 
-    tiprack = labware.load('opentrons-tiprack-300ul', '2')
+    tiprack = labware.load('opentrons_96_tiprack_300ul', '2')
 
     pipette = instruments.P300_Single(
         mount='left',
@@ -652,7 +652,7 @@ We will be using the code-block below to perform our examples.
     plate_384 = labware.load('384-plate', '3')
     trough = labware.load('trough-12row', '4')
 
-    tiprack = labware.load('opentrons-tiprack-300ul', '2')
+    tiprack = labware.load('opentrons_96_tiprack_300ul', '2')
 
     multi_pipette = instruments.P300_Multi(
         mount='left',

--- a/api/docs/v1/examples.rst
+++ b/api/docs/v1/examples.rst
@@ -13,8 +13,8 @@ All examples on this page assume the following labware and pipette:
   plate = labware.load('96-flat', '1')
   trough = labware.load('trough-12row', '2')
 
-  tiprack_1 = labware.load('tiprack-200ul', '3')
-  tiprack_2 = labware.load('tiprack-200ul', '4')
+  tiprack_1 = labware.load('opentrons_96_tiprack_300ul', '3')
+  tiprack_2 = labware.load('opentrons_96_tiprack_300ul', '4')
 
   p300 = instruments.P300_Single(
       mount='left',

--- a/api/docs/v1/hardware_control.rst
+++ b/api/docs/v1/hardware_control.rst
@@ -23,7 +23,7 @@ The robot module can be thought of as the parent for all aspects of the Opentron
     from opentrons import robot, labware, instruments
 
     plate = labware.load('96-flat', 'B1', 'my-plate')
-    tiprack = labware.load('tiprack-200ul', 'A1', 'my-rack')
+    tiprack = labware.load('opentrons_96_tiprack_300ul', 'A1', 'my-rack')
 
     pipette = instruments.P300_Single(mount='left', tip_racks=[tiprack])
 
@@ -153,7 +153,7 @@ will print out...
 
 .. code-block:: python
 
-    my-rack tiprack-200ul
+    my-rack opentrons_96_tiprack_300ul
     my-plate 96-flat
 
 

--- a/api/docs/v1/index.rst
+++ b/api/docs/v1/index.rst
@@ -67,7 +67,7 @@ If we were to rewrite this with the Opentrons API, it would look like the follow
 
     # labware
     plate = labware.load('96-flat', '2')
-    tiprack = labware.load('opentrons-tiprack-300ul', '1')
+    tiprack = labware.load('opentrons_96_tiprack_300ul', '1')
 
     # pipettes
     pipette = instruments.P300_Single(mount='left', tip_racks=[tiprack])
@@ -125,7 +125,7 @@ From the example above, the "labware" section looked like:
 .. code-block:: python
 
     plate = labware.load('96-flat', '2')
-    tiprack = labware.load('tiprack-200ul', '1')
+    tiprack = labware.load('opentrons_96_tiprack_300ul', '1')
 
 .. _index-pipettes:
 

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -1103,7 +1103,7 @@ class Pipette(CommandPublisher):
         ..
         >>> from opentrons import instruments, labware, robot # doctest: +SKIP
         >>> robot.reset() # doctest: +SKIP
-        >>> tiprack = labware.load('tiprack-200ul', 'C2') # doctest: +SKIP
+        >>> tiprack = labware.load('opentrons_96_tiprack_300ul', 'C2') # doctest: +SKIP  # noqa E501
         >>> trash = labware.load('point', 'A3') # doctest: +SKIP
         >>> p300 = instruments.P300_Single(mount='left') # doctest: +SKIP
         >>> p300.pick_up_tip(tiprack[0]) # doctest: +SKIP


### PR DESCRIPTION
## overview
This PR replaces all very ancient `tiprack-200ul` definitions and the not-as-ancient-but-still-out-of-date `opentrons-tiprack-300ul` to `opentrons_96_tiprack_300ul`.

closes #4587

## review request
make sure the old definitions are no longer being used in:
http://sandbox.docs.opentrons.com/docs_remove-old-tiprack-defs/v1/