### PR TITLE
refactor(app): Make resource card responsive

### DIFF
--- a/app/src/components/App.js
+++ b/app/src/components/App.js
@@ -11,14 +11,14 @@ import NavBar from './nav-bar'
 import { PageWrapper } from '../components/Page'
 import SidePanel from '../pages/SidePanel'
 import Robots from '../pages/Robots'
-import More from '../pages/More'
+import { More } from '../pages/More'
 import Upload from '../pages/Upload'
 import Calibrate from '../pages/Calibrate'
 import Run from '../pages/Run'
 import { PortalRoot as ModalPortalRoot } from './portal'
 import styles from './App.css'
 
-export default function App() {
+export function App() {
   return (
     <div className={styles.wrapper} onDragOver={stopEvent} onDrop={stopEvent}>
       <NavBar />

--- a/app/src/components/Resources/ResourceCard.js
+++ b/app/src/components/Resources/ResourceCard.js
@@ -11,7 +11,7 @@ type Props = {
   url: string,
 }
 
-export default function ResourceCard(props: Props) {
+export function ResourceCard(props: Props) {
   return (
     <Card title={props.title}>
       <div className={styles.card_content}>

--- a/app/src/components/Resources/index.js
+++ b/app/src/components/Resources/index.js
@@ -2,10 +2,10 @@
 // resources page layout
 import * as React from 'react'
 
-import ResourceCard from './ResourceCard'
+import { ResourceCard } from './ResourceCard'
 import { CardContainer, CardRow } from '../layout'
 
-export default function Resources() {
+export function Resources() {
   return (
     <CardContainer>
       <CardRow>

--- a/app/src/components/Resources/styles.css
+++ b/app/src/components/Resources/styles.css
@@ -8,16 +8,17 @@
 
 .card_content {
   padding: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .link_label {
   @apply --font-body-1-dark;
 
   max-width: var(--mw-labeled-button);
-  display: inline-block;
-  line-height: 2.25rem;
 }
 
 .link_button {
-  float: right;
+  flex-shrink: 0;
 }

--- a/app/src/components/Resources/styles.css
+++ b/app/src/components/Resources/styles.css
@@ -21,4 +21,5 @@
 
 .link_button {
   flex-shrink: 0;
+  margin-left: var(--resources_card_spacing);
 }

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -21,7 +21,7 @@ import { rootReducer, history } from './reducer'
 import { rootEpic } from './epic'
 
 // components
-import App from './components/App'
+import { App } from './components/App'
 
 const log = createLogger(__filename)
 

--- a/app/src/pages/More/Resources.js
+++ b/app/src/pages/More/Resources.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react'
 import Page from '../../components/Page'
-import Resources from '../../components/Resources'
+import { Resources } from '../../components/Resources'
 
-export default function ResourcesPage() {
+export function ResourcesPage() {
   return (
     <Page titleBarProps={{ title: 'Resources' }}>
       <Resources />

--- a/app/src/pages/More/index.js
+++ b/app/src/pages/More/index.js
@@ -5,11 +5,11 @@ import { Switch, Route, Redirect } from 'react-router-dom'
 
 import AppSettings from './AppSettings'
 import CustomLabware from './CustomLabware'
-import Resources from './Resources'
+import { ResourcesPage } from './Resources'
 
 import type { ContextRouter } from 'react-router-dom'
 
-export default function More(props: ContextRouter) {
+export function More(props: ContextRouter) {
   const { path } = props.match
   const appPath = `${path}/app`
 
@@ -18,7 +18,7 @@ export default function More(props: ContextRouter) {
       <Redirect exact from={path} to={appPath} />
       <Route path={appPath} component={AppSettings} />
       <Route path={`${path}/custom-labware`} component={CustomLabware} />
-      <Route path={`${path}/resources`} component={Resources} />
+      <Route path={`${path}/resources`} component={ResourcesPage} />
     </Switch>
   )
 }


### PR DESCRIPTION
## changelog

This PR closes #4813 by wrapping text in the resources card on smaller screens. See ticket for prev /buggy behavior. While I was in there, I hit a few export default warnings, and cleared them up. hence the 7 affected files instead of 1 CSS file.

## review requests

- Open app
- Navigate to More > Resources
- [x] resource cards look the same
- Resize app screen (smaller)
- [x] resource label/text wraps and button does not stack below anymore

- [x] removal of default exports in affected files is sane + doesn't break anything
