### PR TITLE
feat(protocol-designer): reset time fields in pause step

### DIFF
--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdatePause.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdatePause.js
@@ -17,7 +17,12 @@ const updatePatchOnPauseTemperatureChange = (
   if (fieldHasChanged(rawForm, patch, 'pauseForAmountOfTime')) {
     return {
       ...patch,
-      ...getDefaultFields('pauseTemperature'),
+      ...getDefaultFields(
+        'pauseTemperature',
+        'pauseHour',
+        'pauseMinute',
+        'pauseSecond'
+      ),
     }
   }
   return patch


### PR DESCRIPTION
## overview

This PR closes #4949 by clearing the three time fields in the pause step form when the radio button selection changes.

This is a follow up PR to https://github.com/Opentrons/opentrons/pull/4944#discussion_r376620836

## review requests

Create a protocol with a temp deck
Make a temp step (can be empty)
Make a pause step 
Select `Delay for an amount of time` 
FIll in time seconds, minutes, hours fields
Change the radio button
- [ ] The time fields should be cleared when you reselect `Delay for an amount of time` 