### PR TITLE
refactor(app): add wifi configure actions and epics to networking module

### DIFF
--- a/app/src/networking/__fixtures__/configure.js
+++ b/app/src/networking/__fixtures__/configure.js
@@ -1,0 +1,31 @@
+// @flow
+// fixtures for /wifi/configure
+
+import { POST } from '../../robot-api'
+import {
+  makeResponseFixtures,
+  mockFailureBody,
+} from '../../robot-api/__fixtures__'
+
+import { WIFI_CONFIGURE_PATH } from '../constants'
+
+import type { WifiConfigureResponse } from '../types'
+
+const { successMeta, failureMeta, success, failure } = makeResponseFixtures<
+  WifiConfigureResponse,
+  {| message: string |}
+>({
+  method: POST,
+  path: WIFI_CONFIGURE_PATH,
+  successStatus: 200,
+  successBody: { ssid: 'network-name', message: 'connected' },
+  failureStatus: 500,
+  failureBody: mockFailureBody,
+})
+
+export {
+  successMeta as mockWifiConfigureSuccessMeta,
+  failureMeta as mockWifiConfigureFailureMeta,
+  success as mockWifiConfigureSuccess,
+  failure as mockWifiConfigureFailure,
+}

--- a/app/src/networking/__fixtures__/index.js
+++ b/app/src/networking/__fixtures__/index.js
@@ -1,5 +1,6 @@
 // @flow
 // mock responses for networking endpoints
 
+export * from './configure'
 export * from './list'
 export * from './status'

--- a/app/src/networking/__tests__/actions.test.js
+++ b/app/src/networking/__tests__/actions.test.js
@@ -105,6 +105,49 @@ describe('networking actions', () => {
         meta: mockRequestMeta,
       },
     },
