### PR TITLE
build(make): ensure SHELL includes PATH in its environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # opentrons platform makefile
 # https://github.com/Opentrons/opentrons
 
-# adding the -c to SHELL prevents macOS optimizing away our PATH update
-SHELL := /bin/bash -c
+# using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
+SHELL := bash
 
 # add node_modules/.bin to PATH
 PATH := $(shell yarn bin):$(PATH)

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 # opentrons platform makefile
 # https://github.com/Opentrons/opentrons
 
+# adding the -c to SHELL prevents macOS optimizing away our PATH update
+SHELL := /bin/bash -c
+
 # add node_modules/.bin to PATH
 PATH := $(shell yarn bin):$(PATH)
-# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
-SHELL := env PATH=$(PATH) /bin/bash
 
 API_DIR := api
 DISCOVERY_CLIENT_DIR := discovery-client

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # opentrons platform makefile
 # https://github.com/Opentrons/opentrons
 
-SHELL := /bin/bash
-
 # add node_modules/.bin to PATH
 PATH := $(shell yarn bin):$(PATH)
+# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
+SHELL := env PATH=$(PATH) /bin/bash
 
 API_DIR := api
 DISCOVERY_CLIENT_DIR := discovery-client

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,12 +1,12 @@
 # opentrons api makefile
 
+# adding the -c to SHELL prevents macOS optimizing away our PATH update
+SHELL := /bin/bash -c
+
 # add yarn CLI dev deps to PATH (for cross platform POSIX commands via shx)
 # and also make an explicit version for shx for use in the shell function,
 # where PATH won’t be propagated
 PATH := $(shell cd .. && yarn bin):$(PATH)
-# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
-SHELL := env PATH=$(PATH) /bin/bash
-
 SHX := npx shx
 
 # make push wheel file (= rather than := to expand at every use)

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,7 +1,7 @@
 # opentrons api makefile
 
-# adding the -c to SHELL prevents macOS optimizing away our PATH update
-SHELL := /bin/bash -c
+# using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
+SHELL := bash
 
 # add yarn CLI dev deps to PATH (for cross platform POSIX commands via shx)
 # and also make an explicit version for shx for use in the shell function,

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,11 +1,12 @@
 # opentrons api makefile
 
-SHELL := /bin/bash
-
 # add yarn CLI dev deps to PATH (for cross platform POSIX commands via shx)
 # and also make an explicit version for shx for use in the shell function,
 # where PATH won’t be propagated
 PATH := $(shell cd .. && yarn bin):$(PATH)
+# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
+SHELL := env PATH=$(PATH) /bin/bash
+
 SHX := npx shx
 
 # make push wheel file (= rather than := to expand at every use)

--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -1,7 +1,7 @@
 # opentrons app desktop shell makefile
 
-# adding the -c to SHELL prevents macOS optimizing away our PATH update
-SHELL := /bin/bash -c
+# using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
+SHELL := bash
 
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)

--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -1,9 +1,10 @@
 # opentrons app desktop shell makefile
 
+# adding the -c to SHELL prevents macOS optimizing away our PATH update
+SHELL := /bin/bash -c
+
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)
-# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
-SHELL := env PATH=$(PATH) /bin/bash
 
 # dev server port
 PORT ?= 8090

--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -1,9 +1,9 @@
 # opentrons app desktop shell makefile
 
-SHELL := /bin/bash
-
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)
+# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
+SHELL := env PATH=$(PATH) /bin/bash
 
 # dev server port
 PORT ?= 8090

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,9 +1,9 @@
 # opentrons app makefile
 
-SHELL := /bin/bash
-
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)
+# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
+SHELL := env PATH=$(PATH) /bin/bash
 
 # dev server port
 PORT ?= 8090

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,9 +1,10 @@
 # opentrons app makefile
 
+# adding the -c to SHELL prevents macOS optimizing away our PATH update
+SHELL := /bin/bash -c
+
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)
-# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
-SHELL := env PATH=$(PATH) /bin/bash
 
 # dev server port
 PORT ?= 8090

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,7 +1,7 @@
 # opentrons app makefile
 
-# adding the -c to SHELL prevents macOS optimizing away our PATH update
-SHELL := /bin/bash -c
+# using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
+SHELL := bash
 
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)

--- a/components/Makefile
+++ b/components/Makefile
@@ -1,9 +1,10 @@
 # opentrons component library makefile
 
