### PR TITLE
docs(api): update example apiLevel to 2.2

### DIFF
--- a/api/docs/v2/index.rst
+++ b/api/docs/v2/index.rst
@@ -62,7 +62,7 @@ If we were to rewrite this with the Python Protocol API, it would look like the 
         'protocolName': 'My Protocol',
         'author': 'Name <email@address.com>',
         'description': 'Simple protocol to get started using OT2',
-        'apiLevel': '2.0'
+        'apiLevel': '2.2'
     }
 
     # protocol run function. the part after the colon lets your editor know
@@ -114,7 +114,7 @@ Protocols are structured around a function called ``run(protocol)``, defined in 
 
    from opentrons import protocol_api
 
-   metadata = {'apiLevel': '2.0'}
+   metadata = {'apiLevel': '2.2'}
 
    def run(protocol: protocol_api.ProtocolContext):
        pass

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -13,7 +13,7 @@ The examples in this section would be added to the following:
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
         tiprack = protocol.load_labware('corning_96_wellplate_360ul_flat', 2)
@@ -119,7 +119,7 @@ For this section, instead of using the protocol defined above, consider this set
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
         plate = protocol.load_labware(
@@ -192,7 +192,7 @@ The examples in this section should be inserted in the following:
 
 .. code-block:: python
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol):
         tiprack = protocol.load_labware('corning_96_wellplate_360ul_flat', 2)
@@ -434,7 +434,7 @@ will be displayed in the Opentrons App when protocol execution pauses.
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
         # The start of your protocol goes here...
@@ -465,7 +465,7 @@ None of these functions take any arguments:
 
     from opentrons import protocol_api, types
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
         pipette = protocol.load_instrument('p300_single', 'right')
@@ -486,7 +486,7 @@ The method :py:meth:`.ProtocolContext.comment` lets you display messages in the 
 
     from opentrons import protocol_api, types
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
         protocol.comment('Hello, world!')

--- a/api/docs/v2/new_complex_commands.rst
+++ b/api/docs/v2/new_complex_commands.rst
@@ -17,7 +17,7 @@ The examples in this section will use the following set up:
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
         plate = protocol.load_labware('corning_96_wellplate_360ul_flat', 1)

--- a/api/docs/v2/new_examples.rst
+++ b/api/docs/v2/new_examples.rst
@@ -18,7 +18,7 @@ Moving 100 µL from one well to another:
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
         plate = protocol.load_labware('corning_96_wellplate_360ul_flat', 1)
@@ -34,7 +34,7 @@ This accomplishes the same thing as the following basic commands:
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
         plate = protocol.load_labware('corning_96_wellplate_360ul_flat', 1)
@@ -58,7 +58,7 @@ Loops in Python allow your protocol to perform many actions, or act upon many we
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
         plate = protocol.load_labware('corning_96_wellplate_360ul_flat', 1)
@@ -85,7 +85,7 @@ The OT-2 pipettes can do some things that a human cannot do with a pipette, like
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
         plate = protocol.load_labware('corning_96_wellplate_360ul_flat', 1)
@@ -113,7 +113,7 @@ This example first spreads a diluent to all wells of a plate. It then dilutes 8 
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
         plate = protocol.load_labware('corning_96_wellplate_360ul_flat', 1)
@@ -150,7 +150,7 @@ This example deposits various volumes of liquids into the same plate of wells an
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
         plate = protocol.load_labware('corning_96_wellplate_360ul_flat', 1)

--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -77,7 +77,7 @@ The ending well will be in the bottom right, see the diagram below for further e
     '''
     Examples in this section expect the following
     '''
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol):
 
@@ -308,7 +308,7 @@ To move a location, you create a :py:class:`.types.Point` representing a
 
    from opentrons import types
 
