### PR TITLE
test(protocol-designer): add cypress.io infrastructure and initial tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,8 @@ sample_protocol.py
 api/opentrons/server/endpoints/ignore.json
 labware-library/cypress/screenshots/
 labware-library/cypress/videos/
+protocol-designer/cypress/screenshots/
+protocol-designer/cypress/videos/
 
 # Local Calibration Data
 calibrations/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,15 +189,14 @@ We use:
 You can tests with:
 
 ```shell
-# run all tests
+# run all tests (except e2e)
 make test
 
 # run tests per language
 make test-py
 make test-js
 
-# run cypress tests for the labware-library
-cd labware-library
+# run cypress e2e tests
 make test-e2e
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ PATH := $(shell yarn bin):$(PATH)
 
 API_DIR := api
 DISCOVERY_CLIENT_DIR := discovery-client
+LABWARE_LIBRARY_DIR := labware-library
+PROTOCOL_DESIGNER_DIR := protocol-designer
 SHARED_DATA_DIR := shared-data
 UPDATE_SERVER_DIR := update-server
 
@@ -95,6 +97,11 @@ term:
 # all tests
 .PHONY: test
 test: test-py test-js
+
+.PHONY: test-e2e
+test-e2e:
+	$(MAKE) -C $(LABWARE_LIBRARY_DIR) test-e2e
+	$(MAKE) -C $(PROTOCOL_DESIGNER_DIR) test-e2e
 
 .PHONY: test-py
 test-py:

--- a/labware-library/Makefile
+++ b/labware-library/Makefile
@@ -33,6 +33,6 @@ serve: all
 # end to end tests
 .PHONY: test-e2e
 test-e2e:
-	concurrently --no-color --kill-others --names "server,tests" \
+	concurrently --no-color --kill-others --success "first" --names "labware-library,labware-library-tests" \
 		"$(MAKE) dev" \
 		"cypress run --browser chrome"

--- a/labware-library/cypress/integration/labware-creator/fileImport.spec.js
+++ b/labware-library/cypress/integration/labware-creator/fileImport.spec.js
@@ -108,5 +108,8 @@ context('File Import', () => {
     cy.contains(
       'Please resolve all invalid fields in order to export the labware definition'
     ).should('not.exist')
+
+    // Wait for the file to finish downloading. We can't control this.
+    cy.wait(1500) // eslint-disable-line cypress/no-unnecessary-waiting
   })
 })

--- a/protocol-designer/Makefile
+++ b/protocol-designer/Makefile
@@ -40,3 +40,10 @@ dev:
 .PHONY: serve
 serve: all
 	node ../scripts/serve-static dist
+
+# end to end tests
+.PHONY: test-e2e
+test-e2e:
+	concurrently --no-color --kill-others --success "first" --names "protocol-designer,protocol-designer-tests" \
+		"$(MAKE) dev" \
+		"cypress run --browser chrome"

--- a/protocol-designer/cypress.json
+++ b/protocol-designer/cypress.json
@@ -1,0 +1,3 @@
+{
+  "baseUrl": "http://localhost:8080"
+}

--- a/protocol-designer/cypress/integration/home.spec.js
+++ b/protocol-designer/cypress/integration/home.spec.js
@@ -1,0 +1,31 @@
+describe('The Home Page', () => {
+  beforeEach(() => {
+    cy.visit('/')
+  })
+
+  it('successfully loads', () => {
+    cy.title().should('equal', 'Opentrons Protocol Designer BETA')
+  })
+
+  it('has the right charset', () => {
+    cy.document()
+      .should('have.property', 'charset')
+      .and('eq', 'UTF-8')
+  })
+
+  it('displays all the expected text', () => {
+    cy.contains('Protocol File')
+    cy.contains('Create New')
+    cy.contains('Import')
+    cy.contains('Export')
+    cy.contains('FILE')
+    cy.contains('LIQUIDS')
+    cy.contains('DESIGN')
+    cy.contains('HELP')
+    cy.contains('Settings')
+    cy.contains('Protocol Designer')
+    cy.contains('beta')
+  })
+
+  it('displays all the expected images', () => {})
+})

--- a/protocol-designer/cypress/integration/newProtocol.spec.js
+++ b/protocol-designer/cypress/integration/newProtocol.spec.js
@@ -1,0 +1,475 @@
+describe('Desktop Navigation', () => {
+  before(() => {
+    cy.visit('/')
+    cy.viewport('macbook-15')
+  })
+
+  describe('the setup form', () => {
+    it('clicks the "CREATE NEW" button', () => {
+      cy.get('button')
+        .contains('Create New')
+        .click()
+    })
+
+    it('displays the setup form', () => {
+      // Check to make sure all the form elements are present
+      cy.get("input[placeholder='Untitled']").should('exist')
+      cy.contains('Left Pipette')
+        .next()
+        .contains('None')
+        .should('exist')
+      cy.contains('Right Pipette')
+        .next()
+        .contains('None')
+        .should('exist')
+      cy.contains('Left Tiprack')
+        .next()
+        .get('select')
+        .should('be.disabled')
+      cy.contains('Right Tiprack')
+        .next()
+        .get('select')
+        .should('be.disabled')
+      cy.get('button')
+        .contains('save')
+        .should('be.disabled')
+      cy.get('button')
+        .contains('cancel')
+        .should('not.be.disabled')
+    })
+
+    it('cancel the setup form', () => {
+      // Click cancel
+      cy.get('button')
+        .contains('cancel')
+        .click()
+      // The form goes away
+      cy.contains('Create New Protocol').should('not.exist')
+    })
+
+    it('completes the setup form', () => {
+      // Get the form back
+      cy.get('button')
+        .contains('Create New')
+        .click()
+      // Give it a name
+      cy.get("input[placeholder='Untitled']").type('Cypress Test Protocol')
+      // Choose pipette types
+      cy.contains('Left Pipette')
+        .next()
+        .contains('None')
+        .click()
+      cy.contains('Left Pipette')
+        .next()
+        .contains('P20')
+        .click()
+      cy.contains('Right Pipette')
+        .next()
+        .contains('None')
+        .click()
+      cy.contains('Right Pipette')
+        .next()
+        .contains('P300')
+        .click()
+      // Diagrams of the pipettes are displayed
+      cy.get("div[class*='FilePipettesModal__left_pipette__']")
+        .get('img')
+        .should('exist')
+      cy.get("div[class*='FilePipettesModal__right_pipette__']")
+        .get('img')
+        .should('exist')
+      // The tiprack dropdowns are now available
+      cy.contains('Left Tiprack')
+        .next()
+        .get('select')
+        .should('not.be.disabled')
+      cy.contains('Right Tiprack')
+        .next()
+        .get('select')
+        .should('not.be.disabled')
+      // Select some tipracks
+      cy.get("select[name*='left.tiprack']").select(
+        'Opentrons 96 Filter Tip Rack 200 µL'
+      )
+      cy.get("select[name*='right.tiprack']").select(
+        'Opentrons 96 Filter Tip Rack 20 µL'
+      )
+      // Diagrams of the tip racks are displayed
+      cy.get("div[class*='FilePipettesModal__tiprack_labware__']")
+        .first()
+        .get('svg')
+        .should('exist')
+      cy.get("div[class*='FilePipettesModal__tiprack_labware__']")
+        .last()
+        .get('svg')
+        .should('exist')
+      // The save button is now available...
+      cy.get('button')
+        .contains('save')
+        .should('not.be.disabled')
+      // ...so click it
+      cy.get('button')
+        .contains('save')
+        .click()
+      // And now the "file details" form is displayed
+      cy.contains('File Details').should('exist')
+    })
+  })
+
+  describe('the file details form', () => {
+    it('displays the file details form', () => {
+      // Check to make sure all the form elements are present
+      const todaysDate = Cypress.moment().format('MMM DD, YYYY')
+      cy.contains(todaysDate).should('exist')
+      cy.contains('Last Exported')
+        .next()
+        .should('not.exist')
+      cy.get("input[value='Cypress Test Protocol']").should('exist')
+      cy.get("input[name='author']").should('exist')
+      cy.get("input[name='description']").should('exist')
+      cy.get('button')
+        .contains('UPDATED')
+        .should('be.disabled')
+      // We should see the pipette info we entered earlier
+      cy.contains('left pipette')
+        .next()
+        .contains('P20 Single-Channel GEN2')
+        .should('exist')
+      cy.contains('right pipette')
+        .next()
+        .contains('P300 Single-Channel GEN2')
+        .should('exist')
+      cy.contains('left pipette')
+        .parent()
+        .parent()
+        .contains('tip rack')
+        .next()
+        .contains('Opentrons 96 Filter Tip Rack 200 µL')
+        .should('exist')
+      cy.contains('right pipette')
+        .parent()
+        .parent()
+        .contains('tip rack')
+        .next()
+        .contains('Opentrons 96 Filter Tip Rack 20 µL')
+        .should('exist')
+      cy.get('button')
+        .contains('edit')
+        .should('exist')
+      cy.get('button')
+        .contains('swap')
+        .should('exist')
+      cy.get('button')
+        .contains('Continue to Liquids')
+        .should('exist')
+    })
+
+    it('fills out the file details form', () => {
+      // There's only two fields, so fill them out
+      cy.get("input[name='author']").type('Opentrons Automated Testing')
+      cy.get("input[name='description']").type(
+        'This protocol was created via automated cypress.io tests'
+      )
+      cy.get('button')
+        .contains('UPDATE')
+        .should('not.be.disabled')
+      cy.get('button')
+        .contains('UPDATE')
+        .click()
+    })
+
+    describe('exporting what we have got', () => {
+      it('displays a warning modal', () => {
+        cy.get('button')
+          .contains('Export')
+          .click()
+        // We are shown a warning modal
+        cy.contains('Your protocol has no steps').should('exist')
+        // It has a link to help
+        cy.get('a')
+          .contains('here')
+          .should('have.prop', 'href')
+          .and(
+            'equal',
+            'https://intercom.help/opentrons-protocol-designer/en/collections/1606688-building-a-protocol#steps'
+          )
+        // And buttons to get out
+        cy.get('button')
+          .contains('CANCEL')
+          .should('exist')
+        cy.get('button')
+          .contains('CONTINUE WITH EXPORT')
+          .should('exist')
+      })
+
+      it('goes away when we click cancel', () => {
+        cy.get('button')
+          .contains('CANCEL')
+          .click()
+        // No more modal
+        cy.contains('Your protocol has no steps').should('not.exist')
+      })
+
+      it('downloads a file when we continue', () => {
+        cy.get('button')
+          .contains('Export')
+          .click()
+        cy.get('button')
+          .contains('CONTINUE WITH EXPORT')
+          .click()
+        //
+        // TODO Cypress doesn't handle file downloads very well.
+        // Perhaps the app can be modified to react more directly
+        // with cypress. See https://github.com/cypress-io/cypress/issues/949
+        //
+        // No more modal
+        cy.contains('Your protocol has no steps').should('not.exist')
+      })
+    })
+  })
+
+  describe('editing the pipettes', () => {
+    // Use the edit button to make changes to our pipettes
+    it('edits the pipettes', () => {
+      cy.get('button')
+        .contains('edit')
+        .click()
+      cy.contains('Right Pipette')
+        .next()
+        .contains('P300')
+        .click()
+      cy.contains('Right Pipette')
+        .next()
+        .contains('P1000')
+        .click()
+      cy.get("select[name*='right.tiprack']").select(
+        'Opentrons 96 Filter Tip Rack 10 µL'
+      )
+    })
+
+    it('cancels the edits', () => {
+      cy.get('button')
+        .contains('cancel')
+        .click()
+      // Our tentative edits were not saved
+      cy.contains('left pipette')
+        .next()
+        .contains('P20 Single-Channel GEN2')
+        .should('exist')
+      cy.contains('right pipette')
+        .next()
+        .contains('P300 Single-Channel GEN2')
+        .should('exist')
+      cy.contains('left pipette')
+        .parent()
+        .parent()
+        .contains('tip rack')
+        .next()
+        .contains('Opentrons 96 Filter Tip Rack 200 µL')
+        .should('exist')
+      cy.contains('right pipette')
+        .parent()
+        .parent()
+        .contains('tip rack')
+        .next()
+        .contains('Opentrons 96 Filter Tip Rack 20 µL')
+        .should('exist')
+    })
+
+    it('edits the pipettes again', () => {
+      // Same edits as above
+      cy.get('button')
+        .contains('edit')
+        .click()
+      cy.contains('Right Pipette')
+        .next()
+        .contains('P300')
+        .click()
+      cy.contains('Right Pipette')
+        .next()
+        .contains('P1000')
+        .click()
+      cy.get("select[name*='right.tiprack']").select(
+        'Opentrons 96 Filter Tip Rack 10 µL'
+      )
+    })
+
+    it('saves the edits', () => {
+      cy.get('button')
+        .contains('save')
+        .click()
+    })
+
+    it('displays a confirmation modal', () => {
+      // We need to confirm our changes
+      cy.contains('Are you sure you want to make this change?').should('exist')
+      cy.get("div[class*='StepChangesConfirmModal__button_row__']")
+        .contains('cancel')
+        .should('exist')
+      cy.get('button')
+        .contains('continue')
+        .should('exist')
+    })
+
+    it('cancels the changes from the confirmation modal', () => {
+      // No, let's go back
+      cy.get("div[class*='StepChangesConfirmModal__button_row__']")
+        .contains('cancel')
+        .click({ force: true })
+      cy.contains('Change Pipette Selection').should('exist')
+    })
+
+    it('saves the changes for real', () => {
+      // Click save
+      cy.get('button')
+        .contains('save')
+        .click()
+      // Click continue
+      cy.get('button')
+        .contains('continue')
+        .click({ force: true })
+      // See our edits
+      cy.contains('left pipette')
+        .next()
+        .contains('P20 Single-Channel GEN2')
+        .should('exist')
+      cy.contains('left pipette')
+        .parent()
+        .parent()
+        .contains('tip rack')
+        .next()
+        .contains('Opentrons 96 Filter Tip Rack 200 µL')
+        .should('exist')
+      cy.contains('right pipette')
+        .next()
+        .contains('P1000 Single-Channel GEN2')
+        .should('exist')
+      cy.contains('right pipette')
+        .parent()
+        .parent()
+        .contains('tip rack')
+        .next()
+        .contains('Opentrons 96 Filter Tip Rack 10 µL')
+        .should('exist')
+    })
+  })
+
+  describe('pipette swapping', () => {
+    it('swaps the pipettes', () => {
+      // Click the swap button
+      cy.get('button')
+        .contains('swap')
+        .click()
+      // What was left is now right and vice versa
+      cy.contains('left pipette')
+        .next()
+        .contains('P1000 Single-Channel GEN2')
+        .should('exist')
+      cy.contains('left pipette')
+        .parent()
+        .parent()
+        .contains('tip rack')
+        .next()
+        .contains('Opentrons 96 Filter Tip Rack 10 µL')
+        .should('exist')
+      cy.contains('right pipette')
+        .next()
+        .contains('P20 Single-Channel GEN2')
+        .should('exist')
+      cy.contains('right pipette')
+        .parent()
+        .parent()
+        .contains('tip rack')
+        .next()
+        .contains('Opentrons 96 Filter Tip Rack 200 µL')
+        .should('exist')
+    })
+  })
+
+  describe('the new liquid form', () => {
+    it('displays the new liquid form', () => {
+      // Check to make sure all the form elements are present
+      cy.get('button')
+        .contains('Continue to Liquids')
+        .click()
+      cy.get('button')
+        .contains('New Liquid')
+        .should('exist')
+        .and('not.be.disabled')
+      cy.get('button')
+        .contains('New Liquid')
+        .click()
+      cy.get("input[name='name']").should('exist')
+      cy.get("input[name='description']").should('exist')
+      cy.get("input[name='serialize']").should('exist')
+      cy.get('button')
+        .contains('delete')
+        .should('be.disabled')
+      cy.get('button')
+        .contains('cancel')
+        .should('not.be.disabled')
+      cy.get('button')
+        .contains('save')
+        .should('be.disabled')
+    })
+
+    it('fills out the new liquid form', () => {
+      // No error message yet
+      cy.contains('Liquid name is required').should('not.exist')
+      // Touch the name and leave to trigger an error message
+      cy.get("input[name='name']")
+        .focus()
+        .blur()
+      cy.contains('Liquid name is required').should('exist')
+      // Type a name to see the error message go away
+      cy.get("input[name='name']").type('Water')
+      cy.contains('Liquid name is required').should('not.exist')
+      // Fill out the rest of the form
+      cy.get("input[name='description']").type('It is just water')
+      cy.get("input[name='serialize']").check({ force: true })
+      cy.get('button')
+        .contains('save')
+        .click()
+    })
+
+    it('adds a second liquid', () => {
+      // Make another. Why not?
+      cy.get('button')
+        .contains('New Liquid')
+        .click()
+      cy.get("input[name='name']").type('Orange Juice')
+      cy.get("input[name='description']").type('Mmmmm... orange juice!')
+      cy.get('button')
+        .contains('save')
+        .click()
+    })
+
+    it('adds a third liquid', () => {
+      // We're on a roll
+      cy.get('button')
+        .contains('New Liquid')
+        .click()
+    })
+
+    it('cancels the third liquid', () => {
+      // Never mind
+      cy.get('button')
+        .contains('cancel')
+        .click()
+      // The form goes away
+      cy.contains('Define your liquids').should('exist')
+    })
+  })
+
+  describe('design page', () => {
+    it('moves on to the design step', () => {
+      cy.get("button[class*='navbar__tab__']")
+        .contains('DESIGN')
+        .parent()
+        .click()
+      cy.get('button')
+        .contains('ok')
+        .click()
+    })
+  })
+})

--- a/protocol-designer/cypress/integration/settings.spec.js
+++ b/protocol-designer/cypress/integration/settings.spec.js
@@ -1,0 +1,169 @@
+describe('The Settings Page', () => {
+  before(() => {
+    cy.visit('/')
+  })
+
+  it('contains a working settings button', () => {
+    cy.get("button[class*='navbar__tab__']")
+      .contains('Settings')
+      .click()
+    cy.contains('App Settings')
+  })
+
+  it('contains an information section', () => {
+    cy.get('h3')
+      .contains('Information')
+      .should('exist')
+  })
+
+  it('contains version information', () => {
+    cy.contains('Protocol Designer Version').should('exist')
+  })
+
+  it('contains a hints section', () => {
+    cy.get('h3')
+      .contains('Hints')
+      .should('exist')
+  })
+
+  it('contains a privacy section', () => {
+    cy.get('h3')
+      .contains('Privacy')
+      .should('exist')
+  })
+
+  it('contains a share settings button in the pivacy section', () => {
+    // It's toggled off by default
+    cy.contains('Share sessions')
+      .next()
+      .should('have.attr', 'class')
+      .and('match', /toggled_off/)
+    // Click it
+    cy.contains('Share sessions')
+      .next()
+      .click()
+    // Now it's toggled on
+    cy.contains('Share sessions')
+      .next()
+      .should('have.attr', 'class')
+      .and('match', /toggled_on/)
+    // Click it again
+    cy.contains('Share sessions')
+      .next()
+      .click()
+    // Now it's toggled off again
+    cy.contains('Share sessions')
+      .next()
+      .should('have.attr', 'class')
+      .and('match', /toggled_off/)
+  })
+
+  it('contains an experimental settings section', () => {
+    cy.get('h3')
+      .contains('Experimental Settings')
+      .should('exist')
+  })
+
+  it("contains a 'enable multi gen2 pipettes' button in the pivacy section", () => {
+    // It's toggled off by default
+    cy.contains('Enable multi')
+      .next()
+      .should('have.attr', 'class')
+      .and('match', /toggled_off/)
+    // Click it
+    cy.contains('Enable multi')
+      .next()
+      .click()
+    // We have to confirm this one
+    cy.contains('Switching on an experimental feature').should('exist')
+    cy.get('button')
+      .contains('Cancel')
+      .should('exist')
+    cy.get('button')
+      .contains('Continue')
+      .should('exist')
+    // Abort!
+    cy.get('button')
+      .contains('Cancel')
+      .click()
+    // Still toggled off
+    cy.contains('Enable multi')
+      .next()
+      .should('have.attr', 'class')
+      .and('match', /toggled_off/)
+    // Click it again and confirm
+    cy.contains('Enable multi')
+      .next()
+      .click()
+    cy.get('button')
+      .contains('Continue')
+      .click()
+    // Now it's toggled on
+    cy.contains('Enable multi')
+      .next()
+      .should('have.attr', 'class')
+      .and('match', /toggled_on/)
+    // Click it again
+    cy.contains('Enable multi')
+      .next()
+      .click()
+    // We have to confirm to turn it off?
+    // TODO That doesn't seem right...
+    cy.get('button')
+      .contains('Continue')
+      .click()
+    // Now it's toggled off again
+    cy.contains('Enable multi')
+      .next()
+      .should('have.attr', 'class')
+      .and('match', /toggled_off/)
+  })
+
+  it('remembers when we enable things', () => {
+    // Enable a button
+    // We're not using the privacy button because that
+    // interacts with analytics libraries, which might
+    // not be accessible in a headless environment
+    cy.contains('Enable multi')
+      .next()
+      .click()
+    cy.get('button')
+      .contains('Continue')
+      .click()
+    // Leave the settings page
+    cy.get("button[class*='navbar__tab__']").contains('FILE')
+    // Go back to settings
+    cy.get("button[class*='navbar__tab__']")
+      .contains('Settings')
+      .click()
+    // The toggle is still on
+    cy.contains('Enable multi')
+      .next()
+      .should('have.attr', 'class')
+      .and('match', /toggled_on/)
+  })
+
+  it('remembers when we disable things', () => {
+    // Disable a button
+    // We're not using the privacy button because that
+    // interacts with analytics libraries, which might
+    // not be accessible in a headless environment
+    cy.contains('Enable multi')
+      .next()
+      .click()
+    cy.get('button')
+      .contains('Continue')
+      .click()
+    // Leave the settings page
+    cy.get("button[class*='navbar__tab__']").contains('FILE')
+    // Go back to settings
+    cy.get("button[class*='navbar__tab__']")
+      .contains('Settings')
+      .click()
+    // The toggle is still off
+    cy.contains('Enable multi')
+      .next()
+      .should('have.attr', 'class')
+      .and('match', /toggled_off/)
+  })
+})

--- a/protocol-designer/cypress/integration/sidebar.spec.js
+++ b/protocol-designer/cypress/integration/sidebar.spec.js
@@ -1,0 +1,49 @@
+describe('Desktop Navigation', () => {
+  before(() => {
+    cy.visit('/')
+    cy.viewport('macbook-15')
+  })
+
+  it('contains a working file button', () => {
+    cy.get("button[class*='navbar__tab__']")
+      .contains('FILE')
+      .parent()
+      .should('have.prop', 'disabled')
+      .and('equal', false)
+  })
+
+  it('contains a disabled liquids button', () => {
+    cy.get("button[class*='navbar__tab__']")
+      .contains('LIQUIDS')
+      .parent()
+      .should('have.prop', 'disabled')
+  })
+
+  it('contains a disabled design button', () => {
+    cy.get("button[class*='navbar__tab__']")
+      .contains('DESIGN')
+      .parent()
+      .should('have.prop', 'disabled')
+  })
+
+  it('contains a help button with external link', () => {
+    cy.get("a[class*='navbar__tab__']")
+      .contains('HELP')
+      .parent()
+      .should('have.prop', 'href')
+      .and('equal', 'https://intercom.help/opentrons-protocol-designer')
+  })
+
+  it('contains a settings button', () => {
+    cy.get("button[class*='navbar__tab__']")
+      .contains('Settings')
+      .should('exist')
+  })
+
+  it('returns to the file controls when the file button is clicked', () => {
+    cy.get("button[class*='navbar__tab__']")
+      .contains('FILE')
+      .click()
+    cy.contains('Protocol File')
+  })
+})

--- a/protocol-designer/cypress/plugins/index.js
+++ b/protocol-designer/cypress/plugins/index.js
@@ -1,0 +1,17 @@
+// ***********************************************************
+// This example plugins/index.js can be used to load plugins
+//
+// You can change the location of this file or turn off loading
+// the plugins file with the 'pluginsFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/plugins-guide
+// ***********************************************************
+
+// This function is called when a project is opened or re-opened (e.g. due to
+// the project's config changing)
+
+module.exports = (on, config) => {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+}

--- a/protocol-designer/cypress/support/commands.js
+++ b/protocol-designer/cypress/support/commands.js
@@ -1,0 +1,26 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+import 'cypress-file-upload'
+//
+// -- This is a parent command --
+// Cypress.Commands.add("login", (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })

--- a/protocol-designer/cypress/support/index.js
+++ b/protocol-designer/cypress/support/index.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')


### PR DESCRIPTION
## overview

Building on my cypress.io tests for the labware-library, this PR adds testing to the protocol-designer. here is a lot to test with this complex app, and I wanted to get what I have done now merged while I work on the rest. These tests include page navigation, the settings page, and protocol definitions up through liquids.

I also added a global `make test-e2e` command that runs all existing cypress tests for all the apps. I had to tweak the existing labware-library tests slightly to make this work.

## changelog

- Added the required file layout for cypress.io in the protocol-designer app. 
- Created e2e tests that go up through adding liquids.
- Added a global 'make test-e2e' command that runs all existing cypress tests for all apps.

## review requests

There are no breaking changes. This PR takes what I made for the labware-library and extends it to the protocol-designer.
