### PR TITLE
refactor(app): add state for GET /wifi/list to networking module

### DIFF
--- a/app/src/networking/__fixtures__/index.js
+++ b/app/src/networking/__fixtures__/index.js
@@ -1,4 +1,5 @@
 // @flow
 // mock responses for networking endpoints
 
+export * from './list'
 export * from './status'

--- a/app/src/networking/__fixtures__/list.js
+++ b/app/src/networking/__fixtures__/list.js
@@ -1,0 +1,40 @@
+// @flow
+// fixtures for /wifi/list
+
+import { GET } from '../../robot-api'
+import {
+  makeResponseFixtures,
+  mockFailureBody,
+} from '../../robot-api/__fixtures__'
+import { WIFI_LIST_PATH, SECURITY_WPA_EAP } from '../constants'
+
+import type { WifiNetwork, WifiListResponse } from '../types'
+
+export const mockWifiNetwork: WifiNetwork = {
+  ssid: 'linksys',
+  signal: 50,
+  active: false,
+  security: 'WPA2 802.1X',
+  securityType: SECURITY_WPA_EAP,
+}
+
+export const mockWifiList = { list: [mockWifiNetwork] }
+
+const { successMeta, failureMeta, success, failure } = makeResponseFixtures<
+  WifiListResponse,
+  {| message: string |}
+>({
+  method: GET,
+  path: WIFI_LIST_PATH,
+  successStatus: 200,
+  successBody: mockWifiList,
+  failureStatus: 500,
+  failureBody: mockFailureBody,
+})
+
+export {
+  successMeta as mockWifiListSuccessMeta,
+  failureMeta as mockWifiListFailureMeta,
+  success as mockWifiListSuccess,
+  failure as mockWifiListFailure,
+}

--- a/app/src/networking/__tests__/actions.test.js
+++ b/app/src/networking/__tests__/actions.test.js
@@ -61,6 +61,50 @@ describe('networking actions', () => {
         meta: mockRequestMeta,
       },
     },
+    {
+      name: 'networking:FETCH_WIFI_LIST',
+      creator: Actions.fetchWifiList,
+      args: [mockRobot.name],
+      expected: {
+        type: 'networking:FETCH_WIFI_LIST',
+        payload: { robotName: mockRobot.name },
+        meta: {},
+      },
+    },
+    {
+      name: 'networking:FETCH_WIFI_LIST_SUCCESS',
+      creator: Actions.fetchWifiListSuccess,
+      args: [
+        mockRobot.name,
+        Fixtures.mockWifiListSuccess.body.list,
+        mockRequestMeta,
+      ],
+      expected: {
+        type: 'networking:FETCH_WIFI_LIST_SUCCESS',
+        payload: {
+          robotName: mockRobot.name,
+          wifiList: Fixtures.mockWifiListSuccess.body.list,
+        },
+        meta: mockRequestMeta,
+      },
+    },
+    {
+      name: 'networking:FETCH_WIFI_LIST_FAILURE',
+      creator: Actions.fetchWifiListFailure,
+      args: [
+        mockRobot.name,
+        Fixtures.mockWifiListFailure.body,
+        mockRequestMeta,
+      ],
+      expected: {
+        type: 'networking:FETCH_WIFI_LIST_FAILURE',
+        payload: {
+          robotName: mockRobot.name,
+          error: Fixtures.mockWifiListFailure.body,
+        },
+        meta: mockRequestMeta,
+      },
+    },
   ]
 
   SPECS.forEach(spec => {

--- a/app/src/networking/__tests__/reducer.test.js
+++ b/app/src/networking/__tests__/reducer.test.js
@@ -25,12 +25,37 @@ const SPECS: Array<ReducerSpec> = [
       {}
     ),
     state: {
-      [ROBOT_NAME]: {},
+      [ROBOT_NAME]: {
+        wifiList: [],
+      },
     },
     expected: {
       [ROBOT_NAME]: {
         internetStatus: Fixtures.mockNetworkingStatus.status,
         interfaces: Fixtures.mockNetworkingStatus.interfaces,
+        wifiList: [],
+      },
+    },
+  },
+  {
+    name: 'handles fetch wifi list success action',
+    action: Actions.fetchWifiListSuccess(
+      ROBOT_NAME,
+      [Fixtures.mockWifiNetwork],
+      {}
+    ),
+    state: {
+      [ROBOT_NAME]: {
+        internetStatus: Fixtures.mockNetworkingStatus.status,
+        interfaces: Fixtures.mockNetworkingStatus.interfaces,
+        wifiList: [],
+      },
+    },
+    expected: {
+      [ROBOT_NAME]: {
+        internetStatus: Fixtures.mockNetworkingStatus.status,
+        interfaces: Fixtures.mockNetworkingStatus.interfaces,
+        wifiList: [Fixtures.mockWifiNetwork],
       },
     },
   },

--- a/app/src/networking/__tests__/selectors.test.js
+++ b/app/src/networking/__tests__/selectors.test.js
@@ -122,6 +122,62 @@ describe('robot settings selectors', () => {
         },
       },
     },
