### PR TITLE
feat(api): add wifi disconnect capability

### DIFF
--- a/api/src/opentrons/server/endpoints/networking.py
+++ b/api/src/opentrons/server/endpoints/networking.py
@@ -26,15 +26,11 @@ EAP_CONFIG_SHAPE = {
 
 
 class ConfigureArgsError(Exception):
-    def __init__(self, message):
-        self.msg = message
-        super().__init__()
+    pass
 
 
 class DisconnectArgsError(Exception):
-    def __init__(self, message):
-        self.msg = message
-        super().__init__()
+    pass
 
 
 async def list_networks(request: web.Request) -> web.Response:
@@ -260,7 +256,7 @@ async def configure(request: web.Request) -> web.Response:
     try:
         configure_kwargs = _check_configure_args(body)
     except ConfigureArgsError as e:
-        return web.json_response({'message': e.msg}, status=400)
+        return web.json_response({'message': str(e)}, status=400)
 
     try:
         ok, message = await nmcli.configure(**configure_kwargs)
@@ -305,7 +301,7 @@ async def disconnect(request: web.Request) -> web.Response:
         if not ssid or not isinstance(ssid, str):
             raise DisconnectArgsError("SSID must be specified as a string")
     except DisconnectArgsError as e:
-        return web.json_response({'message': e.msg}, status=400)
+        return web.json_response({'message': str(e)}, status=400)
 
     try:
         ok, message = await nmcli.wifi_disconnect(ssid)

--- a/api/src/opentrons/server/endpoints/networking.py
+++ b/api/src/opentrons/server/endpoints/networking.py
@@ -308,9 +308,9 @@ async def disconnect(request: web.Request) -> web.Response:
         return web.json_response({'message': str(excep)}, status=400)
 
     if ok:
-        return web.json_response({'message': message}, status=201)
+        return web.json_response({'message': message}, status=200)
     else:
-        return web.json_response({'message': message}, status=401)
+        return web.json_response({'message': message}, status=400)
 
 
 async def status(request: web.Request) -> web.Response:

--- a/api/src/opentrons/server/endpoints/networking.py
+++ b/api/src/opentrons/server/endpoints/networking.py
@@ -314,12 +314,10 @@ async def disconnect(request: web.Request) -> web.Response:
 
     response = {'message': message}
     if ok:
-        if 'successfully deleted' in message:
-            return web.json_response(response, status=200)
-        else:
-            return web.json_response(response, status=207)
+        stat = 200 if 'successfully deleted' in message else 207
     else:
-        return web.json_response(response, status=500)
+        stat = 500
+    return web.json_response(response, status=stat)
 
 
 async def status(request: web.Request) -> web.Response:

--- a/api/src/opentrons/server/endpoints/networking.py
+++ b/api/src/opentrons/server/endpoints/networking.py
@@ -291,19 +291,20 @@ async def disconnect(request: web.Request) -> web.Response:
     try:
         body = await request.json()
     except json.JSONDecodeError as e:
-        log.debug("Error: JSONDecodeError in /wifi/disconnect: {}".format(e))
+        log.exception("Error: JSONDecodeError in "
+                      "/wifi/disconnect: {}".format(e))
         return web.json_response({'message': e.msg}, status=400)
 
+    ssid = body.get('ssid')
     try:
         # SSID must always be present
-        if not body.get('ssid') \
-                or not isinstance(body.get('ssid'), str):
+        if not ssid or not isinstance(ssid, str):
             raise DisconnectArgsError("SSID must be specified as a string")
     except DisconnectArgsError as e:
         return web.json_response({'message': e.msg}, status=400)
 
     try:
-        ok, message = await nmcli.wifi_disconnect(body.get('ssid'))
+        ok, message = await nmcli.wifi_disconnect(ssid)
     except Exception as excep:
         return web.json_response({'message': str(excep)}, status=400)
 

--- a/api/src/opentrons/server/http.py
+++ b/api/src/opentrons/server/http.py
@@ -28,6 +28,7 @@ class HTTPServer(object):
             '/wifi/keys/{key_uuid}', networking.remove_key)
         self.app.router.add_get(
             '/wifi/eap-options', networking.eap_options)
