### PR TITLE
fix(app): Deck cal: Tell users to attach an Opentrons tip, not a GEB tip.

### DIFF
--- a/app/src/components/CalibrateDeck/AttachTip.js
+++ b/app/src/components/CalibrateDeck/AttachTip.js
@@ -33,7 +33,7 @@ export default function AttachTipModal(props: Props) {
   if (props.calibrationStep === '1') {
     instructions = (
       <span>
-        <p>Place a GEB tip on the {tipLocation} pipette before continuing.</p>
+        <p>Place an Opentrons tip on the {tipLocation} pipette before continuing.</p>
         <p>Confirm tip is attached to start calibration.</p>
       </span>
     )
@@ -41,7 +41,7 @@ export default function AttachTipModal(props: Props) {
   } else {
     instructions = (
       <span>
-        <p>Remove the GEB tip from the pipette. </p>
+        <p>Remove the Opentrons tip from the pipette.</p>
         <p>
           You must restart your robot to finish the initial robot calibration
           process and have the new settings take effect. It may take several

--- a/app/src/components/CalibrateDeck/AttachTip.js
+++ b/app/src/components/CalibrateDeck/AttachTip.js
@@ -33,7 +33,9 @@ export default function AttachTipModal(props: Props) {
   if (props.calibrationStep === '1') {
     instructions = (
       <span>
-        <p>Place an Opentrons tip on the {tipLocation} pipette before continuing.</p>
+        <p>
+          Place an Opentrons tip on the {tipLocation} pipette before continuing.
+        </p>
         <p>Confirm tip is attached to start calibration.</p>
       </span>
     )


### PR DESCRIPTION
# Overview

During deck calibration, the app tells users to "Place *a GEB tip* on the...pipette before continuing."

This PR is a proposal to say "an *Opentrons tip*" instead.

# Background

Our tip situation is a confusing mess. I won't attempt to tell the full history, but, currently:

* The [Labware Library](https://labware.opentrons.com/?category=tipRack) has GEB tip racks, which are colorful and don't fit on the deck without an adapter, as well as Opentrons tip racks, which are black.
* We only sell, support, and test with [Opentrons tips](https://shop.opentrons.com/collections/opentrons-tips).
* Opentrons tips are manufactured by GEB, and they unfortunately bear a GEB sticker, but Hardware is working on getting an Opentrons sticker added.
* The Hardware team keeps talking about getting better tips from GEB. Surely, this quality improvement would only apply to Opentrons tips, and not other tips that GEB sells.
* GEB's [vast tip catalog](http://www.ge-bio.com/product/product.php?lang=en&class1=44) includes, presumably, tips that will do bad things if you try to use them to calibrate an OT-2.

In short, it seems that the direction we're moving in is for Opentrons tips to be GEB _only behind the scenes_; as far as customers should be concerned, they're their own thing. That makes any in-app mention of GEB vestigial.

# Do not merge

Do not merge unless and until this is agreed to be a good idea by:

* [x] Hardware
* [x] UX

And anyone else with an opinion.

EDIT: Approval obtained on Slack.