### PR TITLE
feat(protocol-designer): use dev-only data attr for test

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,7 +3,10 @@
 module.exports = {
   env: {
     production: {
-      plugins: ['babel-plugin-unassert'],
+      plugins: [
+        'babel-plugin-unassert',
+        'babel-plugin-jsx-remove-data-test-id',
+      ],
     },
     development: {
       plugins: ['react-hot-loader/babel'],

--- a/components/src/structure/Card.js
+++ b/components/src/structure/Card.js
@@ -15,6 +15,8 @@ type Props = {|
   disabled?: boolean,
   /** Additional class names */
   className?: string,
+  /** data-test-id value for use in automated tests */
+  testId?: string,
 |}
 
 /**
@@ -23,14 +25,14 @@ type Props = {|
  * Titles and other children handle their own styles and layout.
  */
 export default function Card(props: Props) {
-  const { title, children } = props
+  const { title, children, testId } = props
 
   const style = cx(styles.card, props.className, {
     [styles.disabled]: props.disabled,
   })
 
   return (
-    <section className={style}>
+    <section className={style} data-test-id={testId}>
       {title && <h3 className={styles.card_title}>{title}</h3>}
       {children}
     </section>

--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "eslint": "^6.0.1",
     "eslint-config-prettier": "^6.3.0",
     "eslint-config-standard": "^12.0.0",
-    "eslint-plugin-flowtype": "^3.11.1",
     "eslint-plugin-cypress": "^2.8.1",
+    "eslint-plugin-flowtype": "^3.11.1",
     "eslint-plugin-import": "^2.18.0",
     "eslint-plugin-json": "^1.4.0",
     "eslint-plugin-node": "^9.1.0",
@@ -119,5 +119,8 @@
     "webpack-node-externals": "^1.7.2",
     "worker-loader": "^2.0.0",
     "ws": "7.1.2"
+  },
+  "dependencies": {
+    "babel-plugin-jsx-remove-data-test-id": "^2.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-dynamic-import-node": "^2.3.0",
+    "babel-plugin-jsx-remove-data-test-id": "^2.1.3",
     "babel-plugin-unassert": "^3.0.1",
     "codecov": "^3.1.0",
     "concurrently": "^4.1.2",
@@ -119,8 +120,5 @@
     "webpack-node-externals": "^1.7.2",
     "worker-loader": "^2.0.0",
     "ws": "7.1.2"
-  },
-  "dependencies": {
-    "babel-plugin-jsx-remove-data-test-id": "^2.1.3"
   }
 }

--- a/protocol-designer/cypress/integration/settings.spec.js
+++ b/protocol-designer/cypress/integration/settings.spec.js
@@ -11,7 +11,7 @@ describe('The Settings Page', () => {
   })
 
   it('contains an information section', () => {
-    cy.get('h3')
+    cy.get('[data-test-id=informationSectionHeader]')
       .contains('Information')
       .should('exist')
   })

--- a/protocol-designer/src/components/SettingsPage/SettingsApp.js
+++ b/protocol-designer/src/components/SettingsPage/SettingsApp.js
@@ -43,7 +43,10 @@ function SettingsApp(props: Props) {
   return (
     <>
       <div className={styles.page_row}>
-        <Card title={i18n.t('card.title.information')}>
+        <Card
+          title={i18n.t('card.title.information')}
+          testId="informationSectionHeader"
+        >
           <div className={styles.card_content}>
             <div className={styles.setting_row}>
               <LabeledValue

--- a/yarn.lock
+++ b/yarn.lock
@@ -3662,6 +3662,11 @@ babel-plugin-jest-hoist@^24.9.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-jsx-remove-data-test-id@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jsx-remove-data-test-id/-/babel-plugin-jsx-remove-data-test-id-2.1.3.tgz#d4e5fc89e85907b608f3d9b0964e5c0f1ad507e1"
+  integrity sha512-FTpcmzr3avLVStllCT4BceTTZNEb+1mJVtLpsicvXDqjojEkyrga1GGOxWj768Ra3tev6KWgNOhZ/Lrucb+MuQ==
+
 babel-plugin-macros@^2.0.0:
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.4.5.tgz#7000a9b1f72d19ceee19a5804f1d23d6daf38c13"
@@ -17278,13 +17283,6 @@ supports-color@^4.0.0, supports-color@^4.5.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
-
-supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
-  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
-  dependencies:
-    has-flag "^3.0.0"
 
 supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.1.0"


### PR DESCRIPTION
## overview

This PR is also an RFC -- is this a good way to approach setting up `data-` attrs for testing?

@mcous mentioned stripping out the `data-` attrs from production code, so I'm trying out this https://www.npmjs.com/package/babel-plugin-jsx-remove-data-test-id

I figured we might as well use the default `data-test-id` data attr name, but we can configure it to something else if we want. Maybe these will be useful in Enzyme tests as well, so `data-test-id` is better than `data-cy`?

## Acceptance criteria

I just changed 1 test and 1 component instance as a proof of concept

FIRST, `make install-js` and kill any running PD dev server you might have going to set up

- [ ] `make -C protocol-designer test-e2e` should still pass
- [ ] The data attr should be gone in production. To test that, `make -C protocol-designer serve`, delete the blocking TypeForm modal with Inspector b/c it's hard to bypass, then inspect the Settings > Information card.

## Discussion Qs

This approach seems like it requires us to add a `testId?: string` prop like this to all our components that may be selected in an E2E test, so it can be passed into a DOM element of that component. That's a lot of new props, but we'd add them gradually we migrate the tests from CSS/`name` to `data-test-id`.

Any ideas for alternative approaches to actually specify the value of the `data-test-id` for a particular component instance other then the `testId` prop?