### PR TITLE
fix(api): split out tc deactivation at driver level

### DIFF
--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -23,12 +23,13 @@ GCODES = {
     'GET_LID_STATUS': 'M119',
     'SET_LID_TEMP': 'M140',
     'GET_LID_TEMP': 'M141',
-    'DEACTIVATE_LID_HEATING': 'M108',
     'EDIT_PID_PARAMS': 'M301',
     'SET_PLATE_TEMP': 'M104',
     'GET_PLATE_TEMP': 'M105',
     'SET_RAMP_RATE': 'M566',
-    'DEACTIVATE': 'M18',
+    'DEACTIVATE_ALL': 'M18',
+    'DEACTIVATE_LID': 'M108',
+    'DEACTIVATE_BLOCK': 'M14',
     'DEVICE_INFO': 'M115'
 }
 LID_TARGET_DEFAULT = 105    # Degree celsius
@@ -263,7 +264,14 @@ class Thermocycler:
         return self
 
     async def deactivate(self):
-        await self._write_and_wait(GCODES['DEACTIVATE'])
+        await self._write_and_wait(GCODES['DEACTIVATE_ALL'])
+
+    async def deactivate_lid(self) -> None:
+        lid_temp_cmd = '{}'.format(GCODES['DEACTIVATE_LID'])
+        await self._write_and_wait(lid_temp_cmd)
+
+    async def deactivate_block(self):
+        await self._write_and_wait(GCODES['DEACTIVATE_BLOCK'])
 
     def is_connected(self) -> bool:
         if not self._poller:
@@ -313,10 +321,6 @@ class Thermocycler:
 
         lid_temp_cmd = '{} S{}'.format(GCODES['SET_LID_TEMP'],
                                        self._lid_target)
-        await self._write_and_wait(lid_temp_cmd)
-
-    async def stop_lid_heating(self) -> None:
-        lid_temp_cmd = '{}'.format(GCODES['DEACTIVATE_LID_HEATING'])
         await self._write_and_wait(lid_temp_cmd)
 
     def _lid_status_update_callback(self, lid_response):

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -263,12 +263,11 @@ class Thermocycler:
         self._poller = None
         return self
 
-    async def deactivate(self):
+    async def deactivate_all(self):
         await self._write_and_wait(GCODES['DEACTIVATE_ALL'])
 
     async def deactivate_lid(self) -> None:
-        lid_temp_cmd = '{}'.format(GCODES['DEACTIVATE_LID'])
-        await self._write_and_wait(lid_temp_cmd)
+        await self._write_and_wait(GCODES['DEACTIVATE_LID'])
 
     async def deactivate_block(self):
         await self._write_and_wait(GCODES['DEACTIVATE_BLOCK'])

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -85,7 +85,7 @@ class SimulatingDriver:
         self._lid_heating_active = True
         self._lid_target = temp
 
-    async def stop_lid_heating(self):
+    async def deactivate_lid(self):
         self._lid_heating_active = False
         self._lid_target = None
 
@@ -254,8 +254,8 @@ class Thermocycler(mod_abc.AbstractModule):
         self._current_task = wait_for_lid_task
         await wait_for_lid_task
 
-    async def stop_lid_heating(self):
-        return await self._driver.stop_lid_heating()
+    async def deactivate_lid(self):
+        return await self._driver.deactivate_lid()
 
     async def wait_for_lid_temp(self):
         """

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -95,7 +95,7 @@ class SimulatingDriver:
         self._hold_time = None
         self._active = None
 
-    async def deactivate(self):
+    async def deactivate_all(self):
         self._target_temp = None
         self._ramp_rate = None
         self._hold_time = None
@@ -266,9 +266,9 @@ class Thermocycler(mod_abc.AbstractModule):
         self._current_task = cycle_task
         await cycle_task
 
-    async def set_lid_temperature(self, temp: float):
+    async def set_lid_temperature(self, temperature: float):
         """ Set the lid temperature in deg Celsius """
-        await self._driver.set_lid_temperature(temp=temp)
+        await self._driver.set_lid_temperature(temp=temperature)
         wait_for_lid_task = self._loop.create_task(self.wait_for_lid_temp())
         self._current_task = wait_for_lid_task
         await wait_for_lid_task

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -89,6 +89,12 @@ class SimulatingDriver:
         self._lid_heating_active = False
         self._lid_target = None
 
+    async def deactivate_block(self):
+        self._target_temp = None
+        self._ramp_rate = None
+        self._hold_time = None
+        self._active = None
+
     async def deactivate(self):
         self._target_temp = None
         self._ramp_rate = None
@@ -181,12 +187,25 @@ class Thermocycler(mod_abc.AbstractModule):
             self._current_task = None
             self._loop.call_soon_threadsafe(self._running_flag.clear)
 
-    async def deactivate(self):
+    def _clear_cycle_counters(self):
         self._total_cycle_count = None
         self._current_cycle_index = None
         self._total_step_count = None
         self._current_step_index = None
-        await self._driver.deactivate()
+
+    async def deactivate_lid(self):
+        """ Deactivate the lid heating pad"""
+        return await self._driver.deactivate_lid()
+
+    async def deactivate_block(self):
+        """ Deactivate the block peltiers"""
+        self._clear_cycle_counters()
+        return await self._driver.deactivate_block()
+
+    async def deactivate(self):
+        """ Deactivate the block peltiers and lid heating pad"""
+        self._clear_cycle_counters()
+        return await self._driver.deactivate_all()
 
     async def open(self) -> str:
         """ Open the lid if it is closed"""

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -273,9 +273,6 @@ class Thermocycler(mod_abc.AbstractModule):
         self._current_task = wait_for_lid_task
         await wait_for_lid_task
 
-    async def deactivate_lid(self):
-        return await self._driver.deactivate_lid()
-
     async def wait_for_lid_temp(self):
         """
         This method only exits if lid target temperature has been reached.

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -2386,13 +2386,13 @@ class ThermocyclerContext(ModuleContext):
     @cmds.publish.both(command=cmds.thermocycler_deactivate_block)
     @requires_version(2, 0)
     def deactivate_block(self):
