### PR TITLE
fix(app): Clarify labels for app version and motor controller firmware version

### DIFF
--- a/app/src/components/AppSettings/AppInfoCard.js
+++ b/app/src/components/AppSettings/AppInfoCard.js
@@ -15,7 +15,7 @@ type Props = {
 }
 
 const TITLE = 'Information'
-const VERSION_LABEL = 'Software Version'
+const VERSION_LABEL = 'Opentrons App Version'
 
 const UPDATE_AVAILABLE = 'view available update'
 const UPDATE_NOT_AVAILABLE = 'up to date'

--- a/app/src/components/RobotSettings/InformationCard.js
+++ b/app/src/components/RobotSettings/InformationCard.js
@@ -35,7 +35,7 @@ type Props = {|
 const TITLE = 'Information'
 const NAME_LABEL = 'Robot name'
 const SERVER_VERSION_LABEL = 'Server version'
-const FIRMWARE_VERSION_LABEL = 'Firmware version'
+const FIRMWARE_VERSION_LABEL = 'Motor controller firmware version'
 const MAX_PROTOCOL_API_VERSION_LABEL = 'Max Protocol API Version'
 
 const UPDATE_SERVER_UNAVAILABLE =


### PR DESCRIPTION
# Overview

This PR adjusts UI labels to address some of the ways that our software versioning has confused users.

* The Opentrons App currently labels its own version as "Software Version." This is ambiguous, and has been conflated with the *robot's* software version (despite being under More > App). Change it to "Opentrons App Version."
* Users have seen "Firmware version" and assumed that that's the "version of the robot software." In fact, it's specifically the firmware on the motor controller board, which is only rarely of interest. Spell it out as "Motor controller firmware version."

# Before

<img width="612" alt="Screen Shot 2020-01-17 at 6 30 06 PM" src="https://user-images.githubusercontent.com/3236864/72653409-c730f080-3958-11ea-9f8f-e2284af04544.png">
<img width="619" alt="Screen Shot 2020-01-17 at 6 29 57 PM" src="https://user-images.githubusercontent.com/3236864/72653426-d7e16680-3958-11ea-93a4-94c73bad790a.png">

# After
<img width="617" alt="Screen Shot 2020-01-17 at 6 29 30 PM" src="https://user-images.githubusercontent.com/3236864/72653442-e4fe5580-3958-11ea-96f6-4b2388e0a7d3.png">
<img width="618" alt="Screen Shot 2020-01-17 at 6 29 41 PM" src="https://user-images.githubusercontent.com/3236864/72653443-e760af80-3958-11ea-9dc0-eb408c1a2c8a.png">



# Reviewing

* Is the line wrap in "Motor controller firmware version" okay?
* We should agree on whether it's officially called the "motor controller," which is the term that I've been using in lieu of "Smoothie" for support documentation. Someone from Hardware mentioned that their name for it is the "stepper motor driver," which seems to me to be too technobabbly to be user-facing, but I'm willing to be overridden for the sake of consistency.