### PR TITLE
feat(protocol-designer): unify "button row" styles

### DIFF
--- a/protocol-designer/src/components/FilePage.css
+++ b/protocol-designer/src/components/FilePage.css
@@ -18,11 +18,6 @@
   margin: 1rem 2.5rem;
 }
 
-.button_row {
-  display: flex;
-  justify-content: flex-end;
-}
-
 .pipette_button_row {
   display: flex;
   justify-content: center;

--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -17,6 +17,7 @@ import { EditPipettesModal } from './modals/EditPipettesModal'
 import { EditModulesModal } from './modals/EditModulesModal'
 import { EditModulesCard } from './modules'
 import styles from './FilePage.css'
+import modalStyles from '../components/modals/modal.css'
 import formStyles from '../components/forms/forms.css'
 import type { FileMetadataFields } from '../file-data'
 import type { ModulesForEditModulesCard } from '../step-forms'
@@ -169,7 +170,7 @@ export class FilePage extends React.Component<Props, State> {
                     onChange={handleChange}
                   />
                 </FormGroup>
-                <div className={styles.button_row}>
+                <div className={modalStyles.button_row}>
                   <OutlineButton
                     type="submit"
                     className={styles.update_button}
@@ -212,7 +213,7 @@ export class FilePage extends React.Component<Props, State> {
           />
         )}
 
-        <div className={styles.button_row}>
+        <div className={modalStyles.button_row}>
           <PrimaryButton
             onClick={goToNextPage}
             className={styles.continue_button}

--- a/protocol-designer/src/components/StepEditForm/ButtonRow/index.js
+++ b/protocol-designer/src/components/StepEditForm/ButtonRow/index.js
@@ -11,8 +11,8 @@ import { getCurrentFormCanBeSaved } from '../../../step-forms/selectors'
 
 import type { BaseState } from '../../../types'
 
+import modalStyles from '../../modals/modal.css'
 import styles from './styles.css'
-const { button_row, form_button, form_wrapper } = styles
 
 const { cancelStepForm } = steplistActions
 const { saveStepForm } = stepFormActions
@@ -29,24 +29,27 @@ export const ButtonRow = ({ onDelete, onClickMoreOptions }: Props) => {
   const dispatch = useDispatch()
 
   return (
-    <div className={cx(button_row, form_wrapper)}>
+    <div className={cx(modalStyles.button_row_divided, styles.form_wrapper)}>
       <div>
-        <OutlineButton className={form_button} onClick={onDelete}>
+        <OutlineButton className={styles.form_button} onClick={onDelete}>
           Delete
         </OutlineButton>
-        <OutlineButton className={form_button} onClick={onClickMoreOptions}>
+        <OutlineButton
+          className={styles.form_button}
+          onClick={onClickMoreOptions}
+        >
           Notes
         </OutlineButton>
       </div>
       <div>
         <PrimaryButton
-          className={form_button}
+          className={styles.form_button}
           onClick={() => dispatch(cancelStepForm())}
         >
           Close
         </PrimaryButton>
         <PrimaryButton
-          className={form_button}
+          className={styles.form_button}
           disabled={!canSave}
           onClick={canSave ? () => dispatch(saveStepForm()) : undefined}
         >

--- a/protocol-designer/src/components/StepEditForm/ButtonRow/styles.css
+++ b/protocol-designer/src/components/StepEditForm/ButtonRow/styles.css
@@ -15,8 +15,3 @@
 .form_button:not(:last-child) {
   margin-right: var(--form-button-margin);
 }
-
-.button_row {
-  display: flex;
-  justify-content: space-between;
-}

--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -205,11 +205,6 @@
   margin-bottom: 1rem;
 }
 
-.button_row {
-  display: flex;
-  justify-content: space-between;
-}
-
 .magnet_section_wrapper {
   display: flex;
   justify-content: flex-start;

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionInput.css
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionInput.css
@@ -71,21 +71,3 @@
   position: relative;
   left: 9px;
 }
-
-.button_row {
-  display: flex;
-  justify-content: space-between;
-}
-
-.reset_button {
-  width: 10rem;
-}
-
-.cancel_button {
-  width: 10rem;
-  margin-right: 1rem;
-}
-
-.done_button {
-  width: 10rem;
-}

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.js
@@ -218,22 +218,25 @@ class TipPositionModalComponent extends React.Component<Props, State> {
                 {/* TODO: xy tip positioning */}
               </div>
             </div>
-            <div className={styles.button_row}>
+            <div className={modalStyles.button_row_divided}>
               <OutlineButton
-                className={styles.reset_button}
+                className={modalStyles.button_medium}
                 onClick={this.handleReset}
               >
                 {i18n.t('button.reset')}
               </OutlineButton>
               <div>
                 <PrimaryButton
-                  className={styles.cancel_button}
+                  className={cx(
+                    modalStyles.button_medium,
+                    modalStyles.button_right_of_break
+                  )}
                   onClick={this.handleCancel}
                 >
                   {i18n.t('button.cancel')}
                 </PrimaryButton>
                 <PrimaryButton
-                  className={styles.done_button}
+                  className={modalStyles.button_medium}
                   onClick={this.handleDone}
                 >
                   {i18n.t('button.done')}

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderInput.css
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderInput.css
@@ -49,24 +49,6 @@
   height: 100px;
 }
 
-.button_row {
-  display: flex;
-  justify-content: space-between;
-}
-
-.reset_button {
-  width: 10rem;
-}
-
-.cancel_button {
-  width: 10rem;
-  margin-right: 1rem;
-}
-
-.done_button {
-  width: 10rem;
-}
-
 .wells_image {
   height: 100px;
   width: 100px;

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderModal.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderModal.js
@@ -172,22 +172,25 @@ class WellOrderModalComponent extends React.Component<Props, State> {
               />
             </FormGroup>
           </div>
-          <div className={styles.button_row}>
+          <div className={modalStyles.button_row_divided}>
             <OutlineButton
-              className={styles.reset_button}
+              className={modalStyles.button_medium}
               onClick={this.handleReset}
             >
               {i18n.t('button.reset')}
             </OutlineButton>
             <div>
               <PrimaryButton
-                className={styles.cancel_button}
+                className={cx(
+                  modalStyles.button_medium,
+                  modalStyles.button_right_of_break
+                )}
                 onClick={this.handleCancel}
               >
                 {i18n.t('button.cancel')}
               </PrimaryButton>
               <PrimaryButton
-                className={styles.done_button}
+                className={modalStyles.button_medium}
                 onClick={this.handleDone}
               >
                 {i18n.t('button.done')}

--- a/protocol-designer/src/components/modals/EditModulesModal/EditModules.css
+++ b/protocol-designer/src/components/modals/EditModulesModal/EditModules.css
@@ -36,14 +36,8 @@
   font-size: var(--fs-caption);
 }
 
-.button_row {
-  margin-top: 1rem;
-  display: flex;
-  justify-content: flex-end;
-
-  & button {
-    margin-left: 1rem;
-  }
+.button_margin {
+  margin-left: 1rem;
 }
 
 .slot_map_container {

--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -180,13 +180,16 @@ export function EditModulesModal(props: EditModulesProps) {
         </div>
       </form>
 
-      <div className={styles.button_row}>
-        <OutlineButton onClick={onCloseClick}>Cancel</OutlineButton>
+      <div className={modalStyles.button_row}>
+        <OutlineButton className={styles.button_margin} onClick={onCloseClick}>
+          {i18n.t('button.cancel')}
+        </OutlineButton>
         <OutlineButton
+          className={styles.button_margin}
           disabled={hasSlotOrIncompatibleError}
           onClick={onSaveClick}
         >
-          Save
+          {i18n.t('button.save')}
         </OutlineButton>
       </div>
     </Modal>

--- a/protocol-designer/src/components/modals/EditPipettesModal/StepChangesConfirmModal.css
+++ b/protocol-designer/src/components/modals/EditPipettesModal/StepChangesConfirmModal.css
@@ -1,11 +1,5 @@
 @import '@opentrons/components';
 
-.button_row {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 2rem;
-}
-
 .continue_button {
   margin-left: 1rem;
 }

--- a/protocol-designer/src/components/modals/EditPipettesModal/StepChangesConfirmModal.js
+++ b/protocol-designer/src/components/modals/EditPipettesModal/StepChangesConfirmModal.js
@@ -66,7 +66,7 @@ export const StepChangesConfirmModal = (props: Props) => {
         </li>
       </ul>
 
-      <div className={styles.button_row}>
+      <div className={modalStyles.button_row}>
         <OutlineButton onClick={onCancel}>
           {i18n.t('button.cancel')}
         </OutlineButton>

--- a/protocol-designer/src/components/modals/FilePipettesModal/FilePipettesModal.css
+++ b/protocol-designer/src/components/modals/FilePipettesModal/FilePipettesModal.css
@@ -52,12 +52,6 @@
   margin: 1rem 0;
 }
 
-.button_row {
-  margin-top: 1rem;
-  display: flex;
-  justify-content: flex-end;
-}
-
 .button {
   margin: 0 0 0 1rem;
 }

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.js
@@ -284,7 +284,7 @@ export class FilePipettesModal extends React.Component<Props, State> {
                 />
               )}
 
-              <div className={styles.button_row}>
+              <div className={modalStyles.button_row}>
                 <OutlineButton
                   onClick={this.props.onCancel}
                   tabIndex={7}

--- a/protocol-designer/src/components/modals/modal.css
+++ b/protocol-designer/src/components/modals/modal.css
@@ -84,12 +84,13 @@
   justify-content: flex-end;
 }
 
-/* TODO IMMEDIATELY: rename, this is when you have a single button on the left and rest on the right */
+/* usually used when there is a single button on the left and rest on the right */
 .button_row_divided {
   display: flex;
   justify-content: space-between;
 }
 
+/* used with .button_row_divided to define the division */
 .button_right_of_break {
   margin-right: 1rem;
 }

--- a/protocol-designer/src/components/modals/modal.css
+++ b/protocol-designer/src/components/modals/modal.css
@@ -77,3 +77,23 @@
   overflow-y: auto;
   margin-bottom: 1rem;
 }
+
+.button_row {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* TODO IMMEDIATELY: rename, this is when you have a single button on the left and rest on the right */
+.button_row_divided {
+  display: flex;
+  justify-content: space-between;
+}
+
+.button_right_of_break {
+  margin-right: 1rem;
+}
+
+.button_medium {
+  width: 10rem;
+}


### PR DESCRIPTION
## overview

Too many styles for buttons!

Addresses #1670. Doesn't close it b/c I didn't want to mess with the lost-grid button rows now.

This does slightly change styles (margin above buttons), but hopefully the margin changes are good and make less subtle variations in the styles. Detailed below

## changelog

- remove multiple `button_row` classes
- new `button_row_divided` class for the common case where there is a button on the left and the rest on the right

## review requests

The easiest way I've found to look for style changes is to open `edge` sandbox in one tab, and open this branch in another tab.

- [ ] New Protocol Modal: no change
- [ ] File Page > File Fields Form: margin above the buttons is increased ~1rem
- [ ] Confirm Edit Pipettes Modal (aka EditPipettesModal/StepChangesConfirmModal. Get here by editing pipettes and clicking OK): margin above the buttons is decreased ~1rem
- [ ] Add/Edit Module Modal: no change
- [ ] Well Order Modal: no change
- [ ] Tip Positioning Modal: no change