+        self.app.router.add_post('/wifi/disconnect', networking.disconnect)
         self.app.router.add_post(
             '/identify', control.identify)
         self.app.router.add_get(

--- a/api/src/opentrons/server/openapi.json
+++ b/api/src/opentrons/server/openapi.json
@@ -931,6 +931,88 @@
         }
       }
     },
+    "/wifi/disconnect": {
+      "post": {
+        "operationId": "disconnectWifi",
+        "tags": ["networking"],
+        "description": "Disconnect the OT-2 from WiFi network",
+        "summary": "Deactivates the wifi connection and removes it from known connections",
+        "requestBody": {
+          "description": "SSID of the network to disconnect from",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ssid": {
+                    "description": "The SSID to disconnect from.",
+                    "type": "string"
+                  }
+                }
+              },
+              "examples": {
+                "summary": "Disconnect robot from wifi network",
+                "value": {
+                  "ssid": "linksys"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The OT-2 successfully disconnected from the specified ssid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["message"],
+                  "properties": {
+                    "message": {
+                      "type": "string", "description": "A human-readable success message"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "207": {
+            "description": "The OT-2 successfully disconnected from the specified ssid but connection not deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["message"],
+                  "properties": {
+                    "message": {
+                      "type": "string", "description": "A human-readable multi-status message"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "A malformed request body of some kind",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/v1ErrorMessage" },
+                "example": {"message": "Error: JSONDecodeError in /wifi/discoonect."}
+              }
+            }
+          },
+          "500": {
+            "description": "The request body was properly formed but the OT-2 could not disconnect from the specified network, likely because the ssid was incorrect or the connection didn't exist",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/v1ErrorMessage"},
+                "example": {"message": "Error: 'linksysss' is not an active connection.\nError: no active connection provided."}
+              }
+            }
+          },
+        }
+      }
+    },
     "/wifi/keys": {
       "description": "Keyfile management for the various kinds of Wifi authentication that require private key data",
       "get": {

--- a/api/src/opentrons/server/openapi.json
+++ b/api/src/opentrons/server/openapi.json
@@ -951,9 +951,11 @@
                 }
               },
               "examples": {
-                "summary": "Disconnect robot from wifi network",
-                "value": {
-                  "ssid": "linksys"
+                "disconnectFromSsid": {
+                  "summary": "Disconnect robot from wifi network",
+                  "value": {
+                    "ssid": "linksys"
+                  }
                 }
               }
             }
@@ -1009,7 +1011,7 @@
                 "example": {"message": "Error: 'linksysss' is not an active connection.\nError: no active connection provided."}
               }
             }
-          },
+          }
         }
       }
     },

