### PR TITLE
fix(protocol-designer): removes error when fn cannot find temperature…

### DIFF
--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/index.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/index.js
@@ -27,10 +27,6 @@ export function getNextDefaultTemperatureModuleId(
     findKey(equippedModulesById, m => m.type === TEMPDECK) ||
     findKey(equippedModulesById, m => m.type === THERMOCYCLER) ||
     null
-  if (!nextDefaultModule) {
-    console.error('Could not get next default module. Something went wrong.')
-    return null
-  }
 
-  return nextDefaultModule
+  return nextDefaultModule || null
 }


### PR DESCRIPTION
## overview
This PR closes #4841 by removing the console error when this helper function cannot find a temperature/thermocycler module on the deck. 

The issue was that pause steps have a `moduleId` field (since we support pause steps waiting for a temperature). I think it's better to just remove the error rather than introducing more logic to discern whether or not pause step in question is a `Pause until temperature reached` step. 

See this logic:   https://github.com/Opentrons/opentrons/blob/1268e04a623f9d4d557c7f09a44304b5cd3466d2/protocol-designer/src/ui/steps/actions/actions.js#L127-L139 

However, If folks do think that it does make sense to do the additional check, I'm open to it! 

Test coverage: since testing that `console.error` was not called seems insignificant, I opted not to. Writing an explicit test that spys on the error method of console to validate that it does not get called seems like it would add more clutter and no value, but open to it folks think it's important. 

## review requests

- Make a protocol with no modules (or just magnet)
- Click add step and click to create a PAUSE step

- [ ]  You should not see an error in the console (compare to edge to see the difference)