### PR TITLE
feat(scripts): python_build_utils supports upcoming api spli

### DIFF
--- a/scripts/python_build_utils.py
+++ b/scripts/python_build_utils.py
@@ -28,9 +28,9 @@ package_entries = {
     'update-server': PackageEntry(
         os.path.join(HERE, '..', 'update-server', 'otupdate', 'package.json'),
         'update_server'),
-    'opentrons': PackageEntry(
-        os.path.join(HERE, '..', 'pyopentrons', 'src', 'opentrons', 'package.json'),
-        'opentrons')
+    'robot-server': PackageEntry(
+        os.path.join(HERE, '..', 'robot-server', 'robot_server', 'package.json'),
+        'robot-server')
 }
 
 

--- a/scripts/python_build_utils.py
+++ b/scripts/python_build_utils.py
@@ -30,7 +30,7 @@ package_entries = {
         'update_server'),
     'robot-server': PackageEntry(
         os.path.join(HERE, '..', 'robot-server', 'robot_server', 'package.json'),
-        'robot-server')
+        'robot_server')
 }
 
 

--- a/scripts/python_build_utils.py
+++ b/scripts/python_build_utils.py
@@ -16,6 +16,10 @@ PackageEntry = namedtuple("PackageEntry", ("pkg_json", "br_version_prefix"))
 
 HERE = os.path.dirname(__file__)
 
+# current working directory for shell calls. will only be empty if running
+# from script directory.
+CWD = HERE or '.'
+
 
 package_entries = {
     'api': PackageEntry(
@@ -56,7 +60,7 @@ def _ref_from_sha(sha):
     # refs
     allrefs = subprocess.check_output(
         ['git', 'show-ref', '--tags', '--heads'],
-        cwd=HERE).strip().decode().split('\n')
+        cwd=CWD).strip().decode().split('\n')
     # Keep...
     matching = [
         this_ref for this_sha, this_ref in   # the refs
@@ -90,7 +94,7 @@ def dump_br_version(project):
     """
     normalized = get_version(project)
     sha = subprocess.check_output(
-        ['git', 'rev-parse', 'HEAD'], cwd=HERE).strip().decode()
+        ['git', 'rev-parse', 'HEAD'], cwd=CWD).strip().decode()
     branch = _ref_from_sha(sha)
     pref = package_entries[project].br_version_prefix
     return json.dumps({pref+'_version': normalized,


### PR DESCRIPTION
## overview

api will be split into api-server and opentrons packages. Adding support in python_build_utils.py. Made a slight refactor to make it easier to add new packages.

Also, enabled running from the scripts directory.

## review requests

Notice that it's to be merged into api_splitup_feature_branch, a feature branch for the split up.

Sorry about the PR noise. This replaces #5051 which was for a bumbbranch.