### PR TITLE
feat(protocol-designer): Conditionally disabled pause until temp

### DIFF
--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -237,3 +237,8 @@
 .select_module_message {
   font-size: var(--fs-body-1);
 }
+
+.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}

--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -238,6 +238,11 @@
   font-size: var(--fs-body-1);
 }
 
+/*
+TODO (ka 2020-1-30): This is a workaround since component library
+RadioGroup does not support a disabled option. Should revisit if
+and when that is implemented.
+*/
 .disabled {
   opacity: 0.5;
   pointer-events: none;

--- a/protocol-designer/src/components/StepEditForm/fields/RadioGroupField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/RadioGroupField.js
@@ -9,6 +9,7 @@ type RadioGroupFieldProps = {|
   ...FocusHandlers,
   name: StepFieldName,
   options: $PropertyType<React.ElementProps<typeof RadioGroup>, 'options'>,
+  className?: string,
 |}
 
 export const RadioGroupField = (props: RadioGroupFieldProps) => {
@@ -18,6 +19,7 @@ export const RadioGroupField = (props: RadioGroupFieldProps) => {
     onFieldBlur,
     focusedField,
     dirtyFields,
+    className,
     ...radioGroupProps
   } = props
   return (
@@ -28,6 +30,7 @@ export const RadioGroupField = (props: RadioGroupFieldProps) => {
       render={({ value, updateValue, errorToShow }) => (
         <RadioGroup
           {...radioGroupProps}
+          className={className}
           value={value ? String(value) : ''}
           error={errorToShow}
           onChange={(e: SyntheticEvent<*>) => {

--- a/protocol-designer/src/components/StepEditForm/forms/PauseForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/PauseForm.js
@@ -4,7 +4,7 @@ import cx from 'classnames'
 import { useSelector } from 'react-redux'
 import { selectors as uiModuleSelectors } from '../../../ui/modules'
 import { selectors as featureFlagSelectors } from '../../../feature-flags'
-import { FormGroup } from '@opentrons/components'
+import { FormGroup, HoverTooltip } from '@opentrons/components'
 import i18n from '../../../localization'
 import {
   PAUSE_UNTIL_RESUME,
@@ -34,6 +34,14 @@ export const PauseForm = (props: PauseFormProps): React.Element<'div'> => {
 
   const pauseUntilTempEnabled = useSelector(
     uiModuleSelectors.getPauseUntilTempEnabled
+  )
+
+  const pauseUntilTempTooltip = (
+    <div className={styles.slot_tooltip}>
+      {i18n.t(
+        `tooltip.step_fields.pauseForAmountOfTime.disabled.wait_until_temp`
+      )}
+    </div>
   )
 
   // time fields blur together
@@ -110,53 +118,64 @@ export const PauseForm = (props: PauseFormProps): React.Element<'div'> => {
             </div>
           </ConditionalOnField>
           {modulesEnabled && (
-            <>
-              <div className={styles.checkbox_row}>
-                <RadioGroupField
-                  className={cx({ [styles.disabled]: !pauseUntilTempEnabled })}
-                  name="pauseForAmountOfTime"
-                  options={[
-                    {
-                      name: i18n.t(
-                        'form.step_edit_form.field.pauseForAmountOfTime.options.untilTemperature'
-                      ),
-                      value: PAUSE_UNTIL_TEMP,
-                    },
-                  ]}
-                  {...focusHandlers}
-                />
-              </div>
-              <ConditionalOnField
-                name={'pauseForAmountOfTime'}
-                condition={val => val === PAUSE_UNTIL_TEMP}
-              >
-                <div className={styles.form_row}>
-                  <FormGroup
-                    label={i18n.t(
-                      'form.step_edit_form.field.moduleActionLabware.label'
-                    )}
-                  >
-                    <StepFormDropdown
-                      {...focusHandlers}
-                      name="moduleId"
-                      options={moduleLabwareOptions}
-                    />
-                  </FormGroup>
-                  <FormGroup
-                    label={i18n.t(
-                      'form.step_edit_form.field.pauseTemperature.label'
-                    )}
-                  >
-                    <TextField
-                      name="pauseTemperature"
-                      className={styles.small_field}
-                      units={i18n.t('application.units.degrees')}
+            <HoverTooltip
+              placement="bottom"
+              tooltipComponent={
+                pauseUntilTempEnabled ? null : pauseUntilTempTooltip
+              }
+            >
+              {hoverTooltipHandlers => (
+                <div {...hoverTooltipHandlers}>
+                  <div className={styles.checkbox_row}>
+                    <RadioGroupField
+                      className={cx({
+                        [styles.disabled]: !pauseUntilTempEnabled,
+                      })}
+                      name="pauseForAmountOfTime"
+                      options={[
+                        {
+                          name: i18n.t(
+                            'form.step_edit_form.field.pauseForAmountOfTime.options.untilTemperature'
+                          ),
+                          value: PAUSE_UNTIL_TEMP,
+                        },
+                      ]}
                       {...focusHandlers}
                     />
-                  </FormGroup>
+                  </div>
+                  <ConditionalOnField
+                    name={'pauseForAmountOfTime'}
+                    condition={val => val === PAUSE_UNTIL_TEMP}
+                  >
+                    <div className={styles.form_row}>
+                      <FormGroup
+                        label={i18n.t(
+                          'form.step_edit_form.field.moduleActionLabware.label'
+                        )}
+                      >
+                        <StepFormDropdown
+                          {...focusHandlers}
+                          name="moduleId"
+                          options={moduleLabwareOptions}
+                        />
+                      </FormGroup>
+                      <FormGroup
+                        label={i18n.t(
+                          'form.step_edit_form.field.pauseTemperature.label'
+                        )}
+                      >
+                        <TextField
+                          name="pauseTemperature"
+                          className={styles.small_field}
+                          units={i18n.t('application.units.degrees')}
+                          {...focusHandlers}
+                        />
+                      </FormGroup>
+                    </div>
+                  </ConditionalOnField>
                 </div>
-              </ConditionalOnField>
-            </>
+              )}
+            </HoverTooltip>
           )}
         </div>
         <div className={styles.section_column}>

--- a/protocol-designer/src/components/StepEditForm/forms/PauseForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/PauseForm.js
@@ -33,7 +33,7 @@ export const PauseForm = (props: PauseFormProps): React.Element<'div'> => {
   )
 
   const pauseUntilTempEnabled = useSelector(
-    uiModuleSelectors.getPauseUntilTempEnabled
+    uiModuleSelectors.getTempdeckOrThermocylerOnDeck
   )
 
   const pauseUntilTempTooltip = (

--- a/protocol-designer/src/components/StepEditForm/forms/PauseForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/PauseForm.js
@@ -33,7 +33,7 @@ export const PauseForm = (props: PauseFormProps): React.Element<'div'> => {
   )
 
   const pauseUntilTempEnabled = useSelector(
-    uiModuleSelectors.getTempdeckOrThermocylerOnDeck
+    uiModuleSelectors.getTempModuleOrThermocyclerIsOnDeck
   )
 
   const pauseUntilTempTooltip = (

--- a/protocol-designer/src/components/StepEditForm/forms/PauseForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/PauseForm.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import cx from 'classnames'
 import { useSelector } from 'react-redux'
 import { selectors as uiModuleSelectors } from '../../../ui/modules'
 import { selectors as featureFlagSelectors } from '../../../feature-flags'
@@ -10,7 +11,6 @@ import {
   PAUSE_UNTIL_TIME,
   PAUSE_UNTIL_TEMP,
 } from '../../../constants'
-
 import {
   ConditionalOnField,
   TextField,
@@ -23,12 +23,17 @@ import styles from '../StepEditForm.css'
 import type { FocusHandlers } from '../types'
 
 type PauseFormProps = { focusHandlers: FocusHandlers }
+
 export const PauseForm = (props: PauseFormProps): React.Element<'div'> => {
   const { focusHandlers } = props
 
   const modulesEnabled = useSelector(featureFlagSelectors.getEnableModules)
   const moduleLabwareOptions = useSelector(
     uiModuleSelectors.getTemperatureLabwareOptions
+  )
+
+  const pauseUntilTempEnabled = useSelector(
+    uiModuleSelectors.getPauseUntilTempEnabled
   )
 
   // time fields blur together
@@ -108,6 +113,7 @@ export const PauseForm = (props: PauseFormProps): React.Element<'div'> => {
             <>
               <div className={styles.checkbox_row}>
                 <RadioGroupField
+                  className={cx({ [styles.disabled]: !pauseUntilTempEnabled })}
                   name="pauseForAmountOfTime"
                   options={[
                     {

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -41,6 +41,11 @@
         "$generic": "Incompatible with current path",
         "blowout_checkbox": "Redundant with disposal volume"
       }
+    },
+    "pauseForAmountOfTime": {
+      "disabled": {
+        "wait_until_temp": "Add a relevant module to use this step, and set a target temperature"
+      }
     }
   },
   "edit_module_modal": {

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -44,7 +44,7 @@
     },
     "pauseForAmountOfTime": {
       "disabled": {
-        "wait_until_temp": "Add a relevant module to use this step, and set a target temperature"
+        "wait_until_temp": "There are no temperature or thermocycler modules on the deck"
       }
     }
   },

--- a/protocol-designer/src/ui/modules/selectors.js
+++ b/protocol-designer/src/ui/modules/selectors.js
@@ -139,7 +139,7 @@ export const getMagnetLabwareEngageHeight: Selector<
 )
 
 /** Returns boolean if TC or Temperature Modules are present on deck  */
-export const getTempdeckOrThermocylerOnDeck: Selector<boolean> = createSelector(
+export const getTempModuleOrThermocyclerIsOnDeck: Selector<boolean> = createSelector(
   stepFormSelectors.getInitialDeckSetup,
   initialDeckSetup => {
     const tempOnDeck = getModuleOnDeckByType(initialDeckSetup, THERMOCYCLER)

--- a/protocol-designer/src/ui/modules/selectors.js
+++ b/protocol-designer/src/ui/modules/selectors.js
@@ -137,3 +137,13 @@ export const getMagnetLabwareEngageHeight: Selector<
     return (labware && getLabwareDefaultEngageHeight(labware.def)) || null
   }
 )
+
+/** Returns boolean if thermocycler module has labware */
+export const getPauseUntilTempEnabled: Selector<boolean> = createSelector(
+  stepFormSelectors.getInitialDeckSetup,
+  initialDeckSetup => {
+    const tempOnDeck = getModuleOnDeckByType(initialDeckSetup, THERMOCYCLER)
+    const tcOnDeck = getModuleOnDeckByType(initialDeckSetup, TEMPDECK)
+    return Boolean(tempOnDeck || tcOnDeck)
+  }
+)

--- a/protocol-designer/src/ui/modules/selectors.js
+++ b/protocol-designer/src/ui/modules/selectors.js
@@ -138,8 +138,8 @@ export const getMagnetLabwareEngageHeight: Selector<
   }
 )
 
-/** Returns boolean if thermocycler module has labware */
-export const getPauseUntilTempEnabled: Selector<boolean> = createSelector(
+/** Returns boolean if TC or Temperature Modules are present on deck  */
+export const getTempdeckOrThermocylerOnDeck: Selector<boolean> = createSelector(
   stepFormSelectors.getInitialDeckSetup,
   initialDeckSetup => {
     const tempOnDeck = getModuleOnDeckByType(initialDeckSetup, THERMOCYCLER)


### PR DESCRIPTION
## overview

This PR closes #4867 by disabling the `Pause until temperature reached` radio field when there is no Thermocycler or Temperature Module present on the deck.

## changelog

- feat(protocol-designer): Conditionally disabled pause until temp
- refactor(protocol-designer): Add optional className to RadioGroupField to enable disabled styles

## review requests

Make a protocol without a temperature or thermocycler module
add a pause step
- [ ] Pause until temperature reached radio field DISABLED
- [ ] Tooltip informs user to add a relevant module and set a temperature

add a temperature or thermocycler module to the deck
- [ ] Pause until temperature reached radio field now ENABLED
- [ ] No tooltip renders