### PR TITLE
fix(protocol-designer): when adding new module only update mag steps …

### DIFF
--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -16,6 +16,7 @@ import {
   FIXED_TRASH_ID,
   SPAN7_8_10_11_SLOT,
   FILE_MODULE_TYPE_TO_MODULE_TYPE,
+  MAGDECK,
 } from '../../constants'
 import { getPDMetadata } from '../../file-types'
 import {
@@ -268,7 +269,10 @@ export const savedStepForms = (
         // and since the Magnet step form doesn't allow users to select a dropdown,
         // we auto-select a newly-added magnetic module for all of them
         // to handle the case where users delete and re-add a magnetic module
-        if (savedForm.stepType === 'magnet') {
+        if (
+          savedForm.stepType === 'magnet' &&
+          action.payload.type === MAGDECK
+        ) {
           return { ...savedForm, moduleId }
         }
 

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/index.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/index.js
@@ -6,6 +6,9 @@ import { TEMPDECK, THERMOCYCLER } from '../../../constants'
 import type { ModuleOnDeck } from '../../../step-forms'
 import type { StepIdType, FormData } from '../../../form-types'
 
+const isLastStepTemp = (lastModuleStep: FormData = {}): boolean =>
+  !!(lastModuleStep.moduleId && lastModuleStep.stepType === 'temperature')
+
 export function getNextDefaultTemperatureModuleId(
   savedForms: { [StepIdType]: FormData },
   orderedStepIds: Array<StepIdType>,
@@ -20,10 +23,10 @@ export function getNextDefaultTemperatureModuleId(
   // TODO (ka 2019-12-20): Since we are hiding the thermocylcer module as an option for now,
   // should we simplify this to only return temperature modules?
   const nextDefaultModule: string | null =
-    (lastModuleStep && lastModuleStep.moduleId) ||
+    (isLastStepTemp(lastModuleStep) && lastModuleStep.moduleId) ||
     findKey(equippedModulesById, m => m.type === TEMPDECK) ||
-    findKey(equippedModulesById, m => m.type === THERMOCYCLER)
-
+    findKey(equippedModulesById, m => m.type === THERMOCYCLER) ||
+    null
   if (!nextDefaultModule) {
     console.error('Could not get next default module. Something went wrong.')
     return null


### PR DESCRIPTION
## overview
This PR closes #4823 by checking to see if a new module is a mag mod before overwriting previous magnet step module ids.

## review requests
Code review (especially the tests)

Enable modules in PD setting
Make a protocol with a magnetic module
Add and save some MAGNET steps
Add a temperature module
- [ ] Correct module is displayed in the step timeline
- [ ] Correct module is displayed inside the magnetic step form
- [ ] Correct plate is displayed in the step timeline
- [ ] Correct plate is displayed inside the magnetic step form