### PR TITLE
fix(api): Avoid Python 3.8 unsupported `str in Enum` expression

### DIFF
--- a/api/src/opentrons/protocol_api/util.py
+++ b/api/src/opentrons/protocol_api/util.py
@@ -139,12 +139,8 @@ class AxisMaxSpeeds(UserDict):
     """
 
     def __getitem__(self, key: Union[str, types.Axis]):
-        if key in types.Axis:
-            return self.data[key]
-        elif isinstance(key, str):
-            return self.data[types.Axis[key.upper()]]
-        else:
-            raise KeyError(key)
+        checked_key = AxisMaxSpeeds._verify_key(key)
+        return self.data[checked_key]
 
     @staticmethod
     def _verify_key(key: Any) -> types.Axis:


### PR DESCRIPTION

<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

* Python 3.6 allows the expression `some_string in SomeEnum` in addition to `some_enum_value in SomeEnum`.
* In April 2018, Python 3.7 [deprecated](https://github.com/python/cpython/pull/6392) `some_string in SomeEnum`.
* In Python 3.8, it raises a `TypeError`.

Because of this, user protocols that adjust `protocol.max_speeds` throw an exception when simulated on Python 3.8. Our own custom labware test protocol does this.


<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

* Replaced ad-hoc key normalization logic in `AxisMaxSpeed.__getitem__` with the same code used elsewhere in the class, which just so happens to avoid the problematic expression.


<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

Please double-check that this doesn't accidentally introduce any behavioral changes that the unit tests don't cover. (I don't think it does.)

## further work

This had been raising `DeprecationWarning`s, but we never saw them because we only test on Python 3.6.

Can we test on other Python versions, too?