### PR TITLE
fix(shared-data): fix typo in v4 protocol schema

### DIFF
--- a/shared-data/protocol/schemas/4.json
+++ b/shared-data/protocol/schemas/4.json
@@ -605,7 +605,7 @@
             "required": ["command", "params"],
             "additionalProperties": false,
             "properties": {
-              "command": { "enum": ["thermocycler/closeLid"] },
+              "command": { "enum": ["thermocycler/runProfile"] },
               "params": {
                 "type": "object",
                 "required": ["module", "profile", "volume"],


### PR DESCRIPTION
## overview

I missed this in the original JSON v4 schema PR! `closeLid` -> `runProfile`. Should match the type in `shared-data/protocol/flowTypes/schemaV4.js`

## changelog


## review requests

- Typo fixed
- No more obvious typos?