### PR TITLE
refactor(app): use defined constants for tempdeck, magdeck, thermocycler

### DIFF
--- a/app/src/components/CalibrateLabware/ProceedToRun.js
+++ b/app/src/components/CalibrateLabware/ProceedToRun.js
@@ -11,7 +11,7 @@ import type { Dispatch } from '../../types'
 import pcrSealSrc from '../../img/place_pcr_seal.png'
 import { Portal } from '../portal'
 import styles from './styles.css'
-import { THERMOCYCLER } from '../../modules/constants'
+import { THERMOCYCLER } from '../../modules'
 
 type Props = {|
   returnTip: () => mixed,

--- a/app/src/components/CalibrateLabware/ProceedToRun.js
+++ b/app/src/components/CalibrateLabware/ProceedToRun.js
@@ -11,7 +11,7 @@ import type { Dispatch } from '../../types'
 import pcrSealSrc from '../../img/place_pcr_seal.png'
 import { Portal } from '../portal'
 import styles from './styles.css'
-import { THERMOCYCLER } from '@opentrons/shared-data/js/constants'
+import { THERMOCYCLER } from '../../modules/constants'
 
 type Props = {|
   returnTip: () => mixed,

--- a/app/src/components/CalibrateLabware/ProceedToRun.js
+++ b/app/src/components/CalibrateLabware/ProceedToRun.js
@@ -11,6 +11,7 @@ import type { Dispatch } from '../../types'
 import pcrSealSrc from '../../img/place_pcr_seal.png'
 import { Portal } from '../portal'
 import styles from './styles.css'
+import { THERMOCYCLER } from '@opentrons/shared-data/js/constants'
 
 type Props = {|
   returnTip: () => mixed,
@@ -24,7 +25,7 @@ function InfoBoxButton(props: Props) {
   const [runPrepModalOpen, setRunPrepModalOpen] = useState(false)
 
   useEffect(() => {
-    if (some(sessionModules, mod => mod.name === 'thermocycler')) {
+    if (some(sessionModules, mod => mod.name === THERMOCYCLER)) {
       setMustPrepForRun(true)
     }
   }, [sessionModules])

--- a/app/src/components/CalibratePanel/LabwareListItem.js
+++ b/app/src/components/CalibratePanel/LabwareListItem.js
@@ -9,9 +9,9 @@ import {
 } from '@opentrons/shared-data'
 import { ListItem, HoverTooltip } from '@opentrons/components'
 import styles from './styles.css'
-import { THERMOCYCLER } from '@opentrons/shared-data/js/constants'
 
 import type { Labware } from '../../robot'
+import { THERMOCYCLER } from '../../modules/constants'
 
 type LabwareListItemProps = {|
   ...$Exact<Labware>,

--- a/app/src/components/CalibratePanel/LabwareListItem.js
+++ b/app/src/components/CalibratePanel/LabwareListItem.js
@@ -11,7 +11,7 @@ import { ListItem, HoverTooltip } from '@opentrons/components'
 import styles from './styles.css'
 
 import type { Labware } from '../../robot'
-import { THERMOCYCLER } from '../../modules/constants'
+import { THERMOCYCLER } from '../../modules'
 
 type LabwareListItemProps = {|
   ...$Exact<Labware>,

--- a/app/src/components/CalibratePanel/LabwareListItem.js
+++ b/app/src/components/CalibratePanel/LabwareListItem.js
@@ -9,6 +9,7 @@ import {
 } from '@opentrons/shared-data'
 import { ListItem, HoverTooltip } from '@opentrons/components'
 import styles from './styles.css'
+import { THERMOCYCLER } from '@opentrons/shared-data/js/constants'
 
 import type { Labware } from '../../robot'
 
@@ -37,7 +38,7 @@ export default function LabwareListItem(props: LabwareListItemProps) {
   const iconName = confirmed ? 'check-circle' : 'checkbox-blank-circle-outline'
   const displayName = definition ? getLabwareDisplayName(definition) : type
   let displaySlot = `Slot ${slot}`
-  if (moduleName === 'thermocycler') {
+  if (moduleName === THERMOCYCLER) {
     displaySlot = 'Slots 7, 8, 10, & 11'
   }
   const moduleDisplayName = moduleName && getModuleDisplayName(moduleName)

--- a/app/src/components/ModuleControls/TemperatureControl.js
+++ b/app/src/components/ModuleControls/TemperatureControl.js
@@ -7,7 +7,6 @@ import {
   CheckboxField,
   HoverTooltip,
 } from '@opentrons/components'
-import { getModuleDisplayName } from '@opentrons/shared-data'
 import { Portal } from '../portal'
 import styles from './styles.css'
 
@@ -16,7 +15,8 @@ import type {
   TemperatureModule,
   ModuleCommand,
 } from '../../modules/types'
-import { THERMOCYCLER } from '@opentrons/shared-data/js/constants'
+import { THERMOCYCLER } from '../../modules/constants'
+import { getModuleDisplayName } from '@opentrons/shared-data'
 
 const CONNECT_FOR_CONTROL = 'Connect to robot to control modules'
 type Props = {|

--- a/app/src/components/ModuleControls/TemperatureControl.js
+++ b/app/src/components/ModuleControls/TemperatureControl.js
@@ -8,7 +8,6 @@ import {
   HoverTooltip,
 } from '@opentrons/components'
 import { getModuleDisplayName } from '@opentrons/shared-data'
-import { THERMOCYCLER } from '../../modules'
 import { Portal } from '../portal'
 import styles from './styles.css'
 
@@ -17,6 +16,7 @@ import type {
   TemperatureModule,
   ModuleCommand,
 } from '../../modules/types'
+import { THERMOCYCLER } from '@opentrons/shared-data/js/constants'
 
 const CONNECT_FOR_CONTROL = 'Connect to robot to control modules'
 type Props = {|
@@ -66,7 +66,7 @@ export const TemperatureControl = ({
     setPrimaryTempValue(null)
     setSecondaryTempValue(null)
   }
-  const isThermocycler = module.name === 'thermocycler'
+  const isThermocycler = module.name === THERMOCYCLER
   const displayName = getModuleDisplayName(module.name)
   const alertHeading = `Set ${displayName} Temp`
   const alertBody = `Pre heat or cool ${displayName}.`

--- a/app/src/components/ModuleControls/TemperatureControl.js
+++ b/app/src/components/ModuleControls/TemperatureControl.js
@@ -15,7 +15,7 @@ import type {
   TemperatureModule,
   ModuleCommand,
 } from '../../modules/types'
-import { THERMOCYCLER } from '../../modules/constants'
+import { THERMOCYCLER } from '../../modules'
 import { getModuleDisplayName } from '@opentrons/shared-data'
 
 const CONNECT_FOR_CONTROL = 'Connect to robot to control modules'

--- a/app/src/components/ModuleControls/index.js
+++ b/app/src/components/ModuleControls/index.js
@@ -7,7 +7,7 @@ import { TemperatureData } from './TemperatureData'
 import styles from './styles.css'
 
 import type { TemperatureModule, ThermocyclerModule } from '../../modules/types'
-import { THERMOCYCLER } from '@opentrons/shared-data/js/constants'
+import { THERMOCYCLER } from '../../modules/constants'
 
 type Props = {|
   module: TemperatureModule | ThermocyclerModule,

--- a/app/src/components/ModuleControls/index.js
+++ b/app/src/components/ModuleControls/index.js
@@ -2,11 +2,12 @@
 import * as React from 'react'
 import { TemperatureControl } from './TemperatureControl'
 
-import { THERMOCYCLER, useSendModuleCommand } from '../../modules'
+import { useSendModuleCommand } from '../../modules'
 import { TemperatureData } from './TemperatureData'
 import styles from './styles.css'
 
 import type { TemperatureModule, ThermocyclerModule } from '../../modules/types'
+import { THERMOCYCLER } from '@opentrons/shared-data/js/constants'
 
 type Props = {|
   module: TemperatureModule | ThermocyclerModule,

--- a/app/src/components/ModuleControls/index.js
+++ b/app/src/components/ModuleControls/index.js
@@ -1,13 +1,12 @@
 // @flow
 import * as React from 'react'
-import { TemperatureControl } from './TemperatureControl'
 
-import { useSendModuleCommand } from '../../modules'
+import { TemperatureControl } from './TemperatureControl'
+import { THERMOCYCLER, useSendModuleCommand } from '../../modules'
 import { TemperatureData } from './TemperatureData'
 import styles from './styles.css'
 
 import type { TemperatureModule, ThermocyclerModule } from '../../modules/types'
-import { THERMOCYCLER } from '../../modules/constants'
 
 type Props = {|
   module: TemperatureModule | ThermocyclerModule,

--- a/app/src/components/ModuleItem/index.js
+++ b/app/src/components/ModuleItem/index.js
@@ -6,7 +6,7 @@ import { ModuleInfo } from './ModuleInfo'
 import { ModuleUpdate } from './ModuleUpdate'
 import { ModuleControls } from '../ModuleControls'
 import styles from './styles.css'
-
+import { THERMOCYCLER, TEMPDECK } from '@opentrons/shared-data/js/constants'
 import type { AttachedModule } from '../../modules/types'
 
 type Props = {|
@@ -25,7 +25,7 @@ export function ModuleItem(props: Props) {
         <ModuleInfo module={module} />
         <ModuleUpdate availableUpdate={props.availableUpdate} />
       </div>
-      {(module.name === 'thermocycler' || module.name === 'tempdeck') && (
+      {(module.name === THERMOCYCLER || module.name === TEMPDECK) && (
         <ModuleControls module={module} canControl={canControl} />
       )}
     </div>

--- a/app/src/components/ModuleItem/index.js
+++ b/app/src/components/ModuleItem/index.js
@@ -6,8 +6,8 @@ import { ModuleInfo } from './ModuleInfo'
 import { ModuleUpdate } from './ModuleUpdate'
 import { ModuleControls } from '../ModuleControls'
 import styles from './styles.css'
-import { THERMOCYCLER, TEMPDECK } from '@opentrons/shared-data/js/constants'
 import type { AttachedModule } from '../../modules/types'
+import { TEMPDECK, THERMOCYCLER } from '../../modules/constants'
 
 type Props = {|
   module: AttachedModule,

--- a/app/src/components/ModuleItem/index.js
+++ b/app/src/components/ModuleItem/index.js
@@ -7,7 +7,7 @@ import { ModuleUpdate } from './ModuleUpdate'
 import { ModuleControls } from '../ModuleControls'
 import styles from './styles.css'
 import type { AttachedModule } from '../../modules/types'
-import { TEMPDECK, THERMOCYCLER } from '../../modules/constants'
+import { TEMPDECK, THERMOCYCLER } from '../../modules'
 
 type Props = {|
   module: AttachedModule,

--- a/app/src/components/ModuleLiveStatusCards/index.js
+++ b/app/src/components/ModuleLiveStatusCards/index.js
@@ -3,10 +3,12 @@ import * as React from 'react'
 import { useSelector } from 'react-redux'
 
 import {
+  THERMOCYCLER,
+  TEMPDECK,
+  MAGDECK,
   useSendModuleCommand,
   getAttachedModulesForConnectedRobot,
 } from '../../modules'
-import { THERMOCYCLER, TEMPDECK, MAGDECK } from '../../modules/constants'
 import { selectors as robotSelectors } from '../../robot'
 import { TempDeckCard } from './TempDeckCard'
 import { MagDeckCard } from './MagDeckCard'

--- a/app/src/components/ModuleLiveStatusCards/index.js
+++ b/app/src/components/ModuleLiveStatusCards/index.js
@@ -5,11 +5,12 @@ import { useSelector } from 'react-redux'
 import {
   useSendModuleCommand,
   getAttachedModulesForConnectedRobot,
+} from '../../modules'
+import {
   THERMOCYCLER,
   TEMPDECK,
   MAGDECK,
-} from '../../modules'
-
+} from '@opentrons/shared-data/js/constants'
 import { selectors as robotSelectors } from '../../robot'
 import { TempDeckCard } from './TempDeckCard'
 import { MagDeckCard } from './MagDeckCard'

--- a/app/src/components/ModuleLiveStatusCards/index.js
+++ b/app/src/components/ModuleLiveStatusCards/index.js
@@ -6,11 +6,7 @@ import {
   useSendModuleCommand,
   getAttachedModulesForConnectedRobot,
 } from '../../modules'
-import {
-  THERMOCYCLER,
-  TEMPDECK,
-  MAGDECK,
-} from '@opentrons/shared-data/js/constants'
+import { THERMOCYCLER, TEMPDECK, MAGDECK } from '../../modules/constants'
 import { selectors as robotSelectors } from '../../robot'
 import { TempDeckCard } from './TempDeckCard'
 import { MagDeckCard } from './MagDeckCard'

--- a/app/src/components/PrepareModules/index.js
+++ b/app/src/components/PrepareModules/index.js
@@ -12,7 +12,7 @@ import { sendModuleCommand } from '../../modules'
 import DeckMap from '../DeckMap'
 import styles from './styles.css'
 import { Portal } from '../portal'
-
+import { THERMOCYCLER } from '@opentrons/shared-data/js/constants'
 import type { Dispatch } from '../../types'
 import type { AttachedModule } from '../../modules/types'
 
@@ -36,7 +36,7 @@ export function PrepareModules(props: Props) {
 
   const handleOpenLidClick = () => {
     modules
-      .filter(mod => mod.name === 'thermocycler')
+      .filter(mod => mod.name === THERMOCYCLER)
       .forEach(mod =>
         dispatch(sendModuleCommand(robotName, mod.serial, 'open'))
       )

--- a/app/src/components/PrepareModules/index.js
+++ b/app/src/components/PrepareModules/index.js
@@ -12,7 +12,7 @@ import { sendModuleCommand } from '../../modules'
 import DeckMap from '../DeckMap'
 import styles from './styles.css'
 import { Portal } from '../portal'
-import { THERMOCYCLER } from '@opentrons/shared-data/js/constants'
+import { THERMOCYCLER } from '../../modules/constants'
 import type { Dispatch } from '../../types'
 import type { AttachedModule } from '../../modules/types'
 

--- a/app/src/components/PrepareModules/index.js
+++ b/app/src/components/PrepareModules/index.js
@@ -8,11 +8,10 @@ import {
   Icon,
 } from '@opentrons/components'
 
-import { sendModuleCommand } from '../../modules'
+import { THERMOCYCLER, sendModuleCommand } from '../../modules'
 import DeckMap from '../DeckMap'
 import styles from './styles.css'
 import { Portal } from '../portal'
-import { THERMOCYCLER } from '../../modules/constants'
 import type { Dispatch } from '../../types'
 import type { AttachedModule } from '../../modules/types'
 

--- a/app/src/components/ReviewDeck/index.js
+++ b/app/src/components/ReviewDeck/index.js
@@ -11,7 +11,7 @@ import {
   selectors as robotSelectors,
 } from '../../robot'
 import secureTCLatchSrc from '../../img/secure_tc_latch.png'
-import { THERMOCYCLER } from '@opentrons/shared-data/js/constants'
+import { THERMOCYCLER } from '../../modules/constants'
 
 import { Portal } from '../portal'
 import DeckMap from '../DeckMap'

--- a/app/src/components/ReviewDeck/index.js
+++ b/app/src/components/ReviewDeck/index.js
@@ -11,6 +11,7 @@ import {
   selectors as robotSelectors,
 } from '../../robot'
 import secureTCLatchSrc from '../../img/secure_tc_latch.png'
+import { THERMOCYCLER } from '@opentrons/shared-data/js/constants'
 
 import { Portal } from '../portal'
 import DeckMap from '../DeckMap'
@@ -31,7 +32,7 @@ function ReviewDeck(props: Props) {
 
   const mustPrepNestedLabware = some(
     sessionModules,
-    mod => mod.name === 'thermocycler'
+    mod => mod.name === THERMOCYCLER
   )
 
   const currentLabware = allLabware.find(lw => lw.slot === slot)

--- a/app/src/components/ReviewDeck/index.js
+++ b/app/src/components/ReviewDeck/index.js
@@ -11,7 +11,7 @@ import {
   selectors as robotSelectors,
 } from '../../robot'
 import secureTCLatchSrc from '../../img/secure_tc_latch.png'
-import { THERMOCYCLER } from '../../modules/constants'
+import { THERMOCYCLER } from '../../modules'
 
 import { Portal } from '../portal'
 import DeckMap from '../DeckMap'

--- a/app/src/modules/constants.js
+++ b/app/src/modules/constants.js
@@ -1,6 +1,12 @@
 // @flow
 import { THERMOCYCLER } from '@opentrons/shared-data'
 
+// common constants
+
+export const PREPARABLE_MODULES = [THERMOCYCLER]
+
+export { MAGDECK, TEMPDECK, THERMOCYCLER } from '@opentrons/shared-data'
+
 // http paths
 
 export const MODULES_PATH: '/modules' = '/modules'
@@ -25,7 +31,3 @@ export const SEND_MODULE_COMMAND_SUCCESS: 'modules:SEND_MODULE_COMMAND_SUCCESS' 
 
 export const SEND_MODULE_COMMAND_FAILURE: 'modules:SEND_MODULE_COMMAND_FAILURE' =
   'modules:SEND_MODULE_COMMAND_FAILURE'
-
-export const PREPARABLE_MODULES = [THERMOCYCLER]
-
-export { MAGDECK, TEMPDECK, THERMOCYCLER } from '@opentrons/shared-data'

--- a/app/src/modules/constants.js
+++ b/app/src/modules/constants.js
@@ -1,10 +1,9 @@
 // @flow
+import { THERMOCYCLER } from '@opentrons/shared-data'
 
 // http paths
 
 export const MODULES_PATH: '/modules' = '/modules'
-
-// action type strings
 
 // fetch modules
 
@@ -26,3 +25,7 @@ export const SEND_MODULE_COMMAND_SUCCESS: 'modules:SEND_MODULE_COMMAND_SUCCESS' 
 
 export const SEND_MODULE_COMMAND_FAILURE: 'modules:SEND_MODULE_COMMAND_FAILURE' =
   'modules:SEND_MODULE_COMMAND_FAILURE'
+
+export const PREPARABLE_MODULES = [THERMOCYCLER]
+
+export { MAGDECK, TEMPDECK, THERMOCYCLER } from '@opentrons/shared-data'

--- a/app/src/modules/constants.js
+++ b/app/src/modules/constants.js
@@ -1,15 +1,5 @@
 // @flow
 
-// common constants
-
-export const THERMOCYCLER: 'thermocycler' = 'thermocycler'
-
-export const TEMPDECK: 'tempdeck' = 'tempdeck'
-
-export const MAGDECK: 'magdeck' = 'magdeck'
-
-export const PREPARABLE_MODULES = [THERMOCYCLER]
-
 // http paths
 
 export const MODULES_PATH: '/modules' = '/modules'

--- a/app/src/modules/selectors.js
+++ b/app/src/modules/selectors.js
@@ -4,11 +4,14 @@ import sortBy from 'lodash/sortBy'
 import countBy from 'lodash/countBy'
 
 import { selectors as RobotSelectors } from '../robot'
-import * as Constants from './constants'
 import * as Types from './types'
 
 import type { State } from '../types'
 import type { SessionModule } from '../robot/types'
+import {
+  PREPARABLE_MODULES,
+  THERMOCYCLER,
+} from '@opentrons/shared-data/js/constants'
 
 export const getAttachedModules: (
   state: State,
@@ -27,7 +30,7 @@ export const getAttachedModulesForConnectedRobot = (
 }
 
 const isModulePrepared = (module: Types.AttachedModule): boolean => {
-  if (module.name === 'thermocycler') return module.data.lid === 'open'
+  if (module.name === THERMOCYCLER) return module.data.lid === 'open'
   return false
 }
 
@@ -38,7 +41,7 @@ export const getUnpreparedModules: (
   RobotSelectors.getModules,
   (attachedModules, protocolModules) => {
     const preparableSessionModules = protocolModules
-      .filter(m => Constants.PREPARABLE_MODULES.includes(m.name))
+      .filter(m => PREPARABLE_MODULES.includes(m.name))
       .map(m => m.name)
 
     // return actual modules that are both

--- a/app/src/modules/selectors.js
+++ b/app/src/modules/selectors.js
@@ -8,10 +8,7 @@ import * as Types from './types'
 
 import type { State } from '../types'
 import type { SessionModule } from '../robot/types'
-import {
-  PREPARABLE_MODULES,
-  THERMOCYCLER,
-} from '@opentrons/shared-data/js/constants'
+import { PREPARABLE_MODULES, THERMOCYCLER } from './constants'
 
 export const getAttachedModules: (
   state: State,

--- a/app/src/modules/types.js
+++ b/app/src/modules/types.js
@@ -1,4 +1,9 @@
 // @flow
+import {
+  MAGDECK,
+  TEMPDECK,
+  THERMOCYCLER,
+} from '@opentrons/shared-data/js/constants'
 
 import type { RobotApiRequestMeta } from '../robot-api/types'
 
@@ -55,21 +60,21 @@ export type MagneticStatus = 'engaged' | 'disengaged'
 
 export type TemperatureModule = {|
   ...BaseModule,
-  name: 'tempdeck',
+  name: typeof TEMPDECK,
   data: TemperatureData,
   status: TemperatureStatus,
 |}
 
 export type MagneticModule = {|
   ...BaseModule,
-  name: 'magdeck',
+  name: typeof MAGDECK,
   data: MagneticData,
   status: MagneticStatus,
 |}
 
 export type ThermocyclerModule = {|
   ...BaseModule,
-  name: 'thermocycler',
+  name: typeof THERMOCYCLER,
   data: ThermocyclerData,
   status: ThermocyclerStatus,
 |}

--- a/app/src/modules/types.js
+++ b/app/src/modules/types.js
@@ -1,11 +1,7 @@
 // @flow
-import {
-  MAGDECK,
-  TEMPDECK,
-  THERMOCYCLER,
-} from '@opentrons/shared-data/js/constants'
 
 import type { RobotApiRequestMeta } from '../robot-api/types'
+import typeof { MAGDECK, TEMPDECK, THERMOCYCLER } from './constants'
 
 // common types
 
@@ -60,21 +56,21 @@ export type MagneticStatus = 'engaged' | 'disengaged'
 
 export type TemperatureModule = {|
   ...BaseModule,
-  name: typeof TEMPDECK,
+  name: TEMPDECK,
   data: TemperatureData,
   status: TemperatureStatus,
 |}
 
 export type MagneticModule = {|
   ...BaseModule,
-  name: typeof MAGDECK,
+  name: MAGDECK,
   data: MagneticData,
   status: MagneticStatus,
 |}
 
 export type ThermocyclerModule = {|
   ...BaseModule,
-  name: typeof THERMOCYCLER,
+  name: THERMOCYCLER,
   data: ThermocyclerData,
   status: ThermocyclerStatus,
 |}

--- a/shared-data/js/constants.js
+++ b/shared-data/js/constants.js
@@ -18,5 +18,3 @@ export const THERMOCYCLER: 'thermocycler' = 'thermocycler'
 export const TEMPDECK: 'tempdeck' = 'tempdeck'
 
 export const MAGDECK: 'magdeck' = 'magdeck'
-
-export const PREPARABLE_MODULES = [THERMOCYCLER]

--- a/shared-data/js/constants.js
+++ b/shared-data/js/constants.js
@@ -12,3 +12,11 @@ export const SLOT_RENDER_HEIGHT = SLOT_WIDTH_MM // along Y axis in SVG coords
 export const FIXED_TRASH_RENDER_HEIGHT = 165.86 // along Y axis in SVG coords
 
 export const OPENTRONS_LABWARE_NAMESPACE = 'opentrons'
+
+export const THERMOCYCLER: 'thermocycler' = 'thermocycler'
+
+export const TEMPDECK: 'tempdeck' = 'tempdeck'
+
+export const MAGDECK: 'magdeck' = 'magdeck'
+
+export const PREPARABLE_MODULES = [THERMOCYCLER]

--- a/shared-data/js/types.js
+++ b/shared-data/js/types.js
@@ -1,4 +1,5 @@
 // @flow
+import { MAGDECK, TEMPDECK, THERMOCYCLER } from './constants'
 // TODO Ian 2019-06-04 split this out into eg ../labware/flowTypes/labwareV1.js
 export type WellDefinition = {
   diameter?: number, // NOTE: presence of diameter indicates a circular well
@@ -144,7 +145,7 @@ export type LabwareDefinition2 = {|
   groups: Array<LabwareWellGroup>,
 |}
 
-export type ModuleType = 'magdeck' | 'tempdeck' | 'thermocycler'
+export type ModuleType = typeof MAGDECK | typeof TEMPDECK | typeof THERMOCYCLER
 
 export type DeckOffset = {|
   x: number,

--- a/shared-data/js/types.js
+++ b/shared-data/js/types.js
@@ -1,5 +1,5 @@
 // @flow
-import { MAGDECK, TEMPDECK, THERMOCYCLER } from './constants'
+import typeof { MAGDECK, TEMPDECK, THERMOCYCLER } from './constants'
 // TODO Ian 2019-06-04 split this out into eg ../labware/flowTypes/labwareV1.js
 export type WellDefinition = {
   diameter?: number, // NOTE: presence of diameter indicates a circular well
@@ -145,7 +145,7 @@ export type LabwareDefinition2 = {|
   groups: Array<LabwareWellGroup>,
 |}
 
-export type ModuleType = typeof MAGDECK | typeof TEMPDECK | typeof THERMOCYCLER
+export type ModuleType = MAGDECK | TEMPDECK | THERMOCYCLER
 
 export type DeckOffset = {|
   x: number,


### PR DESCRIPTION
## overview
Uses defined constants for tempdeck, magdeck, and thermocycler strings. 

## review requests
It looks like test coverage should catch anything that would affect the selector (getUnpreparedModules), and the rest affects the components. 

However, to properly validate that this doesn't break anything, we should probably run protocols that use each of the modules (temp + mag + thermocycler). 

Other parts of the monorepo should also use these same constants, but I'm breaking up the refactor by each of the subrepos. 