### PR TITLE
feat(protocol-designer): Pause until temperature reached

### DIFF
--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -19,6 +19,7 @@
 .form_row {
   min-height: 2.25rem;
   display: flex;
+  align-items: flex-start;
 }
 
 .wrap_group {

--- a/protocol-designer/src/components/StepEditForm/forms/PauseForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/PauseForm.js
@@ -5,6 +5,11 @@ import { selectors as uiModuleSelectors } from '../../../ui/modules'
 import { selectors as featureFlagSelectors } from '../../../feature-flags'
 import { FormGroup } from '@opentrons/components'
 import i18n from '../../../localization'
+import {
+  PAUSE_UNTIL_RESUME,
+  PAUSE_UNTIL_TIME,
+  PAUSE_UNTIL_TEMP,
+} from '../../../constants'
 
 import {
   ConditionalOnField,
@@ -51,7 +56,7 @@ export const PauseForm = (props: PauseFormProps): React.Element<'div'> => {
                   name: i18n.t(
                     'form.step_edit_form.field.pauseForAmountOfTime.options.untilResume'
                   ),
-                  value: 'untilResume',
+                  value: PAUSE_UNTIL_RESUME,
                 },
               ]}
               {...focusHandlers}
@@ -65,7 +70,7 @@ export const PauseForm = (props: PauseFormProps): React.Element<'div'> => {
                   name: i18n.t(
                     'form.step_edit_form.field.pauseForAmountOfTime.options.untilTime'
                   ),
-                  value: 'untilTime',
+                  value: PAUSE_UNTIL_TIME,
                 },
               ]}
               {...focusHandlers}
@@ -73,7 +78,7 @@ export const PauseForm = (props: PauseFormProps): React.Element<'div'> => {
           </div>
           <ConditionalOnField
             name={'pauseForAmountOfTime'}
-            condition={val => val === 'untilTime'}
+            condition={val => val === PAUSE_UNTIL_TIME}
           >
             <div className={styles.form_row}>
               <TextField
@@ -109,7 +114,7 @@ export const PauseForm = (props: PauseFormProps): React.Element<'div'> => {
                       name: i18n.t(
                         'form.step_edit_form.field.pauseForAmountOfTime.options.untilTemperature'
                       ),
-                      value: 'untilTemperature',
+                      value: PAUSE_UNTIL_TEMP,
                     },
                   ]}
                   {...focusHandlers}
