### PR TITLE
refactor(protocol-designer): clean up import order, use defined const…

### DIFF
--- a/protocol-designer/src/components/StepCreationButton.js
+++ b/protocol-designer/src/components/StepCreationButton.js
@@ -3,8 +3,8 @@ import * as React from 'react'
 import { connect } from 'react-redux'
 import cx from 'classnames'
 import without from 'lodash/without'
-import i18n from '../localization'
 import { HoverTooltip, PrimaryButton } from '@opentrons/components'
+import i18n from '../localization'
 import { actions as stepsActions } from '../ui/steps'
 import { selectors as featureFlagSelectors } from '../feature-flags'
 import {
@@ -13,6 +13,7 @@ import {
 } from '../step-forms'
 import { stepIconsByType, type StepType } from '../form-types'
 import type { BaseState, ThunkDispatch } from '../types'
+import { MAGDECK, TEMPDECK, THERMOCYCLER } from '../constants'
 import styles from './listButtons.css'
 
 type SP = {|
@@ -116,11 +117,11 @@ const mapSTP = (state: BaseState): SP => {
       moveLiquid: true,
       mix: true,
       pause: true,
-      magnet: getIsModuleOnDeck(modules, 'magdeck'),
+      magnet: getIsModuleOnDeck(modules, MAGDECK),
       temperature:
-        getIsModuleOnDeck(modules, 'tempdeck') ||
-        getIsModuleOnDeck(modules, 'thermocycler'),
-      thermocycler: getIsModuleOnDeck(modules, 'thermocycler'),
+        getIsModuleOnDeck(modules, TEMPDECK) ||
+        getIsModuleOnDeck(modules, THERMOCYCLER),
+      thermocycler: getIsModuleOnDeck(modules, THERMOCYCLER),
     },
   }
 }

--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -2,6 +2,14 @@
 import * as React from 'react'
 import cx from 'classnames'
 import { useSelector, useDispatch } from 'react-redux'
