### PR TITLE
fix(shared-data): require well(s) in labware schema

### DIFF
--- a/shared-data/labware/schemas/2.json
+++ b/shared-data/labware/schemas/2.json
@@ -166,7 +166,8 @@
         "type": "array",
         "items": {
           "type": "string"
-        }
+        },
+        "minItems": 1
       }
     },
     "cornerOffsetFromSlot": {
@@ -201,6 +202,7 @@
       "type": "object",
       "description": "Unordered object of well objects with position and dimensional information",
       "additionalProperties": false,
+      "minProperties": 1,
       "patternProperties": {
         "[A-Z]+[0-9]+": {
           "type": "object",
@@ -268,7 +270,8 @@
             "description": "An array of wells that contain the same metadata",
             "items": {
               "type": "string"
-            }
+            },
+            "minItems": 1
           },
           "metadata": {
             "type": "object",


### PR DESCRIPTION
## overview
Currently, the JSON schema for labware considers definitions with `wells: {}` valid.

This PR adds having at least one well as a requirement for the top-level `wells`, `groups.wells`, and `ordering`.
 
closes #4506
