### PR TITLE
fix(protocol-designer): fix tests for FileSidebar after merging #5029

### DIFF
--- a/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.js
+++ b/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.js
@@ -1,14 +1,15 @@
+// @flow
 import React from 'react'
 import { shallow } from 'enzyme'
 import fileSaver from 'file-saver'
 import { PrimaryButton, AlertModal, OutlineButton } from '@opentrons/components'
+import { MAGNETIC_MODULE_TYPE } from '@opentrons/shared-data'
 import {
   fixtureP10Single,
   fixtureP300Single,
 } from '@opentrons/shared-data/pipette/fixtures/name'
 import fixture_tiprack_10_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_10_ul.json'
 import { FileSidebar } from '../FileSidebar'
-import { MAGDECK } from '../../../constants'
 
 jest.mock('file-saver')
 
@@ -26,11 +27,15 @@ describe('FileSidebar', () => {
       onDownload: jest.fn(),
       downloadData: {
         fileData: {
+          labware: {},
+          labwareDefinitions: {},
+          metadata: {},
+          pipettes: {},
+          robot: { model: 'OT-2 Standard' },
+          schemaVersion: 4,
           commands: [],
         },
         fileName: 'protocol.json',
-        pipettes: {},
-        modules: {},
       },
       pipettesOnDeck: {},
       modulesOnDeck: {},
@@ -65,7 +70,7 @@ describe('FileSidebar', () => {
 
     modulesOnDeck = {
       magnet123: {
-        type: MAGDECK,
+        type: MAGNETIC_MODULE_TYPE,
       },
     }
 

--- a/protocol-designer/src/components/FileSidebar/utils/__tests__/getUnusedEntities.test.js
+++ b/protocol-designer/src/components/FileSidebar/utils/__tests__/getUnusedEntities.test.js
@@ -5,10 +5,12 @@ import {
 } from '@opentrons/shared-data/pipette/fixtures/name'
 import fixture_tiprack_10_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_10_ul.json'
 import {
-  MAGDECK,
-  TEMPDECK,
-  TEMPERATURE_DEACTIVATED,
-} from '../../../../constants'
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  MAGNETIC_MODULE_V1,
+  TEMPERATURE_MODULE_V1,
+} from '@opentrons/shared-data'
+import { TEMPERATURE_DEACTIVATED } from '../../../../constants'
 import { getUnusedEntities } from '../getUnusedEntities'
 
 describe('getUnusedEntities', () => {
@@ -59,20 +61,20 @@ describe('getUnusedEntities', () => {
     const modulesOnDeck = {
       magnet123: {
         id: 'magnet123',
-        type: MAGDECK,
-        model: 'GEN1',
+        type: MAGNETIC_MODULE_TYPE,
+        model: MAGNETIC_MODULE_V1,
         slot: '3',
         moduleState: {
-          type: MAGDECK,
+          type: MAGNETIC_MODULE_TYPE,
           engaged: false,
         },
       },
       temperature456: {
         id: 'temperature456',
-        type: TEMPDECK,
+        type: TEMPERATURE_MODULE_TYPE,
         model: 'GEN1',
         moduleState: {
-          type: TEMPDECK,
+          type: TEMPERATURE_MODULE_V1,
           status: TEMPERATURE_DEACTIVATED,
           targetTemperature: null,
         },

--- a/protocol-designer/src/components/FileSidebar/utils/__tests__/getUnusedEntities.test.js
+++ b/protocol-designer/src/components/FileSidebar/utils/__tests__/getUnusedEntities.test.js
@@ -72,9 +72,9 @@ describe('getUnusedEntities', () => {
       temperature456: {
         id: 'temperature456',
         type: TEMPERATURE_MODULE_TYPE,
-        model: 'GEN1',
+        model: TEMPERATURE_MODULE_V1,
         moduleState: {
-          type: TEMPERATURE_MODULE_V1,
+          type: TEMPERATURE_MODULE_TYPE,
           status: TEMPERATURE_DEACTIVATED,
           targetTemperature: null,
         },


### PR DESCRIPTION
## overview

My #5029 broke CI for `edge`, this PR updates these tests.

Also add some Flow coverage to the enzyme test, which pointed out the fixture was slightly wrong (FileData keys on the wrong level)

## changelog

## review requests

- [ ] No remaining uses of `MAGDECK` or `TEMPDECK` constants in PD (and no strings `'GEN1'`, no strings/keys `magdeck`, or `tempdeck`)
- [ ] Make sure we did not introduce regressions for #5046 in PD
- [ ] Code review