### PR TITLE
feat(api): add set_acceleration command to api

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -331,8 +331,9 @@ class SmoothieDriver_3_0_0:
         self._combined_speed = float(DEFAULT_AXES_SPEED)
         self._saved_axes_speed = float(self._combined_speed)
         self._steps_per_mm = {}
-        self._acceleration = config.acceleration.copy()
-        self._saved_acceleration = config.acceleration.copy()
+        self._default_acceleration = config.acceleration.copy()
+        self._acceleration = self._default_acceleration.copy()
+        self._saved_acceleration = self._default_acceleration.copy()
 
         # position after homing
         self._homed_position = HOMED_POSITION.copy()
@@ -711,6 +712,8 @@ class SmoothieDriver_3_0_0:
             Dict with axes as valies (e.g.: 'X', 'Y', 'Z', 'A', 'B', or 'C')
             and floating point number for mm-per-second-squared (mm/sec^2)
         '''
+        if not settings:
+            settings = self._default_acceleration
         self._acceleration.update(settings)
         values = ['{}{}'.format(axis.upper(), value)
                   for axis, value in sorted(settings.items())]

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -925,6 +925,9 @@ class API(HardwareAPILike):
         """
         self._config = self._config._replace(**kwargs)
 
+    async def set_acceleration(self, settings):
+        self._backend.set_acceleration(settings)
+
     async def update_deck_calibration(self, new_transform):
         pass
 

--- a/api/src/opentrons/hardware_control/adapters.py
+++ b/api/src/opentrons/hardware_control/adapters.py
@@ -98,7 +98,7 @@ class SynchronousAdapter(HardwareAPILike, threading.Thread):
 
     def __getattribute__(self, attr_name):
         """ Retrieve attributes from our API and wrap coroutines """
-        # Almost every attribute retrieved from us will be fore people actually
+        # Almost every attribute retrieved from us will be for people actually
         # looking for an attribute of the hardware API, so check there first.
         if attr_name == 'discover_modules':
             return object.__getattribute__(self, attr_name)

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -126,6 +126,9 @@ class Controller:
     def set_pipette_speed(self, val: float):
         self._smoothie_driver.set_speed(val)
 
+    def set_acceleration(self, settings):
+        self._smoothie_driver.set_acceleration(settings)
+
     async def watch_modules(self, loop: asyncio.AbstractEventLoop,
                             register_modules: 'RegisterModules'):
         can_watch = aionotify is not None

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -243,6 +243,10 @@ class Simulator:
         if rails is not None:
             self._lights['rails'] = rails
 
+    def set_acceleration(self, settings):
+        if settings:
+            assert type(settings) == dict
+
     def get_lights(self) -> Dict[str, bool]:
         return self._lights
 

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -281,6 +281,10 @@ class ProtocolContext(CommandPublisher):
     def is_simulating(self) -> bool:
         return self._hw_manager.hardware.get_is_simulator()
 
+    @requires_version(2, 1)
+    def set_acceleration(self, settings=None):
+        self._hw_manager.hardware.set_acceleration(settings)
+
     @requires_version(2, 0)
     def load_labware_from_definition(
             self,

--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -121,6 +121,12 @@ def run_protocol(protocol: Protocol,
     :param protocol: The :py:class:`.protocols.types.Protocol` to execute
     :param context: The context to use.
     """
+
+    # Before running any protocol, ensure that the robot is properly set up
+    # Currently, the only thing ensured is that Smoothie acceleration is set to
+    # default
+    context.set_acceleration()
+
     if isinstance(protocol, PythonProtocol):
         if protocol.api_level >= APIVersion(2, 0):
             _run_python(protocol, context)


### PR DESCRIPTION
## overview

This PR is up for discussion, and is by no means finished, so please treat it as such (function arguments should be improved, needs documentation/tests, etc).

Anecdotally, I've heard people comment/complain that the robot moves in a way that is jerky and causes it to shake, and is probably not ideal for many applications. This is an example of how you could provide the ability to set the acceleration of smoothie in PAPIv2.

I don't think this exact interface, or the existing interface for `set_speed` are very good, so I would appreciate feedback on how the call would be formed. No matter what, we shouldn't require the user to understand the XYZABC axis mapping, but the change could be as little as using 'x', 'y', 'z_left', 'z_right', 'plunger_left', 'plunger_right' as the keys.

The corollary to this (which motivated this PR in the first place) is that the default acceleration currently in the driver is probably too aggressive. In the protocol snippet I've included below, I have three acceleration tables for consideration. The first is our current defaults. The second makes the robot shake noticeably less (subjectively, based on the robot on my desk), and the third is quite conservative and almost doesn't shake at all. I have not yet tested how much this impacts the time to do tasks like filling plates, but I plan to before recommending changing the defaults.

## review requests

Here's a protocol that uses the new command:

```
metadata = {
	"apiLevel": "2.1"
}

def run(ctx):
	tr = ctx.load_labware('opentrons_96_tiprack_300ul', '2')
	pipette = ctx.load_instrument("p300_single", "left", tip_racks=[tr])
	source_plate = ctx.load_labware('biorad_96_wellplate_200ul_pcr', '3')
	output_plate = ctx.load_labware('biorad_96_wellplate_200ul_pcr', '10')

	test_settings = [
		{'x': 3000, 'y': 2000, 'z': 1500, 'a': 1500, 'b': 200, 'c': 200},
		{'x': 1500, 'y': 1000, 'z': 1000, 'a': 1000, 'b': 200, 'c': 200},
		{'x': 1000, 'y': 750, 'z': 750, 'a': 750, 'b': 200, 'c': 200}]
	
	for setting in test_settings:
		ctx.set_acceleration(setting)
		pipette.transfer(100, source_plate.wells()[0:2], output_plate.wells()[0:2])
```