### PR TITLE
refactor(js): Fix a variety of type definitions that will break in future Flow versions

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -16,10 +16,6 @@
     "url": "https://github.com/Opentrons/opentrons/issues"
   },
   "homepage": "https://github.com/Opentrons/opentrons",
-  "devDependencies": {
-    "flow-bin": "^0.110.1",
-    "flow-typed": "^2.6.2"
-  },
   "dependencies": {
     "@opentrons/components": "3.15.2",
     "@opentrons/shared-data": "3.15.2",

--- a/app/src/analytics/make-event.js
+++ b/app/src/analytics/make-event.js
@@ -47,8 +47,8 @@ export function makeEvent(
       return getProtocolAnalyticsData(state).then(data => ({
         name: 'protocolUploadRequest',
         properties: {
-          ...data,
           ...getRobotAnalyticsData(state),
+          ...data,
         },
       }))
     }
@@ -63,8 +63,8 @@ export function makeEvent(
       return getProtocolAnalyticsData(state).then(data => ({
         name: 'protocolUploadResponse',
         properties: {
-          ...data,
           ...getRobotAnalyticsData(state),
+          ...data,
           success: actionType === 'robot:SESSION_RESPONSE',
           error: (actionPayload.error && actionPayload.error.message) || '',
         },
@@ -76,8 +76,8 @@ export function makeEvent(
       return getProtocolAnalyticsData(state).then(data => ({
         name: 'runStart',
         properties: {
-          ...data,
           ...getRobotAnalyticsData(state),
+          ...data,
         },
       }))
     }
@@ -94,8 +94,8 @@ export function makeEvent(
       return getProtocolAnalyticsData(state).then(data => ({
         name: 'runFinish',
         properties: {
-          ...data,
           ...getRobotAnalyticsData(state),
+          ...data,
           runTime,
           success,
           error,

--- a/app/src/buildroot/reducer.js
+++ b/app/src/buildroot/reducer.js
@@ -81,6 +81,7 @@ export function buildrootReducer(
 
     case Constants.BR_STATUS: {
       const { stage, progress, message } = action.payload
+      const currentError = state.session?.error || null
 
       return {
         ...state,
@@ -88,7 +89,7 @@ export function buildrootReducer(
           ...state.session,
           stage,
           progress: typeof progress === 'number' ? progress : null,
-          error: stage === Constants.ERROR ? message : state.session?.error,
+          error: stage === Constants.ERROR ? message : currentError,
         },
       }
     }

--- a/app/src/components/CalibrateDeck/AttachTip.js
+++ b/app/src/components/CalibrateDeck/AttachTip.js
@@ -1,19 +1,14 @@
 // @flow
 import * as React from 'react'
-import type { PipetteModelSpecs } from '@opentrons/shared-data'
 import type { CalibrateDeckStartedProps, CalibrationStep } from './types'
 import { PrimaryButton } from '@opentrons/components'
 
 import styles from './styles.css'
 
-type Props = CalibrateDeckStartedProps & {
+type Props = {|
+  ...CalibrateDeckStartedProps,
   proceed: () => mixed,
-}
-
-type DiagramProps = {
-  calibrationStep: CalibrationStep,
-  pipette: PipetteModelSpecs,
-}
+|}
 
 type Channels = 'single' | 'multi'
 
@@ -72,7 +67,7 @@ export default function AttachTipModal(props: Props) {
   )
 }
 
-function getDiagramSrc(props: DiagramProps): string {
+function getDiagramSrc(props: Props): string {
   const { calibrationStep, pipette } = props
   const channelsKey = pipette.channels === 8 ? 'multi' : 'single'
 

--- a/app/src/components/CalibrateDeck/ClearDeckAlert.js
+++ b/app/src/components/CalibrateDeck/ClearDeckAlert.js
@@ -8,7 +8,7 @@ import ClearDeckAlertModal from '../ClearDeckAlertModal'
 import type { Dispatch } from '../../types'
 import type { CalibrateDeckProps } from './types'
 
-type OP = $Exact<CalibrateDeckProps>
+type OP = CalibrateDeckProps
 
 type DP = {|
   onContinue: () => mixed,

--- a/app/src/components/CalibrateDeck/ConfirmPosition.js
+++ b/app/src/components/CalibrateDeck/ConfirmPosition.js
@@ -5,9 +5,10 @@ import { PrimaryButton } from '@opentrons/components'
 import JogControls from '../JogControls'
 import Instructions from './Instructions'
 
-type Props = CalibrateDeckStartedProps & {
+type Props = {|
+  ...CalibrateDeckStartedProps,
   proceed: () => mixed,
-}
+|}
 
 export default function ConfirmPosition(props: Props) {
   return (

--- a/app/src/components/CalibrateDeck/InstructionsModal.js
+++ b/app/src/components/CalibrateDeck/InstructionsModal.js
@@ -16,11 +16,11 @@ import ConfirmPosition from './ConfirmPosition'
 import type { Dispatch } from '../../types'
 import type { CalibrateDeckStartedProps } from './types'
 
-type OP = $Exact<CalibrateDeckStartedProps>
+type OP = CalibrateDeckStartedProps
 
 type DP = {| proceed: () => mixed |}
 
-type Props = { ...OP, ...DP }
+type Props = {| ...OP, ...DP |}
 
 const TITLE = 'Deck Calibration'
 

--- a/app/src/components/CalibrateDeck/types.js
+++ b/app/src/components/CalibrateDeck/types.js
@@ -33,12 +33,12 @@ export type DP = {|
   back: () => mixed,
 |}
 
-export type CalibrateDeckProps = { ...OP, ...SP, ...DP }
+export type CalibrateDeckProps = {| ...OP, ...SP, ...DP |}
 
-export type CalibrateDeckStartedProps = {
-  ...$Exact<CalibrateDeckProps>,
+export type CalibrateDeckStartedProps = {|
+  ...CalibrateDeckProps,
   exitUrl: string,
   mount: Mount,
   pipette: PipetteModelSpecs,
   calibrationStep: CalibrationStep,
-}
+|}

--- a/app/src/components/CalibrateLabware/ConfirmPositionContents.js
+++ b/app/src/components/CalibrateLabware/ConfirmPositionContents.js
@@ -23,7 +23,7 @@ type DP = {|
   jog: Jog,
 |}
 
-type Props = { ...OP, ...DP }
+type Props = {| ...OP, ...DP |}
 
 export default connect<Props, OP, _, _, _, _>(
   null,
@@ -32,6 +32,7 @@ export default connect<Props, OP, _, _, _, _>(
 
 function ConfirmPositionContents(props: Props) {
   const {
+    jog,
     onConfirmClick,
     labware,
     calibrator,
@@ -49,7 +50,7 @@ function ConfirmPositionContents(props: Props) {
         {...{ labware, calibrator, calibrateToBottom, useCenteredTroughs }}
         buttonText={confirmButtonText}
       />
-      <JogControls {...props} />
+      <JogControls jog={jog} />
       <PrimaryButton title="confirm" onClick={onConfirmClick}>
         {confirmButtonText}
       </PrimaryButton>

--- a/app/src/components/CalibrateLabware/ProceedToRun.js
+++ b/app/src/components/CalibrateLabware/ProceedToRun.js
@@ -34,7 +34,6 @@ function ProceedToRun(props: Props) {
   }, [sessionModules])
 
   const handleClick = () => {
-    // $FlowFixMe: robotActions.returnTip is not typed
     returnTip()
     if (mustPrepForRun) {
       setRunPrepModalOpen(true)

--- a/app/src/components/CalibratePanel/LabwareList.js
+++ b/app/src/components/CalibratePanel/LabwareList.js
@@ -24,12 +24,12 @@ type SP = {|
 
 type DP = {| dispatch: Dispatch |}
 
-type Props = {
+type Props = {|
   labware: Array<Labware>,
   modulesBySlot: { [Slot]: SessionModule },
   disabled: boolean,
   setLabware: (labware: Labware) => mixed,
-}
+|}
 
 export default withRouter<{||}, _>(
   connect<Props, _, SP, {||}, State, Dispatch>(
@@ -54,7 +54,6 @@ function LabwareList(props: Props) {
             modulesBySlot[lw.slot].name
           }
           isDisabled={disabled}
-          confirmed={lw.confirmed}
           onClick={() => setLabware(lw)}
         />
       ))}

--- a/app/src/components/CalibratePanel/LabwareListItem.js
+++ b/app/src/components/CalibratePanel/LabwareListItem.js
@@ -14,7 +14,7 @@ import type { Labware } from '../../robot'
 import { THERMOCYCLER } from '../../modules'
 
 type LabwareListItemProps = {|
-  ...$Exact<Labware>,
+  ...Labware,
   moduleName?: ModuleType,
   isDisabled: boolean,
   onClick: () => mixed,

--- a/app/src/components/ConnectPanel/UnreachableRobotItem.js
+++ b/app/src/components/ConnectPanel/UnreachableRobotItem.js
@@ -24,11 +24,7 @@ export default function UnreachableRobotItem(props: UnreachableRobot) {
             disabled
             hoverTooltipHandlers={hoverTooltipHandlers}
           >
-            <Icon
-              name={'alert-circle'}
-              className={styles.robot_item_icon}
-              disabled
-            />
+            <Icon name={'alert-circle'} className={styles.robot_item_icon} />
             <p className={styles.link_text}>{displayName}</p>
           </RobotLink>
         )}

--- a/app/src/components/ReviewDeck/Prompt.js
+++ b/app/src/components/ReviewDeck/Prompt.js
@@ -9,13 +9,14 @@ import { selectors as robotSelectors, type Labware } from '../../robot'
 import styles from './styles.css'
 
 type Props = {|
-  ...$Exact<Labware>,
+  ...Labware,
   onClick: () => void,
 |}
 
 export default function Prompt(props: Props) {
-  const { name, definition, slot, onClick } = props
-  const labwareType = robotSelectors.labwareType(props)
+  const { onClick, ...labware } = props
+  const { name, definition, slot } = labware
+  const labwareType = robotSelectors.labwareType(labware)
   const labwareTitle = definition ? getLabwareDisplayName(definition) : name
 
   return (

--- a/app/src/components/RobotSettings/SelectNetwork/SelectKey.js
+++ b/app/src/components/RobotSettings/SelectNetwork/SelectKey.js
@@ -40,7 +40,6 @@ export default class SelectKey extends React.Component<Props> {
       event.target.value = ''
       // $FlowFixMe: see TODO and HACK in app/src/http-api-client/networking.js
       this.props.addKey(file).then(success => {
-        // $FlowFixMe: ditto
         this.props.onValueChange(this.props.name, success.payload.response.id)
       })
     }

--- a/app/src/components/RobotSettings/SelectNetwork/fields.js
+++ b/app/src/components/RobotSettings/SelectNetwork/fields.js
@@ -31,13 +31,13 @@ type PasswordFieldProps = {
   toggleShowPassword: (name: string) => mixed,
 }
 
-type SelectOptionFieldProps = {
+type SelectOptionFieldProps = {|
   ...BaseFieldProps,
   options: Array<SelectOption>,
   placeholder?: string,
-  onValueChange?: (name: string, value: ?string) => mixed,
+  onValueChange: (name: string, value: ?string) => mixed,
   onLoseFocus?: (name: string) => mixed,
-}
+|}
 
 const SHOW_PASSWORD_LABEL = 'Show password'
 const FIELD_ID_PREFIX = '__ConnectForm__'

--- a/app/src/components/TipProbe/types.js
+++ b/app/src/components/TipProbe/types.js
@@ -1,7 +1,7 @@
 // @flow
 import type { Pipette } from '../../robot'
 
-export type TipProbeProps = $Exact<Pipette>
+export type TipProbeProps = Pipette
 
 export type TipProbeState =
   | 'unprobed'

--- a/app/src/components/calibrate-pipettes/Pipettes.js
+++ b/app/src/components/calibrate-pipettes/Pipettes.js
@@ -6,6 +6,7 @@ import { PIPETTE_MOUNTS } from '../../pipettes'
 import { InstrumentGroup } from '@opentrons/components'
 import styles from './styles.css'
 
+import type { InstrumentInfoProps } from '@opentrons/components'
 import type { Pipette, TiprackByMountMap } from '../../robot/types'
 import type { Mount } from '../../pipettes/types'
 
@@ -19,7 +20,12 @@ type Props = {|
 export default function Pipettes(props: Props) {
   const { currentMount, pipettes, tipracksByMount } = props
 
-  const infoByMount = PIPETTE_MOUNTS.reduce((result, mount) => {
+  const infoByMount = PIPETTE_MOUNTS.reduce<
+    $Shape<{|
+      left?: InstrumentInfoProps,
+      right?: InstrumentInfoProps,
+    |}>
+  >((result, mount) => {
     const pipette = pipettes.find(p => p.mount === mount)
     const tiprack = tipracksByMount[mount]
     const pipetteConfig = pipette?.modelSpecs

--- a/app/src/discovery/types.js
+++ b/app/src/discovery/types.js
@@ -16,37 +16,37 @@ export type ReachableStatus = 'reachable'
 export type UnreachableStatus = 'unreachable'
 
 // service with a known IP address
-export type ResolvedRobot = {
+export type ResolvedRobot = {|
   ...$Exact<Service>,
   ip: $NonMaybeType<$PropertyType<Service, 'ip'>>,
   local: $NonMaybeType<$PropertyType<Service, 'local'>>,
   ok: $NonMaybeType<$PropertyType<Service, 'ok'>>,
   serverOk: $NonMaybeType<$PropertyType<Service, 'serverOk'>>,
   displayName: string,
-}
+|}
 
 // fully connectable robot
-export type Robot = {
+export type Robot = {|
   ...$Exact<ResolvedRobot>,
   ok: true,
   health: $NonMaybeType<$PropertyType<Service, 'health'>>,
   status: ConnectableStatus,
   connected: boolean,
-}
+|}
 
 // robot with a known IP (i.e. advertising over mDNS) but unconnectable
-export type ReachableRobot = {
+export type ReachableRobot = {|
   ...$Exact<ResolvedRobot>,
   ok: false,
   status: ReachableStatus,
-}
+|}
 
 // robot with an unknown IP
-export type UnreachableRobot = {
+export type UnreachableRobot = {|
   ...$Exact<Service>,
   displayName: string,
   status: UnreachableStatus,
-}
+|}
 
 export type ViewableRobot = Robot | ReachableRobot
 

--- a/app/src/http-api-client/calibration.js
+++ b/app/src/http-api-client/calibration.js
@@ -1,5 +1,6 @@
 // @flow
 // http api client module for /calibration/**
+// DEPRECATED(mc, 2020-01-13)
 import { createSelector } from 'reselect'
 
 import type { OutputSelector } from 'reselect'
@@ -68,8 +69,7 @@ export type DeckCalStartState = ApiCall<DeckStartRequest, DeckStartResponse>
 export type DeckCalCommandState = ApiCall<DeckCalRequest, DeckCalResponse>
 
 type RobotCalState = {
-  'calibration/deck/start'?: DeckCalStartState,
-  'calibration/deck'?: DeckCalCommandState,
+  [string]: any,
 }
 
 type CalState = {
@@ -82,7 +82,7 @@ const DECK_START: 'calibration/deck/start' = 'calibration/deck/start'
 // TODO(mc, 2018-07-05): flow helper until we have one reducer, since
 // p === 'constant' checks but p === CONSTANT does not, even if
 // CONSTANT is defined as `const CONSTANT: 'constant' = 'constant'`
-function getCalPath(p: string): ?CalPath {
+function getCalPath(p: string): string | null {
   if (p === 'calibration/deck/start' || p === 'calibration/deck') return p
 
   return null
@@ -158,7 +158,7 @@ export function calibrationReducer(state: ?CalState, action: Action): CalState {
       }
 
       if (path === DECK_START) {
-        stateByName[DECK] = {
+        stateByName[(DECK: string)] = {
           request: null,
           response: null,
           error: null,

--- a/app/src/http-api-client/reducer.js
+++ b/app/src/http-api-client/reducer.js
@@ -1,5 +1,6 @@
 // @flow
 // generic api reducer
+// DEPRECATED(mc, 2020-01-13)
 import isEmpty from 'lodash/isEmpty'
 import reduce from 'lodash/reduce'
 import { normalizeRobots } from '../discovery/reducer'
@@ -7,10 +8,9 @@ import { normalizeRobots } from '../discovery/reducer'
 import type { Service } from '@opentrons/discovery-client'
 import type { State, Action } from '../types'
 import type { BaseRobot } from '../robot'
-import type { NetworkingState } from './networking'
 
 export type RobotApiState = $Shape<{|
-  ...NetworkingState,
+  [path: string]: any,
 |}>
 
 type ApiState = { [name: string]: ?RobotApiState }
@@ -117,7 +117,7 @@ export function getRobotApiState(
   return state.superDeprecatedRobotApi.api[props.name] || {}
 }
 
-function getUpdateInfo(state: ApiState, action: *): * {
+function getUpdateInfo(state: ApiState, action: any): any {
   const {
     path,
     robot: { name },

--- a/app/src/logger.js
+++ b/app/src/logger.js
@@ -13,28 +13,38 @@ export type LogLevel =
   | 'debug'
   | 'silly'
 
-type Logger = { [level: LogLevel]: (message: string, meta?: {}) => void }
+export type Log = (message: string, meta?: {}) => void
 
-const LEVELS: Array<LogLevel> = [
-  'error',
-  'warn',
-  'info',
-  'http',
-  'verbose',
-  'debug',
-  'silly',
-]
+type Logger = {|
+  error: Log,
+  warn: Log,
+  info: Log,
+  http: Log,
+  verbose: Log,
+  debug: Log,
+  silly: Log,
+|}
+
+const ERROR: 'error' = 'error'
+const WARN: 'warn' = 'warn'
+const INFO: 'info' = 'info'
+const HTTP: 'http' = 'http'
+const VERBOSE: 'verbose' = 'verbose'
+const DEBUG: 'debug' = 'debug'
+const SILLY: 'silly' = 'silly'
 
 export default function createLogger(filename: string): Logger {
   const label = `app/${filename}`
 
-  return LEVELS.reduce(
-    (result, level) => ({
-      ...result,
-      [level]: (message, meta) => log(level, message, label, meta),
-    }),
-    {}
-  )
+  return {
+    [ERROR]: (message, meta) => log(ERROR, message, label, meta),
+    [WARN]: (message, meta) => log(WARN, message, label, meta),
+    [INFO]: (message, meta) => log(INFO, message, label, meta),
+    [HTTP]: (message, meta) => log(HTTP, message, label, meta),
+    [VERBOSE]: (message, meta) => log(VERBOSE, message, label, meta),
+    [DEBUG]: (message, meta) => log(DEBUG, message, label, meta),
+    [SILLY]: (message, meta) => log(SILLY, message, label, meta),
+  }
 }
 
 function log(level: LogLevel, message: string, label: string, meta?: {}) {
@@ -56,7 +66,7 @@ function log(level: LogLevel, message: string, label: string, meta?: {}) {
   }
 
   // send to main process for log file collection
-  remote.ipcRenderer.send('log', { level, message, label, ...meta })
+  remote.ipcRenderer.send('log', { ...meta, level, message, label })
 }
 
 // $FlowFixMe(BC, 2019-10-04): ref will never actually be undefined

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -70,7 +70,7 @@ export type Command = {
 }
 
 // instrument as stored in redux state
-export type StatePipette = {
+export type StatePipette = {|
   // resource ID
   _id: number,
   // robot mount instrument is installed on
@@ -88,14 +88,14 @@ export type StatePipette = {
   tipRacks: Array<number>,
   // string specified in protocol to load pipette
   requestedAs?: ?string,
-}
+|}
 
-export type Pipette = {
-  ...$Exact<StatePipette>,
+export type Pipette = {|
+  ...StatePipette,
   probed: boolean,
   tipOn: boolean,
   modelSpecs: PipetteModelSpecs | null,
-}
+|}
 
 // labware as stored in redux state
 export type StateLabware = {|
@@ -117,24 +117,24 @@ export type StateLabware = {|
   calibratorMount: ?Mount,
 |}
 
-export type Labware = {
+export type Labware = {|
   ...StateLabware,
   calibration: LabwareCalibrationStatus,
   confirmed: boolean,
   isMoving: boolean,
   definition: LabwareDefinition2 | null,
-}
+|}
 
 export type LabwareType = 'tiprack' | 'labware'
 
-export type SessionModule = {
+export type SessionModule = {|
   // resource ID
   _id: number,
   // slot module is installed in
   slot: Slot,
   // name identifier of the module
   name: ModuleType,
-}
+|}
 
 export type SessionStatus =
   | ''
@@ -145,14 +145,14 @@ export type SessionStatus =
   | 'finished'
   | 'stopped'
 
-export type SessionUpdate = {
+export type SessionUpdate = {|
   state: SessionStatus,
   startTime: ?number,
-  lastCommand: ?{
+  lastCommand: ?{|
     id: number,
     handledAt: number,
-  },
-}
+  |},
+|}
 
 export type TiprackByMountMap = {|
   left: Labware | null,

--- a/components/package.json
+++ b/components/package.json
@@ -14,10 +14,6 @@
     "url": "https://github.com/Opentrons/opentrons/issues"
   },
   "homepage": "https://github.com/Opentrons/opentrons#readme",
-  "devDependencies": {
-    "flow-bin": "^0.110.1",
-    "flow-typed": "^2.6.2"
-  },
   "peerDependencies": {
     "classnames": "^2.2.5",
     "lodash": "^4.17.4",

--- a/components/src/buttons/IconButton.js
+++ b/components/src/buttons/IconButton.js
@@ -8,20 +8,26 @@ import FlatButton from './FlatButton'
 
 import styles from './buttons.css'
 
-type Props = ButtonProps & IconProps
+type Props = {|
+  ...$Exact<ButtonProps>,
+  name: $PropertyType<IconProps, 'name'>,
+  spin?: $PropertyType<IconProps, 'spin'>,
+|}
 
 /**
  * FlatButton variant for a button that is a single icon. Takes props of
  * both Button _and_ Icon. Use `name` to specify icon name.
  */
 export default function IconButton(props: Props) {
+  const { name, spin, ...buttonProps } = props
+  const iconProps = { name, spin }
   const className = cx(styles.button_icon, props.className, {
     [styles.inverted]: props.inverted,
   })
 
   return (
-    <FlatButton {...props} className={className} iconName={undefined}>
-      <Icon {...props} className={styles.button_only_icon} />
+    <FlatButton {...buttonProps} className={className} iconName={undefined}>
+      <Icon {...iconProps} className={styles.button_only_icon} />
     </FlatButton>
   )
 }

--- a/components/src/controls/ToggleButton.js
+++ b/components/src/controls/ToggleButton.js
@@ -1,16 +1,17 @@
 // @flow
-// reusuable toggle button with on off styling for connect to robot and opt in/out
+// reusable toggle button with on off styling for connect to robot and opt in/out
 import * as React from 'react'
 import cx from 'classnames'
 import { IconButton, type ButtonProps } from '@opentrons/components'
 import styles from './styles.css'
 
-type ToggleProps = ButtonProps & {
+type ToggleProps = {|
+  ...$Exact<ButtonProps>,
   toggledOn: boolean,
-}
+|}
 
 export default function ToggleButton(props: ToggleProps) {
-  const { toggledOn } = props
+  const { toggledOn, ...buttonProps } = props
   const className = cx(styles.robot_item_icon, props.className, {
     [styles.toggled_on]: toggledOn,
     [styles.toggled_off]: !toggledOn,
@@ -18,5 +19,5 @@ export default function ToggleButton(props: ToggleProps) {
 
   const toggleIcon = toggledOn ? 'ot-toggle-switch-on' : 'ot-toggle-switch-off'
 
-  return <IconButton {...props} name={toggleIcon} className={className} />
+  return <IconButton {...buttonProps} name={toggleIcon} className={className} />
 }

--- a/components/src/deck/RobotWorkSpace.js
+++ b/components/src/deck/RobotWorkSpace.js
@@ -27,7 +27,6 @@ function RobotWorkSpace(props: Props) {
   // in Firefox the same fn returns a deprecated SVGMatrix.
   // Until Firefox fixes this and conforms to SVG2 draft,
   // it will suffer from inverted y behavior (ignores css transform)
-  // $FlowFixMe(bc, 2019-05-31): flow type svg ref
   const getRobotCoordsFromDOMCoords: GetRobotCoordsFromDOMCoords = (x, y) => {
     if (!wrapperRef.current) return { x: 0, y: 0 }
     const cursorPoint = wrapperRef.current.createSVGPoint()

--- a/components/src/deck/labwareInternals/types.js
+++ b/components/src/deck/labwareInternals/types.js
@@ -8,4 +8,4 @@ export type WellMouseEvent = {|
 export type WellFill = { [wellName: string]: string }
 
 // Use this like a Set!
-export type WellGroup = { [wellName: string]: null }
+export type WellGroup = $Shape<{| [wellName: string]: null |}>

--- a/components/src/forms/InputField.js
+++ b/components/src/forms/InputField.js
@@ -6,7 +6,7 @@ import styles from './forms.css'
 
 // TODO: Ian 2018-09-14 remove 'label' prop when IngredientPropertiesForm gets updated
 
-type Props = {
+type Props = {|
   /** field is disabled if value is true */
   disabled?: boolean,
   /** change handler */
@@ -47,7 +47,7 @@ type Props = {
   tabIndex?: number,
   /** automatically focus field on render */
   autoFocus?: boolean,
-}
+|}
 
 export default function InputField(props: Props) {
   const error = props.error != null

--- a/components/src/forms/SelectField.js
+++ b/components/src/forms/SelectField.js
@@ -90,11 +90,9 @@ export default class SelectField extends React.Component<SelectProps> {
         <Select
           id={id}
           name={name}
-          // $FlowFixMe: our types are more strict than react-select
           options={options}
           value={value}
           error={error}
-          // $FlowFixMe: our types are more strict than react-select
           onChange={this.handleChange}
           onBlur={this.handleBlur}
           isDisabled={disabled}

--- a/components/src/icons/Icon.js
+++ b/components/src/icons/Icon.js
@@ -5,7 +5,7 @@ import classnames from 'classnames'
 import ICON_DATA_BY_NAME, { type IconName } from './icon-data'
 import styles from './icons.css'
 
-export type IconProps = {
+export type IconProps = {|
   /** name constant of the icon to display */
   name: IconName,
   /** classes to apply */
@@ -24,7 +24,7 @@ export type IconProps = {
   style?: { [string]: string },
   /** optional children */
   children?: React.Node,
-}
+|}
 
 /**
  * Inline SVG icon component

--- a/components/src/icons/NotificationIcon.js
+++ b/components/src/icons/NotificationIcon.js
@@ -4,13 +4,13 @@ import * as React from 'react'
 import Icon, { type IconProps } from './Icon'
 import iconData, { type IconName } from './icon-data'
 
-type Props = {
-  ...$Exact<IconProps>,
+type Props = {|
+  ...IconProps,
   /** name constant of the optional notifcation icon to display */
   childName: ?IconName,
   /** classes to apply (e.g. for color) to notification icon */
   childClassName?: string,
-}
+|}
 
 const SCALE_FACTOR = 3
 
@@ -25,18 +25,18 @@ const SCALE_FACTOR = 3
  */
 
 export default function NotificationIcon(props: Props) {
-  const { name, childName } = props
-  if (!(name in iconData)) {
-    console.error(`"${name}" is not a valid Icon name`)
+  const { childName, childClassName, ...iconProps } = props
+  if (!(iconProps.name in iconData)) {
+    console.error(`"${iconProps.name}" is not a valid Icon name`)
     return null
   }
-  const { viewBox } = iconData[name]
+  const { viewBox } = iconData[iconProps.name]
   const [x, y, width, height] = viewBox.split(' ').map(Number)
   const scaledWidth = width / SCALE_FACTOR
   const scaledHeight = height / SCALE_FACTOR
 
   return (
-    <Icon {...props}>
+    <Icon {...iconProps}>
       {childName && (
         <Icon
           name={childName}

--- a/components/src/instrument/InstrumentGroup.js
+++ b/components/src/instrument/InstrumentGroup.js
@@ -5,11 +5,11 @@ import InstrumentInfo, { type InstrumentInfoProps } from './InstrumentInfo'
 
 import styles from './instrument.css'
 
-type Props = {|
-  showMountLabel?: ?boolean,
-  left?: InstrumentInfoProps,
-  right?: InstrumentInfoProps,
-|}
+type Props = $Shape<{|
+  showMountLabel: ?boolean,
+  left: ?InstrumentInfoProps,
+  right: ?InstrumentInfoProps,
+|}>
 
 const EMPTY_INSTRUMENT_PROPS = {
   description: 'None',

--- a/components/src/instrument/InstrumentGroup.js
+++ b/components/src/instrument/InstrumentGroup.js
@@ -5,11 +5,11 @@ import InstrumentInfo, { type InstrumentInfoProps } from './InstrumentInfo'
 
 import styles from './instrument.css'
 
-type Props = {
+type Props = {|
   showMountLabel?: ?boolean,
   left?: InstrumentInfoProps,
   right?: InstrumentInfoProps,
-}
+|}
 
 const EMPTY_INSTRUMENT_PROPS = {
   description: 'None',

--- a/components/src/structure/PageTabs.js
+++ b/components/src/structure/PageTabs.js
@@ -7,16 +7,16 @@ import { Link } from 'react-router-dom'
 
 import styles from './structure.css'
 
-type TabProps = {
+type TabProps = {|
   title: string,
   href: string,
   isActive: boolean,
   isDisabled: boolean,
-}
+|}
 
-export type PageTabProps = {
+export type PageTabProps = {|
   pages: Array<TabProps>,
-}
+|}
 
 export default function PageTabs(props: PageTabProps) {
   return (

--- a/discovery-client/package.json
+++ b/discovery-client/package.json
@@ -17,10 +17,6 @@
     "url": "https://github.com/Opentrons/opentrons/issues"
   },
   "homepage": "https://github.com/Opentrons/opentrons#readme",
-  "devDependencies": {
-    "flow-bin": "^0.110.1",
-    "flow-typed": "^2.6.2"
-  },
   "dependencies": {
     "escape-string-regexp": "^1.0.5",
     "lodash": "^4.17.4",

--- a/discovery-client/src/service.js
+++ b/discovery-client/src/service.js
@@ -62,7 +62,6 @@ export function updateService(
     const prevVal = result[key]
     const nextVal = defaultTo(next[key], prevVal)
     // use isEqual to deep compare response objects
-    // $FlowFixMe: flow can't type [key]: nextVal but we know this is correct
     return isEqual(nextVal, prevVal) ? result : { ...result, [key]: nextVal }
   }, service)
 }

--- a/labware-designer/package.json
+++ b/labware-designer/package.json
@@ -20,9 +20,5 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@opentrons/shared-data": "3.15.2"
-  },
-  "devDependencies": {
-    "flow-bin": "^0.110.1",
-    "flow-typed": "^2.6.2"
   }
 }

--- a/labware-library/src/analytics/fullstory.js
+++ b/labware-library/src/analytics/fullstory.js
@@ -51,7 +51,10 @@ export const inferFsKeyWithSuffix = (
   return null
 }
 
-export const fullstoryEvent = (name: string, parameters: Object) => {
+export const fullstoryEvent = (
+  name: string,
+  parameters: $Shape<{| [string]: mixed |}> = {}
+) => {
   // NOTE: make sure user has opted in before calling this fn
   const fs = _getFullstory()
   if (fs && fs.event) {
@@ -60,7 +63,8 @@ export const fullstoryEvent = (name: string, parameters: Object) => {
     const _parameters = Object.keys(parameters).reduce((acc, key) => {
       const value = parameters[key]
       const suffix = inferFsKeyWithSuffix(key, value)
-      return { ...acc, [suffix === null ? key : `${key}_${suffix}`]: value }
+      const name: string = suffix === null ? key : `${key}_${suffix}`
+      return { ...acc, [name]: value }
     }, {})
     fs.event(name, _parameters)
   }
@@ -104,12 +108,10 @@ export const initializeFullstory = () => {
     }
     g.q = []
     o = n.createElement(t)
-    // $FlowFixMe
     o.async = 1
     o.crossOrigin = 'anonymous'
     o.src = 'https://' + global._fs_host + '/s/fs.js'
     y = n.getElementsByTagName(t)[0]
-    // $FlowFixMe
     y.parentNode.insertBefore(o, y)
     g.identify = function(i, v, s) {
       g(l, { uid: i }, s)

--- a/labware-library/src/analytics/types.js
+++ b/labware-library/src/analytics/types.js
@@ -2,7 +2,7 @@
 
 export type AnalyticsEvent = {|
   name: string,
-  properties?: Object,
+  properties?: $Shape<{| [string]: mixed |}>,
 |}
 
 // this state is persisted in browser storage (via cookie).

--- a/labware-library/src/components/ui/ClickableIcon.js
+++ b/labware-library/src/components/ui/ClickableIcon.js
@@ -6,11 +6,12 @@ import { Icon } from '@opentrons/components'
 import styles from './styles.css'
 import type { IconName } from '@opentrons/components'
 
-export type ClickableIconProps = {
-  ...$Exact<React.ElementProps<'button'>>,
+export type ClickableIconProps = {|
   name: IconName,
   className?: string,
-}
+  title?: string,
+  onClick?: (SyntheticMouseEvent<>) => mixed,
+|}
 
 export function ClickableIcon(props: ClickableIconProps) {
   const { name, className, ...buttonProps } = props

--- a/labware-library/src/labware-creator/components/RadioField.js
+++ b/labware-library/src/labware-creator/components/RadioField.js
@@ -33,7 +33,7 @@ const RadioField = (props: Props) => (
                 //
                 // NOTE: onBlur doesn't work on Firefox on Mac for radio fields,
                 // so we can't do `e.currentTarget.blur()`. See https://bugzilla.mozilla.org/show_bug.cgi?id=756028
-                form.setTouched({ [props.name]: true })
+                form.setTouched({ [(props.name: string)]: true })
               }, 0)
 
               reportFieldEdit({ value: field.value, name: field.name })

--- a/protocol-designer/package.json
+++ b/protocol-designer/package.json
@@ -45,8 +45,6 @@
     "yup": "^0.26.6"
   },
   "devDependencies": {
-    "flow-bin": "^0.110.1",
-    "flow-typed": "^2.6.2",
     "reselect-tools": "^0.0.7"
   }
 }

--- a/protocol-designer/src/analytics/fullstory.js
+++ b/protocol-designer/src/analytics/fullstory.js
@@ -51,12 +51,10 @@ export const initializeFullstory = () => {
     }
     g.q = []
     o = n.createElement(t)
-    // $FlowFixMe
     o.async = 1
     o.crossOrigin = 'anonymous'
     o.src = 'https://' + global._fs_host + '/s/fs.js'
     y = n.getElementsByTagName(t)[0]
-    // $FlowFixMe
     y.parentNode.insertBefore(o, y)
     g.identify = function(i, v, s) {
       g(l, { uid: i }, s)

--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -21,7 +21,7 @@ import formStyles from '../components/forms/forms.css'
 import type { FileMetadataFields } from '../file-data'
 import type { ModulesForEditModulesCard } from '../step-forms'
 import type { ModuleType } from '@opentrons/shared-data'
-export type Props = {
+export type Props = {|
   formValues: FileMetadataFields,
   instruments: React.ElementProps<typeof InstrumentGroup>,
   goToNextPage: () => mixed,
@@ -30,16 +30,16 @@ export type Props = {
   modulesEnabled: ?boolean,
   thermocyclerEnabled: ?boolean,
   modules: ModulesForEditModulesCard,
-}
+|}
 
-type State = {
+type State = {|
   isEditPipetteModalOpen: boolean,
   isEditModulesModalOpen: boolean,
-  currentModule: {
+  currentModule: {|
     moduleType: ?ModuleType,
     moduleId: ?string,
-  },
-}
+  |},
+|}
 
 const DATE_ONLY_FORMAT = 'MMM DD, YYYY'
 const DATETIME_FORMAT = 'MMM DD, YYYY | h:mm A'

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
@@ -168,7 +168,7 @@ const LabwareSelectionModal = (props: Props) => {
     >(
       defs,
       (acc, def: $Values<typeof defs>) => {
-        const category = def.metadata.displayCategory
+        const category: string = def.metadata.displayCategory
         // filter out non-permitted tipracks
         if (
           category === 'tipRack' &&

--- a/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.js
@@ -29,7 +29,7 @@ type SP = {|
   maxDisposalVolume: ?number,
 |}
 
-type Props = { ...OP, ...SP }
+type Props = {| ...OP, ...SP, dispatch: mixed |}
 
 const DisposalVolumeFieldComponent = (props: Props) => (
   <FormGroup label={i18n.t('form.step_edit_form.multiDispenseOptionsLabel')}>

--- a/protocol-designer/src/components/StepEditForm/fields/FlowRateField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/FlowRateField/index.js
@@ -8,10 +8,12 @@ import { getDisabledFields } from '../../../../steplist/formLevel'
 import type { StepFieldName } from '../../../../steplist/fieldLevel'
 import type { BaseState, ThunkDispatch } from '../../../../types'
 
-type Props = {
+type Props = {|
   ...$Exact<React.ElementProps<typeof FlowRateInput>>,
+  name: StepFieldName,
+  pipetteFieldName: StepFieldName,
   innerKey: string,
-}
+|}
 
 type OP = {|
   name: StepFieldName,
@@ -25,7 +27,7 @@ type DP = {|
   updateValue: $PropertyType<Props, 'updateValue'>,
 |}
 
-type SP = $Rest<$Exact<Props>, {| ...OP, ...DP |}>
+type SP = $Rest<Props, {| ...OP, ...DP |}>
 
 // Add a key to force re-constructing component when values change
 function FlowRateInputWithKey(props: Props) {

--- a/protocol-designer/src/components/StepEditForm/fields/RadioGroupField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/RadioGroupField.js
@@ -5,10 +5,12 @@ import type { StepFieldName } from '../../../steplist/fieldLevel'
 import type { FocusHandlers } from '../types'
 import { FieldConnector } from './FieldConnector'
 
-type RadioGroupFieldProps = {
+type RadioGroupFieldProps = {|
+  ...FocusHandlers,
   name: StepFieldName,
   options: $PropertyType<React.ElementProps<typeof RadioGroup>, 'options'>,
-} & FocusHandlers
+|}
+
 export const RadioGroupField = (props: RadioGroupFieldProps) => {
   const {
     name,

--- a/protocol-designer/src/components/StepEditForm/fields/TextField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TextField.js
@@ -5,13 +5,16 @@ import type { StepFieldName } from '../../../steplist/fieldLevel'
 import type { FocusHandlers } from '../types'
 import { FieldConnector } from './FieldConnector'
 
-type TextFieldProps = {
+type TextFieldProps = {|
+  ...FocusHandlers,
   className?: string,
   name: StepFieldName,
-} & FocusHandlers
-export const TextField = (
-  props: TextFieldProps & React.ElementProps<typeof InputField>
-) => {
+|}
+
+export const TextField = (props: {|
+  ...TextFieldProps,
+  ...React.ElementProps<typeof InputField>,
+|}) => {
   const {
     name,
     focusedField,
@@ -20,6 +23,7 @@ export const TextField = (
     onFieldBlur,
     ...inputProps
   } = props
+
   return (
     <FieldConnector
       name={name}

--- a/protocol-designer/src/components/StepEditForm/types.js
+++ b/protocol-designer/src/components/StepEditForm/types.js
@@ -2,9 +2,9 @@
 
 import type { StepFieldName } from '../../form-types'
 
-export type FocusHandlers = {
+export type FocusHandlers = {|
   focusedField: StepFieldName,
   dirtyFields: Array<StepFieldName>,
   onFieldFocus: StepFieldName => void,
   onFieldBlur: StepFieldName => void,
-}
+|}

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.js
@@ -84,11 +84,11 @@ export default class FilePipettesModal extends React.Component<Props, State> {
       ...initialState,
       pipettesByMount: {
         ...initialState.pipettesByMount,
-        ...(props.initialPipetteValues || {}),
+        ...props.initialPipetteValues,
       },
       modulesByType: {
         ...initialState.modulesByType,
-        ...(props.initialModuleValues || {}),
+        ...props.initialModuleValues,
       },
     }
   }

--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -48,7 +48,6 @@ function mergeProps(
 
   return {
     ...passThruProps,
-    ...dispatchProps,
     goToNextPage: () => dispatch(navActions.navigateToPage('liquids')),
     saveFileMetadata: (nextFormValues: FileMetadataFields) =>
       dispatch(actions.saveFileMetadata(nextFormValues)),

--- a/protocol-designer/src/feature-flags/actions.js
+++ b/protocol-designer/src/feature-flags/actions.js
@@ -3,7 +3,7 @@ import type { Flags } from './types'
 
 export type SetFeatureFlagAction = {|
   type: 'SET_FEATURE_FLAGS',
-  payload: Flags,
+  payload: $Shape<Flags>,
 |}
 
 export const setFeatureFlags = (payload: Flags): SetFeatureFlagAction => ({

--- a/protocol-designer/src/labware-defs/selectors.js
+++ b/protocol-designer/src/labware-defs/selectors.js
@@ -24,7 +24,9 @@ const _getLabwareDef = (
   )
 }
 
-const _makeCustomLabwareDefsObj = (customDefs: LabwareDefByDefURI) => {
+const _makeCustomLabwareDefsObj = (
+  customDefs: LabwareDefByDefURI
+): LabwareDefByDefURI => {
   const allCustomIds = Object.keys(customDefs)
   const customDefsById = allCustomIds.reduce(
     (acc, id) => ({

--- a/protocol-designer/src/labware-ingred/actions/actions.js
+++ b/protocol-designer/src/labware-ingred/actions/actions.js
@@ -6,8 +6,6 @@ import { selectors } from '../selectors'
 import type { DeckSlot, GetState } from '../../types'
 import type { IngredInputs } from '../types'
 
-type IngredInputsExact = $Exact<IngredInputs>
-
 // ===== Labware selector actions =====
 
 export const openAddLabwareModal = createAction<
@@ -185,15 +183,15 @@ export type EditLiquidGroupAction = {|
   type: 'EDIT_LIQUID_GROUP',
   payload: {|
     liquidGroupId: string,
-    ...IngredInputsExact,
+    ...IngredInputs,
   |},
 |}
 
 // NOTE: with no ID, a new one is assigned
-export const editLiquidGroup = (args: {
+export const editLiquidGroup = (args: {|
   liquidGroupId: ?string,
-  ...IngredInputsExact,
-}) => (dispatch: Dispatch<EditLiquidGroupAction>, getState: GetState) => {
+  ...IngredInputs,
+|}) => (dispatch: Dispatch<EditLiquidGroupAction>, getState: GetState) => {
   const { liquidGroupId, ...payloadArgs } = args // NOTE: separate liquidGroupId for flow to understand unpacking :/
   dispatch({
     type: 'EDIT_LIQUID_GROUP',

--- a/protocol-designer/src/labware-ingred/types.js
+++ b/protocol-designer/src/labware-ingred/types.js
@@ -40,15 +40,16 @@ export type OrderedLiquids = Array<{
 }>
 
 // TODO: Ian 2018-10-15 audit & rename these confusing types
-export type LiquidGroup = {
+export type LiquidGroup = {|
   name: ?string,
   description: ?string,
   serialize: boolean,
-}
+|}
 
-export type IngredInputs = LiquidGroup & {
-  volume: ?number,
-}
+export type IngredInputs = {|
+  ...LiquidGroup,
+  volume?: ?number,
+|}
 
 export type IngredGroupAccessor = $Keys<IngredInputs>
 

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -294,7 +294,7 @@ export const getPipettesForInstrumentGroup: Selector<PipettesForInstrumentGroup>
           [pipetteOnDeck.mount]: pipetteForInstrumentGroup,
         }
       },
-      {}
+      { left: undefined, right: undefined }
     )
 )
 

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -294,7 +294,7 @@ export const getPipettesForInstrumentGroup: Selector<PipettesForInstrumentGroup>
           [pipetteOnDeck.mount]: pipetteForInstrumentGroup,
         }
       },
-      { left: undefined, right: undefined }
+      {}
     )
 )
 

--- a/protocol-designer/src/step-forms/types.js
+++ b/protocol-designer/src/step-forms/types.js
@@ -8,11 +8,11 @@ import type {
 import type { DeckSlot } from '../types'
 import typeof { MAGDECK, TEMPDECK, THERMOCYCLER } from '../constants'
 
-export type FormPipette = { pipetteName: ?string, tiprackDefURI: ?string }
-export type FormPipettesByMount = {
+export type FormPipette = {| pipetteName: ?string, tiprackDefURI: ?string |}
+export type FormPipettesByMount = {|
   left: FormPipette,
   right: FormPipette,
-}
+|}
 
 // "entities" have only properties that are time-invariant
 // when they are de-normalized, the definitions they reference are baked in
@@ -40,9 +40,11 @@ export type PipetteEntities = {
 // =========== MODULES ========
 // Note: 'model' is like 'GEN1'/'GEN2' etc
 export type FormModule = {| onDeck: boolean, model: string, slot: DeckSlot |}
-export type FormModulesByType = {
-  [type: ModuleType]: FormModule,
-}
+export type FormModulesByType = {|
+  tempdeck: FormModule,
+  magdeck: FormModule,
+  thermocycler: FormModule,
+|}
 
 export type ModuleEntity = {| id: string, type: ModuleType, model: string |}
 export type ModuleEntities = { [moduleId: string]: ModuleEntity }

--- a/protocol-library-kludge/package.json
+++ b/protocol-library-kludge/package.json
@@ -26,9 +26,5 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-hot-loader": "^3.0.0-beta.7"
-  },
-  "devDependencies": {
-    "flow-bin": "^0.110.1",
-    "flow-typed": "^2.6.2"
   }
 }

--- a/shared-data/package.json
+++ b/shared-data/package.json
@@ -9,10 +9,6 @@
   "author": "Opentrons Labworks",
   "license": "Apache-2.0",
   "main": "js/index.js",
-  "devDependencies": {
-    "flow-bin": "^0.110.1",
-    "flow-typed": "^2.6.2"
-  },
   "dependencies": {
     "uuid": "3.3.2"
   }


### PR DESCRIPTION
## overview

Flow v0.111 (latest: 0.115, ours: 0.110.1) introduced drastic changes to how object spreads are typed. If we upgrade, roughly 300 individual flow errors are introduced by ~150 lines in about ~50 files.

In my examination, we can break these cases down into a few categories:

1. Problems solved by strict object typing
2. Actually incorrect code
3. Problems in code that is deprecated anyway
4. New errors caused by the fact the Flow [no longer allows union types as the indexer in object types](https://medium.com/flow-type/spreads-common-errors-fixes-9701012e9d58#0953)

## changelog

This PR attempts to...

- Make object types exact where it helps (1)
- Fix the *most trivial* instances of (2)
    - Trivial meaning 1 or 2 line fixes that were ideally already covered by tests
- Remove any unnecessary existing `$FlowFixMe`s

...without actually updating the version of Flow we use.

## review requests

Point (4) above is a gnarly one. Basically, we do a lot of stuff like this:

```js
type Mount = 'left' | 'right'

type StateByMount = {| [Mount]: boolean |} 
```

Moving forward with Flow, *this won't work anymore*. (Aside: this also doesn't work with TypeScript, but TS has something else called [Mapped Types](https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types) which we would use instead)

This makes a whole host of things we do a lot stop working. Flow's recommendation moving forward to is explicitly define the types at the get-go...

```js
type StateByMount = {|
  left: boolean,
  right: boolean,
|}
```

...which works for some stuff, but is onerous for others.

Flow v0.115, however, **is quite fast**. So I think organizationally, we have some decisions to make regarding:

- Are we going to just consider ourselves stuck on Flow 0.110?
- If yes, how hard + fast do we want to push on getting to TypeScript?
- If no, how many $FlowFixMe's are we willing to tolerate in non-deprecated code?
    - [Interesting take that suggests "as many as you need to be on the latest version of Flow"](https://medium.com/flow-type/upgrading-flow-codebases-40ef8dd3ccd8)

### remaining flow errors

After this PR is applied, updating `flow-bin` and suppressing all errors results in:

- 232 new Flow errors suppressed by...
- 97 new `$FlowFixMe`s in...
- App - 6 files
    - `app/src/components/DeckMap/index.js`
    - `app/src/components/JogControls/index.js`
    - `app/src/components/RobotSettings/SelectNetwork/ConnectForm.js`
    - `app/src/components/calibrate-pipettes/Pipettes.js`
    - `app/src/pipettes/selectors.js`
    - `app/src/robot/reducer/calibration.js`
- Components - 2 files
    - `components/src/deck/RobotCoordsForeignDiv.js`
    - `components/src/tooltips/Tooltip.js`
- Protocol Designer - 22 files
    - `protocol-designer/src/components/SettingsPage/FeatureFlagCard/FeatureFlagCard.js`
    - `protocol-designer/src/components/StepEditForm/fields/TipPosition/TipPositionModal.js`
    - `protocol-designer/src/components/modals/FilePipettesModal/index.js`
    - `protocol-designer/src/file-data/selectors/fileCreator.js`
    - `protocol-designer/src/labware-ingred/reducers/index.js`
    - `protocol-designer/src/labware-ingred/selectors.js`
    - `protocol-designer/src/load-file/migration/1_1_0.js`
    - `protocol-designer/src/persist.js`
    - `protocol-designer/src/step-forms/reducers/index.js`
    - `protocol-designer/src/step-forms/selectors/index.js`
    - `protocol-designer/src/step-generation/getNextRobotStateAndWarnings/dispenseUpdateLiquidState.js`
    - `protocol-designer/src/step-generation/test-with-flow/fixtures/robotStateFixtures.js`
    - `protocol-designer/src/step-generation/test-with-flow/mix.test.js`
    - `protocol-designer/src/step-generation/test-with-flow/transfer.test.js`
    - `protocol-designer/src/step-generation/utils/misc.js`
    - `protocol-designer/src/steplist/formLevel/generateNewForm.js`
    - `protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.js`
    - `protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js`
    - `protocol-designer/src/steplist/generateSubsteps.js`
    - `protocol-designer/src/steplist/substepTimeline.js`
    - `protocol-designer/src/tutorial/reducers.js`
    - `protocol-designer/src/ui/steps/actions/actions.js`