### PR TITLE
fix(app): add spinner to "Save" button in Pipette Settings

### DIFF
--- a/app/src/components/ConfigurePipette/ConfigErrorBanner.js
+++ b/app/src/components/ConfigurePipette/ConfigErrorBanner.js
@@ -2,37 +2,31 @@
 import * as React from 'react'
 import { AlertItem } from '@opentrons/components'
 import styles from './styles.css'
-type Props = {
+
+type Props = {|
   message: ?string,
-}
-type State = { dismissed: boolean }
+|}
 
 const TITLE = 'Error updating pipette settings'
-export default class ConfigBanner extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props)
-    this.state = { dismissed: false }
-  }
 
-  render() {
-    const { message } = this.props
-    const isVisible = message && !this.state.dismissed
-    if (!isVisible) return null
+export function ConfigErrorBanner(props: Props) {
+  const { message } = props
+  const [dismissed, setDismissed] = React.useState(false)
+  if (message == null || dismissed) return null
 
-    return (
-      <AlertItem
-        type="warning"
-        onCloseClick={() => this.setState({ dismissed: true })}
-        title={TITLE}
-      >
-        <p className={styles.config_submit_error}>
-          Some of the pipette config settings submitted were not valid.
-        </p>
-        <p className={styles.config_submit_error}>
-          <strong>ERROR: {message}</strong>
-        </p>
-        <p className={styles.config_submit_error}>Please contact support.</p>
-      </AlertItem>
-    )
-  }
+  return (
+    <AlertItem
+      type="warning"
+      onCloseClick={() => setDismissed(true)}
+      title={TITLE}
+    >
+      <p className={styles.config_submit_error}>
+        Some of the pipette config settings submitted were not valid.
+      </p>
+      <p className={styles.config_submit_error}>
+        <strong>ERROR: {message}</strong>
+      </p>
+      <p className={styles.config_submit_error}>Please contact support.</p>
+    </AlertItem>
+  )
 }

--- a/app/src/components/ConfigurePipette/ConfigForm.js
+++ b/app/src/components/ConfigurePipette/ConfigForm.js
@@ -11,6 +11,7 @@ import omit from 'lodash/omit'
 import set from 'lodash/set'
 import isEmpty from 'lodash/isEmpty'
 
+import { Icon } from '@opentrons/components'
 import FormButtonBar from './FormButtonBar'
 import ConfigFormGroup, {
   FormColumn,
@@ -39,6 +40,7 @@ export type DisplayQuirkFieldProps = {|
 
 type Props = {|
   settings: PipetteSettingsFieldsMap,
+  updateInProgress: boolean,
   updateSettings: (fields: PipetteSettingsFieldsUpdate) => mixed,
   closeModal: () => mixed,
   __showHiddenFields: boolean,
@@ -49,7 +51,7 @@ const POWER_KEYS = ['plungerCurrent', 'pickUpCurrent', 'dropTipCurrent']
 const TIP_KEYS = ['dropTipSpeed', 'pickUpDistance']
 const QUIRK_KEY = 'quirks'
 
-export default class ConfigForm extends React.Component<Props> {
+export class ConfigForm extends React.Component<Props> {
   getFieldsByKey(
     keys: Array<string>,
     fields: PipetteSettingsFieldsMap
@@ -175,7 +177,7 @@ export default class ConfigForm extends React.Component<Props> {
   }
 
   render() {
-    const { closeModal } = this.props
+    const { updateInProgress, closeModal } = this.props
     const fields = this.getVisibleFields()
     const UNKNOWN_KEYS = this.getUnknownKeys()
     const plungerFields = this.getFieldsByKey(PLUNGER_KEYS, fields)
@@ -240,9 +242,22 @@ export default class ConfigForm extends React.Component<Props> {
                   {
                     children: 'reset all',
                     onClick: handleReset,
+                    disabled: updateInProgress,
                   },
-                  { children: 'cancel', onClick: closeModal },
-                  { children: 'save', type: 'submit', disabled: disableSubmit },
+                  {
+                    children: 'cancel',
+                    onClick: closeModal,
+                    disabled: updateInProgress,
+                  },
+                  {
+                    type: 'submit',
+                    disabled: disableSubmit || updateInProgress,
+                    children: updateInProgress ? (
+                      <Icon name="ot-spinner" height="1em" spin />
+                    ) : (
+                      'save'
+                    ),
+                  },
                 ]}
               />
             </Form>

--- a/app/src/components/ConfigurePipette/ConfigMessage.js
+++ b/app/src/components/ConfigurePipette/ConfigMessage.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import styles from './styles.css'
 
 // TODO (ka 2019-2-12): Add intercom onClick to assistance text
-export default function ConfigMessage() {
+export function ConfigMessage() {
   return (
     <div className={styles.config_message}>
       <h3 className={styles.warning_title}>Warning:</h3>

--- a/app/src/components/ConfigurePipette/index.js
+++ b/app/src/components/ConfigurePipette/index.js
@@ -6,6 +6,7 @@ import last from 'lodash/last'
 import {
   SUCCESS,
   FAILURE,
+  PENDING,
   useDispatchApiRequest,
   getRequestById,
 } from '../../robot-api'
@@ -17,9 +18,9 @@ import {
 import { getConfig } from '../../config'
 
 import { ScrollableAlertModal } from '../modals'
-import ConfigMessage from './ConfigMessage'
-import ConfigForm from './ConfigForm'
-import ConfigErrorBanner from './ConfigErrorBanner'
+import { ConfigMessage } from './ConfigMessage'
+import { ConfigForm } from './ConfigForm'
+import { ConfigErrorBanner } from './ConfigErrorBanner'
 
 import type { State } from '../../types'
 
@@ -84,6 +85,7 @@ export function ConfigurePipette(props: Props) {
       {settings && (
         <ConfigForm
           settings={settings}
+          updateInProgress={updateRequest?.status === PENDING}
           updateSettings={updateSettings}
           closeModal={closeModal}
           __showHiddenFields={__showHiddenFields}


### PR DESCRIPTION
## overview

This PR adds a spinner to the "Save" button in Pipette Settings. Closes #4583

## review requests

- [ ] Save some pipette settings. The buttons should all disable and a spinner should show on the "Save" button while the save is in progress