--- a/api/src/opentrons/system/nmcli.py
+++ b/api/src/opentrons/system/nmcli.py
@@ -494,7 +494,8 @@ async def configure(ssid: str,
 
 async def wifi_disconnect(ssid: str) -> Tuple[bool, str]:
     """
-    Disconnect from specified wireless network.
+    Disconnect from specified wireless network and delete the connection.
+
     Ideally, user would be allowed to disconnect a robot from wifi only over an
     ethernet connection to the robot so that, 1) they get the disconnect
     response back and 2) their robot isn't left with no connectivity at all
@@ -507,6 +508,11 @@ async def wifi_disconnect(ssid: str) -> Tuple[bool, str]:
     """
     res, err = await _call(['connection', 'down', ssid])
     if 'successfully deactivated' in res:
+        rem_ok, rem_res = await remove(ssid)
+        if rem_ok:
+            res = res + '.\n ' + rem_res
+        else:
+            res = res + '.\n Error: Could not remove ssid. ' + rem_res
         return True, res
     else:
         return False, err

--- a/api/src/opentrons/system/nmcli.py
+++ b/api/src/opentrons/system/nmcli.py
@@ -499,6 +499,15 @@ async def wifi_disconnect(ssid: str = None) -> Tuple[bool, str]:
     Returns (True, msg) if the network was disconnected from successfully,
             (False, msg) otherwise
     """
+    # Verify robot is connected via ethernet before disconnecting from wifi
+    # Warning: Users should make the disconnect request over the wired
+    #          connection. This code doesn't check for that. So the app must
+    #          make sure to check that the request is over a wired conn.
+    _res, _err = await _call(['-g', 'WIRED-PROPERTIES.CARRIER',
+                              'device', 'show', 'eth0'])
+    if 'off' in _res or _err:
+        return False, 'You should be connected to the robot via ethernet ' \
+                      'before disconnecting it from wifi network'
     res, err = await _call(['connection', 'down', ssid])
     if 'successfully deactivated' in res:
         return True, res

--- a/api/src/opentrons/system/nmcli.py
+++ b/api/src/opentrons/system/nmcli.py
@@ -492,7 +492,7 @@ async def configure(ssid: str,
         return False, err.split('\r')[-1]
 
 
-async def wifi_disconnect(ssid: str = None) -> Tuple[bool, str]:
+async def wifi_disconnect(ssid: str) -> Tuple[bool, str]:
     """
     Disconnect from specified wireless network.
     Ideally, user would be allowed to disconnect a robot from wifi only over an
@@ -505,7 +505,6 @@ async def wifi_disconnect(ssid: str = None) -> Tuple[bool, str]:
     Returns (True, msg) if the network was disconnected from successfully,
             (False, msg) otherwise
     """
-
     res, err = await _call(['connection', 'down', ssid])
     if 'successfully deactivated' in res:
         return True, res

--- a/api/src/opentrons/system/nmcli.py
+++ b/api/src/opentrons/system/nmcli.py
@@ -495,19 +495,17 @@ async def configure(ssid: str,
 async def wifi_disconnect(ssid: str = None) -> Tuple[bool, str]:
     """
     Disconnect from specified wireless network.
+    Ideally, user would be allowed to disconnect a robot from wifi only over an
+    ethernet connection to the robot so that, 1) they get the disconnect
+    response back and 2) their robot isn't left with no connectivity at all
+    However, with robot discovery (over eth0) issues still pending, we will
+    allow the users to disconnect the robot from wifi regardless of whether
+    they are connected via ethernet.
 
     Returns (True, msg) if the network was disconnected from successfully,
             (False, msg) otherwise
     """
-    # Verify robot is connected via ethernet before disconnecting from wifi
-    # Warning: Users should make the disconnect request over the wired
-    #          connection. This code doesn't check for that. So the app must
-    #          make sure to check that the request is over a wired conn.
-    _res, _err = await _call(['-g', 'WIRED-PROPERTIES.CARRIER',
-                              'device', 'show', 'eth0'])
-    if 'off' in _res or _err:
-        return False, 'You should be connected to the robot via ethernet ' \
-                      'before disconnecting it from wifi network'
+
     res, err = await _call(['connection', 'down', ssid])
     if 'successfully deactivated' in res:
         return True, res

--- a/api/src/opentrons/system/nmcli.py
+++ b/api/src/opentrons/system/nmcli.py
@@ -492,6 +492,20 @@ async def configure(ssid: str,
         return False, err.split('\r')[-1]
 
 
+async def wifi_disconnect(ssid: str = None) -> Tuple[bool, str]:
+    """
+    Disconnect from specified wireless network.
+
+    Returns (True, msg) if the network was disconnected from successfully,
+            (False, msg) otherwise
+    """
+    res, err = await _call(['connection', 'down', ssid])
+    if 'successfully deactivated' in res:
+        return True, res
+    else:
+        return False, err
+
+
 async def remove(ssid: str = None, name: str = None) -> Tuple[bool, str]:
     """ Remove a network. Depending on what is known, specify either ssid
     (in which case this function will call ``connection_exists`` to get the

--- a/api/tests/opentrons/server/test_networking_endpoints.py
+++ b/api/tests/opentrons/server/test_networking_endpoints.py
@@ -137,11 +137,13 @@ async def test_wifi_disconnect(loop, aiohttp_client, monkeypatch):
     app = init()
     cli = await loop.create_task(aiohttp_client(app))
 
-    msg = {'message': 'Connection \'ot_wifi\' successfully deactivated'}
+    msg1 = 'Connection \'ot_wifi\' successfully deactivated. ' \
+           'Connection \'ot_wifi\' (fa7ed807-23ef-41f0-ab3e-34' \
+           '99cc5a960e) successfully deleted'
 
     async def mock_disconnect(ssid):
         # Command: nmcli connection down ssid
-        return True, msg
+        return True, msg1
 
     monkeypatch.setattr(nmcli, 'wifi_disconnect', mock_disconnect)
 
@@ -154,6 +156,20 @@ async def test_wifi_disconnect(loop, aiohttp_client, monkeypatch):
     resp = await cli.post('wifi/disconnect', json={'ssid': 'ot_wifi'})
     body = await resp.json()
     assert resp.status == 200
+    assert 'message' in body
+
+    msg2 = 'Connection \'ot_wifi\' successfully deactivated. \n' \
+           'Error: Could not remove ssid. No connection for ssid ot_wif123'
+
+    async def mock_bad_disconnect(ssid):
+        # Command: nmcli connection down ssid
+        return True, msg2
+
+    monkeypatch.setattr(nmcli, 'wifi_disconnect', mock_bad_disconnect)
+
+    resp = await cli.post('wifi/disconnect', json={'ssid': 'ot_wifi'})
+    body = await resp.json()
+    assert resp.status == 207
     assert 'message' in body
 
 

--- a/api/tests/opentrons/server/test_networking_endpoints.py
+++ b/api/tests/opentrons/server/test_networking_endpoints.py
@@ -133,6 +133,30 @@ async def test_wifi_configure(
     assert 'message' in body
 
 
+async def test_wifi_disconnect(loop, aiohttp_client, monkeypatch):
+    app = init()
+    cli = await loop.create_task(aiohttp_client(app))
+
+    msg = {'message': 'Connection \'ot_wifi\' successfully deactivated'}
+
+    async def mock_disconnect(ssid):
+        # Command: nmcli connection down ssid
+        return True, msg
+
+    monkeypatch.setattr(nmcli, 'wifi_disconnect', mock_disconnect)
+
+    expected = {'message': 'SSID must be specified as a string'}
+    resp = await cli.post('/wifi/disconnect', json={})
+    body = await resp.json()
+    assert resp.status == 400
+    assert body == expected
+
+    resp = await cli.post('wifi/disconnect', json={'ssid': 'ot_wifi'})
+    body = await resp.json()
+    assert resp.status == 200
+    assert 'message' in body
+
+
 def test_deduce_security():
     with pytest.raises(networking.ConfigureArgsError):
         networking._deduce_security({'psk': 'hi', 'eapConfig': {'hi': 'nope'}})


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->
Closes #4847 
## overview

This PR allows us to disconnect the robot wifi by using `/wifi/disconnect` endpoint. The endpoint needs the wifi ssid specified in the body of the `POST` request as a string in JSON format: `{'ssid': 'your_wifi_ssid'}`
Upon disconnecting from wifi, the robot should not auto-connect to the ssid unless it is re-booted.
Uses nmcli.

## changelog

- added disconnect endpoint & networking request handler
- added disconnect method to `nmcli`
- added a networking endpoints test

## review requests

- plz make sure the code looks good
- test by sending a POST request with the ssid to a robot connected over wifi. Best to send the request over a wired connection so you can receive the response back. Also try to disconnect over the wifi connection; the robot should disconnect but you wouldn't get any response to the http request
