### PR TITLE
refactor(app): add home actions and calls to robot-controls module

### DIFF
--- a/app/src/robot-controls/__fixtures__/home.js
+++ b/app/src/robot-controls/__fixtures__/home.js
@@ -1,0 +1,31 @@
+// @flow
+
+import { mockRobot } from '../../robot-api/__fixtures__'
+
+// POST /robot/home
+
+export const mockHomeSuccessMeta = {
+  method: 'POST',
+  path: '/robot/home',
+  ok: true,
+  status: 200,
+}
+
+export const mockHomeSuccess = {
+  ...mockHomeSuccessMeta,
+  host: mockRobot,
+  body: { message: 'Robot homed successfully.' },
+}
+
+export const mockHomeFailureMeta = {
+  method: 'POST',
+  path: '/robot/home',
+  ok: false,
+  status: 500,
+}
+
+export const mockHomeFailure = {
+  ...mockHomeFailureMeta,
+  host: mockRobot,
+  body: { message: 'AH' },
+}

--- a/app/src/robot-controls/__fixtures__/index.js
+++ b/app/src/robot-controls/__fixtures__/index.js
@@ -1,3 +1,4 @@
 // @flow
 
 export * from './lights'
+export * from './home'

--- a/app/src/robot-controls/__tests__/actions.test.js
+++ b/app/src/robot-controls/__tests__/actions.test.js
@@ -84,6 +84,55 @@ const SPECS: Array<ActionSpec> = [
       meta: { requestId: 'abc' },
     },
   },
