### PR TITLE
fix(protocol-designer): Update maskToNumber to allow for negatives and 0

### DIFF
--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -8,7 +8,7 @@ import {
   maxFieldValue,
 } from './errors'
 import {
-  maskToNumber,
+  maskToInteger,
   maskToFloat,
   onlyPositiveNumbers,
   defaultTo,
@@ -58,7 +58,7 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
     hydrate: getLabwareEntity,
   },
   aspirate_mix_times: {
-    maskValue: composeMaskers(maskToNumber, onlyPositiveNumbers, defaultTo(1)),
+    maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers, defaultTo(1)),
     castValue: Number,
   },
   aspirate_mix_volume: {
@@ -77,7 +77,7 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
     hydrate: getLabwareEntity,
   },
   dispense_mix_times: {
-    maskValue: composeMaskers(maskToNumber, onlyPositiveNumbers, defaultTo(1)),
+    maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers, defaultTo(1)),
     castValue: Number,
   },
   dispense_mix_volume: {
@@ -100,13 +100,13 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
     hydrate: getLabwareEntity,
   },
   pauseHour: {
-    maskValue: composeMaskers(maskToNumber, onlyPositiveNumbers),
+    maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
   },
   pauseMinute: {
-    maskValue: composeMaskers(maskToNumber, onlyPositiveNumbers),
+    maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
   },
   pauseSecond: {
-    maskValue: composeMaskers(maskToNumber, onlyPositiveNumbers),
+    maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
   },
   pipette: {
     getErrors: composeErrors(requiredField),
@@ -114,7 +114,7 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
   },
   times: {
     getErrors: composeErrors(requiredField),
-    maskValue: composeMaskers(maskToNumber, onlyPositiveNumbers, defaultTo(0)),
+    maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers, defaultTo(0)),
     castValue: Number,
   },
   volume: {
@@ -141,7 +141,7 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
       minFieldValue(MIN_TEMP_MODULE_TEMP),
       maxFieldValue(MAX_TEMP_MODULE_TEMP)
     ),
-    maskValue: composeMaskers(maskToNumber, onlyPositiveNumbers),
+    maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
     castValue: Number,
   },
 }

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -157,8 +157,7 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
       minFieldValue(MIN_TEMP_MODULE_TEMP),
       maxFieldValue(MAX_TEMP_MODULE_TEMP)
     ),
