### PR TITLE
fix(protocol-designer): set magnetic module params for both pristine …

### DIFF
--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -82,6 +82,7 @@ export function getDefaultsForStepType(
       }
     case 'magnet':
       return {
+        moduleId: null,
         magnetAction: null,
         engageHeight: null,
       }

--- a/protocol-designer/src/ui/steps/actions/actions.js
+++ b/protocol-designer/src/ui/steps/actions/actions.js
@@ -140,7 +140,7 @@ export const selectStep = (
   }
 
   // auto-select magnetic module if it exists (assumes no more than 1 magnetic module)
-  if (newStepType === 'magnet') {
+  if (formData && formData.stepType === 'magnet') {
     const moduleId = uiModulesSelectors.getSingleMagneticModuleId(state)
     const magnetAction = getNextDefaultMagnetAction(
       stepFormSelectors.getSavedStepForms(state),


### PR DESCRIPTION
## overview

This PR closes #4908 by always setting magnetic module form params regardless of whether or not the form is pristine. 

Note: I did not add any test coverage. As per discussion with @IanLondon we plan to remove the non pristine form logic so I just simply added this patch for the time being. 

## review requests

- Make a protocol with a magnetic module
- Add a MAGNET step but don't save it
- Click on another step eg Initial Deck Setup
- Click on the MAGNET step again to select it
- [ ]  Click "Save" on the MAGNET step form, the step should have saved successfully 
