### PR TITLE
feat(protocol-designer): add labware hover highlighting to modules

### DIFF
--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareControls.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareControls.js
@@ -77,11 +77,16 @@ const LabwareControls = (props: Props) => {
   )
 }
 
-const mapStateToProps = (state: BaseState, ownProps: OP): SP => ({
-  highlighted: stepsSelectors
-    .getHoveredStepLabware(state)
-    .includes(ownProps.labwareOnDeck.id),
-})
+const mapStateToProps = (state: BaseState, ownProps: OP): SP => {
+  const hoveredLabware = stepsSelectors.getHoveredStepLabware(state)
+  const isLabwareOrOnModule =
+    hoveredLabware.includes(ownProps.labwareOnDeck.id) ||
+    hoveredLabware.includes(ownProps.labwareOnDeck.slot)
+
+  return {
+    highlighted: isLabwareOrOnModule,
+  }
+}
 
 export default connect<Props, OP, SP, {||}, _, _>(mapStateToProps)(
   LabwareControls

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareControls.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareControls.js
@@ -77,16 +77,11 @@ const LabwareControls = (props: Props) => {
   )
 }
 
-const mapStateToProps = (state: BaseState, ownProps: OP): SP => {
-  const hoveredLabware = stepsSelectors.getHoveredStepLabware(state)
-  const isLabwareOrOnModule =
-    hoveredLabware.includes(ownProps.labwareOnDeck.id) ||
-    hoveredLabware.includes(ownProps.labwareOnDeck.slot)
-
-  return {
-    highlighted: isLabwareOrOnModule,
-  }
-}
+const mapStateToProps = (state: BaseState, ownProps: OP): SP => ({
+  highlighted: stepsSelectors
+    .getHoveredStepLabware(state)
+    .includes(ownProps.labwareOnDeck.id),
+})
 
 export default connect<Props, OP, SP, {||}, _, _>(mapStateToProps)(
   LabwareControls

--- a/protocol-designer/src/ui/steps/selectors.js
+++ b/protocol-designer/src/ui/steps/selectors.js
@@ -3,6 +3,8 @@ import { createSelector } from 'reselect'
 import last from 'lodash/last'
 
 import { selectors as stepFormSelectors } from '../../step-forms'
+import { getLabwareOnModule } from '../modules/utils'
+import { getInitialDeckSetup } from '../../step-forms/selectors'
 import type { StepIdType } from '../../form-types'
 import type { BaseState, Selector } from '../../types'
 import {
@@ -57,7 +59,8 @@ const getHoveredStepId: Selector<?StepIdType> = createSelector(
 const getHoveredStepLabware: Selector<Array<string>> = createSelector(
   stepFormSelectors.getArgsAndErrorsByStepId,
   getHoveredStepId,
-  (allStepArgsAndErrors, hoveredStep) => {
+  getInitialDeckSetup,
+  (allStepArgsAndErrors, hoveredStep, initialDeckState) => {
     const blank = []
     if (!hoveredStep || !allStepArgsAndErrors[hoveredStep]) {
       return blank
@@ -87,7 +90,8 @@ const getHoveredStepLabware: Selector<Array<string>> = createSelector(
     }
 
     if (stepArgs.module) {
-      return [stepArgs.module]
+      const labware = getLabwareOnModule(initialDeckState, stepArgs.module)
+      return labware ? [labware.id] : []
     }
 
     // step types that have no labware that gets highlighted

--- a/protocol-designer/src/ui/steps/selectors.js
+++ b/protocol-designer/src/ui/steps/selectors.js
@@ -86,6 +86,10 @@ const getHoveredStepLabware: Selector<Array<string>> = createSelector(
       return [stepArgs.labware]
     }
 
+    if (stepArgs.module) {
+      return [stepArgs.module]
+    }
+
     // step types that have no labware that gets highlighted
     if (!(stepArgs.commandCreatorFnName === 'delay')) {
       // TODO Ian 2018-05-08 use assert here

--- a/protocol-designer/src/ui/steps/selectors.js
+++ b/protocol-designer/src/ui/steps/selectors.js
@@ -4,7 +4,6 @@ import last from 'lodash/last'
 
 import { selectors as stepFormSelectors } from '../../step-forms'
 import { getLabwareOnModule } from '../modules/utils'
-import { getInitialDeckSetup } from '../../step-forms/selectors'
 import type { StepIdType } from '../../form-types'
 import type { BaseState, Selector } from '../../types'
 import {
@@ -59,7 +58,7 @@ const getHoveredStepId: Selector<?StepIdType> = createSelector(
 const getHoveredStepLabware: Selector<Array<string>> = createSelector(
   stepFormSelectors.getArgsAndErrorsByStepId,
   getHoveredStepId,
-  getInitialDeckSetup,
+  stepFormSelectors.getInitialDeckSetup,
   (allStepArgsAndErrors, hoveredStep, initialDeckState) => {
     const blank = []
     if (!hoveredStep || !allStepArgsAndErrors[hoveredStep]) {

--- a/protocol-designer/src/ui/steps/test/selectors.test.js
+++ b/protocol-designer/src/ui/steps/test/selectors.test.js
@@ -2,10 +2,9 @@
 import selectors from '../selectors'
 import * as utils from '../../modules/utils'
 
-function getArgsAndErrorsByStepId(stepId, stepArgs) {
+function createArgsForStepId(stepId, stepArgs) {
   return {
     [stepId]: {
-      errors: {},
       stepArgs,
     },
   }
@@ -29,14 +28,11 @@ describe('getHoveredStepLabware', () => {
       commandCreatorFnName: mixCommand,
       labware,
     }
-    const allStepArgsAndErrors = getArgsAndErrorsByStepId(
-      hoveredStepId,
-      stepArgs
-    )
+    const argsByStepId = createArgsForStepId(hoveredStepId, stepArgs)
     const hoveredStep = null
 
     const result = selectors.getHoveredStepLabware.resultFunc(
-      allStepArgsAndErrors,
+      argsByStepId,
       hoveredStep,
       initialDeckState
     )
@@ -49,14 +45,11 @@ describe('getHoveredStepLabware', () => {
       commandCreatorFnName: mixCommand,
       labware,
     }
-    const allStepArgsAndErrors = getArgsAndErrorsByStepId(
-      hoveredStepId,
-      stepArgs
-    )
+    const argsByStepId = createArgsForStepId(hoveredStepId, stepArgs)
     const hoveredStep = 'another-step'
 
     const result = selectors.getHoveredStepLabware.resultFunc(
-      allStepArgsAndErrors,
+      argsByStepId,
       hoveredStep,
       initialDeckState
     )
@@ -66,13 +59,10 @@ describe('getHoveredStepLabware', () => {
 
   test('no labware is returned when no step arguments', () => {
     const stepArgs = null
-    const allStepArgsAndErrors = getArgsAndErrorsByStepId(
-      hoveredStepId,
-      stepArgs
-    )
+    const argsByStepId = createArgsForStepId(hoveredStepId, stepArgs)
 
     const result = selectors.getHoveredStepLabware.resultFunc(
-      allStepArgsAndErrors,
+      argsByStepId,
       hoveredStepId,
       initialDeckState
     )
@@ -87,13 +77,10 @@ describe('getHoveredStepLabware', () => {
         destLabware: labware,
         sourceLabware,
       }
-      const allStepArgsAndErrors = getArgsAndErrorsByStepId(
-        hoveredStepId,
-        stepArgs
-      )
+      const argsByStepId = createArgsForStepId(hoveredStepId, stepArgs)
 
       const result = selectors.getHoveredStepLabware.resultFunc(
-        allStepArgsAndErrors,
+        argsByStepId,
         hoveredStepId,
         initialDeckState
       )
@@ -107,13 +94,10 @@ describe('getHoveredStepLabware', () => {
       commandCreatorFnName: mixCommand,
       labware,
     }
-    const allStepArgsAndErrors = getArgsAndErrorsByStepId(
-      hoveredStepId,
-      stepArgs
-    )
+    const argsByStepId = createArgsForStepId(hoveredStepId, stepArgs)
 
     const result = selectors.getHoveredStepLabware.resultFunc(
-      allStepArgsAndErrors,
+      argsByStepId,
       hoveredStepId,
       initialDeckState
     )
@@ -154,13 +138,10 @@ describe('getHoveredStepLabware', () => {
         commandCreatorFnName: setTempCommand,
         module: type,
       }
-      const allStepArgsAndErrors = getArgsAndErrorsByStepId(
-        hoveredStepId,
-        stepArgs
-      )
+      const argsByStepId = createArgsForStepId(hoveredStepId, stepArgs)
 
       const result = selectors.getHoveredStepLabware.resultFunc(
-        allStepArgsAndErrors,
+        argsByStepId,
         hoveredStepId,
         initialDeckState
       )
@@ -174,13 +155,10 @@ describe('getHoveredStepLabware', () => {
         commandCreatorFnName: setTempCommand,
         module: type,
       }
-      const allStepArgsAndErrors = getArgsAndErrorsByStepId(
-        hoveredStepId,
-        stepArgs
-      )
+      const argsByStepId = createArgsForStepId(hoveredStepId, stepArgs)
 
       const result = selectors.getHoveredStepLabware.resultFunc(
-        allStepArgsAndErrors,
+        argsByStepId,
         hoveredStepId,
         initialDeckState
       )

--- a/protocol-designer/src/ui/steps/test/selectors.test.js
+++ b/protocol-designer/src/ui/steps/test/selectors.test.js
@@ -1,0 +1,191 @@
+// @flow
+import selectors from '../selectors'
+import * as utils from '../../modules/utils'
+
+function getArgsAndErrorsByStepId(stepId, stepArgs) {
+  return {
+    [stepId]: {
+      errors: {},
+      stepArgs,
+    },
+  }
+}
+
+const hoveredStepId = 'hoveredStepId'
+const labware = 'well plate'
+const mixCommand = 'mix'
+describe('getHoveredStepLabware', () => {
+  let initialDeckState
+  beforeEach(() => {
+    initialDeckState = {
+      labware: {},
+      pipettes: {},
+      modules: {},
+    }
+  })
+
+  test('no labware is returned when no hovered step', () => {
+    const stepArgs = {
+      commandCreatorFnName: mixCommand,
+      labware,
+    }
+    const allStepArgsAndErrors = getArgsAndErrorsByStepId(
+      hoveredStepId,
+      stepArgs
+    )
+    const hoveredStep = null
+
+    const result = selectors.getHoveredStepLabware.resultFunc(
+      allStepArgsAndErrors,
+      hoveredStep,
+      initialDeckState
+    )
+
+    expect(result).toEqual([])
+  })
+
+  test('no labware is returned when step is not found', () => {
+    const stepArgs = {
+      commandCreatorFnName: mixCommand,
+      labware,
+    }
+    const allStepArgsAndErrors = getArgsAndErrorsByStepId(
+      hoveredStepId,
+      stepArgs
+    )
+    const hoveredStep = 'another-step'
+
+    const result = selectors.getHoveredStepLabware.resultFunc(
+      allStepArgsAndErrors,
+      hoveredStep,
+      initialDeckState
+    )
+
+    expect(result).toEqual([])
+  })
+
+  test('no labware is returned when no step arguments', () => {
+    const stepArgs = null
+    const allStepArgsAndErrors = getArgsAndErrorsByStepId(
+      hoveredStepId,
+      stepArgs
+    )
+
+    const result = selectors.getHoveredStepLabware.resultFunc(
+      allStepArgsAndErrors,
+      hoveredStepId,
+      initialDeckState
+    )
+
+    expect(result).toEqual([])
+  })
+  ;['consolidate', 'distribute', 'transfer'].forEach(command => {
+    test(`source and destination labware is returned when ${command}`, () => {
+      const sourceLabware = 'test tube'
+      const stepArgs = {
+        commandCreatorFnName: command,
+        destLabware: labware,
+        sourceLabware,
+      }
+      const allStepArgsAndErrors = getArgsAndErrorsByStepId(
+        hoveredStepId,
+        stepArgs
+      )
+
+      const result = selectors.getHoveredStepLabware.resultFunc(
+        allStepArgsAndErrors,
+        hoveredStepId,
+        initialDeckState
+      )
+
+      expect(result).toEqual([sourceLabware, labware])
+    })
+  })
+
+  test('labware is returned when command is mix', () => {
+    const stepArgs = {
+      commandCreatorFnName: mixCommand,
+      labware,
+    }
+    const allStepArgsAndErrors = getArgsAndErrorsByStepId(
+      hoveredStepId,
+      stepArgs
+    )
+
+    const result = selectors.getHoveredStepLabware.resultFunc(
+      allStepArgsAndErrors,
+      hoveredStepId,
+      initialDeckState
+    )
+
+    expect(result).toEqual([labware])
+  })
+
+  describe('modules', () => {
+    const type = 'tempdeck'
+    const setTempCommand = 'setTemperature'
+    beforeEach(() => {
+      initialDeckState = {
+        labware: {
+          def098: {
+            slot: type,
+          },
+        },
+        pipettes: {},
+        modules: {
+          abc123: {
+            id: 'abc123',
+            type,
+            model: 'GEN1',
+            slot: '1',
+            moduleState: {
+              type,
+              status: 'TEMPERATURE_DEACTIVATED',
+              targetTemperature: null,
+            },
+          },
+        },
+      }
+    })
+
+    test('labware on module is returned when module id exists', () => {
+      utils.getLabwareOnModule = jest.fn().mockReturnValue({ id: labware })
+      const stepArgs = {
+        commandCreatorFnName: setTempCommand,
+        module: type,
+      }
+      const allStepArgsAndErrors = getArgsAndErrorsByStepId(
+        hoveredStepId,
+        stepArgs
+      )
+
+      const result = selectors.getHoveredStepLabware.resultFunc(
+        allStepArgsAndErrors,
+        hoveredStepId,
+        initialDeckState
+      )
+
+      expect(result).toEqual([labware])
+    })
+
+    test('no labware is returned when no labware on module', () => {
+      utils.getLabwareOnModule = jest.fn().mockReturnValue(null)
+      const stepArgs = {
+        commandCreatorFnName: setTempCommand,
+        module: type,
+      }
+      const allStepArgsAndErrors = getArgsAndErrorsByStepId(
+        hoveredStepId,
+        stepArgs
+      )
+
+      const result = selectors.getHoveredStepLabware.resultFunc(
+        allStepArgsAndErrors,
+        hoveredStepId,
+        initialDeckState
+      )
+
+      expect(result).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
## overview
Allow highlighting of labware when hovering over module steps in the timeline. closes #4696

## changelog
- return module id in getHoveredStepLabware if stepArgs is a module
- Update highlighted flag in LabwareControls to allow labware on these modules to be highlighted

## review requests
[http://sandbox.designer.opentrons.com/pd_highlight-modules/](http://sandbox.designer.opentrons.com/pd_highlight-modules/)

- [ ] Enable modules in pd
- [ ] Create a new protocol with a magnetic and temperature module
- [ ] Create a new protocol with a couple of transfers, mix, magnetic steps (engage and disengage), and temperature steps (change to temperature and deactivate)
- [ ] Hovering over the temperature and magnet steps highlight the labware on top of each of the modules
- [ ] Move your mouse and hover through all the various steps and make sure the proper labware is highlighted