### PR TITLE
feat(api): apiv1: add height_from_base arg to magdeck.engage()

### DIFF
--- a/api/docs/v1/modules.rst
+++ b/api/docs/v1/modules.rst
@@ -227,11 +227,11 @@ You can also move the position of the magnets relative to the base of the labwar
     module.engage(height_from_base=7)
 
 The ``height_from_base`` should be specifed in mm from the bottom of the labware. A ``module.engage(height_from_base=0)``
-should move the top of the magnets to level with base of the labware.
+should move the tops of the magnets to level with base of the labware.
 
 .. note::
 
-    There is a +/- 1 mmm variance across magnetic module units, using ``height_from_base=0`` might not be able to get the magnets to completely flush with base of the labware. Please test before carrying out your experiment to ensure the magnets are at the desired height.
+    There is a +/- 1 mmm variance across magnetic module units, using ``height_from_base=0`` might not be able to get the magnets to completely flush with base of the labware. Please test before carrying out your experiment to ensure the desired engage height for your labware.
 
 
 .. note::

--- a/api/docs/v1/modules.rst
+++ b/api/docs/v1/modules.rst
@@ -220,10 +220,24 @@ You can also use a custom height parameter with engage():
 The height should be specified in mm from the magdeck home position (i.e. the position of magnets when power-cycled or
 disengaged)
 
-** Note **
-`engage()` and `engage(offset=y)` can only be used for labware that have default heights defined in the api. If your
-labware doesn't yet have a default height definition and your protocol uses either of those methods then you will get
-an error. Simply use the height parameter to provide a custom height for you labware in such a case.
+You can also move the position of the magnets relative to the base of the labware that is loaded on the module:
+
+.. code-block:: python
+
+    module.engage(height_from_base=7)
+
+The ``height_from_base`` should be specifed in mm from the bottom of the labware. A ``module.engage(height_from_base=0)``
+should move the top of the magnets to level with base of the labware.
+
+.. note::
+
+    There is a +/- 1 mmm variance across magnetic module units, using ``height_from_base=0`` might not be able to get the magnets to completely flush with base of the labware. Please test before carrying out your experiment to ensure the magnets are at the desired height.
+
+
+.. note::
+    `engage()` and `engage(offset=y)` can only be used for labware that have default heights defined in the api. If your
+    labware doesn't yet have a default height definition and your protocol uses either of those methods then you will get
+    an error. Simply use the height parameter to provide a custom height for you labware in such a case.
 
 Disengage
 =========

--- a/api/docs/v1/modules.rst
+++ b/api/docs/v1/modules.rst
@@ -237,7 +237,7 @@ should move the tops of the magnets to level with base of the labware.
 .. note::
     `engage()` and `engage(offset=y)` can only be used for labware that have default heights defined in the api. If your
     labware doesn't yet have a default height definition and your protocol uses either of those methods then you will get
-    an error. Simply use the height parameter to provide a custom height for you labware in such a case.
+    an error. Simply use the ``height`` or ``height_from_base`` parameter to provide a custom height for you labware in such a case.
 
 Disengage
 =========

--- a/api/src/opentrons/legacy_api/modules/magdeck.py
+++ b/api/src/opentrons/legacy_api/modules/magdeck.py
@@ -50,6 +50,8 @@ class MagDeck(commands.CommandPublisher):
         '''
         if 'height' in kwargs:
             height = kwargs.get('height')
+        elif 'height_from_base' in kwargs:
+            height = kwargs.get('height_from_base') + OFFSET_TO_LABWARE_BOTTOM
         else:
             try:
                 height = self.labware.get_children_list()[1].\
@@ -64,9 +66,7 @@ class MagDeck(commands.CommandPublisher):
                         self.labware.get_children_list()[1].get_name()))
             if 'offset' in kwargs:
                 height += kwargs.get('offset')
-            elif 'height_from_base' in kwargs:
-                height = kwargs.get('height_from_base') + \
-                    OFFSET_TO_LABWARE_BOTTOM
+
         if height > MAX_ENGAGE_HEIGHT or height < 0:
             raise ValueError('Invalid engage height. Should be 0 to {}'.format(
                 MAX_ENGAGE_HEIGHT))

--- a/api/src/opentrons/legacy_api/modules/magdeck.py
+++ b/api/src/opentrons/legacy_api/modules/magdeck.py
@@ -5,6 +5,7 @@ from opentrons import commands
 LABWARE_ENGAGE_HEIGHT = {
     'biorad-hardshell-96-PCR': 18}  # mm
 MAX_ENGAGE_HEIGHT = 45  # mm from home position
+OFFSET_TO_LABWARE_BOTTOM = 5  # mm from home position
 
 
 class MissingDevicePortError(Exception):
@@ -45,6 +46,7 @@ class MagDeck(commands.CommandPublisher):
             [engage(offset=2)]
         or  a 'height' value specified as mm from magdeck home position
             [engage(height=20)]
+        or a 'height_from_base' specified as mm from the bottom of the labware
         '''
         if 'height' in kwargs:
             height = kwargs.get('height')
