### PR TITLE
refactor(update-server): Make regex string raw.

### DIFF
--- a/update-server/otupdate/balena/install.py
+++ b/update-server/otupdate/balena/install.py
@@ -13,7 +13,7 @@ VENV_NAME = 'env'
 # This regex should match a PEP427 compliant wheel filename and extract its
 # version into separate groups. Groups 1, 2, 3, and 4 should be the major,
 # minor, patch, and tag respectively. The tag capture group is optional
-WHEEL_VERSION_RE = re.compile('^[\w]+-([\d]+).([\d]+).([\d]+)([\w.]+)?-.*\.whl') # noqa
+WHEEL_VERSION_RE = re.compile(r'^[\w]+-([\d]+).([\d]+).([\d]+)([\w.]+)?-.*\.whl') # noqa
 FIRST_PROVISIONED_VERSION = (3, 3, 0)
 
 


### PR DESCRIPTION
# Overview

This fixes one of the warnings caught by the test suite.  A regex string relied on the deprecated behavior of unrecognized backslash escape sequences expanding to the literal backslash plus the literal character.  It's said that these will be syntax errors in the future.

Fix it by making the string raw.
