### PR TITLE
fix(api): Add back in useProtocolApi2 feature flag

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -64,6 +64,11 @@ settings = [
                     ' robots that do not have crosses etched on the deck'
     ),
     Setting(
+        _id='useProtocolApi2',
+        title='Use Protocol API version 2',
+        description='Deprecated feature flag'
+    ),
+    Setting(
         _id='disableHomeOnBoot',
         old_id='disable-home-on-boot',
         title='Disable home on boot',
@@ -218,6 +223,7 @@ def _migrate2to3(previous: SettingsMap) -> SettingsMap:
     """
     newmap = {k: v for k, v in previous.items()}
     newmap['enableApi1BackCompat'] = None
+    newmap['useProtocolApi2'] = None
     return newmap
 
 

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -10,6 +10,7 @@ good_file_settings = {
     'useOldAspirationFunctions': None,
     'disableLogAggregation': None,
     'enableApi1BackCompat': None,
+    'useProtocolApi2': None
 }
 
 
@@ -26,7 +27,6 @@ def test_migrates_versionless_new_config():
       'calibrateToBottom': True,
       'deckCalibrationDots': False,
       'disableHomeOnBoot': True,
-      'useProtocolApi2': False,
       'useOldAspirationFunctions': True,
     })
 
@@ -39,6 +39,7 @@ def test_migrates_versionless_new_config():
       'useOldAspirationFunctions': True,
       'disableLogAggregation': None,
       'enableApi1BackCompat': None,
+      'useProtocolApi2': None
     }
 
 
@@ -58,7 +59,8 @@ def test_migrates_versionless_old_config():
       'disableHomeOnBoot': None,
       'useOldAspirationFunctions': None,
       'disableLogAggregation': None,
-      'enableApi1BackCompat': None
+      'enableApi1BackCompat': None,
+      'useProtocolApi2': None,
     }
 
 
@@ -79,7 +81,7 @@ def test_migrates_v1_config():
       'calibrateToBottom': True,
       'deckCalibrationDots': False,
       'disableHomeOnBoot': True,
-      'useProtocolApi2': False,
+      'useProtocolApi2': None,
       'useOldAspirationFunctions': True,
     })
     assert version == good_file_version
@@ -90,7 +92,7 @@ def test_migrates_v1_config():
         'disableHomeOnBoot': True,
         'useOldAspirationFunctions': True,
         'disableLogAggregation': None,
-        'useProtocolApi2': False,
+        'useProtocolApi2': None,
         'enableApi1BackCompat': None,
     }
 
@@ -102,7 +104,7 @@ def test_migrates_v2_config():
         'calibrateToBottom': True,
         'deckCalibrationDots': False,
         'disableHomeOnBoot': True,
-        'useProtocolApi2': False,
+        'useProtocolApi2': None,
         'enableApi1BackCompat': False,
         'useOldAspirationFunctions': True,
         'disableLogAggregation': False,
@@ -116,7 +118,7 @@ def test_migrates_v2_config():
         'disableHomeOnBoot': True,
         'useOldAspirationFunctions': True,
         'disableLogAggregation': False,
-        'useProtocolApi2': False,
+        'useProtocolApi2': None,
         'enableApi1BackCompat': None,
     }
 
@@ -128,7 +130,7 @@ def test_migrates_v3_config():
         'calibrateToBottom': True,
         'deckCalibrationDots': False,
         'disableHomeOnBoot': True,
-        'useProtocolApi2': True,
+        'useProtocolApi2': None,
         'useOldAspirationFunctions': True,
         'disableLogAggregation': False,
         'enableApi1BackCompat': False
@@ -141,7 +143,7 @@ def test_migrates_v3_config():
         'disableHomeOnBoot': True,
         'useOldAspirationFunctions': True,
         'disableLogAggregation': False,
-        'useProtocolApi2': True,
+        'useProtocolApi2': None,
         'enableApi1BackCompat': False,
     }
 
@@ -159,4 +161,5 @@ def test_ensures_config():
              'disableHomeOnBoot': None,
              'useOldAspirationFunctions': None,
              'disableLogAggregation': True,
+             'useProtocolApi2': None
          }


### PR DESCRIPTION
## overview

No migration protection was added for the `useProtocolApi2` feature flag. If the flag does not exist and you try to downgrade to a version which requires this feature flag then an error occurs.

## changelog
- Add back in the feature flag

## review requests

Everything look ok?
