### PR TITLE
chore(*): add CODEOWNERS to repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# catchall: someone in software should be notified for any change in this repo
+* @Opentrons/software
+
+# language expertise verticals - if a PR changes things in multiple projects let's
+# notify those language communities
+*.js @Opentrons/js
+*.py @Opentrons/py
+/flow-typed @Opentrons/js
+/webpack-config @Opentrons/js
+
+# subprojects - those with clear team ownership should have appropriate notifications
+/protocol-designer @Opentrons/spddrs
+/labware-designer @Opentrons/spddrs
+/labware-library @Opentrons/spddrs
+/protocol-library-kludge @Opentrons/spddrs
+/update-server @Opentrons/cpx
+/api/src/opentrons @Opentrons/hmg
+
+# subprojects by language - some subprojects are shared by teams but united by a
+# language community (including makefiles and config) so mark them appropriately
+/app @Opentrons/js
+/app-shell @Opentrons/js
+/components @Opentrons/js
+/api @Opentrons/py

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,7 @@
 /protocol-library-kludge @Opentrons/spddrs
 /update-server @Opentrons/cpx
 /api/src/opentrons @Opentrons/hmg
+/discovery-client @Opentrons/cpx
 
 # subprojects by language - some subprojects are shared by teams but united by a
 # language community (including makefiles and config) so mark them appropriately

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,11 @@
 /update-server @Opentrons/cpx
 /api/src/opentrons @Opentrons/hmg
 /discovery-client @Opentrons/cpx
+/shared-data/pipette @Opentrons/hmg
+/shared-data/protocol @Opentrons/spddrs
+/shared-data/module @Opentrons/hmg
+/shared-data/deck @Opentrons/hmg
+/shared-data/labware @Opentrons/hmg
 
 # subprojects by language - some subprojects are shared by teams but united by a
 # language community (including makefiles and config) so mark them appropriately
@@ -23,3 +28,4 @@
 /app-shell @Opentrons/js
 /components @Opentrons/js
 /api @Opentrons/py
+/shared-data/js @Opentrons/js


### PR DESCRIPTION
Adds configuration for github code owners
(https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners)
to the repo