+# adding the -c to SHELL prevents macOS optimizing away our PATH update
+SHELL := /bin/bash -c
+
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)
-# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
-SHELL := env PATH=$(PATH) /bin/bash
 
 # dev server port
 port ?= 8081

--- a/components/Makefile
+++ b/components/Makefile
@@ -1,9 +1,9 @@
 # opentrons component library makefile
 
-SHELL := /bin/bash
-
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)
+# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
+SHELL := env PATH=$(PATH) /bin/bash
 
 # dev server port
 port ?= 8081

--- a/components/Makefile
+++ b/components/Makefile
@@ -1,7 +1,7 @@
 # opentrons component library makefile
 
-# adding the -c to SHELL prevents macOS optimizing away our PATH update
-SHELL := /bin/bash -c
+# using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
+SHELL := bash
 
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)

--- a/discovery-client/Makefile
+++ b/discovery-client/Makefile
@@ -1,9 +1,10 @@
 # opentrons discovery-client makefile
 
+# adding the -c to SHELL prevents macOS optimizing away our PATH update
+SHELL := /bin/bash -c
+
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)
-# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
-SHELL := env PATH=$(PATH) /bin/bash
 
 # standard targets
 #####################################################################

--- a/discovery-client/Makefile
+++ b/discovery-client/Makefile
@@ -1,9 +1,9 @@
 # opentrons discovery-client makefile
 
-SHELL := /bin/bash
-
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)
+# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
+SHELL := env PATH=$(PATH) /bin/bash
 
 # standard targets
 #####################################################################

--- a/discovery-client/Makefile
+++ b/discovery-client/Makefile
@@ -1,7 +1,7 @@
 # opentrons discovery-client makefile
 
-# adding the -c to SHELL prevents macOS optimizing away our PATH update
-SHELL := /bin/bash -c
+# using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
+SHELL := bash
 
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)

--- a/labware-designer/Makefile
+++ b/labware-designer/Makefile
@@ -1,7 +1,7 @@
 # opentrons labware-designer makefile
 
-# adding the -c to SHELL prevents macOS optimizing away our PATH update
-SHELL := /bin/bash -c
+# using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
+SHELL := bash
 
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)

--- a/labware-designer/Makefile
+++ b/labware-designer/Makefile
@@ -1,9 +1,10 @@
 # opentrons labware-designer makefile
 
+# adding the -c to SHELL prevents macOS optimizing away our PATH update
+SHELL := /bin/bash -c
+
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)
-# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
-SHELL := env PATH=$(PATH) /bin/bash
 
 # standard targets
 #####################################################################

--- a/labware-designer/Makefile
+++ b/labware-designer/Makefile
@@ -1,9 +1,9 @@
 # opentrons labware-designer makefile
 
-SHELL := /bin/bash
-
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)
+# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
+SHELL := env PATH=$(PATH) /bin/bash
 
 # standard targets
 #####################################################################

--- a/labware-library/Makefile
+++ b/labware-library/Makefile
@@ -1,7 +1,7 @@
 # opentrons labware-library makefile
 
-# adding the -c to SHELL prevents macOS optimizing away our PATH update
-SHELL := /bin/bash -c
+# using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
+SHELL := bash
 
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)

--- a/labware-library/Makefile
+++ b/labware-library/Makefile
@@ -1,9 +1,9 @@
 # opentrons labware-library makefile
 
-SHELL := /bin/bash
-
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)
+# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
+SHELL := env PATH=$(PATH) /bin/bash
 
 .PHONY: all
 all: clean dist

--- a/labware-library/Makefile
+++ b/labware-library/Makefile
@@ -1,9 +1,10 @@
 # opentrons labware-library makefile
 
+# adding the -c to SHELL prevents macOS optimizing away our PATH update
+SHELL := /bin/bash -c
+
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)
-# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
-SHELL := env PATH=$(PATH) /bin/bash
 
 .PHONY: all
 all: clean dist

--- a/protocol-designer/Makefile
+++ b/protocol-designer/Makefile
@@ -1,9 +1,9 @@
 # opentrons protocol designer makefile
 
-SHELL := /bin/bash
-
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)
+# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
+SHELL := env PATH=$(PATH) /bin/bash
 
 # standard targets
 #####################################################################

--- a/protocol-designer/Makefile
+++ b/protocol-designer/Makefile
@@ -1,9 +1,10 @@
 # opentrons protocol designer makefile
 
