### PR TITLE
feat(protocol-designer): allow temperature deck to be updated

### DIFF
--- a/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/index.js
+++ b/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/index.js
@@ -7,6 +7,10 @@ import { forBlowout } from './forBlowout'
 import { forDropTip } from './forDropTip'
 import { forPickUpTip } from './forPickUpTip'
 import { forEngageMagnet, forDisengageMagnet } from './magnetUpdates'
+import {
+  forSetTemperature,
+  forDeactivateTemperature,
+} from './temperatureUpdates'
 import type { Command } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
 import type {
   InvariantContext,
@@ -56,7 +60,15 @@ function _getNextRobotStateAndWarningsSingleCommand(
       // these commands don't have any effects on the state
       break
     case 'temperatureModule/setTargetTemperature':
+      forSetTemperature(command.params, invariantContext, robotStateAndWarnings)
+      break
     case 'temperatureModule/deactivate':
+      forDeactivateTemperature(
+        command.params,
+        invariantContext,
+        robotStateAndWarnings
+      )
+      break
     case 'thermocycler/setTargetTemperature':
     case 'thermocycler/deactivate':
       console.warn(`NOT IMPLEMENTED: ${command.command}`)

--- a/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/magnetUpdates.js
+++ b/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/magnetUpdates.js
@@ -1,5 +1,6 @@
 // @flow
 import assert from 'assert'
+import { getModuleState } from '../utils/misc'
 import type {
   EngageMagnetParams,
   DisengageMagnetParams,
@@ -20,11 +21,12 @@ export function forEngageMagnet(
 ): void {
   const { module } = params
   let { robotState } = robotStateAndWarnings
+  const moduleState = getModuleState(robotState, module)
   assert(
     module in robotState.modules,
     `forEngageMagnet expected module id "${module}"`
   )
-  _setMagnet(robotState.modules[module].moduleState, true)
+  _setMagnet(moduleState, true)
 }
 
 export function forDisengageMagnet(
@@ -34,9 +36,10 @@ export function forDisengageMagnet(
 ): void {
   const { module } = params
   const { robotState } = robotStateAndWarnings
+  const moduleState = getModuleState(robotState, module)
   assert(
     module in robotState.modules,
     `forDisengageMagnet expected module id "${module}"`
   )
-  _setMagnet(robotState.modules[module].moduleState, false)
+  _setMagnet(moduleState, false)
 }

--- a/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/temperatureUpdates.js
+++ b/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/temperatureUpdates.js
@@ -1,0 +1,59 @@
+// @flow
+import assert from 'assert'
+import { getModuleState } from '../utils/misc'
+import {
+  TEMPDECK,
+  TEMPERATURE_APPROACHING_TARGET,
+  TEMPERATURE_DEACTIVATED,
+} from '../../constants'
+import type {
+  SetTargetTempParams,
+  DeactivateTempParams,
+} from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { InvariantContext, RobotStateAndWarnings } from '../types'
+
+function _setTemperatureAndStatus(moduleState, temperature, status) {
+  if (moduleState.type === TEMPDECK) {
+    moduleState.targetTemperature = temperature
+    moduleState.status = status
+  }
+}
+
+export function forSetTemperature(
+  params: SetTargetTempParams,
+  invariantContext: InvariantContext,
+  robotStateAndWarnings: RobotStateAndWarnings
+): void {
+  const { robotState } = robotStateAndWarnings
+  const { module, temperature } = params
+  const moduleState = getModuleState(robotState, module)
+
+  assert(
+    module in robotState.modules,
+    `forSetTemperature expected module id "${module}"`
+  )
+
+  _setTemperatureAndStatus(
+    moduleState,
+    temperature,
+    TEMPERATURE_APPROACHING_TARGET
+  )
+}
+
+export function forDeactivateTemperature(
+  params: DeactivateTempParams,
+  invariantContext: InvariantContext,
+  robotStateAndWarnings: RobotStateAndWarnings
+): void {
+  const { robotState } = robotStateAndWarnings
+  const { module } = params
+  const moduleState = getModuleState(robotState, module)
+  const temperature = null
+
+  assert(
+    module in robotState.modules,
+    `forDeactivateTemperature expected module id "${module}"`
+  )
+
+  _setTemperatureAndStatus(moduleState, temperature, TEMPERATURE_DEACTIVATED)
+}

--- a/protocol-designer/src/step-generation/test-with-flow/temperatureUpdates.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/temperatureUpdates.test.js
@@ -1,0 +1,122 @@
+// @flow
+import cloneDeep from 'lodash/cloneDeep'
+import { makeImmutableStateUpdater } from './utils/makeImmutableStateUpdater'
+import { makeContext, getInitialRobotStateStandard } from './fixtures'
+import {
+  forSetTemperature as _forSetTemperature,
+  forDeactivateTemperature as _forDeactivateTemperature,
+} from '../getNextRobotStateAndWarnings/temperatureUpdates'
+import {
+  TEMPERATURE_DEACTIVATED,
+  TEMPERATURE_APPROACHING_TARGET,
+} from '../../constants'
+
+const forSetTemperature = makeImmutableStateUpdater(_forSetTemperature)
+const forDeactivateTemperature = makeImmutableStateUpdater(
+  _forDeactivateTemperature
+)
+const moduleId = 'temperatureModuleId'
+const slot = '3'
+let invariantContext, deactivatedRobot, robotWithTemp
+beforeEach(() => {
+  invariantContext = makeContext()
+  invariantContext.moduleEntities[moduleId] = {
+    id: moduleId,
+    type: 'tempdeck',
+    model: 'GEN1',
+  }
+
+  deactivatedRobot = getInitialRobotStateStandard(invariantContext)
+  deactivatedRobot.modules[moduleId] = {
+    slot,
+    moduleState: {
+      type: 'tempdeck',
+      targetTemperature: null,
+      status: TEMPERATURE_DEACTIVATED,
+    },
+  }
+  robotWithTemp = cloneDeep(deactivatedRobot)
+  robotWithTemp.modules[moduleId].moduleState = {
+    type: 'tempdeck',
+    targetTemperature: 45,
+    status: TEMPERATURE_APPROACHING_TARGET,
+  }
+})
+
+describe('forSetTemperature', () => {
+  test('module status is set to approaching and temp is set to target', () => {
+    const params = {
+      module: moduleId,
+      temperature: 45,
+    }
+
+    const result = forSetTemperature(params, invariantContext, deactivatedRobot)
+
+    expect(result).toEqual({
+      robotState: robotWithTemp,
+      warnings: [],
+    })
+  })
+
+  test('module temp is changed to new target temp when already active', () => {
+    const params = {
+      module: moduleId,
+      temperature: 55,
+    }
+
+    const result = forSetTemperature(params, invariantContext, deactivatedRobot)
+
+    expect(result).toEqual({
+      warnings: [],
+      robotState: {
+        ...robotWithTemp,
+        modules: {
+          [moduleId]: {
+            moduleState: {
+              type: 'tempdeck',
+              targetTemperature: 55,
+              status: TEMPERATURE_APPROACHING_TARGET,
+            },
+            slot,
+          },
+        },
+      },
+    })
+  })
+})
+
+describe('forDeactivateTemperature', () => {
+  test('module status is deactivated and no temperature is set', () => {
+    const params = {
+      module: moduleId,
+    }
+
+    const result = forDeactivateTemperature(
+      params,
+      invariantContext,
+      robotWithTemp
+    )
+
+    expect(result).toEqual({
+      robotState: deactivatedRobot,
+      warnings: [],
+    })
+  })
+
+  test('no effect when temp module is not active', () => {
+    const params = {
+      module: moduleId,
+    }
+
+    const result = forDeactivateTemperature(
+      params,
+      invariantContext,
+      deactivatedRobot
+    )
+
+    expect(result).toEqual({
+      robotState: deactivatedRobot,
+      warnings: [],
+    })
+  })
+})

--- a/protocol-designer/src/step-generation/utils/misc.js
+++ b/protocol-designer/src/step-generation/utils/misc.js
@@ -13,7 +13,11 @@ import {
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { BlowoutParams } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
-import type { PipetteEntity, LabwareEntity } from '../../step-forms'
+import type {
+  PipetteEntity,
+  LabwareEntity,
+  ModuleTemporalProperties,
+} from '../../step-forms'
 import type {
   LocationLiquidState,
   InvariantContext,
@@ -313,4 +317,11 @@ export function makeInitialRobotState(args: {|
       ),
     },
   }
+}
+
+export function getModuleState(
+  robotState: RobotState,
+  module: string
+): $PropertyType<ModuleTemporalProperties, 'moduleState'> {
+  return robotState.modules[module].moduleState
 }


### PR DESCRIPTION
## overview

This will close out the remainder of 4693 by allowing the temp deck to be updated.
closes #4693

## changelog

- Create forSetTemperature and forDeactivateTemperature for use in robot state and warnings

## review requests

Nothing on the ui side, just verify that the tests and the data the functions returns is sufficient.
