### PR TITLE
build(opentrons): add no-default-export rule to linter file

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,9 @@ module.exports = {
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
     'no-extra-boolean-cast': 'off',
+    // TODO(isk, 2019-01-15): change no-default-export to error,
+    // once once all warnings are resolved
+    'import/no-default-export': 'warn',
   },
 
   globals: {},


### PR DESCRIPTION
Add no-default-export rule to linter file warning

<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview
Added `no-default-export` as a linter warning since this change affects the codebase broadly. To make this an error and the necessary updates seemed noisy/untenable. We can also scrap if we think the warnings are also too noisy and find a better path forward. 

![image](https://user-images.githubusercontent.com/2371418/72476093-5227b480-37ba-11ea-8c2f-25559b22d250.png)
