### PR TITLE
refactor(discovery-client): switch default exports to named exports

### DIFF
--- a/app-shell/src/__tests__/discovery.test.js
+++ b/app-shell/src/__tests__/discovery.test.js
@@ -2,7 +2,7 @@
 import EventEmitter from 'events'
 import { app } from 'electron'
 import Store from 'electron-store'
-import DiscoveryClient from '@opentrons/discovery-client'
+import { createDiscoveryClient } from '@opentrons/discovery-client'
 import { registerDiscovery } from '../discovery'
 import { getConfig, getOverrides } from '../config'
 
@@ -31,7 +31,7 @@ describe('app-shell/discovery', () => {
     getOverrides.mockReturnValue({})
 
     dispatch = jest.fn()
-    DiscoveryClient.mockReturnValue(mockClient)
+    createDiscoveryClient.mockReturnValue(mockClient)
     Store.__mockReset()
     Store.__store.get.mockImplementation(key => {
       if (key === 'services') return []
@@ -46,7 +46,7 @@ describe('app-shell/discovery', () => {
   test('registerDiscovery creates a DiscoveryClient', () => {
     registerDiscovery(dispatch)
 
-    expect(DiscoveryClient).toHaveBeenCalledWith(
+    expect(createDiscoveryClient).toHaveBeenCalledWith(
       expect.objectContaining({
         pollInterval: expect.any(Number),
         // support for legacy IPv6 wired robots
@@ -170,7 +170,7 @@ describe('app-shell/discovery', () => {
     })
 
     registerDiscovery(dispatch)
-    expect(DiscoveryClient).toHaveBeenCalledWith(
+    expect(createDiscoveryClient).toHaveBeenCalledWith(
       expect.objectContaining({
         services: [{ name: 'foo' }],
       })
@@ -181,7 +181,7 @@ describe('app-shell/discovery', () => {
     getConfig.mockReturnValue({ enabled: true, candidates: ['1.2.3.4'] })
     registerDiscovery(dispatch)
 
-    expect(DiscoveryClient).toHaveBeenCalledWith(
+    expect(createDiscoveryClient).toHaveBeenCalledWith(
       expect.objectContaining({
         candidates: expect.arrayContaining(['1.2.3.4']),
       })
@@ -193,7 +193,7 @@ describe('app-shell/discovery', () => {
     getConfig.mockReturnValue({ enabled: true, candidates: '1.2.3.4' })
     registerDiscovery(dispatch)
 
-    expect(DiscoveryClient).toHaveBeenCalledWith(
+    expect(createDiscoveryClient).toHaveBeenCalledWith(
       expect.objectContaining({
         candidates: expect.arrayContaining(['1.2.3.4']),
       })

--- a/app-shell/src/discovery.js
+++ b/app-shell/src/discovery.js
@@ -4,7 +4,8 @@ import { app } from 'electron'
 import Store from 'electron-store'
 import throttle from 'lodash/throttle'
 
-import DiscoveryClient, {
+import {
+  createDiscoveryClient,
   SERVICE_EVENT,
   SERVICE_REMOVED_EVENT,
 } from '@opentrons/discovery-client'
@@ -33,7 +34,7 @@ export function registerDiscovery(dispatch: Dispatch) {
   config = getConfig('discovery')
   store = new Store({ name: 'discovery', defaults: { services: [] } })
 
-  client = DiscoveryClient({
+  client = createDiscoveryClient({
     pollInterval: SLOW_POLL_INTERVAL_MS,
     logger: log,
     candidates: ['[fd00:0:cafe:fefe::1]'].concat(config.candidates),

--- a/discovery-client/README.md
+++ b/discovery-client/README.md
@@ -12,10 +12,10 @@
 ## api
 
 ```js
-const DiscoveryClient = require('@opentrons/discovery-client')
+const { createDiscoveryClient } = require('@opentrons/discovery-client')
 ```
 
-### DiscoveryClientFactory(options?: Options): DiscoveryClient
+### createDiscoveryClient(options?: Options): DiscoveryClient
 
 Creates a new `DiscoveryClient`.
 
@@ -27,7 +27,7 @@ const options = {
   candidates: [{ ip: '[fd00:0:cafe:fefe::1]', port: 31950 }, 'localhost'],
 }
 
-const client = DiscoveryClientFactory(options)
+const client = createDiscoveryClient(options)
 ```
 
 The discovery client is an [Event Emitter][event-emitter]. In addition to the normal `EventEmitter` methods and properties, the client has:

--- a/discovery-client/src/__fixtures__/mdns-browser-service.js
+++ b/discovery-client/src/__fixtures__/mdns-browser-service.js
@@ -1,13 +1,16 @@
-export default {
+// @flow
+import type { BrowserService, MdnsServiceType } from 'mdns-js'
+
+export const MOCK_BROWSER_SERVICE: BrowserService = {
   addresses: ['192.168.1.42'],
   query: ['_http._tcp.local'],
   type: [
-    {
+    (({
       name: 'http',
       protocol: 'tcp',
       subtypes: [],
       description: 'Web Site',
-    },
+    }: any): MdnsServiceType),
   ],
   txt: [''],
   port: 31950,

--- a/discovery-client/src/__fixtures__/service.js
+++ b/discovery-client/src/__fixtures__/service.js
@@ -1,7 +1,7 @@
 // @flow
 import type { Service } from '../types'
 
-const MOCK_SERVICE: Service = {
+export const MOCK_SERVICE: Service = {
   name: 'opentrons-dev',
   ip: '192.168.1.42',
   port: 31950,
@@ -12,5 +12,3 @@ const MOCK_SERVICE: Service = {
   health: null,
   serverHealth: null,
 }
-
-export default MOCK_SERVICE

--- a/discovery-client/src/__tests__/client.test.js
+++ b/discovery-client/src/__tests__/client.test.js
@@ -1,11 +1,11 @@
 import mdns from 'mdns-js'
 
-import DiscoveryClient from '..'
+import { createDiscoveryClient } from '..'
 import * as poller from '../poller'
 import * as service from '../service'
 import * as serviceList from '../service-list'
-import MOCK_BROWSER_SERVICE from '../__fixtures__/mdns-browser-service'
-import MOCK_SERVICE from '../__fixtures__/service'
+import { MOCK_BROWSER_SERVICE } from '../__fixtures__/mdns-browser-service'
+import { MOCK_SERVICE } from '../__fixtures__/service'
 
 jest.mock('mdns-js')
 jest.mock('../poller')
@@ -23,7 +23,7 @@ describe('discovery client', () => {
   })
 
   test('start creates mdns browser searching for http', () => {
-    const client = DiscoveryClient()
+    const client = createDiscoveryClient()
     const result = client.start()
 
     expect(result).toBe(client)
@@ -32,7 +32,7 @@ describe('discovery client', () => {
   })
 
   test('mdns browser started on ready', () => {
-    const client = DiscoveryClient()
+    const client = createDiscoveryClient()
 
     client.start()
     expect(mdns.__mockBrowser.discover).toHaveBeenCalledTimes(0)
@@ -41,7 +41,7 @@ describe('discovery client', () => {
   })
 
   test('stops browser on client.stop', () => {
-    const client = DiscoveryClient()
+    const client = createDiscoveryClient()
 
     client.start()
     const result = client.stop()
@@ -50,7 +50,7 @@ describe('discovery client', () => {
   })
 
   test('stops browser and creates new one on repeated client.start', () => {
-    const client = DiscoveryClient()
+    const client = createDiscoveryClient()
 
     client.start()
     expect(mdns.createBrowser).toHaveBeenCalledTimes(1)
@@ -61,7 +61,7 @@ describe('discovery client', () => {
   })
 
   test('emits "service" if browser finds a service', done => {
-    const client = DiscoveryClient()
+    const client = createDiscoveryClient()
 
     client.start()
     client.once('service', results => {
@@ -75,7 +75,7 @@ describe('discovery client', () => {
   }, 10)
 
   test('adds robot to client.services if browser finds a service', () => {
-    const client = DiscoveryClient()
+    const client = createDiscoveryClient()
 
     client.start()
     mdns.__mockBrowser.emit('update', MOCK_BROWSER_SERVICE)
@@ -84,7 +84,7 @@ describe('discovery client', () => {
   })
 
   test('new mdns service does not null out ok of existing service', () => {
-    const client = DiscoveryClient()
+    const client = createDiscoveryClient()
 
     client.services = [
       {
@@ -110,7 +110,7 @@ describe('discovery client', () => {
 
   test('services and candidates can be prepopulated', () => {
     const cachedServices = [MOCK_SERVICE]
-    const client = DiscoveryClient({
+    const client = createDiscoveryClient({
       services: cachedServices,
       candidates: [{ ip: '192.168.1.43', port: 31950 }],
     })
@@ -121,7 +121,7 @@ describe('discovery client', () => {
   })
 
   test('candidates should be deduped by services', () => {
-    const client = DiscoveryClient({
+    const client = createDiscoveryClient({
       services: [MOCK_SERVICE],
       candidates: [{ ip: MOCK_SERVICE.ip, port: 31950 }],
     })
@@ -130,7 +130,7 @@ describe('discovery client', () => {
   })
 
   test('client.start should start polling with default interval 5000', () => {
-    const client = DiscoveryClient({
+    const client = createDiscoveryClient({
       services: [
         {
           ...MOCK_SERVICE,
@@ -151,7 +151,7 @@ describe('discovery client', () => {
   })
 
   test('client should have configurable poll interval', () => {
-    const client = DiscoveryClient({
+    const client = createDiscoveryClient({
       pollInterval: 1000,
       candidates: [{ ip: 'foo', port: 31950 }],
     })
@@ -166,7 +166,7 @@ describe('discovery client', () => {
   })
 
   test('client.stop should stop polling', () => {
-    const client = DiscoveryClient({ services: [MOCK_SERVICE] })
+    const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     poller.poll.mockReturnValueOnce({ id: 'foobar' })
     client.start()
@@ -175,7 +175,7 @@ describe('discovery client', () => {
   })
 
   test('if polls come back good, oks should be flagged true from null', () => {
-    const client = DiscoveryClient({ services: [MOCK_SERVICE] })
+    const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     client.start()
     const onHealth = poller.poll.mock.calls[0][2]
@@ -191,7 +191,7 @@ describe('discovery client', () => {
   })
 
   test('if polls come back good, oks should be flagged true from false', () => {
-    const client = DiscoveryClient({ services: [MOCK_SERVICE] })
+    const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     client.services[0].ok = false
     client.services[0].serverOk = false
@@ -208,7 +208,7 @@ describe('discovery client', () => {
   })
 
   test('if API health comes back bad, ok should be flagged false from null', () => {
-    const client = DiscoveryClient({ services: [MOCK_SERVICE] })
+    const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     client.start()
     const onHealth = poller.poll.mock.calls[0][2]
@@ -220,7 +220,7 @@ describe('discovery client', () => {
   })
 
   test('if API health comes back bad, ok should be flagged false from true', () => {
-    const client = DiscoveryClient({ services: [MOCK_SERVICE] })
+    const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     client.services[0].ok = true
     client.start()
@@ -233,7 +233,7 @@ describe('discovery client', () => {
   })
 
   test('if /server health comes back bad, serverOk should be flagged false from null', () => {
-    const client = DiscoveryClient({ services: [MOCK_SERVICE] })
+    const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     client.start()
     const onHealth = poller.poll.mock.calls[0][2]
@@ -248,7 +248,7 @@ describe('discovery client', () => {
   })
 
   test('if /server health comes back bad, serverOk should be flagged false from true', () => {
-    const client = DiscoveryClient({ services: [MOCK_SERVICE] })
+    const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     client.services[0].serverOk = true
     client.start()
@@ -264,7 +264,7 @@ describe('discovery client', () => {
   })
 
   test('if both polls comes back bad, oks should be flagged false from null', () => {
-    const client = DiscoveryClient({ services: [MOCK_SERVICE] })
+    const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     client.start()
     const onHealth = poller.poll.mock.calls[0][2]
@@ -276,7 +276,7 @@ describe('discovery client', () => {
   })
 
   test('if both polls comes back bad, oks should be flagged false from true', () => {
-    const client = DiscoveryClient({ services: [MOCK_SERVICE] })
+    const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     client.services[0].ok = true
     client.services[0].serverOk = true
@@ -290,7 +290,7 @@ describe('discovery client', () => {
   })
 
   test('if names come back conflicting, prefer /server and set ok to false', () => {
-    const client = DiscoveryClient({ services: [MOCK_SERVICE] })
+    const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     client.start()
     const onHealth = poller.poll.mock.calls[0][2]
@@ -305,7 +305,7 @@ describe('discovery client', () => {
   })
 
   test('if health comes back for a candidate, it should be promoted', () => {
-    const client = DiscoveryClient({
+    const client = createDiscoveryClient({
       candidates: [{ ip: '192.168.1.42', port: 31950 }],
     })
 
@@ -330,7 +330,7 @@ describe('discovery client', () => {
   })
 
   test('if health comes back with IP conflict, null out old services', () => {
-    const client = DiscoveryClient()
+    const client = createDiscoveryClient()
 
     client.services = [
       { ...MOCK_SERVICE, name: 'bar', ok: true, serverOk: true },
@@ -359,7 +359,7 @@ describe('discovery client', () => {
   })
 
   test('if new service is added, poller is restarted', () => {
-    const client = DiscoveryClient({
+    const client = createDiscoveryClient({
       candidates: [{ ip: '192.168.1.1', port: 31950 }],
     })
 
@@ -390,7 +390,7 @@ describe('discovery client', () => {
   })
 
   test('services may be removed and removes candidates', () => {
-    const client = DiscoveryClient({
+    const client = createDiscoveryClient({
       services: [
         {
           ...MOCK_SERVICE,
@@ -413,7 +413,7 @@ describe('discovery client', () => {
   })
 
   test('candidate removal restarts poll', () => {
-    const client = DiscoveryClient({ services: [MOCK_SERVICE] })
+    const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     poller.poll.mockReturnValueOnce({ id: 1234 })
     client.start()
@@ -438,7 +438,7 @@ describe('discovery client', () => {
       MOCK_SERVICE,
     ]
 
-    const client = DiscoveryClient({ services })
+    const client = createDiscoveryClient({ services })
 
     client.on('serviceRemoved', results => {
       expect(results).toEqual(services)
@@ -451,7 +451,7 @@ describe('discovery client', () => {
 
   test('passes along mdns errors', done => {
     const mockError = new Error('AH')
-    const client = DiscoveryClient().once('error', error => {
+    const client = createDiscoveryClient().once('error', error => {
       expect(error).toEqual(mockError)
       done()
     })
@@ -461,7 +461,7 @@ describe('discovery client', () => {
   })
 
   test('can filter services by name', () => {
-    const client = DiscoveryClient({ nameFilter: ['OPENTRONS'] })
+    const client = createDiscoveryClient({ nameFilter: ['OPENTRONS'] })
 
     client.start()
     mdns.__mockBrowser.emit('update', MOCK_BROWSER_SERVICE)
@@ -483,7 +483,7 @@ describe('discovery client', () => {
   })
 
   test('can filter services by ip', () => {
-    const client = DiscoveryClient({ ipFilter: ['169.254'] })
+    const client = createDiscoveryClient({ ipFilter: ['169.254'] })
 
     client.start()
     mdns.__mockBrowser.emit('update', {
@@ -499,7 +499,7 @@ describe('discovery client', () => {
   })
 
   test('can filter services by port', () => {
-    const client = DiscoveryClient({ portFilter: [31950, 31951] })
+    const client = createDiscoveryClient({ portFilter: [31950, 31951] })
 
     client.start()
     mdns.__mockBrowser.emit('update', MOCK_BROWSER_SERVICE)
@@ -520,7 +520,7 @@ describe('discovery client', () => {
   })
 
   test('can add a candidate manually (with deduping)', () => {
-    const client = DiscoveryClient()
+    const client = createDiscoveryClient()
     const result = client.add('localhost').add('localhost')
 
     const expectedCandidates = [{ ip: 'localhost', port: 31950 }]
@@ -535,7 +535,7 @@ describe('discovery client', () => {
   })
 
   test('can change polling interval on the fly', () => {
-    const client = DiscoveryClient({ candidates: ['localhost'] })
+    const client = createDiscoveryClient({ candidates: ['localhost'] })
     const expectedCandidates = [{ ip: 'localhost', port: 31950 }]
 
     let result = client.setPollInterval(1000)

--- a/discovery-client/src/__tests__/service-list.test.js
+++ b/discovery-client/src/__tests__/service-list.test.js
@@ -1,5 +1,5 @@
 import * as serviceList from '../service-list'
-import MOCK_SERVICE from '../__fixtures__/service'
+import { MOCK_SERVICE } from '../__fixtures__/service'
 
 describe('serviceList', () => {
   describe('createServiceList', () => {

--- a/discovery-client/src/__tests__/service.test.js
+++ b/discovery-client/src/__tests__/service.test.js
@@ -2,7 +2,7 @@
 import { setIn } from '@thi.ng/paths'
 
 import * as service from '../service'
-import MOCK_BROWSER_SERVICE from '../__fixtures__/mdns-browser-service'
+import { MOCK_BROWSER_SERVICE } from '../__fixtures__/mdns-browser-service'
 
 describe('service utils', () => {
   describe('makeService', () => {

--- a/discovery-client/src/cli.js
+++ b/discovery-client/src/cli.js
@@ -1,5 +1,5 @@
 // @flow
-import DiscoveryClient from '.'
+import { createDiscoveryClient } from '.'
 import { version } from '../package.json'
 
 const LOG_LVLS = ['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly']
@@ -71,7 +71,7 @@ require('yargs')
   .parse()
 
 function browse(argv) {
-  DiscoveryClient(argv)
+  createDiscoveryClient(argv)
     .on('service', s => argv.logger.info('services added or updated:', s))
     .on('serviceRemoved', s => argv.logger.info('services removed:', s))
     .once('error', argv.handleError)
@@ -86,7 +86,7 @@ function find(argv) {
     argv.timeout
   )
 
-  DiscoveryClient(argv)
+  createDiscoveryClient(argv)
     .on('service', updatedServices => {
       updatedServices
         .filter(s => !argv.name || s.name === argv.name)

--- a/discovery-client/src/index.js
+++ b/discovery-client/src/index.js
@@ -8,7 +8,7 @@ import toRegex from 'to-regex'
 import differenceBy from 'lodash/differenceBy'
 import xorBy from 'lodash/xorBy'
 
-import MdnsBrowser, { getKnownIps } from './mdns-browser'
+import { createMdnsBrowser, getKnownIps } from './mdns-browser'
 import { poll, stop, type PollRequest } from './poller'
 import {
   createServiceList,
@@ -57,7 +57,7 @@ const santizeRe = (patterns: ?Array<string | RegExp>) => {
   return patterns.map(p => (typeof p === 'string' ? escape(p) : p))
 }
 
-export default function DiscoveryClientFactory(options?: Options) {
+export function createDiscoveryClient(options?: Options) {
   return new DiscoveryClient(options || {})
 }
 
@@ -200,7 +200,7 @@ export class DiscoveryClient extends EventEmitter {
   _startBrowser(): void {
     this._stopBrowser()
 
-    const browser = MdnsBrowser()
+    const browser = createMdnsBrowser()
       .once('ready', () => browser.discover())
       .on('update', service => this._handleUp(service))
       .on('error', error => this.emit('error', error))

--- a/discovery-client/src/mdns-browser.js
+++ b/discovery-client/src/mdns-browser.js
@@ -7,7 +7,7 @@ import flatMap from 'lodash/flatMap'
 
 monkeyPatchThrowers()
 
-export default function MdnsBrowser(): Browser {
+export function createMdnsBrowser(): Browser {
   return mdns.createBrowser(mdns.tcp('http'))
 }
 


### PR DESCRIPTION
## overview

This PR continues #4830 by switching the discovery client over to named exports

## changelog

- refactor(discovery-client): switch default exports to named exports

## review requests

Smoke test app discovery:

1. Delete `~/Library/Application\ Support/Opentrons/discovery.json` (or the `discovery.json` file in whatever path your OS's config directory is)
2. Open the app

- [ ] Robot list should populate

Smoke test standalone discovery client:

1. `make -C discovery-client`
2. `yarn discovery browse`

- [ ] CLI discovery client should detect robots