### PR TITLE
refactor(labware-creator): Swap PDF and export button order

### DIFF
--- a/labware-library/src/labware-creator/index.js
+++ b/labware-library/src/labware-creator/index.js
@@ -1012,17 +1012,6 @@ const App = () => {
                       </div>
                     </div>
                     <div className={styles.export_section}>
-                      <PrimaryButton
-                        className={styles.export_button}
-                        onClick={() => {
-                          if (!isValid && !showExportErrorModal) {
-                            setShowExportErrorModal(true, values)
-                          }
-                          handleSubmit()
-                        }}
-                      >
-                        EXPORT FILE
-                      </PrimaryButton>
                       <div
                         className={cx(styles.callout, styles.export_callout)}
                       >
@@ -1052,6 +1041,17 @@ const App = () => {
                           view test guide
                         </LinkOut>
                       </div>
+                      <PrimaryButton
+                        className={styles.export_button}
+                        onClick={() => {
+                          if (!isValid && !showExportErrorModal) {
+                            setShowExportErrorModal(true, values)
+                          }
+                          handleSubmit()
+                        }}
+                      >
+                        EXPORT FILE
+                      </PrimaryButton>
                     </div>
                   </Section>
                 </>

--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -236,7 +236,7 @@
 }
 
 .export_button {
-  margin-bottom: 2rem;
+  margin-top: 2rem;
 }
 
 .export_callout {


### PR DESCRIPTION
## overview

This PR closes #4875 by moving the Labware Creator test guidance callout + PDF download button before the export button.

## changelog

- refactor(labware-creator): Swap PDF and export button order

## review requests
http://sandbox.labware.opentrons.com/lc_pdf-export-btn-swap/create/
- [ ] New export/PDF buttons match design
