### PR TITLE
refactor(app): remove remaining circular dependencies from the app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ lint-css:
 check-js:
 	flow $(if $(CI),check,status)
 
-# TODO: Ian 2019-12-17 gradually components and shared-data
+# TODO: Ian 2019-12-17 gradually add components and shared-data
 .PHONY: circular-dependencies-js
 circular-dependencies-js:
 	madge --circular protocol-designer/src/index.js

--- a/Makefile
+++ b/Makefile
@@ -139,11 +139,12 @@ lint-css:
 check-js:
 	flow $(if $(CI),check,status)
 
-# TODO: Ian 2019-12-17 gradually add app, components, and shared-data
+# TODO: Ian 2019-12-17 gradually components and shared-data
 .PHONY: circular-dependencies-js
 circular-dependencies-js:
 	madge --circular protocol-designer/src/index.js
 	madge --circular labware-library/src/index.js
+	madge --circular app/src/index.js
 
 # upload coverage reports
 .PHONY: coverage

--- a/app/src/components/CalibrateLabware/ConfirmPositionContents.js
+++ b/app/src/components/CalibrateLabware/ConfirmPositionContents.js
@@ -8,7 +8,7 @@ import type { Pipette, Labware } from '../../robot'
 
 import { actions as robotActions } from '../../robot'
 import { PrimaryButton } from '@opentrons/components'