@@ -62,6 +64,9 @@ class MagDeck(commands.CommandPublisher):
                         self.labware.get_children_list()[1].get_name()))
             if 'offset' in kwargs:
                 height += kwargs.get('offset')
+            if 'height_from_base' in kwargs:
+                height = kwargs.get('height_from_base') + \
+                    OFFSET_TO_LABWARE_BOTTOM
         if height > MAX_ENGAGE_HEIGHT or height < 0:
             raise ValueError('Invalid engage height. Should be 0 to {}'.format(
                 MAX_ENGAGE_HEIGHT))

--- a/api/src/opentrons/legacy_api/modules/magdeck.py
+++ b/api/src/opentrons/legacy_api/modules/magdeck.py
@@ -64,7 +64,7 @@ class MagDeck(commands.CommandPublisher):
                         self.labware.get_children_list()[1].get_name()))
             if 'offset' in kwargs:
                 height += kwargs.get('offset')
-            if 'height_from_base' in kwargs:
+            elif 'height_from_base' in kwargs:
                 height = kwargs.get('height_from_base') + \
                     OFFSET_TO_LABWARE_BOTTOM
         if height > MAX_ENGAGE_HEIGHT or height < 0:

--- a/api/tests/opentrons/labware/test_modules.py
+++ b/api/tests/opentrons/labware/test_modules.py
@@ -108,7 +108,7 @@ def test_run_tempdeck_connected(
 
 
 @pytest.mark.api1_only
-def test_load_correct_engage_height(robot, modules, labware):
+def test_load_correct_engage_height(robot, modules, labware, monkeypatch):
     robot.reset()
     md = modules.load('magdeck', '1')
     test_container = labware.load('biorad_96_wellplate_200ul_pcr',
@@ -116,6 +116,25 @@ def test_load_correct_engage_height(robot, modules, labware):
     assert test_container.magdeck_engage_height() == 18
     assert md.labware.get_children_list()[1].magdeck_engage_height() == \
         test_container.magdeck_engage_height()
+
+
+@pytest.mark.api1_only
+def test_use_correct_engage_height(robot, modules, labware):
+    robot.reset()
+    md = modules.load('magdeck', '1')
+    test_container = labware.load('biorad_96_wellplate_200ul_pcr',
+                                  '1', share=True)
+    md.engage()
+    assert md._height_shadow == test_container.magdeck_engage_height()
+
+    md.engage(height=test_container.magdeck_engage_height())
+    assert md._height_shadow == test_container.magdeck_engage_height()
+
+    md.engage(offset=-test_container.magdeck_engage_height())
+    assert md._height_shadow == 0
+
+    md.engage(height_from_base=10)
+    assert md._height_shadow == 15
 
 
 @pytest.fixture


### PR DESCRIPTION

## overview

This PR closes #4212 by adding a new argument to `magdeck.engage()` so users can specify the distance to move the magnets relative to the base of the labware that's on top of the module, instead of the home position of the magnets.

## review request
- `magdeck.engage(height_from_base=0)` should move the magnets so that the tops of the magnets are level with the ledge that the labware sits on in the module
- does the note make sense?