### PR TITLE
fix(protocol-designer): Update magnetic module recommended labware

### DIFF
--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
@@ -72,7 +72,7 @@ const RECOMMENDED_LABWARE_BY_MODULE: { [ModuleType]: Array<string> } = {
     'opentrons_24_aluminumblock_nest_2ml_snapcap',
     'opentrons_24_aluminumblock_nest_0.5ml_screwcap',
   ],
-  magdeck: ['biorad_96_wellplate_200ul_pcr'],
+  magdeck: ['nest_96_wellplate_100ul_pcr_full_skirt'],
   thermocycler: ['nest_96_wellplate_100ul_pcr_full_skirt'],
 }
 


### PR DESCRIPTION
## overview

This PR closes #4825 by changing the recommended labware for the magnetic module form biorad to nest.

## changelog

- fix(protocol-designer): Update magnetic module recommended labware

## review requests

Make a protocol with a magnetic module and add a labware to it
- [ ] Nest plate should be recommended
- [ ] Biorad plate should be compatible but not recommended