### PR TITLE
feat(api): apiv2: add height_from_base arg to MagneticModuleContext.engage()

### DIFF
--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -233,6 +233,14 @@ The :py:meth:`.MagneticModuleContext.engage` function raises the magnets to indu
 
         mag_mod.engage(height=18.5)
 
+   - You can also specify the height for the magnet to be raised from the base of the labware:
+
+    .. code-block:: python
+
+       mag_mod.engage(labware_base_offset=13.5)
+
+    .. versionadded:: 2.2
+
 .. note::
 
     Only certain labwares have defined engage heights for the Magnetic

--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -4,9 +4,14 @@
 Hardware Modules
 ################
 
+
 Modules are peripherals that attach to the OT-2 to extend its capabilities.
 
 We currently support the Temperature, Magnetic and Thermocycler Modules.
+
+************
+Module Setup
+************
 
 Loading your Module onto a deck
 ===============================
@@ -133,7 +138,7 @@ section, assume we have the following already:
 .. versionadded:: 2.0
 
 Set Temperature
-^^^^^^^^^^^^^^^
+===============
 
 To set the Temperature Module to 4 °C do the following:
 
@@ -150,7 +155,7 @@ This function will pause your protocol until your target temperature is reached.
 .. versionadded:: 2.0
 
 Read the Current Temperature
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+============================
 
 You can read the current real-time temperature of the Temperature Module using the :py:attr:`.TemperatureModuleContext.temperature` property:
 
@@ -161,7 +166,7 @@ You can read the current real-time temperature of the Temperature Module using t
 .. versionadded:: 2.0
 
 Read the Target Temperature
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+===========================
 
 You can read the current target temperature of the Temperature Module using the :py:attr:`.TemperatureModuleContext.target` property:
 
@@ -172,7 +177,7 @@ You can read the current target temperature of the Temperature Module using the 
 .. versionadded:: 2.0
 
 Deactivate
-^^^^^^^^^^
+==========
 
 This function will stop heating or cooling and will turn off the fan on the Temperature Module.
 
@@ -216,16 +221,18 @@ For the purposes of this section, assume we have the following already:
 
 
 Engage
-^^^^^^
+======
 
 The :py:meth:`.MagneticModuleContext.engage` function raises the magnets to induce a magnetic field in the labware on top of the Magnetic Module. The height of the magnets can be specified in several different ways, based on internally stored default heights for labware:
 
-   - If neither ``height`` nor ``offset`` is specified **and** the labware is supported on the Magnetic Module,
+   - If neither ``height``, ``offset`` nor ``height_from_base`` is specified **and** the labware is supported on the Magnetic Module,
      the magnets will raise to a reasonable default height based on the specified labware.
 
      .. code-block:: python
 
          mag_mod.engage()
+
+    .. versionadded:: 2.0
 
    - If ``height`` is specified, it should be a distance in mm from the home position of the magnets.
 
@@ -233,25 +240,34 @@ The :py:meth:`.MagneticModuleContext.engage` function raises the magnets to indu
 
         mag_mod.engage(height=18.5)
 
-   - You can also specify the height for the magnet to be raised from the base of the labware:
+    .. versionadded:: 2.0
+
+   - You can also specify the height for the magnet to be raised relative to the base of the labware.
 
     .. code-block:: python
 
-       mag_mod.engage(labware_base_offset=13.5)
+       mag_mod.engage(height_from_base=13.5)
+
+    A ``mag_mod.engage(height_from_base=0)`` call should move the tops of the magnets to level with base of the labware.
 
     .. versionadded:: 2.2
+
+.. note::
+    There is a +/- 1 mmm variance across magnetic module units, using ``height_from_base=0`` might not be able to get the magnets to completely flush with base of the labware. Please test before carrying out your experiment to ensure the desired engage height for your labware.
+
 
 .. note::
 
     Only certain labwares have defined engage heights for the Magnetic
     Module. If a labware that does not have a defined engage height is
     loaded on the Magnetic Module (or if no labware is loaded), then
