### PR TITLE
fix(protocol-designer): Update SlotMap and CrashInfoBox styles

### DIFF
--- a/components/src/__tests__/__snapshots__/slotmap.test.js.snap
+++ b/components/src/__tests__/__snapshots__/slotmap.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`SlotMap renders correctly with collision warning 1`] = `
 <svg
-  viewBox="0,0,99, 92"
+  viewBox="-1,-1,101, 94"
 >
   <g
     transform="translate(0 0)"
@@ -124,7 +124,7 @@ exports[`SlotMap renders correctly with collision warning 1`] = `
 
 exports[`SlotMap renders correctly with error 1`] = `
 <svg
-  viewBox="0,0,99, 92"
+  viewBox="-1,-1,101, 94"
 >
   <g
     transform="translate(0 0)"
@@ -230,7 +230,7 @@ exports[`SlotMap renders correctly with error 1`] = `
 
 exports[`SlotMap renders correctly with error and collision warning 1`] = `
 <svg
-  viewBox="0,0,99, 92"
+  viewBox="-1,-1,101, 94"
 >
   <g
     transform="translate(0 0)"
@@ -352,7 +352,7 @@ exports[`SlotMap renders correctly with error and collision warning 1`] = `
 
 exports[`SlotMap renders correctly without collision warnings or errors 1`] = `
 <svg
-  viewBox="0,0,99, 92"
+  viewBox="-1,-1,101, 94"
 >
   <g
     transform="translate(0 0)"

--- a/components/src/slotmap/SlotMap.js
+++ b/components/src/slotmap/SlotMap.js
@@ -29,7 +29,9 @@ const numCols = 3
 export function SlotMap(props: SlotMapProps) {
   const { collisionSlots, occupiedSlots, isError } = props
   return (
-    <svg viewBox={`0,0,${slotWidth * numCols}, ${slotHeight * numRows}`}>
+    <svg
+      viewBox={`-1,-1,${slotWidth * numCols + 2}, ${slotHeight * numRows + 2}`}
+    >
       {SLOT_MAP_SLOTS.flatMap((row, rowIndex) =>
         row.map((slot, colIndex) => {
           const isCollisionSlot =

--- a/components/src/slotmap/__tests__/SlotMap.test.js
+++ b/components/src/slotmap/__tests__/SlotMap.test.js
@@ -1,0 +1,33 @@
+// @flow
+import * as React from 'react'
+import { shallow } from 'enzyme'
+
+import { SlotMap } from '../SlotMap'
+import { Icon } from '../../icons'
+
+describe('SlotMap', () => {
+  test('component renders 11 slots', () => {
+    const wrapper = shallow(<SlotMap occupiedSlots={['1']} />)
+
+    expect(wrapper.find('rect')).toHaveLength(11)
+  })
+
+  test('component renders crash info icon when collision slots present', () => {
+    const wrapper = shallow(
+      <SlotMap occupiedSlots={['1']} collisionSlots={['4']} />
+    )
+
+    expect(wrapper.find(Icon)).toHaveLength(1)
+  })
+
+  test('component applies occupied and error styles', () => {
+    const wrapperDefault = shallow(<SlotMap occupiedSlots={['1']} />)
+    const wrapperWithError = shallow(
+      <SlotMap occupiedSlots={['1']} isError={true} />
+    )
+
+    expect(wrapperDefault.find('.slot_occupied')).toHaveLength(1)
+    expect(wrapperWithError.find('.slot_occupied')).toHaveLength(1)
+    expect(wrapperWithError.find('.slot_occupied.slot_error')).toHaveLength(1)
+  })
+})

--- a/components/src/slotmap/styles.css
+++ b/components/src/slotmap/styles.css
@@ -14,5 +14,5 @@
 }
 
 .collision_icon {
-  color: var(--c-dark-gray);
+  color: var(--c-med-gray);
 }

--- a/protocol-designer/src/components/modules/CrashInfoBox.js
+++ b/protocol-designer/src/components/modules/CrashInfoBox.js
@@ -16,7 +16,7 @@ export function CrashInfoBox(props: Props) {
     <div className={styles.crash_info_container}>
       <div className={styles.crash_info_box}>
         <div className={styles.crash_info_title}>
-          <Icon name="alert-circle" className={styles.alert_icon} />
+          <Icon name="information" className={styles.alert_icon} />
           <strong>Limited access to slots</strong>
         </div>
         <p>

--- a/protocol-designer/src/components/modules/styles.css
+++ b/protocol-designer/src/components/modules/styles.css
@@ -33,6 +33,7 @@
 
 .slot_map {
   flex: 1 0 12%;
+  max-width: 8rem;
 }
 
 .row_title {
@@ -92,7 +93,7 @@
 }
 
 .alert_icon {
-  width: 1rem;
+  width: 1.75rem;
   margin-right: 0.5rem;
   color: var(--c-med-gray);
   vertical-align: top;

--- a/protocol-designer/src/components/modules/styles.css
+++ b/protocol-designer/src/components/modules/styles.css
@@ -33,7 +33,7 @@
 
 .slot_map {
   flex: 1 0 12%;
-  max-width: 8rem;
+  max-width: 6rem;
 }
 
 .row_title {


### PR DESCRIPTION
## overview

This PR closes #4989 by updating the viewbox for the slotmap to not crop the edge slot borders and matching crash warning icons on slotmap and crash info box in File Settings Page.

## changelog
- fix(protocol-designer): Update SlotMap and CrashInfoBox styles
- refactor(components): Add enzyme tests to SlotMap

## review requests
http://sandbox.designer.opentrons.com/pd_slot-map-edits/

- [ ] SlotMap borders all match
- [ ] SlotMap has max width on x-large screens
- [ ] Crash info Icons are both [i] in CrashInfoBox and Slotmap and color matches
- [ ] Tests are sane

