### PR TITLE
style(app): change default exports to named exports

### DIFF
--- a/app-shell/src/__mocks__/log.js
+++ b/app-shell/src/__mocks__/log.js
@@ -1,2 +1,2 @@
 // mock logger
-module.exports = require('../../../app/src/__mocks__/logger').default
+module.exports = require('../../../app/src/__mocks__/logger')

--- a/app-shell/src/buildroot/index.js
+++ b/app-shell/src/buildroot/index.js
@@ -4,7 +4,7 @@ import path from 'path'
 import { readFile, ensureDir } from 'fs-extra'
 import { app } from 'electron'
 
-import createLogger from '../log'
+import { createLogger } from '../log'
 import { getConfig } from '../config'
 import { CURRENT_VERSION } from '../update'
 import { downloadManifest, getReleaseSet } from './release-manifest'

--- a/app-shell/src/buildroot/release-files.js
+++ b/app-shell/src/buildroot/release-files.js
@@ -9,7 +9,7 @@ import { move, readdir } from 'fs-extra'
 import StreamZip from 'node-stream-zip'
 import getStream from 'get-stream'
 
-import createLogger from '../log'
+import { createLogger } from '../log'
 import { fetchToFile } from '../http'
 import type { DownloadProgress } from '../http'
 import type { ReleaseSetUrls, ReleaseSetFilepaths, UserFileInfo } from './types'

--- a/app-shell/src/config.js
+++ b/app-shell/src/config.js
@@ -9,7 +9,7 @@ import uuid from 'uuid/v4'
 import yargsParser from 'yargs-parser'
 
 import pkg from '../package.json'
-import createLogger from './log'
+import { initializeLogger } from './log'
 
 // TODO(mc, 2018-08-08): figure out type exports from app
 import type { Config } from '@opentrons/app/src/config/types'
@@ -99,7 +99,7 @@ let _over
 let _log
 const store = () => _store || (_store = new Store({ defaults: DEFAULTS }))
 const overrides = () => _over || (_over = yargsParser(argv, PARSE_ARGS_OPTS))