-    ``height`` must be specified.
+    ``height``, or ``height_from_labware`` (since version 2.2), must be specified.
+
 
 .. versionadded:: 2.0
 
 Disengage
-^^^^^^^^^
+=========
 
 .. code-block:: python
 
@@ -297,12 +313,12 @@ For the purposes of this section, assume we have the following already:
 .. versionadded:: 2.0
 
 Lid Motor Control
-^^^^^^^^^^^^^^^^^
+=================
 
 The Thermocycler can control its temperature with the lid open or closed. When the lid of the Thermocycler is open, the pipettes can access the loaded labware. You can control the lid position with the methods below.
 
 Open Lid
-++++++++
+--------
 
 .. code-block:: python
 
@@ -312,7 +328,7 @@ Open Lid
 .. versionadded:: 2.0
 
 Close Lid
-+++++++++
+---------
 
 .. code-block:: python
 
@@ -321,14 +337,14 @@ Close Lid
 .. versionadded:: 2.0
 
 Lid Temperature Control
-^^^^^^^^^^^^^^^^^^^^^^^
+=======================
 
 You can control when a lid temperature is set. It is recommended that you set
 the lid temperature before executing a Thermocycler profile (see :ref:`thermocycler-profiles`). The range of the Thermocycler lid is
 37 °C to 110 °C.
 
 Set Lid Temperature
-+++++++++++++++++++
+-------------------
 
 :py:meth:`.ThermocyclerContext.set_lid_temperature` takes one parameter: the ``temperature`` you wish the lid to be set to. The protocol will only proceed once the lid temperature has been reached.
 
@@ -339,14 +355,14 @@ Set Lid Temperature
 .. versionadded:: 2.0
 
 Block Temperature Control
-^^^^^^^^^^^^^^^^^^^^^^^^^
+=========================
 
 To set the block temperature inside the Thermocycler, you can use the method :py:meth:`.ThermocyclerContext.set_block_temperature`. It takes five parameters:
 ``temperature``, ``hold_time_seconds``, ``hold_time_minutes``, ``ramp_rate`` and ``block_max_volume``. Only ``temperature`` is required; the two ``hold_time`` parameters, ``ramp_rate``, and ``block_max_volume`` are optional.
 
 
 Temperature
-+++++++++++
+-----------
 
 If you only specify a ``temperature`` in °C, the Thermocycler will hold this temperature indefinitely until powered off.
 
@@ -357,7 +373,7 @@ If you only specify a ``temperature`` in °C, the Thermocycler will hold this te
 .. versionadded:: 2.0
 
 Hold Time
-+++++++++
+---------
 
 If you set a ``temperature`` and a ``hold_time``, the Thermocycler will hold the temperature for the specified amount of time. Time can be passed in as minutes or seconds.
 
@@ -374,7 +390,7 @@ If you do not specify a hold time the protocol will proceed once the temperature
 .. versionadded:: 2.0
 
 Block Max Volume
-++++++++++++++++
+----------------
 
 The Thermocycler's block temperature controller varies its behavior based on the amount of liquid in the wells of its labware. Specifying an accurate volume allows the Thermocycler to precisely track the temperature of the samples. The ``block_max_volume`` parameter is specified in µL and is the volume of the most-full well in the labware that is loaded on the Thermocycler's block. If not specified, it defaults to 25 µL.
 
@@ -386,7 +402,7 @@ The Thermocycler's block temperature controller varies its behavior based on the
 .. versionadded:: 2.0
 
 Ramp Rate
-+++++++++
+---------
 
 Lastly, you can modify the ``ramp_rate`` in °C/sec for a given ``temperature``.
 
@@ -403,7 +419,7 @@ Lastly, you can modify the ``ramp_rate`` in °C/sec for a given ``temperature``.
 .. _thermocycler-profiles:
 
 Thermocycler Profiles
-^^^^^^^^^^^^^^^^^^^^^
+=====================
 
 The Thermocycler can rapidly cycle through temperatures to execute heat-sensitive reactions. These cycles are defined as profiles.
 
