### PR TITLE
feat(protocol-designer): add field and form level validation f…

### DIFF
--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -144,6 +144,15 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
     castValue: Number,
   },
+  pauseForAmountOfTime: { getErrors: composeErrors(requiredField) },
+  pauseTemperature: {
+    getErrors: composeErrors(
+      minFieldValue(MIN_TEMP_MODULE_TEMP),
+      maxFieldValue(MAX_TEMP_MODULE_TEMP)
+    ),
+    maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
+    castValue: Number,
+  },
 }
 
 export const getFieldErrors = (

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdatePause.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdatePause.js
@@ -1,0 +1,34 @@
+/* eslint-disable import/no-default-export */
+// @flow
+import pick from 'lodash/pick'
+import { chainPatchUpdaters, fieldHasChanged } from './utils'
+import getDefaultsForStepType from '../getDefaultsForStepType'
+import type { FormData, StepFieldName } from '../../../form-types'
+import type { FormPatch } from '../../actions/types'
+
+// TODO: Ian 2019-02-21 import this from a more central place - see #2926
+const getDefaultFields = (...fields: Array<StepFieldName>): FormPatch =>
+  pick(getDefaultsForStepType('pause'), fields)
+
+const updatePatchOnPauseTemperatureChange = (
+  patch: FormPatch,
+  rawForm: FormData
+) => {
+  if (fieldHasChanged(rawForm, patch, 'pauseForAmountOfTime')) {
+    return {
+      ...patch,
+      ...getDefaultFields('pauseTemperature'),
+    }
+  }
+  return patch
+}
+
+export function dependentFieldsUpdatePause(
+  originalPatch: FormPatch,
+  rawForm: FormData // raw = NOT hydrated
+): FormPatch {
+  // sequentially modify parts of the patch until it's fully updated
+  return chainPatchUpdaters(originalPatch, [
+    chainPatch => updatePatchOnPauseTemperatureChange(chainPatch, rawForm),
+  ])
+}

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/index.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/index.js
@@ -2,6 +2,7 @@
 import dependentFieldsUpdateMoveLiquid from './dependentFieldsUpdateMoveLiquid'
 import dependentFieldsUpdateMix from './dependentFieldsUpdateMix'
 import dependentFieldsUpdateMagnet from './dependentFieldsUpdateMagnet'
+import { dependentFieldsUpdatePause } from './dependentFieldsUpdatePause'
 import type { FormData } from '../../../form-types'
 import type { FormPatch } from '../../actions/types'
 import type {
@@ -47,6 +48,10 @@ function handleFormChange(
       patch,
       rawForm
     )
+    return { ...patch, ...dependentFieldsPatch }
+  }
+  if (rawForm.stepType === 'pause') {
+    const dependentFieldsPatch = dependentFieldsUpdatePause(patch, rawForm)
     return { ...patch, ...dependentFieldsPatch }
   }
 

--- a/protocol-designer/src/steplist/formLevel/index.js
+++ b/protocol-designer/src/steplist/formLevel/index.js
@@ -21,6 +21,7 @@ import {
   temperatureRangeExceeded,
   type FormWarning,
   type FormWarningType,
+  pauseTemperatureRangeExceeded,
 } from './warnings'
 import type { StepType } from '../../form-types'
 
@@ -43,7 +44,10 @@ const stepFormHelperMap: { [StepType]: FormHelpers } = {
     getErrors: composeErrors(incompatibleLabware),
     getWarnings: composeWarnings(belowPipetteMinimumVolume),
   },
-  pause: { getErrors: composeErrors(pauseForTimeOrUntilTold) },
+  pause: {
+    getErrors: composeErrors(pauseForTimeOrUntilTold),
+    getWarnings: composeWarnings(pauseTemperatureRangeExceeded),
+  },
   moveLiquid: {
     getErrors: composeErrors(
       incompatibleAspirateLabware,

--- a/protocol-designer/src/steplist/formLevel/warnings.js
+++ b/protocol-designer/src/steplist/formLevel/warnings.js
@@ -21,6 +21,8 @@ export type FormWarningType =
   | 'ENGAGE_HEIGHT_MAX_EXCEEDED'
   | 'TEMPERATURE_MIN_EXCEEDED'
   | 'TEMPERATURE_MAX_EXCEEDED'
+  | 'PAUSE_TEMPERATURE_MIN_EXCEEDED'
+  | 'PAUSE_TEMPERATURE_MAX_EXCEEDED'
 
 export type FormWarning = {
   ...$Exact<FormError>,
@@ -70,7 +72,18 @@ const FORM_WARNINGS: { [FormWarningType]: FormWarning } = {
     title: 'Specified temperature is above module maximum',
     dependentFields: ['setTemperature', 'targetTemperature'],
   },
+  PAUSE_TEMPERATURE_MIN_EXCEEDED: {
+    type: 'TEMPERATURE_MIN_EXCEEDED',
+    title: 'Specified temperature is below module minimum',
+    dependentFields: ['pauseForAmountOfTime', 'pauseTemperature'],
+  },
+  PAUSE_TEMPERATURE_MAX_EXCEEDED: {
+    type: 'TEMPERATURE_MAX_EXCEEDED',
+    title: 'Specified temperature is above module maximum',
+    dependentFields: ['pauseForAmountOfTime', 'pauseTemperature'],
+  },
 }
+
 export type WarningChecker = mixed => ?FormWarning
 
 // TODO: test these
@@ -139,6 +152,19 @@ export const temperatureRangeExceeded = (
     targetTemperature > MAX_TEMP_MODULE_TEMP
   ) {
     return FORM_WARNINGS.TEMPERATURE_MAX_EXCEEDED
+  }
+  return null
+}
+
+export const pauseTemperatureRangeExceeded = (
+  fields: HydratedFormData
+): ?FormWarning => {
+  const { pauseForAmountOfTime, pauseTemperature } = fields
+  const setTemperature = pauseForAmountOfTime === 'untilTemperature'
+  if (setTemperature && pauseTemperature < MIN_TEMP_MODULE_TEMP) {
+    return FORM_WARNINGS.PAUSE_TEMPERATURE_MIN_EXCEEDED
+  } else if (setTemperature && pauseTemperature > MAX_TEMP_MODULE_TEMP) {
+    return FORM_WARNINGS.PAUSE_TEMPERATURE_MAX_EXCEEDED
   }
   return null
 }


### PR DESCRIPTION
## overview
This PR closes #4937 by adding field and form level validation for a pause wait for temp step

Note:
 I didn't add any tests :( but let's think about how we want to test that form/field level validation is doing what it should.

I also introduced a lot of redundancy since there is a lot of shared logic between pause/temperature form validation. I tried decoupling but it ended up being quite painful. When we have time to regroup, we should really address this. 

## review requests
Code review

- Create protocol with temp module
- Add pause step
- Select pause until temperature reached
- [ ] Enter a number above 95 (you should see appropriate warning below the text input as well as the warning modal at the top of the screen)
- [ ] Enter a number below 0 (you should not be able to enter at all)
- [ ] Enter a number non number (you should not be able to enter at all)

- Create protocol with temp module
- Add pause step
- Select pause until temperature reached
- [ ] You should not be able to save form if temp is empty or invalid

- Create protocol with temp module
- Add pause step
- Select pause until temperature reached
- [ ] Selecting other pause step options clears our any previous target temp + possible errors/warnings

