### PR TITLE
feat(protocol-designer): disambiguate module model vs type

### DIFF
--- a/protocol-designer/src/components/DeckSetup/DeckSetup.js
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.js
@@ -11,7 +11,7 @@ import {
 import {
   getLabwareHasQuirk,
   type DeckSlot as DeckDefSlot,
-  type ModuleType,
+  type ModuleRealType,
 } from '@opentrons/shared-data'
 import { getDeckDefinitions } from '@opentrons/components/src/deck/getDeckDefinitions'
 import { PSEUDO_DECK_SLOTS, GEN_ONE_MULTI_PIPETTES } from '../../constants'
@@ -113,9 +113,9 @@ const getSwapBlocked = (args: {
     return false
   }
 
-  const sourceModuleType: ?ModuleType =
+  const sourceModuleType: ?ModuleRealType =
     modulesById[draggedLabware.slot]?.type || null
-  const destModuleType: ?ModuleType =
+  const destModuleType: ?ModuleRealType =
     modulesById[hoveredLabware.slot]?.type || null
 
   const labwareSourceToDestBlocked = sourceModuleType

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.js
@@ -19,7 +19,7 @@ import { DND_TYPES } from './constants'
 import type { DeckSlot, ThunkDispatch } from '../../../types'
 import type {
   DeckSlot as DeckSlotDefinition,
-  ModuleType,
+  ModuleRealType,
   LabwareDefinition2,
 } from '@opentrons/shared-data'
 import styles from './LabwareOverlays.css'
@@ -31,7 +31,7 @@ type DNDP = {|
 |}
 type OP = {|
   slot: {| ...DeckSlotDefinition, id: DeckSlot |}, // NOTE: Ian 2019-10-22 make slot `id` more restrictive when used in PD
-  moduleType: ModuleType | null,
+  moduleType: ModuleRealType | null,
   selectedTerminalItemId: ?TerminalItemId,
   handleDragHover?: () => mixed,
 |}

--- a/protocol-designer/src/components/DeckSetup/ModuleTag.js
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.js
@@ -3,12 +3,14 @@ import * as React from 'react'
 import { useSelector } from 'react-redux'
 import cx from 'classnames'
 import { RobotCoordsForeignDiv } from '@opentrons/components'
+import {
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+} from '@opentrons/shared-data'
 import { i18n } from '../../localization'
 import { timelineFrameBeforeActiveItem } from '../../top-selectors/timelineFrames'
 import { selectors as stepFormSelectors } from '../../step-forms'
 import {
-  MAGDECK,
-  TEMPDECK,
   STD_SLOT_X_DIM,
   STD_SLOT_Y_DIM,
   TEMPERATURE_AT_TARGET,
@@ -61,7 +63,7 @@ export const ModuleStatus = ({
   moduleState: $PropertyType<ModuleTemporalProperties, 'moduleState'>,
 |}) => {
   switch (moduleState.type) {
-    case MAGDECK:
+    case MAGNETIC_MODULE_TYPE:
       return (
         <div className={styles.module_status_line}>
           {i18n.t(
@@ -70,7 +72,7 @@ export const ModuleStatus = ({
         </div>
       )
 
-    case TEMPDECK:
+    case TEMPERATURE_MODULE_TYPE:
       const tempStatus = getTempStatus(moduleState)
       return <div className={styles.module_status_line}>{tempStatus}</div>
 

--- a/protocol-designer/src/components/DeckSetup/__tests__/ModuleTag.test.js
+++ b/protocol-designer/src/components/DeckSetup/__tests__/ModuleTag.test.js
@@ -1,9 +1,12 @@
+// @flow
+import {
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+} from '@opentrons/shared-data'
 import React from 'react'
 import { render } from 'enzyme'
 import { ModuleStatus } from '../ModuleTag'
 import {
-  TEMPDECK,
-  MAGDECK,
   TEMPERATURE_APPROACHING_TARGET,
   TEMPERATURE_AT_TARGET,
   TEMPERATURE_DEACTIVATED,
@@ -14,7 +17,7 @@ describe('ModuleStatus', () => {
     test('displays engaged when magent is engaged', () => {
       const props = {
         engaged: true,
-        type: MAGDECK,
+        type: MAGNETIC_MODULE_TYPE,
       }
 
       const component = render(<ModuleStatus moduleState={props} />)
@@ -25,7 +28,7 @@ describe('ModuleStatus', () => {
     test('displays disengaged when magnet is not engaged', () => {
       const moduleState = {
         engaged: false,
-        type: MAGDECK,
+        type: MAGNETIC_MODULE_TYPE,
       }
 
       const component = render(<ModuleStatus moduleState={moduleState} />)
@@ -37,7 +40,7 @@ describe('ModuleStatus', () => {
   describe('temperature module', () => {
     test('deactivated is shown when module is deactivated', () => {
       const moduleState = {
-        type: TEMPDECK,
+        type: TEMPERATURE_MODULE_TYPE,
         status: TEMPERATURE_DEACTIVATED,
         targetTemperature: null,
       }
@@ -49,7 +52,7 @@ describe('ModuleStatus', () => {
 
     test('target temperature is shown when module is at target', () => {
       const moduleState = {
-        type: TEMPDECK,
+        type: TEMPERATURE_MODULE_TYPE,
         status: TEMPERATURE_AT_TARGET,
         targetTemperature: 45,
       }
@@ -61,7 +64,7 @@ describe('ModuleStatus', () => {
 
     test('going to X is shown when temperature is approaching target', () => {
       const moduleState = {
-        type: TEMPDECK,
+        type: TEMPERATURE_MODULE_TYPE,
         status: TEMPERATURE_APPROACHING_TARGET,
         targetTemperature: 45,
       }

--- a/protocol-designer/src/components/DeckSetup/getModuleVizDims.js
+++ b/protocol-designer/src/components/DeckSetup/getModuleVizDims.js
@@ -6,11 +6,13 @@ import {
   STD_SLOT_Y_DIM as SLOT_Y,
   STD_SLOT_DIVIDER_WIDTH as DIVIDER,
   SPAN7_8_10_11_SLOT,
-  MAGDECK,
-  TEMPDECK,
-  THERMOCYCLER,
 } from '../../constants'
-import type { ModuleType } from '@opentrons/shared-data'
+import {
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
+import type { ModuleRealType } from '@opentrons/shared-data'
 import type { DeckSlot, ModuleOrientation } from '../../types'
 
 // NOTE: all dims are in 'left' orientation. Rotate & transform to obtain 'right' orientation.
@@ -25,8 +27,8 @@ export type ModuleVizDims = {|
   childYDimension: number,
 |}
 
-const MODULE_VIZ_DIMS: { [ModuleType]: ModuleVizDims } = {
-  [MAGDECK]: {
+const MODULE_VIZ_DIMS: { [ModuleRealType]: ModuleVizDims } = {
+  [MAGNETIC_MODULE_TYPE]: {
     xOffset: -1 * (SLOT_X * 0.2 + DIVIDER),
     yOffset: -1 * DIVIDER,
     xDimension: SLOT_X * 1.2 + DIVIDER * 2,
@@ -36,7 +38,7 @@ const MODULE_VIZ_DIMS: { [ModuleType]: ModuleVizDims } = {
     childXDimension: SLOT_X,
     childYDimension: SLOT_Y,
   },
-  [TEMPDECK]: {
+  [TEMPERATURE_MODULE_TYPE]: {
     xOffset: -1 * (SLOT_X * 0.4 + DIVIDER),
     yOffset: -1 * DIVIDER,
     xDimension: SLOT_X * 1.4 + DIVIDER * 2,
@@ -46,7 +48,7 @@ const MODULE_VIZ_DIMS: { [ModuleType]: ModuleVizDims } = {
     childXDimension: SLOT_X,
     childYDimension: SLOT_Y,
   },
-  [THERMOCYCLER]: {
+  [THERMOCYCLER_MODULE_TYPE]: {
     xOffset: -8,
     yOffset: 0,
     xDimension: SLOT_X + DIVIDER + 32,
@@ -60,7 +62,7 @@ const MODULE_VIZ_DIMS: { [ModuleType]: ModuleVizDims } = {
 
 export const getModuleVizDims = (
   orientation: ModuleOrientation,
-  moduleType: ModuleType
+  moduleType: ModuleRealType
 ): ModuleVizDims => {
   const dims = MODULE_VIZ_DIMS[moduleType]
   if (orientation === 'left') return dims

--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -20,7 +20,7 @@ import styles from './FilePage.css'
 import formStyles from '../components/forms/forms.css'
 import type { FileMetadataFields } from '../file-data'
 import type { ModulesForEditModulesCard } from '../step-forms'
-import type { ModuleType } from '@opentrons/shared-data'
+import type { ModuleRealType } from '@opentrons/shared-data'
 export type Props = {|
   formValues: FileMetadataFields,
   instruments: React.ElementProps<typeof InstrumentGroup>,
@@ -36,7 +36,7 @@ type State = {|
   isEditPipetteModalOpen: boolean,
   isEditModulesModalOpen: boolean,
   currentModule: {|
-    moduleType: ?ModuleType,
+    moduleType: ?ModuleRealType,
     moduleId: ?string,
   |},
 |}
@@ -69,7 +69,7 @@ export class FilePage extends React.Component<Props, State> {
   }
   closeEditPipetteModal = () => this.setState({ isEditPipetteModalOpen: false })
 
-  handleEditModule = (moduleType: ModuleType, moduleId?: string) => {
+  handleEditModule = (moduleType: ModuleRealType, moduleId?: string) => {
     this.scrollToTop()
     this.setState({
       isEditModulesModalOpen: true,

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
@@ -17,8 +17,11 @@ import {
 import {
   getLabwareDefURI,
   getLabwareDefIsStandard,
+  TEMPERATURE_MODULE_TYPE,
+  MAGNETIC_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
   type LabwareDefinition2,
-  type ModuleType,
+  type ModuleRealType,
 } from '@opentrons/shared-data'
 import { i18n } from '../../localization'
 import { SPAN7_8_10_11_SLOT } from '../../constants'
@@ -44,7 +47,7 @@ type Props = {|
   /** if adding to a module, the slot of the parent (for display) */
   parentSlot: ?DeckSlot,
   /** if adding to a module, the module's type */
-  moduleType: ?ModuleType,
+  moduleType: ?ModuleRealType,
   /** tipracks that may be added to deck (depends on pipette<>tiprack assignment) */
   permittedTipracks: Array<string>,
 |}
@@ -61,8 +64,8 @@ const orderedCategories: Array<string> = [
   // 'trash', // NOTE: trash intentionally hidden
 ]
 
-const RECOMMENDED_LABWARE_BY_MODULE: { [ModuleType]: Array<string> } = {
-  tempdeck: [
+const RECOMMENDED_LABWARE_BY_MODULE: { [ModuleRealType]: Array<string> } = {
+  [TEMPERATURE_MODULE_TYPE]: [
     'opentrons_24_aluminumblock_generic_2ml_screwcap',
     'opentrons_96_aluminumblock_biorad_wellplate_200ul',
     'opentrons_96_aluminumblock_generic_pcr_strip_200ul',
@@ -72,8 +75,8 @@ const RECOMMENDED_LABWARE_BY_MODULE: { [ModuleType]: Array<string> } = {
     'opentrons_24_aluminumblock_nest_2ml_snapcap',
     'opentrons_24_aluminumblock_nest_0.5ml_screwcap',
   ],
-  magdeck: ['nest_96_wellplate_100ul_pcr_full_skirt'],
-  thermocycler: ['nest_96_wellplate_100ul_pcr_full_skirt'],
+  [MAGNETIC_MODULE_TYPE]: ['nest_96_wellplate_100ul_pcr_full_skirt'],
+  [THERMOCYCLER_MODULE_TYPE]: ['nest_96_wellplate_100ul_pcr_full_skirt'],
 }
 
 export const LabwareSelectionModal = (props: Props) => {

--- a/protocol-designer/src/components/StepCreationButton.js
+++ b/protocol-designer/src/components/StepCreationButton.js
@@ -4,6 +4,11 @@ import { connect } from 'react-redux'
 import cx from 'classnames'
 import without from 'lodash/without'
 import { HoverTooltip, PrimaryButton } from '@opentrons/components'
+import {
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
 import { i18n } from '../localization'
 import { actions as stepsActions } from '../ui/steps'
 import { selectors as featureFlagSelectors } from '../feature-flags'
@@ -13,7 +18,6 @@ import {
 } from '../step-forms'
 import { stepIconsByType, type StepType } from '../form-types'
 import type { BaseState, ThunkDispatch } from '../types'
-import { MAGDECK, TEMPDECK, THERMOCYCLER } from '../constants'
 import styles from './listButtons.css'
 
 type SP = {|
@@ -117,11 +121,11 @@ const mapSTP = (state: BaseState): SP => {
       moveLiquid: true,
       mix: true,
       pause: true,
-      magnet: getIsModuleOnDeck(modules, MAGDECK),
+      magnet: getIsModuleOnDeck(modules, MAGNETIC_MODULE_TYPE),
       temperature:
-        getIsModuleOnDeck(modules, TEMPDECK) ||
-        getIsModuleOnDeck(modules, THERMOCYCLER),
-      thermocycler: getIsModuleOnDeck(modules, THERMOCYCLER),
+        getIsModuleOnDeck(modules, TEMPERATURE_MODULE_TYPE) ||
+        getIsModuleOnDeck(modules, THERMOCYCLER_MODULE_TYPE),
+      thermocycler: getIsModuleOnDeck(modules, THERMOCYCLER_MODULE_TYPE),
     },
   }
 }

--- a/protocol-designer/src/components/modals/EditModulesModal/__tests__/EditModulesModal.test.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/__tests__/EditModulesModal.test.js
@@ -1,13 +1,18 @@
+// TODO: IL 2020-02-19 add Flow directive (need to figure out how to flow-ignore mocking, or refactor to avoid mocking)
 import React from 'react'
 import { Provider } from 'react-redux'
 import { mount } from 'enzyme'
 import { OutlineButton, DropdownField } from '@opentrons/components'
+import {
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+} from '@opentrons/shared-data'
+import { DEFAULT_MODEL_FOR_MODULE_TYPE } from '../../../../constants'
 import { selectors as stepFormSelectors } from '../../../../step-forms'
 import { selectors as featureSelectors } from '../../../../feature-flags'
 import * as stepFormActions from '../../../../step-forms/actions'
 import * as labwareModuleCompatibility from '../../../../utils/labwareModuleCompatibility'
 import * as labwareIngredActions from '../../../../labware-ingred/actions'
-import { MAGDECK, TEMPDECK } from '../../../../constants'
 import { PDAlert } from '../../../alerts/PDAlert'
 import { EditModulesModal } from '../'
 // only mock actions and selectors from step-forms
@@ -52,7 +57,7 @@ describe('EditModulesModal', () => {
     })
     labwareModuleCompatibility.getLabwareIsCompatible.mockReturnValue(false)
     const props = {
-      moduleType: MAGDECK,
+      moduleType: MAGNETIC_MODULE_TYPE,
       moduleId: null,
       onCloseClick: jest.fn(),
     }
@@ -80,7 +85,7 @@ describe('EditModulesModal', () => {
     })
     labwareModuleCompatibility.getLabwareIsCompatible.mockReturnValue(true)
     const props = {
-      moduleType: MAGDECK,
+      moduleType: MAGNETIC_MODULE_TYPE,
       moduleId: null,
       onCloseClick: jest.fn(),
     }
@@ -95,8 +100,8 @@ describe('EditModulesModal', () => {
     expect(warning).toHaveLength(0)
     expect(stepFormActions.createModule).toHaveBeenCalledWith({
       slot,
-      type: MAGDECK,
-      model: 'GEN1',
+      type: MAGNETIC_MODULE_TYPE,
+      model: DEFAULT_MODEL_FOR_MODULE_TYPE[MAGNETIC_MODULE_TYPE],
     })
     expect(props.onCloseClick).toHaveBeenCalled()
   })
@@ -116,7 +121,7 @@ describe('EditModulesModal', () => {
       pipettes: {},
     })
     const props = {
-      moduleType: TEMPDECK,
+      moduleType: TEMPERATURE_MODULE_TYPE,
       moduleId: null,
       onCloseClick: jest.fn(),
     }
@@ -132,8 +137,8 @@ describe('EditModulesModal', () => {
     expect(warning).toHaveLength(0)
     expect(stepFormActions.createModule).toHaveBeenCalledWith({
       slot: newSlot,
-      type: TEMPDECK,
-      model: 'GEN1',
+      type: TEMPERATURE_MODULE_TYPE,
+      model: DEFAULT_MODEL_FOR_MODULE_TYPE[TEMPERATURE_MODULE_TYPE],
     })
     expect(props.onCloseClick).toHaveBeenCalled()
   })
@@ -156,7 +161,7 @@ describe('EditModulesModal', () => {
     })
     labwareModuleCompatibility.getLabwareIsCompatible.mockReturnValue(true)
     const props = {
-      moduleType: MAGDECK,
+      moduleType: MAGNETIC_MODULE_TYPE,
       moduleId: 'magnet123',
       onCloseClick: jest.fn(),
     }
@@ -191,7 +196,7 @@ describe('EditModulesModal', () => {
       pipettes: {},
     })
     const props = {
-      moduleType: MAGDECK,
+      moduleType: MAGNETIC_MODULE_TYPE,
       moduleId: 'magnet123',
       onCloseClick: jest.fn(),
     }
@@ -204,7 +209,7 @@ describe('EditModulesModal', () => {
 
   test('cancel calls onCloseClick to close modal', () => {
     const props = {
-      moduleType: MAGDECK,
+      moduleType: MAGNETIC_MODULE_TYPE,
       moduleId: null,
       onCloseClick: jest.fn(),
     }
@@ -226,7 +231,7 @@ describe('EditModulesModal', () => {
       .fn()
       .mockReturnValue(true)
     const props = {
-      moduleType: MAGDECK,
+      moduleType: MAGNETIC_MODULE_TYPE,
       moduleId: null,
       onCloseClick: jest.fn(),
     }

--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import cx from 'classnames'
 import { useSelector, useDispatch } from 'react-redux'
-import { getModuleDisplayName } from '@opentrons/shared-data'
+import { THERMOCYCLER_MODULE_TYPE } from '@opentrons/shared-data'
 import {
   Modal,
   OutlineButton,
@@ -24,16 +24,20 @@ import {
   SUPPORTED_MODULE_SLOTS,
   getAllModuleSlotsByType,
 } from '../../../modules'
-import { MODELS_FOR_MODULE_TYPE, THERMOCYCLER } from '../../../constants'
+import {
+  MODELS_FOR_MODULE_TYPE,
+  DEFAULT_MODEL_FOR_MODULE_TYPE,
+} from '../../../constants'
 import { i18n } from '../../../localization'
 import { getLabwareIsCompatible } from '../../../utils/labwareModuleCompatibility'
 import { PDAlert } from '../../alerts/PDAlert'
 import modalStyles from '../modal.css'
 import styles from './EditModules.css'
-import type { ModuleType } from '@opentrons/shared-data'
+import type { ModuleRealType } from '@opentrons/shared-data'
 
 type EditModulesProps = {
-  moduleType: ModuleType,
+  moduleType: ModuleRealType,
+  /** if moduleId is not specified, we're creating a new module of the given type */
   moduleId: ?string,
   onCloseClick: () => mixed,
 }
@@ -42,14 +46,16 @@ export function EditModulesModal(props: EditModulesProps) {
   const { moduleType, onCloseClick } = props
   const _initialDeckSetup = useSelector(stepFormSelectors.getInitialDeckSetup)
 
-  const module = props.moduleId && _initialDeckSetup.modules[props.moduleId]
+  const module = props.moduleId
+    ? _initialDeckSetup.modules[props.moduleId]
+    : null
 
   const [selectedSlot, setSelectedSlot] = React.useState<string>(
-    (module && module.slot) || SUPPORTED_MODULE_SLOTS[moduleType][0].value
+    module?.slot || SUPPORTED_MODULE_SLOTS[moduleType][0].value
   )
 
   const [selectedModel, setSelectedModel] = React.useState<string>(
-    (module && module.model) || 'GEN1'
+    module?.model || DEFAULT_MODEL_FOR_MODULE_TYPE[moduleType]
   )
 
   const slotsBlockedBySpanning = getSlotsBlockedBySpanning(_initialDeckSetup)
@@ -71,7 +77,7 @@ export function EditModulesModal(props: EditModulesProps) {
     hasSlotOrIncompatibleError = !labwareIsCompatible
   }
 
-  const showSlotOption = moduleType !== THERMOCYCLER
+  const showSlotOption = moduleType !== THERMOCYCLER_MODULE_TYPE
 
   const enableSlotSelection = useSelector(
     featureFlagSelectors.getDisableModuleRestrictions
@@ -115,8 +121,7 @@ export function EditModulesModal(props: EditModulesProps) {
       onCloseClick()
     }
   }
-
-  const heading = getModuleDisplayName(moduleType)
+  const heading = i18n.t(`modules.module_long_names.${moduleType}`)
 
   const slotOptionTooltip = (
     <div className={styles.slot_tooltip}>

--- a/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.js
@@ -32,6 +32,7 @@ export function ModuleFields(props: Props) {
     <div className={className}>
       {modules.map((moduleType, i) => {
         const label = i18n.t(`modules.module_display_names.${moduleType}`)
+        const defaultModel = DEFAULT_MODEL_FOR_MODULE_TYPE[moduleType]
         return (
           <div className={styles.module_form_group} key={`${moduleType}`}>
             <CheckboxField
@@ -43,7 +44,6 @@ export function ModuleFields(props: Props) {
             <ModuleDiagram type={moduleType} />
             {/*
               TODO (ka 2019-10-22): This field is disabled until Gen 2 Modules are available
-              - Until then, 'GEN1' is hardcoded
               - onChange returns null because onChange is required by DropdownFields
             */}
             <div className={styles.module_model}>
@@ -53,11 +53,13 @@ export function ModuleFields(props: Props) {
                     tabIndex={i}
                     options={[
                       {
-                        name: 'GEN1',
-                        value: DEFAULT_MODEL_FOR_MODULE_TYPE[moduleType],
+                        name: i18n.t(
+                          `modules.model_display_name.${defaultModel}`
+                        ),
+                        value: defaultModel,
                       },
                     ]}
-                    value={DEFAULT_MODEL_FOR_MODULE_TYPE[moduleType]}
+                    value={defaultModel}
                     disabled
                     onChange={() => null}
                   />

--- a/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.js
@@ -1,25 +1,26 @@
 // @flow
 import * as React from 'react'
 import cx from 'classnames'
-import { i18n } from '../../../localization'
 import { CheckboxField, DropdownField, FormGroup } from '@opentrons/components'
+import { i18n } from '../../../localization'
+import { DEFAULT_MODEL_FOR_MODULE_TYPE } from '../../../constants'
 import { ModuleDiagram } from '../../modules'
 
 import styles from './FilePipettesModal.css'
 
-import type { ModuleType } from '@opentrons/shared-data'
+import type { ModuleRealType } from '@opentrons/shared-data'
 import type { FormModulesByType } from '../../../step-forms'
 
 type Props = {|
   values: FormModulesByType,
   thermocyclerEnabled: ?boolean,
-  onFieldChange: (type: ModuleType, value: boolean) => mixed,
+  onFieldChange: (type: ModuleRealType, value: boolean) => mixed,
 |}
 
 export function ModuleFields(props: Props) {
   const { onFieldChange, values, thermocyclerEnabled } = props
   const modules = Object.keys(values)
-  const handleOnDeckChange = (type: ModuleType) => (
+  const handleOnDeckChange = (type: ModuleRealType) => (
     e: SyntheticInputEvent<HTMLInputElement>
   ) => onFieldChange(type, e.currentTarget.checked || false)
 
@@ -50,8 +51,13 @@ export function ModuleFields(props: Props) {
                 <FormGroup label="Model">
                   <DropdownField
                     tabIndex={i}
-                    options={[{ name: 'GEN1', value: 'GEN1' }]}
-                    value={'GEN1'}
+                    options={[
+                      {
+                        name: 'GEN1',
+                        value: DEFAULT_MODEL_FOR_MODULE_TYPE[moduleType],
+                      },
+                    ]}
+                    value={DEFAULT_MODEL_FOR_MODULE_TYPE[moduleType]}
                     disabled
                     onChange={() => null}
                   />

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.js
@@ -12,8 +12,16 @@ import {
   OutlineButton,
   type Mount,
 } from '@opentrons/components'
+import {
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+  MAGDECK_MODEL_GEN1,
+  TEMPDECK_MODEL_GEN1,
+  THERMOCYCLER_MODEL_GEN1,
+} from '@opentrons/shared-data'
 import { i18n } from '../../../localization'
-import { SPAN7_8_10_11_SLOT, THERMOCYCLER } from '../../../constants'
+import { SPAN7_8_10_11_SLOT } from '../../../constants'
 import { StepChangesConfirmModal } from '../EditPipettesModal/StepChangesConfirmModal'
 import { ModuleFields } from './ModuleFields'
 import { PipetteFields } from './PipetteFields'
@@ -21,7 +29,7 @@ import { CrashInfoBox } from '../../modules'
 import styles from './FilePipettesModal.css'
 import formStyles from '../../forms/forms.css'
 import modalStyles from '../modal.css'
-import type { ModuleType } from '@opentrons/shared-data'
+import type { ModuleRealType } from '@opentrons/shared-data'
 import type { DeckSlot } from '../../../types'
 import type { NewProtocolFields } from '../../../load-file'
 import type {
@@ -37,7 +45,11 @@ type PipetteFieldsData = $Diff<
   {| id: mixed, spec: mixed, tiprackLabwareDef: mixed |}
 >
 
-type ModuleCreationArgs = {| type: ModuleType, model: string, slot: DeckSlot |}
+type ModuleCreationArgs = {|
+  type: ModuleRealType,
+  model: string,
+  slot: DeckSlot,
+|}
 
 type State = {|
   fields: NewProtocolFields,
@@ -70,9 +82,21 @@ const initialState: State = {
     right: { pipetteName: '', tiprackDefURI: null },
   },
   modulesByType: {
-    magdeck: { onDeck: false, model: 'GEN1', slot: '1' },
-    tempdeck: { onDeck: false, model: 'GEN1', slot: '3' },
-    thermocycler: { onDeck: false, model: 'GEN1', slot: SPAN7_8_10_11_SLOT },
+    [MAGNETIC_MODULE_TYPE]: {
+      onDeck: false,
+      model: MAGDECK_MODEL_GEN1,
+      slot: '1',
+    },
+    [TEMPERATURE_MODULE_TYPE]: {
+      onDeck: false,
+      model: TEMPDECK_MODEL_GEN1,
+      slot: '3',
+    },
+    [THERMOCYCLER_MODULE_TYPE]: {
+      onDeck: false,
+      model: THERMOCYCLER_MODEL_GEN1,
+      slot: SPAN7_8_10_11_SLOT,
+    },
   },
 }
 
@@ -100,7 +124,10 @@ export class FilePipettesModal extends React.Component<Props, State> {
   }
 
   getCrashableModuleSelected = (modules: FormModulesByType) => {
-    return modules.magdeck.onDeck || modules.tempdeck.onDeck
+    return (
+      modules[MAGNETIC_MODULE_TYPE].onDeck ||
+      modules[TEMPERATURE_MODULE_TYPE].onDeck
+    )
   }
 
   handlePipetteFieldsChange = (
@@ -124,7 +151,7 @@ export class FilePipettesModal extends React.Component<Props, State> {
     })
   }
 
-  handleModuleOnDeckChange = (type: ModuleType, value: boolean) => {
+  handleModuleOnDeckChange = (type: ModuleRealType, value: boolean) => {
     let nextMountState: $Shape<FormModule> = { onDeck: value }
     this.setState({
       modulesByType: {
@@ -164,8 +191,10 @@ export class FilePipettesModal extends React.Component<Props, State> {
     )
 
     // NOTE: this is extra-explicit for flow. Reduce fns won't cooperate
-    // with enum-typed key like `{[ModuleType]: ___}`
-    const moduleTypes: Array<ModuleType> = Object.keys(this.state.modulesByType)
+    // with enum-typed key like `{[ModuleRealType]: ___}`
+    const moduleTypes: Array<ModuleRealType> = Object.keys(
+      this.state.modulesByType
+    )
     const modules: Array<ModuleCreationArgs> = moduleTypes.reduce(
       (acc, moduleType) => {
         const module = this.state.modulesByType[moduleType]
@@ -213,7 +242,7 @@ export class FilePipettesModal extends React.Component<Props, State> {
 
     const visibleModules = this.props.thermocyclerEnabled
       ? this.state.modulesByType
-      : omit(this.state.modulesByType, THERMOCYCLER)
+      : omit(this.state.modulesByType, THERMOCYCLER_MODULE_TYPE)
 
     return (
       <React.Fragment>
@@ -279,8 +308,12 @@ export class FilePipettesModal extends React.Component<Props, State> {
               {showCrashInfoBox && (
                 <CrashInfoBox
                   showDiagram
-                  magnetOnDeck={this.state.modulesByType.magdeck.onDeck}
-                  temperatureOnDeck={this.state.modulesByType.tempdeck.onDeck}
+                  magnetOnDeck={
+                    this.state.modulesByType[MAGNETIC_MODULE_TYPE].onDeck
+                  }
+                  temperatureOnDeck={
+                    this.state.modulesByType[TEMPERATURE_MODULE_TYPE].onDeck
+                  }
                 />
               )}
 

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.js
@@ -16,9 +16,9 @@ import {
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
-  MAGDECK_MODEL_GEN1,
-  TEMPDECK_MODEL_GEN1,
-  THERMOCYCLER_MODEL_GEN1,
+  MAGNETIC_MODULE_V1,
+  TEMPERATURE_MODULE_V1,
+  THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
 import { i18n } from '../../../localization'
 import { SPAN7_8_10_11_SLOT } from '../../../constants'
@@ -84,17 +84,17 @@ const initialState: State = {
   modulesByType: {
     [MAGNETIC_MODULE_TYPE]: {
       onDeck: false,
-      model: MAGDECK_MODEL_GEN1,
+      model: MAGNETIC_MODULE_V1,
       slot: '1',
     },
     [TEMPERATURE_MODULE_TYPE]: {
       onDeck: false,
-      model: TEMPDECK_MODEL_GEN1,
+      model: TEMPERATURE_MODULE_V1,
       slot: '3',
     },
     [THERMOCYCLER_MODULE_TYPE]: {
       onDeck: false,
-      model: THERMOCYCLER_MODEL_GEN1,
+      model: THERMOCYCLER_MODULE_V1,
       slot: SPAN7_8_10_11_SLOT,
     },
   },

--- a/protocol-designer/src/components/modules/EditModulesCard.js
+++ b/protocol-designer/src/components/modules/EditModulesCard.js
@@ -2,24 +2,27 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
 import { Card } from '@opentrons/components'
-
+import {
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
 import {
   selectors as stepFormSelectors,
   getIsCrashablePipetteSelected,
 } from '../../step-forms'
 import { selectors as featureFlagSelectors } from '../../feature-flags'
 import { SUPPORTED_MODULE_TYPES } from '../../modules'
-import { THERMOCYCLER } from '../../constants'
 import { CrashInfoBox } from './CrashInfoBox'
 import { ModuleRow } from './ModuleRow'
 import styles from './styles.css'
-import type { ModuleType } from '@opentrons/shared-data'
+import type { ModuleRealType } from '@opentrons/shared-data'
 import type { ModulesForEditModulesCard } from '../../step-forms'
 
 type Props = {
   modules: ModulesForEditModulesCard,
   thermocyclerEnabled: ?boolean,
-  openEditModuleModal: (moduleType: ModuleType, moduleId?: string) => mixed,
+  openEditModuleModal: (moduleType: ModuleRealType, moduleId?: string) => mixed,
 }
 
 export function EditModulesCard(props: Props) {
@@ -27,7 +30,7 @@ export function EditModulesCard(props: Props) {
 
   const visibleModules = thermocyclerEnabled
     ? SUPPORTED_MODULE_TYPES
-    : SUPPORTED_MODULE_TYPES.filter(m => m !== THERMOCYCLER)
+    : SUPPORTED_MODULE_TYPES.filter(m => m !== THERMOCYCLER_MODULE_TYPE)
 
   const pipettesByMount = useSelector(
     stepFormSelectors.getPipettesForEditPipetteForm
@@ -43,15 +46,16 @@ export function EditModulesCard(props: Props) {
   const warningsEnabled =
     !moduleRestritionsDisabled && crashablePipettesSelected
   const showCrashInfoBox =
-    warningsEnabled && (modules.magdeck || modules.tempdeck)
+    warningsEnabled &&
+    (modules[MAGNETIC_MODULE_TYPE] || modules[TEMPERATURE_MODULE_TYPE])
 
   return (
     <Card title="Modules">
       <div className={styles.modules_card_content}>
         {showCrashInfoBox && (
           <CrashInfoBox
-            magnetOnDeck={Boolean(modules.magdeck)}
-            temperatureOnDeck={Boolean(modules.tempdeck)}
+            magnetOnDeck={Boolean(modules[MAGNETIC_MODULE_TYPE])}
+            temperatureOnDeck={Boolean(modules[TEMPERATURE_MODULE_TYPE])}
           />
         )}
         {visibleModules.map((moduleType, i) => {

--- a/protocol-designer/src/components/modules/ModuleDiagram.js
+++ b/protocol-designer/src/components/modules/ModuleDiagram.js
@@ -1,17 +1,21 @@
 // @flow
 import * as React from 'react'
 import styles from './styles.css'
-
-import type { ModuleType } from '@opentrons/shared-data'
+import {
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+  type ModuleRealType,
+} from '@opentrons/shared-data'
 
 type Props = {
-  type: ModuleType,
+  type: ModuleRealType,
 }
 
-const MODULE_IMG_BY_TYPE = {
-  magdeck: require('../../images/modules/magdeck.jpg'),
-  tempdeck: require('../../images/modules/tempdeck.jpg'),
-  thermocycler: require('../../images/modules/thermocycler.jpg'),
+const MODULE_IMG_BY_TYPE: { [ModuleRealType]: string } = {
+  [MAGNETIC_MODULE_TYPE]: require('../../images/modules/magdeck.jpg'),
+  [TEMPERATURE_MODULE_TYPE]: require('../../images/modules/tempdeck.jpg'),
+  [THERMOCYCLER_MODULE_TYPE]: require('../../images/modules/thermocycler.jpg'),
 }
 
 export function ModuleDiagram(props: Props) {

--- a/protocol-designer/src/components/modules/ModuleRow.js
+++ b/protocol-designer/src/components/modules/ModuleRow.js
@@ -14,19 +14,19 @@ import { ModuleDiagram } from './ModuleDiagram'
 import { SPAN7_8_10_11_SLOT } from '../../constants'
 import styles from './styles.css'
 
-import type { ModuleType } from '@opentrons/shared-data'
+import type { ModuleRealType } from '@opentrons/shared-data'
 import type { ModuleOnDeck } from '../../step-forms'
 
 type Props = {
   module?: ModuleOnDeck,
   showCollisionWarnings?: boolean,
-  type: ModuleType,
-  openEditModuleModal: (moduleType: ModuleType, moduleId?: string) => mixed,
+  type: ModuleRealType,
+  openEditModuleModal: (moduleType: ModuleRealType, moduleId?: string) => mixed,
 }
 
 export function ModuleRow(props: Props) {
   const { module, openEditModuleModal, showCollisionWarnings } = props
-  const type = module?.type || props.type
+  const type: ModuleRealType = module?.type || props.type
 
   const model = module?.model
   const slot = module?.slot
@@ -76,8 +76,10 @@ export function ModuleRow(props: Props) {
     <div className={styles.collision_tolltip}>{collisionTooltipText}</div>
   )
 
-  const setCurrentModule = (moduleType: ModuleType, moduleId?: string) => () =>
-    openEditModuleModal(moduleType, moduleId)
+  const setCurrentModule = (
+    moduleType: ModuleRealType,
+    moduleId?: string
+  ) => () => openEditModuleModal(moduleType, moduleId)
 
   const addRemoveText = module ? 'remove' : 'add'
 

--- a/protocol-designer/src/components/modules/ModuleRow.js
+++ b/protocol-designer/src/components/modules/ModuleRow.js
@@ -1,15 +1,15 @@
 // @flow
 import * as React from 'react'
-import { i18n } from '../../localization'
-import { useDispatch } from 'react-redux'
-import { actions as stepFormActions } from '../../step-forms'
-
 import {
   LabeledValue,
   OutlineButton,
   SlotMap,
   HoverTooltip,
 } from '@opentrons/components'
+import { i18n } from '../../localization'
+import { useDispatch } from 'react-redux'
+import { actions as stepFormActions } from '../../step-forms'
+
 import { ModuleDiagram } from './ModuleDiagram'
 import { SPAN7_8_10_11_SLOT } from '../../constants'
 import styles from './styles.css'
@@ -101,7 +101,12 @@ export function ModuleRow(props: Props) {
           <ModuleDiagram type={type} />
         </div>
         <div className={styles.module_col}>
-          {model && <LabeledValue label="Model" value={model} />}
+          {model && (
+            <LabeledValue
+              label="Model"
+              value={i18n.t(`modules.model_display_name.${model}`)}
+            />
+          )}
         </div>
         <div className={styles.module_col}>
           {slot && <LabeledValue label="Position" value={slotDisplayName} />}

--- a/protocol-designer/src/components/steplist/ModuleStepItems.js
+++ b/protocol-designer/src/components/steplist/ModuleStepItems.js
@@ -7,11 +7,11 @@ import { PDListItem } from '../lists'
 import { Portal } from './TooltipPortal'
 import { LabwareTooltipContents } from './LabwareTooltipContents'
 import styles from './StepItem.css'
-import typeof { TEMPDECK, MAGDECK } from '../../constants'
+import type { ModuleRealType } from '@opentrons/shared-data'
 
 type Props = {|
   action: string,
-  module: MAGDECK | TEMPDECK,
+  moduleType: ModuleRealType,
   actionText: string,
   labwareDisplayName: ?string,
   labwareNickname: ?string,
@@ -24,7 +24,7 @@ export const ModuleStepItems = (props: Props) => (
       <PDListItem className="step-item-message">{props.message}</PDListItem>
     )}
     <li className={styles.module_substep_header}>
-      <span>{i18n.t(`modules.module_long_names.${props.module}`)}</span>
+      <span>{i18n.t(`modules.module_long_names.${props.moduleType}`)}</span>
       <span>{props.action}</span>
     </li>
     <PDListItem

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -1,6 +1,9 @@
 // @flow
 import * as React from 'react'
-
+import {
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+} from '@opentrons/shared-data'
 import { PDTitledList } from '../lists'
 import { SourceDestSubstep } from './SourceDestSubstep'
 import { AspirateDispenseHeader } from './AspirateDispenseHeader'
@@ -10,7 +13,6 @@ import { ModuleStepItems } from './ModuleStepItems'
 import { StepDescription } from '../StepDescription'
 import { stepIconsByType } from '../../form-types'
 import { i18n } from '../../localization'
-import { MAGDECK, TEMPDECK } from '../../constants'
 import styles from './StepItem.css'
 
 import type { FormData, StepIdType, StepType } from '../../form-types'
@@ -128,7 +130,7 @@ export function getStepItemContents(stepItemProps: StepItemProps) {
         actionText={i18n.t(
           `modules.actions.${substeps.engage ? 'engage' : 'disengage'}`
         )}
-        module={MAGDECK}
+        moduleType={MAGNETIC_MODULE_TYPE}
       />
     )
   }
@@ -146,7 +148,7 @@ export function getStepItemContents(stepItemProps: StepItemProps) {
         message={substeps.message}
         action={i18n.t(`modules.actions.go_to`)}
         actionText={temperature}
-        module={TEMPDECK}
+        moduleType={TEMPERATURE_MODULE_TYPE}
       />
     )
   }
@@ -163,7 +165,7 @@ export function getStepItemContents(stepItemProps: StepItemProps) {
         message={substeps.message}
         action={i18n.t(`modules.actions.await_temperature`)}
         actionText={temperature}
-        module={TEMPDECK}
+        moduleType={TEMPERATURE_MODULE_TYPE}
       />
     )
   }

--- a/protocol-designer/src/components/steplist/__tests__/ModuleStepItems.test.js
+++ b/protocol-designer/src/components/steplist/__tests__/ModuleStepItems.test.js
@@ -1,14 +1,14 @@
 // @flow
+import { MAGNETIC_MODULE_TYPE } from '@opentrons/shared-data'
 import React from 'react'
 import { render, shallow, mount } from 'enzyme'
 import { ModuleStepItems } from '../ModuleStepItems'
-import { MAGDECK } from '../../../constants'
 
 let props
 beforeEach(() => {
   props = {
     action: 'action',
-    module: MAGDECK,
+    moduleType: MAGNETIC_MODULE_TYPE,
     actionText: 'engage',
     labwareDisplayName: 'magnet module',
     labwareNickname: 'maggie',

--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -1,12 +1,22 @@
 // @flow
 import mapValues from 'lodash/mapValues'
 import * as componentLib from '@opentrons/components'
-import { MAGDECK, TEMPDECK, THERMOCYCLER } from '@opentrons/shared-data'
+import {
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+  THERMOCYCLER,
+  MAGDECK_MODEL_GEN1,
+  // MAGDECK_MODEL_GEN2,
+  TEMPDECK_MODEL_GEN1,
+  // TEMPDECK_MODEL_GEN2,
+  THERMOCYCLER_MODEL_GEN1,
+} from '@opentrons/shared-data'
 import type { Options } from '@opentrons/components'
 import type {
   LabwareDefinition2,
   DeckSlot as DeckDefSlot,
-  ModuleType,
+  ModuleRealType,
 } from '@opentrons/shared-data'
 import type { DeckSlot, WellVolumes } from './types'
 // TODO Ian 2018-11-27: import these from components lib, not from this constants file
@@ -55,6 +65,8 @@ export const PSEUDO_DECK_SLOTS: { [DeckSlot]: DeckDefSlot } = {
       yDimension: STD_SLOT_Y_DIM * 2 + STD_SLOT_DIVIDER_WIDTH,
       zDimension: 0,
     },
+    // !!! TODO IMMEDIATELY make sure compatibleModules matches update from Seth's PR,
+    // or make separate ticket to update this pseudo-slot
     compatibleModules: [THERMOCYCLER],
   },
 }
@@ -83,8 +95,6 @@ export const MAX_ENGAGE_HEIGHT = 16
 export const MIN_TEMP_MODULE_TEMP = 0
 export const MAX_TEMP_MODULE_TEMP = 95
 
-export { MAGDECK, TEMPDECK, THERMOCYCLER } from '@opentrons/shared-data'
-
 // Temperature statuses
 export const TEMPERATURE_DEACTIVATED: 'TEMPERATURE_DEACTIVATED' =
   'TEMPERATURE_DEACTIVATED'
@@ -93,25 +103,26 @@ export const TEMPERATURE_AT_TARGET: 'TEMPERATURE_AT_TARGET' =
 export const TEMPERATURE_APPROACHING_TARGET: 'TEMPERATURE_APPROACHING_TARGET' =
   'TEMPERATURE_APPROACHING_TARGET'
 
-// NOTE: these MODEL values should match top-level keys in shared-data/module/definitions/2.json
-// (not to be confused with MODULE TYPE)
-export const MAGDECK_MODEL_GEN1: 'magdeck' = 'magdeck'
-export const TEMPDECK_MODEL_GEN1: 'tempdeck' = 'tempdeck'
-export const THERMOCYCLER_MODEL_GEN1: 'thermocycler' = 'thermocycler'
-export const MAGDECK_MODEL_GEN2: 'magdeckGen2' = 'magdeckGen2'
-export const TEMPDECK_MODEL_GEN2: 'tempdeckGen2' = 'tempdeckGen2'
-export const MODELS_FOR_MODULE_TYPE: { [ModuleType]: Options } = {
-  [MAGDECK]: [
+export const MODELS_FOR_MODULE_TYPE: { [ModuleRealType]: Options } = {
+  [MAGNETIC_MODULE_TYPE]: [
     { name: 'GEN1', value: MAGDECK_MODEL_GEN1 },
     // TODO: IL 2019-01-31 enable this to support Magnetic Module GEN2 in PD
     // { name: 'GEN2', value: MAGDECK_MODEL_GEN2 },
   ],
-  [TEMPDECK]: [
+  [TEMPERATURE_MODULE_TYPE]: [
     { name: 'GEN1', value: TEMPDECK_MODEL_GEN1 },
     // TODO: IL 2019-01-31 enable this to support Temperature Module GEN2 in PD
     // { name: 'GEN2', value: TEMPDECK_MODEL_GEN2 },
   ],
-  [THERMOCYCLER]: [{ name: 'GEN1', value: THERMOCYCLER_MODEL_GEN1 }],
+  [THERMOCYCLER_MODULE_TYPE]: [
+    { name: 'GEN1', value: THERMOCYCLER_MODEL_GEN1 },
+  ],
+}
+
+export const DEFAULT_MODEL_FOR_MODULE_TYPE: { [ModuleRealType]: string } = {
+  [MAGNETIC_MODULE_TYPE]: MAGDECK_MODEL_GEN1,
+  [TEMPERATURE_MODULE_TYPE]: TEMPDECK_MODEL_GEN1,
+  [THERMOCYCLER_MODULE_TYPE]: THERMOCYCLER_MODEL_GEN1,
 }
 
 export const PAUSE_UNTIL_RESUME: 'untilResume' = 'untilResume'

--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -6,17 +6,17 @@ import {
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
   THERMOCYCLER,
-  MAGDECK_MODEL_GEN1,
-  // MAGDECK_MODEL_GEN2,
-  TEMPDECK_MODEL_GEN1,
-  // TEMPDECK_MODEL_GEN2,
-  THERMOCYCLER_MODEL_GEN1,
+  MAGNETIC_MODULE_V1,
+  // MAGNETIC_MODULE_V2,
+  TEMPERATURE_MODULE_V1,
+  // TEMPERATURE_MODULE_V2,
+  THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
-import type { Options } from '@opentrons/components'
 import type {
   LabwareDefinition2,
   DeckSlot as DeckDefSlot,
   ModuleRealType,
+  ModuleModel,
 } from '@opentrons/shared-data'
 import type { DeckSlot, WellVolumes } from './types'
 // TODO Ian 2018-11-27: import these from components lib, not from this constants file
@@ -65,8 +65,6 @@ export const PSEUDO_DECK_SLOTS: { [DeckSlot]: DeckDefSlot } = {
       yDimension: STD_SLOT_Y_DIM * 2 + STD_SLOT_DIVIDER_WIDTH,
       zDimension: 0,
     },
-    // !!! TODO IMMEDIATELY make sure compatibleModules matches update from Seth's PR,
-    // or make separate ticket to update this pseudo-slot
     compatibleModules: [THERMOCYCLER],
   },
 }
@@ -103,26 +101,30 @@ export const TEMPERATURE_AT_TARGET: 'TEMPERATURE_AT_TARGET' =
 export const TEMPERATURE_APPROACHING_TARGET: 'TEMPERATURE_APPROACHING_TARGET' =
   'TEMPERATURE_APPROACHING_TARGET'
 
-export const MODELS_FOR_MODULE_TYPE: { [ModuleRealType]: Options } = {
+export const MODELS_FOR_MODULE_TYPE: {
+  [ModuleRealType]: Array<{|
+    name: string,
+    value: ModuleModel,
+    disabled?: boolean,
+  |}>,
+} = {
   [MAGNETIC_MODULE_TYPE]: [
-    { name: 'GEN1', value: MAGDECK_MODEL_GEN1 },
+    { name: 'GEN1', value: MAGNETIC_MODULE_V1 },
     // TODO: IL 2019-01-31 enable this to support Magnetic Module GEN2 in PD
-    // { name: 'GEN2', value: MAGDECK_MODEL_GEN2 },
+    // { name: 'GEN2', value: MAGNETIC_MODULE_V2 },
   ],
   [TEMPERATURE_MODULE_TYPE]: [
-    { name: 'GEN1', value: TEMPDECK_MODEL_GEN1 },
+    { name: 'GEN1', value: TEMPERATURE_MODULE_V1 },
     // TODO: IL 2019-01-31 enable this to support Temperature Module GEN2 in PD
-    // { name: 'GEN2', value: TEMPDECK_MODEL_GEN2 },
+    // { name: 'GEN2', value: TEMPERATURE_MODULE_V2 },
   ],
-  [THERMOCYCLER_MODULE_TYPE]: [
-    { name: 'GEN1', value: THERMOCYCLER_MODEL_GEN1 },
-  ],
+  [THERMOCYCLER_MODULE_TYPE]: [{ name: 'GEN1', value: THERMOCYCLER_MODULE_V1 }],
 }
 
 export const DEFAULT_MODEL_FOR_MODULE_TYPE: { [ModuleRealType]: string } = {
-  [MAGNETIC_MODULE_TYPE]: MAGDECK_MODEL_GEN1,
-  [TEMPERATURE_MODULE_TYPE]: TEMPDECK_MODEL_GEN1,
-  [THERMOCYCLER_MODULE_TYPE]: THERMOCYCLER_MODEL_GEN1,
+  [MAGNETIC_MODULE_TYPE]: MAGNETIC_MODULE_V1,
+  [TEMPERATURE_MODULE_TYPE]: TEMPERATURE_MODULE_V1,
+  [THERMOCYCLER_MODULE_TYPE]: THERMOCYCLER_MODULE_V1,
 }
 
 export const PAUSE_UNTIL_RESUME: 'untilResume' = 'untilResume'

--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -12,6 +12,7 @@ import {
   // TEMPERATURE_MODULE_V2,
   THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
+import { i18n } from './localization'
 import type {
   LabwareDefinition2,
   DeckSlot as DeckDefSlot,
@@ -109,16 +110,27 @@ export const MODELS_FOR_MODULE_TYPE: {
   |}>,
 } = {
   [MAGNETIC_MODULE_TYPE]: [
-    { name: 'GEN1', value: MAGNETIC_MODULE_V1 },
+    {
+      name: i18n.t(`modules.model_display_name.${MAGNETIC_MODULE_V1}`),
+      value: MAGNETIC_MODULE_V1,
+    },
     // TODO: IL 2019-01-31 enable this to support Magnetic Module GEN2 in PD
-    // { name: 'GEN2', value: MAGNETIC_MODULE_V2 },
+    // { name: i18n.t(`modules.model_display_name.${MAGNETIC_MODULE_V2}`), value: MAGNETIC_MODULE_V2 },
   ],
   [TEMPERATURE_MODULE_TYPE]: [
-    { name: 'GEN1', value: TEMPERATURE_MODULE_V1 },
+    {
+      name: i18n.t(`modules.model_display_name.${TEMPERATURE_MODULE_V1}`),
+      value: TEMPERATURE_MODULE_V1,
+    },
     // TODO: IL 2019-01-31 enable this to support Temperature Module GEN2 in PD
-    // { name: 'GEN2', value: TEMPERATURE_MODULE_V2 },
+    // { name: i18n.t(`modules.model_display_name.${TEMPERATURE_MODULE_V2}`, value: TEMPERATURE_MODULE_V2 },
   ],
-  [THERMOCYCLER_MODULE_TYPE]: [{ name: 'GEN1', value: THERMOCYCLER_MODULE_V1 }],
+  [THERMOCYCLER_MODULE_TYPE]: [
+    {
+      name: i18n.t(`modules.model_display_name.${THERMOCYCLER_MODULE_V1}`),
+      value: THERMOCYCLER_MODULE_V1,
+    },
+  ],
 }
 
 export const DEFAULT_MODEL_FOR_MODULE_TYPE: { [ModuleRealType]: string } = {

--- a/protocol-designer/src/localization/en/form.json
+++ b/protocol-designer/src/localization/en/form.json
@@ -100,9 +100,9 @@
       "touchTip": { "label": "touch tip" },
       "moduleActionLabware": { "label": "module" },
       "moduleLabwarePrefix": {
-        "magdeck": "MAG",
-        "tempdeck": "TEMP",
-        "thermocycler": "THERMO"
+        "magneticModuleType": "MAG",
+        "temperatureModuleType": "TEMP",
+        "thermocyclerModuleType": "THERMO"
       },
       "magnetAction": {
         "label": "Magnet action",

--- a/protocol-designer/src/localization/en/modules.json
+++ b/protocol-designer/src/localization/en/modules.json
@@ -1,13 +1,13 @@
 {
   "module_display_names": {
-    "tempdeck": "Temperature",
-    "magdeck": "Magnetic",
-    "thermocycler": "Thermocycler"
+    "temperatureModuleType": "Temperature",
+    "magneticModuleType": "Magnetic",
+    "thermocyclerModuleType": "Thermocycler"
   },
   "module_long_names": {
-    "tempdeck": "Temperature module",
-    "magdeck": "Magnetic module",
-    "thermocycler": "Thermocycler module"
+    "temperatureModuleType": "Temperature module",
+    "magneticModuleType": "Magnetic module",
+    "thermocyclerModuleType": "Thermocycler module"
   },
   "status": {
     "engaged": "engaged",

--- a/protocol-designer/src/localization/en/modules.json
+++ b/protocol-designer/src/localization/en/modules.json
@@ -9,6 +9,13 @@
     "magneticModuleType": "Magnetic module",
     "thermocyclerModuleType": "Thermocycler module"
   },
+  "model_display_name": {
+    "temperatureModuleV1": "GEN1",
+    "temperatureModuleV2": "GEN2",
+    "magneticModuleV1": "GEN1",
+    "magneticModuleV2": "GEN2",
+    "thermocyclerModuleV1": "GEN1"
+  },
   "status": {
     "engaged": "engaged",
     "disengaged": "disengaged",

--- a/protocol-designer/src/modules/moduleData.js
+++ b/protocol-designer/src/modules/moduleData.js
@@ -1,27 +1,29 @@
 // @flow
+import { SPAN7_8_10_11_SLOT } from '../constants'
 import {
-  SPAN7_8_10_11_SLOT,
-  MAGDECK,
-  TEMPDECK,
-  THERMOCYCLER,
-} from '../constants'
-import type { ModuleType } from '@opentrons/shared-data'
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
+import type { ModuleRealType } from '@opentrons/shared-data'
 import type { DropdownOption } from '@opentrons/components'
 
-export const SUPPORTED_MODULE_TYPES: Array<ModuleType> = [
-  MAGDECK,
-  TEMPDECK,
-  THERMOCYCLER,
+export const SUPPORTED_MODULE_TYPES: Array<ModuleRealType> = [
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
 ]
 
 type SupportedSlotMap = {
-  [type: ModuleType]: Array<DropdownOption>,
+  [type: ModuleRealType]: Array<DropdownOption>,
 }
 
 export const SUPPORTED_MODULE_SLOTS: SupportedSlotMap = {
-  magdeck: [{ name: 'Slot 1 (supported)', value: '1' }],
-  tempdeck: [{ name: 'Slot 3 (supported)', value: '3' }],
-  thermocycler: [{ name: 'Thermocycler slots', value: SPAN7_8_10_11_SLOT }],
+  [MAGNETIC_MODULE_TYPE]: [{ name: 'Slot 1 (supported)', value: '1' }],
+  [TEMPERATURE_MODULE_TYPE]: [{ name: 'Slot 3 (supported)', value: '3' }],
+  [THERMOCYCLER_MODULE_TYPE]: [
+    { name: 'Thermocycler slots', value: SPAN7_8_10_11_SLOT },
+  ],
 }
 
 export const ALL_MODULE_SLOTS: Array<DropdownOption> = [
@@ -35,10 +37,10 @@ export const ALL_MODULE_SLOTS: Array<DropdownOption> = [
 ]
 
 export function getAllModuleSlotsByType(
-  moduleType: ModuleType
+  moduleType: ModuleRealType
 ): Array<DropdownOption> {
   const supportedSlotOption = SUPPORTED_MODULE_SLOTS[moduleType]
-  if (moduleType === THERMOCYCLER) {
+  if (moduleType === THERMOCYCLER_MODULE_TYPE) {
     return supportedSlotOption
   }
   const allOtherSlots = ALL_MODULE_SLOTS.filter(

--- a/protocol-designer/src/step-forms/actions/modules.js
+++ b/protocol-designer/src/step-forms/actions/modules.js
@@ -1,14 +1,14 @@
 // @flow
 import { uuid } from '../../utils'
-import type { ModuleType } from '@opentrons/shared-data'
+import type { ModuleRealType } from '@opentrons/shared-data'
 import type { DeckSlot } from '../../types'
 
 export type CreateModuleAction = {|
   type: 'CREATE_MODULE',
   payload: {|
     slot: DeckSlot,
-    type: ModuleType,
-    model: string, // eg 'GEN1',
+    type: ModuleRealType,
+    model: string, // model should match name of module definition,
     id: string,
   |},
 |}

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -9,6 +9,7 @@ import reduce from 'lodash/reduce'
 import {
   getLabwareDefURI,
   getModuleTypeFromModuleModel,
+  MAGNETIC_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import {
   rootReducer as labwareDefsRootReducer,
@@ -18,7 +19,6 @@ import {
   INITIAL_DECK_SETUP_STEP_ID,
   FIXED_TRASH_ID,
   SPAN7_8_10_11_SLOT,
-  MAGDECK,
 } from '../../constants'
 import { getPDMetadata } from '../../file-types'
 import {
@@ -273,7 +273,7 @@ export const savedStepForms = (
         // to handle the case where users delete and re-add a magnetic module
         if (
           savedForm.stepType === 'magnet' &&
-          action.payload.type === MAGDECK
+          action.payload.type === MAGNETIC_MODULE_TYPE
         ) {
           return { ...savedForm, moduleId }
         }

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -10,13 +10,13 @@ import {
   getPipetteNameSpecs,
   getLabwareDisplayName,
   getLabwareDefURI,
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import { i18n } from '../../localization'
 import {
   INITIAL_DECK_SETUP_STEP_ID,
-  MAGDECK,
-  TEMPDECK,
-  THERMOCYCLER,
   TEMPERATURE_DEACTIVATED,
 } from '../../constants'
 import {
@@ -155,16 +155,16 @@ export const getLabwareLocationsForStep = (
 }
 
 const MAGNETIC_MODULE_INITIAL_STATE: MagneticModuleState = {
-  type: MAGDECK,
+  type: MAGNETIC_MODULE_TYPE,
   engaged: false,
 }
 const TEMPERATURE_MODULE_INITIAL_STATE: TemperatureModuleState = {
-  type: TEMPDECK,
+  type: TEMPERATURE_MODULE_TYPE,
   status: TEMPERATURE_DEACTIVATED,
   targetTemperature: null,
 }
 const THERMOCYCLER_MODULE_INITIAL_STATE: ThermocyclerModuleState = {
-  type: THERMOCYCLER,
+  type: THERMOCYCLER_MODULE_TYPE,
 }
 export const getInitialDeckSetup: Selector<InitialDeckSetup> = createSelector(
   getInitialDeckSetupStepForm,
@@ -193,19 +193,19 @@ export const getInitialDeckSetup: Selector<InitialDeckSetup> = createSelector(
         moduleLocations,
         (slot: DeckSlot, moduleId: string): ModuleOnDeck => {
           const module = moduleEntities[moduleId]
-          if (module.type === MAGDECK) {
+          if (module.type === MAGNETIC_MODULE_TYPE) {
             return {
               id: module.id,
               model: module.model,
-              type: MAGDECK,
+              type: MAGNETIC_MODULE_TYPE,
               slot,
               moduleState: MAGNETIC_MODULE_INITIAL_STATE,
             }
-          } else if (module.type === TEMPDECK) {
+          } else if (module.type === TEMPERATURE_MODULE_TYPE) {
             return {
               id: module.id,
               model: module.model,
-              type: TEMPDECK,
+              type: TEMPERATURE_MODULE_TYPE,
               slot,
               moduleState: TEMPERATURE_MODULE_INITIAL_STATE,
             }
@@ -213,7 +213,7 @@ export const getInitialDeckSetup: Selector<InitialDeckSetup> = createSelector(
             return {
               id: module.id,
               model: module.model,
-              type: THERMOCYCLER,
+              type: THERMOCYCLER_MODULE_TYPE,
               slot,
               moduleState: THERMOCYCLER_MODULE_INITIAL_STATE,
             }
@@ -349,9 +349,9 @@ export const getModulesForEditModulesCard: Selector<ModulesForEditModulesCard> =
         }
       },
       {
-        magdeck: null,
-        tempdeck: null,
-        thermocycler: null,
+        [MAGNETIC_MODULE_TYPE]: null,
+        [TEMPERATURE_MODULE_TYPE]: null,
+        [THERMOCYCLER_MODULE_TYPE]: null,
       }
     )
 )

--- a/protocol-designer/src/step-forms/test/reducers.test.js
+++ b/protocol-designer/src/step-forms/test/reducers.test.js
@@ -1,5 +1,10 @@
 // @flow
 import {
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
+import {
   legacySteps as steps,
   orderedStepIds,
   labwareInvariantProperties,
@@ -7,13 +12,7 @@ import {
   savedStepForms,
 } from '../reducers'
 import { moveDeckItem } from '../../labware-ingred/actions'
-import {
-  INITIAL_DECK_SETUP_STEP_ID,
-  SPAN7_8_10_11_SLOT,
-  TEMPDECK,
-  MAGDECK,
-  THERMOCYCLER,
-} from '../../constants'
+import { INITIAL_DECK_SETUP_STEP_ID, SPAN7_8_10_11_SLOT } from '../../constants'
 import type { DeckSlot } from '../../types'
 
 jest.mock('../../labware-defs/utils')
@@ -195,8 +194,8 @@ describe('moduleInvariantProperties reducer', () => {
       [existingModuleId]: {
         id: existingModuleId,
         slot: '1',
-        type: 'magdeck',
-        model: 'GEN1',
+        type: MAGNETIC_MODULE_TYPE,
+        model: 'someMagModel',
       },
     }
   })
@@ -205,8 +204,8 @@ describe('moduleInvariantProperties reducer', () => {
     const newModuleData = {
       id: newId,
       slot: '3',
-      type: 'tempdeck',
-      model: 'GEN1',
+      type: TEMPERATURE_MODULE_TYPE,
+      model: 'someTempModel',
     }
     const result = moduleInvariantProperties(prevState, {
       type: 'CREATE_MODULE',
@@ -223,7 +222,7 @@ describe('moduleInvariantProperties reducer', () => {
   })
 
   test('edit module (change its model)', () => {
-    const newModel = 'GEN2'
+    const newModel = 'someDifferentModel'
     const result = moduleInvariantProperties(prevState, {
       type: 'EDIT_MODULE',
       payload: { id: existingModuleId, model: newModel },
@@ -645,8 +644,8 @@ describe('savedStepForms reducer: initial deck setup step', () => {
               payload: {
                 id: moduleId,
                 slot: destSlot,
-                type: 'tempdeck',
-                model: 'GEN1',
+                type: TEMPERATURE_MODULE_TYPE,
+                model: 'someTempModel',
               },
             }
             const prevRootState = makePrevRootState(makeStateArgs)
@@ -684,8 +683,8 @@ describe('savedStepForms reducer: initial deck setup step', () => {
             payload: {
               id: 'newMagdeckId',
               slot: '1',
-              type: MAGDECK,
-              model: 'GEN1',
+              type: MAGNETIC_MODULE_TYPE,
+              model: 'someMagModel',
             },
           },
           expectedModuleId: 'newMagdeckId',
@@ -697,8 +696,8 @@ describe('savedStepForms reducer: initial deck setup step', () => {
             payload: {
               id: 'tempdeckId',
               slot: '1',
-              type: TEMPDECK,
-              model: 'GEN1',
+              type: TEMPERATURE_MODULE_TYPE,
+              model: 'someTempModel',
             },
           },
           expectedModuleId: 'magdeckId',
@@ -710,8 +709,8 @@ describe('savedStepForms reducer: initial deck setup step', () => {
             payload: {
               id: 'ThermocyclerId',
               slot: '1',
-              type: THERMOCYCLER,
-              model: 'GEN1',
+              type: THERMOCYCLER_MODULE_TYPE,
+              model: 'someThermoModel',
             },
           },
           expectedModuleId: 'magdeckId',

--- a/protocol-designer/src/step-forms/types.js
+++ b/protocol-designer/src/step-forms/types.js
@@ -4,6 +4,7 @@ import type {
   LabwareDefinition2,
   PipetteNameSpecs,
   ModuleRealType,
+  ModuleModel,
 } from '@opentrons/shared-data'
 import type { DeckSlot } from '../types'
 import typeof {
@@ -47,9 +48,11 @@ export type PipetteEntities = {
 }
 
 // =========== MODULES ========
-// Note: in the FORM, 'model' is like 'GEN1'/'GEN2' etc
-// !!! TODO IMMEDIATELY revisit this, should it be a real module MODEL?
-export type FormModule = {| onDeck: boolean, model: string, slot: DeckSlot |}
+export type FormModule = {|
+  onDeck: boolean,
+  model: ModuleModel,
+  slot: DeckSlot,
+|}
 
 // !!! TODO IMMEDIATELY can you use typeof here without a syntax error? It's not great to hard-code these, should use constants
 export type FormModulesByType = {|
@@ -58,7 +61,11 @@ export type FormModulesByType = {|
   thermocyclerModuleType: FormModule,
 |}
 
-export type ModuleEntity = {| id: string, type: ModuleRealType, model: string |}
+export type ModuleEntity = {|
+  id: string,
+  type: ModuleRealType,
+  model: ModuleModel,
+|}
 export type ModuleEntities = { [moduleId: string]: ModuleEntity }
 
 // NOTE: semi-redundant 'type' key in FooModuleState types is required for Flow to disambiguate 'moduleState'

--- a/protocol-designer/src/step-forms/types.js
+++ b/protocol-designer/src/step-forms/types.js
@@ -54,7 +54,9 @@ export type FormModule = {|
   slot: DeckSlot,
 |}
 
-// !!! TODO IMMEDIATELY can you use typeof here without a syntax error? It's not great to hard-code these, should use constants
+// TODO: IL 2020-02-21 somehow use the `typeof X_MODULE_TYPE` imports here instead of writing out the strings.
+// It doesn't seem possible with Flow to use these types as keys in an exact object,
+// unless you write them out like this. See https://github.com/facebook/flow/issues/6492
 export type FormModulesByType = {|
   magneticModuleType: FormModule,
   temperatureModuleType: FormModule,

--- a/protocol-designer/src/step-forms/types.js
+++ b/protocol-designer/src/step-forms/types.js
@@ -3,17 +3,19 @@ import type { Mount } from '@opentrons/components'
 import type {
   LabwareDefinition2,
   PipetteNameSpecs,
-  ModuleType,
+  ModuleRealType,
 } from '@opentrons/shared-data'
 import type { DeckSlot } from '../types'
 import typeof {
-  MAGDECK,
-  TEMPDECK,
-  THERMOCYCLER,
   TEMPERATURE_DEACTIVATED,
   TEMPERATURE_AT_TARGET,
   TEMPERATURE_APPROACHING_TARGET,
 } from '../constants'
+import typeof {
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
 
 export type FormPipette = {| pipetteName: ?string, tiprackDefURI: ?string |}
 export type FormPipettesByMount = {|
@@ -45,30 +47,36 @@ export type PipetteEntities = {
 }
 
 // =========== MODULES ========
-// Note: 'model' is like 'GEN1'/'GEN2' etc
+// Note: in the FORM, 'model' is like 'GEN1'/'GEN2' etc
+// !!! TODO IMMEDIATELY revisit this, should it be a real module MODEL?
 export type FormModule = {| onDeck: boolean, model: string, slot: DeckSlot |}
+
+// !!! TODO IMMEDIATELY can you use typeof here without a syntax error? It's not great to hard-code these, should use constants
 export type FormModulesByType = {|
-  tempdeck: FormModule,
-  magdeck: FormModule,
-  thermocycler: FormModule,
+  magneticModuleType: FormModule,
+  temperatureModuleType: FormModule,
+  thermocyclerModuleType: FormModule,
 |}
 
-export type ModuleEntity = {| id: string, type: ModuleType, model: string |}
+export type ModuleEntity = {| id: string, type: ModuleRealType, model: string |}
 export type ModuleEntities = { [moduleId: string]: ModuleEntity }
 
 // NOTE: semi-redundant 'type' key in FooModuleState types is required for Flow to disambiguate 'moduleState'
-export type MagneticModuleState = {| type: MAGDECK, engaged: boolean |}
+export type MagneticModuleState = {|
+  type: MAGNETIC_MODULE_TYPE,
+  engaged: boolean,
+|}
 
 export type TemperatureStatus =
   | TEMPERATURE_DEACTIVATED
   | TEMPERATURE_AT_TARGET
   | TEMPERATURE_APPROACHING_TARGET
 export type TemperatureModuleState = {|
-  type: TEMPDECK,
+  type: TEMPERATURE_MODULE_TYPE,
   status: TemperatureStatus,
   targetTemperature: number | null,
 |}
-export type ThermocyclerModuleState = {| type: THERMOCYCLER |} // TODO IL 2019-11-18 create this state
+export type ThermocyclerModuleState = {| type: THERMOCYCLER_MODULE_TYPE |} // TODO IL 2019-11-18 create this state
 
 export type ModuleTemporalProperties = {|
   slot: DeckSlot,
@@ -81,7 +89,7 @@ export type ModuleTemporalProperties = {|
 export type ModuleOnDeck = {| ...ModuleEntity, ...ModuleTemporalProperties |}
 
 export type ModulesForEditModulesCard = {
-  [type: ModuleType]: ?ModuleOnDeck,
+  [type: ModuleRealType]: ?ModuleOnDeck,
 }
 
 // =========== LABWARE ========

--- a/protocol-designer/src/step-forms/utils.js
+++ b/protocol-designer/src/step-forms/utils.js
@@ -3,14 +3,16 @@ import assert from 'assert'
 import reduce from 'lodash/reduce'
 import values from 'lodash/values'
 import find from 'lodash/find'
-import { getPipetteNameSpecs } from '@opentrons/shared-data'
+import {
+  getPipetteNameSpecs,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
 import {
   SPAN7_8_10_11_SLOT,
   TC_SPAN_SLOTS,
   GEN_ONE_MULTI_PIPETTES,
-  THERMOCYCLER,
 } from '../constants'
-import type { DeckSlotId, ModuleType } from '@opentrons/shared-data'
+import type { DeckSlotId, ModuleRealType } from '@opentrons/shared-data'
 import type { DeckSlot } from '../types'
 import type { LabwareDefByDefURI } from '../labware-defs'
 import type {
@@ -95,7 +97,8 @@ export const getSlotsBlockedBySpanning = (
   if (
     values(initialDeckSetup.modules).some(
       (module: ModuleOnDeck) =>
-        module.type === THERMOCYCLER && module.slot === SPAN7_8_10_11_SLOT
+        module.type === THERMOCYCLER_MODULE_TYPE &&
+        module.slot === SPAN7_8_10_11_SLOT
     )
   ) {
     return ['7', '8', '10', '11']
@@ -141,7 +144,7 @@ export const getLabwareOnSlot = (
 
 export const getIsCrashablePipetteSelected = (
   pipettesByMount: FormPipettesByMount
-) => {
+): boolean => {
   const { left, right } = pipettesByMount
   return [left, right].some(
     (formPipette: ?FormPipette) =>
@@ -151,7 +154,7 @@ export const getIsCrashablePipetteSelected = (
 
 export const getHasGen1MultiChannelPipette = (
   pipettes: $PropertyType<InitialDeckSetup, 'pipettes'>
-) => {
+): boolean => {
   const pipetteIds = Object.keys(pipettes)
   return pipetteIds.some(pipetteId =>
     GEN_ONE_MULTI_PIPETTES.includes(pipettes[pipetteId]?.name)
@@ -160,8 +163,8 @@ export const getHasGen1MultiChannelPipette = (
 
 export const getIsModuleOnDeck = (
   modules: $PropertyType<InitialDeckSetup, 'modules'>,
-  moduleType: ModuleType
-) => {
+  moduleType: ModuleRealType
+): boolean => {
   const moduleIds = Object.keys(modules)
   return moduleIds.some(moduleId => modules[moduleId]?.type === moduleType)
 }

--- a/protocol-designer/src/step-generation/__fixtures__/robotStateFixtures.js
+++ b/protocol-designer/src/step-generation/__fixtures__/robotStateFixtures.js
@@ -1,7 +1,11 @@
 // @flow
 import cloneDeep from 'lodash/cloneDeep'
 import mapValues from 'lodash/mapValues'
-import { getLabwareDefURI } from '@opentrons/shared-data'
+import {
+  getLabwareDefURI,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
 import {
   fixtureP10Single,
   fixtureP10Multi,
@@ -16,8 +20,6 @@ import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fi
 
 import {
   SPAN7_8_10_11_SLOT,
-  TEMPDECK,
-  THERMOCYCLER,
   TEMPERATURE_APPROACHING_TARGET,
   TEMPERATURE_AT_TARGET,
   TEMPERATURE_DEACTIVATED,
@@ -246,10 +248,14 @@ export const getStateAndContextTempMagModules = ({
   invariantContext.moduleEntities = {
     [temperatureModuleId]: {
       id: temperatureModuleId,
-      type: TEMPDECK,
+      type: TEMPERATURE_MODULE_TYPE,
       model: 'foo',
     },
-    [thermocyclerId]: { id: thermocyclerId, type: THERMOCYCLER, model: 'foo' },
+    [thermocyclerId]: {
+      id: thermocyclerId,
+      type: THERMOCYCLER_MODULE_TYPE,
+      model: 'foo',
+    },
   }
 
   const robotState = makeState({
@@ -262,7 +268,7 @@ export const getStateAndContextTempMagModules = ({
     [temperatureModuleId]: {
       slot: '3',
       moduleState: {
-        type: TEMPDECK,
+        type: TEMPERATURE_MODULE_TYPE,
         status: TEMPERATURE_DEACTIVATED,
         targetTemperature: null,
       },
@@ -270,7 +276,7 @@ export const getStateAndContextTempMagModules = ({
     [thermocyclerId]: {
       slot: SPAN7_8_10_11_SLOT,
       moduleState: {
-        type: THERMOCYCLER,
+        type: THERMOCYCLER_MODULE_TYPE,
         // TODO IL 2020-01-14 create this state when thermocycler state is implemented
       },
     },
@@ -289,7 +295,7 @@ export const robotWithStatusAndTemp = (
 ): RobotState => {
   const robot = cloneDeep(robotState)
   robot.modules[temperatureModuleId].moduleState = {
-    type: TEMPDECK,
+    type: TEMPERATURE_MODULE_TYPE,
     targetTemperature,
     status,
   }

--- a/protocol-designer/src/step-generation/__tests__/__snapshots__/utils.test.js.snap
+++ b/protocol-designer/src/step-generation/__tests__/__snapshots__/utils.test.js.snap
@@ -337,7 +337,7 @@ Object {
       "moduleState": Object {
         "status": "TEMPERATURE_DEACTIVATED",
         "targetTemperature": null,
-        "type": "tempdeck",
+        "type": "temperatureModuleType",
       },
       "slot": "3",
     },

--- a/protocol-designer/src/step-generation/__tests__/disengageMagnet.test.js
+++ b/protocol-designer/src/step-generation/__tests__/disengageMagnet.test.js
@@ -1,4 +1,5 @@
 // @flow
+import { MAGNETIC_MODULE_TYPE } from '@opentrons/shared-data'
 import { makeContext, getInitialRobotStateStandard } from '../__fixtures__'
 import { disengageMagnet } from '../commandCreators/atomic/disengageMagnet'
 
@@ -13,13 +14,13 @@ describe('engageMagnet', () => {
     invariantContext = makeContext()
     invariantContext.moduleEntities[moduleId] = {
       id: moduleId,
-      type: 'magdeck',
-      model: 'GEN1',
+      type: MAGNETIC_MODULE_TYPE,
+      model: 'someMagModel',
     }
     robotState = getInitialRobotStateStandard(invariantContext)
     robotState.modules[moduleId] = {
       slot: '4',
-      moduleState: { type: 'magdeck', engaged: false },
+      moduleState: { type: MAGNETIC_MODULE_TYPE, engaged: false },
     }
   })
   test('creates engage magnet command', () => {

--- a/protocol-designer/src/step-generation/__tests__/disengageMagnet.test.js
+++ b/protocol-designer/src/step-generation/__tests__/disengageMagnet.test.js
@@ -1,5 +1,8 @@
 // @flow
-import { MAGNETIC_MODULE_TYPE } from '@opentrons/shared-data'
+import {
+  MAGNETIC_MODULE_TYPE,
+  MAGNETIC_MODULE_V1,
+} from '@opentrons/shared-data'
 import { makeContext, getInitialRobotStateStandard } from '../__fixtures__'
 import { disengageMagnet } from '../commandCreators/atomic/disengageMagnet'
 
@@ -15,7 +18,7 @@ describe('engageMagnet', () => {
     invariantContext.moduleEntities[moduleId] = {
       id: moduleId,
       type: MAGNETIC_MODULE_TYPE,
-      model: 'someMagModel',
+      model: MAGNETIC_MODULE_V1,
     }
     robotState = getInitialRobotStateStandard(invariantContext)
     robotState.modules[moduleId] = {

--- a/protocol-designer/src/step-generation/__tests__/engageMagnet.test.js
+++ b/protocol-designer/src/step-generation/__tests__/engageMagnet.test.js
@@ -1,4 +1,5 @@
 // @flow
+import { MAGNETIC_MODULE_TYPE } from '@opentrons/shared-data'
 import { makeContext, getInitialRobotStateStandard } from '../__fixtures__'
 import { engageMagnet } from '../commandCreators/atomic/engageMagnet'
 
@@ -13,13 +14,13 @@ describe('engageMagnet', () => {
     invariantContext = makeContext()
     invariantContext.moduleEntities[moduleId] = {
       id: moduleId,
-      type: 'magdeck',
-      model: 'GEN1',
+      type: MAGNETIC_MODULE_TYPE,
+      model: 'someMagModel',
     }
     robotState = getInitialRobotStateStandard(invariantContext)
     robotState.modules[moduleId] = {
       slot: '4',
-      moduleState: { type: 'magdeck', engaged: false },
+      moduleState: { type: MAGNETIC_MODULE_TYPE, engaged: false },
     }
   })
   test('creates engage magnet command', () => {

--- a/protocol-designer/src/step-generation/__tests__/engageMagnet.test.js
+++ b/protocol-designer/src/step-generation/__tests__/engageMagnet.test.js
@@ -1,5 +1,8 @@
 // @flow
-import { MAGNETIC_MODULE_TYPE } from '@opentrons/shared-data'
+import {
+  MAGNETIC_MODULE_TYPE,
+  MAGNETIC_MODULE_V1,
+} from '@opentrons/shared-data'
 import { makeContext, getInitialRobotStateStandard } from '../__fixtures__'
 import { engageMagnet } from '../commandCreators/atomic/engageMagnet'
 
@@ -15,7 +18,7 @@ describe('engageMagnet', () => {
     invariantContext.moduleEntities[moduleId] = {
       id: moduleId,
       type: MAGNETIC_MODULE_TYPE,
-      model: 'someMagModel',
+      model: MAGNETIC_MODULE_V1,
     }
     robotState = getInitialRobotStateStandard(invariantContext)
     robotState.modules[moduleId] = {

--- a/protocol-designer/src/step-generation/__tests__/robotStateSelectors.test.js
+++ b/protocol-designer/src/step-generation/__tests__/robotStateSelectors.test.js
@@ -1,7 +1,6 @@
 // @flow
-import { getLabwareDefURI } from '@opentrons/shared-data'
+import { getLabwareDefURI, MAGNETIC_MODULE_TYPE } from '@opentrons/shared-data'
 import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_300_ul.json'
-
 import {
   makeContext,
   makeState,
@@ -15,7 +14,6 @@ import {
   _getNextTip,
   getModuleState,
 } from '../'
-import { MAGDECK } from '../../constants'
 let invariantContext
 
 beforeEach(() => {
@@ -392,7 +390,7 @@ describe('getModuleState', () => {
   test('returns the state for specified module', () => {
     const magModuleId = 'magdeck123'
     const magModuleState = {
-      type: MAGDECK,
+      type: MAGNETIC_MODULE_TYPE,
       engaged: true,
     }
     const robotState = makeState({

--- a/protocol-designer/src/step-generation/__tests__/updateMagneticModule.test.js
+++ b/protocol-designer/src/step-generation/__tests__/updateMagneticModule.test.js
@@ -1,6 +1,9 @@
 // @flow
 import cloneDeep from 'lodash/cloneDeep'
-import { MAGNETIC_MODULE_TYPE } from '@opentrons/shared-data'
+import {
+  MAGNETIC_MODULE_TYPE,
+  MAGNETIC_MODULE_V1,
+} from '@opentrons/shared-data'
 import { makeImmutableStateUpdater } from '../__utils__'
 import { makeContext, getInitialRobotStateStandard } from '../__fixtures__'
 import {
@@ -20,7 +23,7 @@ beforeEach(() => {
   invariantContext.moduleEntities[moduleId] = {
     id: moduleId,
     type: MAGNETIC_MODULE_TYPE,
-    model: 'GEN1',
+    model: MAGNETIC_MODULE_V1,
   }
   disengagedRobotState = getInitialRobotStateStandard(invariantContext)
   disengagedRobotState.modules[moduleId] = {

--- a/protocol-designer/src/step-generation/__tests__/updateMagneticModule.test.js
+++ b/protocol-designer/src/step-generation/__tests__/updateMagneticModule.test.js
@@ -1,5 +1,6 @@
 // @flow
 import cloneDeep from 'lodash/cloneDeep'
+import { MAGNETIC_MODULE_TYPE } from '@opentrons/shared-data'
 import { makeImmutableStateUpdater } from '../__utils__'
 import { makeContext, getInitialRobotStateStandard } from '../__fixtures__'
 import {
@@ -18,17 +19,17 @@ beforeEach(() => {
   invariantContext = makeContext()
   invariantContext.moduleEntities[moduleId] = {
     id: moduleId,
-    type: 'magdeck',
+    type: MAGNETIC_MODULE_TYPE,
     model: 'GEN1',
   }
   disengagedRobotState = getInitialRobotStateStandard(invariantContext)
   disengagedRobotState.modules[moduleId] = {
     slot: '4',
-    moduleState: { type: 'magdeck', engaged: false },
+    moduleState: { type: MAGNETIC_MODULE_TYPE, engaged: false },
   }
   engagedRobotState = cloneDeep(disengagedRobotState)
   engagedRobotState.modules[moduleId].moduleState = {
-    type: 'magdeck',
+    type: MAGNETIC_MODULE_TYPE,
     engaged: true,
   }
 })

--- a/protocol-designer/src/step-generation/__tests__/utils.test.js
+++ b/protocol-designer/src/step-generation/__tests__/utils.test.js
@@ -2,6 +2,7 @@
 import {
   getLabwareDefURI,
   TEMPERATURE_MODULE_TYPE,
+  TEMPERATURE_MODULE_V1,
 } from '@opentrons/shared-data'
 import {
   fixtureP10Single,
@@ -241,7 +242,7 @@ describe('makeInitialRobotState', () => {
         moduleEntities: {
           someTempModuleId: {
             id: 'someTempModuleId',
-            model: 'someTempModel',
+            model: TEMPERATURE_MODULE_V1,
             type: TEMPERATURE_MODULE_TYPE,
           },
         },

--- a/protocol-designer/src/step-generation/__tests__/utils.test.js
+++ b/protocol-designer/src/step-generation/__tests__/utils.test.js
@@ -1,5 +1,8 @@
 // @flow
-import { getLabwareDefURI } from '@opentrons/shared-data'
+import {
+  getLabwareDefURI,
+  TEMPERATURE_MODULE_TYPE,
+} from '@opentrons/shared-data'
 import {
   fixtureP10Single,
   fixtureP300Multi,
@@ -238,8 +241,8 @@ describe('makeInitialRobotState', () => {
         moduleEntities: {
           someTempModuleId: {
             id: 'someTempModuleId',
-            model: 'GEN1',
-            type: 'tempdeck',
+            model: 'someTempModel',
+            type: TEMPERATURE_MODULE_TYPE,
           },
         },
         labwareEntities: {
@@ -275,7 +278,7 @@ describe('makeInitialRobotState', () => {
         someTempModuleId: {
           slot: '3',
           moduleState: {
-            type: 'tempdeck',
+            type: TEMPERATURE_MODULE_TYPE,
             status: TEMPERATURE_DEACTIVATED,
             targetTemperature: null,
           },

--- a/protocol-designer/src/step-generation/commandCreators/atomic/awaitTemperature.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/awaitTemperature.js
@@ -1,6 +1,6 @@
 // @flow
+import { TEMPERATURE_MODULE_TYPE } from '@opentrons/shared-data'
 import {
-  TEMPDECK,
   TEMPERATURE_AT_TARGET,
   TEMPERATURE_DEACTIVATED,
 } from '../../../constants'
@@ -21,9 +21,9 @@ export const awaitTemperature: CommandCreator<AwaitTemperatureArgs> = (
     return { errors: [errorCreators.missingModuleError()] }
   }
 
-  if (tempModState.type !== TEMPDECK) {
+  if (tempModState.type !== TEMPERATURE_MODULE_TYPE) {
     console.error(
-      `expected module to be ${TEMPDECK} but got ${tempModState.type}`
+      `expected module to be ${TEMPERATURE_MODULE_TYPE} but got ${tempModState.type}`
     )
     return { errors: [errorCreators.missingModuleError()] }
   }
@@ -43,7 +43,7 @@ export const awaitTemperature: CommandCreator<AwaitTemperatureArgs> = (
   const moduleType = invariantContext.moduleEntities[module]?.type
   const params = { module, temperature }
   switch (moduleType) {
-    case TEMPDECK:
+    case TEMPERATURE_MODULE_TYPE:
       return {
         commands: [
           {
@@ -55,7 +55,7 @@ export const awaitTemperature: CommandCreator<AwaitTemperatureArgs> = (
 
     default:
       console.error(
-        `awaitTemperature expected module ${module} to be ${TEMPDECK}, got ${moduleType}`
+        `awaitTemperature expected module ${module} to be ${TEMPERATURE_MODULE_TYPE}, got ${moduleType}`
       )
       return { errors: [errorCreators.missingModuleError()] }
   }

--- a/protocol-designer/src/step-generation/commandCreators/atomic/deactivateTemperature.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/deactivateTemperature.js
@@ -1,5 +1,8 @@
 // @flow
-import { TEMPDECK, THERMOCYCLER } from '../../../constants'
+import {
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
 import * as errorCreators from '../../errorCreators'
 import type { CommandCreator, DeactivateTemperatureArgs } from '../../types'
 
@@ -17,7 +20,7 @@ export const deactivateTemperature: CommandCreator<DeactivateTemperatureArgs> = 
 
   const moduleType = invariantContext.moduleEntities[module]?.type
   const params = { module }
-  if (moduleType === TEMPDECK) {
+  if (moduleType === TEMPERATURE_MODULE_TYPE) {
     return {
       commands: [
         {
@@ -26,7 +29,7 @@ export const deactivateTemperature: CommandCreator<DeactivateTemperatureArgs> = 
         },
       ],
     }
-  } else if (moduleType === THERMOCYCLER) {
+  } else if (moduleType === THERMOCYCLER_MODULE_TYPE) {
     return {
       commands: [
         {
@@ -41,7 +44,7 @@ export const deactivateTemperature: CommandCreator<DeactivateTemperatureArgs> = 
     }
   } else {
     console.error(
-      `setTemperature expected module ${module} to be ${TEMPDECK} or ${THERMOCYCLER}, got ${moduleType}`
+      `setTemperature expected module ${module} to be ${TEMPERATURE_MODULE_TYPE} or ${THERMOCYCLER_MODULE_TYPE}, got ${moduleType}`
     )
     // NOTE: "missing module" isn't exactly the right error here, but better than a whitescreen!
     // This should never be shown.

--- a/protocol-designer/src/step-generation/commandCreators/atomic/disengageMagnet.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/disengageMagnet.js
@@ -1,6 +1,6 @@
 // @flow
 import assert from 'assert'
-import { MAGDECK } from '../../../constants'
+import { MAGNETIC_MODULE_TYPE } from '@opentrons/shared-data'
 import * as errorCreators from '../../errorCreators'
 import type { CommandCreator, DisengageMagnetArgs } from '../../types'
 
@@ -18,7 +18,7 @@ export const disengageMagnet: CommandCreator<DisengageMagnetArgs> = (
   }
 
   assert(
-    invariantContext.moduleEntities[module]?.type === MAGDECK,
+    invariantContext.moduleEntities[module]?.type === MAGNETIC_MODULE_TYPE,
     `expected module ${module} to be magdeck, got ${invariantContext.moduleEntities[module]?.type}`
   )
 

--- a/protocol-designer/src/step-generation/commandCreators/atomic/engageMagnet.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/engageMagnet.js
@@ -1,6 +1,6 @@
 // @flow
 import assert from 'assert'
-import { MAGDECK } from '../../../constants'
+import { MAGNETIC_MODULE_TYPE } from '@opentrons/shared-data'
 import * as errorCreators from '../../errorCreators'
 
 import type {
@@ -23,7 +23,7 @@ export const engageMagnet = (
   }
 
   assert(
-    invariantContext.moduleEntities[module]?.type === MAGDECK,
+    invariantContext.moduleEntities[module]?.type === MAGNETIC_MODULE_TYPE,
     `expected module ${module} to be magdeck, got ${invariantContext.moduleEntities[module]?.type}`
   )
 

--- a/protocol-designer/src/step-generation/commandCreators/atomic/setTemperature.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/setTemperature.js
@@ -1,5 +1,8 @@
 // @flow
-import { TEMPDECK, THERMOCYCLER } from '../../../constants'
+import {
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
 import * as errorCreators from '../../errorCreators'
 import type { CommandCreator, SetTemperatureArgs } from '../../types'
 
@@ -17,7 +20,7 @@ export const setTemperature: CommandCreator<SetTemperatureArgs> = (
 
   const moduleType = invariantContext.moduleEntities[module]?.type
   const params = { module, temperature: targetTemperature }
-  if (moduleType === TEMPDECK) {
+  if (moduleType === TEMPERATURE_MODULE_TYPE) {
     return {
       commands: [
         {
@@ -26,7 +29,7 @@ export const setTemperature: CommandCreator<SetTemperatureArgs> = (
         },
       ],
     }
-  } else if (moduleType === THERMOCYCLER) {
+  } else if (moduleType === THERMOCYCLER_MODULE_TYPE) {
     // TODO: Ian 2019-01-24 implement setting thermocycler temp: block vs lid
     console.error('Thermocycler set temp not implemented!')
     return {
@@ -34,7 +37,7 @@ export const setTemperature: CommandCreator<SetTemperatureArgs> = (
     }
   } else {
     console.error(
-      `setTemperature expected module ${module} to be ${TEMPDECK} or ${THERMOCYCLER}, got ${moduleType}`
+      `setTemperature expected module ${module} to be ${TEMPERATURE_MODULE_TYPE} or ${THERMOCYCLER_MODULE_TYPE}, got ${moduleType}`
     )
     // NOTE: "missing module" isn't exactly the right error here, but better than a whitescreen!
     // This should never be shown.

--- a/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/magnetUpdates.js
+++ b/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/magnetUpdates.js
@@ -1,14 +1,14 @@
 // @flow
 import { getModuleState } from '../robotStateSelectors'
+import { MAGNETIC_MODULE_TYPE } from '@opentrons/shared-data'
 import type {
   EngageMagnetParams,
   ModuleOnlyParams,
 } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
 import type { InvariantContext, RobotStateAndWarnings } from '../types'
-import { MAGDECK } from '../../constants'
 
 function _setMagnet(moduleState, engaged) {
-  if (moduleState.type === MAGDECK) {
+  if (moduleState.type === MAGNETIC_MODULE_TYPE) {
     moduleState.engaged = engaged
   }
 }

--- a/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/temperatureUpdates.js
+++ b/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/temperatureUpdates.js
@@ -1,7 +1,7 @@
 // @flow
+import { TEMPERATURE_MODULE_TYPE } from '@opentrons/shared-data'
 import { getModuleState } from '../robotStateSelectors'
 import {
-  TEMPDECK,
   TEMPERATURE_APPROACHING_TARGET,
   TEMPERATURE_DEACTIVATED,
   TEMPERATURE_AT_TARGET,
@@ -13,7 +13,7 @@ import type {
 import type { InvariantContext, RobotStateAndWarnings } from '../types'
 
 function _setTemperatureAndStatus(moduleState, temperature, status) {
-  if (moduleState.type === TEMPDECK) {
+  if (moduleState.type === TEMPERATURE_MODULE_TYPE) {
     moduleState.targetTemperature = temperature
     moduleState.status = status
   }
@@ -44,7 +44,7 @@ export function forAwaitTemperature(
   const { module, temperature } = params
   const moduleState = getModuleState(robotState, module)
 
-  if (moduleState.type === TEMPDECK) {
+  if (moduleState.type === TEMPERATURE_MODULE_TYPE) {
     if (temperature === moduleState.targetTemperature) {
       moduleState.status = TEMPERATURE_AT_TARGET
     }

--- a/protocol-designer/src/step-generation/utils/modulePipetteCollision.js
+++ b/protocol-designer/src/step-generation/utils/modulePipetteCollision.js
@@ -1,5 +1,9 @@
 // @flow
-import { GEN_ONE_MULTI_PIPETTES, TEMPDECK, MAGDECK } from '../../constants'
+import {
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+} from '@opentrons/shared-data'
+import { GEN_ONE_MULTI_PIPETTES } from '../../constants'
 import type { InvariantContext, RobotState } from '../types'
 
 // HACK Ian 2019-11-12: this is a temporary solution to pass PD runtime feature flags
@@ -50,7 +54,10 @@ export const modulePipetteCollision = (args: {|
     moduleId => {
       const moduleSlot: ?* = prevRobotState.modules[moduleId]?.slot
       const moduleType: ?* = invariantContext.moduleEntities[moduleId]?.type
-      const hasNorthSouthProblem = [TEMPDECK, MAGDECK].includes(moduleType)
+      const hasNorthSouthProblem = [
+        MAGNETIC_MODULE_TYPE,
+        TEMPERATURE_MODULE_TYPE,
+      ].includes(moduleType)
       const labwareInNorthSlot =
         (moduleSlot === '1' && labwareSlot === '4') ||
         (moduleSlot === '3' && labwareSlot === '6')

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/__tests__/getNextDefaultModuleId.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/__tests__/getNextDefaultModuleId.test.js
@@ -3,6 +3,9 @@ import {
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
+  MAGNETIC_MODULE_V1,
+  TEMPERATURE_MODULE_V1,
+  THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
 import { TEMPERATURE_DEACTIVATED } from '../../../../constants'
 import { getNextDefaultTemperatureModuleId } from '..'
@@ -16,7 +19,7 @@ describe('getNextDefaultTemperatureModuleId', () => {
           tempId: {
             id: 'tempId',
             type: TEMPERATURE_MODULE_TYPE,
-            model: 'someTempModel',
+            model: TEMPERATURE_MODULE_V1,
             slot: '3',
             moduleState: {
               type: TEMPERATURE_MODULE_TYPE,
@@ -27,7 +30,7 @@ describe('getNextDefaultTemperatureModuleId', () => {
           tcId: {
             id: 'tcId',
             type: THERMOCYCLER_MODULE_TYPE,
-            model: 'someThermoModel',
+            model: THERMOCYCLER_MODULE_V1,
             slot: '_span781011',
             moduleState: { type: THERMOCYCLER_MODULE_TYPE },
           },
@@ -40,7 +43,7 @@ describe('getNextDefaultTemperatureModuleId', () => {
           tcId: {
             id: 'tcId',
             type: THERMOCYCLER_MODULE_TYPE,
-            model: 'someThermoModel',
+            model: THERMOCYCLER_MODULE_V1,
             slot: '_span781011',
             moduleState: {
               type: THERMOCYCLER_MODULE_TYPE,
@@ -55,7 +58,7 @@ describe('getNextDefaultTemperatureModuleId', () => {
           magId: {
             id: 'magId',
             type: MAGNETIC_MODULE_TYPE,
-            model: 'someMagModel',
+            model: MAGNETIC_MODULE_V1,
             slot: '_span781011',
             moduleState: { type: MAGNETIC_MODULE_TYPE, engaged: false },
           },
@@ -88,7 +91,7 @@ describe('getNextDefaultTemperatureModuleId', () => {
           tempId: {
             id: 'tempId',
             type: TEMPERATURE_MODULE_TYPE,
-            model: 'someTempModule',
+            model: TEMPERATURE_MODULE_V1,
             slot: '3',
             moduleState: {
               type: TEMPERATURE_MODULE_TYPE,
@@ -99,7 +102,7 @@ describe('getNextDefaultTemperatureModuleId', () => {
           tcId: {
             id: 'tcId',
             type: THERMOCYCLER_MODULE_TYPE,
-            model: 'someThermoModel',
+            model: THERMOCYCLER_MODULE_V1,
             slot: '_span781011',
             moduleState: { type: THERMOCYCLER_MODULE_TYPE },
           },
@@ -127,14 +130,14 @@ describe('getNextDefaultTemperatureModuleId', () => {
           magId: {
             id: 'magId',
             type: MAGNETIC_MODULE_TYPE,
-            model: 'someMagModel',
+            model: MAGNETIC_MODULE_V1,
             slot: '_span781011',
             moduleState: { type: MAGNETIC_MODULE_TYPE, engaged: false },
           },
           tempId: {
             id: 'tempId',
             type: TEMPERATURE_MODULE_TYPE,
-            model: 'someTempModel',
+            model: TEMPERATURE_MODULE_V1,
             slot: '3',
             moduleState: {
               type: TEMPERATURE_MODULE_TYPE,

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/__tests__/getNextDefaultModuleId.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/__tests__/getNextDefaultModuleId.test.js
@@ -1,10 +1,10 @@
 // @flow
 import {
-  TEMPERATURE_DEACTIVATED,
-  MAGDECK,
-  THERMOCYCLER,
-  TEMPDECK,
-} from '../../../../constants'
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
+import { TEMPERATURE_DEACTIVATED } from '../../../../constants'
 import { getNextDefaultTemperatureModuleId } from '..'
 
 describe('getNextDefaultTemperatureModuleId', () => {
@@ -15,21 +15,21 @@ describe('getNextDefaultTemperatureModuleId', () => {
         equippedModulesById: {
           tempId: {
             id: 'tempId',
-            type: 'tempdeck',
-            model: 'GEN1',
+            type: TEMPERATURE_MODULE_TYPE,
+            model: 'someTempModel',
             slot: '3',
             moduleState: {
-              type: TEMPDECK,
+              type: TEMPERATURE_MODULE_TYPE,
               status: TEMPERATURE_DEACTIVATED,
               targetTemperature: null,
             },
           },
           tcId: {
             id: 'tcId',
-            type: THERMOCYCLER,
-            model: 'GEN1',
+            type: THERMOCYCLER_MODULE_TYPE,
+            model: 'someThermoModel',
             slot: '_span781011',
-            moduleState: { type: THERMOCYCLER },
+            moduleState: { type: THERMOCYCLER_MODULE_TYPE },
           },
         },
         expected: 'tempId',
@@ -39,11 +39,11 @@ describe('getNextDefaultTemperatureModuleId', () => {
         equippedModulesById: {
           tcId: {
             id: 'tcId',
-            type: THERMOCYCLER,
-            model: 'GEN1',
+            type: THERMOCYCLER_MODULE_TYPE,
+            model: 'someThermoModel',
             slot: '_span781011',
             moduleState: {
-              type: THERMOCYCLER,
+              type: THERMOCYCLER_MODULE_TYPE,
             },
           },
         },
@@ -54,10 +54,10 @@ describe('getNextDefaultTemperatureModuleId', () => {
         equippedModulesById: {
           magId: {
             id: 'magId',
-            type: MAGDECK,
-            model: 'GEN1',
+            type: MAGNETIC_MODULE_TYPE,
+            model: 'someMagModel',
             slot: '_span781011',
-            moduleState: { type: MAGDECK, engaged: false },
+            moduleState: { type: MAGNETIC_MODULE_TYPE, engaged: false },
           },
         },
         expected: null,
@@ -87,21 +87,21 @@ describe('getNextDefaultTemperatureModuleId', () => {
         equippedModulesById: {
           tempId: {
             id: 'tempId',
-            type: 'tempdeck',
-            model: 'GEN1',
+            type: TEMPERATURE_MODULE_TYPE,
+            model: 'someTempModule',
             slot: '3',
             moduleState: {
-              type: TEMPDECK,
+              type: TEMPERATURE_MODULE_TYPE,
               status: TEMPERATURE_DEACTIVATED,
               targetTemperature: null,
             },
           },
           tcId: {
             id: 'tcId',
-            type: THERMOCYCLER,
-            model: 'GEN1',
+            type: THERMOCYCLER_MODULE_TYPE,
+            model: 'someThermoModel',
             slot: '_span781011',
-            moduleState: { type: THERMOCYCLER },
+            moduleState: { type: THERMOCYCLER_MODULE_TYPE },
           },
         },
         savedForms: {
@@ -113,8 +113,8 @@ describe('getNextDefaultTemperatureModuleId', () => {
           },
           tcStepId: {
             id: 'tcStepId',
-            stepType: THERMOCYCLER,
-            stepName: THERMOCYCLER,
+            stepType: THERMOCYCLER_MODULE_TYPE,
+            stepName: THERMOCYCLER_MODULE_TYPE,
             moduleId: 'tcId',
           },
         },
@@ -126,18 +126,18 @@ describe('getNextDefaultTemperatureModuleId', () => {
         equippedModulesById: {
           magId: {
             id: 'magId',
-            type: MAGDECK,
-            model: 'GEN1',
+            type: MAGNETIC_MODULE_TYPE,
+            model: 'someMagModel',
             slot: '_span781011',
-            moduleState: { type: MAGDECK, engaged: false },
+            moduleState: { type: MAGNETIC_MODULE_TYPE, engaged: false },
           },
           tempId: {
             id: 'tempId',
-            type: 'tempdeck',
-            model: 'GEN1',
+            type: TEMPERATURE_MODULE_TYPE,
+            model: 'someTempModel',
             slot: '3',
             moduleState: {
-              type: TEMPDECK,
+              type: TEMPERATURE_MODULE_TYPE,
               status: TEMPERATURE_DEACTIVATED,
               targetTemperature: null,
             },

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/index.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/index.js
@@ -1,7 +1,10 @@
 // @flow
 import findKey from 'lodash/findKey'
 import last from 'lodash/last'
-import { TEMPDECK, THERMOCYCLER } from '../../../constants'
+import {
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
 
 import type { ModuleOnDeck } from '../../../step-forms'
 import type { StepIdType, FormData } from '../../../form-types'
@@ -24,8 +27,8 @@ export function getNextDefaultTemperatureModuleId(
   // should we simplify this to only return temperature modules?
   const nextDefaultModule: string | null =
     (isLastStepTemp(lastModuleStep) && lastModuleStep.moduleId) ||
-    findKey(equippedModulesById, m => m.type === TEMPDECK) ||
-    findKey(equippedModulesById, m => m.type === THERMOCYCLER) ||
+    findKey(equippedModulesById, m => m.type === TEMPERATURE_MODULE_TYPE) ||
+    findKey(equippedModulesById, m => m.type === THERMOCYCLER_MODULE_TYPE) ||
     null
 
   return nextDefaultModule || null

--- a/protocol-designer/src/ui/modules/selectors.js
+++ b/protocol-designer/src/ui/modules/selectors.js
@@ -3,9 +3,11 @@ import { createSelector } from 'reselect'
 import {
   getLabwareDisplayName,
   getLabwareDefaultEngageHeight,
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import mapValues from 'lodash/mapValues'
-import { MAGDECK, TEMPDECK, THERMOCYCLER } from '../../constants'
 import { selectors as stepFormSelectors } from '../../step-forms'
 import { getLabwareNicknamesById } from '../labware/selectors'
 import {
@@ -39,7 +41,11 @@ export const getMagneticLabwareOptions: Selector<Options> = createSelector(
   stepFormSelectors.getInitialDeckSetup,
   getLabwareNicknamesById,
   (initialDeckSetup, nicknamesById) => {
-    return getModuleLabwareOptions(initialDeckSetup, nicknamesById, MAGDECK)
+    return getModuleLabwareOptions(
+      initialDeckSetup,
+      nicknamesById,
+      MAGNETIC_MODULE_TYPE
+    )
   }
 )
 
@@ -51,12 +57,12 @@ export const getTemperatureLabwareOptions: Selector<Options> = createSelector(
     const temperatureModuleOptions = getModuleLabwareOptions(
       initialDeckSetup,
       nicknamesById,
-      TEMPDECK
+      TEMPERATURE_MODULE_TYPE
     )
     const thermocyclerModuleOptions = getModuleLabwareOptions(
       initialDeckSetup,
       nicknamesById,
-      THERMOCYCLER
+      THERMOCYCLER_MODULE_TYPE
     )
     return temperatureModuleOptions.concat(thermocyclerModuleOptions)
   }
@@ -70,7 +76,7 @@ export const getThermocyclerLabwareOptions: Selector<Options> = createSelector(
     return getModuleLabwareOptions(
       initialDeckSetup,
       nicknamesById,
-      THERMOCYCLER
+      THERMOCYCLER_MODULE_TYPE
     )
   }
 )
@@ -81,7 +87,7 @@ export const getSingleMagneticModuleId: Selector<
 > = createSelector(
   stepFormSelectors.getInitialDeckSetup,
   initialDeckSetup =>
-    getModuleOnDeckByType(initialDeckSetup, MAGDECK)?.id || null
+    getModuleOnDeckByType(initialDeckSetup, MAGNETIC_MODULE_TYPE)?.id || null
 )
 
 /** Get single temperature module (assumes no multiples) */
@@ -90,7 +96,7 @@ export const getSingleTemperatureModuleId: Selector<
 > = createSelector(
   stepFormSelectors.getInitialDeckSetup,
   initialDeckSetup =>
-    getModuleOnDeckByType(initialDeckSetup, TEMPDECK)?.id || null
+    getModuleOnDeckByType(initialDeckSetup, TEMPERATURE_MODULE_TYPE)?.id || null
 )
 
 /** Get single temperature module (assumes no multiples) */
@@ -99,14 +105,15 @@ export const getSingleThermocyclerModuleId: Selector<
 > = createSelector(
   stepFormSelectors.getInitialDeckSetup,
   initialDeckSetup =>
-    getModuleOnDeckByType(initialDeckSetup, THERMOCYCLER)?.id || null
+    getModuleOnDeckByType(initialDeckSetup, THERMOCYCLER_MODULE_TYPE)?.id ||
+    null
 )
 
 /** Returns boolean if magnetic module has labware */
 export const getMagnetModuleHasLabware: Selector<boolean> = createSelector(
   stepFormSelectors.getInitialDeckSetup,
   initialDeckSetup => {
-    return getModuleHasLabware(initialDeckSetup, MAGDECK)
+    return getModuleHasLabware(initialDeckSetup, MAGNETIC_MODULE_TYPE)
   }
 )
 
@@ -114,7 +121,7 @@ export const getMagnetModuleHasLabware: Selector<boolean> = createSelector(
 export const getTemperatureModuleHasLabware: Selector<boolean> = createSelector(
   stepFormSelectors.getInitialDeckSetup,
   initialDeckSetup => {
-    return getModuleHasLabware(initialDeckSetup, TEMPDECK)
+    return getModuleHasLabware(initialDeckSetup, TEMPERATURE_MODULE_TYPE)
   }
 )
 
@@ -122,7 +129,7 @@ export const getTemperatureModuleHasLabware: Selector<boolean> = createSelector(
 export const getThermocyclerModuleHasLabware: Selector<boolean> = createSelector(
   stepFormSelectors.getInitialDeckSetup,
   initialDeckSetup => {
-    return getModuleHasLabware(initialDeckSetup, THERMOCYCLER)
+    return getModuleHasLabware(initialDeckSetup, THERMOCYCLER_MODULE_TYPE)
   }
 )
 
@@ -142,8 +149,14 @@ export const getMagnetLabwareEngageHeight: Selector<
 export const getTempModuleOrThermocyclerIsOnDeck: Selector<boolean> = createSelector(
   stepFormSelectors.getInitialDeckSetup,
   initialDeckSetup => {
-    const tempOnDeck = getModuleOnDeckByType(initialDeckSetup, THERMOCYCLER)
-    const tcOnDeck = getModuleOnDeckByType(initialDeckSetup, TEMPDECK)
+    const tempOnDeck = getModuleOnDeckByType(
+      initialDeckSetup,
+      THERMOCYCLER_MODULE_TYPE
+    )
+    const tcOnDeck = getModuleOnDeckByType(
+      initialDeckSetup,
+      TEMPERATURE_MODULE_TYPE
+    )
     return Boolean(tempOnDeck || tcOnDeck)
   }
 )

--- a/protocol-designer/src/ui/modules/utils.js
+++ b/protocol-designer/src/ui/modules/utils.js
@@ -1,7 +1,7 @@
 // @flow
 import values from 'lodash/values'
 import { i18n } from '../../localization'
-import type { ModuleType } from '@opentrons/shared-data'
+import type { ModuleRealType } from '@opentrons/shared-data'
 import type { Options } from '@opentrons/components'
 import type {
   ModuleOnDeck,
@@ -11,7 +11,7 @@ import type {
 
 export function getModuleOnDeckByType(
   initialDeckSetup: InitialDeckSetup,
-  type: ModuleType
+  type: ModuleRealType
 ): ?ModuleOnDeck {
   return values(initialDeckSetup.modules).find(
     (module: ModuleOnDeck) => module.type === type
@@ -30,7 +30,7 @@ export function getLabwareOnModule(
 export function getModuleLabwareOptions(
   initialDeckSetup: InitialDeckSetup,
   nicknamesById: { [labwareId: string]: string },
-  type: ModuleType
+  type: ModuleRealType
 ): Options {
   const module = getModuleOnDeckByType(initialDeckSetup, type)
   const labware = module && getLabwareOnModule(initialDeckSetup, module.id)
@@ -59,7 +59,7 @@ export function getModuleLabwareOptions(
 
 export function getModuleHasLabware(
   initialDeckSetup: InitialDeckSetup,
-  type: ModuleType
+  type: ModuleRealType
 ): boolean {
   const module = getModuleOnDeckByType(initialDeckSetup, type)
   const labware = module && getLabwareOnModule(initialDeckSetup, module.id)

--- a/protocol-designer/src/ui/steps/test/selectors.test.js
+++ b/protocol-designer/src/ui/steps/test/selectors.test.js
@@ -1,4 +1,5 @@
 // @flow
+import { TEMPERATURE_MODULE_TYPE } from '@opentrons/shared-data'
 import { getHoveredStepLabware } from '../selectors'
 import * as utils from '../../modules/utils'
 
@@ -106,7 +107,7 @@ describe('getHoveredStepLabware', () => {
   })
 
   describe('modules', () => {
-    const type = 'tempdeck'
+    const type = TEMPERATURE_MODULE_TYPE
     const setTempCommand = 'setTemperature'
     beforeEach(() => {
       initialDeckState = {
@@ -120,7 +121,7 @@ describe('getHoveredStepLabware', () => {
           abc123: {
             id: 'abc123',
             type,
-            model: 'GEN1',
+            model: 'someTempModel',
             slot: '1',
             moduleState: {
               type,

--- a/protocol-designer/src/utils/labwareModuleCompatibility.js
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.js
@@ -1,13 +1,18 @@
 // @flow
 // PD-specific info about labware<>module compatibilty
 import assert from 'assert'
-import type { LabwareDefinition2, ModuleType } from '@opentrons/shared-data'
+import {
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
+import type { LabwareDefinition2, ModuleRealType } from '@opentrons/shared-data'
 
 // NOTE: this does not distinguish btw versions. Standard labware only (assumes namespace is 'opentrons')
-const COMPATIBLE_LABWARE_WHITELIST_BY_MODULE: {
-  [ModuleType]: $ReadOnlyArray<string>,
+const COMPATIBLE_LABWARE_WHITELIST_BY_MODULE_TYPE: {
+  [ModuleRealType]: $ReadOnlyArray<string>,
 } = {
-  tempdeck: [
+  [TEMPERATURE_MODULE_TYPE]: [
     'eppendorf_6_wellplate_16.8ml_flat',
     'agilent_24_wellplate_10ml_flat',
     'corning_6_wellplate_16.8ml_flat',
@@ -33,12 +38,12 @@ const COMPATIBLE_LABWARE_WHITELIST_BY_MODULE: {
     'opentrons_24_aluminumblock_nest_2ml_snapcap',
     'opentrons_24_aluminumblock_nest_0.5ml_screwcap',
   ],
-  magdeck: [
+  [MAGNETIC_MODULE_TYPE]: [
     'biorad_96_wellplate_200ul_pcr',
     'usascientific_96_wellplate_2.4ml_deep',
     'nest_96_wellplate_100ul_pcr_full_skirt',
   ],
-  thermocycler: [
+  [THERMOCYCLER_MODULE_TYPE]: [
     'biorad_96_wellplate_200ul_pcr',
     'nest_96_wellplate_100ul_pcr_full_skirt',
   ],
@@ -46,12 +51,13 @@ const COMPATIBLE_LABWARE_WHITELIST_BY_MODULE: {
 
 export const getLabwareIsCompatible = (
   def: LabwareDefinition2,
-  moduleType: ModuleType
+  moduleType: ModuleRealType
 ): boolean => {
   assert(
-    moduleType in COMPATIBLE_LABWARE_WHITELIST_BY_MODULE,
+    moduleType in COMPATIBLE_LABWARE_WHITELIST_BY_MODULE_TYPE,
     `expected ${moduleType} in labware<>module compatibility whitelist`
   )
-  const whitelist = COMPATIBLE_LABWARE_WHITELIST_BY_MODULE[moduleType] || []
+  const whitelist =
+    COMPATIBLE_LABWARE_WHITELIST_BY_MODULE_TYPE[moduleType] || []
   return whitelist.includes(def.parameters.loadName)
 }

--- a/shared-data/js/constants.js
+++ b/shared-data/js/constants.js
@@ -13,8 +13,7 @@ export const FIXED_TRASH_RENDER_HEIGHT = 165.86 // along Y axis in SVG coords
 
 export const OPENTRONS_LABWARE_NAMESPACE = 'opentrons'
 
-// TODO: IL 2019-01-31 these 3 are module MODELS. They should be derived from the module definition file.
-// We should ensure we're not using them as if they were types.
+// TODO: IL 2020-02-19 These 3 constants are DEPRECATED because they're ambiguous model vs type.
 export const THERMOCYCLER: 'thermocycler' = 'thermocycler'
 export const TEMPDECK: 'tempdeck' = 'tempdeck'
 export const MAGDECK: 'magdeck' = 'magdeck'

--- a/shared-data/js/constants.js
+++ b/shared-data/js/constants.js
@@ -17,7 +17,8 @@ export const OPENTRONS_LABWARE_NAMESPACE = 'opentrons'
 export const THERMOCYCLER: 'thermocycler' = 'thermocycler'
 export const TEMPDECK: 'tempdeck' = 'tempdeck'
 export const MAGDECK: 'magdeck' = 'magdeck'
-// these are the v2 equivalents of the above. They should match the names of definitions
+// these are the Module Def Schema v2 equivalents of the above. They should match the names of JSON definitions
+// in shared-data/module/definitions/2.
 export const MAGNETIC_MODULE_V1: 'magneticModuleV1' = 'magneticModuleV1'
 export const MAGNETIC_MODULE_V2: 'magneticModuleV2' = 'magneticModuleV2'
 export const TEMPERATURE_MODULE_V1: 'temperatureModuleV1' =

--- a/shared-data/js/modules.js
+++ b/shared-data/js/modules.js
@@ -68,13 +68,27 @@ export const getModuleDef2 = (moduleModel: ModuleModel): ModuleDef2 => {
   }
 }
 
+// DO NOT MERGE! these should immediately be replaced with Seth's constants imported above. These
+// below are redundant.
+
+// NOTE: these MODEL values should match definition names in shared-data/module/definitions/2/
+// (not to be confused with MODULE TYPE)
+// !!! TODO IMMEDIATELY double-check there match Seth's PR. DO NOT MERGE until 4936 is merged.
+export const MAGDECK_MODEL_GEN1: 'magneticModuleV1' = 'magneticModuleV1'
+export const MAGDECK_MODEL_GEN2: 'magneticModuleV2' = 'magneticModuleV2'
+export const TEMPDECK_MODEL_GEN1: 'temperatureModuleV1' = 'temperatureModuleV1'
+export const TEMPDECK_MODEL_GEN2: 'temperatureModuleV2' = 'temperatureModuleV2'
+export const THERMOCYCLER_MODEL_GEN1: 'thermocyclerModuleV1' =
+  'thermocyclerModuleV1'
+
 export const getModuleTypeFromModuleModel = (
   moduleModel: ModuleModel
 ): ModuleRealType => {
   return getModuleDef2(moduleModel).moduleType
 }
 
-// use a name like 'magdeck' or 'magdeckGen2' to get displayName for app
+// use module model (not type!) to get displayName for app
+// !!! TODO IMMEDIATELY: blocked by Seth's PR
 export function getModuleDisplayName(moduleModel: ModuleModel): string {
   return getModuleDef2(moduleModel).displayName
 }

--- a/shared-data/js/modules.js
+++ b/shared-data/js/modules.js
@@ -68,27 +68,13 @@ export const getModuleDef2 = (moduleModel: ModuleModel): ModuleDef2 => {
   }
 }
 
-// DO NOT MERGE! these should immediately be replaced with Seth's constants imported above. These
-// below are redundant.
-
-// NOTE: these MODEL values should match definition names in shared-data/module/definitions/2/
-// (not to be confused with MODULE TYPE)
-// !!! TODO IMMEDIATELY double-check there match Seth's PR. DO NOT MERGE until 4936 is merged.
-export const MAGDECK_MODEL_GEN1: 'magneticModuleV1' = 'magneticModuleV1'
-export const MAGDECK_MODEL_GEN2: 'magneticModuleV2' = 'magneticModuleV2'
-export const TEMPDECK_MODEL_GEN1: 'temperatureModuleV1' = 'temperatureModuleV1'
-export const TEMPDECK_MODEL_GEN2: 'temperatureModuleV2' = 'temperatureModuleV2'
-export const THERMOCYCLER_MODEL_GEN1: 'thermocyclerModuleV1' =
-  'thermocyclerModuleV1'
-
 export const getModuleTypeFromModuleModel = (
   moduleModel: ModuleModel
 ): ModuleRealType => {
   return getModuleDef2(moduleModel).moduleType
 }
 
-// use module model (not type!) to get displayName for app
-// !!! TODO IMMEDIATELY: blocked by Seth's PR
+// use module model (not type!) to get model-specific displayName for UI
 export function getModuleDisplayName(moduleModel: ModuleModel): string {
   return getModuleDef2(moduleModel).displayName
 }

--- a/shared-data/js/types.js
+++ b/shared-data/js/types.js
@@ -3,10 +3,17 @@ import typeof {
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
+  // MAGNETIC_MODULE_V1,
+  // MAGNETIC_MODULE_V2,
+  // TEMPERATURE_MODULE_V1,
+  // TEMPERATURE_MODULE_V2,
+  // THERMOCYCLER_MODULE_V1,
   GEN1,
   GEN2,
+  MAGDECK,
+  TEMPDECK,
+  THERMOCYCLER,
 } from './constants'
-
 // TODO Ian 2019-06-04 split this out into eg ../labware/flowTypes/labwareV1.js
 export type WellDefinition = {
   diameter?: number, // NOTE: presence of diameter indicates a circular well
@@ -152,16 +159,23 @@ export type LabwareDefinition2 = {|
   groups: Array<LabwareWellGroup>,
 |}
 
-// corresponds to `moduleType` key in a module definition. Is NOT model.
+// Module Type corresponds to `moduleType` key in a module definition. Is NOT model.
+// TODO: IL 2020-02-20 ModuleType is DEPRECATED. Replace all instances with ModuleRealType
+// (then finally rename ModuleRealType -> ModuleType)
+export type ModuleType = MAGDECK | TEMPDECK | THERMOCYCLER
 export type ModuleRealType =
   | MAGNETIC_MODULE_TYPE
   | TEMPERATURE_MODULE_TYPE
   | THERMOCYCLER_MODULE_TYPE
 
-// corresponds to top-level keys in shared-data/module/definitions/2
-// TODO IMMEDIATE Change to sum type as soon as callsites are compatible
-export type ModuleModel = string
-export type ModuleType = MAGDECK | TEMPDECK | THERMOCYCLER
+// ModuleModel corresponds to top-level keys in shared-data/module/definitions/2
+export type ModuleModel = string // TODO: IL 2020-02-20 Change to enum type below as soon as callsites are compatible
+// export type ModuleModel =
+//   | MAGNETIC_MODULE_V1
+//   | MAGNETIC_MODULE_V2
+//   | TEMPERATURE_MODULE_V1
+//   | TEMPERATURE_MODULE_V2
+//   | THERMOCYCLER_MODULE_V1
 
 export type DeckOffset = {|
   x: number,

--- a/shared-data/js/types.js
+++ b/shared-data/js/types.js
@@ -1,8 +1,5 @@
 // @flow
 import typeof {
-  MAGDECK,
-  TEMPDECK,
-  THERMOCYCLER,
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
@@ -164,9 +161,7 @@ export type ModuleRealType =
 // corresponds to top-level keys in shared-data/module/definitions/2
 // TODO IMMEDIATE Change to sum type as soon as callsites are compatible
 export type ModuleModel = string
-
 export type ModuleType = MAGDECK | TEMPDECK | THERMOCYCLER
-// TODO IMMEDIATELY: gradually replace this old 'ModuleType' with ModuleModel.
 
 export type DeckOffset = {|
   x: number,

--- a/shared-data/protocol/flowTypes/schemaV4.js
+++ b/shared-data/protocol/flowTypes/schemaV4.js
@@ -1,5 +1,5 @@
 // @flow
-import type { DeckSlotId } from '@opentrons/shared-data'
+import type { DeckSlotId, ModuleModel } from '@opentrons/shared-data'
 import type {
   ProtocolFile as V3ProtocolFile,
   _AspDispAirgapParams,
@@ -13,7 +13,7 @@ export type { BlowoutParams, FilePipette, FileLabware } from './schemaV3'
 
 export type FileModule = {|
   slot: DeckSlotId,
-  model: string, // matches key in shared-data/module/definitions/2
+  model: ModuleModel,
 |}
 
 export type EngageMagnetParams = {|


### PR DESCRIPTION
## overview

closes #4897

## changelog

- replace all PD's uses of ModuleType with ModuleRealType
- replace all PD's uses of magdeck/tempdeck/thermocycler ambiguous strings with either new module types or module models
- remove all non-visual uses of the string "GEN1"

## review requests

**Practical stuff**
- [ ] PD should save and re-load files correctly when they have modules. Should fix #4930 (a symptom of #4897)
- [ ] PD should save JSON with `modules` having correct `model`
- [ ] Smoke test all behavior around modules (especially adding/editing/removing) and review test changes.
- [ ] Anywhere PD should have text like "Magnetic Module" or "GEN1", make sure it says the correct thing

**Code review stuff**
- Redux should NEVER hold the display-only string `'GEN1'`, instead it should hold the model name, type `ModuleModel`. (In fact, Redux should never need hold the moduleType b/c you can always derive type from model with `getModuleTypeFromModuleModel`)
- No instances of `ModuleType` should remain in PD. Replace with either `ModuleRealType` or `ModuleModel`. (Eventually we'll also do this to shared-data and run app and API, Seth is spearheading that side of it)
- Clean up PD comments about module models like "corresponds to top-level keys in shared-data/module/definitions/2". (This might still be in v4 JSON description too). After 4936, they're individual files.