### PR TITLE
refactor(update-server): Don't add extra newlines to /etc/machine-info on update

### DIFF
--- a/update-server/otupdate/buildroot/name_management.py
+++ b/update-server/otupdate/buildroot/name_management.py
@@ -182,12 +182,12 @@ def _update_pretty_hostname(new_val: str):
     except OSError:
         LOG.exception("Couldn't read /etc/machine-info")
         contents = ''
-    new_contents = _new_machine_info_contents(contents, new_val)
+    new_contents = _rewrite_machine_info(contents, new_val)
     with open('/etc/machine-info', 'w') as emi:
         emi.write(new_contents)
 
 
-def _new_machine_info_contents(current_machine_info_contents: str, new_pretty_hostname: str) -> str:
+def _rewrite_machine_info(current_machine_info_contents: str, new_pretty_hostname: str) -> str:
     """
     Return current_machine_info_contents - the full contents of /etc/machine-info - with the
     PRETTY_HOSTNAME=... line rewritten to refer to new_pretty_hostname.

--- a/update-server/otupdate/buildroot/name_management.py
+++ b/update-server/otupdate/buildroot/name_management.py
@@ -192,11 +192,10 @@ def _rewrite_machine_info(current_machine_info_contents: str, new_pretty_hostnam
     Return current_machine_info_contents - the full contents of /etc/machine-info - with the
     PRETTY_HOSTNAME=... line rewritten to refer to new_pretty_hostname.
     """
-    new_contents = ''
-    for line in current_machine_info_contents.split('\n'):
-        if not line.startswith('PRETTY_HOSTNAME'):
-            new_contents += f'{line}\n'
-    new_contents += f'PRETTY_HOSTNAME={new_pretty_hostname}\n'
+    current_lines = current_machine_info_contents.splitlines()
+    preserved_lines = [l for l in current_lines if not l.startswith('PRETTY_HOSTNAME')]
+    new_lines = preserved_lines + [f'PRETTY_HOSTNAME={new_pretty_hostname}']
+    new_contents = '\n'.join(new_lines) + '\n'
     return new_contents
 
 

--- a/update-server/otupdate/buildroot/name_management.py
+++ b/update-server/otupdate/buildroot/name_management.py
@@ -187,13 +187,16 @@ def _update_pretty_hostname(new_val: str):
         emi.write(new_contents)
 
 
-def _rewrite_machine_info(current_machine_info_contents: str, new_pretty_hostname: str) -> str:
+def _rewrite_machine_info(
+        current_machine_info_contents: str, new_pretty_hostname: str) -> str:
     """
-    Return current_machine_info_contents - the full contents of /etc/machine-info - with the
-    PRETTY_HOSTNAME=... line rewritten to refer to new_pretty_hostname.
+    Return current_machine_info_contents - the full contents of
+    /etc/machine-info - with the PRETTY_HOSTNAME=... line rewritten to refer
+    to new_pretty_hostname.
     """
     current_lines = current_machine_info_contents.splitlines()
-    preserved_lines = [l for l in current_lines if not l.startswith('PRETTY_HOSTNAME')]
+    preserved_lines = [
+        l for l in current_lines if not l.startswith('PRETTY_HOSTNAME')]
     new_lines = preserved_lines + [f'PRETTY_HOSTNAME={new_pretty_hostname}']
     new_contents = '\n'.join(new_lines) + '\n'
     return new_contents

--- a/update-server/otupdate/buildroot/name_management.py
+++ b/update-server/otupdate/buildroot/name_management.py
@@ -182,13 +182,22 @@ def _update_pretty_hostname(new_val: str):
     except OSError:
         LOG.exception("Couldn't read /etc/machine-info")
         contents = ''
-    new_contents = ''
-    for line in contents.split('\n'):
-        if not line.startswith('PRETTY_HOSTNAME'):
-            new_contents += f'{line}\n'
-    new_contents += f'PRETTY_HOSTNAME={new_val}\n'
+    new_contents = _new_machine_info_contents(contents, new_val)
     with open('/etc/machine-info', 'w') as emi:
         emi.write(new_contents)
