### PR TITLE
feat(protocol-designer): Hide incompatible labware

### DIFF
--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
@@ -290,38 +290,43 @@ const LabwareSelectionModal = (props: Props) => {
               ))}
             </PDTitledList>
           ) : null}
-          {orderedCategories.map(category => (
-            <PDTitledList
-              key={category}
-              title={startCase(category)}
-              collapsed={selectedCategory !== category}
-              onCollapseToggle={makeToggleCategory(category)}
-              onClick={makeToggleCategory(category)}
-              inert={!populatedCategories[category]}
-            >
-              {labwareByCategory[category] &&
-                labwareByCategory[category].map((labwareDef, index) => {
-                  const isDisabled = getLabwareDisabled(labwareDef)
-                  if (!isDisabled) {
-                    return (
-                      <LabwareItem
-                        key={index}
-                        icon={
-                          getLabwareRecommended(labwareDef)
-                            ? 'check-decagram'
-                            : null
-                        }
-                        disabled={isDisabled}
-                        labwareDef={labwareDef}
-                        selectLabware={selectLabware}
-                        onMouseEnter={() => setPreviewedLabware(labwareDef)}
-                        onMouseLeave={() => setPreviewedLabware()}
-                      />
-                    )
-                  }
-                })}
-            </PDTitledList>
-          ))}
+          {orderedCategories.map(category => {
+            const isPopulated = populatedCategories[category]
+            if (isPopulated) {
+              return (
+                <PDTitledList
+                  key={category}
+                  title={startCase(category)}
+                  collapsed={selectedCategory !== category}
+                  onCollapseToggle={makeToggleCategory(category)}
+                  onClick={makeToggleCategory(category)}
+                  inert={!isPopulated}
+                >
+                  {labwareByCategory[category] &&
+                    labwareByCategory[category].map((labwareDef, index) => {
+                      const isDisabled = getLabwareDisabled(labwareDef)
+                      if (!isDisabled) {
+                        return (
+                          <LabwareItem
+                            key={index}
+                            icon={
+                              getLabwareRecommended(labwareDef)
+                                ? 'check-decagram'
+                                : null
+                            }
+                            disabled={isDisabled}
+                            labwareDef={labwareDef}
+                            selectLabware={selectLabware}
+                            onMouseEnter={() => setPreviewedLabware(labwareDef)}
+                            onMouseLeave={() => setPreviewedLabware()}
+                          />
+                        )
+                      }
+                    })}
+                </PDTitledList>
+              )
+            }
+          })}
         </ul>
 
         <OutlineButton Component="label" className={styles.upload_button}>

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
@@ -300,21 +300,26 @@ const LabwareSelectionModal = (props: Props) => {
               inert={!populatedCategories[category]}
             >
               {labwareByCategory[category] &&
-                labwareByCategory[category].map((labwareDef, index) => (
-                  <LabwareItem
-                    key={index}
-                    icon={
-                      getLabwareRecommended(labwareDef)
-                        ? 'check-decagram'
-                        : null
-                    }
-                    disabled={getLabwareDisabled(labwareDef)}
-                    labwareDef={labwareDef}
-                    selectLabware={selectLabware}
-                    onMouseEnter={() => setPreviewedLabware(labwareDef)}
-                    onMouseLeave={() => setPreviewedLabware()}
-                  />
-                ))}
+                labwareByCategory[category].map((labwareDef, index) => {
+                  const isDisabled = getLabwareDisabled(labwareDef)
+                  if (!isDisabled) {
+                    return (
+                      <LabwareItem
+                        key={index}
+                        icon={
+                          getLabwareRecommended(labwareDef)
+                            ? 'check-decagram'
+                            : null
+                        }
+                        disabled={isDisabled}
+                        labwareDef={labwareDef}
+                        selectLabware={selectLabware}
+                        onMouseEnter={() => setPreviewedLabware(labwareDef)}
+                        onMouseLeave={() => setPreviewedLabware()}
+                      />
+                    )
+                  }
+                })}
             </PDTitledList>
           ))}
         </ul>


### PR DESCRIPTION
## overview

This PR closes #4728 by hiding previously disabled categories/labware options what are incompatible or unavailable for modules.

## changelog

- feat(protocol-designer): Hide incompatible labware

## review requests

http://sandbox.designer.opentrons.com/pd_hide-incompat-labware/

Standard review. 
- [ ] Incompatible categories/labware is correctly hidden for each module type
- [ ] Non module labware slots still render all labware and categories

Note: I conditionally rendered the lists/items rather than touching `TitledList` or `ListItem` or `PDTitledList` to avoid breaking something unintentionally.