### PR TITLE
feat(protocol-designer): allow modules to be placed on compatble labware

### DIFF
--- a/protocol-designer/src/components/modals/EditModulesModal/__tests__/EditModulesModal.test.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/__tests__/EditModulesModal.test.js
@@ -1,0 +1,217 @@
+import React from 'react'
+import { Provider } from 'react-redux'
+import { mount } from 'enzyme'
+import { OutlineButton } from '@opentrons/components'
+import { EditModulesModal } from '../'
+import { PDAlert } from '../../../alerts/PDAlert'
+import { selectors as stepFormSelectors } from '../../../../step-forms'
+import { selectors as featureSelectors } from '../../../../feature-flags'
+import * as stepFormActions from '../../../../step-forms/actions'
+import * as labwareModuleCompatibility from '../../../../utils/labwareModuleCompatibility'
+import * as labwareIngredActions from '../../../../labware-ingred/actions'
+// only mock actions and selectors from step-forms
+jest.mock('../../../../step-forms/actions')
+jest.mock('../../../../labware-ingred/actions')
+jest.mock('../../../../utils/labwareModuleCompatibility')
+
+describe('EditModulesModal', () => {
+  let mockStore
+  function render(props) {
+    return mount(
+      <Provider store={mockStore}>
+        <EditModulesModal {...props} />
+      </Provider>
+    )
+  }
+
+  beforeEach(() => {
+    mockStore = {
+      dispatch: jest.fn(),
+      subscribe: jest.fn(),
+      getState: () => ({}),
+    }
+
+    stepFormSelectors.getInitialDeckSetup = jest.fn().mockReturnValue({
+      labware: {},
+      modules: {},
+      pipettes: {},
+    })
+    featureSelectors.getDisableModuleRestrictions = jest
+      .fn()
+      .mockReturnValue(true)
+  })
+
+  test('displays warning and disabled save button when slot is occupied by incompatible labware', () => {
+    stepFormSelectors.getInitialDeckSetup = jest.fn().mockReturnValue({
+      labware: {
+        well: {
+          slot: '1',
+        },
+      },
+      modules: {},
+      pipettes: {},
+    })
+    labwareModuleCompatibility.getLabwareIsCompatible = jest
+      .fn()
+      .mockReturnValue(false)
+    const props = {
+      moduleType: 'magdeck',
+      moduleId: null,
+      onCloseClick: jest.fn(),
+    }
+
+    const wrapper = render(props)
+    const saveButton = wrapper.find(OutlineButton).at(1)
+    const slotDropdown = wrapper.find('.option_slot select')
+    slotDropdown.simulate('change', { target: { value: '1' } })
+    const warning = wrapper.find(PDAlert)
+
+    expect(warning).toHaveLength(1)
+    expect(saveButton.prop('disabled')).toBe(true)
+  })
+
+  test('save button is clickable and saves when slot is occupied by compatible labware', () => {
+    stepFormSelectors.getInitialDeckSetup = jest.fn().mockReturnValue({
+      labware: {
+        well: {
+          slot: '1',
+        },
+      },
+      modules: {},
+      pipettes: {},
+    })
+    labwareModuleCompatibility.getLabwareIsCompatible = jest
+      .fn()
+      .mockReturnValue(true)
+    const props = {
+      moduleType: 'magdeck',
+      moduleId: null,
+      onCloseClick: jest.fn(),
+    }
+
+    const wrapper = render(props)
+    const saveButton = wrapper.find(OutlineButton).at(1)
+    const slotDropdown = wrapper.find('.option_slot select')
+    slotDropdown.simulate('change', { target: { value: '1' } })
+    saveButton.simulate('click')
+    const warning = wrapper.find(PDAlert)
+
+    expect(warning).toHaveLength(0)
+    expect(stepFormActions.createModule).toHaveBeenCalledWith({
+      slot: '1',
+      type: 'magdeck',
+      model: 'GEN1',
+    })
+    expect(props.onCloseClick).toHaveBeenCalled()
+  })
+
+  test('save button saves when slot is empty', () => {
+    stepFormSelectors.getInitialDeckSetup = jest.fn().mockReturnValue({
+      labware: {
+        well: {
+          slot: '1',
+        },
+      },
+      modules: {
+        magnet: {
+          slot: '3',
+        },
+      },
+      pipettes: {},
+    })
+    const props = {
+      moduleType: 'tempdeck',
+      moduleId: null,
+      onCloseClick: jest.fn(),
+    }
+
+    const wrapper = render(props)
+    const saveButton = wrapper.find(OutlineButton).at(1)
+    const slotDropdown = wrapper.find('.option_slot select')
+    slotDropdown.simulate('change', { target: { value: '10' } })
+    saveButton.simulate('click')
+    const warning = wrapper.find(PDAlert)
+
+    expect(warning).toHaveLength(0)
+    expect(stepFormActions.createModule).toHaveBeenCalledWith({
+      slot: '10',
+      type: 'tempdeck',
+      model: 'GEN1',
+    })
+    expect(props.onCloseClick).toHaveBeenCalled()
+  })
+
+  test('move deck item when moving module to a different slot', () => {
+    stepFormSelectors.getInitialDeckSetup = jest.fn().mockReturnValue({
+      labware: {
+        well: {
+          slot: '1',
+        },
+      },
+      modules: {
+        magnet123: {
+          slot: '1',
+        },
+      },
+      pipettes: {},
+    })
+    labwareModuleCompatibility.getLabwareIsCompatible = jest
+      .fn()
+      .mockReturnValue(true)
+    const props = {
+      moduleType: 'magdeck',
+      moduleId: 'magnet123',
+      onCloseClick: jest.fn(),
+    }
+
+    const wrapper = render(props)
+    const saveButton = wrapper.find(OutlineButton).at(1)
+    const slotDropdown = wrapper.find('.option_slot select')
+    slotDropdown.simulate('change', { target: { value: '10' } })
+    saveButton.simulate('click')
+    const warning = wrapper.find(PDAlert)
+
+    expect(warning).toHaveLength(0)
+    expect(labwareIngredActions.moveDeckItem).toHaveBeenCalledWith('1', '10')
+    expect(props.onCloseClick).toHaveBeenCalled()
+  })
+
+  test('no warning when slot is occupied by same module', () => {
+    stepFormSelectors.getInitialDeckSetup = jest.fn().mockReturnValue({
+      labware: {
+        well: {
+          slot: '1',
+        },
+      },
+      modules: {
+        magnet123: {
+          slot: '3',
+        },
+      },
+      pipettes: {},
+    })
+    const props = {
+      moduleType: 'magdeck',
+      moduleId: 'magnet123',
+      onCloseClick: jest.fn(),
+    }
+
+    const wrapper = render(props)
+    const warning = wrapper.find(PDAlert)
+
+    expect(warning).toHaveLength(0)
+  })
+
+  test('cancel calls onCloseClick to close modal', () => {
+    const props = {
+      moduleType: 'magdeck',
+      moduleId: null,
+      onCloseClick: jest.fn(),
+    }
+    const wrapper = render(props)
+
+    const cancelButton = wrapper.find(OutlineButton).at(0)
+    cancelButton.simulate('click')
+    expect(props.onCloseClick).toHaveBeenCalled()
+  })
+})