@@ -437,13 +453,13 @@ For instance, you can execute the profile defined above 100 times for a 30 µL-p
 .. versionadded:: 2.0
 
 Thermocycler Status
-^^^^^^^^^^^^^^^^^^^
+===================
 
 Throughout your protocol, you may want particular information on the current status of your Thermocycler. Below are
 a few methods that allow you to do that.
 
 Lid Position
-++++++++++++
+------------
 
 The current status of the lid position. It can be one of the strings ``'open'``, ``'closed'`` or ``'in_between'``.
 
@@ -454,7 +470,7 @@ The current status of the lid position. It can be one of the strings ``'open'``,
 .. versionadded:: 2.0
 
 Heated Lid Temperature Status
-+++++++++++++++++++++++++++++
+-----------------------------
 
 The current status of the heated lid temperature controller. It can be one of the strings ``'holding at target'``, ``'heating'``, ``'idle'``,  or ``'error'``.
 
@@ -465,7 +481,7 @@ The current status of the heated lid temperature controller. It can be one of th
 .. versionadded:: 2.0
 
 Block Temperature Status
-++++++++++++++++++++++++
+------------------------
 
 The current status of the well block temperature controller. It can be one of the strings ``'holding at target'``, ``'cooling'``, ``'heating'``, ``'idle'``, or ``'error'``.
 
@@ -478,13 +494,13 @@ The current status of the well block temperature controller. It can be one of th
 .. _thermocycler-deactivation:
 
 Thermocycler Deactivate
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=======================
 
 At some points in your protocol, you may want to deactivate specific temperature controllers of your Thermocycler. This can be done with three methods,
 :py:meth:`.ThermocyclerContext.deactivate`, :py:meth:`.ThermocyclerContext.deactivate_lid`, :py:meth:`.ThermocyclerContext.deactivate_block`.
 
 Deactivate
-++++++++++
+----------
 
 This deactivates both the well block and the heated lid of the Thermocycler.
 
@@ -493,7 +509,7 @@ This deactivates both the well block and the heated lid of the Thermocycler.
   tc_mod.deactivate()
 
 Deactivate Lid
-++++++++++++++
+--------------
 
 This deactivates only the heated lid of the Thermocycler.
 
@@ -504,7 +520,7 @@ This deactivates only the heated lid of the Thermocycler.
 .. versionadded:: 2.0
 
 Deactivate Block
-++++++++++++++++
+----------------
 
 This deactivates only the well block of the Thermocycler.
 

--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -225,44 +225,46 @@ Engage
 
 The :py:meth:`.MagneticModuleContext.engage` function raises the magnets to induce a magnetic field in the labware on top of the Magnetic Module. The height of the magnets can be specified in several different ways, based on internally stored default heights for labware:
 
-   - If neither ``height``, ``offset`` nor ``height_from_base`` is specified **and** the labware is supported on the Magnetic Module,
-     the magnets will raise to a reasonable default height based on the specified labware.
+- If neither ``height_from_base``, ``height`` nor ``offset`` is specified **and** the labware is supported on the Magnetic Module, the magnets will raise to a reasonable default height based on the specified labware.
 
-     .. code-block:: python
+  .. code-block:: python
 
-         mag_mod.engage()
+      mag_mod.engage()
 
-    .. versionadded:: 2.0
+  .. versionadded:: 2.0
 
-   - If ``height`` is specified, it should be a distance in mm from the home position of the magnets.
+- The recommended way to specify the magnets' position is to utilize the ``height_from_base`` parameter, which allows you to raise the height of the magnets relative to the base of the labware.
 
-     .. code-block:: python
+  .. code-block:: python
 
-        mag_mod.engage(height=18.5)
+      mag_mod.engage(height_from_base=13.5)
 
-    .. versionadded:: 2.0
+  A ``mag_mod.engage(height_from_base=0)`` call should move the tops of the magnets to level with base of the labware.
 
