### PR TITLE
feat(protocol-designer): add commands for temperature step

### DIFF
--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -87,6 +87,14 @@ export { MAGDECK, TEMPDECK, THERMOCYCLER } from '@opentrons/shared-data'
 const TEMPMOD: 'temperature module' = 'temperature module'
 const MAGMOD: 'magnetic module' = 'magnetic module'
 
+// Temperature statuses
+export const TEMPERATURE_DEACTIVATED: 'TEMPERATURE_DEACTIVATED' =
+  'TEMPERATURE_DEACTIVATED'
+export const TEMPERATURE_AT_TARGET: 'TEMPERATURE_AT_TARGET' =
+  'TEMPERATURE_AT_TARGET'
+export const TEMPERATURE_APPROACHING_TARGET: 'TEMPERATURE_APPROACHING_TARGET' =
+  'TEMPERATURE_APPROACHING_TARGET'
+
 // TODO: IL 2019-12-03 migrate the ModuleType '___deck' strings to '___ module' forms.
 // We don't call modules 'deck' anymore, but the old code is entrenched
 export const FILE_MODULE_TYPE_TO_MODULE_TYPE: { [string]: ModuleType } = {

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -137,6 +137,16 @@ const commandCreatorFromStepArgs = (
         StepGeneration.disengageMagnet,
         args
       )
+    case 'setTemperature':
+      return StepGeneration.curryCommandCreator(
+        StepGeneration.setTemperature,
+        args
+      )
+    case 'deactivateTemperature':
+      return StepGeneration.curryCommandCreator(
+        StepGeneration.deactivateTemperature,
+        args
+      )
   }
   console.warn(`unhandled commandCreatorFnName: ${args.commandCreatorFnName}`)
   return null
@@ -200,7 +210,9 @@ export const getRobotStateTimeline: Selector<StepGeneration.Timeline> = createSe
         const pipetteId =
           args.commandCreatorFnName !== 'delay' &&
           args.commandCreatorFnName !== 'engageMagnet' &&
