### PR TITLE
fix(api): test_settings_endpoints fails when running independently. 

### DIFF
--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -16,19 +16,13 @@ from opentrons.deck_calibration.endpoints import expected_points
 
 
 @pytest.fixture
-def mock_config():
-    yield robot_configs.load()
-    robot_configs.clear()
-
-
-@pytest.fixture
 def model1():
-    return ('p300_single_v1.4', 'p300_single')
+    return 'p300_single_v1.4', 'p300_single'
 
 
 @pytest.fixture
 def model2():
-    return ('p300_single_v2.0', 'p300_single_gen2')
+    return 'p300_single_v2.0', 'p300_single_gen2'
 
 
 @pytest.fixture

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -1,6 +1,8 @@
 # Uncomment to enable logging during tests
 # import logging
 # from logging.config import dictConfig
+from opentrons.config import robot_configs
+
 try:
     import aionotify
 except OSError:
@@ -117,6 +119,13 @@ def template_db(tmpdir_factory):
     config.CONFIG['labware_database_file'] = str(template_db)
     database_migration.check_version_and_perform_full_migration()
     return template_db
+
+
+@pytest.fixture
+def mock_config():
+    """Robot config setup and teardown"""
+    yield robot_configs.load()
+    robot_configs.clear()
 
 
 @pytest.mark.apiv1

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -260,7 +260,7 @@ async def test_incorrect_modify_pipette_settings(
     assert resp.status == 412
 
 
-async def test_set_log_level(async_client):
+async def test_set_log_level(mock_config, async_client):
     # Check input sanitization
     hardware = async_client.app['com.opentrons.hardware']
     resp = await async_client.post('/settings/log_level/local', json={})
@@ -283,7 +283,7 @@ async def test_set_log_level(async_client):
     assert conf.log_level == 'ERROR'
 
 
-async def test_get_robot_settings(async_client):
+async def test_get_robot_settings(mock_config, async_client):
     resp = await async_client.get('/settings/robot')
     body = await resp.json()
     assert resp.status == 200


### PR DESCRIPTION
## overview
 test_settings_endpoints fails when running independently. specifically, it passes the first time, but fails the second time. the root cause is that a robot settings file is created on the first run and breaks the second run.

fixes #4894 

## changelog

Add config setup/teardown to test_settings_endpoints. 

## review requests

<!--
  Describe any requests for your reviewers here.
-->