-const log = () => _log || (_log = createLogger('config'))
+const log = () => _log || (_log = initializeLogger('config'))
 
 // initialize and register the config module with dispatches from the UI
 export function registerConfig(dispatch: Dispatch) {

--- a/app-shell/src/config.js
+++ b/app-shell/src/config.js
@@ -9,7 +9,7 @@ import uuid from 'uuid/v4'
 import yargsParser from 'yargs-parser'
 
 import pkg from '../package.json'
-import { initializeLogger } from './log'
+import { createLogger } from './log'
 
 // TODO(mc, 2018-08-08): figure out type exports from app
 import type { Config } from '@opentrons/app/src/config/types'
@@ -99,7 +99,7 @@ let _over
 let _log
 const store = () => _store || (_store = new Store({ defaults: DEFAULTS }))
 const overrides = () => _over || (_over = yargsParser(argv, PARSE_ARGS_OPTS))
-const log = () => _log || (_log = initializeLogger('config'))
+const log = () => _log || (_log = createLogger('config'))
 
 // initialize and register the config module with dispatches from the UI
 export function registerConfig(dispatch: Dispatch) {

--- a/app-shell/src/discovery.js
+++ b/app-shell/src/discovery.js
@@ -10,7 +10,7 @@ import DiscoveryClient, {
 } from '@opentrons/discovery-client'
 
 import { getConfig, getOverrides, handleConfigChange } from './config'
-import createLogger from './log'
+import { createLogger } from './log'
 
 import type { Service } from '@opentrons/discovery-client'
 

--- a/app-shell/src/log.js
+++ b/app-shell/src/log.js
@@ -26,11 +26,11 @@ let config
 let transports
 let log
 
-export const initializeLogger = filename => {
+export function createLogger(filename) {
   if (!config) config = getConfig('log')
   if (!transports) initializeTransports()
 
-  return createLogger(filename)
+  return createWinstonLogger(filename)
 }
 
 function initializeTransports() {
@@ -44,7 +44,7 @@ function initializeTransports() {
   }
 
   transports = createTransports()
-  log = createLogger('log')
+  log = createWinstonLogger('log')
 
   if (error) log.error('Could not create log directory', { error })
   log.info(`Level "error" and higher logging to ${ERROR_LOG}`)
@@ -97,7 +97,7 @@ function createTransports() {
   ]
 }
 
-function createLogger(label) {
+function createWinstonLogger(label) {
   log && log.debug(`Creating logger for ${label}`)
 
   const formats = [

--- a/app-shell/src/log.js
+++ b/app-shell/src/log.js
@@ -26,7 +26,7 @@ let config
 let transports
 let log
 
-export default function initializeLogger(filename) {
+export const initializeLogger = filename => {
   if (!config) config = getConfig('log')
   if (!transports) initializeTransports()
 

--- a/app-shell/src/main.js
+++ b/app-shell/src/main.js
@@ -2,9 +2,9 @@
 import { app, ipcMain } from 'electron'
 import contextMenu from 'electron-context-menu'
 
-import createUi from './ui'
-import initializeMenu from './menu'
-import createLogger from './log'
+import { createUi } from './ui'
+import { initializeMenu } from './menu'
+import { createLogger } from './log'
 import { getConfig, getStore, getOverrides, registerConfig } from './config'
 import { registerDiscovery } from './discovery'
 import { registerLabware } from './labware'

--- a/app-shell/src/menu.js
+++ b/app-shell/src/menu.js
@@ -41,6 +41,6 @@ const helpMenu = {
 
 const template = [firstMenu, editMenu, viewMenu, windowMenu, helpMenu]
 
-export default function initializeMenu() {
+export const initializeMenu = () => {
   Menu.setApplicationMenu(Menu.buildFromTemplate(template))
 }

--- a/app-shell/src/menu.js
+++ b/app-shell/src/menu.js
@@ -41,6 +41,6 @@ const helpMenu = {
 
 const template = [firstMenu, editMenu, viewMenu, windowMenu, helpMenu]
 
-export const initializeMenu = () => {
+export function initializeMenu() {
   Menu.setApplicationMenu(Menu.buildFromTemplate(template))
 }

--- a/app-shell/src/robot-logs.js
+++ b/app-shell/src/robot-logs.js
@@ -1,7 +1,7 @@
 // download robot logs manager
 
 import { download } from 'electron-dl'
-import createLogger from './log'
+import { createLogger } from './log'
 
 const log = createLogger('robot-logs')
 

--- a/app-shell/src/ui.js
+++ b/app-shell/src/ui.js
@@ -2,7 +2,7 @@
 import { app, shell, BrowserWindow } from 'electron'
 import path from 'path'
 import { getConfig } from './config'
-import createLogger from './log'
+import { createLogger } from './log'
 
 const config = getConfig('ui')
 const log = createLogger('ui')
@@ -30,7 +30,7 @@ const WINDOW_OPTS = {
   ),
 }
 
-export default function createUi() {
+export const createUi = () => {
   log.debug('Creating main window', { options: WINDOW_OPTS })
 
   const mainWindow = new BrowserWindow(WINDOW_OPTS).once(

--- a/app-shell/src/ui.js
+++ b/app-shell/src/ui.js
@@ -30,7 +30,7 @@ const WINDOW_OPTS = {
   ),
 }
 
-export const createUi = () => {
+export function createUi() {
   log.debug('Creating main window', { options: WINDOW_OPTS })
 
   const mainWindow = new BrowserWindow(WINDOW_OPTS).once(

--- a/app-shell/src/update.js
+++ b/app-shell/src/update.js
@@ -4,7 +4,7 @@ import path from 'path'
 import fs from 'fs'
 import { autoUpdater as updater } from 'electron-updater'
 
-import createLogger from './log'
+import { createLogger } from './log'
 import { getConfig } from './config'
 
 import type { UpdateInfo } from '@opentrons/app/src/shell/types'

--- a/app/src/__mocks__/logger.js
+++ b/app/src/__mocks__/logger.js
@@ -1,7 +1,7 @@
 // mock logger for tests
 import path from 'path'
 
-export default function createLogger(filename) {
+export const createLogger = filename => {
   const label = path.relative(path.join(__dirname, '../../..'), filename)
 
   return new Proxy(

--- a/app/src/__mocks__/logger.js
+++ b/app/src/__mocks__/logger.js
@@ -1,7 +1,7 @@
 // mock logger for tests
 import path from 'path'
 
-export const createLogger = filename => {
+export function createLogger(filename) {
   const label = path.relative(path.join(__dirname, '../../..'), filename)
 
   return new Proxy(

--- a/app/src/analytics/hash.js
+++ b/app/src/analytics/hash.js
@@ -4,7 +4,7 @@
 // considered secure nor should they ever be released publicly
 const ALGORITHM = 'SHA-256'
 
-export default function hash(source: string): Promise<string> {
+export const hash = (source: string): Promise<string> => {
   const encoder = new TextEncoder()
   const data = encoder.encode(source)
 

--- a/app/src/analytics/hash.js
+++ b/app/src/analytics/hash.js
@@ -4,7 +4,7 @@
 // considered secure nor should they ever be released publicly
 const ALGORITHM = 'SHA-256'
 
-export const hash = (source: string): Promise<string> => {
+export function hash(source: string): Promise<string> {
   const encoder = new TextEncoder()
   const data = encoder.encode(source)
 

--- a/app/src/analytics/index.js
+++ b/app/src/analytics/index.js
@@ -1,6 +1,6 @@
 // @flow
 // analytics module
-import createLogger from '../logger'
+import { createLogger } from '../logger'
 import { updateConfig } from '../config'
 import { initializeMixpanel } from './mixpanel'
 

--- a/app/src/analytics/make-event.js
+++ b/app/src/analytics/make-event.js
@@ -1,6 +1,6 @@
 // @flow
 // redux action types to analytics events map
-import createLogger from '../logger'
+import { createLogger } from '../logger'
 import { selectors as robotSelectors } from '../robot'
 import { getConnectedRobot } from '../discovery'
 import * as CustomLabware from '../custom-labware'

--- a/app/src/analytics/mixpanel.js
+++ b/app/src/analytics/mixpanel.js
@@ -2,7 +2,7 @@
 // mixpanel actions
 import mixpanel from 'mixpanel-browser'
 
-import createLogger from '../logger'
+import { createLogger } from '../logger'
 import { CURRENT_VERSION } from '../shell'
 
 import type { AnalyticsEvent, AnalyticsConfig } from './types'

--- a/app/src/analytics/selectors.js
+++ b/app/src/analytics/selectors.js
@@ -27,7 +27,7 @@ import {
 import { getRobotSettings } from '../robot-settings'
 import { getAttachedPipettes } from '../pipettes'
 
-import hash from './hash'
+import { hash } from './hash'
 
 import type { OutputSelector } from 'reselect'
 import type { State } from '../types'

--- a/app/src/components/CalibrateDeck/index.js
+++ b/app/src/components/CalibrateDeck/index.js
@@ -9,7 +9,7 @@ import type { OP, SP, DP, CalibrateDeckProps, CalibrationStep } from './types'
 
 import { getPipetteModelSpecs } from '@opentrons/shared-data'
 import { chainActions } from '../../util'
-import createLogger from '../../logger'
+import { createLogger } from '../../logger'
 
 import { home, ROBOT } from '../../robot-controls'
 import {

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -9,7 +9,7 @@ import thunk from 'redux-thunk'
 import { ConnectedRouter, routerMiddleware } from 'connected-react-router'
 import { createEpicMiddleware } from 'redux-observable'
 
-import createLogger from './logger'
+import { createLogger } from './logger'
 import { checkShellUpdate } from './shell'
 
 import { apiClientMiddleware as robotApiMiddleware } from './robot'

--- a/app/src/logger.js
+++ b/app/src/logger.js
@@ -33,7 +33,7 @@ const VERBOSE: 'verbose' = 'verbose'
 const DEBUG: 'debug' = 'debug'
 const SILLY: 'silly' = 'silly'
 
-export const createLogger = (filename: string): Logger => {
+export function createLogger(filename: string): Logger {
   const label = `app/${filename}`
 
   return {

--- a/app/src/logger.js
+++ b/app/src/logger.js
@@ -33,7 +33,7 @@ const VERBOSE: 'verbose' = 'verbose'
 const DEBUG: 'debug' = 'debug'
 const SILLY: 'silly' = 'silly'
 
-export default function createLogger(filename: string): Logger {
+export const createLogger = (filename: string): Logger => {
   const label = `app/${filename}`
 
   return {

--- a/app/src/pages/Robots/index.js
+++ b/app/src/pages/Robots/index.js
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { useSelector } from 'react-redux'
 import { withRouter, Route, Switch, Redirect } from 'react-router-dom'
 
-import createLogger from '../../logger'
+import { createLogger } from '../../logger'
 
 import {
   CONNECTABLE,

--- a/app/src/protocol/protocol-data.js
+++ b/app/src/protocol/protocol-data.js
@@ -1,6 +1,6 @@
 // @flow
 // functions for parsing protocol files
-import createLogger from '../logger'
+import { createLogger } from '../logger'
 
 import type { ProtocolFile, ProtocolData, ProtocolType } from './types'
 

--- a/app/src/protocol/selectors.js
+++ b/app/src/protocol/selectors.js
@@ -5,7 +5,7 @@ import { createSelector } from 'reselect'
 import { getter } from '@thi.ng/paths'
 import { getProtocolSchemaVersion } from '@opentrons/shared-data'
 import { fileIsJson } from './protocol-data'
-import createLogger from '../logger'
+import { createLogger } from '../logger'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { ProtocolFile as SchemaV3ProtocolFile } from '@opentrons/shared-data/protocol/flowTypes/schemaV3'

--- a/app/src/robot/api-client/index.js
+++ b/app/src/robot/api-client/index.js
@@ -1,7 +1,7 @@
 // robot api client redux middleware
 // wraps the api client worker to handle API side effects in a different thread
 
-import createLogger from '../../logger'
+import { createLogger } from '../../logger'
 import Worker from './worker'
 
 const log = createLogger(__filename)

--- a/app/src/shell/epic.js
+++ b/app/src/shell/epic.js
@@ -3,7 +3,7 @@ import { combineEpics } from 'redux-observable'
 import { fromEvent } from 'rxjs'
 import { filter, tap, ignoreElements } from 'rxjs/operators'
 
-import createLogger from '../logger'
+import { createLogger } from '../logger'
 import remote from './remote'
 
 import type { StrictEpic, Action } from '../types'

--- a/app/src/support.js
+++ b/app/src/support.js
@@ -3,7 +3,7 @@
 import { version } from './../package.json'
 import { FF_PREFIX, getRobotAnalyticsData } from './analytics'
 import { getConnectedRobot } from './discovery'
-import createLogger from './logger'
+import { createLogger } from './logger'
 
 import type { Action, ThunkAction, Middleware } from './types'
 import type { BaseRobot } from './robot/types'

--- a/app/src/util.js
+++ b/app/src/util.js
@@ -2,7 +2,7 @@
 // utility functions
 
 import type { Action, ThunkAction, ThunkPromiseAction } from './types'
-import createLogger from './logger'
+import { createLogger } from './logger'
 
 type Chainable = Action | ThunkAction | ThunkPromiseAction
 


### PR DESCRIPTION
Change default exports to named exports in app and app-shell

<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

I'm trying to fix these linter warning in chunks to make merging and reviewing easier. This is the first bit, more to come. 😅 

I will use this as the base branch and merge all the corresponding PRs into this branch

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->
