### PR TITLE
feat(protocol-designer): change volume label to volume per well

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/Volume.js
+++ b/protocol-designer/src/components/StepEditForm/fields/Volume.js
@@ -1,15 +1,18 @@
 // @flow
 import * as React from 'react'
-import cx from 'classnames'
 import { FormGroup, HoverTooltip } from '@opentrons/components'
 import i18n from '../../../localization'
 import { getTooltipForField } from '../utils'
 import TextField from './Text'
 import type { StepType } from '../../../form-types'
 import type { FocusHandlers } from '../types'
-import styles from '../StepEditForm.css'
 
-type Props = { stepType: StepType, focusHandlers: FocusHandlers, label: string }
+type Props = {|
+  stepType: StepType,
+  focusHandlers: FocusHandlers,
+  label: string,
+  className: string,
+|}
 const Volume = (props: Props) => (
   <HoverTooltip
     tooltipComponent={getTooltipForField(props.stepType, 'volume', false)}
@@ -18,7 +21,7 @@ const Volume = (props: Props) => (
     {hoverTooltipHandlers => (
       <FormGroup
         label={props.label}
-        className={cx(styles.volume_field, styles.small_field)}
+        className={props.className}
         hoverTooltipHandlers={hoverTooltipHandlers}
       >
         <TextField

--- a/protocol-designer/src/components/StepEditForm/fields/Volume.js
+++ b/protocol-designer/src/components/StepEditForm/fields/Volume.js
@@ -6,12 +6,12 @@ import { getTooltipForField } from '../utils'
 import TextField from './Text'
 import type { StepType } from '../../../form-types'
 import type { FocusHandlers } from '../types'
+import styles from '../StepEditForm.css'
 
 type Props = {|
   stepType: StepType,
   focusHandlers: FocusHandlers,
   label: string,
-  className: string,
 |}
 const Volume = (props: Props) => (
   <HoverTooltip
@@ -21,10 +21,11 @@ const Volume = (props: Props) => (
     {hoverTooltipHandlers => (
       <FormGroup
         label={props.label}
-        className={props.className}
+        className={styles.large_field}
         hoverTooltipHandlers={hoverTooltipHandlers}
       >
         <TextField
+          className={styles.small_field}
           name="volume"
           units={i18n.t('application.units.microliter')}
           {...props.focusHandlers}

--- a/protocol-designer/src/components/StepEditForm/fields/Volume.js
+++ b/protocol-designer/src/components/StepEditForm/fields/Volume.js
@@ -12,6 +12,7 @@ type Props = {|
   stepType: StepType,
   focusHandlers: FocusHandlers,
   label: string,
+  className: string,
 |}
 const Volume = (props: Props) => (
   <HoverTooltip
@@ -21,7 +22,7 @@ const Volume = (props: Props) => (
     {hoverTooltipHandlers => (
       <FormGroup
         label={props.label}
-        className={styles.large_field}
+        className={props.className}
         hoverTooltipHandlers={hoverTooltipHandlers}
       >
         <TextField

--- a/protocol-designer/src/components/StepEditForm/forms/Mix.js
+++ b/protocol-designer/src/components/StepEditForm/forms/Mix.js
@@ -48,6 +48,7 @@ class MixForm extends React.Component<Props, State> {
             label={i18n.t('form.step_edit_form.mixVolumeLabel')}
             focusHandlers={focusHandlers}
             stepType="mix"
+            className={styles.small_field}
           />
           <FormGroup
             className={styles.small_field}

--- a/protocol-designer/src/components/StepEditForm/forms/Mix.js
+++ b/protocol-designer/src/components/StepEditForm/forms/Mix.js
@@ -48,7 +48,6 @@ class MixForm extends React.Component<Props, State> {
             label={i18n.t('form.step_edit_form.mixVolumeLabel')}
             focusHandlers={focusHandlers}
             stepType="mix"
-            className={styles.small_field}
           />
           <FormGroup
             className={styles.small_field}

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquid/index.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquid/index.js
@@ -57,6 +57,7 @@ class MoveLiquidForm extends React.Component<Props, State> {
             label={i18n.t('form.step_edit_form.field.volume.label')}
             focusHandlers={focusHandlers}
             stepType={stepType}
+            className={styles.large_field}
           />
         </div>
 

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquid/index.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquid/index.js
@@ -57,7 +57,6 @@ class MoveLiquidForm extends React.Component<Props, State> {
             label={i18n.t('form.step_edit_form.field.volume.label')}
             focusHandlers={focusHandlers}
             stepType={stepType}
-            className={styles.large_field}
           />
         </div>
 

--- a/protocol-designer/src/localization/en/form.json
+++ b/protocol-designer/src/localization/en/form.json
@@ -59,7 +59,7 @@
         }
       },
       "tip_position": { "label": "tip position" },
-      "volume": { "label": "volume" },
+      "volume": { "label": "volume per well" },
       "well_order": {
         "label": "Well order",
         "option": {


### PR DESCRIPTION
## overview
![Screen Shot 2019-12-19 at 5 05 41 PM](https://user-images.githubusercontent.com/18384699/71284613-1f141180-2331-11ea-918a-850e10627759.png)

## changelog

- change volume label to volume per well

## review requests

- [ ] For design, is the larger width of the volume field okay?
- [ ] Code review