### PR TITLE
refactor(protocol-designer): reimplement Redux persistence; enforce no circular imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,7 @@ jobs:
       script:
         - make test-js
         - make lint-js
+        - make circular-dependencies-js
         - make lint-css
         - make format
         - make -C components

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ test-js:
 
 # lints and typechecks
 .PHONY: lint
-lint: lint-py lint-js lint-json lint-css check-js
+lint: lint-py lint-js lint-json lint-css check-js circular-dependencies-js
 
 .PHONY: format
 format:
@@ -138,6 +138,12 @@ lint-css:
 .PHONY: check-js
 check-js:
 	flow $(if $(CI),check,status)
+
+# TODO: Ian 2019-12-17 gradually add app, components, and shared-data
+.PHONY: circular-dependencies-js
+circular-dependencies-js:
+	madge --circular protocol-designer/src/index.js
+	madge --circular labware-library/src/index.js
 
 # upload coverage reports
 .PHONY: coverage

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "babel-loader": "^8.0.6",
     "babel-plugin-dynamic-import-node": "^2.3.0",
     "babel-plugin-unassert": "^3.0.1",
-    "circular-dependency-plugin": "^5.2.0",
     "codecov": "^3.1.0",
     "concurrently": "^4.1.2",
     "core-js": "^3.2.1",

--- a/protocol-designer/src/analytics/reducers.js
+++ b/protocol-designer/src/analytics/reducers.js
@@ -1,10 +1,10 @@
 // @flow
 import { combineReducers } from 'redux'
 import { handleActions } from 'redux-actions'
-import { rehydrate } from '../persist'
 
 import type { Action } from '../types'
 import type { SetOptIn } from './actions'
+import type { RehydratePersistedAction } from '../persist'
 
 type OptInState = boolean | null
 const optInInitialState = null
@@ -12,8 +12,13 @@ const hasOptedIn = handleActions(
   {
     SET_OPT_IN: (state: OptInState, action: SetOptIn): OptInState =>
       action.payload,
-    REHYDRATE_PERSISTED: () =>
-      rehydrate('analytics.hasOptedIn', optInInitialState),
+    REHYDRATE_PERSISTED: (
+      state: OptInState,
+      action: RehydratePersistedAction
+    ) => {
+      const persistedState = action.payload?.['analytics.hasOptedIn']
+      return persistedState !== undefined ? persistedState : optInInitialState
+    },
   },
   optInInitialState
 )

--- a/protocol-designer/src/feature-flags/reducers.js
+++ b/protocol-designer/src/feature-flags/reducers.js
@@ -3,8 +3,8 @@ import omit from 'lodash/omit'
 import mapValues from 'lodash/mapValues'
 import { combineReducers } from 'redux'
 import { handleActions } from 'redux-actions'
-import { rehydrate, type RehydratePersistedAction } from '../persist'
 import { userFacingFlags, DEPRECATED_FLAGS, type Flags } from './types'
+import type { RehydratePersistedAction } from '../persist'
 import type { SetFeatureFlagAction } from './actions'
 import type { Action } from '../types'
 
@@ -37,9 +37,7 @@ const flags = handleActions<Flags, any>(
       action: RehydratePersistedAction
     ): Flags => ({
       ...state,
-      // TODO(mc, 2019-10-15): reading from localStorage is not appropriate
-      // inside a reducer; move this logic elsewhere
-      ...omit(rehydrate('featureFlags.flags', initialFlags), DEPRECATED_FLAGS),
+      ...omit(action.payload?.['featureFlags.flags'], DEPRECATED_FLAGS),
     }),
   },
   initialFlags

--- a/protocol-designer/src/tutorial/reducers.js
+++ b/protocol-designer/src/tutorial/reducers.js
@@ -3,9 +3,9 @@ import { combineReducers } from 'redux'
 import { handleActions } from 'redux-actions'
 import pickBy from 'lodash/pickBy'
 import uniq from 'lodash/uniq'
-import { rehydrate } from '../persist'
 
 import type { Action } from '../types'
+import type { RehydratePersistedAction } from '../persist'
 import type { HintKey } from './index'
 import type { AddHintAction, RemoveHintAction } from './actions'
 import type { NavigateToPageAction } from '../navigation/actions'
@@ -34,9 +34,14 @@ type DismissedHintReducerState = { [HintKey]: { rememberDismissal: boolean } }
 const dismissedHintsInitialState = {}
 const dismissedHints = handleActions(
   {
-    // only rehydrate "rememberDismissal" hints
-    REHYDRATE_PERSISTED: () =>
-      rehydrate('tutorial.dismissedHints', dismissedHintsInitialState),
+    // NOTE: only "rememberDismissal" hints should have been persisted
+    REHYDRATE_PERSISTED: (
+      state: DismissedHintReducerState,
+      action: RehydratePersistedAction
+    ) => {
+      const persistedState = action.payload?.['tutorial.dismissedHints']
+      return persistedState !== undefined ? persistedState : state
+    },
     REMOVE_HINT: (
       state: DismissedHintReducerState,
       action: RemoveHintAction

--- a/webpack-config/lib/base-config.js
+++ b/webpack-config/lib/base-config.js
@@ -1,9 +1,7 @@
 // webpack base config
 'use strict'
 
-const path = require('path')
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
-const CircularDependencyPlugin = require('circular-dependency-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
@@ -44,11 +42,6 @@ module.exports = {
     }),
     ENABLE_ANALYZER &&
       new BundleAnalyzerPlugin({ analyzerMode: 'server', openAnalyzer: true }),
-    ENABLE_ANALYZER &&
-      new CircularDependencyPlugin({
-        exclude: /node_modules/,
-        cwd: path.join(__dirname, '../..'),
-      }),
   ].filter(Boolean),
 
   optimization: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4563,11 +4563,6 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-circular-dependency-plugin@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/circular-dependency-plugin/-/circular-dependency-plugin-5.2.0.tgz#e09dbc2dd3e2928442403e2d45b41cea06bc0a93"
-  integrity sha512-7p4Kn/gffhQaavNfyDFg7LS5S/UT1JAjyGd4UqR2+jzoYF02eDkj0Ec3+48TsIa4zghjLY87nQHIh/ecK9qLdw==
-
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"


### PR DESCRIPTION
## overview

This PR removes the last remaining circular import in PD, and enforces our new experimental "no circular imports" rule in CI for both `protocol-designer` and `labware-library` (LL already is circle-free!)

It reimplements PD's `persist.js` by putting "rehydrated" data originating from localStorage into the `REHYDRATE_PERSISTED` action payload, instead of bad practice before where the reducers read from localStorage upon receiving a (previously no-payload) `REHYDRATE_PERSISTED` action. 

## changelog

## review requests

- [ ] Test that `tutorial.dismissedHints`, feature flags in `featureFlags.flags`, and `analytics.hasOptedIn` are persisted and rehydrated as before.
    - Make a protocol with no steps to get the hint, check the "remember this" and close the hint. PD should remember and not show you this hint when you reload
    - Toggle experimental settings (aka feature flags) on/off, refresh PD, and make sure they persist
    - Toggle the opt-in toggle (right above the experimental settings) should also persist
- [ ] Code review. Any ideas about tests to add?


## dev note

After we merge this, I recommend adding `make circular-dependencies-js` to your pre-push hook (if you use one)