### PR TITLE
fix(protocol-designer): fix warnings not displaying during timeline c…

### DIFF
--- a/protocol-designer/src/step-generation/test-with-flow/glue.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/glue.test.js
@@ -243,7 +243,12 @@ describe('commandCreatorsTimeline', () => {
         {
           robotState: { count: 5 + 4 },
           commands: [{ command: 'add', params: { value: 4 } }],
-          // NOTE: IL 2019-11-19 command creator warnings do not appear in timeline
+          warnings: [
+            {
+              message: 'adding 4 with warning example',
+              type: 'ADD_WARNING',
+            },
+          ],
         },
         // no more steps in the timeline, stopped by error
       ],
@@ -252,6 +257,7 @@ describe('commandCreatorsTimeline', () => {
 
   test('warnings are indexed in an indexed command chain', () => {
     const initialState: any = { count: 5 }
+
     const result = commandCreatorsTimeline(
       [
         curryCommandCreator(addCreatorWithWarning, { value: 3 }),
@@ -267,19 +273,29 @@ describe('commandCreatorsTimeline', () => {
       {
         robotState: { count: 8 },
         commands: [{ command: 'add', params: { value: 3 } }],
-        // NOTE: IL 2019-11-19 command creator warnings do not appear in timeline
+        warnings: [
+          {
+            message: 'adding 3 with warning example',
+            type: 'ADD_WARNING',
+          },
+        ],
       },
       // multiply by 2
       {
         robotState: { count: 16 },
         commands: [{ command: 'multiply', params: { value: 2 } }],
-        // no warnings -> no `warnings` key
+        warnings: [],
       },
       // add 1 w/ warning
       {
         robotState: { count: 17 },
         commands: [{ command: 'add', params: { value: 1 } }],
-        // NOTE: IL 2019-11-19 command creator warnings do not appear in timeline
+        warnings: [
+          {
+            message: 'adding 1 with warning example',
+            type: 'ADD_WARNING',
+          },
+        ],
       },
     ])
   })

--- a/protocol-designer/src/step-generation/utils/commandCreatorsTimeline.js
+++ b/protocol-designer/src/step-generation/utils/commandCreatorsTimeline.js
@@ -50,9 +50,9 @@ export const commandCreatorsTimeline = (
       const nextResult = {
         commands: commandCreatorResult.commands,
         robotState: nextRobotStateAndWarnings.robotState,
+        warnings: commandCreatorResult.warnings,
       }
 
-      // TODO: Ian 2019-11-20 allow warnings in timeline frames?
       return {
         timeline: [...acc.timeline, nextResult],
         errors: null,


### PR DESCRIPTION
## overview
Fix the issue with warnings not being displayed in the timeline.
closes #4829

## changelog

Added missing warning key to the timeline command creators 

## review requests

- [ ] Download Ian's test protocol [https://github.com/Opentrons/opentrons/files/4100017/liquid.test.json.zip](here)
- [ ]  Import it to pd
- [ ] Go to the Design tab. The first transfer step should have a warning icon.
- [ ] Click on the transfer step. There should be two warnings - Not enough liquid in well(s) and Source well is empty.