-    // TODO (sa 2019-12-11): investigate maskToNumber not allowing 0
-    maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
+    maskValue: composeMaskers(maskToNumber, onlyPositiveNumbers),
     castValue: Number,
   },
 }

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -11,7 +11,6 @@ import {
   maskToNumber,
   maskToFloat,
   onlyPositiveNumbers,
-  onlyIntegers,
   defaultTo,
   composeMaskers,
   type ValueMasker,
@@ -59,12 +58,7 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
     hydrate: getLabwareEntity,
   },
   aspirate_mix_times: {
-    maskValue: composeMaskers(
-      maskToNumber,
-      onlyPositiveNumbers,
-      onlyIntegers,
-      defaultTo(1)
-    ),
+    maskValue: composeMaskers(maskToNumber, onlyPositiveNumbers, defaultTo(1)),
     castValue: Number,
   },
   aspirate_mix_volume: {
@@ -83,12 +77,7 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
     hydrate: getLabwareEntity,
   },
   dispense_mix_times: {
-    maskValue: composeMaskers(
-      maskToNumber,
-      onlyPositiveNumbers,
-      onlyIntegers,
-      defaultTo(1)
-    ),
+    maskValue: composeMaskers(maskToNumber, onlyPositiveNumbers, defaultTo(1)),
     castValue: Number,
   },
   dispense_mix_volume: {
@@ -111,13 +100,13 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
     hydrate: getLabwareEntity,
   },
   pauseHour: {
-    maskValue: composeMaskers(maskToNumber, onlyPositiveNumbers, onlyIntegers),
+    maskValue: composeMaskers(maskToNumber, onlyPositiveNumbers),
   },
   pauseMinute: {
-    maskValue: composeMaskers(maskToNumber, onlyPositiveNumbers, onlyIntegers),
+    maskValue: composeMaskers(maskToNumber, onlyPositiveNumbers),
   },
   pauseSecond: {
-    maskValue: composeMaskers(maskToNumber, onlyPositiveNumbers, onlyIntegers),
+    maskValue: composeMaskers(maskToNumber, onlyPositiveNumbers),
   },
   pipette: {
     getErrors: composeErrors(requiredField),
@@ -125,12 +114,7 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
   },
   times: {
     getErrors: composeErrors(requiredField),
-    maskValue: composeMaskers(
-      maskToNumber,
-      onlyPositiveNumbers,
-      onlyIntegers,
-      defaultTo(0)
-    ),
+    maskValue: composeMaskers(maskToNumber, onlyPositiveNumbers, defaultTo(0)),
     castValue: Number,
   },
   volume: {

--- a/protocol-designer/src/steplist/fieldLevel/processing.js
+++ b/protocol-designer/src/steplist/fieldLevel/processing.js
@@ -37,7 +37,6 @@ export const maskToFloat = (rawValue: mixed): ?mixed => {
 
 export const onlyPositiveNumbers = (value: mixed) =>
   value !== null && !Number.isNaN(value) && Number(value) >= 0 ? value : null
-// removed onlyIntegers in favor of maskToInteger
 export const defaultTo = (defaultValue: mixed) => (value: mixed) =>
   value === null || Number.isNaN(value) ? defaultValue : value
 

--- a/protocol-designer/src/steplist/fieldLevel/processing.js
+++ b/protocol-designer/src/steplist/fieldLevel/processing.js
@@ -8,22 +8,20 @@ export type ValueCaster = (value: mixed) => mixed
 
 // Mask to number now allows for 0 and negative numbers, for decimals use maskToFloat
 export const maskToNumber = (rawValue: mixed): mixed => {
-  if (!rawValue) return Number(rawValue)
   const rawNumericValue =
     typeof rawValue === 'string'
-      ? rawValue.replace(/[^-0-9]/, '')
+      ? rawValue.replace(/[^-0-9]/g, '')
       : String(rawValue)
   return rawNumericValue
 }
 
-// rawValue.replace(/[\D]+/g, '')
 const DEFAULT_DECIMAL_PLACES = 1
 
 export const maskToFloat = (rawValue: mixed): ?mixed => {
   if (!rawValue) return Number(rawValue)
   const rawNumericValue =
     typeof rawValue === 'string'
-      ? rawValue.replace(/[^-/.0-9]/, '')
+      ? rawValue.replace(/[^-/.0-9]/g, '')
       : String(rawValue)
   const trimRegex = new RegExp(
     `(\\d*[.]{1}\\d{${DEFAULT_DECIMAL_PLACES}})(\\d*)`

--- a/protocol-designer/src/steplist/fieldLevel/processing.js
+++ b/protocol-designer/src/steplist/fieldLevel/processing.js
@@ -6,19 +6,19 @@ export type ValueCaster = (value: mixed) => mixed
  **  Value Casters   **
  **********************/
 
-// TODO: account for floats and negative numbers
+// Mask to number now allows for 0 and negative numbers, for decimals use maskToFloat
 export const maskToNumber = (rawValue: mixed): mixed => {
-  if (!rawValue) return null
-  let castValue = Number(rawValue)
-  if (Number.isNaN(castValue)) {
-    const cleanValue = String(rawValue).replace(/[\D]+/g, '')
-    return cleanValue
-  } else {
-    return castValue
-  }
+  if (!rawValue) return Number(rawValue)
+  const rawNumericValue =
+    typeof rawValue === 'string'
+      ? rawValue.replace(/[^-0-9]/, '')
+      : String(rawValue)
+  return rawNumericValue
 }
 
+// rawValue.replace(/[\D]+/g, '')
 const DEFAULT_DECIMAL_PLACES = 1
+
 export const maskToFloat = (rawValue: mixed): ?mixed => {
   if (!rawValue) return Number(rawValue)
   const rawNumericValue =

--- a/protocol-designer/src/steplist/fieldLevel/processing.js
+++ b/protocol-designer/src/steplist/fieldLevel/processing.js
@@ -7,7 +7,7 @@ export type ValueCaster = (value: mixed) => mixed
  **********************/
 
 // Mask to number now allows for 0 and negative numbers, for decimals use maskToFloat
-export const maskToNumber = (rawValue: mixed): mixed => {
+export const maskToInteger = (rawValue: mixed): mixed => {
   const rawNumericValue =
     typeof rawValue === 'string'
       ? rawValue.replace(/[^-0-9]/g, '')
@@ -18,7 +18,6 @@ export const maskToNumber = (rawValue: mixed): mixed => {
 const DEFAULT_DECIMAL_PLACES = 1
 
 export const maskToFloat = (rawValue: mixed): ?mixed => {
-  if (!rawValue) return Number(rawValue)
   const rawNumericValue =
     typeof rawValue === 'string'
       ? rawValue.replace(/[^-/.0-9]/g, '')
@@ -37,11 +36,10 @@ export const maskToFloat = (rawValue: mixed): ?mixed => {
 // For the sake of simplicity and flow happiness, they are equipped to deal with parameters of type `mixed`
 
 export const onlyPositiveNumbers = (value: mixed) =>
-  value && Number(value) >= 0 ? value : null
-export const onlyIntegers = (value: mixed) =>
-  value && Number.isInteger(value) ? value : null
+  value !== null && !Number.isNaN(value) && Number(value) >= 0 ? value : null
+// removed onlyIntegers in favor of maskToInteger
 export const defaultTo = (defaultValue: mixed) => (value: mixed) =>
-  value || defaultValue
+  value === null || Number.isNaN(value) ? defaultValue : value
 
 /*******************
  **     Helpers    **


### PR DESCRIPTION
## overview

This PR should finally close out the set temp ticket by updating mask to number to allow for negative numbers and 0.

closes #4305

## changelog

- fix(protocol-designer): Update maskToNumber to allow for negatives and 0

## review requests

Make a protocol with a temperature module
Make a temperature step
Select Set Temperature option

- [ ] temperature field does not allow floats
- [ ] temperature field allows `0` as a valid input
- [ ] temperature field does not allow negative numbers (because of `onlyPositiveNumbers` masker, not `masktoNumber`)
- [ ] other fields that allow negative integers are not affected

Note - I'm not sure if negative integers are an option anywhere but you can test the maskToNumber by removing the `onlyPositiveNumbers` from line 161 `protocol-designer/src/steplist/fieldLevel/index.js`
