### PR TITLE
docs(api): fix redirect loop

### DIFF
--- a/api/docs/root/index.html
+++ b/api/docs/root/index.html
@@ -9,7 +9,8 @@
     <title>Welcome to the OT-2 Python Protocol API Docs &#8212; Opentrons OT-2 Python Protocol API Documentation</title>
 
     <script type="text/javascript">
-     window.onload = (event) => {window.location.href = "./v2/index.html"}
+     window.onload = (event) => {
+         window.location.replace("./v2")}
     </script>
 
   </head>


### PR DESCRIPTION
Closes #4672 

Per @b-cooper suggestion, use a relative url to the v2/ path instead of the full index.html to both avoid the redirect loop and still not have to specify the hostname