### PR TITLE
perf(protocol-designer): improve timeline generation performance

### DIFF
--- a/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/forPickUpTip.js
+++ b/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/forPickUpTip.js
@@ -23,14 +23,15 @@ export function forPickUpTip(
     `forPickUpTip expected ${labware} to be a tiprack`
   )
 
-  const robotState = cloneDeep(prevRobotState)
+  // PERF: Only clone needed part of robot state
+  const tipState = cloneDeep(prevRobotState.tipState)
 
   // pipette now has tip(s)
-  robotState.tipState.pipettes[pipette] = true
+  tipState.pipettes[pipette] = true
 
   // remove tips from tiprack
   if (pipetteSpec.channels === 1) {
-    robotState.tipState.tipracks[labware][well] = false
+    tipState.tipracks[labware][well] = false
   } else if (pipetteSpec.channels === 8) {
     const allWells = tiprackDef.ordering.find(col => col[0] === well)
     if (!allWells) {
@@ -38,12 +39,12 @@ export function forPickUpTip(
       throw new Error('Invalid primary well for tip pickup: ' + well)
     }
     allWells.forEach(function(well) {
-      robotState.tipState.tipracks[labware][well] = false
+      tipState.tipracks[labware][well] = false
     })
   }
 
   return {
     warnings: [],
-    robotState,
+    robotState: { ...prevRobotState, tipState },
   }
 }

--- a/protocol-designer/src/step-generation/utils/reduceCommandCreators.js
+++ b/protocol-designer/src/step-generation/utils/reduceCommandCreators.js
@@ -1,5 +1,4 @@
 // @flow
-import cloneDeep from 'lodash/cloneDeep'
 import { getNextRobotStateAndWarnings } from '../getNextRobotStateAndWarnings'
 import type { Command } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
 import type {
@@ -57,7 +56,7 @@ export const reduceCommandCreators = (
       }
     },
     {
-      robotState: cloneDeep(initialRobotState),
+      robotState: initialRobotState,
       commands: [],
       errors: [],
       warnings: [],

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -224,11 +224,9 @@ function transferLikeSubsteps(args: {|
 
   // Add tips to pipettes, since this is just a "simulation"
   // TODO: Ian 2018-07-31 develop more elegant way to bypass tip handling for simulation/test
-  const robotState = cloneDeep(args.robotState)
-  robotState.tipState.pipettes = mapValues(
-    robotState.tipState.pipettes,
-    () => true
-  )
+  const tipState = cloneDeep(args.robotState.tipState)
+  tipState.pipettes = mapValues(tipState.pipettes, () => true)
+  const initialRobotState = { ...args.robotState, tipState }
   const { pipette: pipetteId } = stepArgs
 
   const pipetteSpec = invariantContext.pipetteEntities[pipetteId]?.spec
@@ -258,7 +256,7 @@ function transferLikeSubsteps(args: {|
     const substepRows: Array<SubstepTimelineFrame> = substepTimeline(
       substepCommandCreator,
       invariantContext,
-      robotState,
+      initialRobotState,
       pipetteSpec.channels
     )
 
@@ -282,7 +280,7 @@ function transferLikeSubsteps(args: {|
     const substepRows = substepTimeline(
       substepCommandCreator,
       invariantContext,
-      robotState,
+      initialRobotState,
       1
     )
 


### PR DESCRIPTION
## overview

Addresses #4697 but still slower than before the step-generation refactor


## review requests

To compare performance, save a protocol that uses a bunch of tips and does a bunch of transfers. Open it in `edge` and time it, then open it in this branch and time it. Should be noticably faster, but still slow.

Also:
- tip pickup behavior should not change
- substep generation should not change
