### PR TITLE
feat(protocol-designer): Add awaitTemperature substep items

### DIFF
--- a/protocol-designer/src/components/steplist/PauseStepItems.js
+++ b/protocol-designer/src/components/steplist/PauseStepItems.js
@@ -1,13 +1,13 @@
 // @flow
 import * as React from 'react'
-import type { PauseArgs } from '../../step-generation'
+import i18n from '../../localization'
 import { PDListItem } from '../lists'
-
+import type { PauseArgs } from '../../step-generation'
 type Props = {
   pauseArgs: PauseArgs,
 }
 
-export default function PauseStepItems(props: Props) {
+export function PauseStepItems(props: Props) {
   const { pauseArgs } = props
   if (!pauseArgs.meta) {
     // No message or time, show nothing
@@ -15,14 +15,21 @@ export default function PauseStepItems(props: Props) {
   }
   const { message, wait } = pauseArgs
   const { hours, minutes, seconds } = pauseArgs.meta
+
   return (
     <React.Fragment>
       {message && <PDListItem>{message}</PDListItem>}
       {wait !== true && (
         <PDListItem>
-          <span>{hours} hr</span>
-          <span>{minutes} m</span>
-          <span>{seconds} s</span>
+          <span>
+            {hours} {i18n.t('application.units.hours')}
+          </span>
+          <span>
+            {minutes} {i18n.t('application.units.minutes')}
+          </span>
+          <span>
+            {seconds} {i18n.t('application.units.seconds')}
+          </span>
           <span />
           <span />
         </PDListItem>

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -6,7 +6,7 @@ import SourceDestSubstep from './SourceDestSubstep'
 import styles from './StepItem.css'
 import AspirateDispenseHeader from './AspirateDispenseHeader'
 import MixHeader from './MixHeader'
-import PauseStepItems from './PauseStepItems'
+import { PauseStepItems } from './PauseStepItems'
 import { ModuleStepItems } from './ModuleStepItems'
 import StepDescription from '../StepDescription'
 import { stepIconsByType } from '../../form-types'
@@ -144,6 +144,23 @@ export function getStepItemContents(stepItemProps: StepItemProps) {
         labwareNickname={substeps.labwareNickname}
         message={substeps.message}
         action={i18n.t(`modules.actions.go_to`)}
+        actionText={temperature}
+        module={TEMPDECK}
+      />
+    )
+  }
+
+  if (substeps && substeps.substepType === 'awaitTemperature') {
+    const temperature = `${substeps.temperature} ${i18n.t(
+      'application.units.degrees'
+    )}`
+
+    return (
+      <ModuleStepItems
+        labwareDisplayName={substeps.labwareDisplayName}
+        labwareNickname={substeps.labwareNickname}
+        message={substeps.message}
+        action={i18n.t(`modules.actions.await_temperature`)}
         actionText={temperature}
         module={TEMPDECK}
       />

--- a/protocol-designer/src/components/steplist/__tests__/StepItem.test.js
+++ b/protocol-designer/src/components/steplist/__tests__/StepItem.test.js
@@ -56,7 +56,6 @@ describe('getStepItemContents', () => {
     test('module rendered with engage when engage is true', () => {
       const StepItemContents = getStepItemContents(magnetProps)
       const wrapper = renderWrapper(StepItemContents)
-
       const component = wrapper.find(ModuleStepItems)
       expect(component).toHaveLength(1)
       expect(component.prop('actionText')).toEqual('engage')
@@ -64,10 +63,8 @@ describe('getStepItemContents', () => {
 
     test('module rendered with disengage when type is disengage', () => {
       magnetProps.substeps.engage = false
-
       const StepItemContents = getStepItemContents(magnetProps)
       const wrapper = renderWrapper(StepItemContents)
-
       const component = wrapper.find(ModuleStepItems)
       expect(component).toHaveLength(1)
       expect(component.prop('actionText')).toEqual('disengage')
@@ -76,8 +73,9 @@ describe('getStepItemContents', () => {
 
   describe('temperature step type', () => {
     let temperatureProps
+    const stepType: 'temperature' = 'temperature'
+
     beforeEach(() => {
-      const stepType = 'temperature'
       temperatureProps = {
         ...props,
         rawForm: {
@@ -85,45 +83,85 @@ describe('getStepItemContents', () => {
           id: stepType,
           StepFieldName: stepType,
         },
-        substeps: {
-          substepType: stepType,
-          temperature: 45,
-          labwareDisplayName: 'temperature display',
-          labwareNickname: 'temperature nickname',
-          message: 'message',
-        },
+        substeps: null,
         stepType: stepType,
         labwareNicknamesById: {
-          magnetId: 'temperature nickname',
+          temperatureId: 'temperature nickname',
         },
         labwareDefDisplayNamesById: {
-          magnetId: 'temperature display',
+          temperatureId: 'temperature display',
         },
       }
     })
 
     test('module is rendered with temperature when temperature exists', () => {
+      temperatureProps.substeps = {
+        substepType: stepType,
+        temperature: 45,
+        labwareDisplayName: 'temperature display',
+        labwareNickname: 'temperature nickname',
+        message: 'message',
+      }
       const Component = getStepItemContents(temperatureProps)
       const wrapper = renderWrapper(Component)
-
       const component = wrapper.find(ModuleStepItems)
       expect(component).toHaveLength(1)
       expect(component.prop('actionText')).toEqual('45 °C')
     })
 
     test('module is rendered with deactivated when temperature is null', () => {
-      // overwrite temperature like this due to flow issue when temperature changes from num to null
       temperatureProps.substeps = {
-        ...temperatureProps.substeps,
+        substepType: stepType,
         temperature: null,
+        labwareDisplayName: 'temperature display',
+        labwareNickname: 'temperature nickname',
+        message: 'message',
       }
-
       const Component = getStepItemContents(temperatureProps)
       const wrapper = renderWrapper(Component)
-
       const component = wrapper.find(ModuleStepItems)
       expect(component).toHaveLength(1)
       expect(component.prop('actionText')).toEqual('Deactivated')
+    })
+  })
+
+  describe('awaitTemperature step type', () => {
+    let awaitTemperatureProps
+    const stepType: 'awaitTemperature' = 'awaitTemperature'
+
+    beforeEach(() => {
+      awaitTemperatureProps = {
+        ...props,
+        rawForm: {
+          stepType,
+          id: stepType,
+          StepFieldName: stepType,
+        },
+        substeps: null,
+        stepType: stepType,
+        labwareNicknamesById: {
+          temperatureId: 'temperature nickname',
+        },
+        labwareDefDisplayNamesById: {
+          temperatureId: 'temperature display',
+        },
+      }
+    })
+
+    test('module is rendered with temperature', () => {
+      awaitTemperatureProps.substeps = {
+        substepType: stepType,
+        temperature: 45,
+        labwareDisplayName: 'temperature display',
+        labwareNickname: 'temperature nickname',
+        message: 'message',
+      }
+      const Component = getStepItemContents(awaitTemperatureProps)
+      const wrapper = renderWrapper(Component)
+      const component = wrapper.find(ModuleStepItems)
+      expect(component).toHaveLength(1)
+      expect(component.prop('action')).toEqual('temperature')
+      expect(component.prop('actionText')).toEqual('45 °C')
     })
   })
 })

--- a/protocol-designer/src/localization/en/modules.json
+++ b/protocol-designer/src/localization/en/modules.json
@@ -17,6 +17,7 @@
     "action": "action",
     "go_to": "go to",
     "engage": "engage",
-    "disengage": "disengage"
+    "disengage": "disengage",
+    "await_temperature": "temperature"
   }
 }

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -160,6 +160,7 @@ export type PauseArgs = {|
   commandCreatorFnName: 'delay',
   message?: string,
   wait: number | true,
+  pauseTemperature?: number | null,
   meta: ?{|
     hours?: number,
     minutes?: number,

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -384,6 +384,16 @@ export function generateSubsteps(
     }
   }
 
+  if (stepArgs.commandCreatorFnName === 'awaitTemperature') {
+    return {
+      substepType: 'awaitTemperature',
+      temperature: stepArgs.temperature,
+      labwareDisplayName: labwareNames?.displayName,
+      labwareNickname: labwareNames?.nickname,
+      message: stepArgs.message,
+    }
+  }
+
   console.warn(
     "allSubsteps doesn't support commandCreatorFnName: ",
     stepArgs.commandCreatorFnName,

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -129,7 +129,7 @@ export type AwaitTemperatureSubstepItem = {|
   labwareDisplayName: ?string,
   labwareNickname: ?string,
   message?: string,
-|} // Pause substeps use same data as processed form
+|}
 
 export type SubstepItemData =
   | SourceDestSubstepItem

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -123,11 +123,20 @@ export type PauseSubstepItem = {|
   pauseStepArgs: PauseArgs,
 |} // Pause substeps use same data as processed form
 
+export type AwaitTemperatureSubstepItem = {|
+  substepType: 'awaitTemperature',
+  temperature: number,
+  labwareDisplayName: ?string,
+  labwareNickname: ?string,
+  message?: string,
+|} // Pause substeps use same data as processed form
+
 export type SubstepItemData =
   | SourceDestSubstepItem
   | PauseSubstepItem
   | MagnetSubstepItem
   | TemperatureSubstepItem
+  | AwaitTemperatureSubstepItem
 
 export type StepItemData = {
   id: StepIdType,


### PR DESCRIPTION
## overview

This PR closes #4863 by adding `awaitTemperature` substeps. Shout out to Jenny for the reusable `ModuleSubstepItem`!

## changelog

- feat(protocol-designer): Add awaitTemperature substep items

## review requests

code review: I added 1 test, since there is only 1 possible way for this substep to render. Am I missing any cases?

create a set temperature step
create a pause until temp step (await temp)
- [ ] Await temperature substeps render under Pause step
- [ ] Magnet and Temperature substeps are unaffected/render correctly