-          args.commandCreatorFnName !== 'disengageMagnet'
+          args.commandCreatorFnName !== 'disengageMagnet' &&
+          args.commandCreatorFnName !== 'setTemperature' &&
+          args.commandCreatorFnName !== 'deactivateTemperature'
             ? args.pipette
             : false
         if (pipetteId) {

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -204,17 +204,7 @@ export const getRobotStateTimeline: Selector<StepGeneration.Timeline> = createSe
         // - If we don't have a 'changeTip: never' step for this pipette in the future,
         // we know the current tip(s) aren't going to be reused, so we can drop them
         // immediately after the current step is done.
-        //
-        // NOTE: this implementation assumes all step forms that use a pipette have both
-        // 'pipette' and 'changeTip' fields (and they're not named something else).
-        const pipetteId =
-          args.commandCreatorFnName !== 'delay' &&
-          args.commandCreatorFnName !== 'engageMagnet' &&
-          args.commandCreatorFnName !== 'disengageMagnet' &&
-          args.commandCreatorFnName !== 'setTemperature' &&
-          args.commandCreatorFnName !== 'deactivateTemperature'
-            ? args.pipette
-            : false
+        const pipetteId = StepGeneration.getPipetteIdFromCCArgs(args)
         if (pipetteId) {
           const nextStepArgsForPipette = continuousStepArgs
             .slice(stepIndex + 1)

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -228,9 +228,19 @@ export type HydratedMagnetFormData = {|
   ...AnnotationFields,
   id: string,
   stepType: 'magnet',
+  stepDetails: string | null,
   moduleId: string | null,
   magnetAction: 'engage' | 'disengage',
-  engageHeight: number | null,
+  engageHeight: string | null,
+|}
+
+export type HydratedTemperatureFormData = {|
+  id: string,
+  stepType: 'temperature',
+  stepDetails: string | null,
+  moduleId: string | null,
+  setTemperature: 'true' | 'false',
+  targetTemperature: string | null,
 |}
 
 // TODO: Ian 2019-01-17 Moving away from this and towards nesting all form fields

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -17,6 +17,7 @@ import {
   MAGDECK,
   TEMPDECK,
   THERMOCYCLER,
+  TEMPERATURE_DEACTIVATED,
 } from '../../constants'
 import {
   generateNewForm,
@@ -159,6 +160,8 @@ const MAGNETIC_MODULE_INITIAL_STATE: MagneticModuleState = {
 }
 const TEMPERATURE_MODULE_INITIAL_STATE: TemperatureModuleState = {
   type: TEMPDECK,
+  status: TEMPERATURE_DEACTIVATED,
+  targetTemperature: null,
 }
 const THERMOCYCLER_MODULE_INITIAL_STATE: ThermocyclerModuleState = {
   type: THERMOCYCLER,

--- a/protocol-designer/src/step-forms/types.js
+++ b/protocol-designer/src/step-forms/types.js
@@ -6,7 +6,14 @@ import type {
   ModuleType,
 } from '@opentrons/shared-data'
 import type { DeckSlot } from '../types'
-import typeof { MAGDECK, TEMPDECK, THERMOCYCLER } from '../constants'
+import typeof {
+  MAGDECK,
+  TEMPDECK,
+  THERMOCYCLER,
+  TEMPERATURE_DEACTIVATED,
+  TEMPERATURE_AT_TARGET,
+  TEMPERATURE_APPROACHING_TARGET,
+} from '../constants'
 
 export type FormPipette = {| pipetteName: ?string, tiprackDefURI: ?string |}
 export type FormPipettesByMount = {|
@@ -51,8 +58,18 @@ export type ModuleEntities = { [moduleId: string]: ModuleEntity }
 
 // NOTE: semi-redundant 'type' key in FooModuleState types is required for Flow to disambiguate 'moduleState'
 export type MagneticModuleState = {| type: MAGDECK, engaged: boolean |}
-export type TemperatureModuleState = {| type: TEMPDECK |} // TODO IL 2019-11-18 create this state
+
+export type TemperatureStatus =
+  | TEMPERATURE_DEACTIVATED
+  | TEMPERATURE_AT_TARGET
+  | TEMPERATURE_APPROACHING_TARGET
+export type TemperatureModuleState = {|
+  type: TEMPDECK,
+  status: TemperatureStatus,
+  targetTemperature: number | null,
+|}
 export type ThermocyclerModuleState = {| type: THERMOCYCLER |} // TODO IL 2019-11-18 create this state
+
 export type ModuleTemporalProperties = {|
   slot: DeckSlot,
   moduleState:

--- a/protocol-designer/src/step-generation/commandCreators/atomic/deactivateTemperature.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/deactivateTemperature.js
@@ -1,0 +1,48 @@
+// @flow
+import assert from 'assert'
+import { TEMPDECK, THERMOCYCLER } from '../../../constants'
+import * as errorCreators from '../../errorCreators'
+import type { CommandCreator, DeactivateTemperatureArgs } from '../../types'
+
+/** Disengage temperature target for specified module. */
+export const deactivateTemperature: CommandCreator<DeactivateTemperatureArgs> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  const { module } = args
+
+  if (module === null) {
+    return { errors: [errorCreators.missingModuleError()] }
+  }
+
+  const moduleType = invariantContext.moduleEntities[module]?.type
+  const params = { module }
+  if (moduleType === TEMPDECK) {
+    return {
+      commands: [
+        {
+          command: 'temperatureModule/deactivate',
+          params,
+        },
+      ],
+    }
+  } else if (moduleType === THERMOCYCLER) {
+    return {
+      commands: [
+        {
+          command: 'thermocycler/deactivate',
+          params,
+        },
+      ],
+    }
+  } else {
+    assert(
+      false,
+      `setTemperature expected module ${module} to be ${TEMPDECK} or ${THERMOCYCLER}, got ${moduleType}`
+    )
+    // NOTE: "missing module" isn't exactly the right error here, but better than a whitescreen!
+    // This should never be shown.
+    return { errors: [errorCreators.missingModuleError()] }
+  }
+}

--- a/protocol-designer/src/step-generation/commandCreators/atomic/deactivateTemperature.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/deactivateTemperature.js
@@ -1,5 +1,4 @@
 // @flow
-import assert from 'assert'
 import { TEMPDECK, THERMOCYCLER } from '../../../constants'
 import * as errorCreators from '../../errorCreators'
 import type { CommandCreator, DeactivateTemperatureArgs } from '../../types'
@@ -37,8 +36,7 @@ export const deactivateTemperature: CommandCreator<DeactivateTemperatureArgs> = 
       ],
     }
   } else {
-    assert(
-      false,
+    console.error(
       `setTemperature expected module ${module} to be ${TEMPDECK} or ${THERMOCYCLER}, got ${moduleType}`
     )
     // NOTE: "missing module" isn't exactly the right error here, but better than a whitescreen!

--- a/protocol-designer/src/step-generation/commandCreators/atomic/disengageMagnet.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/disengageMagnet.js
@@ -2,17 +2,13 @@
 import assert from 'assert'
 import { MAGDECK } from '../../../constants'
 import * as errorCreators from '../../errorCreators'
-import type {
-  InvariantContext,
-  RobotState,
-  DisengageMagnetArgs,
-} from '../../types'
+import type { CommandCreator, DisengageMagnetArgs } from '../../types'
 
 /** Disengage magnet of specified magnetic module. */
-export const disengageMagnet = (
-  args: DisengageMagnetArgs,
-  invariantContext: InvariantContext,
-  prevRobotState: RobotState
+export const disengageMagnet: CommandCreator<DisengageMagnetArgs> = (
+  args,
+  invariantContext,
+  prevRobotState
 ) => {
   const { module } = args
   const command = 'magneticModule/disengageMagnet'

--- a/protocol-designer/src/step-generation/commandCreators/atomic/index.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/index.js
@@ -1,6 +1,7 @@
 // @flow
 import aspirate from './aspirate'
 import blowout from './blowout'
+import { deactivateTemperature } from './deactivateTemperature'
 import delay from './delay'
 import { disengageMagnet } from './disengageMagnet'
 import dispense from './dispense'
@@ -8,11 +9,13 @@ import dropAllTips from './dropAllTips'
 import dropTip from './dropTip'
 import { engageMagnet } from './engageMagnet'
 import replaceTip from './replaceTip'
+import { setTemperature } from './setTemperature'
 import touchTip from './touchTip'
 
 export {
   aspirate,
   blowout,
+  deactivateTemperature,
   delay,
   dispense,
   disengageMagnet,
@@ -20,5 +23,6 @@ export {
   dropTip,
   engageMagnet,
   replaceTip,
+  setTemperature,
   touchTip,
 }

--- a/protocol-designer/src/step-generation/commandCreators/atomic/setTemperature.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/setTemperature.js
@@ -1,5 +1,4 @@
 // @flow
-import assert from 'assert'
 import { TEMPDECK, THERMOCYCLER } from '../../../constants'
 import * as errorCreators from '../../errorCreators'
 import type { CommandCreator, SetTemperatureArgs } from '../../types'
@@ -37,8 +36,7 @@ export const setTemperature: CommandCreator<SetTemperatureArgs> = (
       ],
     }
   } else {
-    assert(
-      false,
+    console.error(
       `setTemperature expected module ${module} to be ${TEMPDECK} or ${THERMOCYCLER}, got ${moduleType}`
     )
     // NOTE: "missing module" isn't exactly the right error here, but better than a whitescreen!

--- a/protocol-designer/src/step-generation/commandCreators/atomic/setTemperature.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/setTemperature.js
@@ -1,0 +1,48 @@
+// @flow
+import assert from 'assert'
+import { TEMPDECK, THERMOCYCLER } from '../../../constants'
+import * as errorCreators from '../../errorCreators'
+import type { CommandCreator, SetTemperatureArgs } from '../../types'
+
+/** Set temperature target for specified module. */
+export const setTemperature: CommandCreator<SetTemperatureArgs> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  const { module, targetTemperature } = args
+
+  if (module === null) {
+    return { errors: [errorCreators.missingModuleError()] }
+  }
+
+  const moduleType = invariantContext.moduleEntities[module]?.type
+  const params = { module, temperature: targetTemperature }
+  if (moduleType === TEMPDECK) {
+    return {
+      commands: [
+        {
+          command: 'temperatureModule/setTargetTemperature',
+          params,
+        },
+      ],
+    }
+  } else if (moduleType === THERMOCYCLER) {
+    return {
+      commands: [
+        {
+          command: 'thermocycler/setTargetTemperature',
+          params,
+        },
+      ],
+    }
+  } else {
+    assert(
+      false,
+      `setTemperature expected module ${module} to be ${TEMPDECK} or ${THERMOCYCLER}, got ${moduleType}`
+    )
+    // NOTE: "missing module" isn't exactly the right error here, but better than a whitescreen!
+    // This should never be shown.
+    return { errors: [errorCreators.missingModuleError()] }
+  }
+}

--- a/protocol-designer/src/step-generation/commandCreators/index.js
+++ b/protocol-designer/src/step-generation/commandCreators/index.js
@@ -4,6 +4,7 @@ export { transfer, mix, consolidate, distribute } from './compound'
 export {
   aspirate,
   blowout,
+  deactivateTemperature,
   delay,
   disengageMagnet,
   dispense,
@@ -11,5 +12,6 @@ export {
   dropTip,
   engageMagnet,
   replaceTip,
+  setTemperature,
   touchTip,
 } from './atomic'

--- a/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/index.js
+++ b/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/index.js
@@ -55,6 +55,13 @@ function _getNextRobotStateAndWarningsSingleCommand(
     case 'delay':
       // these commands don't have any effects on the state
       break
+    case 'temperatureModule/setTargetTemperature':
+    case 'temperatureModule/deactivate':
+    case 'thermocycler/setTargetTemperature':
+    case 'thermocycler/deactivate':
+      console.warn(`NOT IMPLEMENTED: ${command.command}`)
+      break
+
     default:
       assert(
         false,

--- a/protocol-designer/src/step-generation/index.js
+++ b/protocol-designer/src/step-generation/index.js
@@ -4,6 +4,7 @@ export {
   blowout,
   consolidate,
   distribute,
+  deactivateTemperature,
   delay,
   disengageMagnet,
   dispense,
@@ -12,6 +13,7 @@ export {
   engageMagnet,
   mix,
   replaceTip,
+  setTemperature,
   touchTip,
   transfer,
 } from './commandCreators'

--- a/protocol-designer/src/step-generation/test-with-flow/__snapshots__/utils.test.js.snap
+++ b/protocol-designer/src/step-generation/test-with-flow/__snapshots__/utils.test.js.snap
@@ -335,6 +335,8 @@ Object {
   "modules": Object {
     "someTempModuleId": Object {
       "moduleState": Object {
+        "status": "TEMPERATURE_DEACTIVATED",
+        "targetTemperature": null,
         "type": "tempdeck",
       },
       "slot": "3",

--- a/protocol-designer/src/step-generation/test-with-flow/deactivateTemperature.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/deactivateTemperature.test.js
@@ -1,0 +1,3 @@
+// @flow
+
+// TODO IMMEDIATELY

--- a/protocol-designer/src/step-generation/test-with-flow/deactivateTemperature.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/deactivateTemperature.test.js
@@ -1,3 +1,74 @@
 // @flow
+import { getStateAndContextTempMagModules } from './fixtures'
+import { deactivateTemperature } from '../commandCreators/atomic/deactivateTemperature'
 
-// TODO IMMEDIATELY
+const temperatureModuleId = 'temperatureModuleId'
+const thermocyclerId = 'thermocycylerId'
+const commandCreatorFnName = 'deactivateTemperature'
+
+let invariantContext
+let robotState
+
+beforeEach(() => {
+  const stateAndContext = getStateAndContextTempMagModules({
+    temperatureModuleId,
+    thermocyclerId,
+  })
+  invariantContext = stateAndContext.invariantContext
+  robotState = stateAndContext.robotState
+})
+
+describe('deactivateTemperature', () => {
+  const missingModuleError = {
+    errors: [{ message: expect.any(String), type: 'MISSING_MODULE' }],
+  }
+
+  const testCases = [
+    {
+      testName: 'temperature module',
+      moduleId: temperatureModuleId,
+      expected: {
+        commands: [
+          {
+            command: 'temperatureModule/deactivate',
+            params: {
+              module: temperatureModuleId,
+            },
+          },
+        ],
+      },
+    },
+    {
+      testName: 'no such moduleId',
+      moduleId: 'someNonexistentModuleId',
+      expected: missingModuleError,
+    },
+    {
+      testName: 'null moduleId',
+      moduleId: null,
+      expected: missingModuleError,
+    },
+    {
+      testName: 'thermocycler',
+      moduleId: thermocyclerId,
+      expected: {
+        commands: [
+          {
+            command: 'thermocycler/deactivate',
+            params: {
+              module: thermocyclerId,
+            },
+          },
+        ],
+      },
+    },
+  ]
+
+  testCases.forEach(({ expected, moduleId, testName }) => {
+    test(testName, () => {
+      const args = { module: moduleId, commandCreatorFnName }
+      const result = deactivateTemperature(args, invariantContext, robotState)
+      expect(result).toEqual(expected)
+    })
+  })
+})

--- a/protocol-designer/src/step-generation/test-with-flow/deactivateTemperature.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/deactivateTemperature.test.js
@@ -3,7 +3,7 @@ import { getStateAndContextTempMagModules } from './fixtures'
 import { deactivateTemperature } from '../commandCreators/atomic/deactivateTemperature'
 
 const temperatureModuleId = 'temperatureModuleId'
-const thermocyclerId = 'thermocycylerId'
+const thermocyclerId = 'thermocyclerId'
 const commandCreatorFnName = 'deactivateTemperature'
 
 let invariantContext

--- a/protocol-designer/src/step-generation/test-with-flow/fixtures/robotStateFixtures.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtures/robotStateFixtures.js
@@ -14,6 +14,12 @@ import fixture_tiprack_10_ul from '@opentrons/shared-data/labware/fixtures/2/fix
 import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_300_ul.json'
 
 import {
+  SPAN7_8_10_11_SLOT,
+  TEMPDECK,
+  THERMOCYCLER,
+  TEMPERATURE_DEACTIVATED,
+} from '../../../constants'
+import {
   DEFAULT_PIPETTE,
   MULTI_PIPETTE,
   SOURCE_LABWARE,
@@ -224,4 +230,47 @@ export const getRobotInitialStateNoTipsRemain = (
     tiprackSetting: { tiprack1Id: false, tiprack2Id: false },
   })
   return robotInitialStateNoTipsRemain
+}
+
+export const getStateAndContextTempMagModules = ({
+  temperatureModuleId,
+  thermocyclerId,
+}: {
+  temperatureModuleId: string,
+  thermocyclerId: string,
+}) => {
+  const invariantContext = makeContext()
+  invariantContext.moduleEntities = {
+    [temperatureModuleId]: {
+      id: temperatureModuleId,
+      type: TEMPDECK,
+      model: 'foo',
+    },
+    [thermocyclerId]: { id: thermocyclerId, type: THERMOCYCLER, model: 'foo' },
+  }
+
+  const robotState = makeState({
+    ...makeStateArgsStandard(),
+    invariantContext,
+    tiprackSetting: { tiprack1Id: true },
+  })
+
+  robotState.modules = {
+    [temperatureModuleId]: {
+      slot: '3',
+      moduleState: {
+        type: TEMPDECK,
+        status: TEMPERATURE_DEACTIVATED,
+        targetTemperature: null,
+      },
+    },
+    [thermocyclerId]: {
+      slot: SPAN7_8_10_11_SLOT,
+      moduleState: {
+        type: THERMOCYCLER,
+        // TODO IL 2020-01-14 create this state when thermocycler state is implemented
+      },
+    },
+  }
+  return { invariantContext, robotState }
 }

--- a/protocol-designer/src/step-generation/test-with-flow/setTemperature.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/setTemperature.test.js
@@ -1,12 +1,5 @@
 // @flow
-import {
-  SPAN7_8_10_11_SLOT,
-  TEMPDECK,
-  THERMOCYCLER,
-  TEMPERATURE_DEACTIVATED,
-} from '../../constants'
-import { makeStateArgsStandard, makeContext, makeState } from './fixtures'
-
+import { getStateAndContextTempMagModules } from './fixtures'
 import { setTemperature } from '../commandCreators/atomic/setTemperature'
 
 const temperatureModuleId = 'temperatureModuleId'
@@ -17,39 +10,12 @@ let invariantContext
 let robotState
 
 beforeEach(() => {
-  invariantContext = makeContext()
-  invariantContext.moduleEntities = {
-    [temperatureModuleId]: {
-      id: temperatureModuleId,
-      type: TEMPDECK,
-      model: 'foo',
-    },
-    [thermocyclerId]: { id: thermocyclerId, type: THERMOCYCLER, model: 'foo' },
-  }
-
-  robotState = makeState({
-    ...makeStateArgsStandard(),
-    invariantContext,
-    tiprackSetting: { tiprack1Id: true }, // TODO IMMEDIATELY: why this?
+  const stateAndContext = getStateAndContextTempMagModules({
+    temperatureModuleId,
+    thermocyclerId,
   })
-  // TODO IMMEDIATELY: make this a fixture for module-related tests
-  robotState.modules = {
-    [temperatureModuleId]: {
-      slot: '3',
-      moduleState: {
-        type: TEMPDECK,
-        status: TEMPERATURE_DEACTIVATED,
-        targetTemperature: null,
-      },
-    },
-    [thermocyclerId]: {
-      slot: SPAN7_8_10_11_SLOT,
-      moduleState: {
-        type: THERMOCYCLER,
-        // TODO IL 2020-01-14 create this state when thermocycler state is implemented
-      },
-    },
-  }
+  invariantContext = stateAndContext.invariantContext
+  robotState = stateAndContext.robotState
 })
 
 describe('setTemperature', () => {

--- a/protocol-designer/src/step-generation/test-with-flow/setTemperature.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/setTemperature.test.js
@@ -3,7 +3,7 @@ import { getStateAndContextTempMagModules } from './fixtures'
 import { setTemperature } from '../commandCreators/atomic/setTemperature'
 
 const temperatureModuleId = 'temperatureModuleId'
-const thermocyclerId = 'thermocycylerId'
+const thermocyclerId = 'thermocyclerId'
 const commandCreatorFnName = 'setTemperature'
 
 let invariantContext

--- a/protocol-designer/src/step-generation/test-with-flow/setTemperature.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/setTemperature.test.js
@@ -1,0 +1,111 @@
+// @flow
+import {
+  SPAN7_8_10_11_SLOT,
+  TEMPDECK,
+  THERMOCYCLER,
+  TEMPERATURE_DEACTIVATED,
+} from '../../constants'
+import { makeStateArgsStandard, makeContext, makeState } from './fixtures'
+
+import { setTemperature } from '../commandCreators/atomic/setTemperature'
+
+const temperatureModuleId = 'temperatureModuleId'
+const thermocyclerId = 'thermocycylerId'
+const commandCreatorFnName = 'setTemperature'
+
+let invariantContext
+let robotState
+
+beforeEach(() => {
+  invariantContext = makeContext()
+  invariantContext.moduleEntities = {
+    [temperatureModuleId]: {
+      id: temperatureModuleId,
+      type: TEMPDECK,
+      model: 'foo',
+    },
+    [thermocyclerId]: { id: thermocyclerId, type: THERMOCYCLER, model: 'foo' },
+  }
+
+  robotState = makeState({
+    ...makeStateArgsStandard(),
+    invariantContext,
+    tiprackSetting: { tiprack1Id: true }, // TODO IMMEDIATELY: why this?
+  })
+  // TODO IMMEDIATELY: make this a fixture for module-related tests
+  robotState.modules = {
+    [temperatureModuleId]: {
+      slot: '3',
+      moduleState: {
+        type: TEMPDECK,
+        status: TEMPERATURE_DEACTIVATED,
+        targetTemperature: null,
+      },
+    },
+    [thermocyclerId]: {
+      slot: SPAN7_8_10_11_SLOT,
+      moduleState: {
+        type: THERMOCYCLER,
+        // TODO IL 2020-01-14 create this state when thermocycler state is implemented
+      },
+    },
+  }
+})
+
+describe('setTemperature', () => {
+  const targetTemperature = 42
+  const missingModuleError = {
+    errors: [{ message: expect.any(String), type: 'MISSING_MODULE' }],
+  }
+
+  const testCases = [
+    {
+      testName: 'temperature module',
+      moduleId: temperatureModuleId,
+      expected: {
+        commands: [
+          {
+            command: 'temperatureModule/setTargetTemperature',
+            params: {
+              module: temperatureModuleId,
+              temperature: targetTemperature,
+            },
+          },
+        ],
+      },
+    },
+    {
+      testName: 'no such moduleId',
+      moduleId: 'someNonexistentModuleId',
+      expected: missingModuleError,
+    },
+    {
+      testName: 'null moduleId',
+      moduleId: null,
+      expected: missingModuleError,
+    },
+    {
+      testName: 'thermocycler',
+      moduleId: thermocyclerId,
+      expected: {
+        commands: [
+          {
+            command: 'thermocycler/setTargetTemperature',
+            params: {
+              module: thermocyclerId,
+              temperature: targetTemperature,
+            },
+          },
+        ],
+      },
+    },
+  ]
+
+  testCases.forEach(({ expected, moduleId, testName }) => {
+    test(testName, () => {
+      const args = { module: moduleId, targetTemperature, commandCreatorFnName }
+      const result = setTemperature(args, invariantContext, robotState)
+      expect(result).toEqual(expected)
+    })
+  })
+})

--- a/protocol-designer/src/step-generation/test-with-flow/utils.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/utils.test.js
@@ -9,7 +9,7 @@ import fixture_trash from '@opentrons/shared-data/labware/fixtures/2/fixture_tra
 import fixture_96_plate from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
 import fixture_tiprack_10_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_10_ul.json'
 import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_300_ul.json'
-
+import { TEMPERATURE_DEACTIVATED } from '../../constants'
 import {
   splitLiquid,
   mergeLiquid,
@@ -272,7 +272,14 @@ describe('makeInitialRobotState', () => {
         trashId: { slot: '12' },
       },
       moduleLocations: {
-        someTempModuleId: { slot: '3', moduleState: { type: 'tempdeck' } },
+        someTempModuleId: {
+          slot: '3',
+          moduleState: {
+            type: 'tempdeck',
+            status: TEMPERATURE_DEACTIVATED,
+            targetTemperature: null,
+          },
+        },
       },
       pipetteLocations: {
         p10SingleId: { mount: 'left' },

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -181,6 +181,19 @@ export type DisengageMagnetArgs = {|
   message?: string,
 |}
 
+export type SetTemperatureArgs = {|
+  module: string | null,
+  commandCreatorFnName: 'setTemperature',
+  targetTemperature: number,
+  message?: string,
+|}
+
+export type DeactivateTemperatureArgs = {|
+  module: string | null,
+  commandCreatorFnName: 'deactivateTemperature',
+  message?: string,
+|}
+
 export type CommandCreatorArgs =
   | ConsolidateArgs
   | DistributeArgs
@@ -189,6 +202,8 @@ export type CommandCreatorArgs =
   | TransferArgs
   | EngageMagnetArgs
   | DisengageMagnetArgs
+  | SetTemperatureArgs
+  | DeactivateTemperatureArgs
 
 /** tips are numbered 0-7. 0 is the furthest to the back of the robot.
  * For an 8-channel, on a 96-flat, Tip 0 is in row A, Tip 7 is in row H.

--- a/protocol-designer/src/step-generation/utils/commandCreatorArgsGetters.js
+++ b/protocol-designer/src/step-generation/utils/commandCreatorArgsGetters.js
@@ -1,0 +1,28 @@
+// @flow
+// Getter functions for pulling data from CommandCreatorArgs objects.
+// NOTE: PD-specific concepts related to CommandCreatorArgs do NOT belong here
+// (eg, deriving data related to the concept of substeps)
+import type { CommandCreatorArgs } from '../types'
+
+/** If command creator is of a type that uses a pipette, get the pipetteId */
+export const getPipetteIdFromCCArgs = (
+  args: CommandCreatorArgs
+): string | null =>
+  args.commandCreatorFnName !== 'delay' &&
+  args.commandCreatorFnName !== 'engageMagnet' &&
+  args.commandCreatorFnName !== 'disengageMagnet' &&
+  args.commandCreatorFnName !== 'setTemperature' &&
+  args.commandCreatorFnName !== 'deactivateTemperature' &&
+  args.pipette
+    ? args.pipette
+    : null
+
+/** If command creator is of a type that doesn't ever have wells, return true */
+export const getHasNoWellsFromCCArgs = (
+  stepArgs: CommandCreatorArgs
+): boolean =>
+  stepArgs.commandCreatorFnName === 'delay' ||
+  stepArgs.commandCreatorFnName === 'engageMagnet' ||
+  stepArgs.commandCreatorFnName === 'disengageMagnet' ||
+  stepArgs.commandCreatorFnName === 'setTemperature' ||
+  stepArgs.commandCreatorFnName === 'deactivateTemperature'

--- a/protocol-designer/src/step-generation/utils/index.js
+++ b/protocol-designer/src/step-generation/utils/index.js
@@ -10,4 +10,5 @@ export {
   modulePipetteCollision,
 }
 
+export * from './commandCreatorArgsGetters'
 export * from './misc'

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/__tests__/getNextDefaultModuleId.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/__tests__/getNextDefaultModuleId.test.js
@@ -1,4 +1,5 @@
 // @flow
+import { TEMPERATURE_DEACTIVATED } from '../../../../constants'
 import { getNextDefaultTemperatureModuleId } from '..'
 
 describe('getNextDefaultTemperatureModuleId', () => {
@@ -12,14 +13,18 @@ describe('getNextDefaultTemperatureModuleId', () => {
             type: 'tempdeck',
             model: 'GEN1',
             slot: '3',
-            moduleState: { type: 'tempdeck' },
+            moduleState: {
+              type: 'tempdeck',
+              status: TEMPERATURE_DEACTIVATED,
+              targetTemperature: null,
+            },
           },
           tcId: {
             id: 'tcId',
             type: 'thermocycler',
             model: 'GEN1',
             slot: '_span781011',
-            moduleState: { type: 'tempdeck' },
+            moduleState: { type: 'thermocycler' },
           },
         },
         expected: 'tempId',
@@ -32,7 +37,9 @@ describe('getNextDefaultTemperatureModuleId', () => {
             type: 'thermocycler',
             model: 'GEN1',
             slot: '_span781011',
-            moduleState: { type: 'tempdeck' },
+            moduleState: {
+              type: 'thermocycler',
+            },
           },
         },
         expected: 'tcId',

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.js
@@ -4,6 +4,7 @@ import { castField } from '../../../steplist/fieldLevel'
 import mixFormToArgs from './mixFormToArgs'
 import pauseFormToArgs from './pauseFormToArgs'
 import { magnetFormToArgs } from './magnetFormToArgs'
+import { temperatureFormToArgs } from './temperatureFormToArgs'
 import moveLiquidFormToArgs from './moveLiquidFormToArgs'
 import type { FormData } from '../../../form-types'
 import type { CommandCreatorArgs } from '../../../step-generation'
@@ -30,6 +31,8 @@ const stepFormToArgs = (hydratedForm: FormData): StepArgs => {
       return mixFormToArgs(castForm)
     case 'magnet':
       return magnetFormToArgs(castForm)
+    case 'temperature':
+      return temperatureFormToArgs(castForm)
     default:
       console.warn(`stepFormToArgs not implemented for ${castForm.stepType}`)
       return null

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/magnetFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/magnetFormToArgs.js
@@ -11,13 +11,14 @@ type MagnetArgs = EngageMagnetArgs | DisengageMagnetArgs
 export const magnetFormToArgs = (
   hydratedFormData: HydratedMagnetFormData
 ): MagnetArgs => {
-  const { magnetAction, moduleId, engageHeight } = hydratedFormData
+  const { magnetAction, moduleId } = hydratedFormData
+  const engageHeight = parseFloat(hydratedFormData.engageHeight)
 
   assert(
-    magnetAction === 'engage' ? engageHeight != null : true,
-    'magnetFormToArgs expected (hydrated) engageHeight to be non-null if magnetAction is "engage"'
+    magnetAction === 'engage' ? !Number.isNaN(engageHeight) : true,
+    'magnetFormToArgs expected (hydrated) engageHeight to be non-NaN if magnetAction is "engage"'
   )
-  if (magnetAction === 'engage' && engageHeight != null) {
+  if (magnetAction === 'engage' && !Number.isNaN(engageHeight)) {
     return {
       commandCreatorFnName: 'engageMagnet',
       module: moduleId,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/temperatureFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/temperatureFormToArgs.js
@@ -1,0 +1,35 @@
+// @flow
+import assert from 'assert'
+import type { HydratedTemperatureFormData } from '../../../form-types'
+import type {
+  SetTemperatureArgs,
+  DeactivateTemperatureArgs,
+} from '../../../step-generation'
+
+type TemperatureArgs = SetTemperatureArgs | DeactivateTemperatureArgs
+
+export const temperatureFormToArgs = (
+  hydratedFormData: HydratedTemperatureFormData
+): TemperatureArgs => {
+  const { moduleId } = hydratedFormData
+  // cast values
+  const setTemperature = hydratedFormData.setTemperature === 'true'
+  const targetTemperature = parseFloat(hydratedFormData.targetTemperature)
+
+  assert(
+    setTemperature ? !Number.isNaN(targetTemperature) : true,
+    'temperatureFormToArgs expected (hydrated) targetTemperature to be a number when setTemperature is "true"'
+  )
+  if (setTemperature && !Number.isNaN(targetTemperature)) {
+    return {
+      commandCreatorFnName: 'setTemperature',
+      module: moduleId,
+      targetTemperature,
+    }
+  } else {
+    return {
+      commandCreatorFnName: 'deactivateTemperature',
+      module: moduleId,
+    }
+  }
+}

--- a/protocol-designer/src/top-selectors/substep-highlight.js
+++ b/protocol-designer/src/top-selectors/substep-highlight.js
@@ -43,18 +43,14 @@ function _getSelectedWellsForStep(
   frame: StepGeneration.CommandsAndRobotState,
   invariantContext: StepGeneration.InvariantContext
 ): Array<string> {
-  if (
-    stepArgs.commandCreatorFnName === 'delay' ||
-    stepArgs.commandCreatorFnName === 'engageMagnet' ||
-    stepArgs.commandCreatorFnName === 'disengageMagnet' ||
-    stepArgs.commandCreatorFnName === 'setTemperature' ||
-    stepArgs.commandCreatorFnName === 'deactivateTemperature'
-  ) {
+  if (StepGeneration.getHasNoWellsFromCCArgs(stepArgs)) {
     return []
   }
 
-  const pipetteId = stepArgs.pipette
-  const pipetteEntity = invariantContext.pipetteEntities[pipetteId]
+  const pipetteId = StepGeneration.getPipetteIdFromCCArgs(stepArgs)
+  const pipetteEntity = pipetteId
+    ? invariantContext.pipetteEntities[pipetteId]
+    : null
   const labwareEntity = invariantContext.labwareEntities[labwareId]
 
   if (!pipetteEntity || !labwareEntity) {

--- a/protocol-designer/src/top-selectors/substep-highlight.js
+++ b/protocol-designer/src/top-selectors/substep-highlight.js
@@ -46,7 +46,9 @@ function _getSelectedWellsForStep(
   if (
     stepArgs.commandCreatorFnName === 'delay' ||
     stepArgs.commandCreatorFnName === 'engageMagnet' ||
-    stepArgs.commandCreatorFnName === 'disengageMagnet'
+    stepArgs.commandCreatorFnName === 'disengageMagnet' ||
+    stepArgs.commandCreatorFnName === 'setTemperature' ||
+    stepArgs.commandCreatorFnName === 'deactivateTemperature'
   ) {
     return []
   }

--- a/shared-data/protocol/flowTypes/schemaV4.js
+++ b/shared-data/protocol/flowTypes/schemaV4.js
@@ -26,6 +26,10 @@ export type DisengageMagnetParams = {|
   module: string,
 |}
 
+export type SetTargetTempParams = {| module: string, temperature: number |}
+
+export type DeactivateTempParams = {| module: string |}
+
 export type Command =
   | {|
       command: 'aspirate' | 'dispense' | 'airGap',
@@ -56,6 +60,11 @@ export type Command =
       command: 'magneticModule/disengageMagnet',
       params: DisengageMagnetParams,
     |}
+  | {|
+      command: 'temperatureModule/setTargetTemp',
+      params: SetTargetTempParams,
+    |}
+  | {| command: 'temperatureModule/deactivate', params: DeactivateTempParams |}
 
 // NOTE: must be kept in sync with '../schemas/4.json'
 export type ProtocolFile<DesignerApplicationData> = {|

--- a/shared-data/protocol/flowTypes/schemaV4.js
+++ b/shared-data/protocol/flowTypes/schemaV4.js
@@ -61,10 +61,15 @@ export type Command =
       params: DisengageMagnetParams,
     |}
   | {|
-      command: 'temperatureModule/setTargetTemp',
+      command: 'temperatureModule/setTargetTemperature',
       params: SetTargetTempParams,
     |}
   | {| command: 'temperatureModule/deactivate', params: DeactivateTempParams |}
+  | {|
+      command: 'thermocycler/setTargetTemperature',
+      params: SetTargetTempParams,
+    |}
+  | {| command: 'thermocycler/deactivate', params: DeactivateTempParams |}
 
 // NOTE: must be kept in sync with '../schemas/4.json'
 export type ProtocolFile<DesignerApplicationData> = {|


### PR DESCRIPTION
## overview

First part of hooking up Temperature step (addresses #4693) - this should make all possible sorts of valid inputs into the Temperature step get translated into atomic commands (with limited, speculative support for thermocycler).

This does not update the robot state in response to the commands - that will be the next PR.

## changelog

- define & create setTargetTemperature vs deactivateTemperature commands for temperature module and for thermocycler
- hook up Temperature step to mapFormToArgs
- define temperature deck 3-case state (module state in robotState.modules)

## review requests

This isn't a very visual one, you need to inspect the JSON to test it (besides code review of the new tests)

Use Temperature step with temperature module and/or thermocycler. Try set temperature, and deactivate. Save the protocol and observe the `commands` array, it should contain the correct `command` type for the set-vs-deactivate and temp-vs-thermo, and if it's a set temp it should contain the right target temperature param (you can read the tests for an example).