--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -60,15 +60,15 @@ export function EditModulesModal(props: EditModulesProps) {
     (getSlotIsEmpty(_initialDeckSetup, selectedSlot) ||
       previousModuleSlot === selectedSlot)
 
-  let hasSlotOrIncomptatibleError = true
+  let hasSlotOrIncompatibleError = true
   if (slotIsEmpty) {
-    hasSlotOrIncomptatibleError = false
+    hasSlotOrIncompatibleError = false
   } else {
     const labwareOnSlot = getLabwareOnSlot(_initialDeckSetup, selectedSlot)
     const labwareIsCompatible =
       labwareOnSlot && getLabwareIsCompatible(labwareOnSlot.def, moduleType)
 
-    hasSlotOrIncomptatibleError = !labwareIsCompatible
+    hasSlotOrIncompatibleError = !labwareIsCompatible
   }
 
   const showSlotOption = moduleType !== THERMOCYCLER
@@ -77,7 +77,7 @@ export function EditModulesModal(props: EditModulesProps) {
     featureFlagSelectors.getDisableModuleRestrictions
   )
 
-  const occupiedSlotError = hasSlotOrIncomptatibleError
+  const occupiedSlotError = hasSlotOrIncompatibleError
     ? `Slot ${selectedSlot} is occupied by another module or by labware incompatible with this module. Remove module or labware from the slot in order to continue.`
     : null
 
@@ -129,7 +129,7 @@ export function EditModulesModal(props: EditModulesProps) {
       className={cx(modalStyles.modal, styles.edit_module_modal)}
       contentsClassName={styles.modal_contents}
     >
-      {hasSlotOrIncomptatibleError && (
+      {hasSlotOrIncompatibleError && (
         <PDAlert
           alertType="warning"
           title={i18n.t('alert.module_placement.SLOT_OCCUPIED.title')}
@@ -183,7 +183,7 @@ export function EditModulesModal(props: EditModulesProps) {
       <div className={styles.button_row}>
         <OutlineButton onClick={onCloseClick}>Cancel</OutlineButton>
         <OutlineButton
-          disabled={hasSlotOrIncomptatibleError}
+          disabled={hasSlotOrIncompatibleError}
           onClick={onSaveClick}
         >
           Save

--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -26,8 +26,8 @@ import {
 } from '../../../modules'
 import { MODELS_FOR_MODULE_TYPE, THERMOCYCLER } from '../../../constants'
 import { i18n } from '../../../localization'
-import { PDAlert } from '../../alerts/PDAlert'
 import { getLabwareIsCompatible } from '../../../utils/labwareModuleCompatibility'
+import { PDAlert } from '../../alerts/PDAlert'
 import modalStyles from '../modal.css'
 import styles from './EditModules.css'
 import type { ModuleType } from '@opentrons/shared-data'
@@ -60,15 +60,15 @@ export function EditModulesModal(props: EditModulesProps) {
     (getSlotIsEmpty(_initialDeckSetup, selectedSlot) ||
       previousModuleSlot === selectedSlot)
 
-  let hasError = true
+  let hasSlotOrIncomptatibleError = true
   if (slotIsEmpty) {
-    hasError = false
+    hasSlotOrIncomptatibleError = false
   } else {
     const labwareOnSlot = getLabwareOnSlot(_initialDeckSetup, selectedSlot)
     const labwareIsCompatible =
       labwareOnSlot && getLabwareIsCompatible(labwareOnSlot.def, moduleType)
 
-    hasError = !labwareIsCompatible
+    hasSlotOrIncomptatibleError = !labwareIsCompatible
   }
 
   const showSlotOption = moduleType !== THERMOCYCLER
@@ -77,7 +77,7 @@ export function EditModulesModal(props: EditModulesProps) {
     featureFlagSelectors.getDisableModuleRestrictions
   )
 
-  const occupiedSlotError = hasError
+  const occupiedSlotError = hasSlotOrIncomptatibleError
     ? `Slot ${selectedSlot} is occupied by another module or by labware incompatible with this module. Remove module or labware from the slot in order to continue.`
     : null
 
@@ -129,7 +129,7 @@ export function EditModulesModal(props: EditModulesProps) {
       className={cx(modalStyles.modal, styles.edit_module_modal)}
       contentsClassName={styles.modal_contents}
     >
-      {hasError && (
+      {hasSlotOrIncomptatibleError && (
         <PDAlert
           alertType="warning"
           title={i18n.t('alert.module_placement.SLOT_OCCUPIED.title')}
@@ -182,7 +182,10 @@ export function EditModulesModal(props: EditModulesProps) {
 
       <div className={styles.button_row}>
         <OutlineButton onClick={onCloseClick}>Cancel</OutlineButton>
-        <OutlineButton disabled={hasError} onClick={onSaveClick}>
+        <OutlineButton
+          disabled={hasSlotOrIncomptatibleError}
+          onClick={onSaveClick}
+        >
           Save
         </OutlineButton>
       </div>

--- a/protocol-designer/src/step-forms/utils.js
+++ b/protocol-designer/src/step-forms/utils.js
@@ -2,6 +2,7 @@
 import assert from 'assert'
 import reduce from 'lodash/reduce'
 import values from 'lodash/values'
+import find from 'lodash/find'
 import { getPipetteNameSpecs } from '@opentrons/shared-data'
 import {
   SPAN7_8_10_11_SLOT,
@@ -129,6 +130,13 @@ export const getSlotIsEmpty = (
       ),
     ].length === 0
   )
+}
+
+export const getLabwareOnSlot = (
+  initialDeckSetup: InitialDeckSetup,
+  slot: string
+): LabwareOnDeckType => {
+  return find(initialDeckSetup.labware, labware => labware.slot === slot)
 }
 
 export const getIsCrashablePipetteSelected = (


### PR DESCRIPTION
## overview
closes #4726 
This feature allows users to add modules to slots where compatible labware is already set up. The second part of the ticket was already done in another PR.

## changelog
- Add check for compatible labware in edit module modal
- Add tests for existing edit module modal (at least the parts that I worked on in this feature) 

## review requests
http://sandbox.designer.opentrons.com/pd_compatible-labware/
Make sure to disable module placement restrictions

**With compatible labware**

1. Create a protocol without any modules
2. Add a magnet or temperature **compatible** module to any deck slot
3. Add steps if you like
4. Go back to the file page and click on add next to the module that you added compatible labware for
5. Under positions, select the slot that you added the labware to
6. Click save and go back to the deck
- [ ] There should be no errors and the module should show up underneath the labware


**With incompatible labware**

1. Create a protocol without any modules
2. Add a magnet or temperature **incompatible** module to any deck slot
3. Add steps if you like
4. Go back to the file page and click on add next to the module that you added compatible labware for
5. Under positions, select the slot that you added the labware to
- [ ] You should see a warning that says the slot is occupied by another module/labware
- [ ] Save button is disabled
