### PR TITLE
chore(*): Separate feature request and bug report issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,8 +20,7 @@ assignees: ''
 
 <!--
   Use this section to describe your issue at a high level. Please include the
-  type of issue (bug, feature request, other) as well as any issues you could
-  find that may be related.
+  type of issue (bug, or other) as well as any issues you could find that may be related.
 -->
 
 ## current behavior

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,8 +19,8 @@ assignees: ''
 ## overview
 
 <!--
-  Use this section to describe your issue at a high level. Please include the
-  type of issue (bug, or other) as well as any issues you could find that may be related.
+  Use this section to describe your bug at a high level. Please include any
+  issues you can find that may be related.
 -->
 
 ## current behavior

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,21 +16,21 @@ assignees: ''
   below to the best of your ability!
 -->
 
-## overview
+# Overview
 
 <!--
   Use this section to describe your bug at a high level. Please include any
   issues you can find that may be related.
 -->
 
-## current behavior
+# Current behavior
 
 <!--
   Describe how the software currently behaves and how that differs from how you
   think the software should behave.
 -->
 
-## steps to reproduce
+# Steps to reproduce
 
 <!--
   If this is a bug report and there are specific steps we can take to reproduce
@@ -38,7 +38,7 @@ assignees: ''
   software version, hardware version, and operating system.
 -->
 
-## expected behavior
+# Expected behavior
 
 <!--
   Describe how you think the software should behave.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,11 @@
+---
+name: Bug report
+about: File a bug
+title: 'bug:'
+labels: 'bug'
+assignees: ''
+---
+
 <!--
   Thanks for taking the time to file an issue! Please make sure you've read the
   "Opening Issues" section of our Contributing Guide:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,43 @@
+---
+name: Feature request
+about: Suggest an a new feature or edit
+title: 'feat: '
+labels: 'feature'
+assignees: ''
+---
+
+<!--
+  Thanks for taking the time to file a feature request! Please make sure you've read the
+  "Opening Issues" section of our Contributing Guide:
+
+  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-issues
+
+  To ensure your issue can be addressed quickly, please fill out the sections
+  below to the best of your ability!
+-->
+
+## Overview
+
+<!--
+  Use this section to describe your issue at a high level. Please include the
+  type of issue (bug, feature request, other) as well as any issues you could
+  find that may be related.
+-->
+
+## Implementation Details
+
+<!--
+  List any implementation steps, specs, or links to docs here.
+-->
+
+## Design
+
+<!--
+ Attach design images here or link to applicable Zeplin files.
+-->
+
+## Acceptance Criteria
+
+<!--
+ A checklist of requirements and/or testing steps that must be complete before this feature is considered complete. This can also be used as a testing plan for associated PRs.
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an a new feature or edit
 title: 'feat: '
-labels: 'feature'
+labels: 'feature-request'
 assignees: ''
 ---
 
@@ -19,9 +19,7 @@ assignees: ''
 ## Overview
 
 <!--
-  Use this section to describe your issue at a high level. Please include the
-  type of issue (bug, feature request, other) as well as any issues you could
-  find that may be related.
+  Use this section to describe your issue at a high level. Please include some context about why you want this feature. What would this feature allow you to accomplish? Are there any workarounds you use to partially achieve your goal? Are there any issues you could find that may be related?
 -->
 
 ## Implementation Details

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -16,25 +16,25 @@ assignees: ''
   below to the best of your ability!
 -->
 
-## Overview
+# Overview
 
 <!--
   Use this section to describe your issue at a high level. Please include some context about why you want this feature. What would this feature allow you to accomplish? Are there any workarounds you use to partially achieve your goal? Are there any issues you could find that may be related?
 -->
 
-## Implementation Details
+# Implementation details
 
 <!--
   List any implementation steps, specs, or links to docs here.
 -->
 
-## Design
+# Design
 
 <!--
  Attach design images here or link to applicable Zeplin files.
 -->
 
-## Acceptance Criteria
+# Acceptance criteria
 
 <!--
  A checklist of requirements and/or testing steps that must be complete before this feature is considered complete. This can also be used as a testing plan for associated PRs.


### PR DESCRIPTION
## overview

This PR servers as its own ticket. This splits our issue templates between bug reports and feature requests for our own sanity as well as external contributors'

## changelog

- chore(*): Separate feature request and bug report issue templates

## review requests

I left the copy pretty generic. Please include any copy edits you'd like to see.
