### PR TITLE
fix(api): apiv2: allow multi to access all 384 wells in transfer

### DIFF
--- a/api/docs/v2/new_complex_commands.rst
+++ b/api/docs/v2/new_complex_commands.rst
@@ -136,11 +136,13 @@ When you are using a multi-channel pipette, you can transfer the entire column (
 
     pipette.transfer(100, plate.wells_by_name()['A1'], plate.wells_by_name()['A2'])
 
-.. versionadded:: 2.2
+.. note::
+        
+        In API Versions 2.0 and 2.1, multichannel pipettes could only access the first row of a 384 well plate, and access to the second row would be ignored. If you need to transfer from all wells of a 384-well plate, please make sure to use API Version 2.2
 
 .. note::
 
-    There is a limited number of rows your multi-channel pipettes can access in a plate during transfer, distribute and consoldiate. Multi pipettes can only access the wells in the first row (wells A1 - A12) of a 96-well plate, and the first two rows (wells A1 - B24) for a 384-well plate. Wells specified outside of the limit will be ignored.
+        Multichannel pipettes can only access a limited number of rows in a plate during `transfer`, `distribute` and `consolidate`: the first row (wells A1 - A12) of a 96-well plate, and (since API Version 2.2) the first two rows (wells A1 - B24) for a 384-well plate. Wells specified outside of the limit will be ignored. 
 
 Transfer commands will automatically create entire series of :py:meth:`.InstrumentContext.aspirate`, :py:meth:`.InstrumentContext.dispense`, and other :py:meth:`.InstrumentContext` commands.
 

--- a/api/docs/v2/new_complex_commands.rst
+++ b/api/docs/v2/new_complex_commands.rst
@@ -22,12 +22,14 @@ The examples in this section will use the following set up:
     def run(protocol: protocol_api.ProtocolContext):
         plate = protocol.load_labware('corning_96_wellplate_360ul_flat', 1)
         tiprack = protocol.load_labware('opentrons_96_tiprack_300ul', 2)
+        tiprack_multi = protocol.load_labware('opentrons_96_tiprack_300ul', 3)
         pipette = protocol.load_instrument('p300_single', mount='left', tip_racks=[tiprack])
+        pipette_multi = protocol.load_instrument('p300_multi', mount='right', tip_racks=[tiprack_multi])
 
         # The code used in the rest of the examples goes here
 
 
-This loads a `Corning 96 Well Plate <https://labware.opentrons.com/corning_96_wellplate_360ul_flat>`_ in slot 1 and a `Opentrons 300 µL Tiprack <https://labware.opentrons.com/opentrons_96_tiprack_300ul>`_ in slot 2, and uses a P300 Single pipette.
+This loads a `Corning 96 Well Plate <https://labware.opentrons.com/corning_96_wellplate_360ul_flat>`_ in slot 1 and a `Opentrons 300 µL Tiprack <https://labware.opentrons.com/opentrons_96_tiprack_300ul>`_ in slot 2 and 3, and uses a P300 Single pipette and a P300 Multi pipette.
 
 You can follow along and simulate the protocol using our protocol simulator, which can be installed by following the instructions at :ref:`writing`.
 
@@ -122,11 +124,21 @@ Below you will find a few scenarios using the :py:meth:`.InstrumentContext.trans
 Basic
 -----
 
-This example below transfers 100 µL from well ``'A1'`` to well ``'B1'``, automatically picking up a new tip and then disposing of it when finished.
+This example below transfers 100 µL from well ``'A1'`` to well ``'B1'`` using the P300 Single pipette, automatically picking up a new tip and then disposing of it when finished.
 
 .. code-block:: python
 
     pipette.transfer(100, plate.wells_by_name()['A1'], plate.wells_by_name()['B1'])
+
+When you are using a multi-channel pipette, you can transfer the entire column (8 wells) in the plate to another using:
+
+.. code-block:: python
+
+    pipette.transfer(100, plate.wells_by_name()['A1'], plate.wells_by_name()['A2'])
+
+.. note::
+
+    There is a limited number of rows your multi-channel pipettes can access in a plate during transfer, distribute and consoldiate. Multi pipettes can only access the wells in the first row (wells A1 - A12) of a 96-well plate, and the first two rows (wells A1 - B24) for a 384-well plate. Wells specified outside of the limit will be ignored.
 
 Transfer commands will automatically create entire series of :py:meth:`.InstrumentContext.aspirate`, :py:meth:`.InstrumentContext.dispense`, and other :py:meth:`.InstrumentContext` commands.
 

--- a/api/docs/v2/new_complex_commands.rst
+++ b/api/docs/v2/new_complex_commands.rst
@@ -136,6 +136,8 @@ When you are using a multi-channel pipette, you can transfer the entire column (
 
     pipette.transfer(100, plate.wells_by_name()['A1'], plate.wells_by_name()['A2'])
 
+.. versionadded:: 2.2
+
 .. note::
 
     There is a limited number of rows your multi-channel pipettes can access in a plate during transfer, distribute and consoldiate. Multi pipettes can only access the wells in the first row (wells A1 - A12) of a 96-well plate, and the first two rows (wells A1 - B24) for a 384-well plate. Wells specified outside of the limit will be ignored.

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1598,7 +1598,8 @@ class InstrumentContext(CommandPublisher):
         transfer_options = transfers.TransferOptions(transfer=transfer_args,
                                                      mix=mix_opts)
         plan = transfers.TransferPlan(volume, source, dest, self, max_volume,
-                                      kwargs['mode'], transfer_options)
+                                      self.api_version, kwargs['mode'],
+                                      transfer_options)
         self._execute_transfer(plan)
         return self
 

--- a/api/src/opentrons/protocol_api/definitions.py
+++ b/api/src/opentrons/protocol_api/definitions.py
@@ -1,4 +1,4 @@
 from ..protocols import types
 
-MAX_SUPPORTED_VERSION = types.APIVersion(2, 1)
+MAX_SUPPORTED_VERSION = types.APIVersion(2, 2)
 #: The maximum supported protocol API version in this release

--- a/api/src/opentrons/protocol_api/transfers.py
+++ b/api/src/opentrons/protocol_api/transfers.py
@@ -777,6 +777,11 @@ class TransferPlan:
 
         return [_map_volume(i) for i in range(total)]
 
+    def _check_valid_well_list(self, well_list, id, old_well_list):
+        if self._api_version >= APIVersion(2, 2) and len(well_list) < 1:
+            raise RuntimeError(
+                f"Invalid {id} for multichannel transfer: {old_well_list}")
+
     def _multichannel_transfer(self, s, d):
         # TODO: add a check for container being multi-channel compatible?
         # Helper function for multi-channel use-case
@@ -803,6 +808,7 @@ class TransferPlan:
         for well in s:
             if self._is_valid_row(well):
                 new_src.append(well)
+        self._check_valid_well_list(new_src, 'source', s)
 
         if isinstance(d, List) and isinstance(d[0], List):
             # s is a List[List]]; flatten to 1D list
@@ -813,6 +819,7 @@ class TransferPlan:
         for well in d:
             if self._is_valid_row(well):
                 new_dst.append(well)
+        self._check_valid_well_list(new_dst, 'target', d)
         return new_src, new_dst
 
     def _is_valid_row(self, well: Union[Well, types.Location]):

--- a/api/tests/opentrons/protocol_api/test_transfers.py
+++ b/api/tests/opentrons/protocol_api/test_transfers.py
@@ -1001,7 +1001,7 @@ def test_multichannel_transfer_locs(loop):
     # no valid source or targets, raise error
     with pytest.raises(RuntimeError):
         assert tx.TransferPlan(
-            100, lw1.rows()[0][1], lw2.rows()[1][1],
+            100, lw1.rows()[0][1], lw2.rows()[2][1],
             instr_multi,
             max_volume=instr_multi.hw_pipette['working_volume'],
             api_version=ctx.api_version)

--- a/api/tests/opentrons/protocol_api/test_transfers.py
+++ b/api/tests/opentrons/protocol_api/test_transfers.py
@@ -6,7 +6,6 @@ from opentrons.protocol_api import transfers as tx
 from opentrons.protocols.types import APIVersion
 
 
-
 @pytest.fixture
 def _instr_labware(loop):
     ctx = papi.ProtocolContext(loop)
@@ -933,7 +932,7 @@ def test_multichannel_transfer_old_version(loop):
     tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
     instr_multi = ctx.load_instrument(
         'p300_multi', Mount.LEFT, tip_racks=[tiprack])
-    
+
     xfer_plan = tx.TransferPlan(
             100, lw1.rows()[0][0], [lw2.rows()[0][1], lw2.rows()[1][1]],
             instr_multi,

--- a/api/tests/opentrons/protocol_api/test_transfers.py
+++ b/api/tests/opentrons/protocol_api/test_transfers.py
@@ -32,7 +32,8 @@ def test_default_transfers(_instr_labware):
     xfer_plan = tx.TransferPlan(
         100, lw1.columns()[0], lw2.columns()[0],
         _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'])
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version)
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
@@ -76,7 +77,8 @@ def test_default_transfers(_instr_labware):
     dist_plan = tx.TransferPlan(
         50, lw1.columns()[0][0], lw2.columns()[0],
         _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'])
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version)
     dist_plan_list = []
     for step in dist_plan:
         dist_plan_list.append(step)
@@ -108,7 +110,8 @@ def test_default_transfers(_instr_labware):
     consd_plan = tx.TransferPlan(
         50, lw1.columns()[0], lw2.columns()[0][0],
         _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'])
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version)
     consd_plan_list = []
     for step in consd_plan:
         consd_plan_list.append(step)
@@ -152,6 +155,7 @@ def test_uneven_transfers(_instr_labware):
         100, lw1.columns()[0][0], lw2.columns()[1][:4],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version,
         mode='transfer', options=options)
     one_to_many_plan_list = []
     for step in xfer_plan:
@@ -179,6 +183,7 @@ def test_uneven_transfers(_instr_labware):
         [100, 90, 80, 70], lw1.columns()[0][:2], lw2.columns()[1][:4],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version,
         mode='transfer', options=options)
     few_to_many_plan_list = []
     for step in xfer_plan:
@@ -206,6 +211,7 @@ def test_uneven_transfers(_instr_labware):
         [100, 90, 80, 70], lw1.columns()[0][:4], lw2.columns()[1][0],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version,
         mode='transfer', options=options)
     many_to_one_plan_list = []
     for step in xfer_plan:
@@ -244,6 +250,7 @@ def test_location_wells(_instr_labware):
         list_of_locs,
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version,
         mode='transfer')
     idx_dest = 0
     for step in xfer_plan:
@@ -263,6 +270,7 @@ def test_location_wells(_instr_labware):
         multi_locs,
         _instr_labware['instr_multi'],
         max_volume=_instr_labware['instr_multi'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version,
         mode='transfer')
 
     idx_dest = 0
@@ -289,6 +297,7 @@ def test_no_new_tip(_instr_labware):
         100, lw1.columns()[0], lw2.columns()[0],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version,
         options=options)
     for step in xfer_plan:
         assert step['method'] != 'pick_up_tip'
@@ -299,6 +308,7 @@ def test_no_new_tip(_instr_labware):
         30, lw1.columns()[0][0], lw2.columns()[0],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version,
         options=options)
     for step in dist_plan:
         assert step['method'] != 'pick_up_tip'
@@ -309,6 +319,7 @@ def test_no_new_tip(_instr_labware):
         40, lw1.columns()[0], lw2.rows()[0][1],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version,
         options=options)
     for step in consd_plan:
         assert step['method'] != 'pick_up_tip'
@@ -333,6 +344,7 @@ def test_new_tip_always(_instr_labware, monkeypatch):
         lw1.columns()[0][1:5], lw2.columns()[0][1:5],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version,
         options=options)
     xfer_plan_list = []
     for step in xfer_plan:
@@ -384,6 +396,7 @@ def test_transfer_w_touchtip_blowout(_instr_labware):
         100, lw1.columns()[0][:3], lw2.rows()[0][:3],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version,
         options=options)
     xfer_plan_list = []
     for step in xfer_plan:
@@ -429,6 +442,7 @@ def test_transfer_w_touchtip_blowout(_instr_labware):
         30, lw1.columns()[0][0], lw2.rows()[0][:3],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version,
         options=options)
     dist_plan_list = []
     for step in dist_plan:
@@ -467,6 +481,7 @@ def test_transfer_w_airgap_blowout(_instr_labware):
         100, lw1.columns()[0][1:5], lw2.rows()[0][1:5],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version,
         options=options)
     xfer_plan_list = []
     for step in xfer_plan:
@@ -509,6 +524,7 @@ def test_transfer_w_airgap_blowout(_instr_labware):
         60, lw1.columns()[1][0], lw2.rows()[1][1:6],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version,
         options=options)
     dist_plan_list = []
     for step in dist_plan:
@@ -541,6 +557,7 @@ def test_transfer_w_airgap_blowout(_instr_labware):
         60, lw1.columns()[1], lw2.rows()[1][1],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version,
         options=options)
     consd_plan_list = []
     for step in consd_plan:
@@ -595,6 +612,7 @@ def test_touchtip_mix(_instr_labware):
         100, lw1.columns()[0][1:5], lw2.rows()[0][1:5],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version,
         options=options)
     xfer_plan_list = []
     for step in xfer_plan:
@@ -638,6 +656,7 @@ def test_touchtip_mix(_instr_labware):
         60, lw1.columns()[1][0], lw2.rows()[1][1:6],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version,
         options=options)
     dist_plan_list = []
     for step in dist_plan:
@@ -670,6 +689,7 @@ def test_touchtip_mix(_instr_labware):
         60, lw1.columns()[1], lw2.rows()[1][1],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version,
         options=options)
     consd_plan_list = []
     for step in consd_plan:
@@ -740,6 +760,7 @@ def test_all_options(_instr_labware):
         100, lw1.columns()[0][1:4], lw2.rows()[0][1:4],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version,
         options=options)
     xfer_plan_list = []
     for step in xfer_plan:
@@ -782,7 +803,8 @@ def test_oversized_distribute(_instr_labware):
     xfer_plan = tx.TransferPlan(
         700, lw1.columns()[0][0], lw2.rows()[0][1:3],
         _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'])
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version)
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
@@ -824,7 +846,8 @@ def test_oversized_consolidate(_instr_labware):
         700, lw2.rows()[0][1:3],
         lw1.wells_by_index()['A1'],
         _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'])
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version)
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
@@ -865,7 +888,8 @@ def test_oversized_transfer(_instr_labware):
     xfer_plan = tx.TransferPlan(
         700, lw2.rows()[0][1:3], lw1.columns()[0][1:3],
         _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'])
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        api_version=_instr_labware['ctx'].api_version)
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
@@ -910,7 +934,8 @@ def test_multichannel_transfer_locs(loop):
     xfer_plan = tx.TransferPlan(
             100, lw1.rows()[0][1], lw2.rows()[1][1],
             instr_multi,
-            max_volume=instr_multi.hw_pipette['working_volume'])
+            max_volume=instr_multi.hw_pipette['working_volume'],
+            api_version=ctx.api_version)
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
@@ -926,7 +951,8 @@ def test_multichannel_transfer_locs(loop):
     xfer_plan = tx.TransferPlan(
         100, lw1.rows()[0][1], [lw2.rows()[1][1], lw2.rows()[2][1]],
         instr_multi,
-        max_volume=instr_multi.hw_pipette['working_volume'])
+        max_volume=instr_multi.hw_pipette['working_volume'],
+        api_version=ctx.api_version)
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)


### PR DESCRIPTION
## overview
The current TransferPlan limits the multi-channel pipettes to have access only to the first row of any labware. This limitation works fine for plates that are in the standard 96-well format. However, in order to fill all wells of a 384-well plate, a multi-channel pipette would need to access the second row of the plate as well. 

This PR closes #4669 and closes #4664 by allowing both row 1 and 2 to be accessible by multi-channel pipettes when the target plate is in the `384Standard` format.

Note: This PR requires a API version bump to 2.2!!

## review request 
- [ ] Confirm a multi-channel pipette can access all wells (A1-B24) in the 384-well plate in API version 2.2 by running the following protocol:
```python
metadata = {'apiLevel': '2.2'}

def run(protocol):
    tiprack = protocol.load_labware('opentrons_96_tiprack_300ul', 1)
    p50 = protocol.load_instrument('p50_multi', 'left', tip_racks=[tiprack])
    plate384 = protocol.load_labware('corning_384_wellplate_112ul_flat', 3)

    p50.transfer(50, plate384.rows()[0], plate384.rows()[1])

```
- [ ] Confirm the behaviors of transfer/distribute/consolidate remain unchanged for API version below 2.2: the above protocol should raise an error