+    {
+      name: 'getWifiList returns [] if unavailable',
+      selector: Selectors.getWifiList,
+      state: {
+        networking: {},
+      },
+      args: ['robotName'],
+      expected: [],
+    },
+    {
+      name: 'getWifiList returns wifiList from state',
+      selector: Selectors.getWifiList,
+      state: {
+        networking: {
+          robotName: {
+            wifiList: [Fixtures.mockWifiNetwork],
+          },
+        },
+      },
+      args: ['robotName'],
+      expected: [Fixtures.mockWifiNetwork],
+    },
+    {
+      name: 'getWifiList dedupes duplicate SSIDs',
+      selector: Selectors.getWifiList,
+      state: {
+        networking: {
+          robotName: {
+            wifiList: [Fixtures.mockWifiNetwork, Fixtures.mockWifiNetwork],
+          },
+        },
+      },
+      args: ['robotName'],
+      expected: [Fixtures.mockWifiNetwork],
+    },
+    {
+      name: 'getWifiList sorts by active then ssid',
+      selector: Selectors.getWifiList,
+      state: {
+        networking: {
+          robotName: {
+            wifiList: [
+              { ...Fixtures.mockWifiNetwork, ssid: 'bbb' },
+              { ...Fixtures.mockWifiNetwork, ssid: 'aaa' },
+              { ...Fixtures.mockWifiNetwork, active: true, ssid: 'zzz' },
+            ],
+          },
+        },
+      },
+      args: ['robotName'],
+      expected: [
+        { ...Fixtures.mockWifiNetwork, active: true, ssid: 'zzz' },
+        { ...Fixtures.mockWifiNetwork, ssid: 'aaa' },
+        { ...Fixtures.mockWifiNetwork, ssid: 'bbb' },
+      ],
+    },
   ]
 
   SPECS.forEach(spec => {

--- a/app/src/networking/actions.js
+++ b/app/src/networking/actions.js
@@ -31,3 +31,31 @@ export const fetchStatusFailure = (
   payload: { robotName, error },
   meta,
 })
+
+export const fetchWifiList = (
+  robotName: string
+): Types.FetchWifiListAction => ({
+  type: Constants.FETCH_WIFI_LIST,
+  payload: { robotName },
+  meta: {},
+})
+
+export const fetchWifiListSuccess = (
+  robotName: string,
+  wifiList: Array<Types.WifiNetwork>,
+  meta: RobotApiRequestMeta
+): Types.FetchWifiListSuccessAction => ({
+  type: Constants.FETCH_WIFI_LIST_SUCCESS,
+  payload: { robotName, wifiList },
+  meta,
+})
+
+export const fetchWifiListFailure = (
+  robotName: string,
+  error: {},
+  meta: RobotApiRequestMeta
+): Types.FetchWifiListFailureAction => ({
+  type: Constants.FETCH_WIFI_LIST_FAILURE,
+  payload: { robotName, error },
+  meta,
+})

--- a/app/src/networking/constants.js
+++ b/app/src/networking/constants.js
@@ -16,11 +16,18 @@ export const INTERFACE_UNAVAILABLE: 'unavailable' = 'unavailable'
 export const INTERFACE_WIFI: 'wifi' = 'wifi'
 export const INTERFACE_ETHERNET: 'ethernet' = 'ethernet'
 
+export const SECURITY_NONE: 'none' = 'none'
+export const SECURITY_WPA_PSK: 'wpa-psk' = 'wpa-psk'
+export const SECURITY_WPA_EAP: 'wpa-eap' = 'wpa-eap'
+
 // http request paths
 
 export const STATUS_PATH: '/networking/status' = '/networking/status'
+export const WIFI_LIST_PATH: '/wifi/list' = '/wifi/list'
 
 // action type strings
+
+// GET /networking/status
 
 export const FETCH_STATUS: 'networking:FETCH_STATUS' = 'networking:FETCH_STATUS'
 
@@ -29,3 +36,14 @@ export const FETCH_STATUS_SUCCESS: 'networking:FETCH_STATUS_SUCCESS' =
 
 export const FETCH_STATUS_FAILURE: 'networking:FETCH_STATUS_FAILURE' =
   'networking:FETCH_STATUS_FAILURE'
+
+// GET /wifi/list
+
+export const FETCH_WIFI_LIST: 'networking:FETCH_WIFI_LIST' =
+  'networking:FETCH_WIFI_LIST'
+
+export const FETCH_WIFI_LIST_SUCCESS: 'networking:FETCH_WIFI_LIST_SUCCESS' =
+  'networking:FETCH_WIFI_LIST_SUCCESS'
+
+export const FETCH_WIFI_LIST_FAILURE: 'networking:FETCH_WIFI_LIST_FAILURE' =
+  'networking:FETCH_WIFI_LIST_FAILURE'

--- a/app/src/networking/epic/__tests__/wifiListEpic.test.js
+++ b/app/src/networking/epic/__tests__/wifiListEpic.test.js
@@ -1,0 +1,114 @@
+// @flow
+import { TestScheduler } from 'rxjs/testing'
+
+import { mockRobot } from '../../../robot-api/__fixtures__'
+import * as RobotApiHttp from '../../../robot-api/http'
+import * as DiscoverySelectors from '../../../discovery/selectors'
+import * as Fixtures from '../../__fixtures__'
+import * as Actions from '../../actions'
+import * as Types from '../../types'
+import { networkingEpic } from '..'
+
+import type { Observable } from 'rxjs'
+import type {
+  RobotHost,
+  RobotApiRequestOptions,
+  RobotApiResponse,
+} from '../../../robot-api/types'
+
+jest.mock('../../../robot-api/http')
+jest.mock('../../../discovery/selectors')
+jest.mock('../../selectors')
+
+const mockState = { state: true }
+
+const mockFetchRobotApi: JestMockFn<
+  [RobotHost, RobotApiRequestOptions],
+  Observable<RobotApiResponse>
+> = RobotApiHttp.fetchRobotApi
+
+const mockGetRobotByName: JestMockFn<[any, string], mixed> =
+  DiscoverySelectors.getRobotByName
+
+describe('networking wifiListEpic', () => {
+  let testScheduler
+
+  beforeEach(() => {
+    mockGetRobotByName.mockReturnValue(mockRobot)
+
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  const meta = { requestId: '1234' }
+  const action: Types.FetchWifiListAction = {
+    ...Actions.fetchWifiList(mockRobot.name),
+    meta,
+  }
+
+  test('calls GET /wifi/list', () => {
+    testScheduler.run(({ hot, cold, expectObservable, flush }) => {
+      mockFetchRobotApi.mockReturnValue(
+        cold('r', { r: Fixtures.mockWifiListSuccess })
+      )
+
+      const action$ = hot('--a', { a: action })
+      const state$ = hot('a-a', { a: mockState })
+      const output$ = networkingEpic(action$, state$)
+
+      expectObservable(output$)
+      flush()
+
+      expect(mockGetRobotByName).toHaveBeenCalledWith(mockState, mockRobot.name)
+      expect(mockFetchRobotApi).toHaveBeenCalledWith(mockRobot, {
+        method: 'GET',
+        path: '/wifi/list',
+      })
+    })
+  })
+
+  test('maps successful response to FETCH_WIFI_LIST_SUCCESS', () => {
+    testScheduler.run(({ hot, cold, expectObservable, flush }) => {
+      mockFetchRobotApi.mockReturnValue(
+        cold('r', { r: Fixtures.mockWifiListSuccess })
+      )
+
+      const action$ = hot('--a', { a: action })
+      const state$ = hot('a-a', { a: {} })
+      const output$ = networkingEpic(action$, state$)
+
+      expectObservable(output$).toBe('--a', {
+        a: Actions.fetchWifiListSuccess(
+          mockRobot.name,
+          Fixtures.mockWifiListSuccess.body.list,
+          { ...meta, response: Fixtures.mockWifiListSuccessMeta }
+        ),
+      })
+    })
+  })
+
+  test('maps failed response to FETCH_WIFI_LIST_FAILURE', () => {
+    testScheduler.run(({ hot, cold, expectObservable, flush }) => {
+      mockFetchRobotApi.mockReturnValue(
+        cold('r', { r: Fixtures.mockWifiListFailure })
+      )
+
+      const action$ = hot('--a', { a: action })
+      const state$ = hot('a-a', { a: {} })
+      const output$ = networkingEpic(action$, state$)
+
+      expectObservable(output$).toBe('--a', {
+        a: Actions.fetchWifiListFailure(
+          mockRobot.name,
+          Fixtures.mockWifiListFailure.body,
+          { ...meta, response: Fixtures.mockWifiListFailureMeta }
+        ),
+      })
+    })
+  })
+})

--- a/app/src/networking/epic/index.js
+++ b/app/src/networking/epic/index.js
@@ -2,7 +2,8 @@
 import { combineEpics } from 'redux-observable'
 
 import { statusEpic } from './statusEpic'
+import { wifiListEpic } from './wifiListEpic'
 
 import type { Epic } from '../../types'
 
-export const networkingEpic: Epic = combineEpics(statusEpic)
+export const networkingEpic: Epic = combineEpics(statusEpic, wifiListEpic)

--- a/app/src/networking/epic/wifiListEpic.js
+++ b/app/src/networking/epic/wifiListEpic.js
@@ -1,0 +1,43 @@
+// @flow
+import { ofType } from 'redux-observable'
+
+import { GET } from '../../robot-api/constants'
+import { mapToRobotApiRequest } from '../../robot-api/operators'
+import * as Actions from '../actions'
+import * as Constants from '../constants'
+
+import type {
+  ActionToRequestMapper,
+  ResponseToActionMapper,
+} from '../../robot-api/operators'
+import type { Epic } from '../../types'
+import type { FetchWifiListAction } from '../types'
+
+const mapActionToRequest: ActionToRequestMapper<FetchWifiListAction> = action => ({
+  method: GET,
+  path: Constants.WIFI_LIST_PATH,
+})
+
+const mapResponseToAction: ResponseToActionMapper<FetchWifiListAction> = (
+  response,
+  originalAction
+) => {
+  const { host, body, ...responseMeta } = response
+  const meta = { ...originalAction.meta, response: responseMeta }
+
+  return response.ok
+    ? Actions.fetchWifiListSuccess(host.name, body.list, meta)
+    : Actions.fetchWifiListFailure(host.name, body, meta)
+}
+
+export const wifiListEpic: Epic = (action$, state$) => {
+  return action$.pipe(
+    ofType(Constants.FETCH_WIFI_LIST),
+    mapToRobotApiRequest(
+      state$,
+      a => a.payload.robotName,
+      mapActionToRequest,
+      mapResponseToAction
+    )
+  )
+}

--- a/app/src/networking/reducer.js
+++ b/app/src/networking/reducer.js
@@ -8,6 +8,11 @@ import type { NetworkingState, PerRobotNetworkingState } from './types'
 const INITIAL_STATE: NetworkingState = {}
 const INITIAL_ROBOT_STATE: PerRobotNetworkingState = {}
 
+const getRobotState = (
+  state: NetworkingState,
+  robotName: string
+): PerRobotNetworkingState => state[robotName] || INITIAL_ROBOT_STATE
+
 export function networkingReducer(
   state: NetworkingState = INITIAL_STATE,
   action: Action
@@ -15,11 +20,21 @@ export function networkingReducer(
   switch (action.type) {
     case Constants.FETCH_STATUS_SUCCESS: {
       const { robotName, internetStatus, interfaces } = action.payload
-      const robotState = state[robotName] || INITIAL_ROBOT_STATE
+      const robotState = getRobotState(state, robotName)
 
       return {
         ...state,
         [robotName]: { ...robotState, internetStatus, interfaces },
+      }
+    }
+
+    case Constants.FETCH_WIFI_LIST_SUCCESS: {
+      const { robotName, wifiList } = action.payload
+      const robotState = getRobotState(state, robotName)
+
+      return {
+        ...state,
+        [robotName]: { ...robotState, wifiList },
       }
     }
   }

--- a/app/src/networking/selectors.js
+++ b/app/src/networking/selectors.js
@@ -1,7 +1,9 @@
 // @flow
-
+import { createSelector } from 'reselect'
 import find from 'lodash/find'
 import map from 'lodash/map'
+import orderBy from 'lodash/orderBy'
+import uniqBy from 'lodash/uniqBy'
 import { long2ip } from 'netmask'
 
 import { INTERFACE_WIFI, INTERFACE_ETHERNET } from './constants'
@@ -18,34 +20,46 @@ export function getInternetStatus(
   return status != null ? status : null
 }
 
-export function getNetworkInterfaces(
+export const getNetworkInterfaces: (
   state: State,
   robotName: string
-): Types.InterfaceStatusByType {
-  const interfaces = state.networking[robotName]?.interfaces
-  const simpleInterfaces = map(
-    interfaces,
-    (iface: Types.InterfaceStatus): Types.SimpleInterfaceStatus => {
-      const { ipAddress: ipWithMask, macAddress, type } = iface
-      let ipAddress: string | null = null
-      let subnetMask: string | null = null
+) => Types.InterfaceStatusByType = createSelector(
+  (state, robotName) => state.networking[robotName]?.interfaces,
+  interfaces => {
+    const simpleIfaces = map(
+      interfaces,
+      (iface: Types.InterfaceStatus): Types.SimpleInterfaceStatus => {
+        const { ipAddress: ipWithMask, macAddress, type } = iface
+        let ipAddress: string | null = null
+        let subnetMask: string | null = null
 
-      if (ipWithMask != null) {
-        const [ip, mask] = ipWithMask.split('/')
-        const activeMaskBits = mask ? Number(mask) : null
-        ipAddress = ip
-        subnetMask =
-          activeMaskBits && Number.isFinite(activeMaskBits)
-            ? long2ip((0xffffffff << (32 - activeMaskBits)) >>> 0)
-            : null
+        if (ipWithMask != null) {
+          const [ip, mask] = ipWithMask.split('/')
+          const activeMaskBits = mask ? Number(mask) : null
+          ipAddress = ip
+          subnetMask =
+            activeMaskBits && Number.isFinite(activeMaskBits)
+              ? long2ip((0xffffffff << (32 - activeMaskBits)) >>> 0)
+              : null
+        }
+
+        return { ipAddress, subnetMask, macAddress, type }
       }
+    )
 
-      return { ipAddress, subnetMask, macAddress, type }
-    }
-  )
+    const wifi = find(simpleIfaces, { type: INTERFACE_WIFI }) || null
+    const ethernet = find(simpleIfaces, { type: INTERFACE_ETHERNET }) || null
 
-  const wifi = find(simpleInterfaces, { type: INTERFACE_WIFI }) || null
-  const ethernet = find(simpleInterfaces, { type: INTERFACE_ETHERNET }) || null
+    return { wifi, ethernet }
+  }
+)
 
-  return { wifi, ethernet }
-}
+const LIST_ORDER = [['active', 'ssid'], ['desc', 'asc']]
+
+export const getWifiList: (
+  state: State,
+  robotName: string
+) => Array<Types.WifiNetwork> = createSelector(
+  (state, robotName) => state.networking[robotName]?.wifiList,
+  (wifiList = []) => orderBy(uniqBy(wifiList, 'ssid'), ...LIST_ORDER)
+)

--- a/app/src/networking/types.js
+++ b/app/src/networking/types.js
@@ -13,6 +13,15 @@ import typeof {
   INTERFACE_UNAVAILABLE,
   INTERFACE_WIFI,
   INTERFACE_ETHERNET,
+  SECURITY_NONE,
+  SECURITY_WPA_PSK,
+  SECURITY_WPA_EAP,
+  FETCH_STATUS,
+  FETCH_STATUS_SUCCESS,
+  FETCH_STATUS_FAILURE,
+  FETCH_WIFI_LIST,
+  FETCH_WIFI_LIST_SUCCESS,
+  FETCH_WIFI_LIST_FAILURE,
 } from './constants'
 
 // response types
@@ -51,18 +60,37 @@ export type NetworkingStatusResponse = {|
   interfaces: InterfaceStatusMap,
 |}
 
+// GET /wifi/list
+
+export type WifiSecurityType =
+  | SECURITY_NONE
+  | SECURITY_WPA_PSK
+  | SECURITY_WPA_EAP
+
+export type WifiNetwork = {|
+  ssid: string,
+  signal: number,
+  active: boolean,
+  security: string,
+  securityType: WifiSecurityType,
+|}
+
+export type WifiListResponse = {|
+  list: Array<WifiNetwork>,
+|}
+
 // action types
 
 // fetch status
 
 export type FetchStatusAction = {|
-  type: 'networking:FETCH_STATUS',
+  type: FETCH_STATUS,
   payload: {| robotName: string |},
   meta: RobotApiRequestMeta,
 |}
 
 export type FetchStatusSuccessAction = {|
-  type: 'networking:FETCH_STATUS_SUCCESS',
+  type: FETCH_STATUS_SUCCESS,
   payload: {|
     robotName: string,
     internetStatus: InternetStatus,
@@ -72,7 +100,27 @@ export type FetchStatusSuccessAction = {|
 |}
 
 export type FetchStatusFailureAction = {|
-  type: 'networking:FETCH_STATUS_FAILURE',
+  type: FETCH_STATUS_FAILURE,
+  payload: {| robotName: string, error: {} |},
+  meta: RobotApiRequestMeta,
+|}
+
+// fetch wifi list
+
+export type FetchWifiListAction = {|
+  type: FETCH_WIFI_LIST,
+  payload: {| robotName: string |},
+  meta: RobotApiRequestMeta,
+|}
+
+export type FetchWifiListSuccessAction = {|
+  type: FETCH_WIFI_LIST_SUCCESS,
+  payload: {| robotName: string, wifiList: Array<WifiNetwork> |},
+  meta: RobotApiRequestMeta,
+|}
+
+export type FetchWifiListFailureAction = {|
+  type: FETCH_WIFI_LIST_FAILURE,
   payload: {| robotName: string, error: {} |},
   meta: RobotApiRequestMeta,
 |}
@@ -83,12 +131,16 @@ export type NetworkingAction =
   | FetchStatusAction
   | FetchStatusSuccessAction
   | FetchStatusFailureAction
+  | FetchWifiListAction
+  | FetchWifiListSuccessAction
+  | FetchWifiListFailureAction
 
 // state types
 
 export type PerRobotNetworkingState = $Shape<{|
   internetStatus: InternetStatus,
   interfaces: InterfaceStatusMap,
+  wifiList: Array<WifiNetwork>,
 |}>
 
 export type NetworkingState = $Shape<{|


### PR DESCRIPTION
## overview

This PR closes adds actions, reducer, epic, and selector logic to the app's top level `networking` state module to support `GET /wifi/list`. Closes #5021.

This PR does not remove the corresponding logic in `http-api-client/networking.js` nor does it touch component wirings in favor of doing that work in other PRs.

## changelog

- refactor(app): add state for GET /wifi/list to networking module

## review requests

1. Open up Redux devtools
2. Dispatch `networking:FETCH_WIFI_LIST` action

```
{
  type: 'networking:FETCH_WIFI_LIST',
  payload: { robotName: 'sanni-t Bot' },
  meta: {}
}
```

- [ ] `GET /wifi/list` request goes out
- [ ] `networking:FETCH_WIFI_LIST_SUCCESS` action comes back
