### PR TITLE
feat(protocol-designer): show magnetic module status in substeps and on deck

### DIFF
--- a/protocol-designer/src/components/DeckSetup/DeckSetup.js
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.js
@@ -128,6 +128,8 @@ const getSwapBlocked = (args: {
   return labwareSourceToDestBlocked || labwareDestToSourceBlocked
 }
 
+// TODO IL 2020-01-12: to support dynamic labware/module movement during a protocol,
+// don't use initialDeckSetup here. Use some version of timelineFrameForActiveItem
 const DeckSetupContents = (props: ContentsProps) => {
   const {
     initialDeckSetup,
@@ -212,7 +214,7 @@ const DeckSetupContents = (props: ContentsProps) => {
               x={moduleX}
               y={moduleY}
               orientation={orientation}
-              module={module}
+              id={module.id}
             />
           </React.Fragment>
         )

--- a/protocol-designer/src/components/DeckSetup/ModuleTag.css
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.css
@@ -16,3 +16,7 @@
 .module_info_type {
   text-transform: uppercase;
 }
+
+.module_status_line {
+  text-transform: capitalize;
+}

--- a/protocol-designer/src/components/DeckSetup/ModuleTag.js
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.js
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux'
 import cx from 'classnames'
 import { RobotCoordsForeignDiv } from '@opentrons/components'
 import i18n from '../../localization'
-import { timelineFrameAfterActiveItem } from '../../top-selectors/timelineFrames'
+import { timelineFrameBeforeActiveItem } from '../../top-selectors/timelineFrames'
 import { selectors as stepFormSelectors } from '../../step-forms'
 import { STD_SLOT_X_DIM, STD_SLOT_Y_DIM } from '../../constants'
 import { getModuleVizDims } from './getModuleVizDims'
@@ -40,15 +40,13 @@ const ModuleStatus = ({
 }
 
 const ModuleTag = (props: Props) => {
-  const timelineFrame = useSelector(timelineFrameAfterActiveItem)
+  const timelineFrame = useSelector(timelineFrameBeforeActiveItem)
   const moduleEntity = useSelector(stepFormSelectors.getModuleEntities)[
     props.id
   ]
   const moduleState: ?* =
     timelineFrame.robotState.modules[props.id]?.moduleState
   const moduleType: ?* = moduleEntity?.type
-
-  console.log({ moduleState, moduleType })
 
   if (moduleType == null || moduleState == null) {
     // this should never happen, but better to have an empty tag than to whitescreen

--- a/protocol-designer/src/components/DeckSetup/ModuleTag.js
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.js
@@ -6,7 +6,7 @@ import { RobotCoordsForeignDiv } from '@opentrons/components'
 import i18n from '../../localization'
 import { timelineFrameBeforeActiveItem } from '../../top-selectors/timelineFrames'
 import { selectors as stepFormSelectors } from '../../step-forms'
-import { STD_SLOT_X_DIM, STD_SLOT_Y_DIM } from '../../constants'
+import { MAGDECK, STD_SLOT_X_DIM, STD_SLOT_Y_DIM } from '../../constants'
 import { getModuleVizDims } from './getModuleVizDims'
 import styles from './ModuleTag.css'
 import type { ModuleOrientation } from '../../types'
@@ -29,14 +29,21 @@ const ModuleStatus = ({
   moduleState: $PropertyType<ModuleTemporalProperties, 'moduleState'>,
 |}) => {
   switch (moduleState.type) {
-    case 'magdeck':
-      return moduleState.engaged ? 'ENGAGED' : 'DISENGAGED'
+    case MAGDECK:
+      return (
+        <div className={styles.module_status_line}>
+          {i18n.t(
+            `modules.status.${moduleState.engaged ? 'engaged' : 'disengaged'}`
+          )}
+        </div>
+      )
+
     default:
       console.warn(
         `ModuleStatus doesn't support module type ${moduleState.type}`
       )
+      return null
   }
-  return null
 }
 
 const ModuleTag = (props: Props) => {

--- a/protocol-designer/src/components/DeckSetup/ModuleTag.js
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.js
@@ -1,29 +1,66 @@
 // @flow
 import * as React from 'react'
+import { useSelector } from 'react-redux'
 import cx from 'classnames'
 import { RobotCoordsForeignDiv } from '@opentrons/components'
 import i18n from '../../localization'
+import { timelineFrameAfterActiveItem } from '../../top-selectors/timelineFrames'
+import { selectors as stepFormSelectors } from '../../step-forms'
 import { STD_SLOT_X_DIM, STD_SLOT_Y_DIM } from '../../constants'
 import { getModuleVizDims } from './getModuleVizDims'
 import styles from './ModuleTag.css'
-import type { ModuleOnDeck } from '../../step-forms'
 import type { ModuleOrientation } from '../../types'
+import type { ModuleTemporalProperties } from '../../step-forms'
 
 type Props = {|
   x: number,
   y: number,
   orientation: ModuleOrientation,
-  module: ModuleOnDeck,
+  id: string,
 |}
 
 // eyeballed width/height to match designs
 const TAG_HEIGHT = 45
 const TAG_WIDTH = 60
 
+const ModuleStatus = ({
+  moduleState,
+}: {|
+  moduleState: $PropertyType<ModuleTemporalProperties, 'moduleState'>,
+|}) => {
+  switch (moduleState.type) {
+    case 'magdeck':
+      return moduleState.engaged ? 'ENGAGED' : 'DISENGAGED'
+    default:
+      console.warn(
+        `ModuleStatus doesn't support module type ${moduleState.type}`
+      )
+  }
+  return null
+}
+
 const ModuleTag = (props: Props) => {
+  const timelineFrame = useSelector(timelineFrameAfterActiveItem)
+  const moduleEntity = useSelector(stepFormSelectors.getModuleEntities)[
+    props.id
+  ]
+  const moduleState: ?* =
+    timelineFrame.robotState.modules[props.id]?.moduleState
+  const moduleType: ?* = moduleEntity?.type
+
+  console.log({ moduleState, moduleType })
+
+  if (moduleType == null || moduleState == null) {
+    // this should never happen, but better to have an empty tag than to whitescreen
+    console.error(
+      `nullsy moduleType or moduleState for module "${props.id}" in the selected timeline frame`
+    )
+    return null
+  }
+
   const { childXOffset, childYOffset } = getModuleVizDims(
     props.orientation,
-    props.module.type
+    moduleType
   )
   return (
     <RobotCoordsForeignDiv
@@ -41,12 +78,13 @@ const ModuleTag = (props: Props) => {
       }}
     >
       <div className={cx(styles.module_info_type, styles.module_info_line)}>
-        {i18n.t(`modules.module_display_names.${props.module.type}`)}
+        {i18n.t(`modules.module_display_names.${moduleType}`)}
       </div>
-
-      <div className={styles.module_info_line}>Placeholder Status</div>
+      <div className={styles.module_info_line}>
+        <ModuleStatus moduleState={moduleState} />
+      </div>
     </RobotCoordsForeignDiv>
   )
 }
 
-export default ModuleTag
+export default React.memo<Props>(ModuleTag)

--- a/protocol-designer/src/components/steplist/AspirateDispenseHeader.js
+++ b/protocol-designer/src/components/steplist/AspirateDispenseHeader.js
@@ -55,7 +55,7 @@ function AspirateDispenseHeader(props: AspirateDispenseHeaderProps) {
           )}
         </HoverTooltip>
         {/* This is always a "transfer icon" (arrow pointing right) for any step: */}
-        <Icon name="ot-transfer" />
+        <Icon className={styles.step_subitem_spacer} name="ot-transfer" />
         <HoverTooltip
           portal={Portal}
           tooltipComponent={

--- a/protocol-designer/src/components/steplist/MagnetStepItems.js
+++ b/protocol-designer/src/components/steplist/MagnetStepItems.js
@@ -1,0 +1,34 @@
+// @flow
+import * as React from 'react'
+import cx from 'classnames'
+import { PDListItem } from '../lists'
+import styles from './StepItem.css'
+
+type Props = {|
+  engage: boolean,
+  labwareDisplayName: ?string,
+  message?: ?string,
+|}
+
+export const MagnetStepItems = (props: Props) => (
+  <>
+    {props.message && <PDListItem>{props.message}</PDListItem>}
+    {/* TODO IMMEDIATELY i18n here */}
+    <li className={styles.aspirate_dispense}>
+      <span>MAGNETIC MODULE</span>
+      <span className={styles.spacer} />
+      <span>ACTION</span>
+    </li>
+    <PDListItem
+      className={cx(styles.step_subitem_column_header, styles.emphasized_cell)}
+    >
+      <span className={styles.labware_display_name}>
+        {props.labwareDisplayName}
+      </span>
+      <span className={styles.step_subitem_spacer} />
+      <span className={styles.labware_display_name}>
+        {props.engage ? 'Engage' : 'Disengage'}
+      </span>
+    </PDListItem>
+  </>
+)

--- a/protocol-designer/src/components/steplist/MagnetStepItems.js
+++ b/protocol-designer/src/components/steplist/MagnetStepItems.js
@@ -1,12 +1,16 @@
 // @flow
 import * as React from 'react'
 import cx from 'classnames'
+import { HoverTooltip } from '@opentrons/components'
 import { PDListItem } from '../lists'
+import { Portal } from './TooltipPortal'
+import LabwareTooltipContents from './LabwareTooltipContents'
 import styles from './StepItem.css'
 
 type Props = {|
   engage: boolean,
   labwareDisplayName: ?string,
+  labwareNickname: ?string,
   message?: ?string,
 |}
 
@@ -22,9 +26,24 @@ export const MagnetStepItems = (props: Props) => (
     <PDListItem
       className={cx(styles.step_subitem_column_header, styles.emphasized_cell)}
     >
-      <span className={styles.labware_display_name}>
-        {props.labwareDisplayName}
-      </span>
+      <HoverTooltip
+        portal={Portal}
+        tooltipComponent={
+          <LabwareTooltipContents
+            labwareNickname={props.labwareNickname}
+            labwareDefDisplayName={props.labwareDisplayName}
+          />
+        }
+      >
+        {hoverTooltipHandlers => (
+          <span
+            {...hoverTooltipHandlers}
+            className={styles.labware_display_name}
+          >
+            {props.labwareNickname}
+          </span>
+        )}
+      </HoverTooltip>
       <span className={styles.step_subitem_spacer} />
       <span className={styles.labware_display_name}>
         {props.engage ? 'Engage' : 'Disengage'}

--- a/protocol-designer/src/components/steplist/MagnetStepItems.js
+++ b/protocol-designer/src/components/steplist/MagnetStepItems.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import cx from 'classnames'
 import { HoverTooltip } from '@opentrons/components'
+import i18n from '../../localization'
 import { PDListItem } from '../lists'
 import { Portal } from './TooltipPortal'
 import LabwareTooltipContents from './LabwareTooltipContents'
@@ -17,11 +18,10 @@ type Props = {|
 export const MagnetStepItems = (props: Props) => (
   <>
     {props.message && <PDListItem>{props.message}</PDListItem>}
-    {/* TODO IMMEDIATELY i18n here */}
     <li className={styles.aspirate_dispense}>
-      <span>MAGNETIC MODULE</span>
+      <span>{i18n.t('modules.module_long_names.magdeck')}</span>
       <span className={styles.spacer} />
-      <span>ACTION</span>
+      <span>{i18n.t('modules.actions.action')}</span>
     </li>
     <PDListItem
       className={cx(styles.step_subitem_column_header, styles.emphasized_cell)}
@@ -46,7 +46,7 @@ export const MagnetStepItems = (props: Props) => (
       </HoverTooltip>
       <span className={styles.step_subitem_spacer} />
       <span className={styles.labware_display_name}>
-        {props.engage ? 'Engage' : 'Disengage'}
+        {i18n.t(`modules.actions.${props.engage ? 'engage' : 'disengage'}`)}
       </span>
     </PDListItem>
   </>

--- a/protocol-designer/src/components/steplist/StepItem.css
+++ b/protocol-designer/src/components/steplist/StepItem.css
@@ -14,30 +14,31 @@
 }
 
 .emphasized_cell {
-  font-weight: bold;
+  font-weight: var(--fw-semibold);
 }
 
 /* Step Subitem Column Header */
 
 .step_subitem_column_header {
-  & svg {
-    /* Source labware -> Dest Labware arrow icon */
-    flex: 0.5;
-    height: 1.5rem;
-    color: var(--c-med-gray);
-  }
+  padding-top: 0;
 
   & > * {
     text-align: left;
   }
 }
 
+.step_subitem_spacer {
+  flex: 0.5;
+  height: 1.5rem;
+  color: var(--c-med-gray);
+}
+
 /* Aspirate / dispense headers */
 .aspirate_dispense {
   display: flex;
-  margin: 0.5rem;
+  margin: 0.5rem 0.5rem 0 0.5rem;
   text-align: left;
-  font-size: var(--fs-body-1);
+  font-size: var(--fs-caption);
 
   & .spacer {
     flex: 1;
@@ -133,10 +134,6 @@
 
 .multi_substep_header {
   font-style: italic;
-}
-
-.labware_name {
-  font-weight: var(--fw-semibold);
 }
 
 .labware_spacer {

--- a/protocol-designer/src/components/steplist/StepItem.css
+++ b/protocol-designer/src/components/steplist/StepItem.css
@@ -14,6 +14,7 @@
 }
 
 .emphasized_cell {
+  text-transform: capitalize;
   font-weight: var(--fw-semibold);
 }
 
@@ -24,6 +25,7 @@
 
   & > * {
     text-align: left;
+    min-height: 1rem;
   }
 }
 
@@ -39,6 +41,7 @@
   margin: 0.5rem 0.5rem 0 0.5rem;
   text-align: left;
   font-size: var(--fs-caption);
+  text-transform: uppercase;
 
   & .spacer {
     flex: 1;

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -7,6 +7,7 @@ import styles from './StepItem.css'
 import AspirateDispenseHeader from './AspirateDispenseHeader'
 import MixHeader from './MixHeader'
 import PauseStepItems from './PauseStepItems'
+import { MagnetStepItems } from './MagnetStepItems'
 import StepDescription from '../StepDescription'
 import { stepIconsByType } from '../../form-types'
 import type { FormData, StepIdType, StepType } from '../../form-types'
@@ -115,13 +116,12 @@ function getStepItemContents(stepItemProps: StepItemProps) {
   }
 
   if (substeps && substeps.substepType === 'magnet') {
-    // TODO IMMEDIATELY
-    console.log({ substeps })
     return (
-      <div>
-        <div>Engage: {substeps.engage ? 'ENGAGE' : 'DISENGAGE'}</div>
-        <div>Module: {substeps.moduleId}</div>
-      </div>
+      <MagnetStepItems
+        engage={substeps.engage}
+        labwareDisplayName={substeps.labwareDisplayName}
+        message={substeps.message}
+      />
     )
   }
 

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -120,6 +120,7 @@ function getStepItemContents(stepItemProps: StepItemProps) {
       <MagnetStepItems
         engage={substeps.engage}
         labwareDisplayName={substeps.labwareDisplayName}
+        labwareNickname={substeps.labwareNickname}
         message={substeps.message}
       />
     )

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -110,8 +110,19 @@ function getStepItemContents(stepItemProps: StepItemProps) {
   }
 
   // pause substep component uses the delay args directly
-  if (substeps && substeps.commandCreatorFnName === 'delay') {
-    return <PauseStepItems pauseArgs={substeps} />
+  if (substeps && substeps.substepType === 'pause') {
+    return <PauseStepItems pauseArgs={substeps.pauseStepArgs} />
+  }
+
+  if (substeps && substeps.substepType === 'magnet') {
+    // TODO IMMEDIATELY
+    console.log({ substeps })
+    return (
+      <div>
+        <div>Engage: {substeps.engage ? 'ENGAGE' : 'DISENGAGE'}</div>
+        <div>Module: {substeps.moduleId}</div>
+      </div>
+    )
   }
 
   const result = []

--- a/protocol-designer/src/localization/en/modules.json
+++ b/protocol-designer/src/localization/en/modules.json
@@ -1,12 +1,16 @@
 {
   "module_display_names": {
     "tempdeck": "Temperature",
-    "magdeck": "Magnet",
+    "magdeck": "Magnetic",
     "thermocycler": "Thermocycler"
   },
   "module_long_names": {
     "tempdeck": "Temperature module",
     "magdeck": "Magnetic module",
     "thermocycler": "Thermocycler module"
+  },
+  "status": {
+    "engaged": "engaged",
+    "disengaged": "disengaged"
   }
 }

--- a/protocol-designer/src/localization/en/modules.json
+++ b/protocol-designer/src/localization/en/modules.json
@@ -12,5 +12,10 @@
   "status": {
     "engaged": "engaged",
     "disengaged": "disengaged"
+  },
+  "actions": {
+    "action": "action",
+    "engage": "engage",
+    "disengage": "disengage"
   }
 }

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -171,12 +171,14 @@ export type EngageMagnetArgs = {|
   ...EngageMagnetParams,
   module: string | null,
   commandCreatorFnName: 'engageMagnet',
+  message?: string,
 |}
 
 export type DisengageMagnetArgs = {|
   ...DisengageMagnetParams,
   module: string | null,
   commandCreatorFnName: 'disengageMagnet',
+  message?: string,
 |}
 
 export type CommandCreatorArgs =

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -353,7 +353,8 @@ export function generateSubsteps(
     return {
       substepType: 'magnet',
       engage: stepArgs.commandCreatorFnName === 'engageMagnet',
-      moduleId: stepArgs.module,
+      labwareDisplayName: 'foo spam test spam blah spam spam',
+      message: stepArgs.message,
     }
   }
 

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -25,7 +25,6 @@ import type {
   ConsolidateArgs,
   DistributeArgs,
   MixArgs,
-  PauseArgs,
   TransferArgs,
 } from '../step-generation/types'
 import type {
@@ -270,6 +269,7 @@ function transferLikeSubsteps(args: {|
     })
 
     return {
+      substepType: 'sourceDest',
       multichannel: true,
       commandCreatorFnName: stepArgs.commandCreatorFnName,
       parentStepId: stepId,
@@ -289,6 +289,7 @@ function transferLikeSubsteps(args: {|
     )
 
     return {
+      substepType: 'sourceDest',
       multichannel: false,
       commandCreatorFnName: stepArgs.commandCreatorFnName,
       parentStepId: stepId,
@@ -325,9 +326,10 @@ export function generateSubsteps(
   const { stepArgs } = stepArgsAndErrors
 
   if (stepArgs.commandCreatorFnName === 'delay') {
-    // just returns formData
-    const formData: PauseArgs = stepArgs
-    return formData
+    return {
+      substepType: 'pause',
+      pauseStepArgs: stepArgs,
+    }
   }
 
   if (
@@ -348,8 +350,11 @@ export function generateSubsteps(
     stepArgs.commandCreatorFnName === 'disengageMagnet' ||
     stepArgs.commandCreatorFnName === 'engageMagnet'
   ) {
-    // no substeps for these
-    return null
+    return {
+      substepType: 'magnet',
+      engage: stepArgs.commandCreatorFnName === 'engageMagnet',
+      moduleId: stepArgs.module,
+    }
   }
 
   console.warn(

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -303,7 +303,10 @@ export function generateSubsteps(
   stepArgsAndErrors: ?StepArgsAndErrors,
   invariantContext: InvariantContext,
   robotState: ?RobotState,
-  stepId: string
+  stepId: string,
+  labwareNamesByModuleId: {
+    [moduleId: string]: ?{ nickname: ?string, displayName: string },
+  }
 ): ?SubstepItemData {
   if (!robotState) {
     console.info(
@@ -350,10 +353,13 @@ export function generateSubsteps(
     stepArgs.commandCreatorFnName === 'disengageMagnet' ||
     stepArgs.commandCreatorFnName === 'engageMagnet'
   ) {
+    const moduleId = stepArgs.module
+    const labwareNames = moduleId ? labwareNamesByModuleId[moduleId] : null
     return {
       substepType: 'magnet',
       engage: stepArgs.commandCreatorFnName === 'engageMagnet',
-      labwareDisplayName: 'foo spam test spam blah spam spam',
+      labwareDisplayName: labwareNames?.displayName,
+      labwareNickname: labwareNames?.nickname,
       message: stepArgs.message,
     }
   }

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -105,7 +105,8 @@ export type SourceDestSubstepItem =
 export type MagnetSubstepItem = {|
   substepType: 'magnet',
   engage: boolean,
-  moduleId: ?string,
+  labwareDisplayName: ?string,
+  message?: string,
 |}
 
 export type PauseSubstepItem = {|

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -1,5 +1,5 @@
 // @flow
-import type { PauseArgs, CommandCreatorArgs } from '../step-generation'
+import type { CommandCreatorArgs, PauseArgs } from '../step-generation'
 import type {
   FormData,
   StepIdType,
@@ -81,6 +81,7 @@ type SourceDestCommandCreatorName =
   | 'mix'
 
 export type SourceDestSubstepItemSingleChannel = {|
+  substepType: 'sourceDest',
   multichannel: false,
   commandCreatorFnName: SourceDestCommandCreatorName,
   parentStepId: StepIdType,
@@ -88,6 +89,7 @@ export type SourceDestSubstepItemSingleChannel = {|
 |}
 
 export type SourceDestSubstepItemMultiChannel = {|
+  substepType: 'sourceDest',
   multichannel: true,
   commandCreatorFnName: SourceDestCommandCreatorName,
   parentStepId: StepIdType,
@@ -100,7 +102,21 @@ export type SourceDestSubstepItem =
   | SourceDestSubstepItemSingleChannel
   | SourceDestSubstepItemMultiChannel
 
-export type SubstepItemData = SourceDestSubstepItem | PauseArgs // Pause substep uses same data as processed form
+export type MagnetSubstepItem = {|
+  substepType: 'magnet',
+  engage: boolean,
+  moduleId: ?string,
+|}
+
+export type PauseSubstepItem = {|
+  substepType: 'pause',
+  pauseStepArgs: PauseArgs,
+|} // Pause substeps use same data as processed form
+
+export type SubstepItemData =
+  | SourceDestSubstepItem
+  | PauseSubstepItem
+  | MagnetSubstepItem
 
 export type StepItemData = {
   id: StepIdType,

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -106,6 +106,7 @@ export type MagnetSubstepItem = {|
   substepType: 'magnet',
   engage: boolean,
   labwareDisplayName: ?string,
+  labwareNickname: ?string,
   message?: string,
 |}
 

--- a/protocol-designer/src/top-selectors/substep-highlight.js
+++ b/protocol-designer/src/top-selectors/substep-highlight.js
@@ -176,7 +176,7 @@ function _getSelectedWellsForSubstep(
     wells.push(...getWells('dest'))
   }
 
-  if (substeps && substeps.commandCreatorFnName !== 'delay') {
+  if (substeps && substeps.substepType === 'sourceDest') {
     let tipWellSet = []
     if (substeps.multichannel) {
       const { activeTips } = substeps.multiRows[substepIndex][0] // just use first multi row

--- a/protocol-designer/src/top-selectors/substeps.js
+++ b/protocol-designer/src/top-selectors/substeps.js
@@ -1,11 +1,9 @@
 // @flow
 import { createSelector } from 'reselect'
-
 import { selectors as stepFormSelectors } from '../step-forms'
 import { selectors as fileDataSelectors } from '../file-data'
-
+import { selectors as uiModulesSelectors } from '../ui/modules'
 import { generateSubsteps } from '../steplist/generateSubsteps' // TODO Ian 2018-04-11 move generateSubsteps closer to this substeps.js file?
-
 import type { Selector } from '../types'
 import type { StepIdType } from '../form-types'
 import type { SubstepItemData } from '../steplist/types'
@@ -17,12 +15,14 @@ export const allSubsteps: Selector<AllSubsteps> = createSelector(
   stepFormSelectors.getOrderedStepIds,
   fileDataSelectors.getRobotStateTimeline,
   fileDataSelectors.getInitialRobotState,
+  uiModulesSelectors.getLabwareNamesByModuleId,
   (
     allStepArgsAndErrors,
     invariantContext,
     orderedStepIds,
     robotStateTimeline,
-    _initialRobotState
+    _initialRobotState,
+    labwareNamesByModuleId
   ) => {
     // Add initial robot state frame, offsetting the timeline.
     // This is because substeps show the robot state just BEFORE their step has occurred
@@ -38,7 +38,8 @@ export const allSubsteps: Selector<AllSubsteps> = createSelector(
         allStepArgsAndErrors[stepId],
         invariantContext,
         robotState,
-        stepId
+        stepId,
+        labwareNamesByModuleId
       )
 
       return {

--- a/protocol-designer/src/top-selectors/substeps.js
+++ b/protocol-designer/src/top-selectors/substeps.js
@@ -24,6 +24,8 @@ export const allSubsteps: Selector<AllSubsteps> = createSelector(
     robotStateTimeline,
     _initialRobotState
   ) => {
+    // Add initial robot state frame, offsetting the timeline.
+    // This is because substeps show the robot state just BEFORE their step has occurred
     const timeline = [
       { robotState: _initialRobotState },
       ...robotStateTimeline.timeline,

--- a/protocol-designer/src/top-selectors/timelineFrames.js
+++ b/protocol-designer/src/top-selectors/timelineFrames.js
@@ -4,7 +4,6 @@ import { createSelector } from 'reselect'
 import assert from 'assert'
 
 import { selectors as fileDataSelectors } from '../file-data'
-// import { selectors as labwareIngredSelectors } from '../labware-ingred/selectors'
 import { selectors as stepFormSelectors } from '../step-forms'
 import { selectors as stepsSelectors } from '../ui/steps'
 import { START_TERMINAL_ITEM_ID } from '../steplist'
@@ -12,29 +11,23 @@ import { START_TERMINAL_ITEM_ID } from '../steplist'
 import type { Selector } from '../types'
 import type { CommandsAndRobotState } from '../step-generation'
 
-// TODO IMMEDIATELY: copied from getAllWellContentsForActiveItem, import & use this there
-export const timelineFrameBeforeActiveItem: Selector<CommandsAndRobotState> = createSelector(
-  stepsSelectors.getActiveItem,
-  fileDataSelectors.getInitialRobotState,
-  fileDataSelectors.getRobotStateTimeline,
-  fileDataSelectors.lastValidRobotState,
-  stepFormSelectors.getOrderedStepIds,
-  (
-    activeItem,
-    initialRobotState,
-    robotStateTimeline,
-    lastValidRobotState,
-    orderedStepIds
-  ) => {
-    // Add pseudo-frames for start and end terminal items
-    const timeline = [
-      { robotState: initialRobotState, commands: [] },
-      ...robotStateTimeline.timeline,
-      { robotState: lastValidRobotState, commands: [] },
-    ]
-    const lastValidRobotStateIdx = timeline.length - 1
-    let timelineIdx = lastValidRobotStateIdx // default to last valid robot state
+const _timelineFrameHelper = (beforeActiveItem: boolean) => (
+  activeItem,
+  initialRobotState,
+  robotStateTimeline,
+  lastValidRobotState,
+  orderedStepIds
+): CommandsAndRobotState => {
+  // Add pseudo-frames for start and end terminal items
+  const timeline = [
+    { robotState: initialRobotState, commands: [] },
+    ...robotStateTimeline.timeline,
+    { robotState: lastValidRobotState, commands: [] },
+  ]
+  const lastValidRobotStateIdx = timeline.length - 1
+  let timelineIdx = lastValidRobotStateIdx // default to last valid robot state
 
+  if (beforeActiveItem) {
     if (activeItem.isStep) {
       timelineIdx = Math.min(
         orderedStepIds.findIndex(id => id === activeItem.id),
@@ -43,51 +36,39 @@ export const timelineFrameBeforeActiveItem: Selector<CommandsAndRobotState> = cr
     } else if (activeItem.id === START_TERMINAL_ITEM_ID) {
       timelineIdx = 0
     }
-
-    assert(
-      timelineIdx !== -1,
-      `timelineFrameForActiveItem got unhandled terminal id: "${activeItem.id}"`
-    )
-
-    return timeline[timelineIdx]
+  } else {
+    // after active item
+    const idxAfterStep =
+      orderedStepIds.findIndex(id => id === activeItem.id) + 1
+    if (activeItem.isStep && idxAfterStep <= lastValidRobotStateIdx) {
+      timelineIdx = idxAfterStep
+    } else if (activeItem.id === START_TERMINAL_ITEM_ID) {
+      timelineIdx = 0
+    }
   }
+
+  assert(
+    timelineIdx !== -1,
+    `timelineFrameForActiveItem got unhandled terminal id: "${activeItem.id}"`
+  )
+
+  return timeline[timelineIdx]
+}
+
+export const timelineFrameBeforeActiveItem: Selector<CommandsAndRobotState> = createSelector(
+  stepsSelectors.getActiveItem,
+  fileDataSelectors.getInitialRobotState,
+  fileDataSelectors.getRobotStateTimeline,
+  fileDataSelectors.lastValidRobotState,
+  stepFormSelectors.getOrderedStepIds,
+  _timelineFrameHelper(true)
 )
 
-// TODO IMMEDIATELY: de-duplicate code btw this and above
 export const timelineFrameAfterActiveItem: Selector<CommandsAndRobotState> = createSelector(
   stepsSelectors.getActiveItem,
   fileDataSelectors.getInitialRobotState,
   fileDataSelectors.getRobotStateTimeline,
   fileDataSelectors.lastValidRobotState,
   stepFormSelectors.getOrderedStepIds,
-  (
-    activeItem,
-    initialRobotState,
-    robotStateTimeline,
-    lastValidRobotState,
-    orderedStepIds
-  ) => {
-    // Add pseudo-frames for start and end terminal items
-    const timeline = [
-      { robotState: initialRobotState, commands: [] },
-      ...robotStateTimeline.timeline,
-      { robotState: lastValidRobotState, commands: [] },
-    ]
-    const lastValidRobotStateIdx = timeline.length - 1
-    let timelineIdx = lastValidRobotStateIdx // default to last valid robot state
-
-    let idxAfterStep = orderedStepIds.findIndex(id => id === activeItem.id) + 1
-    if (activeItem.isStep && idxAfterStep <= lastValidRobotStateIdx) {
-      timelineIdx = idxAfterStep
-    } else if (activeItem.id === START_TERMINAL_ITEM_ID) {
-      timelineIdx = 0
-    }
-
-    assert(
-      timelineIdx !== -1,
-      `timelineFrameForActiveItem got unhandled terminal id: "${activeItem.id}"`
-    )
-
-    return timeline[timelineIdx]
-  }
+  _timelineFrameHelper(false)
 )

--- a/protocol-designer/src/top-selectors/timelineFrames.js
+++ b/protocol-designer/src/top-selectors/timelineFrames.js
@@ -1,0 +1,93 @@
+// @flow
+import { createSelector } from 'reselect'
+
+import assert from 'assert'
+
+import { selectors as fileDataSelectors } from '../file-data'
+// import { selectors as labwareIngredSelectors } from '../labware-ingred/selectors'
+import { selectors as stepFormSelectors } from '../step-forms'
+import { selectors as stepsSelectors } from '../ui/steps'
+import { START_TERMINAL_ITEM_ID } from '../steplist'
+
+import type { Selector } from '../types'
+import type { CommandsAndRobotState } from '../step-generation'
+
+// TODO IMMEDIATELY: copied from getAllWellContentsForActiveItem, import & use this there
+export const timelineFrameBeforeActiveItem: Selector<CommandsAndRobotState> = createSelector(
+  stepsSelectors.getActiveItem,
+  fileDataSelectors.getInitialRobotState,
+  fileDataSelectors.getRobotStateTimeline,
+  fileDataSelectors.lastValidRobotState,
+  stepFormSelectors.getOrderedStepIds,
+  (
+    activeItem,
+    initialRobotState,
+    robotStateTimeline,
+    lastValidRobotState,
+    orderedStepIds
+  ) => {
+    // Add pseudo-frames for start and end terminal items
+    const timeline = [
+      { robotState: initialRobotState, commands: [] },
+      ...robotStateTimeline.timeline,
+      { robotState: lastValidRobotState, commands: [] },
+    ]
+    const lastValidRobotStateIdx = timeline.length - 1
+    let timelineIdx = lastValidRobotStateIdx // default to last valid robot state
+
+    if (activeItem.isStep) {
+      timelineIdx = Math.min(
+        orderedStepIds.findIndex(id => id === activeItem.id),
+        lastValidRobotStateIdx
+      )
+    } else if (activeItem.id === START_TERMINAL_ITEM_ID) {
+      timelineIdx = 0
+    }
+
+    assert(
+      timelineIdx !== -1,
+      `timelineFrameForActiveItem got unhandled terminal id: "${activeItem.id}"`
+    )
+
+    return timeline[timelineIdx]
+  }
+)
+
+// TODO IMMEDIATELY: de-duplicate code btw this and above
+export const timelineFrameAfterActiveItem: Selector<CommandsAndRobotState> = createSelector(
+  stepsSelectors.getActiveItem,
+  fileDataSelectors.getInitialRobotState,
+  fileDataSelectors.getRobotStateTimeline,
+  fileDataSelectors.lastValidRobotState,
+  stepFormSelectors.getOrderedStepIds,
+  (
+    activeItem,
+    initialRobotState,
+    robotStateTimeline,
+    lastValidRobotState,
+    orderedStepIds
+  ) => {
+    // Add pseudo-frames for start and end terminal items
+    const timeline = [
+      { robotState: initialRobotState, commands: [] },
+      ...robotStateTimeline.timeline,
+      { robotState: lastValidRobotState, commands: [] },
+    ]
+    const lastValidRobotStateIdx = timeline.length - 1
+    let timelineIdx = lastValidRobotStateIdx // default to last valid robot state
+
+    let idxAfterStep = orderedStepIds.findIndex(id => id === activeItem.id) + 1
+    if (activeItem.isStep && idxAfterStep <= lastValidRobotStateIdx) {
+      timelineIdx = idxAfterStep
+    } else if (activeItem.id === START_TERMINAL_ITEM_ID) {
+      timelineIdx = 0
+    }
+
+    assert(
+      timelineIdx !== -1,
+      `timelineFrameForActiveItem got unhandled terminal id: "${activeItem.id}"`
+    )
+
+    return timeline[timelineIdx]
+  }
+)

--- a/protocol-designer/src/top-selectors/tip-contents/index.js
+++ b/protocol-designer/src/top-selectors/tip-contents/index.js
@@ -218,10 +218,7 @@ export const getTipsForCurrentStep: GetTipSelector = createSelector(
         const { substepIndex } = hoveredSubstepIdentifier
         const substepsForStep = allSubsteps[hoveredSubstepIdentifier.stepId]
 
-        if (
-          substepsForStep &&
-          substepsForStep.commandCreatorFnName !== 'delay'
-        ) {
+        if (substepsForStep && substepsForStep.substepType === 'sourceDest') {
           if (substepsForStep.multichannel) {
             const hoveredSubstepData =
               substepsForStep.multiRows[substepIndex][0] // just use first multi row

--- a/protocol-designer/src/ui/modules/selectors.js
+++ b/protocol-designer/src/ui/modules/selectors.js
@@ -1,15 +1,35 @@
 // @flow
 import { createSelector } from 'reselect'
+import { getLabwareDisplayName } from '@opentrons/shared-data'
+import mapValues from 'lodash/mapValues'
 import { MAGDECK, TEMPDECK, THERMOCYCLER } from '../../constants'
 import { selectors as stepFormSelectors } from '../../step-forms'
 import { getLabwareNicknamesById } from '../labware/selectors'
 import {
   getModuleLabwareOptions,
+  getLabwareOnModule,
   getModuleOnDeckByType,
   getModuleHasLabware,
 } from './utils'
 import type { Options } from '@opentrons/components'
 import type { Selector } from '../../types'
+
+export const getLabwareNamesByModuleId: Selector<{
+  [moduleId: string]: ?{ nickname: ?string, displayName: string },
+}> = createSelector(
+  stepFormSelectors.getInitialDeckSetup,
+  getLabwareNicknamesById,
+  (initialDeckSetup, nicknamesById) =>
+    mapValues(initialDeckSetup.modules, (module, moduleId) => {
+      const labware = getLabwareOnModule(initialDeckSetup, moduleId)
+      return labware
+        ? {
+            nickname: nicknamesById[labware.id],
+            displayName: getLabwareDisplayName(labware.def),
+          }
+        : null
+    })
+)
 
 /** Returns dropdown option for labware placed on magnetic module */
 export const getMagneticLabwareOptions: Selector<Options> = createSelector(

--- a/protocol-designer/src/ui/modules/utils.js
+++ b/protocol-designer/src/ui/modules/utils.js
@@ -1,7 +1,7 @@
 // @flow
 import values from 'lodash/values'
 import i18n from '../../localization'
-import { type ModuleType } from '@opentrons/shared-data'
+import type { ModuleType } from '@opentrons/shared-data'
 import type { Options } from '@opentrons/components'
 import type {
   ModuleOnDeck,


### PR DESCRIPTION
## overview

Closes #4304

## review requests

- [ ] Changes to styles did not break Step Items (Transfer, Pause, and Mix step items are affected by the styling changes here). I think the font size and font weight of step items was wrong for a long time, I'm going by the latest https://app.zeplin.io/project/5c87a3f55f998e3943ad5d38/screen/5dc311bd0c01258340ba7309
- [ ] MAGNET step's substep header ACTION should reflect what is chosen for that form (engage/disengage status)
- [ ] MAGNET step's substep header should show correct labware nickname
- [ ] Hovering over the labware nickname in an expanded MAGNET step item should show a popover with `${labwareNickname} ${labwareDisplayName}` just like TRANSFER etc step item headers do 
- [ ] Hovering over or selecting a MAGNET step should show, on the Deck, the engaged/disengaged status of the module BEFORE the step happens. This was discussed with Morgan, the intention is to reflect how liquids on the deck show how liquids are BEFORE the step happens. This means most of the time, the module status on the deck will be the opposite of what the step is doing, because most of the time when you do an engage, it was disengaged before that step.
- [ ] Liquid state info in substep hover-popovers, and liquid state on the deck as you scrub across the timeline, was refactored. It shouldn't change in behavior, please confirm