### PR TITLE
fix(api): fix a spinlock in pre-home plunger unsticking

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -1532,7 +1532,7 @@ class SmoothieDriver_3_0_0:
                 try:
                     # home commands are executed before ack, use a long ack
                     # timeout and short execute timeout
-                    self._send_command(
+                    self._send_command_unsynchronized(
                         command, ack_timeout=DEFAULT_EXECUTE_TIMEOUT,
                         timeout=DEFAULT_ACK_TIMEOUT)
                     self.update_homed_flags(flags={ax: True for ax in axes})
@@ -1602,7 +1602,9 @@ class SmoothieDriver_3_0_0:
             GCODES['ABSOLUTE_COORDS'] + ' ' + \
             self._build_speed_command(self._combined_speed)
         try:
-            self._send_command(command_string, timeout=DEFAULT_EXECUTE_TIMEOUT)
+            with self._serial_lock():
+                self._send_command_unsynchronized(
+                    command_string, timeout=DEFAULT_EXECUTE_TIMEOUT)
         except SmoothieError:
             # these may cause a hard limit error, since we have no idea where
             # we are in this context. Hopefully that's ok though because

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -1532,7 +1532,7 @@ class SmoothieDriver_3_0_0:
                 try:
                     # home commands are executed before ack, use a long ack
                     # timeout and short execute timeout
-                    self._send_command_unsynchronized(
+                    self._send_command(
                         command, ack_timeout=DEFAULT_EXECUTE_TIMEOUT,
                         timeout=DEFAULT_ACK_TIMEOUT)
                     self.update_homed_flags(flags={ax: True for ax in axes})
@@ -1602,14 +1602,17 @@ class SmoothieDriver_3_0_0:
             GCODES['ABSOLUTE_COORDS'] + ' ' + \
             self._build_speed_command(self._combined_speed)
         try:
-            with self._serial_lock():
+            with self._serial_lock:
                 self._send_command_unsynchronized(
-                    command_string, timeout=DEFAULT_EXECUTE_TIMEOUT)
+                    command_string,
+                    ack_timeout=DEFAULT_ACK_TIMEOUT,
+                    execute_timeout=DEFAULT_EXECUTE_TIMEOUT)
         except SmoothieError:
             # these may cause a hard limit error, since we have no idea where
             # we are in this context. Hopefully that's ok though because
             # otherwise we have very little way to get out
             log.exception("Hard limit in pre-home unstick!")
+            self._reset_from_error()
 
     def fast_home(self, axis, safety_margin):
         ''' home after a controlled motor stall


### PR DESCRIPTION
If the plunger of a pipette that requires move splitting is at the top
of its range when a home() occurs, the hard limit error that happens
during the move will cause the api server to spin forever.

Closes #5071
