### PR TITLE
refactor(app): simplify top-level Epic type

### DIFF
--- a/app/src/modules/epic/fetchModulesEpic.js
+++ b/app/src/modules/epic/fetchModulesEpic.js
@@ -7,24 +7,24 @@ import { mapToRobotApiRequest } from '../../robot-api/operators'
 import * as Actions from '../actions'
 import * as Constants from '../constants'
 
-import type { StrictEpic } from '../../types'
+import type { Epic } from '../../types'
 
 import type {
   ActionToRequestMapper,
   ResponseToActionMapper,
 } from '../../robot-api/operators'
 
-import type { FetchModulesAction, FetchModulesDoneAction } from '../types'
+import type { FetchModulesAction } from '../types'
 
 const mapActionToRequest: ActionToRequestMapper<FetchModulesAction> = action => ({
   method: GET,
   path: Constants.MODULES_PATH,
 })
 
-const mapResponseToAction: ResponseToActionMapper<
-  FetchModulesAction,
-  FetchModulesDoneAction
-> = (response, originalAction) => {
+const mapResponseToAction: ResponseToActionMapper<FetchModulesAction> = (
+  response,
+  originalAction
+) => {
   const { host, body, ...responseMeta } = response
   const meta = { ...originalAction.meta, response: responseMeta }
 
@@ -33,10 +33,7 @@ const mapResponseToAction: ResponseToActionMapper<
     : Actions.fetchModulesFailure(host.name, body, meta)
 }
 
-export const fetchModulesEpic: StrictEpic<FetchModulesDoneAction> = (
-  action$,
-  state$
-) => {
+export const fetchModulesEpic: Epic = (action$, state$) => {
   return action$.pipe(
     ofType(Constants.FETCH_MODULES),
     mapToRobotApiRequest(

--- a/app/src/modules/epic/pollModulesWhileConnectedEpic.js
+++ b/app/src/modules/epic/pollModulesWhileConnectedEpic.js
@@ -12,16 +12,12 @@ import {
 import { getConnectedRobotName } from '../../robot/selectors'
 import { fetchModules } from '../actions'
 
-import * as Types from '../types'
-import type { StrictEpic } from '../../types'
+import type { Epic } from '../../types'
 import type { ConnectResponseAction } from '../../robot/actions'
 
 const POLL_MODULE_INTERVAL_MS = 5000
 
-export const pollModulesWhileConnectedEpic: StrictEpic<Types.FetchModulesAction> = (
-  action$,
-  state$
-) => {
+export const pollModulesWhileConnectedEpic: Epic = (action$, state$) => {
   return action$.pipe(
     ofType('robot:CONNECT_RESPONSE'),
     filter<ConnectResponseAction>(action => !action.payload?.error),

--- a/app/src/modules/epic/sendModuleCommandEpic.js
+++ b/app/src/modules/epic/sendModuleCommandEpic.js
@@ -7,17 +7,14 @@ import { mapToRobotApiRequest } from '../../robot-api/operators'
 import * as Actions from '../actions'
 import * as Constants from '../constants'
 
-import type { StrictEpic } from '../../types'
+import type { Epic } from '../../types'
 
 import type {
   ActionToRequestMapper,
   ResponseToActionMapper,
 } from '../../robot-api/operators'
 
-import type {
-  SendModuleCommandAction,
-  SendModuleCommandDoneAction,
-} from '../types'
+import type { SendModuleCommandAction } from '../types'
 
 const mapActionToRequest: ActionToRequestMapper<SendModuleCommandAction> = action => ({
   method: POST,
@@ -28,10 +25,10 @@ const mapActionToRequest: ActionToRequestMapper<SendModuleCommandAction> = actio
   },
 })
 
-const mapResponseToAction: ResponseToActionMapper<
-  SendModuleCommandAction,
-  SendModuleCommandDoneAction
-> = (response, originalAction) => {
+const mapResponseToAction: ResponseToActionMapper<SendModuleCommandAction> = (
+  response,
+  originalAction
+) => {
   const { host, body, ...responseMeta } = response
   const { moduleId, command } = originalAction.payload
   const meta = { ...originalAction.meta, response: responseMeta }
@@ -47,10 +44,7 @@ const mapResponseToAction: ResponseToActionMapper<
     : Actions.sendModuleCommandFailure(host.name, moduleId, command, body, meta)
 }
 
-export const sendModuleCommandEpic: StrictEpic<SendModuleCommandDoneAction> = (
-  action$,
-  state$
-) => {
+export const sendModuleCommandEpic: Epic = (action$, state$) => {
   return action$.pipe(
     ofType(Constants.SEND_MODULE_COMMAND),
     mapToRobotApiRequest(

--- a/app/src/modules/epic/updateModuleEpic.js
+++ b/app/src/modules/epic/updateModuleEpic.js
@@ -7,24 +7,24 @@ import { mapToRobotApiRequest } from '../../robot-api/operators'
 import * as Actions from '../actions'
 import * as Constants from '../constants'
 
-import type { StrictEpic } from '../../types'
+import type { Epic } from '../../types'
 
 import type {
   ActionToRequestMapper,
   ResponseToActionMapper,
 } from '../../robot-api/operators'
 
-import type { UpdateModuleAction, UpdateModuleDoneAction } from '../types'
+import type { UpdateModuleAction } from '../types'
 
 const mapActionToRequest: ActionToRequestMapper<UpdateModuleAction> = action => ({
   method: POST,
   path: `${Constants.MODULES_PATH}/${action.payload.moduleId}/${Constants.MODULE_UPDATE_PATH_EXT}`,
 })
 
-const mapResponseToAction: ResponseToActionMapper<
-  UpdateModuleAction,
-  UpdateModuleDoneAction
-> = (response, originalAction) => {
+const mapResponseToAction: ResponseToActionMapper<UpdateModuleAction> = (
+  response,
+  originalAction
+) => {
   const { host, body, ...responseMeta } = response
   const { moduleId } = originalAction.payload
   const meta = { ...originalAction.meta, response: responseMeta }
@@ -34,10 +34,7 @@ const mapResponseToAction: ResponseToActionMapper<
     : Actions.updateModuleFailure(host.name, moduleId, body, meta)
 }
 
-export const updateModuleEpic: StrictEpic<UpdateModuleDoneAction> = (
-  action$,
-  state$
-) => {
+export const updateModuleEpic: Epic = (action$, state$) => {
   return action$.pipe(
     ofType(Constants.UPDATE_MODULE),
     mapToRobotApiRequest(

--- a/app/src/modules/types.js
+++ b/app/src/modules/types.js
@@ -110,10 +110,6 @@ export type FetchModulesFailureAction = {|
   meta: RobotApiRequestMeta,
 |}
 
-export type FetchModulesDoneAction =
-  | FetchModulesSuccessAction
-  | FetchModulesFailureAction
-
 // fetch module data
 
 export type SendModuleCommandAction = {|
@@ -149,10 +145,6 @@ export type SendModuleCommandFailureAction = {|
   meta: RobotApiRequestMeta,
 |}
 
-export type SendModuleCommandDoneAction =
-  | SendModuleCommandSuccessAction
-  | SendModuleCommandFailureAction
-
 // fetch modules
 
 export type UpdateModuleAction = {|
@@ -180,10 +172,6 @@ export type UpdateModuleFailureAction = {|
   |},
   meta: RobotApiRequestMeta,
 |}
-
-export type UpdateModuleDoneAction =
-  | UpdateModuleSuccessAction
-  | UpdateModuleFailureAction
 
 // action union
 

--- a/app/src/networking/epic/index.js
+++ b/app/src/networking/epic/index.js
@@ -3,6 +3,6 @@ import { combineEpics } from 'redux-observable'
 
 import { statusEpic } from './statusEpic'
 
-import type { StrictEpic } from '../../types'
+import type { Epic } from '../../types'
 
-export const networkingEpic: StrictEpic<> = combineEpics(statusEpic)
+export const networkingEpic: Epic = combineEpics(statusEpic)

--- a/app/src/networking/epic/statusEpic.js
+++ b/app/src/networking/epic/statusEpic.js
@@ -10,7 +10,7 @@ import type {
   ActionToRequestMapper,
   ResponseToActionMapper,
 } from '../../robot-api/operators'
-import type { Action, StrictEpic } from '../../types'
+import type { Epic } from '../../types'
 import type { FetchStatusAction } from '../types'
 
 const mapActionToRequest: ActionToRequestMapper<FetchStatusAction> = action => ({
@@ -18,7 +18,7 @@ const mapActionToRequest: ActionToRequestMapper<FetchStatusAction> = action => (
   path: Constants.STATUS_PATH,
 })
 
-const mapResponseToAction: ResponseToActionMapper<FetchStatusAction, Action> = (
+const mapResponseToAction: ResponseToActionMapper<FetchStatusAction> = (
   response,
   originalAction
 ) => {
@@ -30,7 +30,7 @@ const mapResponseToAction: ResponseToActionMapper<FetchStatusAction, Action> = (
     : Actions.fetchStatusFailure(host.name, body, meta)
 }
 
-export const statusEpic: StrictEpic<> = (action$, state$) => {
+export const statusEpic: Epic = (action$, state$) => {
   return action$.pipe(
     ofType(Constants.FETCH_STATUS),
     mapToRobotApiRequest(

--- a/app/src/pipettes/epic/fetchPipetteSettingsEpic.js
+++ b/app/src/pipettes/epic/fetchPipetteSettingsEpic.js
@@ -7,27 +7,24 @@ import { mapToRobotApiRequest } from '../../robot-api/operators'
 import * as Actions from '../actions'
 import * as Constants from '../constants'
 
-import type { StrictEpic } from '../../types'
+import type { Epic } from '../../types'
 
 import type {
   ActionToRequestMapper,
   ResponseToActionMapper,
 } from '../../robot-api/operators'
 
-import type {
-  FetchPipetteSettingsAction,
-  FetchPipetteSettingsDoneAction,
-} from '../types'
+import type { FetchPipetteSettingsAction } from '../types'
 
 const mapActionToRequest: ActionToRequestMapper<FetchPipetteSettingsAction> = action => ({
   method: GET,
   path: Constants.PIPETTE_SETTINGS_PATH,
 })
 
-const mapResponseToAction: ResponseToActionMapper<
-  FetchPipetteSettingsAction,
-  FetchPipetteSettingsDoneAction
-> = (response, originalAction) => {
+const mapResponseToAction: ResponseToActionMapper<FetchPipetteSettingsAction> = (
+  response,
+  originalAction
+) => {
   const { host, body, ...responseMeta } = response
   const meta = { ...originalAction.meta, response: responseMeta }
 
@@ -36,10 +33,7 @@ const mapResponseToAction: ResponseToActionMapper<
     : Actions.fetchPipetteSettingsFailure(host.name, body, meta)
 }
 
-export const fetchPipetteSettingsEpic: StrictEpic<FetchPipetteSettingsDoneAction> = (
-  action$,
-  state$
-) => {
+export const fetchPipetteSettingsEpic: Epic = (action$, state$) => {
   return action$.pipe(
     ofType(Constants.FETCH_PIPETTE_SETTINGS),
     mapToRobotApiRequest(

--- a/app/src/pipettes/epic/fetchPipettesEpic.js
+++ b/app/src/pipettes/epic/fetchPipettesEpic.js
@@ -7,14 +7,14 @@ import { mapToRobotApiRequest } from '../../robot-api/operators'
 import * as Actions from '../actions'
 import * as Constants from '../constants'
 
-import type { StrictEpic } from '../../types'
+import type { Epic } from '../../types'
 
 import type {
   ActionToRequestMapper,
   ResponseToActionMapper,
 } from '../../robot-api/operators'
 
-import type { FetchPipettesAction, FetchPipettesDoneAction } from '../types'
+import type { FetchPipettesAction } from '../types'
 
 const mapActionToRequest: ActionToRequestMapper<FetchPipettesAction> = action => ({
   method: GET,
@@ -22,10 +22,10 @@ const mapActionToRequest: ActionToRequestMapper<FetchPipettesAction> = action =>
   query: action.payload.refresh ? { refresh: true } : {},
 })
 
-const mapResponseToAction: ResponseToActionMapper<
-  FetchPipettesAction,
-  FetchPipettesDoneAction
-> = (response, originalAction) => {
+const mapResponseToAction: ResponseToActionMapper<FetchPipettesAction> = (
+  response,
+  originalAction
+) => {
   const { host, body, ...responseMeta } = response
   const meta = { ...originalAction.meta, response: responseMeta }
 
@@ -34,10 +34,7 @@ const mapResponseToAction: ResponseToActionMapper<
     : Actions.fetchPipettesFailure(host.name, body, meta)
 }
 
-export const fetchPipettesEpic: StrictEpic<FetchPipettesDoneAction> = (
-  action$,
-  state$
-) => {
+export const fetchPipettesEpic: Epic = (action$, state$) => {
   return action$.pipe(
     ofType(Constants.FETCH_PIPETTES),
     mapToRobotApiRequest(

--- a/app/src/pipettes/epic/fetchPipettesOnConnectEpic.js
+++ b/app/src/pipettes/epic/fetchPipettesOnConnectEpic.js
@@ -6,12 +6,9 @@ import { ofType } from 'redux-observable'
 import { getConnectedRobotName } from '../../robot/selectors'
 import * as Actions from '../actions'
 
-import type { StrictEpic } from '../../types'
-import type { FetchPipettesAction, FetchPipetteSettingsAction } from '../types'
+import type { Epic } from '../../types'
 
-export const fetchPipettesOnConnectEpic: StrictEpic<
-  FetchPipettesAction | FetchPipetteSettingsAction
-> = (action$, state$) => {
+export const fetchPipettesOnConnectEpic: Epic = (action$, state$) => {
   return action$.pipe(
     ofType('robot:CONNECT_RESPONSE'),
     withLatestFrom(state$, (a, s) => [a, getConnectedRobotName(s)]),

--- a/app/src/pipettes/epic/updatePipetteSettingsEpic.js
+++ b/app/src/pipettes/epic/updatePipetteSettingsEpic.js
@@ -8,17 +8,14 @@ import { mapToRobotApiRequest } from '../../robot-api/operators'
 import * as Actions from '../actions'
 import * as Constants from '../constants'
 
-import type { StrictEpic } from '../../types'
+import type { Epic } from '../../types'
 
 import type {
   ActionToRequestMapper,
   ResponseToActionMapper,
 } from '../../robot-api/operators'
 
-import type {
-  UpdatePipetteSettingsAction,
-  UpdatePipetteSettingsDoneAction,
-} from '../types'
+import type { UpdatePipetteSettingsAction } from '../types'
 
 const mapActionToRequest: ActionToRequestMapper<UpdatePipetteSettingsAction> = action => ({
   method: PATCH,
@@ -30,10 +27,10 @@ const mapActionToRequest: ActionToRequestMapper<UpdatePipetteSettingsAction> = a
   },
 })
 
-const mapResponseToAction: ResponseToActionMapper<
-  UpdatePipetteSettingsAction,
-  UpdatePipetteSettingsDoneAction
-> = (response, originalAction) => {
+const mapResponseToAction: ResponseToActionMapper<UpdatePipetteSettingsAction> = (
+  response,
+  originalAction
+) => {
   const { host, body, ...responseMeta } = response
   const { pipetteId } = originalAction.payload
   const meta = { ...originalAction.meta, response: responseMeta }
@@ -48,10 +45,7 @@ const mapResponseToAction: ResponseToActionMapper<
     : Actions.updatePipetteSettingsFailure(host.name, pipetteId, body, meta)
 }
 
-export const updatePipetteSettingsEpic: StrictEpic<UpdatePipetteSettingsDoneAction> = (
-  action$,
-  state$
-) => {
+export const updatePipetteSettingsEpic: Epic = (action$, state$) => {
   return action$.pipe(
     ofType(Constants.UPDATE_PIPETTE_SETTINGS),
     mapToRobotApiRequest(

--- a/app/src/pipettes/types.js
+++ b/app/src/pipettes/types.js
@@ -175,18 +175,6 @@ export type UpdatePipetteSettingsFailureAction = {|
 
 // pipette actions unions
 
-export type FetchPipettesDoneAction =
-  | FetchPipettesSuccessAction
-  | FetchPipettesFailureAction
-
-export type FetchPipetteSettingsDoneAction =
-  | FetchPipetteSettingsSuccessAction
-  | FetchPipetteSettingsFailureAction
-
-export type UpdatePipetteSettingsDoneAction =
-  | UpdatePipetteSettingsSuccessAction
-  | UpdatePipetteSettingsFailureAction
-
 export type PipettesAction =
   | FetchPipettesAction
   | FetchPipettesSuccessAction

--- a/app/src/robot-admin/epic/fetchResetOptionsEpic.js
+++ b/app/src/robot-admin/epic/fetchResetOptionsEpic.js
@@ -5,25 +5,25 @@ import { GET } from '../../robot-api/constants'
 import { mapToRobotApiRequest } from '../../robot-api/operators'
 import * as Constants from '../constants'
 import * as Actions from '../actions'
-import * as Types from '../types'
 
-import type { StrictEpic } from '../../types'
+import type { Epic } from '../../types'
 import type {
   ActionToRequestMapper,
   ResponseToActionMapper,
 } from '../../robot-api/operators'
+import type { FetchResetConfigOptionsAction, ResetConfigOption } from '../types'
 
-const mapActionToRequest: ActionToRequestMapper<Types.FetchResetConfigOptionsAction> = action => ({
+const mapActionToRequest: ActionToRequestMapper<FetchResetConfigOptionsAction> = action => ({
   method: GET,
   path: Constants.RESET_CONFIG_OPTIONS_PATH,
 })
 
-const mapResponseToAction: ResponseToActionMapper<
-  Types.FetchResetConfigOptionsAction,
-  Types.FetchResetConfigOptionsDoneAction
-> = (response, originalAction) => {
+const mapResponseToAction: ResponseToActionMapper<FetchResetConfigOptionsAction> = (
+  response,
+  originalAction
+) => {
   const { host, body, ...responseMeta } = response
-  const options: Array<Types.ResetConfigOption> = body.options
+  const options: Array<ResetConfigOption> = body.options
   const meta = { ...originalAction.meta, response: responseMeta }
 
   return response.ok
@@ -31,10 +31,7 @@ const mapResponseToAction: ResponseToActionMapper<
     : Actions.fetchResetConfigOptionsFailure(host.name, body, meta)
 }
 
-export const fetchResetOptionsEpic: StrictEpic<Types.FetchResetConfigOptionsDoneAction> = (
-  action$,
-  state$
-) => {
+export const fetchResetOptionsEpic: Epic = (action$, state$) => {
   return action$.pipe(
     ofType(Constants.FETCH_RESET_CONFIG_OPTIONS),
     mapToRobotApiRequest(

--- a/app/src/robot-admin/epic/resetConfigEpic.js
+++ b/app/src/robot-admin/epic/resetConfigEpic.js
@@ -6,24 +6,24 @@ import { POST } from '../../robot-api/constants'
 import { mapToRobotApiRequest } from '../../robot-api/operators'
 import * as Constants from '../constants'
 import * as Actions from '../actions'
-import * as Types from '../types'
 
-import type { StrictEpic } from '../../types'
+import type { Epic } from '../../types'
 import type {
   ActionToRequestMapper,
   ResponseToActionMapper,
 } from '../../robot-api/operators'
+import type { ResetConfigAction } from '../types'
 
-const mapActionToRequest: ActionToRequestMapper<Types.ResetConfigAction> = action => ({
+const mapActionToRequest: ActionToRequestMapper<ResetConfigAction> = action => ({
   method: POST,
   path: Constants.RESET_CONFIG_PATH,
   body: action.payload.resets,
 })
 
-const mapResponseToAction: ResponseToActionMapper<
-  Types.ResetConfigAction,
-  Types.ResetConfigDoneAction
-> = (response, originalAction) => {
+const mapResponseToAction: ResponseToActionMapper<ResetConfigAction> = (
+  response,
+  originalAction
+) => {
   const { host, body, ...responseMeta } = response
   const meta = { ...originalAction.meta, response: responseMeta }
 
@@ -32,10 +32,7 @@ const mapResponseToAction: ResponseToActionMapper<
     : Actions.resetConfigFailure(host.name, body, meta)
 }
 
-export const resetConfigEpic: StrictEpic<Types.ResetConfigDoneAction> = (
-  action$,
-  state$
-) => {
+export const resetConfigEpic: Epic = (action$, state$) => {
   return action$.pipe(
     ofType(Constants.RESET_CONFIG),
     mapToRobotApiRequest(
@@ -47,10 +44,10 @@ export const resetConfigEpic: StrictEpic<Types.ResetConfigDoneAction> = (
   )
 }
 
-export const restartOnResetConfigEpic: StrictEpic<Types.RestartRobotAction> = action$ => {
+export const restartOnResetConfigEpic: Epic = action$ => {
   return action$.pipe(
     ofType(Constants.RESET_CONFIG_SUCCESS),
-    map<Types.ResetConfigAction, Types.RestartRobotAction>(a => {
+    map<ResetConfigAction, _>(a => {
       return Actions.restartRobot(a.payload.robotName)
     })
   )

--- a/app/src/robot-admin/epic/restartEpic.js
+++ b/app/src/robot-admin/epic/restartEpic.js
@@ -8,18 +8,17 @@ import { getRobotRestartPath } from '../../robot-settings'
 import { startDiscovery } from '../../discovery'
 import * as Constants from '../constants'
 import * as Actions from '../actions'
-import * as Types from '../types'
 
-import type { StrictEpic } from '../../types'
-import type { StartDiscoveryAction } from '../../discovery/types'
+import type { Epic } from '../../types'
 import type {
   ActionToRequestMapper,
   ResponseToActionMapper,
 } from '../../robot-api/operators'
+import type { RestartRobotAction } from '../types'
 
 const RESTART_DISCOVERY_TIMEOUT_MS = 60000
 
-const mapActionToRequest: ActionToRequestMapper<Types.RestartRobotAction> = (
+const mapActionToRequest: ActionToRequestMapper<RestartRobotAction> = (
   action,
   state
 ) => {
@@ -30,10 +29,10 @@ const mapActionToRequest: ActionToRequestMapper<Types.RestartRobotAction> = (
   return { method: POST, path }
 }
 
-const mapResponseToAction: ResponseToActionMapper<
-  Types.RestartRobotAction,
-  Types.RestartRobotDoneAction
-> = (response, originalAction) => {
+const mapResponseToAction: ResponseToActionMapper<RestartRobotAction> = (
+  response,
+  originalAction
+) => {
   const { host, body, ...responseMeta } = response
   const { robot: _, ...prevMeta } = originalAction.meta
   const meta = { ...prevMeta, response: responseMeta }
@@ -43,10 +42,7 @@ const mapResponseToAction: ResponseToActionMapper<
     : Actions.restartRobotFailure(host.name, body, meta)
 }
 
-export const restartEpic: StrictEpic<Types.RestartRobotDoneAction> = (
-  action$,
-  state$
-) => {
+export const restartEpic: Epic = (action$, state$) => {
   return action$.pipe(
     ofType(Constants.RESTART),
     mapToRobotApiRequest(
@@ -58,7 +54,7 @@ export const restartEpic: StrictEpic<Types.RestartRobotDoneAction> = (
   )
 }
 
-export const startDiscoveryOnRestartEpic: StrictEpic<StartDiscoveryAction> = action$ => {
+export const startDiscoveryOnRestartEpic: Epic = action$ => {
   return action$.pipe(
     ofType(Constants.RESTART_SUCCESS),
     mapTo(startDiscovery(RESTART_DISCOVERY_TIMEOUT_MS))

--- a/app/src/robot-admin/types.js
+++ b/app/src/robot-admin/types.js
@@ -40,10 +40,6 @@ export type RestartRobotFailureAction = {|
   meta: RobotApiRequestMeta,
 |}
 
-export type RestartRobotDoneAction =
-  | RestartRobotSuccessAction
-  | RestartRobotFailureAction
-
 export type FetchResetConfigOptionsAction = {|
   type: 'robotAdmin:FETCH_RESET_CONFIG_OPTIONS',
   payload: {| robotName: string |},
@@ -62,10 +58,6 @@ export type FetchResetConfigOptionsFailureAction = {|
   meta: RobotApiRequestMeta,
 |}
 
-export type FetchResetConfigOptionsDoneAction =
-  | FetchResetConfigOptionsSuccessAction
-  | FetchResetConfigOptionsFailureAction
-
 export type ResetConfigAction = {|
   type: 'robotAdmin:RESET_CONFIG',
   payload: {| robotName: string, resets: ResetConfigRequest |},
@@ -83,10 +75,6 @@ export type ResetConfigFailureAction = {|
   payload: {| robotName: string, error: {} |},
   meta: RobotApiRequestMeta,
 |}
-
-export type ResetConfigDoneAction =
-  | ResetConfigSuccessAction
-  | ResetConfigFailureAction
 
 export type RobotAdminAction =
   | RestartRobotAction

--- a/app/src/robot-api/operators.js
+++ b/app/src/robot-api/operators.js
@@ -7,18 +7,18 @@ import { fetchRobotApi } from './http'
 import * as Types from './types'
 
 import type { Observable } from 'rxjs'
-import type { State } from '../types'
+import type { State, Action } from '../types'
 
-export type ActionToRequestMapper<A> = (
-  A,
+export type ActionToRequestMapper<TriggerAction> = (
+  TriggerAction,
   State
 ) => Types.RobotApiRequestOptions
 
-export type ResponseToActionMapper<A, B> = (
+export type ResponseToActionMapper<TriggerAction> = (
   Types.RobotApiResponse,
-  A,
+  TriggerAction,
   State
-) => B
+) => Action
 
 export function withRobotHost<A>(
   state$: Observable<State>,
@@ -34,12 +34,12 @@ export function withRobotHost<A>(
   )
 }
 
-export function mapToRobotApiRequest<A, B>(
+export function mapToRobotApiRequest<A>(
   state$: Observable<State>,
   getRobotName: A => string,
   mapActionToRequest: ActionToRequestMapper<A>,
-  mapResponseToAction: ResponseToActionMapper<A, B>
-): rxjs$OperatorFunction<A, B> {
+  mapResponseToAction: ResponseToActionMapper<A>
+): rxjs$OperatorFunction<A, Action> {
   return pipe(
     withRobotHost(state$, getRobotName),
     map(([a, s, host]) => [host, mapActionToRequest(a, s), a]),

--- a/app/src/robot-controls/epic/fetchLightsEpic.js
+++ b/app/src/robot-controls/epic/fetchLightsEpic.js
@@ -7,24 +7,24 @@ import { mapToRobotApiRequest } from '../../robot-api/operators'
 import * as Actions from '../actions'
 import * as Constants from '../constants'
 
-import type { StrictEpic } from '../../types'
+import type { Epic } from '../../types'
 
 import type {
   ActionToRequestMapper,
   ResponseToActionMapper,
 } from '../../robot-api/operators'
 
-import type { FetchLightsAction, FetchLightsDoneAction } from '../types'
+import type { FetchLightsAction } from '../types'
 
 const mapActionToRequest: ActionToRequestMapper<FetchLightsAction> = () => ({
   method: GET,
   path: Constants.LIGHTS_PATH,
 })
 
-const mapResponseToAction: ResponseToActionMapper<
-  FetchLightsAction,
-  FetchLightsDoneAction
-> = (response, originalAction) => {
+const mapResponseToAction: ResponseToActionMapper<FetchLightsAction> = (
+  response,
+  originalAction
+) => {
   const { host, body, ...responseMeta } = response
   const meta = { ...originalAction.meta, response: responseMeta }
 
@@ -33,10 +33,7 @@ const mapResponseToAction: ResponseToActionMapper<
     : Actions.fetchLightsFailure(host.name, body, meta)
 }
 
-export const fetchLightsEpic: StrictEpic<FetchLightsDoneAction> = (
-  action$,
-  state$
-) => {
+export const fetchLightsEpic: Epic = (action$, state$) => {
   return action$.pipe(
     ofType(Constants.FETCH_LIGHTS),
     mapToRobotApiRequest(

--- a/app/src/robot-controls/epic/homeEpic.js
+++ b/app/src/robot-controls/epic/homeEpic.js
@@ -7,14 +7,14 @@ import { mapToRobotApiRequest } from '../../robot-api/operators'
 import * as Actions from '../actions'
 import * as Constants from '../constants'
 
-import type { StrictEpic } from '../../types'
+import type { Epic } from '../../types'
 
 import type {
   ActionToRequestMapper,
   ResponseToActionMapper,
 } from '../../robot-api/operators'
 
-import type { HomeAction, HomeDoneAction } from '../types'
+import type { HomeAction } from '../types'
 
 const mapActionToRequest: ActionToRequestMapper<HomeAction> = action => ({
   method: POST,
@@ -25,10 +25,10 @@ const mapActionToRequest: ActionToRequestMapper<HomeAction> = action => ({
       : { target: Constants.PIPETTE, mount: action.payload.mount },
 })
 
-const mapResponseToAction: ResponseToActionMapper<
-  HomeAction,
-  HomeDoneAction
-> = (response, originalAction) => {
+const mapResponseToAction: ResponseToActionMapper<HomeAction> = (
+  response,
+  originalAction
+) => {
   const { host, body, ...responseMeta } = response
   const meta = { ...originalAction.meta, response: responseMeta }
 
@@ -37,7 +37,7 @@ const mapResponseToAction: ResponseToActionMapper<
     : Actions.homeFailure(host.name, body, meta)
 }
 
-export const homeEpic: StrictEpic<HomeDoneAction> = (action$, state$) => {
+export const homeEpic: Epic = (action$, state$) => {
   return action$.pipe(
     ofType(Constants.HOME),
     mapToRobotApiRequest(

--- a/app/src/robot-controls/epic/moveEpic.js
+++ b/app/src/robot-controls/epic/moveEpic.js
@@ -10,13 +10,13 @@ import { getAttachedPipettes } from '../../pipettes'
 import * as Actions from '../actions'
 import * as Constants from '../constants'
 
-import type { State, StrictEpic } from '../../types'
+import type { State, Action, Epic } from '../../types'
 import type {
   RobotApiRequestOptions,
   RobotApiResponse,
 } from '../../robot-api/types'
 
-import type { MoveAction, MoveDoneAction, PositionsResponse } from '../types'
+import type { MoveAction, PositionsResponse } from '../types'
 
 const mapActionToRequest = (
   action: MoveAction,
@@ -46,7 +46,7 @@ const mapActionToRequest = (
 const mapResponseToAction = (
   response: RobotApiResponse,
   originalAction: MoveAction
-): MoveDoneAction => {
+): Action => {
   const { host, body, ...responseMeta } = response
   const meta = { ...originalAction.meta, response: responseMeta }
 
@@ -67,7 +67,7 @@ const disengageMotorsRequest = {
 // 1. Call GET /robot/positions
 // 2. Call POST /robot/move with result of GET /robot/positions
 // 3. Call POST /motors/disengage if we need to
-export const moveEpic: StrictEpic<MoveDoneAction> = (action$, state$) => {
+export const moveEpic: Epic = (action$, state$) => {
   return action$.pipe(
     ofType(Constants.MOVE),
     withRobotHost(state$, a => a.payload.robotName),

--- a/app/src/robot-controls/epic/updateLightsEpic.js
+++ b/app/src/robot-controls/epic/updateLightsEpic.js
@@ -7,14 +7,14 @@ import { mapToRobotApiRequest } from '../../robot-api/operators'
 import * as Actions from '../actions'
 import * as Constants from '../constants'
 
-import type { StrictEpic } from '../../types'
+import type { Epic } from '../../types'
 
 import type {
   ActionToRequestMapper,
   ResponseToActionMapper,
 } from '../../robot-api/operators'
 
-import type { UpdateLightsAction, UpdateLightsDoneAction } from '../types'
+import type { UpdateLightsAction } from '../types'
 
 const mapActionToRequest: ActionToRequestMapper<UpdateLightsAction> = action => ({
   method: POST,
@@ -22,10 +22,10 @@ const mapActionToRequest: ActionToRequestMapper<UpdateLightsAction> = action => 
   body: { on: action.payload.lightsOn },
 })
 
-const mapResponseToAction: ResponseToActionMapper<
-  UpdateLightsAction,
-  UpdateLightsDoneAction
-> = (response, originalAction) => {
+const mapResponseToAction: ResponseToActionMapper<UpdateLightsAction> = (
+  response,
+  originalAction
+) => {
   const { host, body, ...responseMeta } = response
   const meta = { ...originalAction.meta, response: responseMeta }
 
@@ -34,10 +34,7 @@ const mapResponseToAction: ResponseToActionMapper<
     : Actions.updateLightsFailure(host.name, body, meta)
 }
 
-export const updateLightsEpic: StrictEpic<UpdateLightsDoneAction> = (
-  action$,
-  state$
-) => {
+export const updateLightsEpic: Epic = (action$, state$) => {
   return action$.pipe(
     ofType(Constants.UPDATE_LIGHTS),
     mapToRobotApiRequest(

--- a/app/src/robot-controls/types.js
+++ b/app/src/robot-controls/types.js
@@ -44,10 +44,6 @@ export type FetchLightsFailureAction = {|
   meta: RobotApiRequestMeta,
 |}
 
-export type FetchLightsDoneAction =
-  | FetchLightsSuccessAction
-  | FetchLightsFailureAction
-
 // update lights
 
 export type UpdateLightsAction = {|
@@ -67,10 +63,6 @@ export type UpdateLightsFailureAction = {|
   payload: {| robotName: string, error: {| message: string |} |},
   meta: RobotApiRequestMeta,
 |}
-
-export type UpdateLightsDoneAction =
-  | UpdateLightsSuccessAction
-  | UpdateLightsFailureAction
 
 // home
 
@@ -93,8 +85,6 @@ export type HomeFailureAction = {|
   payload: {| robotName: string, error: {| message: string |} |},
   meta: RobotApiRequestMeta,
 |}
-
-export type HomeDoneAction = HomeSuccessAction | HomeFailureAction
 
 // move
 
@@ -120,8 +110,6 @@ export type MoveFailureAction = {|
   payload: {| robotName: string, error: {| message: string |} |},
   meta: RobotApiRequestMeta,
 |}
-
-export type MoveDoneAction = MoveSuccessAction | MoveFailureAction
 
 // clear homing and movement status and error
 

--- a/app/src/robot-settings/epic/clearRestartPathEpic.js
+++ b/app/src/robot-settings/epic/clearRestartPathEpic.js
@@ -5,13 +5,9 @@ import { getRobotAdminStatus, RESTARTING_STATUS } from '../../robot-admin'
 import { clearRestartPath } from '../actions'
 import { getAllRestartRequiredRobots } from '../selectors'
 
-import type { StrictEpic } from '../../types'
-import type { ClearRestartPathAction } from '../types'
+import type { Epic } from '../../types'
 
-export const clearRestartPathEpic: StrictEpic<ClearRestartPathAction> = (
-  action$,
-  state$
-) => {
+export const clearRestartPathEpic: Epic = (action$, state$) => {
   return state$.pipe(
     map(state => {
       return getAllRestartRequiredRobots(state)

--- a/app/src/robot-settings/epic/fetchSettingsEpic.js
+++ b/app/src/robot-settings/epic/fetchSettingsEpic.js
@@ -7,24 +7,24 @@ import { mapToRobotApiRequest } from '../../robot-api/operators'
 import * as Actions from '../actions'
 import * as Constants from '../constants'
 
-import type { StrictEpic } from '../../types'
+import type { Epic } from '../../types'
 
 import type {
   ActionToRequestMapper,
   ResponseToActionMapper,
 } from '../../robot-api/operators'
 
-import type { FetchSettingsAction, FetchSettingsDoneAction } from '../types'
+import type { FetchSettingsAction } from '../types'
 
 const mapActionToRequest: ActionToRequestMapper<FetchSettingsAction> = () => ({
   method: GET,
   path: Constants.SETTINGS_PATH,
 })
 
-const mapResponseToAction: ResponseToActionMapper<
-  FetchSettingsAction,
-  FetchSettingsDoneAction
-> = (response, originalAction) => {
+const mapResponseToAction: ResponseToActionMapper<FetchSettingsAction> = (
+  response,
+  originalAction
+) => {
   const { host, body, ...responseMeta } = response
   const meta = { ...originalAction.meta, response: responseMeta }
 
@@ -38,10 +38,7 @@ const mapResponseToAction: ResponseToActionMapper<
     : Actions.fetchSettingsFailure(host.name, body, meta)
 }
 
-export const fetchSettingsEpic: StrictEpic<FetchSettingsDoneAction> = (
-  action$,
-  state$
-) => {
+export const fetchSettingsEpic: Epic = (action$, state$) => {
   return action$.pipe(
     ofType(Constants.FETCH_SETTINGS),
     mapToRobotApiRequest(

--- a/app/src/robot-settings/epic/updateSettingEpic.js
+++ b/app/src/robot-settings/epic/updateSettingEpic.js
@@ -7,14 +7,14 @@ import { mapToRobotApiRequest } from '../../robot-api/operators'
 import * as Actions from '../actions'
 import * as Constants from '../constants'
 
-import type { StrictEpic } from '../../types'
+import type { Epic } from '../../types'
 
 import type {
   ActionToRequestMapper,
   ResponseToActionMapper,
 } from '../../robot-api/operators'
 
-import type { UpdateSettingAction, UpdateSettingDoneAction } from '../types'
+import type { UpdateSettingAction } from '../types'
 
 const mapActionToRequest: ActionToRequestMapper<UpdateSettingAction> = action => ({
   method: POST,
@@ -22,10 +22,10 @@ const mapActionToRequest: ActionToRequestMapper<UpdateSettingAction> = action =>
   body: { id: action.payload.settingId, value: action.payload.value },
 })
 
-const mapResponseToAction: ResponseToActionMapper<
-  UpdateSettingAction,
-  UpdateSettingDoneAction
-> = (response, originalAction) => {
+const mapResponseToAction: ResponseToActionMapper<UpdateSettingAction> = (
+  response,
+  originalAction
+) => {
   const { host, body, ...responseMeta } = response
   const meta = { ...originalAction.meta, response: responseMeta }
 
@@ -39,10 +39,7 @@ const mapResponseToAction: ResponseToActionMapper<
     : Actions.updateSettingFailure(host.name, body, meta)
 }
 
-export const updateSettingEpic: StrictEpic<UpdateSettingDoneAction> = (
-  action$,
-  state$
-) => {
+export const updateSettingEpic: Epic = (action$, state$) => {
   return action$.pipe(
     ofType(Constants.UPDATE_SETTING),
     mapToRobotApiRequest(

--- a/app/src/robot-settings/types.js
+++ b/app/src/robot-settings/types.js
@@ -57,10 +57,6 @@ export type FetchSettingsFailureAction = {|
   meta: RobotApiRequestMeta,
 |}
 
-export type FetchSettingsDoneAction =
-  | FetchSettingsSuccessAction
-  | FetchSettingsFailureAction
-
 // update setting
 
 export type UpdateSettingAction = {|
@@ -84,10 +80,6 @@ export type UpdateSettingFailureAction = {|
   payload: {| robotName: string, error: {| message: string |} |},
   meta: RobotApiRequestMeta,
 |}
-
-export type UpdateSettingDoneAction =
-  | UpdateSettingSuccessAction
-  | UpdateSettingFailureAction
 
 // clear restart path
 

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -3,7 +3,6 @@ import functions from 'lodash/functions'
 import omit from 'lodash/omit'
 import { push } from 'connected-react-router'
 
-import { delay } from '../../util'
 import client from '../api-client/client'
 import RpcClient from '../../rpc/client'
 import { NAME, actions, constants } from '../'
@@ -18,6 +17,8 @@ import { getCustomLabwareDefinitions } from '../../custom-labware/selectors'
 jest.mock('../../rpc/client')
 jest.mock('../../protocol/selectors')
 jest.mock('../../custom-labware/selectors')
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 describe('api client', () => {
   let dispatch

--- a/app/src/shell/epic.js
+++ b/app/src/shell/epic.js
@@ -6,13 +6,13 @@ import { filter, tap, ignoreElements } from 'rxjs/operators'
 import { createLogger } from '../logger'
 import remote from './remote'
 
-import type { StrictEpic, Action } from '../types'
+import type { Epic, Action } from '../types'
 
 const { ipcRenderer } = remote
 
 const log = createLogger(__filename)
 
-const sendActionToShellEpic: StrictEpic<> = action$ =>
+const sendActionToShellEpic: Epic = action$ =>
   action$.pipe(
     filter<Action>(a => a.meta != null && a.meta.shell != null && a.meta.shell),
     tap<Action>((shellAction: Action) =>
@@ -21,7 +21,7 @@ const sendActionToShellEpic: StrictEpic<> = action$ =>
     ignoreElements()
   )
 
-const receiveActionFromShellEpic: StrictEpic<> = () =>
+const receiveActionFromShellEpic: Epic = () =>
   // IPC event listener: (IpcRendererEvent, ...args) => void
   // our action is the only argument, so pluck it out from index 1
   fromEvent<Action>(
@@ -36,7 +36,7 @@ const receiveActionFromShellEpic: StrictEpic<> = () =>
     })
   )
 
-export const shellEpic: StrictEpic<> = combineEpics(
+export const shellEpic: Epic = combineEpics(
   sendActionToShellEpic,
   receiveActionFromShellEpic
 )

--- a/app/src/types.js
+++ b/app/src/types.js
@@ -94,13 +94,9 @@ type ThunkDispatch = (thunk: ThunkAction) => ?Action
 
 type ThunkPromiseDispatch = (thunk: ThunkPromiseAction) => Promise<?Action>
 
-// DEPRECATED(mc, 2020-01-09): prefer plain Epic
-// TODO(mc, 2020-01-09): remove StrictEpic and refactor code that relies on it
-export type StrictEpic<R: Action = Action> = (
+export type Epic = (
   action$: Observable<Action>,
   state$: Observable<State>
-) => Observable<R>
-
-export type Epic = StrictEpic<>
+) => Observable<Action>
 
 export type Error = { name: string, message: string }

--- a/app/src/util.js
+++ b/app/src/util.js
@@ -1,6 +1,6 @@
 // @flow
 // utility functions
-
+// DEPRECATED(mc, 2020-01-13): do not add to nor import from this file
 import type { Action, ThunkAction, ThunkPromiseAction } from './types'
 import { createLogger } from './logger'
 
@@ -9,10 +9,6 @@ type Chainable = Action | ThunkAction | ThunkPromiseAction
 type ChainAction = Promise<?Action>
 
 const log = createLogger(__filename)
-
-export function delay(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms))
-}
 
 // dispatch a chain of actions or thunk actions until an error occurs
 // error means: error in action, error in payload, or promise rejection


### PR DESCRIPTION
## overview

This PR is a followup to the recent app-side API client changes. In the interest of stronger type-checking and fewer things to type, this PR simplifies the app's typing of epic to a single `Epic` type of the definition:

```js
export type Epic = (
  action$: Observable<Action>,
  state$: Observable<State>
) => Observable<Action>
```

I've had this sitting on a local branch for a while, so now that module firmware updates and get /networking/status are in, now would be a good time to get this change made

## changelog

- Updated the type annotations of the app's epics to use more simple `Epic` definition

## review requests

Did not touch actual source, just type definitions, so please smoke test and make sure the code looks reasonable