-   - You can also specify the height for the magnet to be raised relative to the base of the labware.
-
-    .. code-block:: python
-
-       mag_mod.engage(height_from_base=13.5)
-
-    A ``mag_mod.engage(height_from_base=0)`` call should move the tops of the magnets to level with base of the labware.
-
-    .. versionadded:: 2.2
+  .. versionadded:: 2.2
 
 .. note::
     There is a +/- 1 mmm variance across magnetic module units, using ``height_from_base=0`` might not be able to get the magnets to completely flush with base of the labware. Please test before carrying out your experiment to ensure the desired engage height for your labware.
 
+- You can also specify ``height``, which should be a distance in mm from the home position of the magnets.
+
+  .. code-block:: python
+
+      mag_mod.engage(height=18.5)
+
+  .. versionadded:: 2.0
+
+- An ``offset`` can be applied to move the magnets relatively from the default engage height of the labware, **if** the labware is supported on the Magnetic Module.
+
+  .. code-block:: python
+
+      mag_mod.engage(offset=-2)
+
+  .. versionadded:: 2.0
 
 .. note::
 
-    Only certain labwares have defined engage heights for the Magnetic
-    Module. If a labware that does not have a defined engage height is
-    loaded on the Magnetic Module (or if no labware is loaded), then
-    ``height``, or ``height_from_labware`` (since version 2.2), must be specified.
-
+    Only certain labwares have defined engage heights for the Magnetic Module. If a labware that does not have a defined engage height is loaded on the Magnetic Module (or if no labware is loaded), then ``height_from_labware`` (since version 2.2) or ``height``, must be specified.
 
 .. versionadded:: 2.0
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -42,7 +42,7 @@ The version you specify determines the features and behaviors available to your 
 
 .. code-block:: python
 
