### PR TITLE
chore(api): Constrain jsonschema dependency to current major version

### DIFF
--- a/api/setup.py
+++ b/api/setup.py
@@ -114,7 +114,7 @@ INSTALL_REQUIRES = [
     'aiohttp==3.4.4',
     'numpy>=1.15.1',
     'urwid==1.3.1',
-    'jsonschema>=3.0.2',
+    'jsonschema>=3.0.2,<4',
     'aionotify==0.2.0',
 ]
 


### PR DESCRIPTION
# Overview

This PR tweaks #5005.

jsonschema [uses semantic versioning](https://python-jsonschema.readthedocs.io/en/stable/faq/#how-do-jsonschema-version-numbers-work). So, we can specify that we don't want their next breaking change.

jsonschema has already had one major version bump since we've started using it, apparently. That could have included breaking changes that affect us; we're lucky it didn't.

# Review requests
Should we also change this in the Pipfile?

https://github.com/Opentrons/opentrons/blob/01fccdfc3c6159dc2cd45a59e2ee07cea21031d2/api/Pipfile#L32

# Further reading

* [jsonschema changelog](https://github.com/Julian/jsonschema/blob/master/CHANGELOG.rst).
* It would be nice if we could also do this for NumPy, the only other dependency not to have a pinned version. But we can't, because [they don't use semantic versioning.](https://github.com/numpy/numpy/issues/10156).