### PR TITLE
fix(protocol-designer): Update experimental settings warning text

### DIFF
--- a/protocol-designer/src/components/SettingsPage/FeatureFlagCard/FeatureFlagCard.js
+++ b/protocol-designer/src/components/SettingsPage/FeatureFlagCard/FeatureFlagCard.js
@@ -87,6 +87,12 @@ export const FeatureFlagCard = (props: Props) => {
   const userFacingFlagRows = userFacingFlagNames.map(toFlagRow)
   const prereleaseFlagRows = prereleaseFlagNames.map(toFlagRow)
 
+  let flagSwitchDirection: string = 'on'
+
+  if (modalFlagName) {
+    const isFlagOn: ?boolean = props.flags[modalFlagName]
+    flagSwitchDirection = isFlagOn ? 'off' : 'on'
+  }
   return (
     <>
       {modalFlagName && (
@@ -94,7 +100,9 @@ export const FeatureFlagCard = (props: Props) => {
           <ContinueModal
             alertOverlay
             className={modalStyles.modal}
-            heading={i18n.t('modal.experimental_feature_warning.title')}
+            heading={i18n.t(
+              `modal.experimental_feature_warning.${flagSwitchDirection}.title`
+            )}
             onCancelClick={() => setModalFlagName(null)}
             onContinueClick={() => {
               props.setFeatureFlags({
@@ -103,8 +111,16 @@ export const FeatureFlagCard = (props: Props) => {
               setModalFlagName(null)
             }}
           >
-            <p>{i18n.t('modal.experimental_feature_warning.body1')}</p>
-            <p>{i18n.t('modal.experimental_feature_warning.body2')}</p>
+            <p>
+              {i18n.t(
+                `modal.experimental_feature_warning.${flagSwitchDirection}.body1`
+              )}
+            </p>
+            <p>
+              {i18n.t(
+                `modal.experimental_feature_warning.${flagSwitchDirection}.body2`
+              )}
+            </p>
           </ContinueModal>
         </Portal>
       )}

--- a/protocol-designer/src/components/modals/modal.css
+++ b/protocol-designer/src/components/modals/modal.css
@@ -1,6 +1,10 @@
 .modal {
   z-index: 100;
   align-items: flex-start;
+
+  & p {
+    line-height: 1.5;
+  }
 }
 
 .modal.blocking {

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -90,8 +90,15 @@
     "check_email": "We've sent a confirmation URL to your email that will take you to the Protocol Designer. Keep an eye out for a follow up email which contains links to resources such as our help documents."
   },
   "experimental_feature_warning": {
-    "title": "Switching on an experimental feature",
-    "body1": "Warning: At this time Opentrons does not provide support for protocols with experimental settings turned on.",
-    "body2": "We encourage you to report any bugs you find, however note that at this time we are unable to prioritize fixes as they are a result of experimental features. "
+    "on": {
+      "title": "Switching on an experimental feature",
+      "body1": "Warning: At this time Opentrons does not provide support for protocols with experimental settings turned on.",
+      "body2": "We encourage you to report any bugs you find, however note that at this time we are unable to prioritize fixes as they are a result of experimental features. "
+    },
+    "off": {
+      "title": "Switching off an experimental feature",
+      "body1": "Warning: Any experimental features used in this protocol may cause inconsistent behavior in the Protocol Designer. For example, the Protocol Designer may no longer display all warnings or errors that exist when no experimental features have been used.",
+      "body2": "We encourage you to report any bugs you find, however note that at this time we are unable to prioritize fixes as they are a result of experimental features."
+    }
   }
 }


### PR DESCRIPTION
## overview

This PR closes #4911 by changing the title and content of the experimental settings warning modals. 

## changelog

- fix(protocol-designer): Update experimental settings warning text

## review requests
Go to settings in PD
Toggle an experimental setting ON
- [ ] Warning title reads Switching ON an experimental feature
- [ ] Copy is the same as previous modals

Toggle an experimental setting OFF
- [ ] Warning title reads Switching OFF an experimental feature
- [ ] Copy is different and reads: `Warning: Any experimental features used in this protocol may cause inconsistent behavior in the Protocol Designer. For example, the Protocol Designer may no longer display all warnings or errors that exist when no experimental features have been used.`
