### PR TITLE
feat(protocol-designer): Add missing labware hint to temperature step

### DIFF
--- a/protocol-designer/src/ui/modules/selectors.js
+++ b/protocol-designer/src/ui/modules/selectors.js
@@ -58,3 +58,11 @@ export const getMagnetModuleHasLabware: Selector<boolean> = createSelector(
     return getModuleHasLabware(initialDeckSetup, 'magdeck')
   }
 )
+
+/** Returns boolean if temperature module has labware */
+export const getTemperatureModuleHasLabware: Selector<boolean> = createSelector(
+  stepFormSelectors.getInitialDeckSetup,
+  initialDeckSetup => {
+    return getModuleHasLabware(initialDeckSetup, 'tempdeck')
+  }
+)

--- a/protocol-designer/src/ui/steps/actions/thunks.js
+++ b/protocol-designer/src/ui/steps/actions/thunks.js
@@ -30,14 +30,21 @@ export const addStep = (payload: { stepType: StepType }) => (
   const magnetModuleHasLabware = uiModuleSelectors.getMagnetModuleHasLabware(
     state
   )
+  const temperatureModuleHasLabware = uiModuleSelectors.getTemperatureModuleHasLabware(
+    state
+  )
 
   // TODO: Ian 2019-01-17 move out to centralized step info file - see #2926
   const stepNeedsLiquid = ['mix', 'moveLiquid'].includes(payload.stepType)
   const stepMagnetNeedsLabware = ['magnet'].includes(payload.stepType)
+  const stepTemperatureNeedsLabware = ['temperature'].includes(payload.stepType)
   if (stepNeedsLiquid && !deckHasLiquid) {
     dispatch(tutorialActions.addHint('add_liquids_and_labware'))
   }
-  if (stepMagnetNeedsLabware && !magnetModuleHasLabware) {
+  if (
+    (stepMagnetNeedsLabware && !magnetModuleHasLabware) ||
+    (stepTemperatureNeedsLabware && !temperatureModuleHasLabware)
+  ) {
     dispatch(tutorialActions.addHint('module_without_labware'))
   }
   dispatch(selectStep(stepId, stepType))


### PR DESCRIPTION
## overview

This PR closes #4643 by adding the existing `module_without_labware` hint to the temperature step.

## changelog

- feat(protocol-designer): Add missing labware hint to temperature step

## review requests
This is a tiny one for once!

- Make a protocol with a temperature module
- Add a temperature step
- [ ] Missing labware hint renders when no labware present on module
- [ ] Missing labware hint does not render when labware is present on module

_Note_: This is a hint so if you've previously dismissed it for a magnet step or previous temperature step you will not see it again that session. If you've previously checked [ ] don't show this again when testing the magnet step hint - you will not see this hint so please clear out dismissed hints in settings before testing!