+  {
+    name: 'robotControls:HOME robot',
+    creator: Actions.home,
+    args: ['robot-name', 'robot'],
+    expected: {
+      type: 'robotControls:HOME',
+      payload: { robotName: 'robot-name', target: 'robot' },
+      meta: {},
+    },
+  },
+  {
+    name: 'robotControls:HOME pipette',
+    creator: Actions.home,
+    args: ['robot-name', 'pipette', 'left'],
+    expected: {
+      type: 'robotControls:HOME',
+      payload: { robotName: 'robot-name', target: 'pipette', mount: 'left' },
+      meta: {},
+    },
+  },
+  {
+    name: 'robotControls:HOME_SUCCESS',
+    creator: Actions.homeSuccess,
+    args: ['robot-name', { requestId: 'abc' }],
+    expected: {
+      type: 'robotControls:HOME_SUCCESS',
+      payload: { robotName: 'robot-name' },
+      meta: { requestId: 'abc' },
+    },
+  },
+  {
+    name: 'robotControls:HOME_FAILURE',
+    creator: Actions.homeFailure,
+    args: ['robot-name', { message: 'AH' }, { requestId: 'abc' }],
+    expected: {
+      type: 'robotControls:HOME_FAILURE',
+      payload: { robotName: 'robot-name', error: { message: 'AH' } },
+      meta: { requestId: 'abc' },
+    },
+  },
+  {
+    name: 'robotControls:CLEAR_MOVEMENT_STATUS',
+    creator: Actions.clearMovementStatus,
+    args: ['robot-name'],
+    expected: {
+      type: 'robotControls:CLEAR_MOVEMENT_STATUS',
+      payload: { robotName: 'robot-name' },
+    },
+  },
 ]
 
 describe('robot controls actions', () => {

--- a/app/src/robot-controls/__tests__/reducer.test.js
+++ b/app/src/robot-controls/__tests__/reducer.test.js
@@ -2,13 +2,13 @@
 import { robotControlsReducer } from '../reducer'
 
 import type { Action } from '../../types'
-import type { RobotControlsState } from '../types'
+import type { PerRobotControlsState } from '../types'
 
 type ReducerSpec = {|
   name: string,
-  state: RobotControlsState,
+  state: $Shape<{ [robotName: string]: $Shape<PerRobotControlsState> }>,
   action: Action,
-  expected: RobotControlsState,
+  expected: $Shape<{ [robotName: string]: $Shape<PerRobotControlsState> }>,
 |}
 
 const SPECS: Array<ReducerSpec> = [
@@ -37,6 +37,49 @@ const SPECS: Array<ReducerSpec> = [
     },
     state: { robotName: { lightsOn: true } },
     expected: { robotName: { lightsOn: false } },
+  },
+  {
+    name: 'handles robotControls:HOME',
+    action: {
+      type: 'robotControls:HOME',
+      payload: { robotName: 'robotName', target: 'robot' },
+      meta: {},
+    },
+    state: { robotName: { movementStatus: null } },
+    expected: { robotName: { movementStatus: 'homing', movementError: null } },
+  },
+  {
+    name: 'handles robotControls:HOME_SUCCESS',
+    action: {
+      type: 'robotControls:HOME_SUCCESS',
+      payload: { robotName: 'robotName' },
+      meta: {},
+    },
+    state: { robotName: { movementStatus: 'homing' } },
+    expected: { robotName: { movementStatus: null, movementError: null } },
+  },
+  {
+    name: 'handles robotControls:HOME_FAILURE',
+    action: {
+      type: 'robotControls:HOME_FAILURE',
+      payload: { robotName: 'robotName', error: { message: 'AH' } },
+      meta: {},
+    },
+    state: { robotName: { movementStatus: 'homing' } },
+    expected: {
+      robotName: { movementStatus: 'home-error', movementError: 'AH' },
+    },
+  },
+  {
+    name: 'handles robotControls:CLEAR_MOVEMENT_STATUS',
+    action: {
+      type: 'robotControls:CLEAR_MOVEMENT_STATUS',
+      payload: { robotName: 'robotName' },
+    },
+    state: { robotName: { movementStatus: 'home-error', movementError: 'AH' } },
+    expected: {
+      robotName: { movementStatus: null, movementError: null },
+    },
   },
 ]
 

--- a/app/src/robot-controls/__tests__/selectors.test.js
+++ b/app/src/robot-controls/__tests__/selectors.test.js
@@ -22,9 +22,65 @@ const SPECS: Array<SelectorSpec> = [
   {
     name: 'getLightsOn returns value if present',
     selector: Selectors.getLightsOn,
-    state: { robotControls: { robotName: { lightsOn: false } } },
+    state: {
+      robotControls: {
+        robotName: {
+          lightsOn: false,
+          movementStatus: null,
+          movementError: null,
+        },
+      },
+    },
     args: ['robotName'],
     expected: false,
+  },
+  {
+    name: 'getMovementStatus returns null by default',
+    selector: Selectors.getMovementStatus,
+    state: {
+      robotControls: {},
+    },
+    args: ['robotName'],
+    expected: null,
+  },
+  {
+    name: 'getMovementStatus returns value if present',
+    selector: Selectors.getMovementStatus,
+    state: {
+      robotControls: {
+        robotName: {
+          lightsOn: false,
+          movementStatus: 'homing',
+          movementError: null,
+        },
+      },
+    },
+    args: ['robotName'],
+    expected: 'homing',
+  },
+  {
+    name: 'getMovementError returns null by default',
+    selector: Selectors.getMovementError,
+    state: {
+      robotControls: {},
+    },
+    args: ['robotName'],
+    expected: null,
+  },
+  {
+    name: 'getMovementError returns value if present',
+    selector: Selectors.getMovementError,
+    state: {
+      robotControls: {
+        robotName: {
+          lightsOn: false,
+          movementStatus: null,
+          movementError: 'AH',
+        },
+      },
+    },
+    args: ['robotName'],
+    expected: 'AH',
   },
 ]
 

--- a/app/src/robot-controls/actions.js
+++ b/app/src/robot-controls/actions.js
@@ -4,6 +4,7 @@ import * as Constants from './constants'
 import * as Types from './types'
 
 import type { RobotApiRequestMeta } from '../robot-api/types'
+import type { Mount } from '../pipettes/types'
 
 export const fetchLights = (robotName: string): Types.FetchLightsAction => ({
   type: Constants.FETCH_LIGHTS,
@@ -23,7 +24,7 @@ export const fetchLightsSuccess = (
 
 export const fetchLightsFailure = (
   robotName: string,
-  error: {},
+  error: {| message: string |},
   meta: RobotApiRequestMeta
 ): Types.FetchLightsFailureAction => ({
   type: Constants.FETCH_LIGHTS_FAILURE,
@@ -52,10 +53,51 @@ export const updateLightsSuccess = (
 
 export const updateLightsFailure = (
   robotName: string,
-  error: {},
+  error: {| message: string |},
   meta: RobotApiRequestMeta
 ): Types.UpdateLightsFailureAction => ({
   type: Constants.UPDATE_LIGHTS_FAILURE,
   payload: { robotName, error },
   meta,
+})
+
+type HomeActionCreator = ((
+  robotName: string,
+  target: 'robot'
+) => Types.HomeAction) &
+  ((robotName: string, target: 'pipette', mount: Mount) => Types.HomeAction)
+
+export const home: HomeActionCreator = (robotName, target, mount) => ({
+  type: Constants.HOME,
+  payload:
+    target === Constants.PIPETTE && typeof mount === 'string'
+      ? { robotName, target: Constants.PIPETTE, mount }
+      : { robotName, target: Constants.ROBOT },
+  meta: {},
+})
+
+export const homeSuccess = (
+  robotName: string,
+  meta: RobotApiRequestMeta
+): Types.HomeSuccessAction => ({
+  type: Constants.HOME_SUCCESS,
+  payload: { robotName },
+  meta,
+})
+
+export const homeFailure = (
+  robotName: string,
+  error: {| message: string |},
+  meta: RobotApiRequestMeta
+): Types.HomeFailureAction => ({
+  type: Constants.HOME_FAILURE,
+  payload: { robotName, error },
+  meta,
+})
+
+export const clearMovementStatus = (
+  robotName: string
+): Types.ClearMovementStatusAction => ({
+  type: Constants.CLEAR_MOVEMENT_STATUS,
+  payload: { robotName },
 })

--- a/app/src/robot-controls/constants.js
+++ b/app/src/robot-controls/constants.js
@@ -1,8 +1,21 @@
 // @flow
 
+// homing targets
+
+export const ROBOT: 'robot' = 'robot'
+export const PIPETTE: 'pipette' = 'pipette'
+
+// movement statuses
+
+export const HOMING: 'homing' = 'homing'
+export const HOME_ERROR: 'home-error' = 'home-error'
+export const MOVING: 'moving' = 'moving'
+export const MOVE_ERROR: 'move-error' = 'move-error'
+
 // http paths
 
 export const LIGHTS_PATH: '/robot/lights' = '/robot/lights'
+export const HOME_PATH: '/robot/home' = '/robot/home'
 
 // action type strings
 
@@ -23,3 +36,14 @@ export const UPDATE_LIGHTS_SUCCESS: 'robotControls:UPDATE_LIGHTS_SUCCESS' =
 
 export const UPDATE_LIGHTS_FAILURE: 'robotControls:UPDATE_LIGHTS_FAILURE' =
   'robotControls:UPDATE_LIGHTS_FAILURE'
+
+export const HOME: 'robotControls:HOME' = 'robotControls:HOME'
+
+export const HOME_SUCCESS: 'robotControls:HOME_SUCCESS' =
+  'robotControls:HOME_SUCCESS'
+
+export const HOME_FAILURE: 'robotControls:HOME_FAILURE' =
+  'robotControls:HOME_FAILURE'
+
+export const CLEAR_MOVEMENT_STATUS: 'robotControls:CLEAR_MOVEMENT_STATUS' =
+  'robotControls:CLEAR_MOVEMENT_STATUS'

--- a/app/src/robot-controls/epic/__tests__/homeEpic.test.js
+++ b/app/src/robot-controls/epic/__tests__/homeEpic.test.js
@@ -1,0 +1,139 @@
+// @flow
+import { TestScheduler } from 'rxjs/testing'
+
+import { mockRobot } from '../../../robot-api/__fixtures__'
+import * as RobotApiHttp from '../../../robot-api/http'
+import * as DiscoverySelectors from '../../../discovery/selectors'
+import * as Fixtures from '../../__fixtures__'
+import * as Actions from '../../actions'
+import * as Types from '../../types'
+import { robotControlsEpic } from '..'
+
+import type { Observable } from 'rxjs'
+import type {
+  RobotHost,
+  RobotApiRequestOptions,
+  RobotApiResponse,
+} from '../../../robot-api/types'
+
+jest.mock('../../../robot-api/http')
+jest.mock('../../../discovery/selectors')
+
+const mockState = { state: true }
+
+const mockFetchRobotApi: JestMockFn<
+  [RobotHost, RobotApiRequestOptions],
+  Observable<RobotApiResponse>
+> = RobotApiHttp.fetchRobotApi
+
+const mockGetRobotByName: JestMockFn<[any, string], mixed> =
+  DiscoverySelectors.getRobotByName
+
+describe('homeEpic', () => {
+  let testScheduler
+
+  beforeEach(() => {
+    mockGetRobotByName.mockReturnValue(mockRobot)
+
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  const meta = { requestId: '1234' }
+  const action: Types.HomeAction = {
+    ...Actions.home(mockRobot.name, 'robot'),
+    meta,
+  }
+
+  test('calls POST /robot/home with target: robot', () => {
+    testScheduler.run(({ hot, cold, expectObservable, flush }) => {
+      mockFetchRobotApi.mockReturnValue(
+        cold('r', { r: Fixtures.mockHomeSuccess })
+      )
+
+      const action$ = hot('--a', { a: action })
+      const state$ = hot('a-a', { a: mockState })
+      const output$ = robotControlsEpic(action$, state$)
+
+      expectObservable(output$)
+      flush()
+
+      expect(mockGetRobotByName).toHaveBeenCalledWith(mockState, mockRobot.name)
+      expect(mockFetchRobotApi).toHaveBeenCalledWith(mockRobot, {
+        method: 'POST',
+        path: '/robot/home',
+        body: { target: 'robot' },
+      })
+    })
+  })
+
+  test('calls POST /robot/home with target: pipette', () => {
+    const action: Types.HomeAction = {
+      ...Actions.home(mockRobot.name, 'pipette', 'right'),
+      meta,
+    }
+    testScheduler.run(({ hot, cold, expectObservable, flush }) => {
+      mockFetchRobotApi.mockReturnValue(
+        cold('r', { r: Fixtures.mockHomeSuccess })
+      )
+
+      const action$ = hot('--a', { a: action })
+      const state$ = hot('a-a', { a: mockState })
+      const output$ = robotControlsEpic(action$, state$)
+
+      expectObservable(output$)
+      flush()
+
+      expect(mockGetRobotByName).toHaveBeenCalledWith(mockState, mockRobot.name)
+      expect(mockFetchRobotApi).toHaveBeenCalledWith(mockRobot, {
+        method: 'POST',
+        path: '/robot/home',
+        body: { target: 'pipette', mount: 'right' },
+      })
+    })
+  })
+
+  test('maps successful response to HOME_SUCCESS', () => {
+    testScheduler.run(({ hot, cold, expectObservable, flush }) => {
+      mockFetchRobotApi.mockReturnValue(
+        cold('r', { r: Fixtures.mockHomeSuccess })
+      )
+
+      const action$ = hot('--a', { a: action })
+      const state$ = hot('a-a', { a: {} })
+      const output$ = robotControlsEpic(action$, state$)
+
+      expectObservable(output$).toBe('--a', {
+        a: Actions.homeSuccess(mockRobot.name, {
+          ...meta,
+          response: Fixtures.mockHomeSuccessMeta,
+        }),
+      })
+    })
+  })
+
+  test('maps failed response to HOME_FAILURE', () => {
+    testScheduler.run(({ hot, cold, expectObservable, flush }) => {
+      mockFetchRobotApi.mockReturnValue(
+        cold('r', { r: Fixtures.mockHomeFailure })
+      )
+
+      const action$ = hot('--a', { a: action })
+      const state$ = hot('a-a', { a: {} })
+      const output$ = robotControlsEpic(action$, state$)
+
+      expectObservable(output$).toBe('--a', {
+        a: Actions.homeFailure(
+          mockRobot.name,
+          { message: 'AH' },
+          { ...meta, response: Fixtures.mockHomeFailureMeta }
+        ),
+      })
+    })
+  })
+})

--- a/app/src/robot-controls/epic/homeEpic.js
+++ b/app/src/robot-controls/epic/homeEpic.js
@@ -1,0 +1,50 @@
+// @flow
+import { ofType } from 'redux-observable'
+
+import { POST } from '../../robot-api/constants'
+import { mapToRobotApiRequest } from '../../robot-api/operators'
+
+import * as Actions from '../actions'
+import * as Constants from '../constants'
+
+import type { StrictEpic } from '../../types'
+
+import type {
+  ActionToRequestMapper,
+  ResponseToActionMapper,
+} from '../../robot-api/operators'
+
+import type { HomeAction, HomeDoneAction } from '../types'
+
+const mapActionToRequest: ActionToRequestMapper<HomeAction> = action => ({
+  method: POST,
+  path: Constants.HOME_PATH,
+  body:
+    action.payload.target === Constants.ROBOT
+      ? { target: Constants.ROBOT }
+      : { target: Constants.PIPETTE, mount: action.payload.mount },
+})
+
+const mapResponseToAction: ResponseToActionMapper<
+  HomeAction,
+  HomeDoneAction
+> = (response, originalAction) => {
+  const { host, body, ...responseMeta } = response
+  const meta = { ...originalAction.meta, response: responseMeta }
+
+  return response.ok
+    ? Actions.homeSuccess(host.name, meta)
+    : Actions.homeFailure(host.name, body, meta)
+}
+
+export const homeEpic: StrictEpic<HomeDoneAction> = (action$, state$) => {
+  return action$.pipe(
+    ofType(Constants.HOME),
+    mapToRobotApiRequest(
+      state$,
+      a => a.payload.robotName,
+      mapActionToRequest,
+      mapResponseToAction
+    )
+  )
+}

--- a/app/src/robot-controls/epic/index.js
+++ b/app/src/robot-controls/epic/index.js
@@ -3,10 +3,12 @@ import { combineEpics } from 'redux-observable'
 
 import { fetchLightsEpic } from './fetchLightsEpic'
 import { updateLightsEpic } from './updateLightsEpic'
+import { homeEpic } from './homeEpic'
 
 import type { Epic } from '../../types'
 
 export const robotControlsEpic: Epic = combineEpics(
   fetchLightsEpic,
-  updateLightsEpic
+  updateLightsEpic,
+  homeEpic
 )

--- a/app/src/robot-controls/reducer.js
+++ b/app/src/robot-controls/reducer.js
@@ -9,6 +9,21 @@ const INITIAL_STATE: RobotControlsState = {}
 
 const INITIAL_CONTROLS_STATE: PerRobotControlsState = {
   lightsOn: null,
+  movementStatus: null,
+  movementError: null,
+}
+
+const updateRobotState = (
+  state: RobotControlsState,
+  robotName: string,
+  update: $Shape<PerRobotControlsState>
+): RobotControlsState => {
+  const robotState = state[robotName] || INITIAL_CONTROLS_STATE
+
+  return {
+    ...state,
+    [robotName]: { ...robotState, ...update },
+  }
 }
 
 export function robotControlsReducer(
@@ -19,12 +34,32 @@ export function robotControlsReducer(
     case Constants.FETCH_LIGHTS_SUCCESS:
     case Constants.UPDATE_LIGHTS_SUCCESS: {
       const { robotName, lightsOn } = action.payload
-      const robotState = state[robotName] || INITIAL_CONTROLS_STATE
+      return updateRobotState(state, robotName, { lightsOn })
+    }
 
-      return {
-        ...state,
-        [robotName]: { ...robotState, lightsOn },
-      }
+    case Constants.HOME: {
+      const { robotName } = action.payload
+      return updateRobotState(state, robotName, {
+        movementStatus: Constants.HOMING,
+        movementError: null,
+      })
+    }
+
+    case Constants.HOME_SUCCESS:
+    case Constants.CLEAR_MOVEMENT_STATUS: {
+      const { robotName } = action.payload
+      return updateRobotState(state, robotName, {
+        movementStatus: null,
+        movementError: null,
+      })
+    }
+
+    case Constants.HOME_FAILURE: {
+      const { robotName, error } = action.payload
+      return updateRobotState(state, robotName, {
+        movementStatus: Constants.HOME_ERROR,
+        movementError: error.message,
+      })
     }
   }
 

--- a/app/src/robot-controls/selectors.js
+++ b/app/src/robot-controls/selectors.js
@@ -1,5 +1,6 @@
 // @flow
 import type { State } from '../types'
+import type { MovementStatus } from './types'
 
 export const getLightsOn = (
   state: State,
@@ -7,4 +8,19 @@ export const getLightsOn = (
 ): boolean | null => {
   const lightsOn = state.robotControls[robotName]?.lightsOn
   return lightsOn != null ? lightsOn : null
+}
+
+export const getMovementStatus = (
+  state: State,
+  robotName: string
+): MovementStatus | null => {
+  return state.robotControls[robotName]?.movementStatus || null
+}
+
+export const getMovementError = (
+  state: State,
+  robotName: string
+): string | null => {
+  const errorMessage = state.robotControls[robotName]?.movementError
+  return errorMessage != null ? errorMessage : null
 }

--- a/app/src/robot-controls/types.js
+++ b/app/src/robot-controls/types.js
@@ -1,6 +1,11 @@
 // @flow
 
 import type { RobotApiRequestMeta } from '../robot-api/types'
+import type { Mount } from '../pipettes/types'
+
+// common types
+
+export type MovementStatus = 'homing' | 'home-error' | 'moving' | 'move-error'
 
 // action types
 
@@ -20,7 +25,7 @@ export type FetchLightsSuccessAction = {|
 
 export type FetchLightsFailureAction = {|
   type: 'robotControls:FETCH_LIGHTS_FAILURE',
-  payload: {| robotName: string, error: {} |},
+  payload: {| robotName: string, error: {| message: string |} |},
   meta: RobotApiRequestMeta,
 |}
 
@@ -44,13 +49,44 @@ export type UpdateLightsSuccessAction = {|
 
 export type UpdateLightsFailureAction = {|
   type: 'robotControls:UPDATE_LIGHTS_FAILURE',
-  payload: {| robotName: string, error: {} |},
+  payload: {| robotName: string, error: {| message: string |} |},
   meta: RobotApiRequestMeta,
 |}
 
 export type UpdateLightsDoneAction =
   | UpdateLightsSuccessAction
   | UpdateLightsFailureAction
+
+// home
+
+export type HomeAction = {|
+  type: 'robotControls:HOME',
+  payload:
+    | {| robotName: string, target: 'robot' |}
+    | {| robotName: string, target: 'pipette', mount: Mount |},
+  meta: RobotApiRequestMeta,
+|}
+
+export type HomeSuccessAction = {|
+  type: 'robotControls:HOME_SUCCESS',
+  payload: {| robotName: string |},
+  meta: RobotApiRequestMeta,
+|}
+
+export type HomeFailureAction = {|
+  type: 'robotControls:HOME_FAILURE',
+  payload: {| robotName: string, error: {| message: string |} |},
+  meta: RobotApiRequestMeta,
+|}
+
+export type HomeDoneAction = HomeSuccessAction | HomeFailureAction
+
+// clear homing and movement status and error
+
+export type ClearMovementStatusAction = {|
+  type: 'robotControls:CLEAR_MOVEMENT_STATUS',
+  payload: {| robotName: string |},
+|}
 
 // action union
 
@@ -61,11 +97,17 @@ export type RobotControlsAction =
   | UpdateLightsAction
   | UpdateLightsSuccessAction
   | UpdateLightsFailureAction
+  | HomeAction
+  | HomeSuccessAction
+  | HomeFailureAction
+  | ClearMovementStatusAction
 
 // state types
 
 export type PerRobotControlsState = $ReadOnly<{|
   lightsOn: boolean | null,
+  movementStatus: MovementStatus | null,
+  movementError: string | null,
 |}>
 
 export type RobotControlsState = $Shape<


### PR DESCRIPTION
## overview

This PR follows up on the refactor work completed in #4440, #4477, #4544, #4599, #4615, and #4631. The endpoints being recreated today are:

- `POST /robot/home`

This PR does not wire up these actions because it will involve a fairly heavy rewrite of Change Pipette. That will be its own PR.

## changelog

- Added homing controls to `app/src/robot-controls`
    - Added 4 actions (`home` + success / failure, clear homing status/error)
    - Added homing and homing error state to `state.robotControls` reducer
    - Added 2 selector (`getMovementStatus` and `getMovementError`)
    - Added 1 epic (`homeEpic`)
    - Added tests for all of the above

## review requests

Since this PR doesn't wire anything up to the UI, we can save functional testing for that upcoming PR. For this one, please make sure the code and added unit tests look reasonable!
