### PR TITLE
fix(protocol-designer): round caption under engage height to match input box

### DIFF
--- a/protocol-designer/src/components/StepEditForm/forms/MagnetForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MagnetForm.js
@@ -1,9 +1,10 @@
 // @flow
 import * as React from 'react'
 import { useSelector } from 'react-redux'
-import { selectors as uiModuleSelectors } from '../../../ui/modules'
 import { FormGroup } from '@opentrons/components'
+import { selectors as uiModuleSelectors } from '../../../ui/modules'
 import { i18n } from '../../../localization'
+import { maskField } from '../../../steplist/fieldLevel'
 
 import { ConditionalOnField, TextField, RadioGroupField } from '../fields'
 import styles from '../StepEditForm.css'
@@ -24,9 +25,10 @@ export const MagnetForm = (props: MagnetFormProps): React.Element<'div'> => {
   const defaultEngageHeight = useSelector(
     uiModuleSelectors.getMagnetLabwareEngageHeight
   )
-  const engageHeightCaption = defaultEngageHeight
-    ? `Recommended: ${defaultEngageHeight}`
-    : null
+
+  const engageHeightCaption = `Recommended: ${String(
+    maskField('engageHeight', defaultEngageHeight)
+  )}`
 
   return (
     <div className={styles.form_wrapper}>

--- a/protocol-designer/src/components/StepEditForm/forms/MagnetForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MagnetForm.js
@@ -26,9 +26,9 @@ export const MagnetForm = (props: MagnetFormProps): React.Element<'div'> => {
     uiModuleSelectors.getMagnetLabwareEngageHeight
   )
 
-  const engageHeightCaption = `Recommended: ${String(
-    maskField('engageHeight', defaultEngageHeight)
-  )}`
+  const engageHeightCaption = defaultEngageHeight
+    ? `Recommended: ${String(maskField('engageHeight', defaultEngageHeight))}`
+    : null
 
   return (
     <div className={styles.form_wrapper}>

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/MagnetForm.test.js
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/MagnetForm.test.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import { Provider } from 'react-redux'
+import { mount } from 'enzyme'
+import { selectors as uiModuleSelectors } from '../../../../ui/modules'
+import * as fields from '../../fields'
+import { MagnetForm } from '../MagnetForm'
+
+jest.mock('../../../../ui/modules')
+jest.mock('../../fields')
+
+describe('MagnetForm', () => {
+  let store
+  beforeEach(() => {
+    store = {
+      dispatch: jest.fn(),
+      subscribe: jest.fn(),
+      getState: () => ({}),
+    }
+
+    fields.ConditionalOnField = jest
+      .fn()
+      .mockImplementation(props => <div>{props.children}</div>)
+    fields.TextField = jest.fn().mockImplementation(props => <div />)
+    fields.RadioGroupField = jest.fn().mockImplementation(props => <div />)
+  })
+
+  test('engage height caption is displayed with proper height to decimal scale', () => {
+    const props = {
+      focusedField: 'magnet',
+      dirtyFields: [],
+      onFieldFocus: jest.fn(),
+      onFieldBlur: jest.fn(),
+    }
+    uiModuleSelectors.getMagneticLabwareOptions.mockReturnValue([
+      { name: 'magnet module', value: 'magnet123', disabled: false },
+    ])
+    uiModuleSelectors.getMagnetLabwareEngageHeight.mockReturnValue('10.9444')
+
+    // enzyme seems to have trouble shallow rendering with hooks and redux
+    // https://github.com/airbnb/enzyme/issues/2202
+    const wrapper = mount(
+      <Provider store={store}>
+        <MagnetForm {...props} />
+      </Provider>
+    )
+
+    expect(wrapper.find(fields.TextField).prop('caption')).toEqual(
+      'Recommended: 10.9'
+    )
+  })
+})

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/MagnetForm.test.js
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/MagnetForm.test.js
@@ -10,6 +10,24 @@ jest.mock('../../fields')
 
 describe('MagnetForm', () => {
   let store
+  function render() {
+    const props = {
+      focusHandlers: {
+        focusedField: 'magnet',
+        dirtyFields: [],
+        onFieldFocus: jest.fn(),
+        onFieldBlur: jest.fn(),
+      },
+    }
+    // enzyme seems to have trouble shallow rendering with hooks and redux
+    // https://github.com/airbnb/enzyme/issues/2202
+    return mount(
+      <Provider store={store}>
+        <MagnetForm {...props} />
+      </Provider>
+    )
+  }
+
   beforeEach(() => {
     store = {
       dispatch: jest.fn(),
@@ -22,30 +40,27 @@ describe('MagnetForm', () => {
       .mockImplementation(props => <div>{props.children}</div>)
     fields.TextField = jest.fn().mockImplementation(props => <div />)
     fields.RadioGroupField = jest.fn().mockImplementation(props => <div />)
-  })
 
-  test('engage height caption is displayed with proper height to decimal scale', () => {
-    const props = {
-      focusedField: 'magnet',
-      dirtyFields: [],
-      onFieldFocus: jest.fn(),
-      onFieldBlur: jest.fn(),
-    }
     uiModuleSelectors.getMagneticLabwareOptions.mockReturnValue([
       { name: 'magnet module', value: 'magnet123', disabled: false },
     ])
+  })
+
+  test('engage height caption is displayed with proper height to decimal scale', () => {
     uiModuleSelectors.getMagnetLabwareEngageHeight.mockReturnValue('10.9444')
 
-    // enzyme seems to have trouble shallow rendering with hooks and redux
-    // https://github.com/airbnb/enzyme/issues/2202
-    const wrapper = mount(
-      <Provider store={store}>
-        <MagnetForm {...props} />
-      </Provider>
-    )
+    const wrapper = render()
 
     expect(wrapper.find(fields.TextField).prop('caption')).toEqual(
       'Recommended: 10.9'
     )
+  })
+
+  test('engage height caption is null when no engage height', () => {
+    uiModuleSelectors.getMagnetLabwareEngageHeight.mockReturnValue(null)
+
+    const wrapper = render()
+
+    expect(wrapper.find(fields.TextField).prop('caption')).toBeNull()
   })
 })

--- a/protocol-designer/src/ui/steps/actions/__tests__/actions.test.js
+++ b/protocol-designer/src/ui/steps/actions/__tests__/actions.test.js
@@ -13,9 +13,16 @@ const mockStore = configureMockStore([thunk])
 describe('steps actions', () => {
   describe('selectStep', () => {
     const pipetteId = 'pipetteId'
-    const magnetModule = 'magnet123'
-    const magnetAction = 'engage'
     beforeEach(() => {
+      stepFormSelectors.getInitialDeckSetup.mockReturnValue({
+        pipettes: { mount: 'left' },
+      })
+      formLevel.getNextDefaultPipetteId.mockReturnValue(pipetteId)
+    })
+
+    test('action is created to populate form with default engage height to scale when engage magnet step', () => {
+      const magnetModule = 'magnet123'
+      const magnetAction = 'engage'
       uiModulesSelectors.getSingleMagneticModuleId = jest
         .fn()
         .mockReturnValue(magnetModule)
@@ -23,17 +30,8 @@ describe('steps actions', () => {
       uiModulesSelectors.getMagnetLabwareEngageHeight = jest
         .fn()
         .mockReturnValue(10.9444)
-
-      stepFormSelectors.getInitialDeckSetup.mockReturnValue({
-        pipettes: { mount: 'left' },
-      })
-
-      formLevel.getNextDefaultPipetteId.mockReturnValue(pipetteId)
       formLevel.getNextDefaultMagnetAction.mockReturnValue(magnetAction)
       formLevel.getNextDefaultEngageHeight.mockReturnValue(null)
-    })
-
-    test('action is created to populate form with default engage height to scale when engage magnet step', () => {
       const store = mockStore({})
 
       store.dispatch(actions.selectStep(magnetModule, 'magnet'))
@@ -46,6 +44,35 @@ describe('steps actions', () => {
             moduleId: magnetModule,
             magnetAction: magnetAction,
             engageHeight: '10.9',
+          },
+        },
+      ])
+    })
+
+    test('action is created to populate form with null default engage height when engage magnet step with labware with no engage height', () => {
+      const magnetModule = 'magnet123'
+      const magnetAction = 'engage'
+      uiModulesSelectors.getSingleMagneticModuleId = jest
+        .fn()
+        .mockReturnValue(magnetModule)
+
+      uiModulesSelectors.getMagnetLabwareEngageHeight = jest
+        .fn()
+        .mockReturnValue(null)
+      formLevel.getNextDefaultMagnetAction.mockReturnValue(magnetAction)
+      formLevel.getNextDefaultEngageHeight.mockReturnValue(null)
+      const store = mockStore({})
+
+      store.dispatch(actions.selectStep(magnetModule, 'magnet'))
+
+      expect(store.getActions()).toEqual([
+        { type: 'SELECT_STEP', payload: magnetModule },
+        {
+          type: 'POPULATE_FORM',
+          payload: {
+            moduleId: magnetModule,
+            magnetAction: magnetAction,
+            engageHeight: null,
           },
         },
       ])

--- a/protocol-designer/src/ui/steps/actions/__tests__/actions.test.js
+++ b/protocol-designer/src/ui/steps/actions/__tests__/actions.test.js
@@ -1,0 +1,54 @@
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+import { selectors as stepFormSelectors } from '../../../../step-forms'
+import * as formLevel from '../../../../steplist/formLevel'
+import { selectors as uiModulesSelectors } from '../../../modules'
+import * as actions from '../actions'
+
+jest.mock('../../../../steplist/formLevel')
+jest.mock('../../../../step-forms')
+
+const mockStore = configureMockStore([thunk])
+
+describe('steps actions', () => {
+  describe('selectStep', () => {
+    const pipetteId = 'pipetteId'
+    const magnetModule = 'magnet123'
+    const magnetAction = 'engage'
+    beforeEach(() => {
+      uiModulesSelectors.getSingleMagneticModuleId = jest
+        .fn()
+        .mockReturnValue(magnetModule)
+
+      uiModulesSelectors.getMagnetLabwareEngageHeight = jest
+        .fn()
+        .mockReturnValue(10.9444)
+
+      stepFormSelectors.getInitialDeckSetup.mockReturnValue({
+        pipettes: { mount: 'left' },
+      })
+
+      formLevel.getNextDefaultPipetteId.mockReturnValue(pipetteId)
+      formLevel.getNextDefaultMagnetAction.mockReturnValue(magnetAction)
+      formLevel.getNextDefaultEngageHeight.mockReturnValue(null)
+    })
+
+    test('action is created to populate form with default engage height to scale when engage magnet step', () => {
+      const store = mockStore({})
+
+      store.dispatch(actions.selectStep(magnetModule, 'magnet'))
+
+      expect(store.getActions()).toEqual([
+        { type: 'SELECT_STEP', payload: magnetModule },
+        {
+          type: 'POPULATE_FORM',
+          payload: {
+            moduleId: magnetModule,
+            magnetAction: magnetAction,
+            engageHeight: '10.9',
+          },
+        },
+      ])
+    })
+  })
+})

--- a/protocol-designer/src/ui/steps/actions/actions.js
+++ b/protocol-designer/src/ui/steps/actions/actions.js
@@ -11,6 +11,7 @@ import {
   getNextDefaultEngageHeight,
   handleFormChange,
 } from '../../../steplist/formLevel'
+import { maskField } from '../../../steplist/fieldLevel'
 import type { StepIdType, StepType } from '../../../form-types'
 import type { GetState, ThunkAction, ThunkDispatch } from '../../../types'
 import type { TerminalItemId, SubstepIdentifier } from '../../../steplist/types'
@@ -154,6 +155,10 @@ export const selectStep = (
     const stringDefaultEngageHeight = defaultEngageHeight
       ? defaultEngageHeight.toString()
       : null
+    const defaultHeightToProperDecimal = maskField(
+      'engageHeight',
+      stringDefaultEngageHeight
+    )
 
     const prevEngageHeight = getNextDefaultEngageHeight(
       stepFormSelectors.getSavedStepForms(state),
@@ -162,7 +167,7 @@ export const selectStep = (
 
     // if no previously saved engageHeight, autopopulate with recommended value
     // recommended value is null when no labware found on module
-    const engageHeight = prevEngageHeight || stringDefaultEngageHeight
+    const engageHeight = prevEngageHeight || defaultHeightToProperDecimal
     formData = { ...formData, moduleId, magnetAction, engageHeight }
   }
 

--- a/protocol-designer/src/ui/steps/actions/actions.js
+++ b/protocol-designer/src/ui/steps/actions/actions.js
@@ -153,12 +153,8 @@ export const selectStep = (
     )
 
     const stringDefaultEngageHeight = defaultEngageHeight
-      ? defaultEngageHeight.toString()
+      ? maskField('engageHeight', defaultEngageHeight)
       : null
-    const defaultHeightToProperDecimal = maskField(
-      'engageHeight',
-      stringDefaultEngageHeight
-    )
 
     const prevEngageHeight = getNextDefaultEngageHeight(
       stepFormSelectors.getSavedStepForms(state),
@@ -167,7 +163,7 @@ export const selectStep = (
 
     // if no previously saved engageHeight, autopopulate with recommended value
     // recommended value is null when no labware found on module
-    const engageHeight = prevEngageHeight || defaultHeightToProperDecimal
+    const engageHeight = prevEngageHeight || stringDefaultEngageHeight
     formData = { ...formData, moduleId, magnetAction, engageHeight }
   }
 


### PR DESCRIPTION
## overview

This PR closes #4912 by rounding the caption underneath the engage height input and the default height in the input to match the same rules as when typing in a height. In this case, it will round decimals to the tenth place.

## changelog
- Use same masking logic for the caption in MagnetForm and the default engage height in actions
- Added tests for this part of functionality as agreed on from yesterday's testing meeting

## review requests
Enzyme has a known issue with shallow rendering + diving connected components and hooks. Any ideas on testing the MagnetForm is welcome! I had to mount and manually mock the field components.

**Engage height with more than 1 decimal place**
Create a new protocol with a magnet module
Add the USA Scientific 96 Deep Well Plate 2.4 mL on top of the magnet module
Add a magnet step
The caption underneath the engage height input should say Recommended: 10.9 instead of 10.94
The default engage height filled in the input should say 10.9 instead of 10.94
Export the protocol and open up the json file
The engageHeight should be 10.9 in the json

**Check engage height for other labware did not change**
Create a new protocol with a magnet module
Add the Nest 96 well on top of the magnet module
Add a magnet step
The caption underneath the engage height input should say Recommended: 16
The default engage height filled in the input should say 16
Export the protocol and open up the json file
The engageHeight should be 16 in the json