-        """ Turn off the well block """
+        """ Turn off the well block temperature controller"""
         self._module.deactivate_block()
 
     @cmds.publish.both(command=cmds.thermocycler_deactivate)
     @requires_version(2, 0)
     def deactivate(self):
-        """ Turn off the well block, and heated lid """
+        """ Turn off the well block temperature controller, and heated lid """
         self.deactivate_lid()
         self.deactivate_block()
 

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -2393,8 +2393,7 @@ class ThermocyclerContext(ModuleContext):
     @requires_version(2, 0)
     def deactivate(self):
         """ Turn off the well block temperature controller, and heated lid """
-        self.deactivate_lid()
-        self.deactivate_block()
+        self._module.deactivate()
 
     @property  # type: ignore
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -2381,13 +2381,13 @@ class ThermocyclerContext(ModuleContext):
     @requires_version(2, 0)
     def deactivate_lid(self):
         """ Turn off the heated lid """
-        self._module.stop_lid_heating()
+        self._module.deactivate_lid()
 
     @cmds.publish.both(command=cmds.thermocycler_deactivate_block)
     @requires_version(2, 0)
     def deactivate_block(self):
         """ Turn off the well block """
-        self._module.deactivate()
+        self._module.deactivate_block()
 
     @cmds.publish.both(command=cmds.thermocycler_deactivate)
     @requires_version(2, 0)

--- a/api/tests/opentrons/drivers/module_drivers/test_thermocycler_driver.py
+++ b/api/tests/opentrons/drivers/module_drivers/test_thermocycler_driver.py
@@ -56,3 +56,25 @@ async def test_set_block_temperature():
     await tc.set_temperature(21, ramp_rate=3)
     assert command_log.pop(0) == 'M566 S3'
     assert command_log.pop(0) == 'M104 S21'
+
+
+async def test_deactivates():
+    tc = Thermocycler(lambda x: None)
+    command_log = []
+
+    tc._target_temp = 25
+    tc._current_temp = 25
+
+    async def _mock_write_and_wait(self, command):
+        nonlocal command_log
+        command_log.append(command)
+        return command
+
+    tc._write_and_wait = types.MethodType(_mock_write_and_wait, tc)
+
+    await tc.deactivate_all()
+    assert command_log.pop(0) == 'M18'
+    await tc.deactivate_lid()
+    assert command_log.pop(0) == 'M108'
+    await tc.deactivate_block()
+    assert command_log.pop(0) == 'M14'

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -53,10 +53,33 @@ async def test_sim_update():
     assert therm.target == 10
     assert therm.status == 'holding at target'
     await asyncio.wait_for(therm.wait_for_temp(), timeout=0.2)
+    await therm.deactivate_block()
+    assert therm.temperature is None
+    assert therm.target is None
+    assert therm.status == 'idle'
+
+    await therm.set_lid_temperature(temperature=80)
+    assert therm.lid_temp == 80
+    assert therm.lid_target == 80
+    await asyncio.wait_for(therm.wait_for_lid_temp(), timeout=0.2)
+    await therm.deactivate_lid()
+    assert therm.lid_temp is None
+    assert therm.lid_target is None
+
+    await therm.set_temperature(temperature=10, volume=60, hold_time_seconds=2)
+    await therm.set_lid_temperature(temperature=70)
+    await asyncio.wait_for(therm.wait_for_temp(), timeout=0.2)
+    await asyncio.wait_for(therm.wait_for_lid_temp(), timeout=0.2)
+    assert therm.temperature == 10
+    assert therm.target == 10
+    assert therm.lid_temp == 70
+    assert therm.lid_target == 70
     await therm.deactivate()
     assert therm.temperature is None
     assert therm.target is None
     assert therm.status == 'idle'
+    assert therm.lid_temp is None
+    assert therm.lid_target is None
 
 
 async def test_set_temperature(monkeypatch):


### PR DESCRIPTION
## overview

Previously the tc firmware didn't support a deactivate block only gcode command, so the deactivate block hardware control function would actually deactivate the lid too. This fixes that inconsistency and wires it up to the new gcode for deactivate block


## review requests

- [ ] confirm `thermocycler.deactivate()` deactivates both lid and block
- [ ] confirm `thermocycler.deactivate_lid()` deactivates just lid
- [ ] confirm `thermocycler.deactivate_block()` deactivates just block
