### PR TITLE
fix(protocol-designer): null out deleted module IDs from step forms

### DIFF
--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -407,7 +407,12 @@ export const savedStepForms = (
                 labwareSlot === moduleId ? labwareFallbackSlot : labwareSlot
             ),
           }
-        } else if (form.stepType === 'magnet' && form.moduleId === moduleId) {
+        } else if (
+          (form.stepType === 'magnet' ||
+            form.stepType === 'temperature' ||
+            form.stepType === 'pause') &&
+          form.moduleId === moduleId
+        ) {
           return { ...form, moduleId: null }
         } else {
           // TODO: Ian 2019-10-24 remove modules from forms that may reference them

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -415,8 +415,6 @@ export const savedStepForms = (
         ) {
           return { ...form, moduleId: null }
         } else {
-          // TODO: Ian 2019-10-24 remove modules from forms that may reference them
-          // via handleFormChange
           return form
         }
       })

--- a/protocol-designer/src/step-forms/test/reducers.test.js
+++ b/protocol-designer/src/step-forms/test/reducers.test.js
@@ -787,4 +787,70 @@ describe('savedStepForms reducer: initial deck setup step', () => {
       }
     )
   })
+
+  describe('delete module -> removes references to module from step forms', () => {
+    const stepId = '_stepId'
+    const action = { type: 'DELETE_MODULE', payload: { id: moduleId } }
+    const getPrevRootStateWithStep = step => ({
+      savedStepForms: {
+        [INITIAL_DECK_SETUP_STEP_ID]: makeDeckSetupStep({
+          moduleLocationUpdate: {
+            [moduleId]: '1',
+            [otherModuleId]: '2',
+          },
+        }),
+        [stepId]: step,
+      },
+    })
+
+    const testCases = [
+      {
+        testName: 'pause -> wait until temperature step',
+        step: {
+          id: stepId,
+          stepType: 'pause',
+          stepName: 'pause until 4C',
+          stepDetails: 'some details',
+          pauseForAmountOfTime: 'untilTemperature',
+          pauseHour: null,
+          pauseMinute: null,
+          pauseSecond: null,
+          pauseMessage: '',
+          moduleId,
+          pauseTemperature: '4',
+        },
+      },
+      {
+        testName: 'set temperature step',
+        step: {
+          id: stepId,
+          stepType: 'temperature',
+          stepName: 'temperature to 4',
+          stepDetails: 'some details',
+          moduleId,
+          setTemperature: 'true',
+          targetTemperature: '4',
+        },
+      },
+      {
+        testName: 'magnet step',
+        step: {
+          id: stepId,
+          stepType: 'magnet',
+          stepName: 'engage magnet',
+          stepDetails: 'some details',
+          moduleId,
+          magnetAction: 'engage',
+          engageHeight: '4',
+        },
+      },
+    ]
+
+    testCases.forEach(({ testName, step }) => {
+      test(testName, () => {
+        const result = savedStepForms(getPrevRootStateWithStep(step), action)
+        expect(result[stepId]).toEqual({ ...step, moduleId: null })
+      })
+    })
+  })
 })

--- a/protocol-designer/src/steplist/formLevel/errors.js
+++ b/protocol-designer/src/steplist/formLevel/errors.js
@@ -142,7 +142,7 @@ export const pauseForTimeOrUntilTold = (
     return totalSeconds <= 0 ? FORM_ERRORS.TIME_PARAM_REQUIRED : null
   } else if (pauseForAmountOfTime === PAUSE_UNTIL_TEMP) {
     // user selected pause until temperature reached
-    if (!moduleId) {
+    if (moduleId == null) {
       // missing module field (reached by deleting a module from deck)
       return FORM_ERRORS.MODULE_ID_REQUIRED
     }
@@ -191,7 +191,7 @@ export const moduleIdRequired = (
   fields: HydratedFormData
 ): FormError | null => {
   const { moduleId } = fields
-  if (!moduleId) return FORM_ERRORS.MODULE_ID_REQUIRED
+  if (moduleId == null) return FORM_ERRORS.MODULE_ID_REQUIRED
   return null
 }
 

--- a/protocol-designer/src/steplist/formLevel/index.js
+++ b/protocol-designer/src/steplist/formLevel/index.js
@@ -34,11 +34,13 @@ export { getNextDefaultTemperatureModuleId } from './getNextDefaultModuleId'
 export { getNextDefaultMagnetAction } from './getNextDefaultMagnetAction'
 export { getNextDefaultEngageHeight } from './getNextDefaultEngageHeight'
 export { stepFormToArgs } from './stepFormToArgs'
+export type { FormError, FormWarning, FormWarningType }
 
-type FormHelpers = {
+type FormHelpers = {|
   getErrors?: mixed => Array<FormError>,
   getWarnings?: mixed => Array<FormWarning>,
-}
+|}
+
 const stepFormHelperMap: { [StepType]: FormHelpers } = {
   mix: {
     getErrors: composeErrors(incompatibleLabware),
@@ -61,17 +63,18 @@ const stepFormHelperMap: { [StepType]: FormHelpers } = {
     ),
   },
   magnet: {
-    getErrors: composeErrors(magnetActionRequired, engageHeightRequired),
+    getErrors: composeErrors(
+      magnetActionRequired,
+      engageHeightRequired,
+      moduleIdRequired
+    ),
     getWarnings: composeWarnings(engageHeightRangeExceeded),
   },
   temperature: {
-    moduleId: composeErrors(moduleIdRequired),
-    getErrors: composeErrors(targetTemperatureRequired),
+    getErrors: composeErrors(targetTemperatureRequired, moduleIdRequired),
     getWarnings: composeWarnings(temperatureRangeExceeded),
   },
 }
-
-export type { FormError, FormWarning, FormWarningType }
 
 export const getFormErrors = (
   stepType: StepType,


### PR DESCRIPTION
## overview

Closes #4883

This is mostly a data-sanity cleanup, ensuring `moduleId` doesn't retain deleted modules' IDs. The UX should be unchanged, b/c it already gives you the same "missing module" timeline error whether the ID is `null` or invalid.

UPDATE: we were missing form-level errors for these forms. This PR adds/fixes them.

## changelog

- null out moduleId when corresponding module is deleted
- fix/create form-level errors for module forms

## review requests

* Creating any step that refers to a module (magnet, temperature, pause until temp) and deleting that module should set that step's `moduleId` to `null` instead of retaining the old ID
  - [ ] Unit test coverage
  - [ ] Confirm in Redux DevTools if you want
- [ ] UX behaves as expected when you delete/re-add modules when you have already make steps referencing those modules: shows form-level error "Module is required". This should preclude the timeline-level "missing module" error
- [ ] Deleting a module should not affect moduleId fields referencing a _different_ module (eg make magnet steps, then delete temp module -- magnet steps should be OK with no errors)