### PR TITLE
feat(protocol-designer): Hide thermocycler functionality behind flag

### DIFF
--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -28,6 +28,7 @@ export type Props = {
   saveFileMetadata: FileMetadataFields => mixed,
   swapPipettes: () => mixed,
   modulesEnabled: ?boolean,
+  thermocyclerEnabled: ?boolean,
   modules: ModulesForEditModulesCard,
 }
 
@@ -206,6 +207,7 @@ class FilePage extends React.Component<Props, State> {
         {this.props.modulesEnabled && (
           <EditModulesCard
             modules={modules}
+            thermocyclerEnabled={this.props.thermocyclerEnabled}
             openEditModuleModal={this.handleEditModule}
           />
         )}

--- a/protocol-designer/src/components/modals/EditPipettesModal/index.js
+++ b/protocol-designer/src/components/modals/EditPipettesModal/index.js
@@ -29,6 +29,7 @@ type SP = {|
   _prevPipettes: { [pipetteId: string]: PipetteOnDeck },
   _orderedStepIds: Array<StepIdType>,
   modulesEnabled: ?boolean,
+  thermocyclerEnabled: ?boolean,
 |}
 
 type OP = {|
@@ -43,6 +44,7 @@ const mapSTP = (state: BaseState): SP => {
     _prevPipettes: stepFormSelectors.getInitialDeckSetup(state).pipettes, // TODO: Ian 2019-01-02 when multi-step editing is supported, don't use initial deck state. Instead, show the pipettes available for the selected step range
     _orderedStepIds: stepFormSelectors.getOrderedStepIds(state),
     modulesEnabled: featureFlagSelectors.getEnableModules(state),
+    thermocyclerEnabled: featureFlagSelectors.getEnableThermocycler(state),
   }
 }
 

--- a/protocol-designer/src/components/modals/FilePipettesModal/FilePipettesModal.css
+++ b/protocol-designer/src/components/modals/FilePipettesModal/FilePipettesModal.css
@@ -90,6 +90,10 @@
   flex-direction: row;
 }
 