-   metadata = {'apiLevel': '2.0'}
+   metadata = {'apiLevel': '2.2'}
 
    def run(protocol):
         plate = protocol.load_labware(

--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -24,7 +24,7 @@ Modules are loaded using the function :py:meth:`.ProtocolContext.load_module`:
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
          module = protocol.load_module('Module Name', slot)
@@ -65,7 +65,7 @@ Like specifying labware that will be present on the deck of the OT-2, you must s
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.1'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
          module = protocol.load_module('Temperature Module', slot)
@@ -86,7 +86,7 @@ Any custom labware added to your Opentrons App (see :ref:`v2-custom-labware`) is
 
 .. note::
 
-    In API version 2.0, :py:meth:`.ModuleContext.load_labware` only took a ``load_name`` argument. In API version 2.1 (introduced in Robot Software version 3.15.2) you can now specify a label, version, and namespace (though most of the time you won't have to).
+    In API version 2.0, :py:meth:`.ModuleContext.load_labware` only took a ``load_name`` argument. In API version 2.1 (introduced in Robot Software version 3.15.2) or higher you can now specify a label, version, and namespace (though most of the time you won't have to).
 
 
 Checking The Status Of Your Module
@@ -98,7 +98,7 @@ All modules have the ability to check what state they are currently in:
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
          module = protocol.load_module('Module Name', slot)
@@ -128,7 +128,7 @@ section, assume we have the following already:
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
         temp_mod = protocol.load_module('temperature module', '1')
@@ -210,7 +210,7 @@ For the purposes of this section, assume we have the following already:
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
         mag_mod = protocol.load_module('magnetic module', '1')
@@ -301,7 +301,7 @@ For the purposes of this section, assume we have the following already:
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
         tc_mod = protocol.load_module('Thermocycler Module')

--- a/api/docs/v2/new_pipette.rst
+++ b/api/docs/v2/new_pipette.rst
@@ -20,7 +20,7 @@ Pipettes are specified in a protocol using the method :py:meth:`.ProtocolContext
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
         # Load a P50 multi on the left slot
@@ -98,7 +98,7 @@ For instance, in this protocol you can see the effects of specifying tipracks:
 
    from opentrons import protocol_api
 
-   metadata = {'apiLevel': '2.0'}
+   metadata = {'apiLevel': '2.2'}
 
    def run(protocol: protocol_api.ProtocolContext):
        tiprack_left = protocol.load_labware('opentrons_96_tiprack_300ul', '1')
@@ -162,7 +162,7 @@ Each of these attributes can be altered without affecting the others.
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
         tiprack = protocol.load_labware('opentrons_96_tiprack_300ul', '1')
@@ -232,7 +232,7 @@ executed as part of a transfer.
 
     from opentrons import protocol_api, types
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
         tiprack = protocol.load_labware('opentrons_96_tiprack_300ul', '1')
@@ -279,7 +279,7 @@ the overall speed of the gantry. Its default is 400 mm/s.
 
     from opentrons import protocol_api, types
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol: protocol_api.ProtocolContext):
         pipette = protocol.load_instrument('p300_single', 'right')
@@ -306,7 +306,7 @@ resets that axis's limit to the default:
 
 .. code-block:: python
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.2'}
 
     def run(protocol):
         protocol.max_speeds['X'] = 50  # limit x axis to 50 mm/s

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -26,7 +26,7 @@ You must specify the API version you are targeting at the top of your Python pro
    from opentrons import protocol_api
 
    metadata = {
-       'apiLevel': '2.0',
+       'apiLevel': '2.2',
        'author': 'A. Biologist'}
 
    def run(protocol: protocol_api.ProtocolContext):


### PR DESCRIPTION
## overview

Some bugs have been fixed since the release of PAPI version 2.0 that are still switched behind the apiLevel metadata. As a result, users should be encouraged to use the more recent version of the API as a default. Users who copy-paste example code from the docs have been getting a metadata object with apiLevel set to 2.0 and thus have encountered problems such as inability to access the 2nd half of 384-well plates.

## changelog

- updated API docs example code metadata to apiLevel 2.2

## review requests

Take a look at the docs and make sure I didn't change something I shouldn't have.
