### PR TITLE
fix(api): fix cancelling during the pre-protocol home

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -488,9 +488,9 @@ class Session(object):
         self.set_state('running')
 
         try:
-            self.resume()
-            self._pre_run_hooks()
             if self._use_v2:
+                self.resume()
+                self._pre_run_hooks()
                 self._hardware.cache_instruments()
                 ctx = ProtocolContext.build_using(
                     self._protocol,
@@ -510,6 +510,8 @@ class Session(object):
                     'Internal error: v1 should only be used for python'
                 if not robot.is_connected():
                     robot.connect()
+                self.resume()
+                self._pre_run_hooks()
                 robot.cache_instrument_models()
                 robot.discover_modules()
                 exec(self._protocol.contents, {})


### PR DESCRIPTION
If you cancelled when the robot was homing before the protocol, it wouldn't
actually cancel the protocol itself because it wasn't using the right hardware
backend sometimes.

This makes it correctly cancel the protocol.

## Testing

- Run a v1 protocol and cancel while the robot is homing before the protocol begins; the robot should home and then stop moving
- Run a v2 protocol and cancel while the robot is homing before the protocol begins; the robot should home and then stop moving.