### PR TITLE
refactor(protocol-designer): Revise deckmap crash warning

### DIFF
--- a/protocol-designer/src/localization/en/deck.json
+++ b/protocol-designer/src/localization/en/deck.json
@@ -1,6 +1,6 @@
 {
   "warning": {
-    "gen1multichannel": "No 8-Channel GEN1 access"
+    "gen1multichannel": "No GEN1 8-Channel access"
   },
   "blocked_slot": {
     "MODULE_INCOMPATIBLE_SINGLE_LABWARE": "Labware incompatible with this module",


### PR DESCRIPTION
Fix #4725

## overview
Switches warning text to match the text in #4725

## review requests

Create a protocol in PD with a gen1 8-Channel pipette, as well as a module
Validate that the correct deck warning text renders on the deckmap 
