### PR TITLE
fix(api): Clarify intended use of "Use older pipette calibrations" flag

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -79,7 +79,7 @@ settings = [
         title='Use older aspirate behavior',
         description='Aspirate with the less accurate volumetric calibrations'
                     ' that were used before version 3.7.0. Use this if you'
-                    ' need consistency with pre-3.7.0 results. This only'
+                    ' need consistency with pre-v3.7.0 results. This only'
                     ' affects GEN1 P10S, P10M, P50S, P50M, and P300S pipettes.'
     )
 ]

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -76,12 +76,11 @@ settings = [
     ),
     Setting(
         _id='useOldAspirationFunctions',
-        title='Use older pipette calibrations',
-        description='Use the older pipette calibrations for P10S, P10M, P50S,'
-                    ' P50M, and P300S pipettes. Note this will cause the '
-                    ' default aspirate behavior (ul to mm conversion) to '
-                    ' function as it did prior to version 3.7.0. '
-                    ' NOTE: this does not impact GEN2 pipettes'
+        title='Use older aspirate behavior',
+        description='Aspirate with the less accurate volumetric calibrations'
+                    ' that were used before version 3.7.0. Use this if you'
+                    ' need consistency with pre-3.7.0 results. This only'
+                    ' affects GEN1 P10S, P10M, P50S, P50M, and P300S pipettes.'
     )
 ]
 


### PR DESCRIPTION
This renames and reworks the copy of the "Use older pipette calibrations" advanced setting to clarify that it only affects *volumetric* calibration, and to give a hint about its intended usage.  This should help avoid confused users mistakenly trying it when they run into positional calibration problems.