### PR TITLE
feat(protocol-designer): Auto-select module in set temperature form

### DIFF
--- a/protocol-designer/src/components/StepEditForm/forms/TemperatureForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/TemperatureForm.js
@@ -36,7 +36,7 @@ function TemperatureForm(props: TemperatureFormProps): React.Element<'div'> {
         >
           <StepFormDropdown
             {...focusHandlers}
-            name="temperatureActionLabware"
+            name="moduleId"
             options={moduleLabwareOptions}
           />
         </FormGroup>

--- a/protocol-designer/src/components/StepEditForm/forms/TemperatureForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/TemperatureForm.js
@@ -22,6 +22,13 @@ function TemperatureForm(props: TemperatureFormProps): React.Element<'div'> {
   const moduleLabwareOptions = useSelector(
     uiModuleSelectors.getTemperatureLabwareOptions
   )
+  const temperatureModuleId = useSelector(
+    uiModuleSelectors.getSingleTemperatureModuleId
+  )
+  const thermocyclerModuleId = useSelector(
+    uiModuleSelectors.getSingleThermocyclerModuleId
+  )
+
   return (
     <div className={styles.form_wrapper}>
       <div className={styles.section_header}>
@@ -40,46 +47,58 @@ function TemperatureForm(props: TemperatureFormProps): React.Element<'div'> {
             options={moduleLabwareOptions}
           />
         </FormGroup>
-
-        <div className={styles.checkbox_row}>
-          <RadioGroupField
-            name="setTemperature"
-            options={[
-              {
-                name: i18n.t(
-                  'form.step_edit_form.field.setTemperature.options.true'
-                ),
-                value: 'true',
-              },
-            ]}
-            {...focusHandlers}
-          />
-          <ConditionalOnField
-            name={'setTemperature'}
-            condition={val => val === 'true'}
-          >
-            <TextField
-              name="targetTemperature"
-              className={styles.small_field}
-              units={i18n.t('application.units.degrees')}
+        {/* TODO (ka 2019-12-20): Only render form for temperature modules at the moment */}
+        <ConditionalOnField
+          name={'moduleId'}
+          condition={val => val === temperatureModuleId}
+        >
+          <div className={styles.checkbox_row}>
+            <RadioGroupField
+              name="setTemperature"
+              options={[
+                {
+                  name: i18n.t(
+                    'form.step_edit_form.field.setTemperature.options.true'
+                  ),
+                  value: 'true',
+                },
+              ]}
               {...focusHandlers}
             />
-          </ConditionalOnField>
-        </div>
-        <div className={styles.checkbox_row}>
-          <RadioGroupField
-            name="setTemperature"
-            options={[
-              {
-                name: i18n.t(
-                  'form.step_edit_form.field.setTemperature.options.false'
-                ),
-                value: 'false',
-              },
-            ]}
-            {...focusHandlers}
-          />
-        </div>
+            <ConditionalOnField
+              name={'setTemperature'}
+              condition={val => val === 'true'}
+            >
+              <TextField
+                name="targetTemperature"
+                className={styles.small_field}
+                units={i18n.t('application.units.degrees')}
+                {...focusHandlers}
+              />
+            </ConditionalOnField>
+          </div>
+          <div className={styles.checkbox_row}>
+            <RadioGroupField
+              name="setTemperature"
+              options={[
+                {
+                  name: i18n.t(
+                    'form.step_edit_form.field.setTemperature.options.false'
+                  ),
+                  value: 'false',
+                },
+              ]}
+              {...focusHandlers}
+            />
+          </div>
+        </ConditionalOnField>
+        {/* TODO (ka 2019-12-20): Implement thermocycler set temp form */}
+        <ConditionalOnField
+          name={'moduleId'}
+          condition={value => value === thermocyclerModuleId}
+        >
+          TODO: Thermocycler set temperature form not implemented
+        </ConditionalOnField>
       </div>
     </div>
   )

--- a/protocol-designer/src/components/StepEditForm/forms/TemperatureForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/TemperatureForm.js
@@ -47,10 +47,18 @@ function TemperatureForm(props: TemperatureFormProps): React.Element<'div'> {
             options={moduleLabwareOptions}
           />
         </FormGroup>
-        {/* TODO (ka 2019-12-20): Only render form for temperature modules at the moment */}
+        {/* TODO (ka 2020-1-6):
+          moduleID dropdown will autoselect when creating a new step,
+          but this will not be the case when returning to a never saved form.
+          Rather than defaulting to one or the other when null,
+          display a message (copy, design, etc TBD) that you need to select a module to continue
+        */}
+        <ConditionalOnField name={'moduleId'} condition={val => val === null}>
+          <p>Please select a module for this temperature step.</p>
+        </ConditionalOnField>
         <ConditionalOnField
           name={'moduleId'}
-          condition={val => val === temperatureModuleId}
+          condition={val => val === temperatureModuleId && val != null}
         >
           <div className={styles.checkbox_row}>
             <RadioGroupField
@@ -95,7 +103,7 @@ function TemperatureForm(props: TemperatureFormProps): React.Element<'div'> {
         {/* TODO (ka 2019-12-20): Implement thermocycler set temp form */}
         <ConditionalOnField
           name={'moduleId'}
-          condition={value => value === thermocyclerModuleId}
+          condition={value => value === thermocyclerModuleId && value != null}
         >
           TODO: Thermocycler set temperature form not implemented
         </ConditionalOnField>

--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -81,6 +81,10 @@ export const MAX_ENGAGE_HEIGHT = 16
 export const MIN_TEMP_MODULE_TEMP = 0
 export const MAX_TEMP_MODULE_TEMP = 95
 
+export const MAGNET_TYPE = 'magdeck'
+export const TEMPERATURE_TYPE = 'tempdeck'
+export const THERMO_TYPE = 'thermocycler'
+
 // TODO: IL 2019-12-03 migrate the ModuleType '___deck' strings to '___ module' forms.
 // We don't call modules 'deck' anymore, but the old code is entrenched
 export const FILE_MODULE_TYPE_TO_MODULE_TYPE: { [string]: ModuleType } = {

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -85,6 +85,7 @@ export default function getDefaultsForStepType(
       }
     case 'temperature':
       return {
+        moduleId: null,
         setTemperature: null,
         targetTemperature: null,
       }

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/__tests__/getNextDefaultModuleId.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/__tests__/getNextDefaultModuleId.test.js
@@ -1,5 +1,5 @@
 // @flow
-import { getNextDefaultTemperatureModuleId } from '../'
+import { getNextDefaultTemperatureModuleId } from '..'
 
 describe('getNextDefaultTemperatureModuleId', () => {
   describe('no previous forms', () => {

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/__tests__/index.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/__tests__/index.js
@@ -1,0 +1,58 @@
+// @flow
+import { getNextDefaultTemperatureModuleId } from '../'
+
+describe('getNextDefaultTemperatureModuleId', () => {
+  describe('no previous forms', () => {
+    const testCases = [
+      {
+        testMsg: 'temp and TC module present: use temp',
+        equippedModulesById: {
+          tempId: {
+            id: 'tempId',
+            type: 'tempdeck',
+            model: 'GEN1',
+            slot: '3',
+            moduleState: { type: 'tempdeck' },
+          },
+          tcId: {
+            id: 'tcId',
+            type: 'thermocycler',
+            model: 'GEN1',
+            slot: '_span781011',
+            moduleState: { type: 'tempdeck' },
+          },
+        },
+        expected: 'tempId',
+      },
+      {
+        testMsg: 'thermocycler only: use tc',
+        equippedModulesById: {
+          tcId: {
+            id: 'tcId',
+            type: 'thermocycler',
+            model: 'GEN1',
+            slot: '_span781011',
+            moduleState: { type: 'tempdeck' },
+          },
+        },
+        expected: 'tcId',
+      },
+    ]
+
+    testCases.forEach(({ testMsg, equippedModulesById, expected }) => {
+      test(testMsg, () => {
+        const savedForms = {}
+        const orderedStepIds = []
+
+        const result = getNextDefaultTemperatureModuleId(
+          savedForms,
+          orderedStepIds,
+          equippedModulesById
+        )
+
+        expect(result).toBe(expected)
+      })
+    })
+  })
+  // TODO (ka 2019-12-20): Add in tests for existing temperature form steps once wired up
+})

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/index.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/index.js
@@ -4,11 +4,13 @@ import last from 'lodash/last'
 import type { ModuleOnDeck } from '../../../step-forms'
 import type { StepIdType, FormData } from '../../../form-types'
 
+import { TEMPERATURE_TYPE, THERMO_TYPE } from '../../../constants'
+
 export function getNextDefaultTemperatureModuleId(
   savedForms: { [StepIdType]: FormData },
   orderedStepIds: Array<StepIdType>,
   equippedModulesById: { [moduleId: string]: ModuleOnDeck }
-): string {
+): string | null {
   const prevModuleSteps = orderedStepIds
     .map(stepId => savedForms[stepId])
     .filter(form => form && form.moduleId)
@@ -17,14 +19,14 @@ export function getNextDefaultTemperatureModuleId(
 
   // TODO (ka 2019-12-20): Since we are hiding the thermocylcer module as an option for now,
   // should we simplify this to only return temperature modules?
-  const nextDefaultModule: ?string =
+  const nextDefaultModule: string | null =
     (lastModuleStep && lastModuleStep.moduleId) ||
-    findKey(equippedModulesById, m => m.type === 'tempdeck') ||
-    findKey(equippedModulesById, m => m.type === 'thermocycler')
+    findKey(equippedModulesById, m => m.type === TEMPERATURE_TYPE) ||
+    findKey(equippedModulesById, m => m.type === THERMO_TYPE)
 
   if (!nextDefaultModule) {
     console.error('Could not get next default module. Something went wrong.')
-    return ''
+    return null
   }
 
   return nextDefaultModule

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/index.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/index.js
@@ -1,0 +1,31 @@
+// @flow
+import findKey from 'lodash/findKey'
+import last from 'lodash/last'
+import type { ModuleOnDeck } from '../../../step-forms'
+import type { StepIdType, FormData } from '../../../form-types'
+
+export function getNextDefaultTemperatureModuleId(
+  savedForms: { [StepIdType]: FormData },
+  orderedStepIds: Array<StepIdType>,
+  equippedModulesById: { [moduleId: string]: ModuleOnDeck }
+): string {
+  const prevModuleSteps = orderedStepIds
+    .map(stepId => savedForms[stepId])
+    .filter(form => form && form.moduleId)
+
+  const lastModuleStep = last(prevModuleSteps)
+
+  // TODO (ka 2019-12-20): Since we are hiding the thermocylcer module as an option for now,
+  // should we simplify this to only return temperature modules?
+  const nextDefaultModule: ?string =
+    (lastModuleStep && lastModuleStep.moduleId) ||
+    findKey(equippedModulesById, m => m.type === 'tempdeck') ||
+    findKey(equippedModulesById, m => m.type === 'thermocycler')
+
+  if (!nextDefaultModule) {
+    console.error('Could not get next default module. Something went wrong.')
+    return ''
+  }
+
+  return nextDefaultModule
+}

--- a/protocol-designer/src/steplist/formLevel/index.js
+++ b/protocol-designer/src/steplist/formLevel/index.js
@@ -28,6 +28,7 @@ export { default as generateNewForm } from './generateNewForm'
 export { default as getDefaultsForStepType } from './getDefaultsForStepType'
 export { default as getDisabledFields } from './getDisabledFields'
 export { default as getNextDefaultPipetteId } from './getNextDefaultPipetteId'
+export { getNextDefaultTemperatureModuleId } from './getNextDefaultModuleId'
 export { default as stepFormToArgs } from './stepFormToArgs'
 
 type FormHelpers = {

--- a/protocol-designer/src/ui/modules/selectors.js
+++ b/protocol-designer/src/ui/modules/selectors.js
@@ -25,7 +25,17 @@ export const getTemperatureLabwareOptions: Selector<Options> = createSelector(
   stepFormSelectors.getInitialDeckSetup,
   getLabwareNicknamesById,
   (initialDeckSetup, nicknamesById) => {
-    return getModuleLabwareOptions(initialDeckSetup, nicknamesById, 'tempdeck')
+    const temperatureModuleOptions = getModuleLabwareOptions(
+      initialDeckSetup,
+      nicknamesById,
+      'tempdeck'
+    )
+    const thermocyclerModuleOptions = getModuleLabwareOptions(
+      initialDeckSetup,
+      nicknamesById,
+      'thermocycler'
+    )
+    return temperatureModuleOptions.concat(thermocyclerModuleOptions)
   }
 )
 
@@ -51,6 +61,24 @@ export const getSingleMagneticModuleId: Selector<
     getModuleOnDeckByType(initialDeckSetup, 'magdeck')?.id || null
 )
 
+/** Get single temperature module (assumes no multiples) */
+export const getSingleTemperatureModuleId: Selector<
+  string | null
+> = createSelector(
+  stepFormSelectors.getInitialDeckSetup,
+  initialDeckSetup =>
+    getModuleOnDeckByType(initialDeckSetup, 'tempdeck')?.id || null
+)
+
+/** Get single temperature module (assumes no multiples) */
+export const getSingleThermocyclerModuleId: Selector<
+  string | null
+> = createSelector(
+  stepFormSelectors.getInitialDeckSetup,
+  initialDeckSetup =>
+    getModuleOnDeckByType(initialDeckSetup, 'thermocycler')?.id || null
+)
+
 /** Returns boolean if magnetic module has labware */
 export const getMagnetModuleHasLabware: Selector<boolean> = createSelector(
   stepFormSelectors.getInitialDeckSetup,
@@ -64,5 +92,13 @@ export const getTemperatureModuleHasLabware: Selector<boolean> = createSelector(
   stepFormSelectors.getInitialDeckSetup,
   initialDeckSetup => {
     return getModuleHasLabware(initialDeckSetup, 'tempdeck')
+  }
+)
+
+/** Returns boolean if thermocycler module has labware */
+export const getThermocyclerModuleHasLabware: Selector<boolean> = createSelector(
+  stepFormSelectors.getInitialDeckSetup,
+  initialDeckSetup => {
+    return getModuleHasLabware(initialDeckSetup, 'thermocycler')
   }
 )

--- a/protocol-designer/src/ui/steps/actions/actions.js
+++ b/protocol-designer/src/ui/steps/actions/actions.js
@@ -6,6 +6,7 @@ import { selectors as uiModulesSelectors } from '../../modules'
 
 import {
   getNextDefaultPipetteId,
+  getNextDefaultTemperatureModuleId,
   handleFormChange,
 } from '../../../steplist/formLevel'
 import type { StepIdType, StepType } from '../../../form-types'
@@ -120,6 +121,15 @@ export const selectStep = (
   // auto-select magnetic module if it exists (assumes no more than 1 magnetic module)
   if (newStepType === 'magnet') {
     const moduleId = uiModulesSelectors.getSingleMagneticModuleId(state)
+    formData = { ...formData, moduleId }
+  }
+
+  if (newStepType === 'temperature') {
+    const moduleId = getNextDefaultTemperatureModuleId(
+      stepFormSelectors.getSavedStepForms(state),
+      stepFormSelectors.getOrderedStepIds(state),
+      stepFormSelectors.getInitialDeckSetup(state).modules
+    )
     formData = { ...formData, moduleId }
   }
 

--- a/protocol-designer/src/ui/steps/actions/thunks.js
+++ b/protocol-designer/src/ui/steps/actions/thunks.js
@@ -47,15 +47,15 @@ export const addStep = (payload: { stepType: StepType }) => (
   const stepNeedsLiquid = ['mix', 'moveLiquid'].includes(payload.stepType)
   const stepMagnetNeedsLabware = ['magnet'].includes(payload.stepType)
   const stepTemperatureNeedsLabware = ['temperature'].includes(payload.stepType)
-  if (stepNeedsLiquid && !deckHasLiquid) {
-    dispatch(tutorialActions.addHint('add_liquids_and_labware'))
-  }
-  if (
+  const stepModuleMissingLabware =
     (stepMagnetNeedsLabware && !magnetModuleHasLabware) ||
     (stepTemperatureNeedsLabware &&
       ((temperatureModuleOnDeck && !temperatureModuleHasLabware) ||
         (thermocyclerModuleOnDeck && !thermocyclerModuleHasLabware)))
-  ) {
+  if (stepNeedsLiquid && !deckHasLiquid) {
+    dispatch(tutorialActions.addHint('add_liquids_and_labware'))
+  }
+  if (stepModuleMissingLabware) {
     dispatch(tutorialActions.addHint('module_without_labware'))
   }
   dispatch(selectStep(stepId, stepType))

--- a/protocol-designer/src/ui/steps/actions/thunks.js
+++ b/protocol-designer/src/ui/steps/actions/thunks.js
@@ -33,6 +33,15 @@ export const addStep = (payload: { stepType: StepType }) => (
   const temperatureModuleHasLabware = uiModuleSelectors.getTemperatureModuleHasLabware(
     state
   )
+  const thermocyclerModuleHasLabware = uiModuleSelectors.getThermocyclerModuleHasLabware(
+    state
+  )
+  const temperatureModuleOnDeck = uiModuleSelectors.getSingleTemperatureModuleId(
+    state
+  )
+  const thermocyclerModuleOnDeck = uiModuleSelectors.getSingleThermocyclerModuleId(
+    state
+  )
 
   // TODO: Ian 2019-01-17 move out to centralized step info file - see #2926
   const stepNeedsLiquid = ['mix', 'moveLiquid'].includes(payload.stepType)
@@ -43,7 +52,9 @@ export const addStep = (payload: { stepType: StepType }) => (
   }
   if (
     (stepMagnetNeedsLabware && !magnetModuleHasLabware) ||
-    (stepTemperatureNeedsLabware && !temperatureModuleHasLabware)
+    (stepTemperatureNeedsLabware &&
+      ((temperatureModuleOnDeck && !temperatureModuleHasLabware) ||
+        (thermocyclerModuleOnDeck && !thermocyclerModuleHasLabware)))
   ) {
     dispatch(tutorialActions.addHint('module_without_labware'))
   }


### PR DESCRIPTION
## overview

This PR closes #4642 by adding the logic to auto-select modules in the set temperature form. 

The work grew a bit due to the fact that the TC set temperature form is not yet implemented. See changelog

## changelog

- feat(protocol-designer): Auto-select module in set temperature form
- Add thermocycler module option to set temp dropdown options
- Auto-select temperature module by default, if only TC present, autoselect TC
- Update missing labware hint to check for module present and missing labware for temperature step
- conditionally render set temperature form for temperature module, render TODO for TC form

## review requests

This one's a bit of a pain to test...

http://sandbox.designer.opentrons.com/pd_autoselect-module-id/

**Temp module without labware**
- Create a protocol with a temperature module + no labware
- Create a temperature step
- [ ] Module missing labware hint renders
- [ ] `TEMP: No labware on module` is autoselected
- [ ] Set temperature form renders below

**Temp module with labware**
- Create a protocol with a temperature module +  labware
- Create a temperature step
- [ ] Module missing labware hint DOES NOT render
- [ ] `TEMP: {labware name}` is autoselected
- [ ] Set temperature form renders below

**TC module without labware**
- Create a protocol with a TC module + no labware
- Create a temperature step
- [ ] Module missing labware hint renders
- [ ] `THERMO: No labware on module` is autoselected
- [ ] TODO form message renders below

**TC module with labware**
- Create a protocol with a TC module +  labware
- Create a temperature step
- [ ] Module missing labware hint DOES NOT render
- [ ] `THERMO: {labware name}` is autoselected
- [ ] TODO form message renders below

**Temp module without labware TC module with labware**
- Create a protocol with a temperature module + no labware, TC module with labware
- Create a temperature step
- [ ] Module missing labware hint renders
- [ ] `TEMP: No labware on module` is autoselected
- [ ] Set temperature form renders below
- toggle to TC module
- [ ] TODO form message renders below

^ I think this covers all of the variations, but basically please run to ground:
- hint logic
- autoselect logic
-  form conditional render logic