+import { getModuleDisplayName } from '@opentrons/shared-data'
+import {
+  Modal,
+  OutlineButton,
+  FormGroup,
+  DropdownField,
+  HoverTooltip,
+} from '@opentrons/components'
 import {
   selectors as stepFormSelectors,
   actions as stepFormActions,
@@ -15,20 +23,12 @@ import {
   SUPPORTED_MODULE_SLOTS,
   getAllModuleSlotsByType,
 } from '../../../modules'
+import { MAGDECK, TEMPDECK, THERMOCYCLER } from '../../../constants'
 import i18n from '../../../localization'
-import { getModuleDisplayName } from '@opentrons/shared-data'
-import {
-  Modal,
-  OutlineButton,
-  FormGroup,
-  DropdownField,
-  HoverTooltip,
-} from '@opentrons/components'
 import { PDAlert } from '../../alerts/PDAlert'
 import { CrashInfoBox } from '../../modules'
-import styles from './EditModules.css'
 import modalStyles from '../modal.css'
-
+import styles from './EditModules.css'
 import type { ModuleType } from '@opentrons/shared-data'
 
 type EditModulesProps = {
@@ -57,7 +57,7 @@ export default function EditModulesModal(props: EditModulesProps) {
 
   const showCrashInfoBox =
     getCrashablePipetteSelected(pipettesByMount) &&
-    (moduleType === 'magdeck' || moduleType === 'tempdeck')
+    (moduleType === MAGDECK || moduleType === TEMPDECK)
 
   const slotsBlockedBySpanning = getSlotsBlockedBySpanning(_initialDeckSetup)
   const previousModuleSlot = module && module.slot
@@ -67,7 +67,7 @@ export default function EditModulesModal(props: EditModulesProps) {
     (getSlotIsEmpty(_initialDeckSetup, selectedSlot) ||
       previousModuleSlot === selectedSlot)
 
-  const showSlotOption = moduleType !== 'thermocycler'
+  const showSlotOption = moduleType !== THERMOCYCLER
 
   const enableSlotSelection = useSelector(
     featureFlagSelectors.getDisableModuleRestrictions

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.js
@@ -13,7 +13,7 @@ import {
   type Mount,
 } from '@opentrons/components'
 import i18n from '../../../localization'
-import { SPAN7_8_10_11_SLOT, THERMO_TYPE } from '../../../constants'
+import { SPAN7_8_10_11_SLOT, THERMOCYCLER } from '../../../constants'
 import StepChangesConfirmModal from '../EditPipettesModal/StepChangesConfirmModal'
 import ModuleFields from './ModuleFields'
 import PipetteFields from './PipetteFields'
@@ -213,7 +213,7 @@ export default class FilePipettesModal extends React.Component<Props, State> {
 
     const visibleModules = this.props.thermocyclerEnabled
       ? this.state.modulesByType
-      : omit(this.state.modulesByType, THERMO_TYPE)
+      : omit(this.state.modulesByType, THERMOCYCLER)
 
     return (
       <React.Fragment>

--- a/protocol-designer/src/components/modules/EditModulesCard.js
+++ b/protocol-designer/src/components/modules/EditModulesCard.js
@@ -6,7 +6,7 @@ import styles from './styles.css'
 
 import type { ModuleType } from '@opentrons/shared-data'
 import { SUPPORTED_MODULE_TYPES } from '../../modules'
-import { THERMO_TYPE } from '../../constants'
+import { THERMOCYCLER } from '../../constants'
 import type { ModulesForEditModulesCard } from '../../step-forms'
 type Props = {
   modules: ModulesForEditModulesCard,
@@ -19,7 +19,7 @@ export default function EditModulesCard(props: Props) {
 
   const visibleModules = thermocyclerEnabled
     ? SUPPORTED_MODULE_TYPES
-    : SUPPORTED_MODULE_TYPES.filter(m => m !== THERMO_TYPE)
+    : SUPPORTED_MODULE_TYPES.filter(m => m !== THERMOCYCLER)
 
   return (
     <Card title="Modules">

--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -1,6 +1,7 @@
 // @flow
 import mapValues from 'lodash/mapValues'
 import * as componentLib from '@opentrons/components'
+import { MAGDECK, TEMPDECK, THERMOCYCLER } from '@opentrons/shared-data'
 import type {
   LabwareDefinition2,
   DeckSlot as DeckDefSlot,
@@ -53,7 +54,7 @@ export const PSEUDO_DECK_SLOTS: { [DeckSlot]: DeckDefSlot } = {
       yDimension: STD_SLOT_Y_DIM * 2 + STD_SLOT_DIVIDER_WIDTH,
       zDimension: 0,
     },
-    compatibleModules: ['thermocycler'],
+    compatibleModules: [THERMOCYCLER],
   },
 }
 
@@ -81,19 +82,20 @@ export const MAX_ENGAGE_HEIGHT = 16
 export const MIN_TEMP_MODULE_TEMP = 0
 export const MAX_TEMP_MODULE_TEMP = 95
 
-export const MAGNET_TYPE = 'magdeck'
-export const TEMPERATURE_TYPE = 'tempdeck'
-export const THERMO_TYPE = 'thermocycler'
+export { MAGDECK, TEMPDECK, THERMOCYCLER } from '@opentrons/shared-data'
+
+const TEMPMOD: 'temperature module' = 'temperature module'
+const MAGMOD: 'magnetic module' = 'magnetic module'
 
 // TODO: IL 2019-12-03 migrate the ModuleType '___deck' strings to '___ module' forms.
 // We don't call modules 'deck' anymore, but the old code is entrenched
 export const FILE_MODULE_TYPE_TO_MODULE_TYPE: { [string]: ModuleType } = {
-  'temperature module': 'tempdeck',
-  'magnetic module': 'magdeck',
-  thermocycler: 'thermocycler',
+  [TEMPMOD]: TEMPDECK,
+  [MAGMOD]: MAGDECK,
+  [THERMOCYCLER]: THERMOCYCLER,
 }
 export const MODULE_TYPE_TO_FILE_MODULE_TYPE: { [ModuleType]: string } = {
-  tempdeck: 'temperature module',
-  magdeck: 'magnetic module',
-  thermocycler: 'thermocycler',
+  [TEMPDECK]: TEMPMOD,
+  [MAGDECK]: MAGMOD,
+  [THERMOCYCLER]: THERMOCYCLER,
 }

--- a/protocol-designer/src/modules/moduleData.js
+++ b/protocol-designer/src/modules/moduleData.js
@@ -1,12 +1,17 @@
 // @flow
-import { SPAN7_8_10_11_SLOT } from '../constants'
+import {
+  SPAN7_8_10_11_SLOT,
+  MAGDECK,
+  TEMPDECK,
+  THERMOCYCLER,
+} from '../constants'
 import type { ModuleType } from '@opentrons/shared-data'
 import type { DropdownOption } from '@opentrons/components'
 
 export const SUPPORTED_MODULE_TYPES: Array<ModuleType> = [
-  'magdeck',
-  'tempdeck',
-  'thermocycler',
+  MAGDECK,
+  TEMPDECK,
+  THERMOCYCLER,
 ]
 
 type SupportedSlotMap = {
@@ -33,7 +38,7 @@ export function getAllModuleSlotsByType(
   moduleType: ModuleType
 ): Array<DropdownOption> {
   const supportedSlotOption = SUPPORTED_MODULE_SLOTS[moduleType]
-  if (moduleType === 'thermocycler') {
+  if (moduleType === THERMOCYCLER) {
     return supportedSlotOption
   }
   const allOtherSlots = ALL_MODULE_SLOTS.filter(

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -1,11 +1,5 @@
 // @flow
 import type { ElementProps } from 'react'
-import type {
-  DropdownOption,
-  Mount,
-  InstrumentInfoProps,
-} from '@opentrons/components'
-import { typeof InstrumentGroup as InstrumentGroupProps } from '@opentrons/components'
 import assert from 'assert'
 import forEach from 'lodash/forEach'
 import isEmpty from 'lodash/isEmpty'
@@ -18,7 +12,12 @@ import {
   getLabwareDefURI,
 } from '@opentrons/shared-data'
 import i18n from '../../localization'
-import { INITIAL_DECK_SETUP_STEP_ID } from '../../constants'
+import {
+  INITIAL_DECK_SETUP_STEP_ID,
+  MAGDECK,
+  TEMPDECK,
+  THERMOCYCLER,
+} from '../../constants'
 import {
   generateNewForm,
   getFormWarnings,
@@ -32,6 +31,12 @@ import {
   type LabwareDefByDefURI,
 } from '../../labware-defs'
 
+import { typeof InstrumentGroup as InstrumentGroupProps } from '@opentrons/components'
+import type {
+  DropdownOption,
+  Mount,
+  InstrumentInfoProps,
+} from '@opentrons/components'
 import type { FormWarning } from '../../steplist/formLevel'
 import type { BaseState, Selector, DeckSlot } from '../../types'
 import type { FormData, StepIdType, StepType } from '../../form-types'
@@ -149,14 +154,14 @@ export const getLabwareLocationsForStep = (
 }
 
 const MAGNETIC_MODULE_INITIAL_STATE: MagneticModuleState = {
-  type: 'magdeck',
+  type: MAGDECK,
   engaged: false,
 }
 const TEMPERATURE_MODULE_INITIAL_STATE: TemperatureModuleState = {
-  type: 'tempdeck',
+  type: TEMPDECK,
 }
 const THERMOCYCLER_MODULE_INITIAL_STATE: ThermocyclerModuleState = {
-  type: 'thermocycler',
+  type: THERMOCYCLER,
 }
 export const getInitialDeckSetup: Selector<InitialDeckSetup> = createSelector(
   getInitialDeckSetupStepForm,
@@ -185,19 +190,19 @@ export const getInitialDeckSetup: Selector<InitialDeckSetup> = createSelector(
         moduleLocations,
         (slot: DeckSlot, moduleId: string): ModuleOnDeck => {
           const module = moduleEntities[moduleId]
-          if (module.type === 'magdeck') {
+          if (module.type === MAGDECK) {
             return {
               id: module.id,
               model: module.model,
-              type: 'magdeck',
+              type: MAGDECK,
               slot,
               moduleState: MAGNETIC_MODULE_INITIAL_STATE,
             }
-          } else if (module.type === 'tempdeck') {
+          } else if (module.type === TEMPDECK) {
             return {
               id: module.id,
               model: module.model,
-              type: 'tempdeck',
+              type: TEMPDECK,
               slot,
               moduleState: TEMPERATURE_MODULE_INITIAL_STATE,
             }
@@ -205,7 +210,7 @@ export const getInitialDeckSetup: Selector<InitialDeckSetup> = createSelector(
             return {
               id: module.id,
               model: module.model,
-              type: 'thermocycler',
+              type: THERMOCYCLER,
               slot,
               moduleState: THERMOCYCLER_MODULE_INITIAL_STATE,
             }

--- a/protocol-designer/src/step-forms/types.js
+++ b/protocol-designer/src/step-forms/types.js
@@ -6,6 +6,7 @@ import type {
   ModuleType,
 } from '@opentrons/shared-data'
 import type { DeckSlot } from '../types'
+import typeof { MAGDECK, TEMPDECK, THERMOCYCLER } from '../constants'
 
 export type FormPipette = { pipetteName: ?string, tiprackDefURI: ?string }
 export type FormPipettesByMount = {
@@ -47,9 +48,9 @@ export type ModuleEntity = {| id: string, type: ModuleType, model: string |}
 export type ModuleEntities = { [moduleId: string]: ModuleEntity }
 
 // NOTE: semi-redundant 'type' key in FooModuleState types is required for Flow to disambiguate 'moduleState'
-export type MagneticModuleState = {| type: 'magdeck', engaged: boolean |}
-export type TemperatureModuleState = {| type: 'tempdeck' |} // TODO IL 2019-11-18 create this state
-export type ThermocyclerModuleState = {| type: 'thermocycler' |} // TODO IL 2019-11-18 create this state
+export type MagneticModuleState = {| type: MAGDECK, engaged: boolean |}
+export type TemperatureModuleState = {| type: TEMPDECK |} // TODO IL 2019-11-18 create this state
+export type ThermocyclerModuleState = {| type: THERMOCYCLER |} // TODO IL 2019-11-18 create this state
 export type ModuleTemporalProperties = {|
   slot: DeckSlot,
   moduleState:

--- a/protocol-designer/src/step-forms/utils.js
+++ b/protocol-designer/src/step-forms/utils.js
@@ -2,16 +2,15 @@
 import assert from 'assert'
 import reduce from 'lodash/reduce'
 import values from 'lodash/values'
-import {
-  getPipetteNameSpecs,
-  type DeckSlotId,
-  type ModuleType,
-} from '@opentrons/shared-data'
+import { getPipetteNameSpecs } from '@opentrons/shared-data'
 import {
   SPAN7_8_10_11_SLOT,
   TC_SPAN_SLOTS,
   GEN_ONE_MULTI_PIPETTES,
+  THERMOCYCLER,
 } from '../constants'
+import type { DeckSlotId, ModuleType } from '@opentrons/shared-data'
+import type { DeckSlot } from '../types'
 import type { LabwareDefByDefURI } from '../labware-defs'
 import type {
   NormalizedPipette,
@@ -24,7 +23,6 @@ import type {
   FormPipette,
   LabwareOnDeck as LabwareOnDeckType,
 } from './types'
-import type { DeckSlot } from '../types'
 
 export function getIdsInRange<T: string | number>(
   orderedIds: Array<T>,
@@ -96,7 +94,7 @@ export const getSlotsBlockedBySpanning = (
   if (
     values(initialDeckSetup.modules).some(
       (module: ModuleOnDeck) =>
-        module.type === 'thermocycler' && module.slot === SPAN7_8_10_11_SLOT
+        module.type === THERMOCYCLER && module.slot === SPAN7_8_10_11_SLOT
     )
   ) {
     return ['7', '8', '10', '11']

--- a/protocol-designer/src/step-generation/commandCreators/atomic/disengageMagnet.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/disengageMagnet.js
@@ -1,5 +1,6 @@
 // @flow
 import assert from 'assert'
+import { MAGDECK } from '../../../constants'
 import * as errorCreators from '../../errorCreators'
 import type {
   InvariantContext,
@@ -21,7 +22,7 @@ export const disengageMagnet = (
   }
 
   assert(
-    invariantContext.moduleEntities[module]?.type === 'magdeck',
+    invariantContext.moduleEntities[module]?.type === MAGDECK,
     `expected module ${module} to be magdeck, got ${invariantContext.moduleEntities[module]?.type}`
   )
 

--- a/protocol-designer/src/step-generation/commandCreators/atomic/engageMagnet.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/engageMagnet.js
@@ -1,6 +1,8 @@
 // @flow
 import assert from 'assert'
+import { MAGDECK } from '../../../constants'
 import * as errorCreators from '../../errorCreators'
+
 import type {
   InvariantContext,
   RobotState,
@@ -21,7 +23,7 @@ export const engageMagnet = (
   }
 
   assert(
-    invariantContext.moduleEntities[module]?.type === 'magdeck',
+    invariantContext.moduleEntities[module]?.type === MAGDECK,
     `expected module ${module} to be magdeck, got ${invariantContext.moduleEntities[module]?.type}`
   )
 

--- a/protocol-designer/src/step-generation/utils/modulePipetteCollision.js
+++ b/protocol-designer/src/step-generation/utils/modulePipetteCollision.js
@@ -1,5 +1,5 @@
 // @flow
-import { GEN_ONE_MULTI_PIPETTES } from '../../constants'
+import { GEN_ONE_MULTI_PIPETTES, TEMPDECK, MAGDECK } from '../../constants'
 import type { InvariantContext, RobotState } from '../types'
 
 // HACK Ian 2019-11-12: this is a temporary solution to pass PD runtime feature flags
@@ -50,7 +50,7 @@ export const modulePipetteCollision = (args: {|
     moduleId => {
       const moduleSlot: ?* = prevRobotState.modules[moduleId]?.slot
       const moduleType: ?* = invariantContext.moduleEntities[moduleId]?.type
-      const hasNorthSouthProblem = ['tempdeck', 'magdeck'].includes(moduleType)
+      const hasNorthSouthProblem = [TEMPDECK, MAGDECK].includes(moduleType)
       const labwareInNorthSlot =
         (moduleSlot === '1' && labwareSlot === '4') ||
         (moduleSlot === '3' && labwareSlot === '6')

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/index.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/index.js
@@ -1,10 +1,10 @@
 // @flow
 import findKey from 'lodash/findKey'
 import last from 'lodash/last'
+import { TEMPDECK, THERMOCYCLER } from '../../../constants'
+
 import type { ModuleOnDeck } from '../../../step-forms'
 import type { StepIdType, FormData } from '../../../form-types'
-
-import { TEMPERATURE_TYPE, THERMO_TYPE } from '../../../constants'
 
 export function getNextDefaultTemperatureModuleId(
   savedForms: { [StepIdType]: FormData },
@@ -21,8 +21,8 @@ export function getNextDefaultTemperatureModuleId(
   // should we simplify this to only return temperature modules?
   const nextDefaultModule: string | null =
     (lastModuleStep && lastModuleStep.moduleId) ||
-    findKey(equippedModulesById, m => m.type === TEMPERATURE_TYPE) ||
-    findKey(equippedModulesById, m => m.type === THERMO_TYPE)
+    findKey(equippedModulesById, m => m.type === TEMPDECK) ||
+    findKey(equippedModulesById, m => m.type === THERMOCYCLER)
 
   if (!nextDefaultModule) {
     console.error('Could not get next default module. Something went wrong.')

--- a/protocol-designer/src/ui/modules/selectors.js
+++ b/protocol-designer/src/ui/modules/selectors.js
@@ -1,13 +1,13 @@
 // @flow
 import { createSelector } from 'reselect'
-
+import { MAGDECK, TEMPDECK, THERMOCYCLER } from '../../constants'
 import { selectors as stepFormSelectors } from '../../step-forms'
+import { getLabwareNicknamesById } from '../labware/selectors'
 import {
   getModuleLabwareOptions,
   getModuleOnDeckByType,
   getModuleHasLabware,
 } from './utils'
-import { getLabwareNicknamesById } from '../labware/selectors'
 import type { Options } from '@opentrons/components'
 import type { Selector } from '../../types'
 
@@ -16,7 +16,7 @@ export const getMagneticLabwareOptions: Selector<Options> = createSelector(
   stepFormSelectors.getInitialDeckSetup,
   getLabwareNicknamesById,
   (initialDeckSetup, nicknamesById) => {
-    return getModuleLabwareOptions(initialDeckSetup, nicknamesById, 'magdeck')
+    return getModuleLabwareOptions(initialDeckSetup, nicknamesById, MAGDECK)
   }
 )
 
@@ -28,12 +28,12 @@ export const getTemperatureLabwareOptions: Selector<Options> = createSelector(
     const temperatureModuleOptions = getModuleLabwareOptions(
       initialDeckSetup,
       nicknamesById,
-      'tempdeck'
+      TEMPDECK
     )
     const thermocyclerModuleOptions = getModuleLabwareOptions(
       initialDeckSetup,
       nicknamesById,
-      'thermocycler'
+      THERMOCYCLER
     )
     return temperatureModuleOptions.concat(thermocyclerModuleOptions)
   }
@@ -47,7 +47,7 @@ export const getThermocyclerLabwareOptions: Selector<Options> = createSelector(
     return getModuleLabwareOptions(
       initialDeckSetup,
       nicknamesById,
-      'thermocycler'
+      THERMOCYCLER
     )
   }
 )
@@ -58,7 +58,7 @@ export const getSingleMagneticModuleId: Selector<
 > = createSelector(
   stepFormSelectors.getInitialDeckSetup,
   initialDeckSetup =>
-    getModuleOnDeckByType(initialDeckSetup, 'magdeck')?.id || null
+    getModuleOnDeckByType(initialDeckSetup, MAGDECK)?.id || null
 )
 
 /** Get single temperature module (assumes no multiples) */
@@ -67,7 +67,7 @@ export const getSingleTemperatureModuleId: Selector<
 > = createSelector(
   stepFormSelectors.getInitialDeckSetup,
   initialDeckSetup =>
-    getModuleOnDeckByType(initialDeckSetup, 'tempdeck')?.id || null
+    getModuleOnDeckByType(initialDeckSetup, TEMPDECK)?.id || null
 )
 
 /** Get single temperature module (assumes no multiples) */
@@ -76,14 +76,14 @@ export const getSingleThermocyclerModuleId: Selector<
 > = createSelector(
   stepFormSelectors.getInitialDeckSetup,
   initialDeckSetup =>
-    getModuleOnDeckByType(initialDeckSetup, 'thermocycler')?.id || null
+    getModuleOnDeckByType(initialDeckSetup, THERMOCYCLER)?.id || null
 )
 
 /** Returns boolean if magnetic module has labware */
 export const getMagnetModuleHasLabware: Selector<boolean> = createSelector(
   stepFormSelectors.getInitialDeckSetup,
   initialDeckSetup => {
-    return getModuleHasLabware(initialDeckSetup, 'magdeck')
+    return getModuleHasLabware(initialDeckSetup, MAGDECK)
   }
 )
 
@@ -91,7 +91,7 @@ export const getMagnetModuleHasLabware: Selector<boolean> = createSelector(
 export const getTemperatureModuleHasLabware: Selector<boolean> = createSelector(
   stepFormSelectors.getInitialDeckSetup,
   initialDeckSetup => {
-    return getModuleHasLabware(initialDeckSetup, 'tempdeck')
+    return getModuleHasLabware(initialDeckSetup, TEMPDECK)
   }
 )
 
@@ -99,6 +99,6 @@ export const getTemperatureModuleHasLabware: Selector<boolean> = createSelector(
 export const getThermocyclerModuleHasLabware: Selector<boolean> = createSelector(
   stepFormSelectors.getInitialDeckSetup,
   initialDeckSetup => {
-    return getModuleHasLabware(initialDeckSetup, 'thermocycler')
+    return getModuleHasLabware(initialDeckSetup, THERMOCYCLER)
   }
 )


### PR DESCRIPTION
## overview
Following [#4680](https://github.com/Opentrons/opentrons/pull/4680) and [#4686 ](https://github.com/Opentrons/opentrons/pull/4686) cleaning up magic strings.

Reorders imports according to [this](https://github.com/Opentrons/opentrons/pull/4680#discussion_r363102698).
Uses defined constants for tempdeck, magdeck, and thermocycler strings.

As per [this discussion](https://github.com/Opentrons/opentrons/pull/4686#discussion_r363809311), I reexported these constants from inside of `protocol-designer`.

## review requests
Code review

Since this PR touches parts of protocol designer that affect each of the modules (magnet, temp, TC), make sure you're able to successfully build a protocol with each of these modules. Note, since the temp + TC modules aren't finished being hooked up, you won't be able to export any protocols with those steps, but you should still be able to build them. 