-import ConfirmPositionDiagram from './ConfirmPositionDiagram'
+import { ConfirmPositionDiagram } from './ConfirmPositionDiagram'
 import JogControls, { type Jog } from '../JogControls'
 
 type OP = {|
@@ -33,17 +33,22 @@ export default connect<Props, OP, _, _, _, _>(
 function ConfirmPositionContents(props: Props) {
   const {
     onConfirmClick,
-    labware: { isTiprack },
-    calibrator: { channels },
+    labware,
+    calibrator,
+    calibrateToBottom,
+    useCenteredTroughs,
   } = props
 
-  const confirmButtonText = isTiprack
-    ? `pick up tip${channels === 8 ? 's' : ''}`
+  const confirmButtonText = labware.isTiprack
+    ? `pick up tip${calibrator.channels === 8 ? 's' : ''}`
     : 'save calibration'
 
   return (
     <div>
-      <ConfirmPositionDiagram {...props} buttonText={confirmButtonText} />
+      <ConfirmPositionDiagram
+        {...{ labware, calibrator, calibrateToBottom, useCenteredTroughs }}
+        buttonText={confirmButtonText}
+      />
       <JogControls {...props} />
       <PrimaryButton title="confirm" onClick={onConfirmClick}>
         {confirmButtonText}
@@ -53,10 +58,8 @@ function ConfirmPositionContents(props: Props) {
 }
 
 function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
-  const {
-    labware: { slot, isTiprack },
-    calibrator: { mount },
-  } = ownProps
+  const { slot, isTiprack } = ownProps.labware
+  const { mount } = ownProps.calibrator
 
   const onConfirmAction = isTiprack
     ? robotActions.pickupAndHome(mount, slot)

--- a/app/src/components/CalibrateLabware/ConfirmPositionDiagram.js
+++ b/app/src/components/CalibrateLabware/ConfirmPositionDiagram.js
@@ -8,15 +8,15 @@ import InstructionStep from '../InstructionStep'
 import { getInstructionsByType, getDiagramSrc } from './instructions-data'
 import styles from '../InstructionStep/styles.css'
 
-export type LabwareCalibrationProps = {
+export type LabwareCalibrationProps = {|
   labware: Labware,
   calibrator: Pipette,
   calibrateToBottom: boolean,
   buttonText: string,
   useCenteredTroughs: boolean,
-}
+|}
 
-export default function ConfirmPositionDiagram(props: LabwareCalibrationProps) {
+export function ConfirmPositionDiagram(props: LabwareCalibrationProps) {
   const instructions = getInstructionsByType(props)
   const diagrams = getDiagramSrc(props)
 

--- a/app/src/components/CalibrateLabware/instructions-data.js
+++ b/app/src/components/CalibrateLabware/instructions-data.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import { type LabwareCalibrationProps } from './ConfirmPositionDiagram'
+import type { LabwareCalibrationProps } from './ConfirmPositionDiagram'
 
 type Step = 'one' | 'two'
 type Channels = 'single' | 'multi'

--- a/app/src/components/modals/BottomButtonBar.js
+++ b/app/src/components/modals/BottomButtonBar.js
@@ -9,13 +9,13 @@ import styles from './styles.css'
 
 import type { ButtonProps } from '@opentrons/components'
 
-type Props = {
+type Props = {|
   buttons: Array<?ButtonProps>,
   className?: string,
   description?: React.Node,
-}
+|}
 
-export default function BottomButtonBar(props: Props) {
+export function BottomButtonBar(props: Props) {
   const buttons = props.buttons.filter(Boolean)
   const className = cx(styles.bottom_button_bar, props.className)
 

--- a/app/src/components/modals/ErrorModal.js
+++ b/app/src/components/modals/ErrorModal.js
@@ -8,17 +8,17 @@ import type { Error } from '../../types'
 
 import styles from './styles.css'
 
-type Props = {
+type Props = {|
   heading?: ?string,
   description: string,
   close?: () => mixed,
   closeUrl?: string,
   error: Error,
-}
+|}
 
 const DEFAULT_HEADING = 'Unexpected Error'
 
-export default function ErrorModal(props: Props) {
+export function ErrorModal(props: Props) {
   const { description, error } = props
   const heading = props.heading || DEFAULT_HEADING
   let closeButtonProps = { children: 'close', onClick: props.close }

--- a/app/src/components/modals/Modal.js
+++ b/app/src/components/modals/Modal.js
@@ -8,16 +8,16 @@ import SessionHeader from '../SessionHeader'
 
 import styles from './styles.css'
 
-type Props = {
+type Props = {|
   children: React.Node,
-}
+|}
 
 const titleBarProps = {
   title: <SessionHeader />,
   className: styles.title_bar,
 }
 
-export default function Modal(props: Props) {
+export function Modal(props: Props) {
   return (
     <div className={styles.modal}>
       <Overlay />

--- a/app/src/components/modals/ScrollableAlertModal.js
+++ b/app/src/components/modals/ScrollableAlertModal.js
@@ -1,15 +1,15 @@
 // @flow
-// AlertModal for updating to newest app version
+// AlertModal with vertical scrolling
 import * as React from 'react'
 import omit from 'lodash/omit'
 
 import { AlertModal } from '@opentrons/components'
-import { BottomButtonBar } from './'
+import { BottomButtonBar } from './BottomButtonBar'
 import styles from './styles.css'
 
 type Props = React.ElementProps<typeof AlertModal>
 
-export default function ScrollableAlertModal(props: Props) {
+export function ScrollableAlertModal(props: Props) {
   return (
     <AlertModal
       {...omit(props, 'buttons', 'children')}

--- a/app/src/components/modals/index.js
+++ b/app/src/components/modals/index.js
@@ -1,8 +1,6 @@
 // @flow
 // app specific modals
-import Modal from './Modal'
-import ErrorModal from './ErrorModal'
-import BottomButtonBar from './BottomButtonBar'
-import ScrollableAlertModal from './ScrollableAlertModal'
-
-export { Modal, ErrorModal, BottomButtonBar, ScrollableAlertModal }
+export * from './Modal'
+export * from './ErrorModal'
+export * from './BottomButtonBar'
+export * from './ScrollableAlertModal'


### PR DESCRIPTION
## overview

This PR follows up on #4630 and removes the run app's two circular dependency warnings and enables madge checking for `app/src`

## changelog

- refactor(app): remove remaining circular dependencies from the app

## review requests

The files touched were part of the labware calibration wizard, so smoke testing labware calibration couldn't hurt