+.hide_thermo {
+  justify-content: flex-start;
+}
+
 .module_form_group {
   width: 30%;
 

--- a/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import cx from 'classnames'
 import i18n from '../../../localization'
 import { CheckboxField, DropdownField, FormGroup } from '@opentrons/components'
 import { ModuleDiagram } from '../../modules'
@@ -11,18 +12,23 @@ import type { FormModulesByType } from '../../../step-forms'
 
 type Props = {|
   values: FormModulesByType,
+  thermocyclerEnabled: ?boolean,
   onFieldChange: (type: ModuleType, value: boolean) => mixed,
 |}
 
 export default function ModuleFields(props: Props) {
-  const { onFieldChange, values } = props
+  const { onFieldChange, values, thermocyclerEnabled } = props
   const modules = Object.keys(values)
   const handleOnDeckChange = (type: ModuleType) => (
     e: SyntheticInputEvent<HTMLInputElement>
   ) => onFieldChange(type, e.currentTarget.checked || false)
 
+  const className = cx(styles.modules_row, {
+    [styles.hide_thermo]: !thermocyclerEnabled,
+  })
+
   return (
-    <div className={styles.modules_row}>
+    <div className={className}>
       {modules.map((moduleType, i) => {
         const label = i18n.t(`modules.module_display_names.${moduleType}`)
         return (

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.js
@@ -1,6 +1,7 @@
 // @flow
 import assert from 'assert'
 import reduce from 'lodash/reduce'
+import omit from 'lodash/omit'
 import * as React from 'react'
 import cx from 'classnames'
 import { getCrashablePipetteSelected } from '../../../step-forms'
@@ -12,7 +13,7 @@ import {
   type Mount,
 } from '@opentrons/components'
 import i18n from '../../../localization'
-import { SPAN7_8_10_11_SLOT } from '../../../constants'
+import { SPAN7_8_10_11_SLOT, THERMO_TYPE } from '../../../constants'
 import StepChangesConfirmModal from '../EditPipettesModal/StepChangesConfirmModal'
 import ModuleFields from './ModuleFields'
 import PipetteFields from './PipetteFields'
@@ -58,6 +59,7 @@ type Props = {|
     modules: Array<ModuleCreationArgs>,
   |}) => mixed,
   modulesEnabled: ?boolean,
+  thermocyclerEnabled: ?boolean,
 |}
 
 const initialState: State = {
@@ -209,6 +211,10 @@ export default class FilePipettesModal extends React.Component<Props, State> {
       getCrashablePipetteSelected(this.state.pipettesByMount) &&
       this.getCrashableModuleSelected(this.state.modulesByType)
 
+    const visibleModules = this.props.thermocyclerEnabled
+      ? this.state.modulesByType
+      : omit(this.state.modulesByType, THERMO_TYPE)
+
     return (
       <React.Fragment>
         <Modal
@@ -262,7 +268,8 @@ export default class FilePipettesModal extends React.Component<Props, State> {
                       {i18n.t('modal.new_protocol.title.PROTOCOL_MODULES')}
                     </h2>
                     <ModuleFields
-                      values={this.state.modulesByType}
+                      values={visibleModules}
+                      thermocyclerEnabled={this.props.thermocyclerEnabled}
                       onFieldChange={this.handleModuleOnDeckChange}
                     />
                   </div>

--- a/protocol-designer/src/components/modals/NewFileModal/index.js
+++ b/protocol-designer/src/components/modals/NewFileModal/index.js
@@ -30,6 +30,7 @@ type SP = {|
   hideModal: $PropertyType<Props, 'hideModal'>,
   _hasUnsavedChanges: ?boolean,
   modulesEnabled: ?boolean,
+  thermocyclerEnabled: ?boolean,
 |}
 
 type DP = {|
@@ -48,6 +49,7 @@ function mapStateToProps(state: BaseState): SP {
     hideModal: !selectors.getNewProtocolModal(state),
     _hasUnsavedChanges: loadFileSelectors.getHasUnsavedChanges(state),
     modulesEnabled: featureFlagSelectors.getEnableModules(state),
+    thermocyclerEnabled: featureFlagSelectors.getEnableThermocycler(state),
   }
 }
 
@@ -108,6 +110,7 @@ function mergeProps(stateProps: SP, dispatchProps: DP, ownProps: OP): Props {
   return {
     ...ownProps,
     modulesEnabled: stateProps.modulesEnabled,
+    thermocyclerEnabled: stateProps.thermocyclerEnabled,
     showModulesFields: true,
     hideModal: stateProps.hideModal,
     onCancel: dispatchProps.onCancel,

--- a/protocol-designer/src/components/modules/EditModulesCard.js
+++ b/protocol-designer/src/components/modules/EditModulesCard.js
@@ -6,19 +6,25 @@ import styles from './styles.css'
 
 import type { ModuleType } from '@opentrons/shared-data'
 import { SUPPORTED_MODULE_TYPES } from '../../modules'
+import { THERMO_TYPE } from '../../constants'
 import type { ModulesForEditModulesCard } from '../../step-forms'
-
 type Props = {
   modules: ModulesForEditModulesCard,
+  thermocyclerEnabled: ?boolean,
   openEditModuleModal: (moduleType: ModuleType, moduleId?: string) => mixed,
 }
 
 export default function EditModulesCard(props: Props) {
-  const { modules, openEditModuleModal } = props
+  const { modules, thermocyclerEnabled, openEditModuleModal } = props
+
+  const visibleModules = thermocyclerEnabled
+    ? SUPPORTED_MODULE_TYPES
+    : SUPPORTED_MODULE_TYPES.filter(m => m !== THERMO_TYPE)
+
   return (
     <Card title="Modules">
       <div className={styles.modules_card_content}>
-        {SUPPORTED_MODULE_TYPES.map((moduleType, i) => {
+        {visibleModules.map((moduleType, i) => {
           const moduleData = modules[moduleType]
           if (moduleData) {
             return (

--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -20,6 +20,7 @@ type SP = {|
   formValues: $PropertyType<Props, 'formValues'>,
   _initialDeckSetup: InitialDeckSetup,
   modulesEnabled: ?boolean,
+  thermocyclerEnabled: ?boolean,
   modules: $PropertyType<Props, 'modules'>,
 |}
 
@@ -30,6 +31,7 @@ const mapStateToProps = (state: BaseState): SP => {
     modules: stepFormSelectors.getModulesForEditModulesCard(state),
     _initialDeckSetup: stepFormSelectors.getInitialDeckSetup(state),
     modulesEnabled: featureFlagSelectors.getEnableModules(state),
+    thermocyclerEnabled: featureFlagSelectors.getEnableThermocycler(state),
   }
 }
 

--- a/protocol-designer/src/feature-flags/reducers.js
+++ b/protocol-designer/src/feature-flags/reducers.js
@@ -16,6 +16,7 @@ const initialFlags: Flags = {
   OT_PD_ENABLE_MODULES: false,
   OT_PD_DISABLE_MODULE_RESTRICTIONS: false,
   OT_PD_ENABLE_MULTI_GEN2_PIPETTES: false,
+  OT_PD_ENABLE_THERMOCYCLER: false,
 }
 
 const flags = handleActions<Flags, any>(

--- a/protocol-designer/src/feature-flags/selectors.js
+++ b/protocol-designer/src/feature-flags/selectors.js
@@ -19,6 +19,11 @@ export const getDisableModuleRestrictions: Selector<?boolean> = createSelector(
   flags => flags.OT_PD_DISABLE_MODULE_RESTRICTIONS
 )
 
+export const getEnableThermocycler: Selector<?boolean> = createSelector(
+  getFeatureFlagData,
+  flags => flags.OT_PD_ENABLE_THERMOCYCLER
+)
+
 export const getEnableMultiGEN2Pipettes: Selector<?boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ENABLE_MULTI_GEN2_PIPETTES

--- a/protocol-designer/src/feature-flags/types.js
+++ b/protocol-designer/src/feature-flags/types.js
@@ -15,6 +15,7 @@ export type FlagTypes =
   | 'OT_PD_ENABLE_MODULES'
   | 'OT_PD_DISABLE_MODULE_RESTRICTIONS'
   | 'OT_PD_ENABLE_MULTI_GEN2_PIPETTES'
+  | 'OT_PD_ENABLE_THERMOCYCLER'
 
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: Array<FlagTypes> = [

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -12,6 +12,10 @@
     "description_1": "Turn off all restrictions on module placement and related pipette crash guidance.",
     "description_2": "NOT recommended! Switching from default positions may cause crashes and the Protocol Designer cannot yet give guidance on what to expect. Use at your own discretion. "
   },
+  "OT_PD_ENABLE_THERMOCYCLER": {
+    "title": "Enable thermocycler module",
+    "description": "Allow adding thermocycler modules and steps to protocols."
+  },
   "OT_PD_ENABLE_MULTI_GEN2_PIPETTES": {
     "title": "Enable multi GEN2 pipettes in PD",
     "description": "Allow multi GEN2 pipettes to be specified from Pipette Selection"


### PR DESCRIPTION
## overview

This PR closes #4695 by hiding the thermocycler module options for create/edit protocol behind a dev internal feature flag.

## changelog

- feat(protocol-designer): Hide thermocycler functionality behind flag

## review requests

Check settings. Ensure `Enable Thermocycler` feature flag is toggled OFF
- [ ] No thermocycler option available when creating a new protocol file (file creation modal)
- [ ] No thermocycler option available when editing a protocol file (file page)
- [ ] Can't reach any thermocycler specific steps (Thermocycler profile is disabled)

Toggle `Enable Thermocycler` feature flag ON
- [ ] Thermocycler option available when creating a new protocol file (file creation modal)
- [ ] Thermocycler option available when editing a protocol file (file page)
- [ ] Presence of a TC on deck enables temperature step button

Obviously, if you imported a file you created with the FF on, you will still see the TC on the deck and step generation regardless of the FF setting. That aside, please confirm this PR does not miss some weird edge case where TC stuff is visible with the flag off.