+
+
+def _new_machine_info_contents(current_machine_info_contents: str, new_pretty_hostname: str) -> str:
+    """
+    Return current_machine_info_contents - the full contents of /etc/machine-info - with the
+    PRETTY_HOSTNAME=... line rewritten to refer to new_pretty_hostname.
+    """
+    new_contents = ''
+    for line in current_machine_info_contents.split('\n'):
+        if not line.startswith('PRETTY_HOSTNAME'):
+            new_contents += f'{line}\n'
+    new_contents += f'PRETTY_HOSTNAME={new_pretty_hostname}\n'
+    return new_contents
 
 
 def get_name(default: str = 'no name set'):

--- a/update-server/tests/buildroot/test_name_management.py
+++ b/update-server/tests/buildroot/test_name_management.py
@@ -2,6 +2,7 @@ from otupdate.buildroot import name_management
 import pytest
 from collections import Counter
 
+
 async def test_name_endpoint(test_cli, monkeypatch):
     async def fake_name(name):
         return name + name
@@ -54,15 +55,19 @@ machine_info_examples = [
 
 @pytest.mark.parametrize('initial_contents', machine_info_examples)
 def test_rewrite_machine_info_updates_pretty_hostname(initial_contents):
-    rewrite = name_management._rewrite_machine_info(initial_contents, 'new_pretty_hostname')
-    assert 'PRETTY_HOSTNAME=new_pretty_hostname' in rewrite.splitlines(), 'new PRETTY_HOSTNAME should be present.'
-    assert rewrite.count('PRETTY_HOSTNAME') == 1, 'Old PRETTY_HOSTNAME should be deleted.'
+    rewrite = name_management._rewrite_machine_info(
+        initial_contents, 'new_pretty_hostname')
+    assert 'PRETTY_HOSTNAME=new_pretty_hostname' in rewrite.splitlines(), \
+        'new PRETTY_HOSTNAME should be present.'
+    assert rewrite.count('PRETTY_HOSTNAME') == 1, \
+        'Old PRETTY_HOSTNAME should be deleted.'
 
 
 @pytest.mark.parametrize('initial_contents', machine_info_examples)
 def test_rewrite_machine_info_preserves_other_lines(initial_contents):
     intitial_lines = Counter(initial_contents.splitlines())
-    rewrite_string = name_management._rewrite_machine_info(initial_contents, 'new_pretty_hostname')
+    rewrite_string = name_management._rewrite_machine_info(
+        initial_contents, 'new_pretty_hostname')
     rewrite_lines = Counter(rewrite_string.splitlines())
     lost_lines = intitial_lines - rewrite_lines
     for line in lost_lines:
@@ -73,6 +78,8 @@ def test_rewrite_machine_info_preserves_other_lines(initial_contents):
 
 @pytest.mark.parametrize('initial_contents', machine_info_examples)
 def test_rewrite_machine_info_is_idempotent(initial_contents):
-    first_rewrite = name_management._rewrite_machine_info(initial_contents, 'new_pretty_hostname')
-    second_rewrite = name_management._rewrite_machine_info(first_rewrite, 'new_pretty_hostname')
+    first_rewrite = name_management._rewrite_machine_info(
+        initial_contents, 'new_pretty_hostname')
+    second_rewrite = name_management._rewrite_machine_info(
+        first_rewrite, 'new_pretty_hostname')
     assert second_rewrite == first_rewrite

--- a/update-server/tests/buildroot/test_name_management.py
+++ b/update-server/tests/buildroot/test_name_management.py
@@ -1,5 +1,6 @@
 from otupdate.buildroot import name_management
-
+import pytest
+from collections import Counter
 
 async def test_name_endpoint(test_cli, monkeypatch):
     async def fake_name(name):
@@ -43,8 +44,35 @@ async def test_name_endpoint(test_cli, monkeypatch):
     assert health_body['name'] == to_set + to_set
 
 
-def test_rewrite_machine_info_idempotent():
-    initial_contents = "PRETTY_HOSTNAME=foo\nSOME_OTHER_VARIABLE=some_other_variable\n"
-    first_rewrite = name_management._rewrite_machine_info(initial_contents, "bar")
-    second_rewrite = name_management._rewrite_machine_info(first_rewrite, "bar")
+machine_info_examples = [
+    '',
+    'FOO=foo',
+    'PRETTY_HOSTNAME=initial_pretty_hostname',
+    'FOO=foo\nPRETTY_HOSTNAME=initial_pretty_hostname\nBAR=bar'
+]
+
+
+@pytest.mark.parametrize('initial_contents', machine_info_examples)
+def test_rewrite_machine_info_updates_pretty_hostname(initial_contents):
+    rewrite = name_management._rewrite_machine_info(initial_contents, 'new_pretty_hostname')
+    assert 'PRETTY_HOSTNAME=new_pretty_hostname' in rewrite.splitlines(), 'new PRETTY_HOSTNAME should be present.'
+    assert rewrite.count('PRETTY_HOSTNAME') == 1, 'Old PRETTY_HOSTNAME should be deleted.'
+
+
+@pytest.mark.parametrize('initial_contents', machine_info_examples)
+def test_rewrite_machine_info_preserves_other_lines(initial_contents):
+    intitial_lines = Counter(initial_contents.splitlines())
+    rewrite_string = name_management._rewrite_machine_info(initial_contents, 'new_pretty_hostname')
+    rewrite_lines = Counter(rewrite_string.splitlines())
+    lost_lines = intitial_lines - rewrite_lines
+    for line in lost_lines:
+        # Lines are only allowed to be "lost" in the rewrite if they were an
+        # old PRETTY_HOSTNAME assignment, or were blank.
+        assert line.startswith('PRETTY_HOSTNAME=') or line == ''
+
+
+@pytest.mark.parametrize('initial_contents', machine_info_examples)
+def test_rewrite_machine_info_is_idempotent(initial_contents):
+    first_rewrite = name_management._rewrite_machine_info(initial_contents, 'new_pretty_hostname')
+    second_rewrite = name_management._rewrite_machine_info(first_rewrite, 'new_pretty_hostname')
     assert second_rewrite == first_rewrite

--- a/update-server/tests/buildroot/test_name_management.py
+++ b/update-server/tests/buildroot/test_name_management.py
@@ -41,3 +41,10 @@ async def test_name_endpoint(test_cli, monkeypatch):
     health = await test_cli.get('/server/update/health')
     health_body = await health.json()
     assert health_body['name'] == to_set + to_set
+
+
+def test_new_machine_info_contents_idempotent():
+    initial_contents = "PRETTY_HOSTNAME=foo\nSOME_OTHER_VARIABLE=some_other_variable\n"
+    first_rewrite = name_management._new_machine_info_contents(initial_contents, "bar")
+    second_rewrite = name_management._new_machine_info_contents(first_rewrite, "bar")
+    assert second_rewrite == first_rewrite

--- a/update-server/tests/buildroot/test_name_management.py
+++ b/update-server/tests/buildroot/test_name_management.py
@@ -43,8 +43,8 @@ async def test_name_endpoint(test_cli, monkeypatch):
     assert health_body['name'] == to_set + to_set
 
 
-def test_new_machine_info_contents_idempotent():
+def test_rewrite_machine_info_idempotent():
     initial_contents = "PRETTY_HOSTNAME=foo\nSOME_OTHER_VARIABLE=some_other_variable\n"
-    first_rewrite = name_management._new_machine_info_contents(initial_contents, "bar")
-    second_rewrite = name_management._new_machine_info_contents(first_rewrite, "bar")
+    first_rewrite = name_management._rewrite_machine_info(initial_contents, "bar")
+    second_rewrite = name_management._rewrite_machine_info(first_rewrite, "bar")
     assert second_rewrite == first_rewrite


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview
Every time an OT-2 has its robot software updated, an extra blank line is inserted in the middle of `/etc/machine-info`, causing the file to grow slowly over time. By a quick calculation, this will cause us to run out of space on the SD card somewhere around release v3.15000000000.0.

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

* Fixed the issue described above.
* Added some unit tests. It doesn't look like this code was previously covered.

## todo

* Figure out what to do about the linter, which complains about long lines, but also doesn't let me break them up into multiple lines with subsequent lines indented.

## review requests

### testing

1. Update your OT-2 with this build.
2. Check the contents of `/etc/machine-info`, paying special attention to blank lines.  I think the OT-2s have `md5sum` pre-installed, to help.
3. Update your OT-2 again.
4. Check `/etc/machine-info` again.  It should match exactly.

### code review

This was a little TDD ✨learning exercise ✨for me. Any suggestions for how the tests could be set up better would be appreciated.
