### PR TITLE
feat(labware-library): Support more pipettes in custom labware test protocol

### DIFF
--- a/labware-library/src/labware-creator/__tests__/loadAndSaveIntegration.test.js
+++ b/labware-library/src/labware-creator/__tests__/loadAndSaveIntegration.test.js
@@ -9,7 +9,7 @@ import fixture12Trough from '@opentrons/shared-data/labware/fixtures/2/fixture_1
 jest.mock('../../definitions')
 
 describe('load and immediately save integrity test', () => {
-  const pipetteName = 'P10_Single'
+  const pipetteName = 'p10_single'
   const fakeDisplayName = 'Fake Display Name'
   const fakeLoadName = 'fake_load_name'
 

--- a/labware-library/src/labware-creator/labwareTestProtocol.js
+++ b/labware-library/src/labware-creator/labwareTestProtocol.js
@@ -2,14 +2,39 @@
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { Options } from './fields'
 
-const tiprackForPipette = {
-  P10_Single: 'opentrons_96_tiprack_10ul',
-  P300_Single: 'opentrons_96_tiprack_300ul',
-  P1000_Single: 'opentrons_96_tiprack_1000ul',
+const pipettes = {
+  'P20 Single GEN2': {
+    loadName: 'p20_single_gen2',
+    tiprack: 'opentrons_96_tiprack_10ul',
+  },
+  'P300 Single GEN2': {
+    loadName: 'p300_single_gen2',
+    tiprack: 'opentrons_96_tiprack_300ul',
+  },
+  'P1000 Single GEN2': {
+    loadName: 'p1000_single_gen2',
+    tiprack: 'opentrons_96_tiprack_1000ul',
+  },
+  'P10 Single GEN1': {
+    loadName: 'p10_single',
+    tiprack: 'opentrons_96_tiprack_10ul',
+  },
+  'P50 Single GEN1': {
+    loadName: 'p50_single',
+    tiprack: 'opentrons_96_tiprack_300ul',
+  },
+  'P300 Single GEN1': {
+    loadName: 'p300_single',
+    tiprack: 'opentrons_96_tiprack_300ul',
+  },
+  'P1000 Single GEN1': {
+    loadName: 'p1000_single',
+    tiprack: 'opentrons_96_tiprack_1000ul',
+  },
 }
 
-export const pipetteNameOptions: Options = Object.keys(tiprackForPipette).map(
-  pipetteName => ({ name: pipetteName.replace(/_/g, ' '), value: pipetteName })
+export const pipetteNameOptions: Options = Object.keys(pipettes).map(
+  pipetteName => ({ name: pipetteName, value: pipetteName })
 )
 
 type LabwareTestProtocolArgs = {|
@@ -21,8 +46,8 @@ export const labwareTestProtocol = ({
   pipetteName,
   definition,
 }: LabwareTestProtocolArgs): string => {
-  const instrumentName = pipetteName.toLowerCase()
-  const tiprackLoadName = tiprackForPipette[pipetteName]
+  const instrumentName = pipettes[pipetteName].loadName
+  const tiprackLoadName = pipettes[pipetteName].tiprack
   const mount = 'right' // NOTE: for now, we'll ONLY use right so that mount-offset issues are reduced
 
   return `import json

--- a/labware-library/src/labware-creator/labwareTestProtocol.js
+++ b/labware-library/src/labware-creator/labwareTestProtocol.js
@@ -3,38 +3,38 @@ import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { Options } from './fields'
 
 const pipettes = {
-  'P20 Single GEN2': {
-    loadName: 'p20_single_gen2',
+  p20_single_gen2: {
+    displayName: 'P20 Single GEN2',
     tiprack: 'opentrons_96_tiprack_10ul',
   },
-  'P300 Single GEN2': {
-    loadName: 'p300_single_gen2',
+  p300_single_gen2: {
+    displayName: 'P300 Single GEN2',
     tiprack: 'opentrons_96_tiprack_300ul',
   },
-  'P1000 Single GEN2': {
-    loadName: 'p1000_single_gen2',
+  p1000_single_gen2: {
+    displayName: 'P1000 Single GEN2',
     tiprack: 'opentrons_96_tiprack_1000ul',
   },
-  'P10 Single GEN1': {
-    loadName: 'p10_single',
+  p10_single: {
+    displayName: 'P10 Single GEN1',
     tiprack: 'opentrons_96_tiprack_10ul',
   },
-  'P50 Single GEN1': {
-    loadName: 'p50_single',
+  p50_single: {
+    displayName: 'P50 Single GEN1',
     tiprack: 'opentrons_96_tiprack_300ul',
   },
-  'P300 Single GEN1': {
-    loadName: 'p300_single',
+  p300_single: {
+    displayName: 'P300 Single GEN1',
     tiprack: 'opentrons_96_tiprack_300ul',
   },
-  'P1000 Single GEN1': {
-    loadName: 'p1000_single',
+  p1000_single: {
+    displayName: 'P1000 Single GEN1',
     tiprack: 'opentrons_96_tiprack_1000ul',
   },
 }
 
 export const pipetteNameOptions: Options = Object.keys(pipettes).map(
-  pipetteName => ({ name: pipetteName, value: pipetteName })
+  loadName => ({ name: pipettes[loadName].displayName, value: loadName })
 )
 
 type LabwareTestProtocolArgs = {|
@@ -46,7 +46,6 @@ export const labwareTestProtocol = ({
   pipetteName,
   definition,
 }: LabwareTestProtocolArgs): string => {
-  const instrumentName = pipettes[pipetteName].loadName
   const tiprackLoadName = pipettes[pipetteName].tiprack
   const mount = 'right' // NOTE: for now, we'll ONLY use right so that mount-offset issues are reduced
 
@@ -77,7 +76,7 @@ RATE = 0.25  # % of default speeds
 SLOWER_RATE = 0.1
 
 PIPETTE_MOUNT = '${mount}'
-PIPETTE_NAME = '${instrumentName}'
+PIPETTE_NAME = '${pipetteName}'
 
 TIPRACK_SLOT = '5'
 TIPRACK_LOADNAME = '${tiprackLoadName}'

--- a/labware-library/src/labware-creator/labwareTestProtocol.js
+++ b/labware-library/src/labware-creator/labwareTestProtocol.js
@@ -33,7 +33,6 @@ const pipettes = {
   },
 }
 
-// Relying on insertion order == enumeration order.
 export const pipetteNameOptions: Options = Object.keys(pipettes).map(
   loadName => ({ name: pipettes[loadName].displayName, value: loadName })
 )

--- a/labware-library/src/labware-creator/labwareTestProtocol.js
+++ b/labware-library/src/labware-creator/labwareTestProtocol.js
@@ -33,6 +33,7 @@ const pipettes = {
   },
 }
 
+// Relying on insertion order == enumeration order.
 export const pipetteNameOptions: Options = Object.keys(pipettes).map(
   loadName => ({ name: pipettes[loadName].displayName, value: loadName })
 )

--- a/labware-library/src/labware-creator/labwareTestProtocol.js
+++ b/labware-library/src/labware-creator/labwareTestProtocol.js
@@ -5,7 +5,7 @@ import type { Options } from './fields'
 const pipettes = {
   p20_single_gen2: {
     displayName: 'P20 Single GEN2',
-    tiprack: 'opentrons_96_tiprack_10ul',
+    tiprack: 'opentrons_96_tiprack_20ul',
   },
   p300_single_gen2: {
     displayName: 'P300 Single GEN2',
@@ -17,7 +17,7 @@ const pipettes = {
   },
   p10_single: {
     displayName: 'P10 Single GEN1',
-    tiprack: 'opentrons_96_tiprack_10ul',
+    tiprack: 'opentrons_96_tiprack_20ul',
   },
   p50_single: {
     displayName: 'P50 Single GEN1',


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

The Custom Labware Creator generates a Python protocol to test the exported labware, but it only provides a few pipettes to pick from. 

This PR adds the rest of the single-channels. As far as I know, there's no reason for the test protocol *not* to support these pipettes. It was just never prioritized.

(People occasionally reach out to Support about this. We just edit the generated protocol and send them the modified file. So, if the rest of the pipettes *were* deliberately excluded, uh...)

Closes #4789.

## changelog

* Added dropdown entries for GEN2 single-channels and the P50S GEN1.
* Replaced some code that dynamically generated human-readable pipette names from their API load names, and vice-versa, with a big dumb table. Generalizing the code to support the GEN2s would have made it unnecessarily hard to follow.

## review requests

* I've eyeballed the generated protocol and made sure it simulates with `opentrons_simulate` for a few pipette choices, but double-check my work.
* JS is not my forté, so if there's a more idiomatic way to do any of this, let me know.
* Are the new names in the dropdown acceptable? They're intended to match what you see in the Opentrons App, but I'm working from memory.
