### PR TITLE
feat(protocol-designer): Auto-select !previous magnet action

### DIFF
--- a/protocol-designer/src/steplist/formLevel/getNextDefaultMagnetAction/__tests__/getNextDefaultModuleAction.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultMagnetAction/__tests__/getNextDefaultModuleAction.test.js
@@ -1,0 +1,52 @@
+// @flow
+import { getNextDefaultMagnetAction } from '../'
+
+describe('getNextDefaultMagnetAction', () => {
+  describe('no previous forms', () => {
+    const testCases = [
+      {
+        testMsg: 'no previous magnet action',
+        expected: null,
+      },
+    ]
+
+    testCases.forEach(({ testMsg, expected }) => {
+      test(testMsg, () => {
+        const savedForms = {}
+        const orderedStepIds = []
+
+        const result = getNextDefaultMagnetAction(savedForms, orderedStepIds)
+
+        expect(result).toBe(expected)
+      })
+    })
+  })
+
+  describe('with previous forms', () => {
+    const testCases = [
+      {
+        testMsg: 'returns disengage when engage previous selected',
+        orderedStepIds: ['e', 'd', 'e'],
+        expected: 'disengage',
+      },
+      {
+        testMsg: 'returns engage when disengage previous selected',
+        orderedStepIds: ['d', 'e', 'd'],
+        expected: 'engage',
+      },
+    ]
+
+    testCases.forEach(({ testMsg, orderedStepIds, expected }) => {
+      test(testMsg, () => {
+        const savedForms = {
+          e: { id: 'moduleId', stepType: 'magnet', magnetAction: 'engage' },
+          d: { id: 'moduleId', stepType: 'magnet', magnetAction: 'disengage' },
+        }
+
+        const result = getNextDefaultMagnetAction(savedForms, orderedStepIds)
+
+        expect(result).toBe(expected)
+      })
+    })
+  })
+})

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultMagnetAction/index.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultMagnetAction/index.js
@@ -1,0 +1,23 @@
+// @flow
+import last from 'lodash/last'
+import type { StepIdType, FormData } from '../../../form-types'
+
+export function getNextDefaultMagnetAction(
+  savedForms: { [StepIdType]: FormData },
+  orderedStepIds: Array<StepIdType>
+): ?string {
+  const prevMagnetSteps = orderedStepIds
+    .map(stepId => savedForms[stepId])
+    .filter(form => form && form.magnetAction)
+
+  const lastMagnetStep = last(prevMagnetSteps)
+
+  let nextDefaultMagnetAction: ?string = null
+
+  if (lastMagnetStep && lastMagnetStep.magnetAction) {
+    nextDefaultMagnetAction =
+      lastMagnetStep.magnetAction === 'engage' ? 'disengage' : 'engage'
+  }
+
+  return nextDefaultMagnetAction
+}

--- a/protocol-designer/src/steplist/formLevel/index.js
+++ b/protocol-designer/src/steplist/formLevel/index.js
@@ -28,6 +28,7 @@ export { default as generateNewForm } from './generateNewForm'
 export { default as getDefaultsForStepType } from './getDefaultsForStepType'
 export { default as getDisabledFields } from './getDisabledFields'
 export { default as getNextDefaultPipetteId } from './getNextDefaultPipetteId'
+export { getNextDefaultMagnetAction } from './getNextDefaultMagnetAction'
 export { default as stepFormToArgs } from './stepFormToArgs'
 
 type FormHelpers = {

--- a/protocol-designer/src/ui/steps/actions/actions.js
+++ b/protocol-designer/src/ui/steps/actions/actions.js
@@ -6,6 +6,7 @@ import { selectors as uiModulesSelectors } from '../../modules'
 
 import {
   getNextDefaultPipetteId,
+  getNextDefaultMagnetAction,
   handleFormChange,
 } from '../../../steplist/formLevel'
 import type { StepIdType, StepType } from '../../../form-types'
@@ -120,7 +121,11 @@ export const selectStep = (
   // auto-select magnetic module if it exists (assumes no more than 1 magnetic module)
   if (newStepType === 'magnet') {
     const moduleId = uiModulesSelectors.getSingleMagneticModuleId(state)
-    formData = { ...formData, moduleId }
+    const magnetAction = getNextDefaultMagnetAction(
+      stepFormSelectors.getSavedStepForms(state),
+      stepFormSelectors.getOrderedStepIds(state)
+    )
+    formData = { ...formData, moduleId, magnetAction }
   }
 
   dispatch({


### PR DESCRIPTION
## overview

closes #4449 by auto-selecting the opposite of the previous magnet step magnetAction value when a previous magnet step is present.

## changelog

- feat(protocol-designer): Auto-select !previous magnet action

## review requests

http://sandbox.designer.opentrons.com/pd_default-magnet-action/

- Create a protocol with a magnetic module
- create a magnet step with magnetAction = 'engage' + save
- create a second magnet step
- [ ] 'Disengage' magnetAction is selected by default
- save with disengage selected
- create a third magnet step
- [ ] 'Engage' magnetAction is selected by default