+# adding the -c to SHELL prevents macOS optimizing away our PATH update
+SHELL := /bin/bash -c
+
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)
-# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
-SHELL := env PATH=$(PATH) /bin/bash
 
 # standard targets
 #####################################################################

--- a/protocol-designer/Makefile
+++ b/protocol-designer/Makefile
@@ -1,7 +1,7 @@
 # opentrons protocol designer makefile
 
-# adding the -c to SHELL prevents macOS optimizing away our PATH update
-SHELL := /bin/bash -c
+# using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
+SHELL := bash
 
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)

--- a/protocol-library-kludge/Makefile
+++ b/protocol-library-kludge/Makefile
@@ -1,9 +1,10 @@
 # opentrons protocol-library-kludge makefile
 
+# adding the -c to SHELL prevents macOS optimizing away our PATH update
+SHELL := /bin/bash -c
+
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)
-# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
-SHELL := env PATH=$(PATH) /bin/bash
 
 # standard targets
 #####################################################################

--- a/protocol-library-kludge/Makefile
+++ b/protocol-library-kludge/Makefile
@@ -1,9 +1,9 @@
 # opentrons protocol-library-kludge makefile
 
-SHELL := /bin/bash
-
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)
+# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
+SHELL := env PATH=$(PATH) /bin/bash
 
 # standard targets
 #####################################################################

--- a/protocol-library-kludge/Makefile
+++ b/protocol-library-kludge/Makefile
@@ -1,7 +1,7 @@
 # opentrons protocol-library-kludge makefile
 
-# adding the -c to SHELL prevents macOS optimizing away our PATH update
-SHELL := /bin/bash -c
+# using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
+SHELL := bash
 
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)

--- a/shared-data/Makefile
+++ b/shared-data/Makefile
@@ -1,9 +1,9 @@
 # opentrons app makefile
 
-SHELL := /bin/bash
-
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)
+# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
+SHELL := env PATH=$(PATH) /bin/bash
 
 # TODO(mc, 2018-10-25): use dist to match other projects
 BUILD_DIR := build

--- a/shared-data/Makefile
+++ b/shared-data/Makefile
@@ -1,7 +1,7 @@
 # opentrons app makefile
 
-# adding the -c to SHELL prevents macOS optimizing away our PATH update
-SHELL := /bin/bash -c
+# using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
+SHELL := bash
 
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)

--- a/shared-data/Makefile
+++ b/shared-data/Makefile
@@ -1,9 +1,10 @@
 # opentrons app makefile
 
+# adding the -c to SHELL prevents macOS optimizing away our PATH update
+SHELL := /bin/bash -c
+
 # add node_modules/.bin to PATH
 PATH := $(shell cd .. && yarn bin):$(PATH)
-# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
-SHELL := env PATH=$(PATH) /bin/bash
 
 # TODO(mc, 2018-10-25): use dist to match other projects
 BUILD_DIR := build

--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -1,5 +1,5 @@
-# adding the -c to SHELL prevents macOS optimizing away our PATH update
-SHELL := /bin/bash -c
+# using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
+SHELL := bash
 
 PATH := $(shell cd .. && yarn bin):$(PATH)
 SHX := npx shx

--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -1,6 +1,7 @@
-SHELL := /bin/bash
-
 PATH := $(shell cd .. && yarn bin):$(PATH)
+# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
+SHELL := env PATH=$(PATH) /bin/bash
+
 SHX := npx shx
 
 # add yarn CLI dev deps to PATH (for cross platform POSIX commands via shx)

--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -1,7 +1,7 @@
-PATH := $(shell cd .. && yarn bin):$(PATH)
-# ensure PATH is honored when shell invoked (this gets round an issue on macOS)
-SHELL := env PATH=$(PATH) /bin/bash
+# adding the -c to SHELL prevents macOS optimizing away our PATH update
+SHELL := /bin/bash -c
 
+PATH := $(shell cd .. && yarn bin):$(PATH)
 SHX := npx shx
 
 # add yarn CLI dev deps to PATH (for cross platform POSIX commands via shx)


### PR DESCRIPTION
## overview

make on macOS does not seem to honor updates to PATH within the Makefile for shell invocation. This can be resolved be setting the PATH env variable as part of the SHELL command. This change is benign for GNU make.

fix #4808


## changelog

All Makefiles have been updated to modify the existing line that set the SHELL env variable to include the PATH.

## review requests

I have tested this using standard make on macOS (10.15) and GNU make on Ubuntu linux. Some tests on other configurations would provide confidence that this works across the supported environments.
