### PR TITLE
fix(api): properly clean up threads in opentrons_simulate, _execute

### DIFF
--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -301,6 +301,7 @@ def execute(protocol_file: TextIO,
                 commands.command_types.COMMAND, emit_runlog)
         context.home()
         execute_apiv2.run_protocol(protocol, context)
+        context.cleanup()
 
 
 def make_runlog_cb():

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -163,6 +163,12 @@ class ProtocolContext(CommandPublisher):
         """
         return self._bundled_data
 
+    def cleanup(self):
+        """ Finalize and clean up the protocol context. """
+        if self._unsubscribe_commands:
+            self._unsubscribe_commands()
+        self._hw_manager.cleanup()
+
     def __del__(self):
         if getattr(self, '_unsubscribe_commands', None):
             self._unsubscribe_commands()

--- a/api/src/opentrons/protocol_api/util.py
+++ b/api/src/opentrons/protocol_api/util.py
@@ -205,7 +205,7 @@ class HardwareManager:
         return self._current
 
     def set_hw(self, hardware):
-        if (self._is_orig or self._built_own_adapter):
+        if self._current and (self._is_orig or self._built_own_adapter):
             self._current.join()
         if isinstance(hardware, adapters.SynchronousAdapter):
             self._current = hardware

--- a/api/src/opentrons/protocol_api/util.py
+++ b/api/src/opentrons/protocol_api/util.py
@@ -188,46 +188,58 @@ class HardwareManager:
     def __init__(self, hardware):
         if None is hardware:
             self._is_orig = True
+            self._built_own_adapter = True
             self._current = adapters.SynchronousAdapter.build(
                 API.build_hardware_simulator)
         elif isinstance(hardware, adapters.SynchronousAdapter):
             self._is_orig = False
             self._current = hardware
+            self._built_own_adapter = False
         else:
             self._is_orig = False
             self._current = adapters.SynchronousAdapter(hardware)
+            self._built_own_adapter = True
 
     @property
     def hardware(self):
         return self._current
 
     def set_hw(self, hardware):
-        if self._is_orig:
-            self._is_orig = False
+        if (self._is_orig or self._built_own_adapter):
             self._current.join()
         if isinstance(hardware, adapters.SynchronousAdapter):
             self._current = hardware
+            self._built_own_adapter = False
         elif isinstance(hardware, HardwareAPILike):
             self._current = adapters.SynchronousAdapter(hardware)
+            self._built_own_adapter = True
         else:
             raise TypeError(
                 "hardware should be API or synch adapter but is {}"
                 .format(hardware))
+        self._is_orig = False
         return self._current
 
     def reset_hw(self):
-        if self._is_orig:
+        if self._is_orig or self._built_own_adapter:
             self._current.join()
         self._current = adapters.SynchronousAdapter.build(
             API.build_hardware_simulator)
         self._is_orig = True
+        self._built_own_adapter = True
         return self._current
 
     def __del__(self):
         orig = getattr(self, '_is_orig', False)
         cur = getattr(self, '_current', None)
-        if orig and cur:
+        built_own = getattr(self, '_built_own_adapter')
+        if cur and (orig or built_own):
             cur.join()
+
+    def cleanup(self):
+        """ Call to cleanup attached hardware (if it was created locally) """
+        if self._current and (self._is_orig or self._built_own_adapter):
+            self._current.join()
 
 
 def clamp_value(

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -320,6 +320,7 @@ def simulate(protocol_file: TextIO,
            and allow_bundle():
             bundle_contents = bundle_from_sim(
                 protocol, context)
+        context.cleanup()
 
     return scraper.commands, bundle_contents
 

--- a/api/tests/opentrons/protocol_api/test_util.py
+++ b/api/tests/opentrons/protocol_api/test_util.py
@@ -8,6 +8,7 @@ def test_hw_manager(loop):
     # When built without an input it should build its own adapter
     mgr = HardwareManager(None)
     assert mgr._is_orig
+    assert mgr._built_own_adapter
     adapter = mgr.hardware
     # When "disconnecting" from its own simulator, the adapter should
     # be stopped and a new one created
@@ -18,26 +19,33 @@ def test_hw_manager(loop):
     # When deleted, the self-created adapter should be stopped
     del mgr
     assert not new.is_alive()
-    # When built with a hardware API input it should wrap it but not
-    # build its own
+
+    # When built with a hardware API input it should wrap it with a new
+    # synchronous adapter and not build its own API
     mgr = HardwareManager(
         API.build_hardware_simulator(loop=loop))
     assert isinstance(mgr.hardware, adapters.SynchronousAdapter)
     assert not mgr._is_orig
+    assert mgr._built_own_adapter
     passed = mgr.hardware
     # When disconnecting from a real external adapter, it should create
-    # its own simulator and should _not_ stop the old hardware thread
+    # its own simulator and should stop the old hardware thread
     new = mgr.reset_hw()
     assert new is not passed
     assert mgr._is_orig
-    assert passed.is_alive()
+    assert mgr._built_own_adapter
+    assert not passed.is_alive()
+
+    sa = adapters.SynchronousAdapter.build(API.build_hardware_simulator)
     # When connecting to an adapter it shouldn’t rewrap it
-    assert mgr.set_hw(passed) is passed
+    assert mgr.set_hw(sa) is sa
     # And should kill its old one
     assert not new.is_alive()
+    # it should know it didn't build its own adapter
+    assert not mgr._built_own_adapter
     del mgr
     # but not its new one, even if deleted
-    assert passed.is_alive()
+    assert sa.is_alive()
 
 
 def test_max_speeds_userdict():


### PR DESCRIPTION
When these created synchronous adapter threads for hardware controllers, they
would never clean them up. This was fine on python 3.6 and 3.7 but not on
subsequent versions. We now clean them up properly.

Closes #4666 

## Testing
- simulate and (much less importantly since it always runs in a controlled environment) execute and make sure the program actually exits cleanly