### PR TITLE
docs(api): add version parameter in jupyter instructions

### DIFF
--- a/api/docs/v2/writing.rst
+++ b/api/docs/v2/writing.rst
@@ -142,7 +142,7 @@ In your Jupyter notebook, you can use the Python Protocol API simulator by doing
 .. code-block:: python
 
     from opentrons import simulate
-    protocol = simulate.get_protocol_api()
+    protocol = simulate.get_protocol_api('2.0')
     p300 = protocol.load_instrument('p300_single', 'right')
     ...
 

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -45,7 +45,7 @@ def get_protocol_api(
     .. code-block:: python
 
         >>> from opentrons.execute import get_protocol_api
-        >>> protocol = get_protocol_api()
+        >>> protocol = get_protocol_api('2.0')
         >>> instr = protocol.load_instrument('p300_single', 'right')
         >>> instr.home()
 

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -120,7 +120,7 @@ def get_protocol_api(
     .. code-block:: python
 
         >>> from opentrons.simulate import get_protocol_api
-        >>> protocol = get_protocol_api()
+        >>> protocol = get_protocol_api('2.0')
         >>> instr = protocol.load_instrument('p300_single', 'right')
         >>> instr.home()
 


### PR DESCRIPTION
A required parameter was added to the `get_protocol_api` method of `opentrons.simulate` and `opentrons.execute`, but the corresponding documentation was not all updated.