### PR TITLE
fix(api): do not pick up returned tips

### DIFF
--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -76,6 +76,36 @@ To retun the tip to the original location, you can call :py:meth:`.InstrumentCon
     pipette.pick_up_tip(tiprack['A3'])
     pipette.return_tip()
 
+.. note:
+
+    In API Version 2.0 and 2.1, the returned tips are added back into the tip-tracker and thus treated as `unused`. If you make a subsequent call to `pick_up_tip` then the software will treat returned tips as valid locations.
+    In API Version 2.2, returned tips are no longer added back into the tip tracker. This means that returned tips are no longer valid locations and the pipette will not attempt to pick up tips from these locations. 
+
+In API version 2.2 or above:
+
+.. code-block:: python
+
+    tip_rack = protocol.load_labware(
+            'opentrons_96_tiprack_300ul', 1)
+    pipette = protocol.load_instrument(
+        'p300_single_gen2', mount='left', tip_racks=[tip_rack])
+
+    pipette.pick_up_tip() # picks up tip_rack:A1
+    pipette.return_tip()
+    pipette.pick_up_tip() # picks up tip_rack:B1
+
+In API version 2.0 and 2.1:
+
+.. code-block:: python
+
+    tip_rack = protocol.load_labware(
+            'opentrons_96_tiprack_300ul', 1)
+    pipette = protocol.load_instrument(
+        'p300_single_gen2', mount='left', tip_racks=[tip_rack])
+
+    pipette.pick_up_tip() # picks up tip_rack:A1
+    pipette.return_tip()
+    pipette.pick_up_tip() # picks up tip_rack:A1
 
 Iterating Through Tips
 ----------------------
@@ -121,10 +151,6 @@ If you try to :py:meth:`.InstrumentContext.pick_up_tip()` again when all the tip
 
     # this will raise an exception if run after the previous code block
     pipette.pick_up_tip()
-
-.. note:
-
-    In API Version 2.0 and 2.1, the returned tip would be picked up by a subsequent ``pick_up_tip()`` call. The above example in versions 2.0 and 2.1 would not iterate through the list of tip racks as described. This bug has been fixed since API version 2.2, so that the next unused tip will be picked up after a tip is returned.
 
 To change the location of the first tip used by the pipette, you can use :py:attr:`.InstrumentContext.starting_tip`:
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -122,6 +122,10 @@ If you try to :py:meth:`.InstrumentContext.pick_up_tip()` again when all the tip
     # this will raise an exception if run after the previous code block
     pipette.pick_up_tip()
 
+.. note:
+
+    In API Version 2.0 and 2.1, the returned tip would be picked up by a subsequent ``pick_up_tip()`` call. The above example in versions 2.0 and 2.1 would not iterate through the list of tip racks as described. This bug has been fixed since API version 2.2, so that the next unused tip will be picked up after a tip is returned.
+
 To change the location of the first tip used by the pipette, you can use :py:attr:`.InstrumentContext.starting_tip`:
 
 .. code-block:: python

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1358,18 +1358,6 @@ class InstrumentContext(CommandPublisher):
         self._hw_manager.hardware.drop_tip(self._mount, home_after=home_after)
         cmds.do_publish(self.broker, cmds.drop_tip, self.drop_tip,
                         'after', self, None, self, location=target)
-        if isinstance(target.labware, Well)\
-           and target.labware.parent.is_tiprack:
-            # If this is a tiprack we can try and add the tip back to the
-            # tracker
-            try:
-                target.labware.parent.return_tips(
-                    target.labware, self.channels)
-            except AssertionError:
-                # Similarly to :py:meth:`return_tips`, the failure case here
-                # just means the tip can't be reused, so don't actually stop
-                # the protocol
-                self._log.exception(f'Could not return tip to {target}')
         self._last_tip_picked_up_from = None
         return self
 

--- a/api/src/opentrons/protocol_api/definitions.py
+++ b/api/src/opentrons/protocol_api/definitions.py
@@ -1,4 +1,4 @@
 from ..protocols import types
 
-MAX_SUPPORTED_VERSION = types.APIVersion(2, 1)
+MAX_SUPPORTED_VERSION = types.APIVersion(2, 2)
 #: The maximum supported protocol API version in this release

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -200,9 +200,10 @@ def test_pick_up_and_drop_tip(loop, get_labware_def):
     new_offset = model_offset - Point(0, 0,
                                       tip_length-overlap)
     assert pipette.critical_point() == new_offset
+    assert pipette.has_tip
 
     instr.drop_tip(target_location)
-    assert tiprack.wells()[0].has_tip
+    assert not pipette.has_tip
     assert pipette.critical_point() == model_offset
 
 
@@ -227,7 +228,6 @@ def test_return_tip(loop, get_labware_def):
 
     instr.return_tip()
     assert not pipette.has_tip
-    assert tiprack.wells()[0].has_tip
 
 
 def test_use_filter_tips(loop, get_labware_def):
@@ -285,7 +285,7 @@ def test_pick_up_tip_no_location(loop, get_labware_def,
 
     # TODO: remove argument and verify once trash container is added
     instr.drop_tip(tiprack1.wells()[0].top())
-    assert tiprack1.wells()[0].has_tip
+    assert not pipette.has_tip
     assert pipette.critical_point() == model_offset
 
     for well in tiprack1.wells():


### PR DESCRIPTION
## overview
Currently in APIv2, after a tip is returned, the tip is added back to the tip tracker and will again be picked up by the subsequent `pick_up_tip` call. The documentations however states that the next unused tip will be picked up instead.

This PR closes #4668 by not adding the tip back to the tracker for API version 2.2 and above. A note has been added to the documentations to notify users of the changes made. 

## review request
- confirm that the next unused tip is being picked up in version 2.2 rather than the returned tip
