### PR TITLE
fix(api): bug in MalformedProtocolError.__str__

### DIFF
--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -51,7 +51,7 @@ class MalformedProtocolError(Exception):
         super().__init__(message)
 
     def __str__(self):
-        return self._msg + PROTOCOL_MALFORMED
+        return self.message + PROTOCOL_MALFORMED
 
     def __repr__(self):
         return '<{}: {}>'.format(self.__class__.__name__, self.message)


### PR DESCRIPTION
## overview

Happened to see this while browsing code. `self._msg` doesn't exist. Use `self.message` for concatenation.

