### PR TITLE
feat(components): Add mini slot map to shared components

### DIFF
--- a/components/src/__tests__/__snapshots__/slotmap.test.js.snap
+++ b/components/src/__tests__/__snapshots__/slotmap.test.js.snap
@@ -1,0 +1,457 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SlotMap renders correctly with collision warning 1`] = `
+<svg
+  viewBox="0,0,99, 92"
+>
+  <g
+    transform="translate(0 0)"
+  >
+    <rect
+      className="slot_rect"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(33 0)"
+  >
+    <rect
+      className="slot_rect"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(0 23)"
+  >
+    <rect
+      className="slot_rect"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(33 23)"
+  >
+    <rect
+      className="slot_rect"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(66 23)"
+  >
+    <rect
+      className="slot_rect"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(0 46)"
+  >
+    <rect
+      className="slot_rect"
+      height={23}
+      width={33}
+    />
+    <svg
+      aria-hidden="true"
+      className="collision_icon"
+      fill="currentColor"
+      height={20}
+      version="1.1"
+      viewBox="0 0 24 24"
+      width={20}
+      x={6.5}
+      y={1.5}
+    >
+      <path
+        d="M13 9h-2V7h2m0 10h-2v-6h2m-1-9A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10A10 10 0 0 0 12 2z"
+        fillRule="evenodd"
+      />
+    </svg>
+  </g>
+  <g
+    transform="translate(33 46)"
+  >
+    <rect
+      className="slot_rect"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(66 46)"
+  >
+    <rect
+      className="slot_rect"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(0 69)"
+  >
+    <rect
+      className="slot_rect slot_occupied"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(33 69)"
+  >
+    <rect
+      className="slot_rect"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(66 69)"
+  >
+    <rect
+      className="slot_rect"
+      height={23}
+      width={33}
+    />
+  </g>
+</svg>
+`;
+
+exports[`SlotMap renders correctly with error 1`] = `
+<svg
+  viewBox="0,0,99, 92"
+>
+  <g
+    transform="translate(0 0)"
+  >
+    <rect
+      className="slot_rect slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(33 0)"
+  >
+    <rect
+      className="slot_rect slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(0 23)"
+  >
+    <rect
+      className="slot_rect slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(33 23)"
+  >
+    <rect
+      className="slot_rect slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(66 23)"
+  >
+    <rect
+      className="slot_rect slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(0 46)"
+  >
+    <rect
+      className="slot_rect slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(33 46)"
+  >
+    <rect
+      className="slot_rect slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(66 46)"
+  >
+    <rect
+      className="slot_rect slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(0 69)"
+  >
+    <rect
+      className="slot_rect slot_occupied slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(33 69)"
+  >
+    <rect
+      className="slot_rect slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(66 69)"
+  >
+    <rect
+      className="slot_rect slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+</svg>
+`;
+
+exports[`SlotMap renders correctly with error and collision warning 1`] = `
+<svg
+  viewBox="0,0,99, 92"
+>
+  <g
+    transform="translate(0 0)"
+  >
+    <rect
+      className="slot_rect slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(33 0)"
+  >
+    <rect
+      className="slot_rect slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(0 23)"
+  >
+    <rect
+      className="slot_rect slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(33 23)"
+  >
+    <rect
+      className="slot_rect slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(66 23)"
+  >
+    <rect
+      className="slot_rect slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(0 46)"
+  >
+    <rect
+      className="slot_rect slot_error"
+      height={23}
+      width={33}
+    />
+    <svg
+      aria-hidden="true"
+      className="collision_icon"
+      fill="currentColor"
+      height={20}
+      version="1.1"
+      viewBox="0 0 24 24"
+      width={20}
+      x={6.5}
+      y={1.5}
+    >
+      <path
+        d="M13 9h-2V7h2m0 10h-2v-6h2m-1-9A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10A10 10 0 0 0 12 2z"
+        fillRule="evenodd"
+      />
+    </svg>
+  </g>
+  <g
+    transform="translate(33 46)"
+  >
+    <rect
+      className="slot_rect slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(66 46)"
+  >
+    <rect
+      className="slot_rect slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(0 69)"
+  >
+    <rect
+      className="slot_rect slot_occupied slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(33 69)"
+  >
+    <rect
+      className="slot_rect slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(66 69)"
+  >
+    <rect
+      className="slot_rect slot_error"
+      height={23}
+      width={33}
+    />
+  </g>
+</svg>
+`;
+
+exports[`SlotMap renders correctly without collision warnings or errors 1`] = `
+<svg
+  viewBox="0,0,99, 92"
+>
+  <g
+    transform="translate(0 0)"
+  >
+    <rect
+      className="slot_rect"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(33 0)"
+  >
+    <rect
+      className="slot_rect"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(0 23)"
+  >
+    <rect
+      className="slot_rect"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(33 23)"
+  >
+    <rect
+      className="slot_rect"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(66 23)"
+  >
+    <rect
+      className="slot_rect"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(0 46)"
+  >
+    <rect
+      className="slot_rect"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(33 46)"
+  >
+    <rect
+      className="slot_rect"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(66 46)"
+  >
+    <rect
+      className="slot_rect"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(0 69)"
+  >
+    <rect
+      className="slot_rect slot_occupied"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(33 69)"
+  >
+    <rect
+      className="slot_rect"
+      height={23}
+      width={33}
+    />
+  </g>
+  <g
+    transform="translate(66 69)"
+  >
+    <rect
+      className="slot_rect"
+      height={23}
+      width={33}
+    />
+  </g>
+</svg>
+`;

--- a/components/src/__tests__/slotmap.test.js
+++ b/components/src/__tests__/slotmap.test.js
@@ -1,0 +1,36 @@
+// slot map  component tests
+import React from 'react'
+import Renderer from 'react-test-renderer'
+import { SlotMap } from '..'
+
+describe('SlotMap', () => {
+  test('renders correctly without collision warnings or errors', () => {
+    const tree = Renderer.create(<SlotMap occupiedSlots={['1']} />).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('renders correctly with collision warning', () => {
+    const tree = Renderer.create(
+      <SlotMap occupiedSlots={['1']} collisionSlots={['4']} />
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('renders correctly with error', () => {
+    const tree = Renderer.create(
+      <SlotMap occupiedSlots={['1']} isError />
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('renders correctly with error and collision warning', () => {
+    const tree = Renderer.create(
+      <SlotMap occupiedSlots={['1']} collisionSlots={['4']} isError />
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/components/src/index.js
+++ b/components/src/index.js
@@ -23,6 +23,7 @@ export * from './lists'
 export * from './modals'
 export * from './nav'
 export * from './tabbedNav'
+export * from './slotmap'
 export * from './structure'
 export * from './tooltips'
 

--- a/components/src/slotmap/SlotMap.js
+++ b/components/src/slotmap/SlotMap.js
@@ -13,7 +13,7 @@ export type SlotMapProps = {
   isError?: boolean,
 }
 
-export const SLOT_MAP_SLOTS = [
+const SLOT_MAP_SLOTS = [
   ['10', '11'],
   ['7', '8', '9'],
   ['4', '5', '6'],
@@ -23,11 +23,13 @@ export const SLOT_MAP_SLOTS = [
 const slotWidth = 33
 const slotHeight = 23
 const iconSize = 20
+const numRows = 4
+const numCols = 3
 
 export function SlotMap(props: SlotMapProps) {
   const { collisionSlots, occupiedSlots, isError } = props
   return (
-    <svg viewBox={`0,0,${slotWidth * 3}, ${slotHeight * 4}`}>
+    <svg viewBox={`0,0,${slotWidth * numCols}, ${slotHeight * numRows}`}>
       {SLOT_MAP_SLOTS.flatMap((row, rowIndex) =>
         row.map((slot, colIndex) => {
           const isCollisionSlot =

--- a/components/src/slotmap/SlotMap.js
+++ b/components/src/slotmap/SlotMap.js
@@ -1,0 +1,66 @@
+// @flow
+import * as React from 'react'
+import cx from 'classnames'
+import { Icon } from '../icons'
+import styles from './styles.css'
+
+export type SlotMapProps = {
+  /** Slot(s) to highlight */
+  occupiedSlots: Array<string>,
+  /** Optional collision warning */
+  collisionSlots?: Array<string>,
+  /** Optional error styling */
+  isError?: boolean,
+}
+
+export const SLOT_MAP_SLOTS = [
+  ['10', '11'],
+  ['7', '8', '9'],
+  ['4', '5', '6'],
+  ['1', '2', '3'],
+]
+
+const slotWidth = 33
+const slotHeight = 23
+const iconSize = 20
+
+export function SlotMap(props: SlotMapProps) {
+  const { collisionSlots, occupiedSlots, isError } = props
+  return (
+    <svg viewBox={`0,0,${slotWidth * 3}, ${slotHeight * 4}`}>
+      {SLOT_MAP_SLOTS.flatMap((row, rowIndex) =>
+        row.map((slot, colIndex) => {
+          const isCollisionSlot =
+            collisionSlots && collisionSlots.includes(slot)
+          const isOccupiedSlot = occupiedSlots.includes(slot)
+          return (
+            <g
+              key={slot}
+              transform={`translate(${colIndex * slotWidth} ${rowIndex *
+                slotHeight})`}
+            >
+              <rect
+                className={cx(styles.slot_rect, {
+                  [styles.slot_occupied]: isOccupiedSlot,
+                  [styles.slot_error]: isError,
+                })}
+                width={slotWidth}
+                height={slotHeight}
+              />
+              {isCollisionSlot && (
+                <Icon
+                  className={styles.collision_icon}
+                  name="information"
+                  width={iconSize}
+                  height={iconSize}
+                  x={slotWidth / 2 - iconSize / 2}
+                  y={slotHeight / 2 - iconSize / 2}
+                />
+              )}
+            </g>
+          )
+        })
+      )}
+    </svg>
+  )
+}

--- a/components/src/slotmap/SlotMap.md
+++ b/components/src/slotmap/SlotMap.md
@@ -1,0 +1,31 @@
+Basic usage:
+
+```js
+<div style={{ width: '100px' }}>
+  <SlotMap occupiedSlots={['1']} />
+</div>
+```
+
+Basic usage multiple occupied slots
+
+```js
+<div style={{ width: '100px' }}>
+  <SlotMap occupiedSlots={['7', '8', '10', '11']} />
+</div>
+```
+
+Optional collision warning notification
+
+```js
+<div style={{ width: '100px' }}>
+  <SlotMap occupiedSlots={['1']} collisionSlots={['4']} />
+</div>
+```
+
+Optional error styling
+
+```js
+<div style={{ width: '100px' }}>
+  <SlotMap occupiedSlots={['1']} isError />
+</div>
+```

--- a/components/src/slotmap/index.js
+++ b/components/src/slotmap/index.js
@@ -1,0 +1,2 @@
+// @flow
+export * from './SlotMap'

--- a/components/src/slotmap/styles.css
+++ b/components/src/slotmap/styles.css
@@ -1,0 +1,18 @@
+@import '..';
+
+.slot_rect {
+  stroke: var(--c-med-gray);
+  fill: none;
+}
+
+.slot_occupied {
+  fill: var(--c-light-gray);
+}
+
+.slot_occupied .slot_error {
+  fill: var(--c-warning-light);
+}
+
+.collision_icon {
+  color: var(--c-dark-gray);
+}

--- a/components/src/slotmap/styles.css
+++ b/components/src/slotmap/styles.css
@@ -9,7 +9,7 @@
   fill: var(--c-light-gray);
 }
 
-.slot_occupied .slot_error {
+.slot_occupied.slot_error {
   fill: var(--c-warning-light);
 }
 

--- a/components/styleguide.config.js
+++ b/components/styleguide.config.js
@@ -53,6 +53,10 @@ module.exports = {
       components: 'src/deck/[A-Z]*.js',
     },
     {
+      name: 'SlotMap',
+      components: 'src/slotmap/[A-Z]*.js',
+    },
+    {
       name: 'Instrument',
       components: 'src/instrument/[A-Z]*.js',
     },


### PR DESCRIPTION
## overview

This PR addresses #4815 by adding the SVG mini slot map to the component library. 

Splitting up the component library and PD implementation into 2 separate PRs  for sanity sake. Thanks @IanLondon for the SVG pairing!

## changelog

- feat(components): Add mini slot map to shared components

## review requests

- [ ] component library examples match designs
- [ ] code looks sane
