### PR TITLE
feat(protocol-designer): Make moduleId field required for temperature step

### DIFF
--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -232,3 +232,7 @@
   font-size: var(--fs-body-1);
   margin-top: 0.5rem;
 }
+
+.select_module_message {
+  font-size: var(--fs-body-1);
+}

--- a/protocol-designer/src/components/StepEditForm/forms/TemperatureForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/TemperatureForm.js
@@ -54,7 +54,10 @@ function TemperatureForm(props: TemperatureFormProps): React.Element<'div'> {
           display a message (copy, design, etc TBD) that you need to select a module to continue
         */}
         <ConditionalOnField name={'moduleId'} condition={val => val === null}>
-          <p>Please select a module for this temperature step.</p>
+          <p className={styles.select_module_message}>
+            Please ensure a compatible module is present on the deck and
+            selected to create a temperature step.
+          </p>
         </ConditionalOnField>
         <ConditionalOnField
           name={'moduleId'}

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -135,6 +135,7 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
     maskValue: composeMaskers(maskToFloat),
     castValue: Number,
   },
+  moduleId: { getErrors: composeErrors(requiredField) },
   setTemperature: { getErrors: composeErrors(requiredField) },
   targetTemperature: {
     getErrors: composeErrors(

--- a/protocol-designer/src/steplist/formLevel/errors.js
+++ b/protocol-designer/src/steplist/formLevel/errors.js
@@ -131,7 +131,9 @@ export const pauseForTimeOrUntilTold = (
   }
 }
 
-export const wellRatioMoveLiquid = (fields: HydratedFormData): ?FormError => {
+export const wellRatioMoveLiquid = (
+  fields: HydratedFormData
+): FormError | null => {
   const { aspirate_wells, dispense_wells } = fields
   if (!aspirate_wells || !dispense_wells) return null
   return getWellRatio(aspirate_wells, dispense_wells)
@@ -139,20 +141,26 @@ export const wellRatioMoveLiquid = (fields: HydratedFormData): ?FormError => {
     : FORM_ERRORS.WELL_RATIO_MOVE_LIQUID
 }
 
-export const magnetActionRequired = (fields: HydratedFormData): ?FormError => {
+export const magnetActionRequired = (
+  fields: HydratedFormData
+): FormError | null => {
   const { magnetAction } = fields
   if (!magnetAction) return FORM_ERRORS.MAGNET_ACTION_TYPE_REQUIRED
   return null
 }
 
-export const engageHeightRequired = (fields: HydratedFormData): ?FormError => {
+export const engageHeightRequired = (
+  fields: HydratedFormData
+): FormError | null => {
   const { magnetAction, engageHeight } = fields
   return magnetAction === 'engage' && !engageHeight
     ? FORM_ERRORS.ENGAGE_HEIGHT_REQUIRED
     : null
 }
 
-export const moduleIdRequired = (fields: HydratedFormData): ?FormError => {
+export const moduleIdRequired = (
+  fields: HydratedFormData
+): FormError | null => {
   const { moduleId } = fields
   if (!moduleId) return FORM_ERRORS.MODULE_ID_REQUIRED
   return null
@@ -160,7 +168,7 @@ export const moduleIdRequired = (fields: HydratedFormData): ?FormError => {
 
 export const targetTemperatureRequired = (
   fields: HydratedFormData
-): ?FormError => {
+): FormError | null => {
   const { setTemperature, targetTemperature } = fields
   return setTemperature === 'true' && !targetTemperature
     ? FORM_ERRORS.TARGET_TEMPERATURE_REQUIRED

--- a/protocol-designer/src/steplist/formLevel/errors.js
+++ b/protocol-designer/src/steplist/formLevel/errors.js
@@ -16,6 +16,7 @@ export type FormErrorKey =
   | 'TIME_PARAM_REQUIRED'
   | 'MAGNET_ACTION_TYPE_REQUIRED'
   | 'ENGAGE_HEIGHT_REQUIRED'
+  | 'MODULE_ID_REQUIRED'
   | 'TARGET_TEMPERATURE_REQUIRED'
 
 export type FormError = {
@@ -61,6 +62,11 @@ const FORM_ERRORS: { [FormErrorKey]: FormError } = {
   ENGAGE_HEIGHT_REQUIRED: {
     title: 'Engage height is required',
     dependentFields: ['magnetAction', 'engageHeight'],
+  },
+  MODULE_ID_REQUIRED: {
+    title:
+      'Module is required. Ensure the appropriate module is present on the deck and selected for this step',
+    dependentFields: ['moduleId'],
   },
   TARGET_TEMPERATURE_REQUIRED: {
     title: 'Temperature is required',
@@ -144,6 +150,12 @@ export const engageHeightRequired = (fields: HydratedFormData): ?FormError => {
   return magnetAction === 'engage' && !engageHeight
     ? FORM_ERRORS.ENGAGE_HEIGHT_REQUIRED
     : null
+}
+
+export const moduleIdRequired = (fields: HydratedFormData): ?FormError => {
+  const { moduleId } = fields
+  if (!moduleId) return FORM_ERRORS.MODULE_ID_REQUIRED
+  return null
 }
 
 export const targetTemperatureRequired = (

--- a/protocol-designer/src/steplist/formLevel/index.js
+++ b/protocol-designer/src/steplist/formLevel/index.js
@@ -9,6 +9,7 @@ import {
   magnetActionRequired,
   engageHeightRequired,
   type FormError,
+  moduleIdRequired,
   targetTemperatureRequired,
 } from './errors'
 import {
@@ -59,6 +60,7 @@ const stepFormHelperMap: { [StepType]: FormHelpers } = {
     getWarnings: composeWarnings(engageHeightRangeExceeded),
   },
   temperature: {
+    moduleId: composeErrors(moduleIdRequired),
     getErrors: composeErrors(targetTemperatureRequired),
     getWarnings: composeWarnings(temperatureRangeExceeded),
   },


### PR DESCRIPTION
## overview

This PR addresses #4286 by making moduleId field required for temperature step. This will only show when a module is deleted that is used saved temperature step. Since set temp step is not fully wired up, this is code only for now.

## changelog

- feat(protocol-designer): Make moduleId field required for temperature step

## review requests

As mentioned above, there's still some work to be done wiring up set temp step, so we can't test this in the UI just yet. 

- [ ] Code looks sane
- [ ] Error message copy is informative enough
