### PR TITLE
feat(protocol-designer): Populate engageHeight field with previous values

### DIFF
--- a/protocol-designer/src/components/StepEditForm/forms/MagnetForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MagnetForm.js
@@ -20,6 +20,13 @@ export const MagnetForm = (props: MagnetFormProps): React.Element<'div'> => {
     ? moduleLabwareOptions[0].name
     : 'No magnetic module'
 
+  const defaultEngageHeight = useSelector(
+    uiModuleSelectors.getMagnetLabwareEngageHeight
+  )
+  const engageHeightCaption = defaultEngageHeight
+    ? `Recommended: ${defaultEngageHeight}`
+    : null
+
   return (
     <div className={styles.form_wrapper}>
       <div className={styles.section_header}>
@@ -76,6 +83,7 @@ export const MagnetForm = (props: MagnetFormProps): React.Element<'div'> => {
               name="engageHeight"
               className={styles.small_field}
               units={i18n.t('application.units.millimeter')}
+              caption={engageHeightCaption}
               {...focusHandlers}
             />
           </FormGroup>

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultEngageHeight/__tests__/getNextDefautEngageHeight.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultEngageHeight/__tests__/getNextDefautEngageHeight.test.js
@@ -1,0 +1,68 @@
+// @flow
+import { getNextDefaultEngageHeight } from '../'
+
+describe('getNextDefaultEngageHeight', () => {
+  describe('no previous forms', () => {
+    const testCases = [
+      {
+        testMsg: 'no previous magnet action',
+        expected: null,
+      },
+    ]
+
+    testCases.forEach(({ testMsg, expected }) => {
+      test(testMsg, () => {
+        const savedForms = {}
+        const orderedStepIds = []
+
+        const result = getNextDefaultEngageHeight(savedForms, orderedStepIds)
+
+        expect(result).toBe(expected)
+      })
+    })
+  })
+
+  describe('with previous forms', () => {
+    const testCases = [
+      {
+        testMsg:
+          'returns null when disengage previous selected and no previous engage height entered',
+        orderedStepIds: ['d'],
+        expected: null,
+      },
+      {
+        testMsg:
+          'returns default when disengage previous selected and previous engage height entered',
+        orderedStepIds: ['e', 'd', 'e'],
+        expected: 14,
+      },
+      {
+        testMsg: 'returns default when engage previous selected',
+        orderedStepIds: ['d', 'e', 'd'],
+        expected: 14,
+      },
+    ]
+
+    testCases.forEach(({ testMsg, orderedStepIds, expected }) => {
+      test(testMsg, () => {
+        const savedForms = {
+          e: {
+            id: 'moduleId',
+            stepType: 'magnet',
+            magnetAction: 'engage',
+            engageHeight: 14,
+          },
+          d: {
+            id: 'moduleId',
+            stepType: 'magnet',
+            magnetAction: 'disengage',
+          },
+        }
+
+        const result = getNextDefaultEngageHeight(savedForms, orderedStepIds)
+
+        expect(result).toBe(expected)
+      })
+    })
+  })
+})

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultEngageHeight/index.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultEngageHeight/index.js
@@ -5,14 +5,14 @@ import type { StepIdType, FormData } from '../../../form-types'
 export function getNextDefaultEngageHeight(
   savedForms: { [StepIdType]: FormData },
   orderedStepIds: Array<StepIdType>
-): ?number {
+): ?string {
   const prevMagnetSteps = orderedStepIds
     .map(stepId => savedForms[stepId])
     .filter(form => form && form.engageHeight)
 
   const lastMagnetStep = last(prevMagnetSteps)
 
-  let nextDefaultEngageHeight: number | null = null
+  let nextDefaultEngageHeight: string | null = null
 
   if (lastMagnetStep && lastMagnetStep.magnetAction) {
     nextDefaultEngageHeight = lastMagnetStep.engageHeight

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultEngageHeight/index.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultEngageHeight/index.js
@@ -1,0 +1,24 @@
+// @flow
+import last from 'lodash/last'
+import type { StepIdType, FormData } from '../../../form-types'
+
+export function getNextDefaultEngageHeight(
+  savedForms: { [StepIdType]: FormData },
+  orderedStepIds: Array<StepIdType>
+): ?number {
+  const prevMagnetSteps = orderedStepIds
+    .map(stepId => savedForms[stepId])
+    .filter(form => form && form.engageHeight)
+
+  const lastMagnetStep = last(prevMagnetSteps)
+
+  let nextDefaultEngageHeight: number | null = null
+
+  if (lastMagnetStep && lastMagnetStep.magnetAction) {
+    nextDefaultEngageHeight = lastMagnetStep.engageHeight
+      ? lastMagnetStep.engageHeight
+      : null
+  }
+
+  return nextDefaultEngageHeight
+}

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultMagnetAction/__tests__/getNextDefaultModuleAction.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultMagnetAction/__tests__/getNextDefaultModuleAction.test.js
@@ -2,11 +2,11 @@
 import { getNextDefaultMagnetAction } from '../'
 
 describe('getNextDefaultMagnetAction', () => {
-  describe('no previous forms', () => {
+  describe('no previous forms defaults to engage', () => {
     const testCases = [
       {
         testMsg: 'no previous magnet action',
-        expected: null,
+        expected: 'engage',
       },
     ]
 

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultMagnetAction/index.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultMagnetAction/index.js
@@ -12,7 +12,9 @@ export function getNextDefaultMagnetAction(
 
   const lastMagnetStep = last(prevMagnetSteps)
 
-  let nextDefaultMagnetAction: ?string = null
+  // default the first magnet step to engage so that
+  // recommended engage height can auto populate
+  let nextDefaultMagnetAction: ?string = 'engage'
 
   if (lastMagnetStep && lastMagnetStep.magnetAction) {
     nextDefaultMagnetAction =

--- a/protocol-designer/src/steplist/formLevel/index.js
+++ b/protocol-designer/src/steplist/formLevel/index.js
@@ -31,6 +31,7 @@ export { default as getDisabledFields } from './getDisabledFields'
 export { default as getNextDefaultPipetteId } from './getNextDefaultPipetteId'
 export { getNextDefaultTemperatureModuleId } from './getNextDefaultModuleId'
 export { getNextDefaultMagnetAction } from './getNextDefaultMagnetAction'
+export { getNextDefaultEngageHeight } from './getNextDefaultEngageHeight'
 export { default as stepFormToArgs } from './stepFormToArgs'
 
 type FormHelpers = {

--- a/protocol-designer/src/ui/modules/selectors.js
+++ b/protocol-designer/src/ui/modules/selectors.js
@@ -1,6 +1,9 @@
 // @flow
 import { createSelector } from 'reselect'
-import { getLabwareDisplayName } from '@opentrons/shared-data'
+import {
+  getLabwareDisplayName,
+  getLabwareDefaultEngageHeight,
+} from '@opentrons/shared-data'
 import mapValues from 'lodash/mapValues'
 import { MAGDECK, TEMPDECK, THERMOCYCLER } from '../../constants'
 import { selectors as stepFormSelectors } from '../../step-forms'
@@ -120,5 +123,17 @@ export const getThermocyclerModuleHasLabware: Selector<boolean> = createSelector
   stepFormSelectors.getInitialDeckSetup,
   initialDeckSetup => {
     return getModuleHasLabware(initialDeckSetup, THERMOCYCLER)
+  }
+)
+
+export const getMagnetLabwareEngageHeight: Selector<
+  number | null
+> = createSelector(
+  stepFormSelectors.getInitialDeckSetup,
+  getSingleMagneticModuleId,
+  (initialDeckSetup, magnetModuleId) => {
+    const labware =
+      magnetModuleId && getLabwareOnModule(initialDeckSetup, magnetModuleId)
+    return (labware && getLabwareDefaultEngageHeight(labware.def)) || null
   }
 )

--- a/protocol-designer/src/ui/steps/actions/actions.js
+++ b/protocol-designer/src/ui/steps/actions/actions.js
@@ -151,6 +151,10 @@ export const selectStep = (
       state
     )
 
+    const stringDefaultEngageHeight = defaultEngageHeight
+      ? defaultEngageHeight.toString()
+      : null
+
     const prevEngageHeight = getNextDefaultEngageHeight(
       stepFormSelectors.getSavedStepForms(state),
       stepFormSelectors.getOrderedStepIds(state)
@@ -158,7 +162,7 @@ export const selectStep = (
 
     // if no previously saved engageHeight, autopopulate with recommended value
     // recommended value is null when no labware found on module
-    const engageHeight = prevEngageHeight || defaultEngageHeight
+    const engageHeight = prevEngageHeight || stringDefaultEngageHeight
     formData = { ...formData, moduleId, magnetAction, engageHeight }
   }
 

--- a/protocol-designer/src/ui/steps/actions/actions.js
+++ b/protocol-designer/src/ui/steps/actions/actions.js
@@ -98,12 +98,6 @@ export const selectStep = (
     stepFormSelectors.getInitialDeckSetup(state).pipettes
   )
 
-  const moduleId = getNextDefaultTemperatureModuleId(
-    stepFormSelectors.getSavedStepForms(state),
-    stepFormSelectors.getOrderedStepIds(state),
-    stepFormSelectors.getInitialDeckSetup(state).modules
-  )
-
   // For a pristine step, if there is a `pipette` field in the form
   // (added by upstream `getDefaultsForStepType` fn),
   // then set `pipette` field of new steps to the next default pipette id.
@@ -133,6 +127,11 @@ export const selectStep = (
     (newStepType === 'pause' || newStepType === 'temperature') &&
     formHasModuleIdField
   ) {
+    const moduleId = getNextDefaultTemperatureModuleId(
+      stepFormSelectors.getSavedStepForms(state),
+      stepFormSelectors.getOrderedStepIds(state),
+      stepFormSelectors.getInitialDeckSetup(state).modules
+    )
     formData = {
       ...formData,
       moduleId,

--- a/protocol-designer/src/ui/steps/actions/actions.js
+++ b/protocol-designer/src/ui/steps/actions/actions.js
@@ -8,6 +8,7 @@ import {
   getNextDefaultPipetteId,
   getNextDefaultTemperatureModuleId,
   getNextDefaultMagnetAction,
+  getNextDefaultEngageHeight,
   handleFormChange,
 } from '../../../steplist/formLevel'
 import type { StepIdType, StepType } from '../../../form-types'
@@ -145,7 +146,15 @@ export const selectStep = (
       stepFormSelectors.getSavedStepForms(state),
       stepFormSelectors.getOrderedStepIds(state)
     )
-    formData = { ...formData, moduleId, magnetAction }
+
+    // TODO (ka 2020-1-16): Investigate autopopulating engageHeight
+    // conditional field with shared-data default
+    const engageHeight = getNextDefaultEngageHeight(
+      stepFormSelectors.getSavedStepForms(state),
+      stepFormSelectors.getOrderedStepIds(state)
+    )
+
+    formData = { ...formData, moduleId, magnetAction, engageHeight }
   }
 
   dispatch({

--- a/protocol-designer/src/ui/steps/actions/actions.js
+++ b/protocol-designer/src/ui/steps/actions/actions.js
@@ -147,13 +147,18 @@ export const selectStep = (
       stepFormSelectors.getOrderedStepIds(state)
     )
 
-    // TODO (ka 2020-1-16): Investigate autopopulating engageHeight
-    // conditional field with shared-data default
-    const engageHeight = getNextDefaultEngageHeight(
+    const defaultEngageHeight = uiModulesSelectors.getMagnetLabwareEngageHeight(
+      state
+    )
+
+    const prevEngageHeight = getNextDefaultEngageHeight(
       stepFormSelectors.getSavedStepForms(state),
       stepFormSelectors.getOrderedStepIds(state)
     )
 
+    // if no previously saved engageHeight, autopopulate with recommended value
+    // recommended value is null when no labware found on module
+    const engageHeight = prevEngageHeight || defaultEngageHeight
     formData = { ...formData, moduleId, magnetAction, engageHeight }
   }
 

--- a/shared-data/js/constants.js
+++ b/shared-data/js/constants.js
@@ -18,3 +18,5 @@ export const THERMOCYCLER: 'thermocycler' = 'thermocycler'
 export const TEMPDECK: 'tempdeck' = 'tempdeck'
 
 export const MAGDECK: 'magdeck' = 'magdeck'
+
+export const ENGAGE_HEIGHT_OFFSET = -4

--- a/shared-data/js/constants.js
+++ b/shared-data/js/constants.js
@@ -19,4 +19,5 @@ export const TEMPDECK: 'tempdeck' = 'tempdeck'
 
 export const MAGDECK: 'magdeck' = 'magdeck'
 
+// offset added to parameters.magneticModuleEngageHeight for displaying reccomended height in PD
 export const ENGAGE_HEIGHT_OFFSET = -4

--- a/shared-data/js/getLabware.js
+++ b/shared-data/js/getLabware.js
@@ -3,7 +3,11 @@ import assert from 'assert'
 import mapValues from 'lodash/mapValues'
 // TODO: Ian 2019-06-04 remove the shared-data build process for labware v1
 import definitions from '../build/labware.json'
-import { SLOT_RENDER_HEIGHT, FIXED_TRASH_RENDER_HEIGHT } from './constants'
+import {
+  SLOT_RENDER_HEIGHT,
+  FIXED_TRASH_RENDER_HEIGHT,
+  ENGAGE_HEIGHT_OFFSET,
+} from './constants'
 import type {
   LabwareDefinition1,
   LabwareDefinition2,
@@ -42,6 +46,15 @@ export function getIsLabwareV1Tiprack(def: LabwareDefinition1): boolean {
 
 export function getIsTiprack(labwareDef: LabwareDefinition2): boolean {
   return labwareDef.parameters.isTiprack
+}
+
+export function getLabwareDefaultEngageHeight(
+  labwareDef: LabwareDefinition2
+): number | null {
+  const defaultEngageHeight: ?number =
+    labwareDef.parameters.magneticModuleEngageHeight &&
+    labwareDef.parameters.magneticModuleEngageHeight - ENGAGE_HEIGHT_OFFSET
+  return defaultEngageHeight || null
 }
 
 /* Render Helpers */

--- a/shared-data/js/getLabware.js
+++ b/shared-data/js/getLabware.js
@@ -51,10 +51,9 @@ export function getIsTiprack(labwareDef: LabwareDefinition2): boolean {
 export function getLabwareDefaultEngageHeight(
   labwareDef: LabwareDefinition2
 ): number | null {
-  const rawEngageHeight = labwareDef.parameters.magneticModuleEngageHeight
-  return rawEngageHeight === null
-    ? null
-    : rawEngageHeight + ENGAGE_HEIGHT_OFFSET
+  const rawEngageHeight: ?number =
+    labwareDef.parameters.magneticModuleEngageHeight
+  return rawEngageHeight == null ? null : rawEngageHeight + ENGAGE_HEIGHT_OFFSET
 }
 
 /* Render Helpers */

--- a/shared-data/js/getLabware.js
+++ b/shared-data/js/getLabware.js
@@ -53,7 +53,9 @@ export function getLabwareDefaultEngageHeight(
 ): number | null {
   const defaultEngageHeight: ?number =
     labwareDef.parameters.magneticModuleEngageHeight &&
-    labwareDef.parameters.magneticModuleEngageHeight + ENGAGE_HEIGHT_OFFSET
+    Number(
+      labwareDef.parameters.magneticModuleEngageHeight + ENGAGE_HEIGHT_OFFSET
+    )
   return defaultEngageHeight || null
 }
 

--- a/shared-data/js/getLabware.js
+++ b/shared-data/js/getLabware.js
@@ -53,7 +53,7 @@ export function getLabwareDefaultEngageHeight(
 ): number | null {
   const defaultEngageHeight: ?number =
     labwareDef.parameters.magneticModuleEngageHeight &&
-    labwareDef.parameters.magneticModuleEngageHeight - ENGAGE_HEIGHT_OFFSET
+    labwareDef.parameters.magneticModuleEngageHeight + ENGAGE_HEIGHT_OFFSET
   return defaultEngageHeight || null
 }
 

--- a/shared-data/js/getLabware.js
+++ b/shared-data/js/getLabware.js
@@ -51,12 +51,10 @@ export function getIsTiprack(labwareDef: LabwareDefinition2): boolean {
 export function getLabwareDefaultEngageHeight(
   labwareDef: LabwareDefinition2
 ): number | null {
-  const defaultEngageHeight: ?number =
-    labwareDef.parameters.magneticModuleEngageHeight &&
-    Number(
-      labwareDef.parameters.magneticModuleEngageHeight + ENGAGE_HEIGHT_OFFSET
-    )
-  return defaultEngageHeight || null
+  const rawEngageHeight = labwareDef.parameters.magneticModuleEngageHeight
+  return rawEngageHeight === null
+    ? null
+    : rawEngageHeight + ENGAGE_HEIGHT_OFFSET
 }
 
 /* Render Helpers */


### PR DESCRIPTION
## overview

This PR closes #4764 by adding a function to shared data to calculate recommended engage height for supported labware and rendering recommended value message as engageHeight caption.

## changelog

- add `getLabwareDefaultEngageHeight` to shared-data
- feat(protocol-designer): Populate engageHeight field with prev values || recommended
- default first `magnetAction` to 'engage'

## review requests

Make a protocol with a magnetic module
Do not add labware
Make a magnet engage step
- [ ] no recommended value caption

Make a protocol with a magnetic module
Add supported labware
Make first magnetic step
- [ ] caption should render recommended engageHeight caption
- [ ] engageHeight should be auto-populated with recommended value
Add disengage step
Add another engage step
- [ ] caption should render recommended engageHeight caption
- [ ] previously saved value should autofill engageHeight

Make a protocol with a magnetic module
Upload custom labware 
Make a magnet engage step
- [ ] no recommended value caption
Add disengage step
Add another engage step
- [ ] previously saved value should autofill engageHeight

This PR also defaults the first `magnetAction` to `'engage'` to avoid nulling out `engageHeight` on first `magnetAction` selection. Nulling out `engageHeight` on `magnetAction` change is necessary for clearing out form level errors particular to 'engage' only fields.