### PR TITLE
chore(api): bump required jsonschema in pypi config

### DIFF
--- a/api/setup.py
+++ b/api/setup.py
@@ -114,7 +114,7 @@ INSTALL_REQUIRES = [
     'aiohttp==3.4.4',
     'numpy>=1.15.1',
     'urwid==1.3.1',
-    'jsonschema>=2.5.1',
+    'jsonschema>=3.0.2',
     'aionotify==0.2.0',
 ]
 


### PR DESCRIPTION
This matches the version on the robot, and can actually parse labware requirements.

Closes #5004 