### PR TITLE
fix(app): clear lw calibration state if top level home is called

### DIFF
--- a/app/src/robot/reducer/calibration.js
+++ b/app/src/robot/reducer/calibration.js
@@ -4,6 +4,7 @@
 import mapValues from 'lodash/mapValues'
 
 import type { Action, Error } from '../../types'
+import { HOME } from '../../robot-controls'
 import type { Mount, Slot } from '../types'
 import { actionTypes } from '../actions'
 import type {
@@ -84,7 +85,7 @@ export default function calibrationReducer(
       return INITIAL_STATE
 
     // reset calibration state on robot home
-    case 'robotControls:HOME':
+    case HOME:
     case 'robot:CLEAR_CALIBRATION_REQUEST':
       return {
         ...state,

--- a/app/src/robot/reducer/calibration.js
+++ b/app/src/robot/reducer/calibration.js
@@ -84,6 +84,7 @@ export default function calibrationReducer(
       return INITIAL_STATE
 
     // reset calibration state on robot home
+    case 'robotControls:HOME':
     case 'robot:CLEAR_CALIBRATION_REQUEST':
       return {
         ...state,

--- a/app/src/robot/test/calibration-reducer.test.js
+++ b/app/src/robot/test/calibration-reducer.test.js
@@ -1,4 +1,5 @@
 // calibration reducer tests
+import { HOME } from '../../robot-controls'
 import { robotReducer as reducer, actionTypes } from '../'
 
 const EXPECTED_INITIAL_STATE = {
@@ -679,6 +680,29 @@ describe('robot reducer - calibration', () => {
 
     expect(reducer(state, action).calibration).toEqual({
       confirmedBySlot: { 5: true },
+    })
+  })
+
+  test('handles CLEAR_CALIBRATION_REQUEST and robot home actions', () => {
+    const state = {
+      calibration: {
+        calibrationRequest: {
+          type: 'JOG',
+          inProgress: true,
+          error: null,
+          mount: 'right',
+        },
+      },
+    }
+
+    const clearAction = { type: 'robot:CLEAR_CALIBRATION_REQUEST' }
+    expect(reducer(state, clearAction).calibration).toEqual({
+      calibrationRequest: { type: '', inProgress: false, error: null },
+    })
+
+    const homeAction = { type: HOME }
+    expect(reducer(state, homeAction).calibration).toEqual({
+      calibrationRequest: { type: '', inProgress: false, error: null },
     })
   })
 })


### PR DESCRIPTION
## overview

This should fix a behavior where a user starts labware calibration and exits the flow to home the robot from the robots tab, which breaks their calibration experience when they return. 