@@ -117,7 +122,7 @@ export const PauseForm = (props: PauseFormProps): React.Element<'div'> => {
               </div>
               <ConditionalOnField
                 name={'pauseForAmountOfTime'}
-                condition={val => val === 'untilTemperature'}
+                condition={val => val === PAUSE_UNTIL_TEMP}
               >
                 <div className={styles.form_row}>
                   <FormGroup

--- a/protocol-designer/src/components/StepEditForm/forms/PauseForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/PauseForm.js
@@ -1,9 +1,17 @@
 // @flow
 import * as React from 'react'
+import { useSelector } from 'react-redux'
+import { selectors as uiModuleSelectors } from '../../../ui/modules'
+import { selectors as featureFlagSelectors } from '../../../feature-flags'
 import { FormGroup } from '@opentrons/components'
 import i18n from '../../../localization'
 
-import { ConditionalOnField, TextField, RadioGroupField } from '../fields'
+import {
+  ConditionalOnField,
+  TextField,
+  RadioGroupField,
+  StepFormDropdown,
+} from '../fields'
 import { FieldConnector } from '../fields/FieldConnector'
 import styles from '../StepEditForm.css'
 
@@ -12,6 +20,11 @@ import type { FocusHandlers } from '../types'
 type PauseFormProps = { focusHandlers: FocusHandlers }
 export const PauseForm = (props: PauseFormProps): React.Element<'div'> => {
   const { focusHandlers } = props
+
+  const modulesEnabled = useSelector(featureFlagSelectors.getEnableModules)
+  const moduleLabwareOptions = useSelector(
+    uiModuleSelectors.getTemperatureLabwareOptions
+  )
 
   // time fields blur together
   const blurAllTimeUnitFields = () => {
@@ -36,9 +49,9 @@ export const PauseForm = (props: PauseFormProps): React.Element<'div'> => {
               options={[
                 {
                   name: i18n.t(
-                    'form.step_edit_form.field.pauseForAmountOfTime.options.false'
+                    'form.step_edit_form.field.pauseForAmountOfTime.options.untilResume'
                   ),
-                  value: 'false',
+                  value: 'untilResume',
                 },
               ]}
               {...focusHandlers}
@@ -50,9 +63,9 @@ export const PauseForm = (props: PauseFormProps): React.Element<'div'> => {
               options={[
                 {
                   name: i18n.t(
-                    'form.step_edit_form.field.pauseForAmountOfTime.options.true'
+                    'form.step_edit_form.field.pauseForAmountOfTime.options.untilTime'
                   ),
-                  value: 'true',
+                  value: 'untilTime',
                 },
               ]}
               {...focusHandlers}
@@ -60,7 +73,7 @@ export const PauseForm = (props: PauseFormProps): React.Element<'div'> => {
           </div>
           <ConditionalOnField
             name={'pauseForAmountOfTime'}
-            condition={val => val === 'true'}
+            condition={val => val === 'untilTime'}
           >
             <div className={styles.form_row}>
               <TextField
@@ -86,6 +99,54 @@ export const PauseForm = (props: PauseFormProps): React.Element<'div'> => {
               />
             </div>
           </ConditionalOnField>
+          {modulesEnabled && (
+            <>
+              <div className={styles.checkbox_row}>
+                <RadioGroupField
+                  name="pauseForAmountOfTime"
+                  options={[
+                    {
+                      name: i18n.t(
+                        'form.step_edit_form.field.pauseForAmountOfTime.options.untilTemperature'
+                      ),
+                      value: 'untilTemperature',
+                    },
+                  ]}
+                  {...focusHandlers}
+                />
+              </div>
+              <ConditionalOnField
+                name={'pauseForAmountOfTime'}
+                condition={val => val === 'untilTemperature'}
+              >
+                <div className={styles.form_row}>
+                  <FormGroup
+                    label={i18n.t(
+                      'form.step_edit_form.field.moduleActionLabware.label'
+                    )}
+                  >
+                    <StepFormDropdown
+                      {...focusHandlers}
+                      name="moduleId"
+                      options={moduleLabwareOptions}
+                    />
+                  </FormGroup>
+                  <FormGroup
+                    label={i18n.t(
+                      'form.step_edit_form.field.pauseTemperature.label'
+                    )}
+                  >
+                    <TextField
+                      name="pauseTemperature"
+                      className={styles.small_field}
+                      units={i18n.t('application.units.degrees')}
+                      {...focusHandlers}
+                    />
+                  </FormGroup>
+                </div>
+              </ConditionalOnField>
+            </>
+          )}
         </div>
         <div className={styles.section_column}>
           <div className={styles.form_row}>

--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -99,3 +99,7 @@ export const MODULE_TYPE_TO_FILE_MODULE_TYPE: { [ModuleType]: string } = {
   [MAGDECK]: MAGMOD,
   [THERMOCYCLER]: THERMOCYCLER,
 }
+
+export const PAUSE_UNTIL_RESUME = 'untilResume'
+export const PAUSE_UNTIL_TIME = 'untilTime'
+export const PAUSE_UNTIL_TEMP = 'untilTemperature'

--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -100,6 +100,6 @@ export const MODULE_TYPE_TO_FILE_MODULE_TYPE: { [ModuleType]: string } = {
   [THERMOCYCLER]: THERMOCYCLER,
 }
 
-export const PAUSE_UNTIL_RESUME = 'untilResume'
-export const PAUSE_UNTIL_TIME = 'untilTime'
-export const PAUSE_UNTIL_TEMP = 'untilTemperature'
+export const PAUSE_UNTIL_RESUME: 'untilResume' = 'untilResume'
+export const PAUSE_UNTIL_TIME: 'untilTime' = 'untilTime'
+export const PAUSE_UNTIL_TEMP: 'untilTemperature' = 'untilTemperature'

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -1,4 +1,9 @@
 // @flow
+import {
+  PAUSE_UNTIL_RESUME,
+  PAUSE_UNTIL_TIME,
+  PAUSE_UNTIL_TEMP,
+} from './constants'
 import type { IconName } from '@opentrons/components'
 import type { LabwareEntity, PipetteEntity } from './step-forms'
 import type { ChangeTipOptions } from './step-generation'
@@ -116,7 +121,11 @@ export type PauseForm = {|
   stepType: 'pause',
   id: StepIdType,
 
-  pauseForAmountOfTime?: 'untilTime' | 'untilTemperature' | 'untilResume',
+  pauseForAmountOfTime?:
+    | typeof PAUSE_UNTIL_RESUME
+    | typeof PAUSE_UNTIL_TIME
+    | typeof PAUSE_UNTIL_TEMP,
+
   pauseHour?: string,
   pauseMinute?: string,
   pauseSecond?: string,

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -116,11 +116,12 @@ export type PauseForm = {|
   stepType: 'pause',
   id: StepIdType,
 
-  pauseForAmountOfTime?: 'true' | 'false',
+  pauseForAmountOfTime?: 'untilTime' | 'untilTemperature' | 'untilResume',
   pauseHour?: string,
   pauseMinute?: string,
   pauseSecond?: string,
   pauseMessage?: string,
+  pauseTemperature?: string,
 |}
 
 // TODO: separate field values from from metadata

--- a/protocol-designer/src/localization/en/form.json
+++ b/protocol-designer/src/localization/en/form.json
@@ -74,10 +74,12 @@
       "mix": { "label": "mix" },
       "pauseForAmountOfTime": {
         "options": {
-          "false": "Pause until told to resume",
-          "true": "Delay for an amount of time"
+          "untilResume": "Pause until told to resume",
+          "untilTime": "Delay for an amount of time",
+          "untilTemperature": "Pause until temperature reached"
         }
       },
+      "pauseTemperature": { "label": "Temp" },
       "pauseMessage": { "label": "message to display" },
       "path": {
         "title": {

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -135,7 +135,6 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
     maskValue: composeMaskers(maskToFloat),
     castValue: Number,
   },
-  moduleId: { getErrors: composeErrors(requiredField) },
   setTemperature: { getErrors: composeErrors(requiredField) },
   targetTemperature: {
     getErrors: composeErrors(

--- a/protocol-designer/src/steplist/formLevel/errors.js
+++ b/protocol-designer/src/steplist/formLevel/errors.js
@@ -2,6 +2,11 @@
 import * as React from 'react'
 import { getWellRatio } from '../utils'
 import { canPipetteUseLabware } from '../../utils'
+import {
+  PAUSE_UNTIL_RESUME,
+  PAUSE_UNTIL_TIME,
+  PAUSE_UNTIL_TEMP,
+} from '../../constants'
 import type { StepFieldName } from '../../form-types'
 
 /*******************
@@ -128,14 +133,14 @@ export const pauseForTimeOrUntilTold = (
     moduleId,
     pauseTemperature,
   } = fields
-  if (pauseForAmountOfTime === 'untilTime') {
+  if (pauseForAmountOfTime === PAUSE_UNTIL_TIME) {
     // user selected pause for amount of time
     const hours = parseFloat(pauseHour) || 0
     const minutes = parseFloat(pauseMinute) || 0
     const seconds = parseFloat(pauseSecond) || 0
     const totalSeconds = hours * 3600 + minutes * 60 + seconds
     return totalSeconds <= 0 ? FORM_ERRORS.TIME_PARAM_REQUIRED : null
-  } else if (pauseForAmountOfTime === 'untilTemperature') {
+  } else if (pauseForAmountOfTime === PAUSE_UNTIL_TEMP) {
     // user selected pause until temperature reached
     if (!moduleId) {
       // missing module field (reached by deleting a module from deck)
@@ -146,7 +151,7 @@ export const pauseForTimeOrUntilTold = (
       return FORM_ERRORS.PAUSE_TEMP_PARAM_REQUIRED
     }
     return null
-  } else if (pauseForAmountOfTime === 'untilResume') {
+  } else if (pauseForAmountOfTime === PAUSE_UNTIL_RESUME) {
     // user selected pause until resume
     return null
   } else {

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -71,6 +71,8 @@ export default function getDefaultsForStepType(
         pauseMinute: null,
         pauseSecond: null,
         pauseMessage: '',
+        moduleId: null,
+        pauseTemperature: null,
       }
     case 'manualIntervention':
       return {

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.js
@@ -8,6 +8,14 @@ const pauseFormToArgs = (formData: FormData): PauseArgs => {
   const minutes = parseFloat(formData['pauseMinute']) || 0
   const seconds = parseFloat(formData['pauseSecond']) || 0
   const totalSeconds = hours * 3600 + minutes * 60 + seconds
+  const temperature = parseFloat(formData['pauseTemperature'])
+
+  let wait = true
+  if (formData['pauseForAmountOfTime'] === 'untilTemperature') {
+    wait = temperature // TODO: differentiate between seconds and temperature in step generation
+  } else if (formData['pauseForAmountOfTime'] === 'untilTime') {
+    wait = totalSeconds
+  }
 
   const message = formData['pauseMessage'] || ''
 
@@ -15,7 +23,7 @@ const pauseFormToArgs = (formData: FormData): PauseArgs => {
     commandCreatorFnName: 'delay',
     name: `Pause ${formData.id}`, // TODO real name for steps
     description: 'description would be here 2018-03-01', // TODO get from form
-    wait: formData['pauseForAmountOfTime'] === 'false' ? true : totalSeconds,
+    wait,
     message,
     meta: {
       hours,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.js
@@ -1,4 +1,5 @@
 // @flow
+import { PAUSE_UNTIL_TIME, PAUSE_UNTIL_TEMP } from '../../../constants'
 
 import type { FormData } from '../../../form-types'
 import type { PauseArgs } from '../../../step-generation'
@@ -11,9 +12,9 @@ const pauseFormToArgs = (formData: FormData): PauseArgs => {
   const temperature = parseFloat(formData['pauseTemperature'])
 
   let wait = true
-  if (formData['pauseForAmountOfTime'] === 'untilTemperature') {
+  if (formData['pauseForAmountOfTime'] === PAUSE_UNTIL_TEMP) {
     wait = temperature // TODO: differentiate between seconds and temperature in step generation
-  } else if (formData['pauseForAmountOfTime'] === 'untilTime') {
+  } else if (formData['pauseForAmountOfTime'] === PAUSE_UNTIL_TIME) {
     wait = totalSeconds
   }
 

--- a/protocol-designer/src/ui/steps/actions/actions.js
+++ b/protocol-designer/src/ui/steps/actions/actions.js
@@ -98,6 +98,12 @@ export const selectStep = (
     stepFormSelectors.getInitialDeckSetup(state).pipettes
   )
 
+  const moduleId = getNextDefaultTemperatureModuleId(
+    stepFormSelectors.getSavedStepForms(state),
+    stepFormSelectors.getOrderedStepIds(state),
+    stepFormSelectors.getInitialDeckSetup(state).modules
+  )
+
   // For a pristine step, if there is a `pipette` field in the form
   // (added by upstream `getDefaultsForStepType` fn),
   // then set `pipette` field of new steps to the next default pipette id.
@@ -119,6 +125,17 @@ export const selectStep = (
     }
   }
 
+  // For a pristine step, if there is a `moduleId` field in the form
+  // (added by upstream `getDefaultsForStepType` fn),
+  // then set `moduleID` field of new steps to the next default module id.
+  const formHasModuleIdField = formData && 'moduleId' in formData
+  if (newStepType && formHasModuleIdField) {
+    formData = {
+      ...formData,
+      moduleId,
+    }
+  }
+
   // auto-select magnetic module if it exists (assumes no more than 1 magnetic module)
   if (newStepType === 'magnet') {
     const moduleId = uiModulesSelectors.getSingleMagneticModuleId(state)
@@ -127,15 +144,6 @@ export const selectStep = (
       stepFormSelectors.getOrderedStepIds(state)
     )
     formData = { ...formData, moduleId, magnetAction }
-  }
-
-  if (newStepType === 'temperature') {
-    const moduleId = getNextDefaultTemperatureModuleId(
-      stepFormSelectors.getSavedStepForms(state),
-      stepFormSelectors.getOrderedStepIds(state),
-      stepFormSelectors.getInitialDeckSetup(state).modules
-    )
-    formData = { ...formData, moduleId }
   }
 
   dispatch({

--- a/protocol-designer/src/ui/steps/actions/actions.js
+++ b/protocol-designer/src/ui/steps/actions/actions.js
@@ -129,7 +129,10 @@ export const selectStep = (
   // (added by upstream `getDefaultsForStepType` fn),
   // then set `moduleID` field of new steps to the next default module id.
   const formHasModuleIdField = formData && 'moduleId' in formData
-  if (newStepType && formHasModuleIdField) {
+  if (
+    (newStepType === 'pause' || newStepType === 'temperature') &&
+    formHasModuleIdField
+  ) {
     formData = {
       ...formData,
       moduleId,


### PR DESCRIPTION
## overview

This PR closes #4306 by adding the UI side of pause until temp to the pause form behind the modules feature flag.

## changelog

- feat(protocol-designer): Pause until temperature reached
- refactor: Update `getDefaultModuleId` to apply to any moduleId field
- refactor: Update `pauseForAmountOfTime` to accept `'untilTime' | 'untilTemperature' | 'untilResume'
- refactor: Remove moduleIdRequired field level validation (was disabling pause for amount of time when module FF was off)

## review requests

http://sandbox.designer.opentrons.com/pd_wait-until-temp/

Turn Modules in PD FF off
- [ ] Pause step form behaves as expected
- [ ] Pause until temp reached option is not visible

Turn Modules in PD FF on
- [ ]  Pause step form [until told to resume] behaves as expected
- [ ]  Pause step form [for an amount of time] behaves as expected
- [ ] Selecting [Pause until temperature reached] shows module and temp fields
- [ ] Module/Labware dropdown is automatically filled 
- [ ] Temperature field is then required for save

**Known weirdness not covered by this PR:**
- I had to update the pauseFormToArgs wait field. Right now, saving a Pause until temperature reached saves as a pause for amount of time with 0h 0m 0s. This needs to be handled when updating the pause step actions.
- I removed the required field level validation from moduleId (still covered by form level) since field level validation doesn't check other conditional fields

