### PR TITLE
refactor(components): use defined constants for tempdeck, magdeck, th…

### DIFF
--- a/components/src/constants.js
+++ b/components/src/constants.js
@@ -1,4 +1,7 @@
 // @flow
+// common constants
+
+export { MAGDECK, TEMPDECK, THERMOCYCLER } from '@opentrons/shared-data'
 
 // ========= STYLE ================
 

--- a/components/src/constants.js
+++ b/components/src/constants.js
@@ -1,7 +1,4 @@
 // @flow
-// common constants
-
-export { MAGDECK, TEMPDECK, THERMOCYCLER } from '@opentrons/shared-data'
 
 // ========= STYLE ================
 

--- a/components/src/deck/Module.js
+++ b/components/src/deck/Module.js
@@ -2,13 +2,18 @@
 import React, { useMemo } from 'react'
 import cx from 'classnames'
 
-import { getModuleDisplayName, type ModuleType } from '@opentrons/shared-data'
+import {
+  getModuleDisplayName,
+  type ModuleType,
+  MAGDECK,
+  TEMPDECK,
+  THERMOCYCLER,
+} from '@opentrons/shared-data'
 import { getDeckDefinitions } from '@opentrons/components/src/deck/getDeckDefinitions'
 
 import { Icon } from '../icons'
 import RobotCoordsForeignDiv from './RobotCoordsForeignDiv'
 import styles from './Module.css'
-import { MAGDECK, TEMPDECK, THERMOCYCLER } from '../constants'
 
 export type Props = {
   /** name of module, eg 'magdeck', 'tempdeck', or 'thermocycler' */

--- a/components/src/deck/Module.js
+++ b/components/src/deck/Module.js
@@ -8,6 +8,7 @@ import { getDeckDefinitions } from '@opentrons/components/src/deck/getDeckDefini
 import { Icon } from '../icons'
 import RobotCoordsForeignDiv from './RobotCoordsForeignDiv'
 import styles from './Module.css'
+import { MAGDECK, TEMPDECK, THERMOCYCLER } from '../constants'
 
 export type Props = {
   /** name of module, eg 'magdeck', 'tempdeck', or 'thermocycler' */
@@ -28,21 +29,21 @@ export default function Module(props: Props) {
   } = deckDef?.locations?.orderedSlots[0]?.boundingBox
 
   switch (props.name) {
-    case 'magdeck': {
+    case MAGDECK: {
       width = 137
       height = 91
       x = -7
       y = 4
       break
     }
-    case 'tempdeck': {
+    case TEMPDECK: {
       width = 196
       height = 91
       x = -66
       y = 4
       break
     }
-    case 'thermocycler': {
+    case THERMOCYCLER: {
       // TODO: BC 2019-07-24 these are taken from snapshots of the cad file, they should
       // be included in the module spec schema and added to the data
       width = 172


### PR DESCRIPTION
## overview
Following [this PR](https://github.com/Opentrons/opentrons/pull/4680) cleaning up magic strings

Uses defined constants for tempdeck, magdeck, and thermocycler strings. 

I reexported these constants from inside of the `components` subrepo, but open to just importing them from `shared-data/constants` directly.

## review requests
code review

this affects the [`Module` component ](https://s3-us-west-2.amazonaws.com/opentrons-components/edge/index.html#module) so just double check that each module renders properly in the run app