+    {
+      name: 'networking:POST_WIFI_CONFIGURE',
+      creator: Actions.postWifiConfigure,
+      args: [mockRobot.name, { ssid: 'network-name', psk: 'network-password' }],
+      expected: {
+        type: 'networking:POST_WIFI_CONFIGURE',
+        payload: {
+          robotName: mockRobot.name,
+          options: { ssid: 'network-name', psk: 'network-password' },
+        },
+        meta: {},
+      },
+    },
+    {
+      name: 'networking:POST_WIFI_CONFIGURE_SUCCESS',
+      creator: Actions.postWifiConfigureSuccess,
+      args: [mockRobot.name, 'network-name', mockRequestMeta],
+      expected: {
+        type: 'networking:POST_WIFI_CONFIGURE_SUCCESS',
+        payload: {
+          robotName: mockRobot.name,
+          ssid: 'network-name',
+        },
+        meta: mockRequestMeta,
+      },
+    },
+    {
+      name: 'networking:POST_WIFI_CONFIGURE_FAILURE',
+      creator: Actions.postWifiConfigureFailure,
+      args: [
+        mockRobot.name,
+        Fixtures.mockWifiConfigureFailure.body,
+        mockRequestMeta,
+      ],
+      expected: {
+        type: 'networking:POST_WIFI_CONFIGURE_FAILURE',
+        payload: {
+          robotName: mockRobot.name,
+          error: Fixtures.mockWifiListFailure.body,
+        },
+        meta: mockRequestMeta,
+      },
+    },
   ]
 
   SPECS.forEach(spec => {

--- a/app/src/networking/actions.js
+++ b/app/src/networking/actions.js
@@ -24,7 +24,7 @@ export const fetchStatusSuccess = (
 
 export const fetchStatusFailure = (
   robotName: string,
-  error: {},
+  error: { ... },
   meta: RobotApiRequestMeta
 ): Types.FetchStatusFailureAction => ({
   type: Constants.FETCH_STATUS_FAILURE,
@@ -52,10 +52,39 @@ export const fetchWifiListSuccess = (
 
 export const fetchWifiListFailure = (
   robotName: string,
-  error: {},
+  error: { ... },
   meta: RobotApiRequestMeta
 ): Types.FetchWifiListFailureAction => ({
   type: Constants.FETCH_WIFI_LIST_FAILURE,
+  payload: { robotName, error },
+  meta,
+})
+
+export const postWifiConfigure = (
+  robotName: string,
+  options: Types.WifiConfigureRequest
+): Types.PostWifiConfigureAction => ({
+  type: Constants.POST_WIFI_CONFIGURE,
+  payload: { robotName, options },
+  meta: {},
+})
+
+export const postWifiConfigureSuccess = (
+  robotName: string,
+  ssid: string,
+  meta: RobotApiRequestMeta
+): Types.PostWifiConfigureSuccessAction => ({
+  type: Constants.POST_WIFI_CONFIGURE_SUCCESS,
+  payload: { robotName, ssid },
+  meta,
+})
+
+export const postWifiConfigureFailure = (
+  robotName: string,
+  error: { ... },
+  meta: RobotApiRequestMeta
+): Types.PostWifiConfigureFailureAction => ({
+  type: Constants.POST_WIFI_CONFIGURE_FAILURE,
   payload: { robotName, error },
   meta,
 })

--- a/app/src/networking/api-types.js
+++ b/app/src/networking/api-types.js
@@ -1,0 +1,89 @@
+// @flow
+
+import typeof {
+  STATUS_NONE,
+  STATUS_PORTAL,
+  STATUS_LIMITED,
+  STATUS_FULL,
+  STATUS_UNKNOWN,
+  INTERFACE_CONNECTED,
+  INTERFACE_CONNECTING,
+  INTERFACE_DISCONNECTED,
+  INTERFACE_UNAVAILABLE,
+  INTERFACE_WIFI,
+  INTERFACE_ETHERNET,
+  SECURITY_NONE,
+  SECURITY_WPA_PSK,
+  SECURITY_WPA_EAP,
+} from './constants'
+
+// GET /networking/status
+
+export type InternetStatus =
+  | STATUS_NONE
+  | STATUS_PORTAL
+  | STATUS_LIMITED
+  | STATUS_FULL
+  | STATUS_UNKNOWN
+
+export type InterfaceState =
+  | INTERFACE_CONNECTED
+  | INTERFACE_CONNECTING
+  | INTERFACE_DISCONNECTED
+  | INTERFACE_UNAVAILABLE
+
+export type InterfaceType = INTERFACE_WIFI | INTERFACE_ETHERNET
+
+export type InterfaceStatus = {|
+  ipAddress: string | null,
+  macAddress: string,
+  gatewayAddress: string | null,
+  state: InterfaceState,
+  type: InterfaceType,
+|}
+
+export type InterfaceStatusMap = $Shape<{|
+  [device: string]: InterfaceStatus,
+|}>
+
+export type NetworkingStatusResponse = {|
+  status: InternetStatus,
+  interfaces: InterfaceStatusMap,
+|}
+
+// GET /wifi/list
+
+export type WifiSecurityType =
+  | SECURITY_NONE
+  | SECURITY_WPA_PSK
+  | SECURITY_WPA_EAP
+
+export type WifiNetwork = {|
+  ssid: string,
+  signal: number,
+  active: boolean,
+  security: string,
+  securityType: WifiSecurityType,
+|}
+
+export type WifiListResponse = {|
+  list: Array<WifiNetwork>,
+|}
+
+// POST /wifi/configure
+
+export type WifiConfigureRequest = {|
+  ssid: string,
+  psk?: string,
+  securityType?: WifiSecurityType,
+  hidden?: boolean,
+  eapConfig?: {|
+    [eapOption: string]: string,
+    eapType: string,
+  |},
+|}
+
+export type WifiConfigureResponse = {|
+  ssid: string,
+  message: string,
+|}

--- a/app/src/networking/constants.js
+++ b/app/src/networking/constants.js
@@ -24,6 +24,7 @@ export const SECURITY_WPA_EAP: 'wpa-eap' = 'wpa-eap'
 
 export const STATUS_PATH: '/networking/status' = '/networking/status'
 export const WIFI_LIST_PATH: '/wifi/list' = '/wifi/list'
+export const WIFI_CONFIGURE_PATH: '/wifi/configure' = '/wifi/configure'
 
 // action type strings
 
@@ -47,3 +48,14 @@ export const FETCH_WIFI_LIST_SUCCESS: 'networking:FETCH_WIFI_LIST_SUCCESS' =
 
 export const FETCH_WIFI_LIST_FAILURE: 'networking:FETCH_WIFI_LIST_FAILURE' =
   'networking:FETCH_WIFI_LIST_FAILURE'
+
+// POST /wifi/configure
+
+export const POST_WIFI_CONFIGURE: 'networking:POST_WIFI_CONFIGURE' =
+  'networking:POST_WIFI_CONFIGURE'
+
+export const POST_WIFI_CONFIGURE_SUCCESS: 'networking:POST_WIFI_CONFIGURE_SUCCESS' =
+  'networking:POST_WIFI_CONFIGURE_SUCCESS'
+
+export const POST_WIFI_CONFIGURE_FAILURE: 'networking:POST_WIFI_CONFIGURE_FAILURE' =
+  'networking:POST_WIFI_CONFIGURE_FAILURE'

--- a/app/src/networking/epic/__tests__/wifiConfigureEpic.test.js
+++ b/app/src/networking/epic/__tests__/wifiConfigureEpic.test.js
@@ -1,0 +1,133 @@
+// @flow
+import { TestScheduler } from 'rxjs/testing'
+
+import { mockRobot } from '../../../robot-api/__fixtures__'
+import * as RobotApiHttp from '../../../robot-api/http'
+import * as Discovery from '../../../discovery'
+import * as Fixtures from '../../__fixtures__'
+import * as Actions from '../../actions'
+import * as Types from '../../types'
+import { networkingEpic } from '..'
+
+import type { Observable } from 'rxjs'
+import type {
+  RobotHost,
+  RobotApiRequestOptions,
+  RobotApiResponse,
+} from '../../../robot-api/types'
+
+jest.mock('../../../robot-api/http')
+jest.mock('../../../discovery/selectors')
+jest.mock('../../selectors')
+
+const mockState = { state: true }
+
+const mockFetchRobotApi: JestMockFn<
+  [RobotHost, RobotApiRequestOptions],
+  Observable<RobotApiResponse>
+> = RobotApiHttp.fetchRobotApi
+
+const mockGetRobotByName: JestMockFn<[any, string], mixed> =
+  Discovery.getRobotByName
+
+describe('networking wifiConfigureEpic', () => {
+  let testScheduler
+
+  beforeEach(() => {
+    mockGetRobotByName.mockReturnValue(mockRobot)
+
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  const meta = { requestId: '1234' }
+  const action: Types.PostWifiConfigureAction = {
+    ...Actions.postWifiConfigure(mockRobot.name, {
+      ssid: 'network-name',
+      psk: 'network-password',
+    }),
+    meta,
+  }
+
+  it('calls POST /wifi/configure with options', () => {
+    testScheduler.run(({ hot, cold, expectObservable, flush }) => {
+      mockFetchRobotApi.mockReturnValue(
+        cold('r', { r: Fixtures.mockWifiConfigureSuccess })
+      )
+
+      const action$ = hot('--a', { a: action })
+      const state$ = hot('a-a', { a: mockState })
+      const output$ = networkingEpic(action$, state$)
+
+      expectObservable(output$)
+      flush()
+
+      expect(mockGetRobotByName).toHaveBeenCalledWith(mockState, mockRobot.name)
+      expect(mockFetchRobotApi).toHaveBeenCalledWith(mockRobot, {
+        method: 'POST',
+        path: '/wifi/configure',
+        body: { ssid: 'network-name', psk: 'network-password' },
+      })
+    })
+  })
+
+  it('maps successful response to FETCH_WIFI_CONFIGURE_SUCCESS', () => {
+    testScheduler.run(({ hot, cold, expectObservable, flush }) => {
+      mockFetchRobotApi.mockReturnValue(
+        cold('r', { r: Fixtures.mockWifiConfigureSuccess })
+      )
+
+      const action$ = hot('--a', { a: action })
+      const state$ = hot('a-a', { a: {} })
+      const output$ = networkingEpic(action$, state$)
+
+      expectObservable(output$).toBe('--a', {
+        a: Actions.postWifiConfigureSuccess(
+          mockRobot.name,
+          Fixtures.mockWifiConfigureSuccess.body.ssid,
+          { ...meta, response: Fixtures.mockWifiConfigureSuccessMeta }
+        ),
+      })
+    })
+  })
+
+  it('maps failed response to FETCH_WIFI_CONFIGURE_FAILURE', () => {
+    testScheduler.run(({ hot, cold, expectObservable, flush }) => {
+      mockFetchRobotApi.mockReturnValue(
+        cold('r', { r: Fixtures.mockWifiConfigureFailure })
+      )
+
+      const action$ = hot('--a', { a: action })
+      const state$ = hot('a-a', { a: {} })
+      const output$ = networkingEpic(action$, state$)
+
+      expectObservable(output$).toBe('--a', {
+        a: Actions.postWifiConfigureFailure(
+          mockRobot.name,
+          Fixtures.mockWifiConfigureFailure.body,
+          { ...meta, response: Fixtures.mockWifiConfigureFailureMeta }
+        ),
+      })
+    })
+  })
+
+  it('dispatches FETCH_WIFI_LIST and START_DISCOVERY on success', () => {
+    testScheduler.run(({ hot, cold, expectObservable, flush }) => {
+      const action$ = hot('--a', {
+        a: Actions.postWifiConfigureSuccess(mockRobot.name, 'network-name', {}),
+      })
+      const state$ = hot('a-a', { a: {} })
+      const output$ = networkingEpic(action$, state$)
+
+      expectObservable(output$).toBe('--(ab)', {
+        a: Actions.fetchWifiList(mockRobot.name),
+        b: Discovery.startDiscovery(),
+      })
+    })
+  })
+})

--- a/app/src/networking/epic/index.js
+++ b/app/src/networking/epic/index.js
@@ -2,8 +2,13 @@
 import { combineEpics } from 'redux-observable'
 
 import { statusEpic } from './statusEpic'
+import { wifiConfigureEpic } from './wifiConfigureEpic'
 import { wifiListEpic } from './wifiListEpic'
 
 import type { Epic } from '../../types'
 
-export const networkingEpic: Epic = combineEpics(statusEpic, wifiListEpic)
+export const networkingEpic: Epic = combineEpics(
+  statusEpic,
+  wifiConfigureEpic,
+  wifiListEpic
+)

--- a/app/src/networking/epic/wifiConfigureEpic.js
+++ b/app/src/networking/epic/wifiConfigureEpic.js
@@ -1,0 +1,61 @@
+// @flow
+import { of } from 'rxjs'
+import { ofType, combineEpics } from 'redux-observable'
+import { switchMap } from 'rxjs/operators'
+
+import { startDiscovery } from '../../discovery'
+import { POST } from '../../robot-api/constants'
+import { mapToRobotApiRequest } from '../../robot-api/operators'
+import * as Actions from '../actions'
+import * as Constants from '../constants'
+
+import type {
+  ActionToRequestMapper,
+  ResponseToActionMapper,
+} from '../../robot-api/operators'
+import type { Epic } from '../../types'
+import type { PostWifiConfigureAction } from '../types'
+
+const mapActionToRequest: ActionToRequestMapper<PostWifiConfigureAction> = action => ({
+  method: POST,
+  path: Constants.WIFI_CONFIGURE_PATH,
+  body: action.payload.options,
+})
+
+const mapResponseToAction: ResponseToActionMapper<PostWifiConfigureAction> = (
+  response,
+  originalAction
+) => {
+  const { host, body, ...responseMeta } = response
+  const meta = { ...originalAction.meta, response: responseMeta }
+
+  return response.ok
+    ? Actions.postWifiConfigureSuccess(host.name, body.ssid, meta)
+    : Actions.postWifiConfigureFailure(host.name, body, meta)
+}
+
+const postWifiConfigureEpic: Epic = (action$, state$) => {
+  return action$.pipe(
+    ofType(Constants.POST_WIFI_CONFIGURE),
+    mapToRobotApiRequest(
+      state$,
+      a => a.payload.robotName,
+      mapActionToRequest,
+      mapResponseToAction
+    )
+  )
+}
+
+const handleWifiConfigureSuccessEpic: Epic = action$ => {
+  return action$.pipe(
+    ofType(Constants.POST_WIFI_CONFIGURE_SUCCESS),
+    switchMap(action =>
+      of(Actions.fetchWifiList(action.payload.robotName), startDiscovery())
+    )
+  )
+}
+
+export const wifiConfigureEpic: Epic = combineEpics(
+  postWifiConfigureEpic,
+  handleWifiConfigureSuccessEpic
+)

--- a/app/src/networking/types.js
+++ b/app/src/networking/types.js
@@ -1,85 +1,22 @@
 // @flow
 
 import type { RobotApiRequestMeta } from '../robot-api/types'
+
 import typeof {
-  STATUS_NONE,
-  STATUS_PORTAL,
-  STATUS_LIMITED,
-  STATUS_FULL,
-  STATUS_UNKNOWN,
-  INTERFACE_CONNECTED,
-  INTERFACE_CONNECTING,
-  INTERFACE_DISCONNECTED,
-  INTERFACE_UNAVAILABLE,
-  INTERFACE_WIFI,
-  INTERFACE_ETHERNET,
-  SECURITY_NONE,
-  SECURITY_WPA_PSK,
-  SECURITY_WPA_EAP,
   FETCH_STATUS,
   FETCH_STATUS_SUCCESS,
   FETCH_STATUS_FAILURE,
   FETCH_WIFI_LIST,
   FETCH_WIFI_LIST_SUCCESS,
   FETCH_WIFI_LIST_FAILURE,
+  POST_WIFI_CONFIGURE,
+  POST_WIFI_CONFIGURE_SUCCESS,
+  POST_WIFI_CONFIGURE_FAILURE,
 } from './constants'
 
-// response types
+import * as ApiTypes from './api-types'
 
-// GET /networking/status
-
-export type InternetStatus =
-  | STATUS_NONE
-  | STATUS_PORTAL
-  | STATUS_LIMITED
-  | STATUS_FULL
-  | STATUS_UNKNOWN
-
-export type InterfaceState =
-  | INTERFACE_CONNECTED
-  | INTERFACE_CONNECTING
-  | INTERFACE_DISCONNECTED
-  | INTERFACE_UNAVAILABLE
-
-export type InterfaceType = INTERFACE_WIFI | INTERFACE_ETHERNET
-
-export type InterfaceStatus = {|
-  ipAddress: string | null,
-  macAddress: string,
-  gatewayAddress: string | null,
-  state: InterfaceState,
-  type: InterfaceType,
-|}
-
-export type InterfaceStatusMap = $Shape<{|
-  [device: string]: InterfaceStatus,
-|}>
-
-export type NetworkingStatusResponse = {|
-  status: InternetStatus,
-  interfaces: InterfaceStatusMap,
-|}
-
-// GET /wifi/list
-
-export type WifiSecurityType =
-  | SECURITY_NONE
-  | SECURITY_WPA_PSK
-  | SECURITY_WPA_EAP
-
-export type WifiNetwork = {|
-  ssid: string,
-  signal: number,
-  active: boolean,
-  security: string,
-  securityType: WifiSecurityType,
-|}
-
-export type WifiListResponse = {|
-  list: Array<WifiNetwork>,
-|}
-
-// action types
+export * from './api-types'
 
 // fetch status
 
@@ -93,15 +30,15 @@ export type FetchStatusSuccessAction = {|
   type: FETCH_STATUS_SUCCESS,
   payload: {|
     robotName: string,
-    internetStatus: InternetStatus,
-    interfaces: InterfaceStatusMap,
+    internetStatus: ApiTypes.InternetStatus,
+    interfaces: ApiTypes.InterfaceStatusMap,
   |},
   meta: RobotApiRequestMeta,
 |}
 
 export type FetchStatusFailureAction = {|
   type: FETCH_STATUS_FAILURE,
-  payload: {| robotName: string, error: {} |},
+  payload: {| robotName: string, error: { ... } |},
   meta: RobotApiRequestMeta,
 |}
 
@@ -115,13 +52,33 @@ export type FetchWifiListAction = {|
 
 export type FetchWifiListSuccessAction = {|
   type: FETCH_WIFI_LIST_SUCCESS,
-  payload: {| robotName: string, wifiList: Array<WifiNetwork> |},
+  payload: {| robotName: string, wifiList: Array<ApiTypes.WifiNetwork> |},
   meta: RobotApiRequestMeta,
 |}
 
 export type FetchWifiListFailureAction = {|
   type: FETCH_WIFI_LIST_FAILURE,
-  payload: {| robotName: string, error: {} |},
+  payload: {| robotName: string, error: { ... } |},
+  meta: RobotApiRequestMeta,
+|}
+
+// connect to new network
+
+export type PostWifiConfigureAction = {|
+  type: POST_WIFI_CONFIGURE,
+  payload: {| robotName: string, options: ApiTypes.WifiConfigureRequest |},
+  meta: RobotApiRequestMeta,
+|}
+
+export type PostWifiConfigureSuccessAction = {|
+  type: POST_WIFI_CONFIGURE_SUCCESS,
+  payload: {| robotName: string, ssid: string |},
+  meta: RobotApiRequestMeta,
+|}
+
+export type PostWifiConfigureFailureAction = {|
+  type: POST_WIFI_CONFIGURE_FAILURE,
+  payload: {| robotName: string, error: { ... } |},
   meta: RobotApiRequestMeta,
 |}
 
@@ -134,13 +91,16 @@ export type NetworkingAction =
   | FetchWifiListAction
   | FetchWifiListSuccessAction
   | FetchWifiListFailureAction
+  | PostWifiConfigureAction
+  | PostWifiConfigureSuccessAction
+  | PostWifiConfigureFailureAction
 
 // state types
 
 export type PerRobotNetworkingState = $Shape<{|
-  internetStatus: InternetStatus,
-  interfaces: InterfaceStatusMap,
-  wifiList: Array<WifiNetwork>,
+  internetStatus: ApiTypes.InternetStatus,
+  interfaces: ApiTypes.InterfaceStatusMap,
+  wifiList: Array<ApiTypes.WifiNetwork>,
 |}>
 
 export type NetworkingState = $Shape<{|
@@ -153,7 +113,7 @@ export type SimpleInterfaceStatus = {|
   ipAddress: string | null,
   subnetMask: string | null,
   macAddress: string,
-  type: InterfaceType,
+  type: ApiTypes.InterfaceType,
 |}
 
 export type InterfaceStatusByType = {|


### PR DESCRIPTION
## overview

Part of #4842 

This PR adds actions, epics, etc. to `app/src/networking` for `POST /wifi/configure`. It does not wire any of these up to the UI because the configuration UI is currently being refactored in #5028; the wireup will happen there

## changelog

- [ ] refactor(app): add wifi configure actions and epics to networking module

## review requests

To test, use the Redux devtools to dispatch a configure action:

```js
{
  type: 'networking:POST_WIFI_CONFIGURE',
  payload: {
    robotName: 'some-robot-name',
    options: { ssid: 'network-name', psk: 'network-password' },
  },
  meta: {}
}
```

- [ ] Network request goes out if `robotName` exists and is reachable
- [ ] Success or failure action comes back
- [ ] If success, `FETCH_WIFI_LIST` and `START_DISCOVERY` get dispatched automatically
    - Note: this replaces existing logic in `mapDispatchToProps` of `app/src/components/RobotSettings/SelectNetwork/index.js`