-    
+
    from opentrons import protocol_api
 
    metadata = {
@@ -94,4 +94,6 @@ This table lists the correspondence between Protocol API versions and robot soft
 |     2.0     |          3.14.0             |
 +-------------+-----------------------------+
 |     2.1     |          3.15.2             |
++-------------+-----------------------------+
+|     2.2     |          3.16.0             |
 +-------------+-----------------------------+

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -6,6 +6,7 @@ from . import update, mod_abc
 
 LABWARE_ENGAGE_HEIGHT = {'biorad-hardshell-96-PCR': 18}    # mm
 MAX_ENGAGE_HEIGHT = 45  # mm from home position
+PLACEHOLDER_HEIGHT = 5
 
 
 class MissingDevicePortError(Exception):

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -6,7 +6,7 @@ from . import update, mod_abc
 
 LABWARE_ENGAGE_HEIGHT = {'biorad-hardshell-96-PCR': 18}    # mm
 MAX_ENGAGE_HEIGHT = 45  # mm from home position
-PLACEHOLDER_HEIGHT = 5
+OFFSET_TO_LABWARE_BOTTOM = 5
 
 
 class MissingDevicePortError(Exception):

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -2168,7 +2168,10 @@ class MagneticModuleContext(ModuleContext):
 
     @cmds.publish.both(command=cmds.magdeck_engage)
     @requires_version(2, 0)
-    def engage(self, height: float = None, offset: float = None):
+    def engage(self,
+               height: float = None,
+               offset: float = None,
+               labware_base_offset: float = None):
         """ Raise the Magnetic Module's magnets.
 
         The destination of the magnets can be specified in several different
@@ -2191,6 +2194,7 @@ class MagneticModuleContext(ModuleContext):
         :param height: The height to raise the magnets to, in mm from home.
         :param offset: An offset relative to the default height for the labware
                        in mm
+        :param :
         """
         if height:
             dist = height
@@ -2198,6 +2202,8 @@ class MagneticModuleContext(ModuleContext):
             dist = self.labware.magdeck_engage_height
             if offset:
                 dist += offset
+            if labware_base_offset:
+                dist = labware_base_offset + modules.magdeck.PLACEHOLDER_HEIGHT
         else:
             raise ValueError(
                 "Currently loaded labware {} does not have a known engage "

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -2177,9 +2177,9 @@ class MagneticModuleContext(ModuleContext):
         The destination of the magnets can be specified in several different
         ways, based on internally stored default heights for labware:
 
-           - If neither ``height``, ``height_from_base`` nor ``offset`` is specified,
-             the magnets will raise to a reasonable default height based on the
-             specified labware.
+           - If neither ``height``, ``height_from_base`` nor ``offset`` is
+             specified, the magnets will raise to a reasonable default height
+             based on the specified labware.
            - The recommended way to adjust the height of the magnets is to
              specify ``height_from_base``, which should be a distance in mm
              relative to the base of the labware that is on the magnetic module

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -2180,25 +2180,26 @@ class MagneticModuleContext(ModuleContext):
            - If neither `height`, `height_from_base` nor `offset` is specified,
              the magnets will raise to a reasonable default height based on the
              specified labware.
+           - The recommended way to adjust the height of the magnets is to
+             specify `height_from_base`, which should be a distance in mm
+             relative to the base of the labware that is on the magnetic module
            - If `height` is specified, it should be a distance in mm from the
              home position of the magnets.
            - If `offset` is specified, it should be an offset in mm from the
              default position. A positive number moves the magnets higher and
              a negative number moves the magnets lower.
-           - If `height_from_base` is specified, it should be a distance in mm
-             relative to the base of the labware that is on the magnetic module
 
         Only certain labwares have defined engage heights for the Magnetic
         Module. If a labware that does not have a defined engage height is
         loaded on the Magnetic Module (or if no labware is loaded), then
         `height` or `height_from_labware` must be specified.
 
-        :param height: The height to raise the magnets to, in mm from home.
-        :param offset: An offset relative to the default height for the labware
-                       in mm
         :param height_from_base: The height to raise the magnets to, in mm from
                                  the base of the labware
         .. versionadded:: 2.1
+        :param height: The height to raise the magnets to, in mm from home.
+        :param offset: An offset relative to the default height for the labware
+                       in mm
         """
         if height:
             dist = height

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -2171,39 +2171,43 @@ class MagneticModuleContext(ModuleContext):
     def engage(self,
                height: float = None,
                offset: float = None,
-               labware_base_offset: float = None):
+               height_from_base: float = None):
         """ Raise the Magnetic Module's magnets.
 
         The destination of the magnets can be specified in several different
         ways, based on internally stored default heights for labware:
 
-           - If neither `height` nor `offset` is specified, the magnets will
-             raise to a reasonable default height based on the specified
-             labware.
+           - If neither `height`, `height_from_base` nor `offset` is specified,
+             the magnets will raise to a reasonable default height based on the
+             specified labware.
            - If `height` is specified, it should be a distance in mm from the
              home position of the magnets.
            - If `offset` is specified, it should be an offset in mm from the
              default position. A positive number moves the magnets higher and
              a negative number moves the magnets lower.
+           - If `height_from_base` is specified, it should be a distance in mm
+             relative to the base of the labware that is on the magnetic module
 
         Only certain labwares have defined engage heights for the Magnetic
         Module. If a labware that does not have a defined engage height is
         loaded on the Magnetic Module (or if no labware is loaded), then
-        `height` must be specified.
+        `height` or `height_from_labware` must be specified.
 
         :param height: The height to raise the magnets to, in mm from home.
         :param offset: An offset relative to the default height for the labware
                        in mm
-        :param :
+        :param height_from_base: The height to raise the magnets to, in mm from
+                                 the base of the labware
+        .. versionadded:: 2.1
         """
         if height:
             dist = height
+        elif height_from_base and self._ctx._api_version >= APIVersion(2, 2):
+            dist = height_from_base + modules.magdeck.OFFSET_TO_LABWARE_BOTTOM
         elif self.labware and self.labware.magdeck_engage_height is not None:
             dist = self.labware.magdeck_engage_height
             if offset:
                 dist += offset
-            if labware_base_offset:
-                dist = labware_base_offset + modules.magdeck.PLACEHOLDER_HEIGHT
         else:
             raise ValueError(
                 "Currently loaded labware {} does not have a known engage "

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -2177,22 +2177,22 @@ class MagneticModuleContext(ModuleContext):
         The destination of the magnets can be specified in several different
         ways, based on internally stored default heights for labware:
 
-           - If neither `height`, `height_from_base` nor `offset` is specified,
+           - If neither ``height``, ``height_from_base`` nor ``offset`` is specified,
              the magnets will raise to a reasonable default height based on the
              specified labware.
            - The recommended way to adjust the height of the magnets is to
-             specify `height_from_base`, which should be a distance in mm
+             specify ``height_from_base``, which should be a distance in mm
              relative to the base of the labware that is on the magnetic module
-           - If `height` is specified, it should be a distance in mm from the
+           - If ``height`` is specified, it should be a distance in mm from the
              home position of the magnets.
-           - If `offset` is specified, it should be an offset in mm from the
+           - If ``offset`` is specified, it should be an offset in mm from the
              default position. A positive number moves the magnets higher and
              a negative number moves the magnets lower.
 
         Only certain labwares have defined engage heights for the Magnetic
         Module. If a labware that does not have a defined engage height is
         loaded on the Magnetic Module (or if no labware is loaded), then
-        `height` or `height_from_labware` must be specified.
+        ``height`` or ``height_from_labware`` must be specified.
 
         :param height_from_base: The height to raise the magnets to, in mm from
                                  the base of the labware

--- a/api/tests/opentrons/data/mad_mag_v2.py
+++ b/api/tests/opentrons/data/mad_mag_v2.py
@@ -1,0 +1,33 @@
+from opentrons import types
+
+metadata = {
+    'protocolName': 'Mad Mag',
+    'author': 'Opentrons <engineering@opentrons.com>',
+    'description': 'A Magnetic Module Test',
+    'source': 'Opentrons Repository',
+    'apiLevel': '2.2'
+}
+
+
+def run(ctx):
+    ctx.home()
+    tr = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
+    mm = ctx.load_module('magnetic module', 4)
+    lw = mm.load_labware('nest_96_wellplate_100ul_pcr_fullskirt')
+    right = ctx.load_instrument('p300_single_gen2', types.Mount.RIGHT, [tr])
+
+    mm.disengage()
+
+    right.transfer(30, lw.wells()[0].bottom(1), lw.wells()[1].bottom(1))
+
+    mm.engage()
+    mm.disengage()
+
+    mm.engage(height=30)
+    mm.disenage()
+
+    mm.engage(offset=-10)
+    mm.disengage()
+
+    mm.engage(height_from_base=15)
+    mm.disengage()

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -1,6 +1,7 @@
 import json
 import pkgutil
 from unittest import mock
+from opentrons.hardware_control.modules.magdeck import OFFSET_TO_LABWARE_BOTTOM
 import opentrons.protocol_api as papi
 from opentrons.types import Point
 
@@ -372,3 +373,5 @@ def test_magdeck_labware_props(loop):
         mod.engage(offset=1)
     mod.engage(height=2)
     assert mod._module._driver.plate_height == 2
+    mod.engage(height_from_base=2)
+    assert mod._module._driver.plate_height == 2 + OFFSET_TO_LABWARE_BOTTOM


### PR DESCRIPTION
## overview
Similar to #4705, this PR adds a keyword argument to `MagneticModuleContext.engage()` to allow users to move the magnets on the module relative to the base of the labware. 

closes #4213

## changelog
- add kwarg to `engage()`
- update test
- add some note to docs
- add API version 2.2. to `versioning.html`
- fix `new_modules.html` formatting so the titles are rendered properly

## review requests
- `MagneticModuleContext.engage(height_from_base=0)` should move the magnets so that the tops of the magnets are level with the ledge that the labware sits on in the module