### PR TITLE
refactor(js): convert jest "test" to "it"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,6 +61,7 @@ module.exports = {
         'jest/expect-expect': 'off',
         'jest/no-standalone-expect': 'off',
         'jest/no-disabled-tests': 'error',
+        'jest/consistent-test-it': 'error',
       },
     },
     {

--- a/app-shell/src/__tests__/discovery.test.js
+++ b/app-shell/src/__tests__/discovery.test.js
@@ -43,7 +43,7 @@ describe('app-shell/discovery', () => {
     jest.clearAllMocks()
   })
 
-  test('registerDiscovery creates a DiscoveryClient', () => {
+  it('registerDiscovery creates a DiscoveryClient', () => {
     registerDiscovery(dispatch)
 
     expect(createDiscoveryClient).toHaveBeenCalledWith(
@@ -56,17 +56,17 @@ describe('app-shell/discovery', () => {
     )
   })
 
-  test('calls client.start on discovery registration', () => {
+  it('calls client.start on discovery registration', () => {
     registerDiscovery(dispatch)
     expect(mockClient.start).toHaveBeenCalled()
   })
 
-  test('calls client.start on "discovery:START"', () => {
+  it('calls client.start on "discovery:START"', () => {
     registerDiscovery(dispatch)({ type: 'discovery:START' })
     expect(mockClient.start).toHaveBeenCalledTimes(2)
   })
 
-  test('calls client.stop when electron app emits "will-quit"', () => {
+  it('calls client.stop when electron app emits "will-quit"', () => {
     expect(app.once).toHaveBeenCalledTimes(0)
 
     registerDiscovery(dispatch)
@@ -82,7 +82,7 @@ describe('app-shell/discovery', () => {
     expect(mockClient.stop).toHaveBeenCalledTimes(1)
   })
 
-  test('sets poll speed on "discovery:START" and "discovery:FINISH"', () => {
+  it('sets poll speed on "discovery:START" and "discovery:FINISH"', () => {
     const handleAction = registerDiscovery(dispatch)
 
     handleAction({ type: 'discovery:START' })
@@ -100,7 +100,7 @@ describe('app-shell/discovery', () => {
     expect(fastPoll).toBeLessThan(slowPoll)
   })
 
-  test('always sends "discovery:UPDATE_LIST" on "discovery:START"', () => {
+  it('always sends "discovery:UPDATE_LIST" on "discovery:START"', () => {
     const expected = [
       { name: 'opentrons-dev', ip: '192.168.1.42', port: 31950, ok: true },
     ]
@@ -126,7 +126,7 @@ describe('app-shell/discovery', () => {
     ]
 
     SPECS.forEach(spec =>
-      test(spec.name, () => {
+      it(spec.name, () => {
         mockClient.services = spec.services
 
         mockClient.emit('service')
@@ -138,7 +138,7 @@ describe('app-shell/discovery', () => {
     )
   })
 
-  test('stores services to file on service events', () => {
+  it('stores services to file on service events', () => {
     registerDiscovery(dispatch)
     expect(Store).toHaveBeenCalledWith({
       name: 'discovery',
@@ -153,7 +153,7 @@ describe('app-shell/discovery', () => {
     ])
   })
 
-  test('stores services to file on serviceRemoved events', () => {
+  it('stores services to file on serviceRemoved events', () => {
     registerDiscovery(dispatch)
 
     mockClient.services = [{ name: 'foo' }]
@@ -163,7 +163,7 @@ describe('app-shell/discovery', () => {
     ])
   })
 
-  test('loads services from file on client initialization', () => {
+  it('loads services from file on client initialization', () => {
     Store.__store.get.mockImplementation(key => {
       if (key === 'services') return [{ name: 'foo' }]
       return null
@@ -177,7 +177,7 @@ describe('app-shell/discovery', () => {
     )
   })
 
-  test('loads candidates from config on client initialization', () => {
+  it('loads candidates from config on client initialization', () => {
     getConfig.mockReturnValue({ enabled: true, candidates: ['1.2.3.4'] })
     registerDiscovery(dispatch)
 
@@ -189,7 +189,7 @@ describe('app-shell/discovery', () => {
   })
 
   // ensures config override works with only one candidate specified
-  test('candidates in config can be single value', () => {
+  it('candidates in config can be single value', () => {
     getConfig.mockReturnValue({ enabled: true, candidates: '1.2.3.4' })
     registerDiscovery(dispatch)
 
@@ -200,7 +200,7 @@ describe('app-shell/discovery', () => {
     )
   })
 
-  test('services from overridden candidates are not persisted', () => {
+  it('services from overridden candidates are not persisted', () => {
     getConfig.mockReturnValue({ enabled: true, candidates: 'localhost' })
     getOverrides.mockImplementation(key => {
       if (key === 'discovery.candidates') return ['1.2.3.4', '5.6.7.8']
@@ -216,7 +216,7 @@ describe('app-shell/discovery', () => {
     ])
   })
 
-  test('service from overridden single candidate is not persisted', () => {
+  it('service from overridden single candidate is not persisted', () => {
     getConfig.mockReturnValue({ enabled: true, candidates: 'localhost' })
     getOverrides.mockImplementation(key => {
       if (key === 'discovery.candidates') return '1.2.3.4'
@@ -232,7 +232,7 @@ describe('app-shell/discovery', () => {
     ])
   })
 
-  test('calls client.remove on discovery:REMOVE', () => {
+  it('calls client.remove on discovery:REMOVE', () => {
     const handleAction = registerDiscovery(dispatch)
     handleAction({
       type: 'discovery:REMOVE',

--- a/app-shell/src/__tests__/http.test.js
+++ b/app-shell/src/__tests__/http.test.js
@@ -69,7 +69,7 @@ describe('app-shell main http module', () => {
   SUCCESS_SPECS.forEach(spec => {
     const { name, method, request, requestOptions, response, expected } = spec
 
-    test(name, () => {
+    it(name, () => {
       mockFetch.mockResolvedValueOnce(response)
 
       return method(request).then(result => {
@@ -82,7 +82,7 @@ describe('app-shell main http module', () => {
   FAILURE_SPECS.forEach(spec => {
     const { name, method, request, response, expected } = spec
 
-    test(name, () => {
+    it(name, () => {
       if (isError(response)) {
         mockFetch.mockRejectedValueOnce(response)
       } else {

--- a/app-shell/src/__tests__/update.test.js
+++ b/app-shell/src/__tests__/update.test.js
@@ -24,7 +24,7 @@ describe('update', () => {
     __updaterMockReset()
   })
 
-  test('handles shell:CHECK_UPDATE with available update', () => {
+  it('handles shell:CHECK_UPDATE with available update', () => {
     getConfig.mockReturnValue('dev')
     handleAction({ type: 'shell:CHECK_UPDATE' })
 
@@ -40,7 +40,7 @@ describe('update', () => {
     })
   })
 
-  test('handles shell:CHECK_UPDATE with no available update', () => {
+  it('handles shell:CHECK_UPDATE with no available update', () => {
     handleAction({ type: 'shell:CHECK_UPDATE' })
     autoUpdater.emit('update-not-available', { version: '1.0.0' })
 
@@ -50,7 +50,7 @@ describe('update', () => {
     })
   })
 
-  test('handles shell:CHECK_UPDATE with error', () => {
+  it('handles shell:CHECK_UPDATE with error', () => {
     handleAction({ type: 'shell:CHECK_UPDATE' })
     autoUpdater.emit('error', new Error('AH'))
 
@@ -60,7 +60,7 @@ describe('update', () => {
     })
   })
 
-  test('handles shell:DOWNLOAD_UPDATE', () => {
+  it('handles shell:DOWNLOAD_UPDATE', () => {
     handleAction({ type: 'shell:DOWNLOAD_UPDATE' })
 
     expect(autoUpdater.downloadUpdate).toHaveBeenCalledTimes(1)
@@ -73,7 +73,7 @@ describe('update', () => {
     })
   })
 
-  test('handles shell:DOWNLOAD_UPDATE with error', () => {
+  it('handles shell:DOWNLOAD_UPDATE with error', () => {
     handleAction({ type: 'shell:DOWNLOAD_UPDATE' })
     autoUpdater.emit('error', new Error('AH'))
 
@@ -83,7 +83,7 @@ describe('update', () => {
     })
   })
 
-  test('handles shell:APPLY_UPDATE', () => {
+  it('handles shell:APPLY_UPDATE', () => {
     handleAction({ type: 'shell:APPLY_UPDATE' })
     expect(autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1)
   })

--- a/app-shell/src/dialogs/__tests__/dialogs.test.js
+++ b/app-shell/src/dialogs/__tests__/dialogs.test.js
@@ -15,7 +15,7 @@ const mockMainWindow = { mainWindow: true }
 
 describe('dialog boxes', () => {
   describe('showOpenDirectoryDialog', () => {
-    test('directory select with cancel', () => {
+    it('directory select with cancel', () => {
       mockShowOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] })
 
       return Dialogs.showOpenDirectoryDialog(mockMainWindow).then(filePaths => {
@@ -26,7 +26,7 @@ describe('dialog boxes', () => {
       })
     })
 
-    test('directory select with files', () => {
+    it('directory select with files', () => {
       mockShowOpenDialog.mockResolvedValue({
         canceled: false,
         filePaths: ['/path/to/dir'],
@@ -40,7 +40,7 @@ describe('dialog boxes', () => {
       })
     })
 
-    test('directory select with default location', () => {
+    it('directory select with default location', () => {
       mockShowOpenDialog.mockResolvedValue({
         canceled: false,
         filePaths: ['/path/to/dir'],
@@ -59,7 +59,7 @@ describe('dialog boxes', () => {
   })
 
   describe('showOpenFileDialog', () => {
-    test('file select with cancel', () => {
+    it('file select with cancel', () => {
       mockShowOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] })
 
       return Dialogs.showOpenFileDialog(mockMainWindow).then(filePaths => {
@@ -70,7 +70,7 @@ describe('dialog boxes', () => {
       })
     })
 
-    test('file select with files', () => {
+    it('file select with files', () => {
       mockShowOpenDialog.mockResolvedValue({
         canceled: false,
         filePaths: ['/path/to/file.json'],
@@ -84,7 +84,7 @@ describe('dialog boxes', () => {
       })
     })
 
-    test('file select with filters', () => {
+    it('file select with filters', () => {
       mockShowOpenDialog.mockResolvedValue({
         canceled: false,
         filePaths: ['/path/to/file.json'],
@@ -103,7 +103,7 @@ describe('dialog boxes', () => {
       )
     })
 
-    test('file select with default location', () => {
+    it('file select with default location', () => {
       mockShowOpenDialog.mockResolvedValue({
         canceled: false,
         filePaths: ['/path/to/file.json'],

--- a/app-shell/src/labware/__tests__/definitions.test.js
+++ b/app-shell/src/labware/__tests__/definitions.test.js
@@ -28,18 +28,18 @@ describe('labware directory utilities', () => {
   })
 
   describe('readLabwareDirectory', () => {
-    test('resolves empty array for empty directory', () => {
+    it('resolves empty array for empty directory', () => {
       const dir = makeEmptyDir()
       return expect(readLabwareDirectory(dir)).resolves.toEqual([])
     })
 
-    test('rejects if directory is not found', () => {
+    it('rejects if directory is not found', () => {
       return expect(
         readLabwareDirectory('__not_a_directory__')
       ).rejects.toThrow(/no such file/)
     })
 
-    test('returns paths to *.json files in directory', () => {
+    it('returns paths to *.json files in directory', () => {
       const dir = makeEmptyDir()
 
       return Promise.all([
@@ -55,7 +55,7 @@ describe('labware directory utilities', () => {
       })
     })
 
-    test('returns paths to nested JSON files in directory', () => {
+    it('returns paths to nested JSON files in directory', () => {
       const dir = makeEmptyDir()
       const nested = path.join(dir, 'nested')
 
@@ -77,7 +77,7 @@ describe('labware directory utilities', () => {
         })
     })
 
-    test('returns paths to *.JSON files in directory', () => {
+    it('returns paths to *.JSON files in directory', () => {
       const dir = makeEmptyDir()
 
       return Promise.all([
@@ -95,7 +95,7 @@ describe('labware directory utilities', () => {
   })
 
   describe('parseLabwareFiles', () => {
-    test('reads and parses JSON files', () => {
+    it('reads and parses JSON files', () => {
       const dir = makeEmptyDir()
       const files = [
         path.join(dir, 'a.json'),
@@ -128,7 +128,7 @@ describe('labware directory utilities', () => {
       })
     })
 
-    test('surfaces parse errors as null data', () => {
+    it('surfaces parse errors as null data', () => {
       const dir = makeEmptyDir()
       const files = [
         path.join(dir, 'a.json'),
@@ -159,7 +159,7 @@ describe('labware directory utilities', () => {
   })
 
   describe('addLabwareFile', () => {
-    test('writes a labware file to the directory', () => {
+    it('writes a labware file to the directory', () => {
       const sourceDir = makeEmptyDir()
       const destDir = makeEmptyDir()
       const sourceName = path.join(sourceDir, 'source.json')
@@ -181,7 +181,7 @@ describe('labware directory utilities', () => {
         })
     })
 
-    test('increments filename to avoid collisions', () => {
+    it('increments filename to avoid collisions', () => {
       const sourceDir = makeEmptyDir()
       const destDir = makeEmptyDir()
       const sourceName = path.join(sourceDir, 'source.json')
@@ -210,7 +210,7 @@ describe('labware directory utilities', () => {
   })
 
   describe('remove labware file', () => {
-    test('calls Electron.shell.moveItemToTrash', () => {
+    it('calls Electron.shell.moveItemToTrash', () => {
       const dir = makeEmptyDir()
       const filename = path.join(dir, 'foo.json')
 
@@ -221,7 +221,7 @@ describe('labware directory utilities', () => {
       })
     })
 
-    test('deletes the file if Electron fails to trash it', () => {
+    it('deletes the file if Electron fails to trash it', () => {
       const dir = makeEmptyDir()
       const filename = path.join(dir, 'foo.json')
       const setup = fs.writeJson(filename, { name: 'a' })

--- a/app-shell/src/labware/__tests__/dispatch.test.js
+++ b/app-shell/src/labware/__tests__/dispatch.test.js
@@ -101,12 +101,12 @@ describe('labware module dispatches', () => {
     jest.resetAllMocks()
   })
 
-  test('ensures labware directory exists on FETCH_CUSTOM_LABWARE', () => {
+  it('ensures labware directory exists on FETCH_CUSTOM_LABWARE', () => {
     handleAction(CustomLabware.fetchCustomLabware())
     expect(ensureDir).toHaveBeenCalledWith(labwareDir)
   })
 
-  test('reads labware directory on FETCH_CUSTOM_LABWARE', () => {
+  it('reads labware directory on FETCH_CUSTOM_LABWARE', () => {
     handleAction(CustomLabware.fetchCustomLabware())
 
     return flush().then(() =>
@@ -115,7 +115,7 @@ describe('labware module dispatches', () => {
   })
 
   // TODO(mc, 2019-11-25): refactor this action to be shell:INITIALIZE
-  test('reads labware directory on shell:CHECK_UPDATE', () => {
+  it('reads labware directory on shell:CHECK_UPDATE', () => {
     handleAction({ type: 'shell:CHECK_UPDATE', meta: { shell: true } })
 
     return flush().then(() =>
@@ -123,7 +123,7 @@ describe('labware module dispatches', () => {
     )
   })
 
-  test('reads and parses definition files', () => {
+  it('reads and parses definition files', () => {
     const mockDirectoryListing = ['a.json', 'b.json', 'c.json', 'd.json']
     const mockParsedFiles = [
       { filename: 'a.json', created: 0, data: {} },
@@ -143,7 +143,7 @@ describe('labware module dispatches', () => {
     })
   })
 
-  test('dispatches CUSTOM_LABWARE_LIST with labware files', () => {
+  it('dispatches CUSTOM_LABWARE_LIST with labware files', () => {
     const mockValidatedFiles = [
       CustomLabwareFixtures.mockInvalidLabware,
       CustomLabwareFixtures.mockDuplicateLabware,
@@ -161,7 +161,7 @@ describe('labware module dispatches', () => {
     })
   })
 
-  test('dispatches CUSTOM_LABWARE_LIST_FAILURE if read fails', () => {
+  it('dispatches CUSTOM_LABWARE_LIST_FAILURE if read fails', () => {
     readLabwareDirectory.mockRejectedValue((new Error('AH'): any))
 
     handleAction(CustomLabware.fetchCustomLabware())
@@ -173,7 +173,7 @@ describe('labware module dispatches', () => {
     })
   })
 
-  test('opens file picker on CHANGE_CUSTOM_LABWARE_DIRECTORY', () => {
+  it('opens file picker on CHANGE_CUSTOM_LABWARE_DIRECTORY', () => {
     handleAction(CustomLabware.changeCustomLabwareDirectory())
 
     return flush().then(() => {
@@ -184,7 +184,7 @@ describe('labware module dispatches', () => {
     })
   })
 
-  test('dispatches config:UPDATE on labware dir selection', () => {
+  it('dispatches config:UPDATE on labware dir selection', () => {
     showOpenDirectoryDialog.mockResolvedValue(['/path/to/labware'])
 
     handleAction(CustomLabware.changeCustomLabwareDirectory())
@@ -198,7 +198,7 @@ describe('labware module dispatches', () => {
     })
   })
 
-  test('reads labware directory on config change', () => {
+  it('reads labware directory on config change', () => {
     expect(handleConfigChange).toHaveBeenCalledWith(
       'labware.directory',
       expect.any(Function)
@@ -215,7 +215,7 @@ describe('labware module dispatches', () => {
     })
   })
 
-  test('dispatches labware directory list error on config change', () => {
+  it('dispatches labware directory list error on config change', () => {
     const changeHandler = handleConfigChange.mock.calls[0][1]
 
     readLabwareDirectory.mockRejectedValue((new Error('AH'): any))
@@ -229,7 +229,7 @@ describe('labware module dispatches', () => {
     })
   })
 
-  test('opens file picker on ADD_CUSTOM_LABWARE', () => {
+  it('opens file picker on ADD_CUSTOM_LABWARE', () => {
     handleAction(CustomLabware.addCustomLabware())
 
     return flush().then(() => {
@@ -241,7 +241,7 @@ describe('labware module dispatches', () => {
     })
   })
 
-  test('reads labware directory and new file and compares', () => {
+  it('reads labware directory and new file and compares', () => {
     const mockValidatedFiles = [CustomLabwareFixtures.mockInvalidLabware]
 
     const mockNewUncheckedFile = {
@@ -270,7 +270,7 @@ describe('labware module dispatches', () => {
     })
   })
 
-  test('dispatches ADD_CUSTOM_LABWARE_FAILURE if checked file is invalid', () => {
+  it('dispatches ADD_CUSTOM_LABWARE_FAILURE if checked file is invalid', () => {
     const mockInvalidFile = CustomLabwareFixtures.mockInvalidLabware
     const expectedAction = CustomLabware.addCustomLabwareFailure(
       mockInvalidFile
@@ -286,7 +286,7 @@ describe('labware module dispatches', () => {
     })
   })
 
-  test('adds file and triggers a re-scan if valid', () => {
+  it('adds file and triggers a re-scan if valid', () => {
     const mockValidFile = CustomLabwareFixtures.mockValidLabware
     const expectedAction = CustomLabware.customLabwareList(
       [mockValidFile],
@@ -312,7 +312,7 @@ describe('labware module dispatches', () => {
     })
   })
 
-  test('dispatches ADD_CUSTOM_LABWARE_FAILURE if something rejects', () => {
+  it('dispatches ADD_CUSTOM_LABWARE_FAILURE if something rejects', () => {
     const mockValidFile = CustomLabwareFixtures.mockValidLabware
     const expectedAction = CustomLabware.addCustomLabwareFailure(null, 'AH')
 
@@ -328,7 +328,7 @@ describe('labware module dispatches', () => {
     })
   })
 
-  test('skips file picker on ADD_CUSTOM_LABWARE with overwrite', () => {
+  it('skips file picker on ADD_CUSTOM_LABWARE with overwrite', () => {
     const duplicate = CustomLabwareFixtures.mockDuplicateLabware
     const mockExisting = [
       ({ ...duplicate, filename: '/duplicate1.json' }: DuplicateLabwareFile),
@@ -358,7 +358,7 @@ describe('labware module dispatches', () => {
     })
   })
 
-  test('sends ADD_CUSTOM_LABWARE_FAILURE if a something rejects', () => {
+  it('sends ADD_CUSTOM_LABWARE_FAILURE if a something rejects', () => {
     const duplicate = CustomLabwareFixtures.mockDuplicateLabware
     const mockExisting = [
       ({ ...duplicate, filename: '/duplicate1.json' }: DuplicateLabwareFile),
@@ -376,7 +376,7 @@ describe('labware module dispatches', () => {
     })
   })
 
-  test('opens custom labware directory on OPEN_CUSTOM_LABWARE_DIRECTORY', () => {
+  it('opens custom labware directory on OPEN_CUSTOM_LABWARE_DIRECTORY', () => {
     handleAction(CustomLabware.openCustomLabwareDirectory())
 
     return flush().then(() => {

--- a/app-shell/src/labware/__tests__/validation.test.js
+++ b/app-shell/src/labware/__tests__/validation.test.js
@@ -5,7 +5,7 @@ import validLabwareA from '@opentrons/shared-data/labware/fixtures/2/fixture_96_
 import validLabwareB from '@opentrons/shared-data/labware/fixtures/2/fixture_12_trough.json'
 
 describe('validateLabwareFiles', () => {
-  test('handles unparseable and invalid labware files', () => {
+  it('handles unparseable and invalid labware files', () => {
     const files = [
       { filename: 'a.json', data: null, created: Date.now() },
       { filename: 'b.json', data: { baz: 'qux' }, created: Date.now() },
@@ -25,7 +25,7 @@ describe('validateLabwareFiles', () => {
     ])
   })
 
-  test('handles valid labware files', () => {
+  it('handles valid labware files', () => {
     const files = [
       { filename: 'a.json', data: validLabwareA, created: Date.now() },
       { filename: 'b.json', data: validLabwareB, created: Date.now() },
@@ -47,7 +47,7 @@ describe('validateLabwareFiles', () => {
     ])
   })
 
-  test('handles non-unique labware files', () => {
+  it('handles non-unique labware files', () => {
     const files = [
       { filename: 'a.json', data: validLabwareA, created: 3 },
       { filename: 'b.json', data: validLabwareB, created: 2 },
@@ -77,7 +77,7 @@ describe('validateLabwareFiles', () => {
     ])
   })
 
-  test('handles Opentrons-standard labware files', () => {
+  it('handles Opentrons-standard labware files', () => {
     const opentronsDef = { ...validLabwareA, namespace: 'opentrons' }
     const files = [
       { filename: 'a.json', data: opentronsDef, created: Date.now() },
@@ -95,7 +95,7 @@ describe('validateLabwareFiles', () => {
 })
 
 describe('validateNewLabwareFile', () => {
-  test('validates a new file', () => {
+  it('validates a new file', () => {
     const existing = []
     const newFile = {
       filename: 'a.json',
@@ -111,7 +111,7 @@ describe('validateNewLabwareFile', () => {
     })
   })
 
-  test('returns a duplicate if new file conflicts with existing', () => {
+  it('returns a duplicate if new file conflicts with existing', () => {
     const existing = [
       {
         type: 'VALID_LABWARE_FILE',

--- a/app/src/__tests__/util.test.js
+++ b/app/src/__tests__/util.test.js
@@ -18,7 +18,7 @@ describe('chainActions utility', () => {
     store = mockStore(state)
   })
 
-  test('dispatches a chain of plain actions', () => {
+  it('dispatches a chain of plain actions', () => {
     const actions = [{ type: 'foo' }, { type: 'bar' }, { type: 'baz' }]
 
     return store.dispatch(chainActions(...actions)).then(result => {
@@ -27,7 +27,7 @@ describe('chainActions utility', () => {
     })
   })
 
-  test('dispatches a chain of thunk actions', () => {
+  it('dispatches a chain of thunk actions', () => {
     const actions = [{ type: 'foo' }, { type: 'bar' }, { type: 'baz' }]
     const thunks = actions.map(a => dispatch => dispatch(a))
 
@@ -37,7 +37,7 @@ describe('chainActions utility', () => {
     })
   })
 
-  test('dispatches a chain of thunk promise actions', () => {
+  it('dispatches a chain of thunk promise actions', () => {
     const actions = [{ type: 'foo' }, { type: 'bar' }, { type: 'baz' }]
     const thunks = actions.map(a => dispatch => Promise.resolve(dispatch(a)))
 
@@ -47,7 +47,7 @@ describe('chainActions utility', () => {
     })
   })
 
-  test('dispatches a combination of action types', () => {
+  it('dispatches a combination of action types', () => {
     const actions = [{ type: 'foo' }, { type: 'bar' }, { type: 'baz' }]
     const thunks = [
       dispatch => dispatch(actions[0]),
@@ -61,7 +61,7 @@ describe('chainActions utility', () => {
     })
   })
 
-  test('bails out early if a plain action has an error', () => {
+  it('bails out early if a plain action has an error', () => {
     const actions = [{ type: 'foo', error: new Error('AH') }, { type: 'bar' }]
 
     return store.dispatch(chainActions(...actions)).then(result => {
@@ -70,7 +70,7 @@ describe('chainActions utility', () => {
     })
   })
 
-  test('bails out early if a thunk action has an error', () => {
+  it('bails out early if a thunk action has an error', () => {
     const errorAction = { type: 'foo', error: new Error('AH') }
     const actions = [dispatch => dispatch(errorAction), { type: 'bar' }]
 
@@ -80,7 +80,7 @@ describe('chainActions utility', () => {
     })
   })
 
-  test('bails out early if a thunk promise has an error', () => {
+  it('bails out early if a thunk promise has an error', () => {
     const errorAction = { type: 'foo', error: new Error('AH') }
     const actions = [
       dispatch => Promise.resolve(dispatch(errorAction)),
@@ -93,7 +93,7 @@ describe('chainActions utility', () => {
     })
   })
 
-  test('bails out early if a plain action has an error in the payload', () => {
+  it('bails out early if a plain action has an error in the payload', () => {
     const actions = [
       { type: 'foo', payload: { error: new Error('AH') } },
       { type: 'bar' },
@@ -105,7 +105,7 @@ describe('chainActions utility', () => {
     })
   })
 
-  test('bails out early if a thunk action has an error in the payload', () => {
+  it('bails out early if a thunk action has an error in the payload', () => {
     const errorAction = { type: 'foo', payload: { error: new Error('AH') } }
     const actions = [dispatch => dispatch(errorAction), { type: 'bar' }]
 
@@ -115,7 +115,7 @@ describe('chainActions utility', () => {
     })
   })
 
-  test('bails out early if a thunk promise has an error in the payload', () => {
+  it('bails out early if a thunk promise has an error in the payload', () => {
     const errorAction = { type: 'foo', payload: { error: new Error('AH') } }
     const actions = [
       dispatch => Promise.resolve(dispatch(errorAction)),
@@ -128,7 +128,7 @@ describe('chainActions utility', () => {
     })
   })
 
-  test('bails out early if a thunk promise rejects', () => {
+  it('bails out early if a thunk promise rejects', () => {
     const actions = [
       dispatch => Promise.reject(new Error('AH')),
       { type: 'bar' },

--- a/app/src/analytics/__tests__/custom-labware-events.test.js
+++ b/app/src/analytics/__tests__/custom-labware-events.test.js
@@ -107,7 +107,7 @@ const MOCK_STATE: State = ({ mockState: true }: any)
 describe('custom labware analytics events', () => {
   SPECS.forEach(spec => {
     const { name, action, expected } = spec
-    test(name, () => {
+    it(name, () => {
       return expect(makeEvent(action, MOCK_STATE)).resolves.toEqual(expected)
     })
   })

--- a/app/src/analytics/__tests__/epics.test.js
+++ b/app/src/analytics/__tests__/epics.test.js
@@ -21,7 +21,7 @@ describe('analytics epics', () => {
     jest.resetAllMocks()
   })
 
-  test('sendAnalyticsEventEpic handles events', () => {
+  it('sendAnalyticsEventEpic handles events', () => {
     const action = { type: 'foo' }
     const state = { config: { analytics: { optedIn: true } } }
     const event = { name: 'fooEvent', properties: {} }
@@ -39,7 +39,7 @@ describe('analytics epics', () => {
     expect(trackEvent).toHaveBeenCalledWith(event, state.config.analytics)
   })
 
-  test('sendAnalyticsEventEpic handles nulls', () => {
+  it('sendAnalyticsEventEpic handles nulls', () => {
     const action = { type: 'foo' }
     const state = { config: { analytics: { optedIn: true } } }
 
@@ -60,7 +60,7 @@ describe('analytics epics', () => {
     const off = { config: { analytics: { optedIn: false } } }
     const on = { config: { analytics: { optedIn: true } } }
 
-    test('sets opt-in', () => {
+    it('sets opt-in', () => {
       testScheduler.run(({ hot, expectObservable }) => {
         const state$ = hot('-a-b', { a: off, b: on })
         const output$ = epics.optIntoAnalyticsEpic(null, state$)
@@ -70,7 +70,7 @@ describe('analytics epics', () => {
       expect(setMixpanelTracking).toHaveBeenCalledWith({ optedIn: true })
     })
 
-    test('sets opt-out', () => {
+    it('sets opt-out', () => {
       testScheduler.run(({ hot, expectObservable }) => {
         const state$ = hot('-a-b', { a: on, b: off })
         const output$ = epics.optIntoAnalyticsEpic(null, state$)
@@ -80,7 +80,7 @@ describe('analytics epics', () => {
       expect(setMixpanelTracking).toHaveBeenCalledWith({ optedIn: false })
     })
 
-    test('noops on no change in status', () => {
+    it('noops on no change in status', () => {
       testScheduler.run(({ hot, expectObservable }) => {
         const state$ = hot('-a-b', { a: on, b: on })
         const output$ = epics.optIntoAnalyticsEpic(null, state$)

--- a/app/src/analytics/__tests__/make-event.test.js
+++ b/app/src/analytics/__tests__/make-event.test.js
@@ -16,7 +16,7 @@ describe('analytics events map', () => {
     jest.resetAllMocks()
   })
 
-  test('robot:CONNECT_RESPONSE -> robotConnected event', () => {
+  it('robot:CONNECT_RESPONSE -> robotConnected event', () => {
     discoverySelectors.getConnectedRobot.mockImplementation(state => {
       if (state === 'wired') {
         return {
@@ -80,7 +80,7 @@ describe('analytics events map', () => {
       selectors.getProtocolAnalyticsData.mockResolvedValue(protocolData)
     })
 
-    test('robot:PROTOCOL_UPLOAD > protocolUploadRequest', () => {
+    it('robot:PROTOCOL_UPLOAD > protocolUploadRequest', () => {
       const nextState = {}
       const success = { type: 'protocol:UPLOAD', payload: {} }
 
@@ -90,7 +90,7 @@ describe('analytics events map', () => {
       })
     })
 
-    test('robot:SESSION_RESPONSE with upload in flight', () => {
+    it('robot:SESSION_RESPONSE with upload in flight', () => {
       const nextState = {}
       const success = {
         type: 'robot:SESSION_RESPONSE',
@@ -104,7 +104,7 @@ describe('analytics events map', () => {
       })
     })
 
-    test('robot:SESSION_ERROR with upload in flight', () => {
+    it('robot:SESSION_ERROR with upload in flight', () => {
       const nextState = {}
       const failure = {
         type: 'robot:SESSION_ERROR',
@@ -118,7 +118,7 @@ describe('analytics events map', () => {
       })
     })
 
-    test('robot:SESSION_RESPONSE/ERROR with no upload in flight', () => {
+    it('robot:SESSION_RESPONSE/ERROR with no upload in flight', () => {
       const nextState = {}
       const success = {
         type: 'robot:SESSION_RESPONSE',
@@ -137,7 +137,7 @@ describe('analytics events map', () => {
       ])
     })
 
-    test('robot:RUN -> runStart event', () => {
+    it('robot:RUN -> runStart event', () => {
       const state = {}
       const action = { type: 'robot:RUN' }
 
@@ -147,7 +147,7 @@ describe('analytics events map', () => {
       })
     })
 
-    test('robot:RUN_RESPONSE success -> runFinish event', () => {
+    it('robot:RUN_RESPONSE success -> runFinish event', () => {
       const state = {}
       const action = { type: 'robot:RUN_RESPONSE', error: false }
 
@@ -159,7 +159,7 @@ describe('analytics events map', () => {
       })
     })
 
-    test('robot:RUN_RESPONSE error -> runFinish event', () => {
+    it('robot:RUN_RESPONSE error -> runFinish event', () => {
       const state = {}
       const action = {
         type: 'robot:RUN_RESPONSE',
@@ -180,7 +180,7 @@ describe('analytics events map', () => {
       })
     })
 
-    test('robot:PAUSE -> runPause event', () => {
+    it('robot:PAUSE -> runPause event', () => {
       const state = {}
       const action = { type: 'robot:PAUSE' }
 
@@ -195,7 +195,7 @@ describe('analytics events map', () => {
       })
     })
 
-    test('robot:RESUME -> runResume event', () => {
+    it('robot:RESUME -> runResume event', () => {
       const state = {}
       const action = { type: 'robot:RESUME' }
 
@@ -210,7 +210,7 @@ describe('analytics events map', () => {
       })
     })
 
-    test('robot:CANCEL-> runCancel event', () => {
+    it('robot:CANCEL-> runCancel event', () => {
       const state = {}
       const action = { type: 'robot:CANCEL' }
 

--- a/app/src/buildroot/__tests__/actions.test.js
+++ b/app/src/buildroot/__tests__/actions.test.js
@@ -169,6 +169,6 @@ describe('buildroot action creators', () => {
 
   SPECS.forEach(spec => {
     const { name, creator, args, expected } = spec
-    test(name, () => expect(creator(...args)).toEqual(expected))
+    it(name, () => expect(creator(...args)).toEqual(expected))
   })
 })

--- a/app/src/buildroot/__tests__/epic.test.js
+++ b/app/src/buildroot/__tests__/epic.test.js
@@ -53,7 +53,7 @@ describe('buildroot update epics', () => {
   })
 
   describe('startUpdateEpic', () => {
-    test('with BR robot sends CREATE_SESSION', () => {
+    it('with BR robot sends CREATE_SESSION', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
         selectors.getBuildrootRobot.mockReturnValueOnce(brRobot)
 
@@ -69,7 +69,7 @@ describe('buildroot update epics', () => {
       })
     })
 
-    test('with BR-ready robot sends CREATE_SESSION', () => {
+    it('with BR-ready robot sends CREATE_SESSION', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
         selectors.getBuildrootRobot.mockReturnValueOnce(brReadyRobot)
 
@@ -88,7 +88,7 @@ describe('buildroot update epics', () => {
       })
     })
 
-    test('with balena robot sends START_PREMIGRATION', () => {
+    it('with balena robot sends START_PREMIGRATION', () => {
       testScheduler.run(({ hot, expectObservable }) => {
         const action = actions.startBuildrootUpdate(robot.name)
 
@@ -104,7 +104,7 @@ describe('buildroot update epics', () => {
       })
     })
 
-    test('with systemFile in payload sends READ_USER_FILE', () => {
+    it('with systemFile in payload sends READ_USER_FILE', () => {
       testScheduler.run(({ hot, expectObservable }) => {
         const action = actions.startBuildrootUpdate(
           robot.name,
@@ -123,7 +123,7 @@ describe('buildroot update epics', () => {
       })
     })
 
-    test('with bad robot sends UNEXPECTED_ERROR', () => {
+    it('with bad robot sends UNEXPECTED_ERROR', () => {
       testScheduler.run(({ hot, expectObservable }) => {
         const action = actions.startBuildrootUpdate(robot.name)
 
@@ -143,7 +143,7 @@ describe('buildroot update epics', () => {
   })
 
   describe('createSessionEpic', () => {
-    test('sends request to token URL from payload and issues CREATE_SESSION_SUCCESS', () => {
+    it('sends request to token URL from payload and issues CREATE_SESSION_SUCCESS', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         const action = actions.createSession(robot, '/server/update/begin')
 
@@ -171,7 +171,7 @@ describe('buildroot update epics', () => {
       })
     })
 
-    test('sends request to cancel URL if 409 and reissues CREATE_SESSION', () => {
+    it('sends request to cancel URL if 409 and reissues CREATE_SESSION', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         const action = actions.createSession(robot, '/server/update/begin')
 
@@ -196,7 +196,7 @@ describe('buildroot update epics', () => {
       })
     })
 
-    test('issues error if begin request fails without 409', () => {
+    it('issues error if begin request fails without 409', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         const action = actions.createSession(robot, '/server/update/begin')
 
@@ -214,7 +214,7 @@ describe('buildroot update epics', () => {
       })
     })
 
-    test('issues error if cancel request fails', () => {
+    it('issues error if cancel request fails', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         const action = actions.createSession(robot, '/server/update/begin')
 
@@ -239,7 +239,7 @@ describe('buildroot update epics', () => {
     })
   })
 
-  test('retryAfterPremigrationEpic', () => {
+  it('retryAfterPremigrationEpic', () => {
     testScheduler.run(({ hot, expectObservable }) => {
       selectors.getBuildrootRobot.mockReturnValueOnce(brReadyRobot)
       selectors.getBuildrootRobotName.mockReturnValueOnce(brReadyRobot.name)
@@ -257,7 +257,7 @@ describe('buildroot update epics', () => {
     })
   })
 
-  test('statusPollEpic', () => {
+  it('statusPollEpic', () => {
     testScheduler.run(
       ({ hot, cold, expectObservable, expectSubscriptions, flush }) => {
         const action = {
@@ -300,7 +300,7 @@ describe('buildroot update epics', () => {
     )
   })
 
-  test('uploadFileEpic', () => {
+  it('uploadFileEpic', () => {
     testScheduler.run(({ hot, expectObservable }) => {
       const session = {
         pathPrefix: '/server/update/migration',
@@ -334,7 +334,7 @@ describe('buildroot update epics', () => {
       step: 'processFile',
     }
 
-    test('commit request success', () => {
+    it('commit request success', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         selectors.getBuildrootRobot.mockReturnValue(brRobot)
         selectors.getBuildrootSession.mockReturnValue(session)
@@ -359,7 +359,7 @@ describe('buildroot update epics', () => {
       })
     })
 
-    test('commit request failure', () => {
+    it('commit request failure', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
         selectors.getBuildrootRobot.mockReturnValue(brRobot)
         selectors.getBuildrootSession.mockReturnValue(session)
@@ -388,7 +388,7 @@ describe('buildroot update epics', () => {
       step: 'commitUpdate',
     }
 
-    test('restart request success', () => {
+    it('restart request success', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         selectors.getBuildrootRobot.mockReturnValue(brRobot)
         selectors.getBuildrootSession.mockReturnValue(session)
@@ -414,7 +414,7 @@ describe('buildroot update epics', () => {
       })
     })
 
-    test('restart request failure', () => {
+    it('restart request failure', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
         selectors.getBuildrootRobot.mockReturnValue(brRobot)
         selectors.getBuildrootSession.mockReturnValue(session)
@@ -436,7 +436,7 @@ describe('buildroot update epics', () => {
   })
 
   describe('user file upload epics', () => {
-    test('retryAfterUserFileInfoEpic', () => {
+    it('retryAfterUserFileInfoEpic', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
         selectors.getBuildrootRobotName.mockReturnValue(balenaRobot.name)
 
@@ -450,7 +450,7 @@ describe('buildroot update epics', () => {
       })
     })
 
-    test('uploadFileEpic sends systemFile if it exists in session', () => {
+    it('uploadFileEpic sends systemFile if it exists in session', () => {
       testScheduler.run(({ hot, expectObservable }) => {
         const session = {
           pathPrefix: '/server/update/migration',

--- a/app/src/buildroot/__tests__/reducer.test.js
+++ b/app/src/buildroot/__tests__/reducer.test.js
@@ -260,7 +260,7 @@ describe('buildroot reducer', () => {
 
   SPECS.forEach(spec => {
     const { name, action, initialState, expected } = spec
-    test(name, () =>
+    it(name, () =>
       expect(buildrootReducer(initialState, action)).toEqual(expected)
     )
   })

--- a/app/src/buildroot/__tests__/selectors.test.js
+++ b/app/src/buildroot/__tests__/selectors.test.js
@@ -197,6 +197,6 @@ describe('buildroot selectors', () => {
     const { name, selector, state, expected, setup } = spec
     const args = spec.args || []
     if (typeof setup === 'function') setup()
-    test(name, () => expect(selector(state, ...args)).toEqual(expected))
+    it(name, () => expect(selector(state, ...args)).toEqual(expected))
   })
 })

--- a/app/src/components/AddLabwareCard/__tests__/AddLabware.test.js
+++ b/app/src/components/AddLabwareCard/__tests__/AddLabware.test.js
@@ -11,7 +11,7 @@ describe('AddLabware', () => {
     jest.resetAllMocks()
   })
 
-  test('has a button that calls onAddLabware on click', () => {
+  it('has a button that calls onAddLabware on click', () => {
     const wrapper = mount(<AddLabware onAddLabware={mockOnAddLabware} />)
 
     expect(mockOnAddLabware).toHaveBeenCalledTimes(0)

--- a/app/src/components/AddLabwareCard/__tests__/AddLabwareCard.test.js
+++ b/app/src/components/AddLabwareCard/__tests__/AddLabwareCard.test.js
@@ -51,7 +51,7 @@ describe('AddLabwareCard', () => {
     jest.resetAllMocks()
   })
 
-  test('passes labware directory to ManagePath', () => {
+  it('passes labware directory to ManagePath', () => {
     const wrapper = render()
     const detail = wrapper.find(ManagePath)
 
@@ -59,7 +59,7 @@ describe('AddLabwareCard', () => {
     expect(detail.prop('path')).toEqual(mockLabwarePath)
   })
 
-  test('passes change path function to ManagePath', () => {
+  it('passes change path function to ManagePath', () => {
     const wrapper = render()
     const control = wrapper.find(ManagePath)
     const expectedChangeAction = CustomLabware.changeCustomLabwareDirectory()
@@ -69,7 +69,7 @@ describe('AddLabwareCard', () => {
     expect(mockStore.dispatch).toHaveBeenCalledWith(expectedChangeAction)
   })
 
-  test('passes open path function to ManagePath', () => {
+  it('passes open path function to ManagePath', () => {
     const wrapper = render()
     const control = wrapper.find(ManagePath)
     const expectedOpenAction = CustomLabware.openCustomLabwareDirectory()
@@ -79,7 +79,7 @@ describe('AddLabwareCard', () => {
     expect(mockStore.dispatch).toHaveBeenCalledWith(expectedOpenAction)
   })
 
-  test('passes reset path function to ManagePath', () => {
+  it('passes reset path function to ManagePath', () => {
     const wrapper = render()
     const control = wrapper.find(ManagePath)
     const expectedOpenAction = CustomLabware.resetCustomLabwareDirectory()
@@ -89,7 +89,7 @@ describe('AddLabwareCard', () => {
     expect(mockStore.dispatch).toHaveBeenCalledWith(expectedOpenAction)
   })
 
-  test('passes dispatch function to AddLabware', () => {
+  it('passes dispatch function to AddLabware', () => {
     const wrapper = render()
     const control = wrapper.find(AddLabware)
     const expectedAction = CustomLabware.addCustomLabware()
@@ -99,7 +99,7 @@ describe('AddLabwareCard', () => {
     expect(mockStore.dispatch).toHaveBeenCalledWith(expectedAction)
   })
 
-  test('renders an AddLabwareFailureModal if add labware fails', () => {
+  it('renders an AddLabwareFailureModal if add labware fails', () => {
     mockGetAddLabwareFailure.mockReturnValue({
       file: CustomLabwareFixtures.mockInvalidLabware,
       errorMessage: 'AH',
@@ -117,7 +117,7 @@ describe('AddLabwareCard', () => {
     })
   })
 
-  test('AddLabwareFailureModal onCancel and onOverwrite hooked to dispatch', () => {
+  it('AddLabwareFailureModal onCancel and onOverwrite hooked to dispatch', () => {
     const file = CustomLabwareFixtures.mockDuplicateLabware
 
     mockGetAddLabwareFailure.mockReturnValue({ file, errorMessage: null })

--- a/app/src/components/AddLabwareCard/__tests__/AddLabwareFailureModal.test.js
+++ b/app/src/components/AddLabwareCard/__tests__/AddLabwareFailureModal.test.js
@@ -27,7 +27,7 @@ describe('AddLabwareFailureModal', () => {
     jest.resetAllMocks()
   })
 
-  test('renders inside a Portal', () => {
+  it('renders inside a Portal', () => {
     const wrapper = shallow(<AddLabwareFailureModal {...emptyProps} />)
     const portal = wrapper.find(Portal)
     const modal = portal.find(AddLabwareFailureModalTemplate)
@@ -35,13 +35,13 @@ describe('AddLabwareFailureModal', () => {
     expect(modal.props()).toEqual(emptyProps)
   })
 
-  test('renders an AlertModal', () => {
+  it('renders an AlertModal', () => {
     const wrapper = shallow(<AddLabwareFailureModalTemplate {...emptyProps} />)
 
     expect(wrapper.exists(AlertModal)).toBe(true)
   })
 
-  test('renders a cancel button that calls props.onCancel', () => {
+  it('renders a cancel button that calls props.onCancel', () => {
     const wrapper = mount(<AddLabwareFailureModalTemplate {...emptyProps} />)
     const button = wrapper.findWhere(
       c => c.type() === 'button' && c.text().toLowerCase() === 'cancel'
@@ -51,7 +51,7 @@ describe('AddLabwareFailureModal', () => {
     expect(mockOnCancel).toHaveBeenCalled()
   })
 
-  test('renders proper title for error', () => {
+  it('renders proper title for error', () => {
     const wrapper = mount(
       <AddLabwareFailureModalTemplate {...emptyProps} errorMessage="AHHH!" />
     )
@@ -71,7 +71,7 @@ describe('AddLabwareFailureModal', () => {
       )
     }
 
-    test('renders proper copy for invalid file', () => {
+    it('renders proper copy for invalid file', () => {
       const file = LabwareFixtures.mockInvalidLabware
       const wrapper = render(file)
       const html = wrapper.html()
@@ -83,7 +83,7 @@ describe('AddLabwareFailureModal', () => {
       expect(html).toContain(file.filename)
     })
 
-    test('renders proper copy for an Opentrons conflicting file', () => {
+    it('renders proper copy for an Opentrons conflicting file', () => {
       const file = LabwareFixtures.mockOpentronsLabware
       const wrapper = render(file)
       const html = wrapper.html()
@@ -99,7 +99,7 @@ describe('AddLabwareFailureModal', () => {
       expect(html).toContain(file.filename)
     })
 
-    test('renders proper copy for an duplicate file', () => {
+    it('renders proper copy for an duplicate file', () => {
       const file = LabwareFixtures.mockDuplicateLabware
       const wrapper = render(file)
       const html = wrapper.html()
@@ -113,7 +113,7 @@ describe('AddLabwareFailureModal', () => {
       expect(html).toContain(file.filename)
     })
 
-    test('duplicate file adds overwrite button', () => {
+    it('duplicate file adds overwrite button', () => {
       const file = LabwareFixtures.mockDuplicateLabware
       const wrapper = render(file)
       const button = wrapper.findWhere(

--- a/app/src/components/AddLabwareCard/__tests__/ConfirmResetPathModal.test.js
+++ b/app/src/components/AddLabwareCard/__tests__/ConfirmResetPathModal.test.js
@@ -23,7 +23,7 @@ describe('ConfirmResetPathModal', () => {
     jest.resetAllMocks()
   })
 
-  test('renders inside a Portal', () => {
+  it('renders inside a Portal', () => {
     const wrapper = shallow(<ConfirmResetPathModal {...props} />)
     const portal = wrapper.find(Portal)
     const modal = portal.find(ConfirmResetPathModalTemplate)
@@ -31,13 +31,13 @@ describe('ConfirmResetPathModal', () => {
     expect(modal.props()).toEqual(props)
   })
 
-  test('renders an AlertModal', () => {
+  it('renders an AlertModal', () => {
     const wrapper = shallow(<ConfirmResetPathModalTemplate {...props} />)
 
     expect(wrapper.exists(AlertModal)).toBe(true)
   })
 
-  test('renders a cancel button that calls props.onCancel', () => {
+  it('renders a cancel button that calls props.onCancel', () => {
     const wrapper = mount(<ConfirmResetPathModalTemplate {...props} />)
     const button = wrapper.find(`button[name="${CANCEL_NAME}"]`)
 
@@ -45,7 +45,7 @@ describe('ConfirmResetPathModal', () => {
     expect(mockOnCancel).toHaveBeenCalled()
   })
 
-  test('renders a confirm button that calls props.onConfirm', () => {
+  it('renders a confirm button that calls props.onConfirm', () => {
     const wrapper = mount(<ConfirmResetPathModalTemplate {...props} />)
     const button = wrapper.find(`button[name="${RESET_SOURCE_NAME}"]`)
 

--- a/app/src/components/AddLabwareCard/__tests__/ManagePath.test.js
+++ b/app/src/components/AddLabwareCard/__tests__/ManagePath.test.js
@@ -33,11 +33,11 @@ describe('ManagePath', () => {
     jest.resetAllMocks()
   })
 
-  test('component displays path', () => {
+  it('component displays path', () => {
     expect(wrapper.html()).toContain(mockPath)
   })
 
-  test('has a OutlineButton that calls onOpenPath on click', () => {
+  it('has a OutlineButton that calls onOpenPath on click', () => {
     expect(mockOnOpenPath).toHaveBeenCalledTimes(0)
     wrapper
       .find(`OutlineButton[name="${OPEN_SOURCE_NAME}"]`)
@@ -45,7 +45,7 @@ describe('ManagePath', () => {
     expect(mockOnOpenPath).toHaveBeenCalledTimes(1)
   })
 
-  test('has an IconCta that calls onChangePath on click', () => {
+  it('has an IconCta that calls onChangePath on click', () => {
     expect(mockOnChangePath).toHaveBeenCalledTimes(0)
     wrapper.find(`IconCta[name="${CHANGE_SOURCE_NAME}"]`).invoke('onClick')()
     expect(mockOnChangePath).toHaveBeenCalledTimes(1)
@@ -62,11 +62,11 @@ describe('ManagePath', () => {
       wrapper.update()
     })
 
-    test('has an IconCta that opens a ConfirmResetPathModal', () => {
+    it('has an IconCta that opens a ConfirmResetPathModal', () => {
       expect(wrapper.exists(ConfirmResetPathModal)).toBe(true)
     })
 
-    test('ConfirmResetPathModal::onCancel closes modal without resetting path', () => {
+    it('ConfirmResetPathModal::onCancel closes modal without resetting path', () => {
       act(() => {
         wrapper.find(ConfirmResetPathModal).invoke('onCancel')()
       })
@@ -76,7 +76,7 @@ describe('ManagePath', () => {
       expect(wrapper.exists(ConfirmResetPathModal)).toBe(false)
     })
 
-    test('ConfirmResetPathModal::onConfirm calls onResetPath and closes modal', () => {
+    it('ConfirmResetPathModal::onConfirm calls onResetPath and closes modal', () => {
       expect(mockOnResetPath).toHaveBeenCalledTimes(0)
       act(() => {
         wrapper.find(ConfirmResetPathModal).invoke('onConfirm')()

--- a/app/src/components/IconCta/__tests__/IconCta.test.js
+++ b/app/src/components/IconCta/__tests__/IconCta.test.js
@@ -27,20 +27,20 @@ describe('IconCta', () => {
     jest.resetAllMocks()
   })
 
-  test('renders a <button>', () => {
+  it('renders a <button>', () => {
     expect(wrapper.find('button')).toHaveLength(1)
   })
 
-  test('renders an <Icon>', () => {
+  it('renders an <Icon>', () => {
     const icon = wrapper.find(Icon)
     expect(icon.prop('name')).toEqual(ICON_NAME)
   })
 
-  test('renders text', () => {
+  it('renders text', () => {
     expect(wrapper.find('span').html()).toContain(TEXT)
   })
 
-  test('is clickable', () => {
+  it('is clickable', () => {
     expect(mockHandleClick).toHaveBeenCalledTimes(0)
     wrapper.find('button').invoke('onClick')()
     expect(mockHandleClick).toHaveBeenCalledTimes(1)

--- a/app/src/components/ListLabwareCard/__tests__/LabwareItem.test.js
+++ b/app/src/components/ListLabwareCard/__tests__/LabwareItem.test.js
@@ -39,7 +39,7 @@ describe('LabwareItem', () => {
     },
   }
 
-  test('component renders', () => {
+  it('component renders', () => {
     const treeInvalid = shallow(<LabwareItem file={invalidFile} />)
     const treeValid = shallow(<LabwareItem file={validFile} />)
 
@@ -47,13 +47,13 @@ describe('LabwareItem', () => {
     expect(treeValid).toMatchSnapshot()
   })
 
-  test('is a <li>', () => {
+  it('is a <li>', () => {
     const tree = mount(<LabwareItem file={invalidFile} />)
 
     expect(tree.getDOMNode().tagName).toBe('LI')
   })
 
-  test('renders props', () => {
+  it('renders props', () => {
     const html = mount(<LabwareItem file={validFile} />).html()
 
     // file name
@@ -68,7 +68,7 @@ describe('LabwareItem', () => {
     expect(html).toContain('2019-10-21')
   })
 
-  test('displays a Warning for invalid files', () => {
+  it('displays a Warning for invalid files', () => {
     const SPECS = [
       {
         file: CustomLabwareFixtures.mockInvalidLabware,

--- a/app/src/components/ListLabwareCard/__tests__/LabwareList.test.js
+++ b/app/src/components/ListLabwareCard/__tests__/LabwareList.test.js
@@ -19,7 +19,7 @@ describe('LabwareList', () => {
     errorMessage: null,
   }
 
-  test('component renders', () => {
+  it('component renders', () => {
     const treeEmpty = shallow(<LabwareList {...emptyProps} />)
     const treeError = shallow(<LabwareList {...errorProps} />)
     const treeList = shallow(<LabwareList {...listProps} />)
@@ -29,14 +29,14 @@ describe('LabwareList', () => {
     expect(treeList).toMatchSnapshot()
   })
 
-  test('renders empty list copy without a <ul> if no labware', () => {
+  it('renders empty list copy without a <ul> if no labware', () => {
     const tree = mount(<LabwareList {...emptyProps} />)
 
     expect(tree.find('ul')).toHaveLength(0)
     expect(tree.html()).toMatch(/No labware definitions found/)
   })
 
-  test('renders error message without a <ul> if error message', () => {
+  it('renders error message without a <ul> if error message', () => {
     const tree = mount(<LabwareList {...errorProps} />)
 
     expect(tree.find('ul')).toHaveLength(0)
@@ -44,7 +44,7 @@ describe('LabwareList', () => {
     expect(tree.html()).toContain('AH!!!')
   })
 
-  test('renders labware children in a <ul>', () => {
+  it('renders labware children in a <ul>', () => {
     const tree = shallow(<LabwareList {...listProps} />)
     const list = tree.find('ul')
     const items = tree.find(LabwareItem)

--- a/app/src/components/ListLabwareCard/__tests__/ListLabwareCard.test.js
+++ b/app/src/components/ListLabwareCard/__tests__/ListLabwareCard.test.js
@@ -51,12 +51,12 @@ describe('ListLabwareCard', () => {
     jest.useRealTimers()
   })
 
-  test('renders a LabwareList', () => {
+  it('renders a LabwareList', () => {
     const tree = render()
     expect(tree.find(LabwareList)).toHaveLength(1)
   })
 
-  test('passes labware list and list error to LabwareList', () => {
+  it('passes labware list and list error to LabwareList', () => {
     mockGetCustomLabware.mockReturnValue([
       LabwareFixtures.mockValidLabware,
       LabwareFixtures.mockInvalidLabware,
@@ -74,7 +74,7 @@ describe('ListLabwareCard', () => {
     })
   })
 
-  test('dispatches FETCH_CUSTOM_LABWARE on mount and an interval', () => {
+  it('dispatches FETCH_CUSTOM_LABWARE on mount and an interval', () => {
     const expected = LabwareActions.fetchCustomLabware()
 
     render()

--- a/app/src/components/ListLabwareCard/__tests__/Warning.test.js
+++ b/app/src/components/ListLabwareCard/__tests__/Warning.test.js
@@ -5,7 +5,7 @@ import { shallow } from 'enzyme'
 import { Warning } from '../Warning'
 
 describe('Warning', () => {
-  test('component renders', () => {
+  it('component renders', () => {
     const wrapper = shallow(<Warning>AH!!!</Warning>)
 
     expect(wrapper).toMatchSnapshot()

--- a/app/src/components/ModuleItem/__tests__/ModuleUpdate.test.js
+++ b/app/src/components/ModuleItem/__tests__/ModuleUpdate.test.js
@@ -25,7 +25,7 @@ describe('ModuleUpdate', () => {
     jest.resetAllMocks()
   })
 
-  test('component renders', () => {
+  it('component renders', () => {
     const treeAvailableCanControl = shallow(
       <Provider store={store}>
         <ModuleUpdate
@@ -68,7 +68,7 @@ describe('ModuleUpdate', () => {
     expect(treeNotAvailableNoControl).toMatchSnapshot()
   })
 
-  test('displays a Warning for invalid files', () => {
+  it('displays a Warning for invalid files', () => {
     const SPECS = [
       {
         canControl: true,

--- a/app/src/components/RobotSettings/__tests__/ConnectionCard.test.js
+++ b/app/src/components/RobotSettings/__tests__/ConnectionCard.test.js
@@ -62,13 +62,13 @@ describe('ConnectionCard', () => {
     jest.useRealTimers()
   })
 
-  test('calls fetchStatus on mount', () => {
+  it('calls fetchStatus on mount', () => {
     const expected = Networking.fetchStatus(mockRobot.name)
     render()
     expect(dispatch).toHaveBeenCalledWith(expected)
   })
 
-  test('calls fetchStatus on an interval', () => {
+  it('calls fetchStatus on an interval', () => {
     const expected = Networking.fetchStatus(mockRobot.name)
 
     render()
@@ -78,7 +78,7 @@ describe('ConnectionCard', () => {
     expect(dispatch).toHaveBeenNthCalledWith(3, expected)
   })
 
-  test('passes internet status to ConnectionStatusMessage', () => {
+  it('passes internet status to ConnectionStatusMessage', () => {
     mockGetInternetStatus.mockReturnValue(Networking.STATUS_FULL)
 
     const wrapper = render()
@@ -87,7 +87,7 @@ describe('ConnectionCard', () => {
     expect(status.prop('status')).toEqual(Networking.STATUS_FULL)
   })
 
-  test('passes type ConnectionStatusMessage based on robot.local', () => {
+  it('passes type ConnectionStatusMessage based on robot.local', () => {
     mockGetInternetStatus.mockReturnValue(Networking.STATUS_FULL)
 
     const localRobot: ViewableRobot = ({ ...mockRobot, local: true }: any)
@@ -102,7 +102,7 @@ describe('ConnectionCard', () => {
     expect(wifiStatus.prop('type')).toEqual('Wi-Fi')
   })
 
-  test('passes ethernet status to ConnectionInfo', () => {
+  it('passes ethernet status to ConnectionInfo', () => {
     const mockEthernet = {
       ipAddress: null,
       subnetMask: null,
@@ -121,7 +121,7 @@ describe('ConnectionCard', () => {
     expect(info.prop('connection')).toEqual(mockEthernet)
   })
 
-  test('passes wifi status to ConnectionInfo', () => {
+  it('passes wifi status to ConnectionInfo', () => {
     const mockWifi = {
       ipAddress: null,
       subnetMask: null,
@@ -140,7 +140,7 @@ describe('ConnectionCard', () => {
     expect(info.prop('connection')).toEqual(mockWifi)
   })
 
-  test('renders SelectNetwork', () => {
+  it('renders SelectNetwork', () => {
     const wrapper = render()
     const select = wrapper.find(SelectNetwork)
 

--- a/app/src/components/RobotSettings/__tests__/ControlsCard.test.js
+++ b/app/src/components/RobotSettings/__tests__/ControlsCard.test.js
@@ -74,7 +74,7 @@ describe('ControlsCard', () => {
     jest.resetAllMocks()
   })
 
-  test('calls fetchLights on mount', () => {
+  it('calls fetchLights on mount', () => {
     mount(
       <Provider store={mockStore}>
         <ControlsCard robot={mockRobot} calibrateDeckUrl="/deck/calibrate" />
@@ -86,7 +86,7 @@ describe('ControlsCard', () => {
     )
   })
 
-  test('calls updateLights with toggle on button click', () => {
+  it('calls updateLights with toggle on button click', () => {
     mockGetLightsOn.mockReturnValue(true)
 
     const wrapper = mount(
@@ -102,7 +102,7 @@ describe('ControlsCard', () => {
     )
   })
 
-  test('calls restartRobot on button click', () => {
+  it('calls restartRobot on button click', () => {
     const wrapper = mount(
       <Provider store={mockStore}>
         <ControlsCard robot={mockRobot} calibrateDeckUrl="/deck/calibrate" />
@@ -116,7 +116,7 @@ describe('ControlsCard', () => {
     )
   })
 
-  test('calls home on button click', () => {
+  it('calls home on button click', () => {
     const wrapper = mount(
       <Provider store={mockStore}>
         <ControlsCard robot={mockRobot} calibrateDeckUrl="/deck/calibrate" />
@@ -130,7 +130,7 @@ describe('ControlsCard', () => {
     )
   })
 
-  test('DC, home, and restart buttons enabled if connected and not running', () => {
+  it('DC, home, and restart buttons enabled if connected and not running', () => {
     mockGetIsRunning.mockReturnValue(false)
 
     const wrapper = mount(
@@ -147,7 +147,7 @@ describe('ControlsCard', () => {
     expect(getRestartButton(wrapper).prop('disabled')).toBe(true)
   })
 
-  test('DC, home, and restart buttons disabled if not connectable', () => {
+  it('DC, home, and restart buttons disabled if not connectable', () => {
     const wrapper = mount(
       <Provider store={mockStore}>
         <ControlsCard
@@ -162,7 +162,7 @@ describe('ControlsCard', () => {
     expect(getRestartButton(wrapper).prop('disabled')).toBe(true)
   })
 
-  test('DC, home, and restart buttons disabled if not connected', () => {
+  it('DC, home, and restart buttons disabled if not connected', () => {
     const mockRobot: ViewableRobot = ({
       name: 'robot-name',
       connected: false,
@@ -180,7 +180,7 @@ describe('ControlsCard', () => {
     expect(getRestartButton(wrapper).prop('disabled')).toBe(true)
   })
 
-  test('DC, home, and restart buttons disabled if protocol running', () => {
+  it('DC, home, and restart buttons disabled if protocol running', () => {
     mockGetIsRunning.mockReturnValue(true)
 
     const wrapper = mount(

--- a/app/src/config/__tests__/config.test.js
+++ b/app/src/config/__tests__/config.test.js
@@ -22,7 +22,7 @@ describe('config', () => {
 
   describe('actions', () => {
     // updateConfig triggers an update call to app-shell
-    test('config:UPDATE', () => {
+    it('config:UPDATE', () => {
       expect(updateConfig('foo.bar', false)).toEqual({
         type: 'config:UPDATE',
         payload: { path: 'foo.bar', value: false },
@@ -30,7 +30,7 @@ describe('config', () => {
       })
     })
 
-    test('config:RESET', () => {
+    it('config:RESET', () => {
       expect(resetConfig('foo.bar')).toEqual({
         type: 'config:RESET',
         payload: { path: 'foo.bar' },
@@ -44,11 +44,11 @@ describe('config', () => {
       state = state.config
     })
 
-    test('gets store and overrides from remote for initial state', () => {
+    it('gets store and overrides from remote for initial state', () => {
       expect(configReducer(null, {})).toEqual({ isConfig: true })
     })
 
-    test('handles config:SET', () => {
+    it('handles config:SET', () => {
       const action = {
         type: 'config:SET',
         payload: { path: 'foo.bar', value: 'xyz' },
@@ -62,7 +62,7 @@ describe('config', () => {
   })
 
   describe('selectors', () => {
-    test('getConfig', () => {
+    it('getConfig', () => {
       expect(getConfig(state)).toEqual(state.config)
     })
   })

--- a/app/src/custom-labware/__tests__/actions.test.js
+++ b/app/src/custom-labware/__tests__/actions.test.js
@@ -154,6 +154,6 @@ describe('custom labware actions', () => {
 
   SPECS.forEach(spec => {
     const { name, creator, expected, args = [] } = spec
-    test(name, () => expect(creator(...args)).toEqual(expected))
+    it(name, () => expect(creator(...args)).toEqual(expected))
   })
 })

--- a/app/src/custom-labware/__tests__/reducer.test.js
+++ b/app/src/custom-labware/__tests__/reducer.test.js
@@ -120,7 +120,7 @@ describe('customLabwareReducer', () => {
   SPECS.forEach(spec => {
     const { name, state, action, expected } = spec
 
-    test(name, () => {
+    it(name, () => {
       const result = customLabwareReducer(state, action)
       expect(result).toEqual(expected)
       // check for new reference

--- a/app/src/custom-labware/__tests__/selectors.test.js
+++ b/app/src/custom-labware/__tests__/selectors.test.js
@@ -150,6 +150,6 @@ describe('custom labware selectors', () => {
 
   SPECS.forEach(spec => {
     const { name, selector, state, expected } = spec
-    test(name, () => expect(selector(state)).toEqual(expected))
+    it(name, () => expect(selector(state)).toEqual(expected))
   })
 })

--- a/app/src/discovery/__tests__/actions.test.js
+++ b/app/src/discovery/__tests__/actions.test.js
@@ -44,6 +44,6 @@ describe('discovery actions', () => {
   SPECS.forEach(spec => {
     const { name, creator, args, expected } = spec
 
-    test(name, () => expect(creator(...args)).toEqual(expected))
+    it(name, () => expect(creator(...args)).toEqual(expected))
   })
 })

--- a/app/src/discovery/__tests__/epic.test.js
+++ b/app/src/discovery/__tests__/epic.test.js
@@ -12,7 +12,7 @@ describe('discovery actions', () => {
     })
   })
 
-  test('startDiscoveryEpic with default timeout', () => {
+  it('startDiscoveryEpic with default timeout', () => {
     testScheduler.run(({ hot, expectObservable }) => {
       const action$ = hot('-a', { a: actions.startDiscovery() })
       const output$ = discoveryEpic(action$)
@@ -23,7 +23,7 @@ describe('discovery actions', () => {
     })
   })
 
-  test('startDiscoveryEpic with specified timeout', () => {
+  it('startDiscoveryEpic with specified timeout', () => {
     testScheduler.run(({ hot, expectObservable }) => {
       const action$ = hot('-a', { a: actions.startDiscovery(42) })
       const output$ = discoveryEpic(action$)
@@ -34,7 +34,7 @@ describe('discovery actions', () => {
     })
   })
 
-  test('startDiscoveryOnRestartEpic', () => {
+  it('startDiscoveryOnRestartEpic', () => {
     testScheduler.run(({ hot, expectObservable }) => {
       const serverSuccessAction = {
         type: 'api:SERVER_SUCCESS',

--- a/app/src/discovery/__tests__/reducer.test.js
+++ b/app/src/discovery/__tests__/reducer.test.js
@@ -63,7 +63,7 @@ describe('discoveryReducer', () => {
 
   SPECS.forEach(spec => {
     const { name, action, initialState, expectedState } = spec
-    test(name, () =>
+    it(name, () =>
       expect(discoveryReducer(initialState, action)).toEqual(expectedState)
     )
   })

--- a/app/src/discovery/__tests__/selectors.test.js
+++ b/app/src/discovery/__tests__/selectors.test.js
@@ -431,6 +431,6 @@ describe('discovery selectors', () => {
 
   SPECS.forEach(spec => {
     const { name, selector, state, expected } = spec
-    test(name, () => expect(selector(state)).toEqual(expected))
+    it(name, () => expect(selector(state)).toEqual(expected))
   })
 })

--- a/app/src/http-api-client/__tests__/calibration.test.js
+++ b/app/src/http-api-client/__tests__/calibration.test.js
@@ -38,7 +38,7 @@ describe('/calibration/**', () => {
       pipette: { mount: 'left', model: 'p300_single_v1' },
     }
 
-    test('calls POST /calibration/deck/start', () => {
+    it('calls POST /calibration/deck/start', () => {
       const expected = { force: false }
 
       client.__setMockResponse(response)
@@ -55,7 +55,7 @@ describe('/calibration/**', () => {
         )
     })
 
-    test('calls POST /calibration/deck/start with force: true', () => {
+    it('calls POST /calibration/deck/start with force: true', () => {
       const expected = { force: true }
 
       client.__setMockResponse(response)
@@ -72,7 +72,7 @@ describe('/calibration/**', () => {
         )
     })
 
-    test('dispatches api:REQUEST and api:SUCCESS', () => {
+    it('dispatches api:REQUEST and api:SUCCESS', () => {
       const request = { force: false }
       const expectedActions = [
         { type: 'api:REQUEST', payload: { robot, request, path } },
@@ -86,7 +86,7 @@ describe('/calibration/**', () => {
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
 
-    test('dispatches api:REQUEST and api:FAILURE', () => {
+    it('dispatches api:REQUEST and api:FAILURE', () => {
       const request = { force: false }
       const error = { name: 'ResponseError', status: 409, message: '' }
       const expectedActions = [
@@ -114,7 +114,7 @@ describe('/calibration/**', () => {
       }
     })
 
-    test('calls POST /calibration/deck and adds token to request', () => {
+    it('calls POST /calibration/deck and adds token to request', () => {
       client.__setMockResponse(response)
 
       return store
@@ -129,7 +129,7 @@ describe('/calibration/**', () => {
         )
     })
 
-    test('dispatches api:REQUEST and api:SUCCESS', () => {
+    it('dispatches api:REQUEST and api:SUCCESS', () => {
       const expectedActions = [
         { type: 'api:REQUEST', payload: { robot, request, path } },
         { type: 'api:SUCCESS', payload: { robot, response, path } },
@@ -142,7 +142,7 @@ describe('/calibration/**', () => {
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
 
-    test('dispatches api:REQUEST and api:FAILURE', () => {
+    it('dispatches api:REQUEST and api:FAILURE', () => {
       const error = { name: 'ResponseError', message: 'AH' }
       const expectedActions = [
         { type: 'api:REQUEST', payload: { robot, request, path } },
@@ -156,7 +156,7 @@ describe('/calibration/**', () => {
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
 
-    test('dispatchs api:CLEAR_RESPONSE if command is "release"', () => {
+    it('dispatchs api:CLEAR_RESPONSE if command is "release"', () => {
       const request = { command: 'release' }
       const expectedActions = [
         {
@@ -202,7 +202,7 @@ describe('/calibration/**', () => {
       // TODO(mc, 2019-04-23): these tests (and the module they test) are
       // brittle; rewrite tests when HTTP request state is redone
       describe(`reducer with /calibration/${path}`, () => {
-        test('handles api:REQUEST', () => {
+        it('handles api:REQUEST', () => {
           const action = {
             type: 'api:REQUEST',
             payload: { path, robot, request },
@@ -220,7 +220,7 @@ describe('/calibration/**', () => {
           })
         })
 
-        test('handles api:SUCCESS', () => {
+        it('handles api:SUCCESS', () => {
           const action = {
             type: 'api:SUCCESS',
             payload: { path, robot, response },
@@ -247,7 +247,7 @@ describe('/calibration/**', () => {
           })
         })
 
-        test('handles api:FAILURE', () => {
+        it('handles api:FAILURE', () => {
           const error = { message: 'we did not do it!' }
           const action = {
             type: 'api:FAILURE',
@@ -278,7 +278,7 @@ describe('/calibration/**', () => {
     })
   })
 
-  test('reducer with api:CLEAR_RESPONSE', () => {
+  it('reducer with api:CLEAR_RESPONSE', () => {
     state = state.superDeprecatedRobotApi
 
     const path = 'calibration/deck/start'
@@ -309,7 +309,7 @@ describe('/calibration/**', () => {
       }
     })
 
-    test('makeGetDeckCalibrationStartState', () => {
+    it('makeGetDeckCalibrationStartState', () => {
       const getStartState = makeGetDeckCalibrationStartState()
 
       expect(getStartState(state, robot)).toEqual(
@@ -323,7 +323,7 @@ describe('/calibration/**', () => {
       })
     })
 
-    test('makeGetDeckCalibrationCommandState', () => {
+    it('makeGetDeckCalibrationCommandState', () => {
       const getCommandState = makeGetDeckCalibrationCommandState()
 
       expect(getCommandState(state, robot)).toEqual(

--- a/app/src/http-api-client/__tests__/client.test.js
+++ b/app/src/http-api-client/__tests__/client.test.js
@@ -34,7 +34,7 @@ describe('http api client', () => {
     global.fetch.mockClear()
   })
 
-  test('GET request', () => {
+  it('GET request', () => {
     const robot = {
       ip: '1.2.3.4',
       port: 8080,
@@ -56,7 +56,7 @@ describe('http api client', () => {
       )
   })
 
-  test('GET request failure', () => {
+  it('GET request failure', () => {
     const robot = {
       ip: '1.2.3.4',
       port: 8080,
@@ -78,7 +78,7 @@ describe('http api client', () => {
     )
   })
 
-  test('GET request error', () => {
+  it('GET request error', () => {
     const robot = {
       ip: '1.2.3.4',
       port: 8080,
@@ -93,7 +93,7 @@ describe('http api client', () => {
     )
   })
 
-  test('POST request', () => {
+  it('POST request', () => {
     const robot = {
       ip: '1.2.3.4',
       port: 8080,
@@ -115,7 +115,7 @@ describe('http api client', () => {
       )
   })
 
-  test('POST request failure', () => {
+  it('POST request failure', () => {
     const robot = {
       ip: '1.2.3.4',
       port: 8080,
@@ -137,7 +137,7 @@ describe('http api client', () => {
     )
   })
 
-  test('POST request error', () => {
+  it('POST request error', () => {
     const robot = {
       ip: '1.2.3.4',
       port: 8080,

--- a/app/src/http-api-client/__tests__/networking.test.js
+++ b/app/src/http-api-client/__tests__/networking.test.js
@@ -70,17 +70,17 @@ describe('networking', () => {
     SPECS.forEach(spec => {
       const { name, selector, state, props, expected } = spec
 
-      test(`${name} with known robot`, () =>
+      it(`${name} with known robot`, () =>
         expect(selector()(state, props)).toEqual(expected))
 
-      test(`${name} with unknown robot`, () =>
+      it(`${name} with unknown robot`, () =>
         expect(selector()(state, { name: 'foo' })).toEqual({
           inProgress: false,
         }))
     })
   })
 
-  test('clearConfigureWifiResponse action creator', () => {
+  it('clearConfigureWifiResponse action creator', () => {
     expect(networking.clearConfigureWifiResponse({ name: 'foo' })).toEqual({
       type: 'api:CLEAR_RESPONSE',
       payload: { robot: { name: 'foo' }, path: 'wifi/configure' },
@@ -120,7 +120,7 @@ describe('networking', () => {
     SPECS.forEach(spec => {
       const { name, action, method, path, request, success, failure } = spec
 
-      test(`${name} makes HTTP call`, () => {
+      it(`${name} makes HTTP call`, () => {
         client.__setMockResponse(success)
         return store
           .dispatch(action(robot, request))
@@ -129,7 +129,7 @@ describe('networking', () => {
           )
       })
 
-      test(`${name} handles success`, () => {
+      it(`${name} handles success`, () => {
         const expectedActions = [
           { type: 'api:REQUEST', payload: { robot, path, request } },
           { type: 'api:SUCCESS', payload: { robot, path, response: success } },
@@ -142,7 +142,7 @@ describe('networking', () => {
           .then(() => expect(store.getActions()).toEqual(expectedActions))
       })
 
-      test(`${name} handles failure`, () => {
+      it(`${name} handles failure`, () => {
         const expectedActions = [
           { type: 'api:REQUEST', payload: { robot, path, request } },
           { type: 'api:FAILURE', payload: { robot, path, error: failure } },

--- a/app/src/http-api-client/__tests__/reducer.test.js
+++ b/app/src/http-api-client/__tests__/reducer.test.js
@@ -2,7 +2,7 @@
 import { apiReducer } from '../reducer'
 
 describe('apiReducer', () => {
-  test('handles api:REQUEST', () => {
+  it('handles api:REQUEST', () => {
     const emptyState = {}
     const oldRequestState = {
       name: {
@@ -44,7 +44,7 @@ describe('apiReducer', () => {
     })
   })
 
-  test('handles api:SUCCESS', () => {
+  it('handles api:SUCCESS', () => {
     const emptyState = {}
     const oldRequestState = {
       name: {
@@ -86,7 +86,7 @@ describe('apiReducer', () => {
     })
   })
 
-  test('handles api:FAILURE', () => {
+  it('handles api:FAILURE', () => {
     const state = {
       name: {
         otherPath: { inProgress: false },
@@ -121,7 +121,7 @@ describe('apiReducer', () => {
     })
   })
 
-  test('api:FAILURE noops if no inProgress state', () => {
+  it('api:FAILURE noops if no inProgress state', () => {
     const state = { name: { path: { inProgress: false } } }
 
     const action = {
@@ -136,7 +136,7 @@ describe('apiReducer', () => {
     expect(apiReducer(state, action)).toEqual(state)
   })
 
-  test('clears state for unhealthy robots on discovery:UPDATE_LIST', () => {
+  it('clears state for unhealthy robots on discovery:UPDATE_LIST', () => {
     const robots = [
       { name: 'offline', ok: false, serverOk: false, advertising: false },
       { name: 'advertising', ok: false, serverOk: false, advertising: true },

--- a/app/src/modules/__tests__/actions.test.js
+++ b/app/src/modules/__tests__/actions.test.js
@@ -156,6 +156,6 @@ describe('robot modules actions', () => {
 
   SPECS.forEach(spec => {
     const { name, creator, args, expected } = spec
-    test(name, () => expect(creator(...args)).toEqual(expected))
+    it(name, () => expect(creator(...args)).toEqual(expected))
   })
 })

--- a/app/src/modules/__tests__/hooks.test.js
+++ b/app/src/modules/__tests__/hooks.test.js
@@ -39,7 +39,7 @@ describe('modules hooks', () => {
       jest.resetAllMocks()
     })
 
-    test('returns noop function if no connected robot', () => {
+    it('returns noop function if no connected robot', () => {
       mockGetConnectedRobotName.mockReturnValue(null)
 
       mount(
@@ -52,7 +52,7 @@ describe('modules hooks', () => {
       expect(store.getActions()).toEqual([])
     })
 
-    test('returns dispatch function if no connected robot', () => {
+    it('returns dispatch function if no connected robot', () => {
       mockGetConnectedRobotName.mockReturnValue('robot-name')
 
       mount(

--- a/app/src/modules/__tests__/reducer.test.js
+++ b/app/src/modules/__tests__/reducer.test.js
@@ -42,6 +42,6 @@ const SPECS: Array<ReducerSpec> = [
 describe('pipettesReducer', () => {
   SPECS.forEach(spec => {
     const { name, state, action, expected } = spec
-    test(name, () => expect(modulesReducer(state, action)).toEqual(expected))
+    it(name, () => expect(modulesReducer(state, action)).toEqual(expected))
   })
 })

--- a/app/src/modules/__tests__/selectors.test.js
+++ b/app/src/modules/__tests__/selectors.test.js
@@ -126,7 +126,7 @@ const SPECS: Array<SelectorSpec> = [
 describe('robot api selectors', () => {
   SPECS.forEach(spec => {
     const { name, selector, state, args = [], before = noop, expected } = spec
-    test(name, () => {
+    it(name, () => {
       before()
       expect(selector(state, ...args)).toEqual(expected)
     })

--- a/app/src/modules/epic/__tests__/fetchModulesEpic.test.js
+++ b/app/src/modules/epic/__tests__/fetchModulesEpic.test.js
@@ -51,7 +51,7 @@ describe('fetchModulesEpic', () => {
     jest.resetAllMocks()
   })
 
-  test('calls GET /modules', () => {
+  it('calls GET /modules', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockFetchModulesSuccess })
@@ -72,7 +72,7 @@ describe('fetchModulesEpic', () => {
     })
   })
 
-  test('maps successful response to FETCH_MODULES_SUCCESS', () => {
+  it('maps successful response to FETCH_MODULES_SUCCESS', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockFetchModulesSuccess })
@@ -92,7 +92,7 @@ describe('fetchModulesEpic', () => {
     })
   })
 
-  test('maps failed response to FETCH_MODULES_FAILURE', () => {
+  it('maps failed response to FETCH_MODULES_FAILURE', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockFetchModulesFailure })

--- a/app/src/modules/epic/__tests__/pollModulesWhileConnectedEpic.test.js
+++ b/app/src/modules/epic/__tests__/pollModulesWhileConnectedEpic.test.js
@@ -34,7 +34,7 @@ describe('pollModulesWhileConnectedEpic', () => {
     jest.resetAllMocks()
   })
 
-  test('does nothing if connect fails', () => {
+  it('does nothing if connect fails', () => {
     testScheduler.run(({ hot, expectObservable }) => {
       const action = RobotActions.connectResponse(new Error('AH'))
 
@@ -46,7 +46,7 @@ describe('pollModulesWhileConnectedEpic', () => {
     })
   })
 
-  test('polls connected robot until no longer connected', () => {
+  it('polls connected robot until no longer connected', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const action = RobotActions.connectResponse(null, ['create'])
 

--- a/app/src/modules/epic/__tests__/sendModuleCommandEpic.test.js
+++ b/app/src/modules/epic/__tests__/sendModuleCommandEpic.test.js
@@ -53,7 +53,7 @@ describe('sendModuleCommand', () => {
     jest.resetAllMocks()
   })
 
-  test('calls POST /modules/{serial}', () => {
+  it('calls POST /modules/{serial}', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockSendModuleCommandSuccess })
@@ -78,7 +78,7 @@ describe('sendModuleCommand', () => {
     })
   })
 
-  test('maps successful response to SEND_MODULE_COMMAND_SUCCESS', () => {
+  it('maps successful response to SEND_MODULE_COMMAND_SUCCESS', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockSendModuleCommandSuccess })
@@ -100,7 +100,7 @@ describe('sendModuleCommand', () => {
     })
   })
 
-  test('maps failed response to SEND_MODULE_COMMAND_FAILURE', () => {
+  it('maps failed response to SEND_MODULE_COMMAND_FAILURE', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockSendModuleCommandFailure })

--- a/app/src/modules/epic/__tests__/updateModuleEpic.test.js
+++ b/app/src/modules/epic/__tests__/updateModuleEpic.test.js
@@ -51,7 +51,7 @@ describe('updateModuleEpic', () => {
     jest.resetAllMocks()
   })
 
-  test('calls POST /modules/{serial}/update', () => {
+  it('calls POST /modules/{serial}/update', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockUpdateModuleSuccess })
@@ -72,7 +72,7 @@ describe('updateModuleEpic', () => {
     })
   })
 
-  test('maps successful response to SEND_MODULE_COMMAND_SUCCESS', () => {
+  it('maps successful response to SEND_MODULE_COMMAND_SUCCESS', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockUpdateModuleSuccess })
@@ -93,7 +93,7 @@ describe('updateModuleEpic', () => {
     })
   })
 
-  test('maps failed response to SEND_MODULE_COMMAND_FAILURE', () => {
+  it('maps failed response to SEND_MODULE_COMMAND_FAILURE', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockUpdateModuleFailure })

--- a/app/src/nav/__tests__/calibrate-selectors.test.js
+++ b/app/src/nav/__tests__/calibrate-selectors.test.js
@@ -124,7 +124,7 @@ describe('calibrate nav selectors', () => {
     const { name, selector, expected, before = noop, after = noop } = spec
     const state = { ...mockState }
 
-    test(name, () => {
+    it(name, () => {
       before()
       expect(selector(state)).toEqual(expected)
       after()

--- a/app/src/nav/__tests__/selectors.test.js
+++ b/app/src/nav/__tests__/selectors.test.js
@@ -342,7 +342,7 @@ describe('nav selectors', () => {
     const { name, selector, expected, before = noop, after = noop } = spec
     const state = { ...mockState }
 
-    test(name, () => {
+    it(name, () => {
       before()
       expect(selector(state)).toEqual(expected)
       after()

--- a/app/src/pipettes/__tests__/actions.test.js
+++ b/app/src/pipettes/__tests__/actions.test.js
@@ -160,6 +160,6 @@ describe('robot pipettes actions', () => {
 
   SPECS.forEach(spec => {
     const { name, creator, args, expected } = spec
-    test(name, () => expect(creator(...args)).toEqual(expected))
+    it(name, () => expect(creator(...args)).toEqual(expected))
   })
 })

--- a/app/src/pipettes/__tests__/protocol-pipette-selectors.test.js
+++ b/app/src/pipettes/__tests__/protocol-pipette-selectors.test.js
@@ -272,7 +272,7 @@ describe('protocol pipettes comparison selectors', () => {
       after = noop,
     } = spec
 
-    test(name, () => {
+    it(name, () => {
       before()
       expect(selector(state, 'robotName')).toEqual(expected)
       after()

--- a/app/src/pipettes/__tests__/reducer.test.js
+++ b/app/src/pipettes/__tests__/reducer.test.js
@@ -104,6 +104,6 @@ const SPECS: Array<ReducerSpec> = [
 describe('pipettesReducer', () => {
   SPECS.forEach(spec => {
     const { name, state, action, expected } = spec
-    test(name, () => expect(pipettesReducer(state, action)).toEqual(expected))
+    it(name, () => expect(pipettesReducer(state, action)).toEqual(expected))
   })
 })

--- a/app/src/pipettes/__tests__/selectors.test.js
+++ b/app/src/pipettes/__tests__/selectors.test.js
@@ -68,6 +68,6 @@ const SPECS: Array<SelectorSpec> = [
 describe('robot api selectors', () => {
   SPECS.forEach(spec => {
     const { name, selector, state, args = [], expected } = spec
-    test(name, () => expect(selector(state, ...args)).toEqual(expected))
+    it(name, () => expect(selector(state, ...args)).toEqual(expected))
   })
 })

--- a/app/src/pipettes/epic/__tests__/fetchPipetteSettingsEpic.test.js
+++ b/app/src/pipettes/epic/__tests__/fetchPipetteSettingsEpic.test.js
@@ -52,7 +52,7 @@ describe('fetchPipetteSettingsEpic', () => {
       meta,
     }
 
-    test('calls GET /settings/pipettes', () => {
+    it('calls GET /settings/pipettes', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         mockFetchRobotApi.mockReturnValue(
           cold('r', { r: Fixtures.mockFetchPipetteSettingsSuccess })
@@ -76,7 +76,7 @@ describe('fetchPipetteSettingsEpic', () => {
       })
     })
 
-    test('maps successful response to FETCH_PIPETTE_SETTINGS_SUCCESS', () => {
+    it('maps successful response to FETCH_PIPETTE_SETTINGS_SUCCESS', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         mockFetchRobotApi.mockReturnValue(
           cold('r', { r: Fixtures.mockFetchPipetteSettingsSuccess })
@@ -96,7 +96,7 @@ describe('fetchPipetteSettingsEpic', () => {
       })
     })
 
-    test('maps failed response to FETCH_PIPETTE_SETTINGS_FAILURE', () => {
+    it('maps failed response to FETCH_PIPETTE_SETTINGS_FAILURE', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         mockFetchRobotApi.mockReturnValue(
           cold('r', { r: Fixtures.mockFetchPipetteSettingsFailure })

--- a/app/src/pipettes/epic/__tests__/fetchPipettesEpic.test.js
+++ b/app/src/pipettes/epic/__tests__/fetchPipettesEpic.test.js
@@ -52,7 +52,7 @@ describe('fetchPipettesEpic', () => {
       meta,
     }
 
-    test('calls GET /pipettes', () => {
+    it('calls GET /pipettes', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         mockFetchRobotApi.mockReturnValue(
           cold('r', { r: Fixtures.mockFetchPipettesSuccess })
@@ -77,7 +77,7 @@ describe('fetchPipettesEpic', () => {
       })
     })
 
-    test('maps successful response to FETCH_PIPETTES_SUCCESS', () => {
+    it('maps successful response to FETCH_PIPETTES_SUCCESS', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         mockFetchRobotApi.mockReturnValue(
           cold('r', { r: Fixtures.mockFetchPipettesSuccess })
@@ -97,7 +97,7 @@ describe('fetchPipettesEpic', () => {
       })
     })
 
-    test('maps failed response to FETCH_PIPETTES_FAILURE', () => {
+    it('maps failed response to FETCH_PIPETTES_FAILURE', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         mockFetchRobotApi.mockReturnValue(
           cold('r', { r: Fixtures.mockFetchPipettesFailure })

--- a/app/src/pipettes/epic/__tests__/fetchPipettesOnConnectEpic.test.js
+++ b/app/src/pipettes/epic/__tests__/fetchPipettesOnConnectEpic.test.js
@@ -35,7 +35,7 @@ describe('fetchPipettesOnConnectEpic', () => {
     jest.resetAllMocks()
   })
 
-  test('dispatches nothing robot:CONNECT_RESPONSE failure', () => {
+  it('dispatches nothing robot:CONNECT_RESPONSE failure', () => {
     const action = {
       type: 'robot:CONNECT_RESPONSE',
       payload: { error: { message: 'AH' } },
@@ -52,7 +52,7 @@ describe('fetchPipettesOnConnectEpic', () => {
     })
   })
 
-  test('dispatches FETCH_PIPETTES and FETCH_PIPETTE_SETTINGS on robot:CONNECT_RESPONSE success', () => {
+  it('dispatches FETCH_PIPETTES and FETCH_PIPETTE_SETTINGS on robot:CONNECT_RESPONSE success', () => {
     const action = {
       type: 'robot:CONNECT_RESPONSE',
       payload: {},

--- a/app/src/pipettes/epic/__tests__/updatePipetteSettingsEpic.test.js
+++ b/app/src/pipettes/epic/__tests__/updatePipetteSettingsEpic.test.js
@@ -55,7 +55,7 @@ describe('updatePipetteSettingsEpic', () => {
       meta,
     }
 
-    test('calls PATCH /settings/pipettes/:pipetteId', () => {
+    it('calls PATCH /settings/pipettes/:pipetteId', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         mockFetchRobotApi.mockReturnValue(
           cold('r', { r: Fixtures.mockFetchPipetteSettingsSuccess })
@@ -80,7 +80,7 @@ describe('updatePipetteSettingsEpic', () => {
       })
     })
 
-    test('maps successful response to UPDATE_PIPETTE_SETTINGS_SUCCESS', () => {
+    it('maps successful response to UPDATE_PIPETTE_SETTINGS_SUCCESS', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         mockFetchRobotApi.mockReturnValue(
           cold('r', { r: Fixtures.mockUpdatePipetteSettingsSuccess })
@@ -101,7 +101,7 @@ describe('updatePipetteSettingsEpic', () => {
       })
     })
 
-    test('maps failed response to UPDATE_PIPETTE_SETTINGS_FAILURE', () => {
+    it('maps failed response to UPDATE_PIPETTE_SETTINGS_FAILURE', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         mockFetchRobotApi.mockReturnValue(
           cold('r', { r: Fixtures.mockUpdatePipetteSettingsFailure })

--- a/app/src/protocol/__tests__/actions.test.js
+++ b/app/src/protocol/__tests__/actions.test.js
@@ -49,7 +49,7 @@ describe('protocol actions', () => {
       lastModified: 456,
     }
 
-    test('dispatches a protocol:OPEN', () => {
+    it('dispatches a protocol:OPEN', () => {
       const result = store.dispatch(openProtocol(pythonFile))
       const expected = {
         type: 'protocol:OPEN',
@@ -60,13 +60,13 @@ describe('protocol actions', () => {
       expect(store.getActions()).toEqual([expected])
     })
 
-    test('reads a file', () => {
+    it('reads a file', () => {
       store.dispatch(openProtocol(pythonFile))
       expect(mockReader.readAsText).toHaveBeenCalledWith(pythonFile)
       expect(mockReader.onload).toEqual(expect.any(Function))
     })
 
-    test('dispatches protocol:UPLOAD on python read completion', () => {
+    it('dispatches protocol:UPLOAD on python read completion', () => {
       store.dispatch(openProtocol(pythonFile))
       mockReader.result = 'file contents'
       mockReader.onload()
@@ -80,7 +80,7 @@ describe('protocol actions', () => {
       })
     })
 
-    test('dispatches protocol:UPLOAD on JSON read completion', () => {
+    it('dispatches protocol:UPLOAD on JSON read completion', () => {
       const protocol = { metadata: {} }
 
       store.dispatch(openProtocol(jsonFile))
@@ -98,7 +98,7 @@ describe('protocol actions', () => {
     })
 
     describe('bundle upload', () => {
-      test('dispatches a protocol:OPEN', () => {
+      it('dispatches a protocol:OPEN', () => {
         ConfigSelectors.getFeatureFlags.mockReturnValue({
           enableBundleUpload: true,
         })
@@ -112,7 +112,7 @@ describe('protocol actions', () => {
         expect(store.getActions()).toEqual([expected])
       })
 
-      test('dispatches a protocol:INVALID_FILE without bundles enabled', () => {
+      it('dispatches a protocol:INVALID_FILE without bundles enabled', () => {
         const result = store.dispatch(openProtocol(bundleFile))
         const expected = {
           type: 'protocol:INVALID_FILE',
@@ -128,7 +128,7 @@ describe('protocol actions', () => {
         expect(store.getActions()).toEqual([expected])
       })
 
-      test('dispatches protocol:UPLOAD on bundle read completion', () => {
+      it('dispatches protocol:UPLOAD on bundle read completion', () => {
         const arrayBuff = new ArrayBuffer(3)
         const uint8array = new Uint8Array(arrayBuff)
         uint8array[0] = 57

--- a/app/src/protocol/__tests__/reducer.test.js
+++ b/app/src/protocol/__tests__/reducer.test.js
@@ -3,7 +3,7 @@
 import { protocolReducer } from '../reducer'
 
 describe('protocolReducer', () => {
-  test('initial state', () => {
+  it('initial state', () => {
     expect(protocolReducer(undefined, {})).toEqual({
       file: null,
       contents: null,
@@ -130,7 +130,7 @@ describe('protocolReducer', () => {
   SPECS.forEach(spec => {
     const { name, action, initialState, expectedState } = spec
 
-    test(name, () => {
+    it(name, () => {
       expect(protocolReducer(initialState, action)).toEqual(expectedState)
     })
   })

--- a/app/src/protocol/__tests__/selectors.test.js
+++ b/app/src/protocol/__tests__/selectors.test.js
@@ -268,6 +268,6 @@ const SPECS = [
 describe('protocol selectors', () => {
   SPECS.forEach(spec => {
     const { name, selector, state, expected } = spec
-    test(name, () => expect(selector(state)).toEqual(expected))
+    it(name, () => expect(selector(state)).toEqual(expected))
   })
 })

--- a/app/src/robot-admin/__tests__/actions.test.js
+++ b/app/src/robot-admin/__tests__/actions.test.js
@@ -118,6 +118,6 @@ describe('robot admin actions', () => {
 
   SPECS.forEach(spec => {
     const { name, creator, args, expected } = spec
-    test(name, () => expect(creator(...args)).toEqual(expected))
+    it(name, () => expect(creator(...args)).toEqual(expected))
   })
 })

--- a/app/src/robot-admin/__tests__/epic.test.js
+++ b/app/src/robot-admin/__tests__/epic.test.js
@@ -53,7 +53,7 @@ describe('robotAdminEpic', () => {
     const action = Actions.restartRobot(mockRobot.name)
     const expectedRequest = { method: 'POST', path: '/server/restart' }
 
-    test('calls POST /server/restart', () => {
+    it('calls POST /server/restart', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         mockFetchRobotApi.mockReturnValue(
           cold('r', { r: Fixtures.mockRestartSuccess })
@@ -77,7 +77,7 @@ describe('robotAdminEpic', () => {
       })
     })
 
-    test('calls POST with restart path in settings capabilities', () => {
+    it('calls POST with restart path in settings capabilities', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         mockFetchRobotApi.mockReturnValue(
           cold('r', { r: Fixtures.mockRestartSuccess })
@@ -103,7 +103,7 @@ describe('robotAdminEpic', () => {
       })
     })
 
-    test('maps successful response to RESTART_ROBOT_SUCCESS', () => {
+    it('maps successful response to RESTART_ROBOT_SUCCESS', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         mockFetchRobotApi.mockReturnValue(
           cold('r', { r: Fixtures.mockRestartSuccess })
@@ -121,7 +121,7 @@ describe('robotAdminEpic', () => {
       })
     })
 
-    test('maps failed response to RESTART_ROBOT_FAILURE', () => {
+    it('maps failed response to RESTART_ROBOT_FAILURE', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         mockFetchRobotApi.mockReturnValue(
           cold('r', { r: Fixtures.mockRestartFailure })
@@ -141,7 +141,7 @@ describe('robotAdminEpic', () => {
       })
     })
 
-    test('starts discovery on RESTART_SUCCESS', () => {
+    it('starts discovery on RESTART_SUCCESS', () => {
       const action = Actions.restartRobotSuccess(mockRobot.name, {})
 
       testScheduler.run(({ hot, expectObservable }) => {
@@ -160,7 +160,7 @@ describe('robotAdminEpic', () => {
     const action = Actions.fetchResetConfigOptions(mockRobot.name)
     const expectedRequest = { method: 'GET', path: '/settings/reset/options' }
 
-    test('calls GET /settings/reset/options', () => {
+    it('calls GET /settings/reset/options', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         mockFetchRobotApi.mockReturnValue(
           cold('r', { r: Fixtures.mockFetchResetOptionsSuccess })
@@ -184,7 +184,7 @@ describe('robotAdminEpic', () => {
       })
     })
 
-    test('maps successful response to FETCH_RESET_CONFIG_OPTIONS_SUCCESS', () => {
+    it('maps successful response to FETCH_RESET_CONFIG_OPTIONS_SUCCESS', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         mockFetchRobotApi.mockReturnValue(
           cold('r', { r: Fixtures.mockFetchResetOptionsSuccess })
@@ -204,7 +204,7 @@ describe('robotAdminEpic', () => {
       })
     })
 
-    test('maps failed response to FETCH_RESET_CONFIG_OPTIONS_FAILURE', () => {
+    it('maps failed response to FETCH_RESET_CONFIG_OPTIONS_FAILURE', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         mockFetchRobotApi.mockReturnValue(
           cold('r', { r: Fixtures.mockFetchResetOptionsFailure })
@@ -231,7 +231,7 @@ describe('robotAdminEpic', () => {
       bar: false,
     })
 
-    test('calls POST /settings/reset', () => {
+    it('calls POST /settings/reset', () => {
       const expectedRequest = {
         method: 'POST',
         path: '/settings/reset',
@@ -261,7 +261,7 @@ describe('robotAdminEpic', () => {
       })
     })
 
-    test('maps successful response to RESET_CONFIG_SUCCESS', () => {
+    it('maps successful response to RESET_CONFIG_SUCCESS', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         mockFetchRobotApi.mockReturnValue(
           cold('r', { r: Fixtures.mockResetConfigSuccess })
@@ -279,7 +279,7 @@ describe('robotAdminEpic', () => {
       })
     })
 
-    test('maps failed response to RESET_CONFIG_FAILURE', () => {
+    it('maps failed response to RESET_CONFIG_FAILURE', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         mockFetchRobotApi.mockReturnValue(
           cold('r', { r: Fixtures.mockResetConfigFailure })
@@ -299,7 +299,7 @@ describe('robotAdminEpic', () => {
       })
     })
 
-    test('dispatches RESTART on RESET_CONFIG_SUCCESS', () => {
+    it('dispatches RESTART on RESET_CONFIG_SUCCESS', () => {
       const action = Actions.resetConfigSuccess(mockRobot.name, {})
 
       testScheduler.run(({ hot, expectObservable }) => {

--- a/app/src/robot-admin/__tests__/reducer.test.js
+++ b/app/src/robot-admin/__tests__/reducer.test.js
@@ -128,7 +128,7 @@ describe('robotAdminReducer', () => {
   SPECS.forEach(spec => {
     const { name, action, state, expected } = spec
 
-    test(name, () => {
+    it(name, () => {
       expect(robotAdminReducer(state, action)).toEqual(expected)
     })
   })

--- a/app/src/robot-admin/__tests__/selectors.test.js
+++ b/app/src/robot-admin/__tests__/selectors.test.js
@@ -92,7 +92,7 @@ describe('robot admin selectors', () => {
   SPECS.forEach(spec => {
     const { name, selector, state, args = [], expected } = spec
 
-    test(name, () => {
+    it(name, () => {
       const result = selector(state, ...args)
       expect(result).toEqual(expected)
     })

--- a/app/src/robot-api/__tests__/actions.test.js
+++ b/app/src/robot-api/__tests__/actions.test.js
@@ -24,6 +24,6 @@ describe('robot admin actions', () => {
 
   SPECS.forEach(spec => {
     const { name, creator, args, expected } = spec
-    test(name, () => expect(creator(...args)).toEqual(expected))
+    it(name, () => expect(creator(...args)).toEqual(expected))
   })
 })

--- a/app/src/robot-api/__tests__/hooks.test.js
+++ b/app/src/robot-api/__tests__/hooks.test.js
@@ -40,7 +40,7 @@ describe('useDispatchApiRequest', () => {
     jest.resetAllMocks()
   })
 
-  test('adds meta.requestId to action and dispatches it', () => {
+  it('adds meta.requestId to action and dispatches it', () => {
     expect(mockDispatch).toHaveBeenCalledTimes(0)
 
     act(() => wrapper.find('button').invoke('onClick')())
@@ -52,14 +52,14 @@ describe('useDispatchApiRequest', () => {
     })
   })
 
-  test('adds requestId to requestIds list', () => {
+  it('adds requestId to requestIds list', () => {
     act(() => wrapper.find('button').invoke('onClick')())
     wrapper.update()
 
     expect(wrapper.text()).toEqual('mockId_0')
   })
 
-  test('can dispatch multiple requests', () => {
+  it('can dispatch multiple requests', () => {
     act(() => wrapper.find('button').invoke('onClick')())
     wrapper.update()
     act(() => wrapper.find('button').invoke('onClick')())

--- a/app/src/robot-api/__tests__/reducer.test.js
+++ b/app/src/robot-api/__tests__/reducer.test.js
@@ -70,6 +70,6 @@ const SPECS: Array<ReducerSpec> = [
 describe('robotApiReducer', () => {
   SPECS.forEach(spec => {
     const { name, state, action, expected } = spec
-    test(name, () => expect(robotApiReducer(state, action)).toEqual(expected))
+    it(name, () => expect(robotApiReducer(state, action)).toEqual(expected))
   })
 })

--- a/app/src/robot-api/__tests__/selectors.test.js
+++ b/app/src/robot-api/__tests__/selectors.test.js
@@ -38,6 +38,6 @@ const SPECS: Array<SelectorSpec> = [
 describe('robot api selectors', () => {
   SPECS.forEach(spec => {
     const { name, selector, state, args = [], expected } = spec
-    test(name, () => expect(selector(state, ...args)).toEqual(expected))
+    it(name, () => expect(selector(state, ...args)).toEqual(expected))
   })
 })

--- a/app/src/robot-controls/__tests__/actions.test.js
+++ b/app/src/robot-controls/__tests__/actions.test.js
@@ -173,6 +173,6 @@ const SPECS: Array<ActionSpec> = [
 describe('robot controls actions', () => {
   SPECS.forEach(spec => {
     const { name, creator, args, expected } = spec
-    test(name, () => expect(creator(...args)).toEqual(expected))
+    it(name, () => expect(creator(...args)).toEqual(expected))
   })
 })

--- a/app/src/robot-controls/__tests__/reducer.test.js
+++ b/app/src/robot-controls/__tests__/reducer.test.js
@@ -123,7 +123,7 @@ const SPECS: Array<ReducerSpec> = [
 describe('robotControlsReducer', () => {
   SPECS.forEach(spec => {
     const { name, state, action, expected } = spec
-    test(name, () =>
+    it(name, () =>
       expect(robotControlsReducer(state, action)).toEqual(expected)
     )
   })

--- a/app/src/robot-controls/__tests__/selectors.test.js
+++ b/app/src/robot-controls/__tests__/selectors.test.js
@@ -87,6 +87,6 @@ const SPECS: Array<SelectorSpec> = [
 describe('robot controls selectors', () => {
   SPECS.forEach(spec => {
     const { name, selector, state, args = [], expected } = spec
-    test(name, () => expect(selector(state, ...args)).toEqual(expected))
+    it(name, () => expect(selector(state, ...args)).toEqual(expected))
   })
 })

--- a/app/src/robot-controls/epic/__tests__/fetchLightsEpic.test.js
+++ b/app/src/robot-controls/epic/__tests__/fetchLightsEpic.test.js
@@ -50,7 +50,7 @@ describe('fetchLightsEpic', () => {
     meta,
   }
 
-  test('calls GET /robot/lights', () => {
+  it('calls GET /robot/lights', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockFetchLightsSuccess })
@@ -71,7 +71,7 @@ describe('fetchLightsEpic', () => {
     })
   })
 
-  test('maps successful response to FETCH_LIGHTS_SUCCESS', () => {
+  it('maps successful response to FETCH_LIGHTS_SUCCESS', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockFetchLightsSuccess })
@@ -91,7 +91,7 @@ describe('fetchLightsEpic', () => {
     })
   })
 
-  test('maps failed response to FETCH_LIGHTS_FAILURE', () => {
+  it('maps failed response to FETCH_LIGHTS_FAILURE', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockFetchLightsFailure })

--- a/app/src/robot-controls/epic/__tests__/homeEpic.test.js
+++ b/app/src/robot-controls/epic/__tests__/homeEpic.test.js
@@ -50,7 +50,7 @@ describe('homeEpic', () => {
     meta,
   }
 
-  test('calls POST /robot/home with target: robot', () => {
+  it('calls POST /robot/home with target: robot', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockHomeSuccess })
@@ -72,7 +72,7 @@ describe('homeEpic', () => {
     })
   })
 
-  test('calls POST /robot/home with target: pipette', () => {
+  it('calls POST /robot/home with target: pipette', () => {
     const action: Types.HomeAction = {
       ...Actions.home(mockRobot.name, 'pipette', 'right'),
       meta,
@@ -98,7 +98,7 @@ describe('homeEpic', () => {
     })
   })
 
-  test('maps successful response to HOME_SUCCESS', () => {
+  it('maps successful response to HOME_SUCCESS', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockHomeSuccess })
@@ -117,7 +117,7 @@ describe('homeEpic', () => {
     })
   })
 
-  test('maps failed response to HOME_FAILURE', () => {
+  it('maps failed response to HOME_FAILURE', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockHomeFailure })

--- a/app/src/robot-controls/epic/__tests__/moveEpic.test.js
+++ b/app/src/robot-controls/epic/__tests__/moveEpic.test.js
@@ -51,7 +51,7 @@ describe('moveEpic', () => {
 
   const meta = { requestId: '1234' }
 
-  test('calls GET /robot/positions and then POST /robot/move with position: changePipette', () => {
+  it('calls GET /robot/positions and then POST /robot/move with position: changePipette', () => {
     const action: Types.MoveAction = {
       ...Actions.move(mockRobot.name, 'changePipette', 'left'),
       meta,
@@ -88,7 +88,7 @@ describe('moveEpic', () => {
     })
   })
 
-  test('calls GET /robot/positions and POST /robot/move with position: attachTip', () => {
+  it('calls GET /robot/positions and POST /robot/move with position: attachTip', () => {
     const action: Types.MoveAction = {
       ...Actions.move(mockRobot.name, 'attachTip', 'right'),
       meta,
@@ -131,7 +131,7 @@ describe('moveEpic', () => {
     })
   })
 
-  test('calls POST /motors/disengage if disengageMotors: true', () => {
+  it('calls POST /motors/disengage if disengageMotors: true', () => {
     const action: Types.MoveAction = {
       ...Actions.move(mockRobot.name, 'changePipette', 'left', true),
       meta,
@@ -163,7 +163,7 @@ describe('moveEpic', () => {
     })
   })
 
-  test('maps successful response to MOVE_SUCCESS without disengage', () => {
+  it('maps successful response to MOVE_SUCCESS without disengage', () => {
     const action: Types.MoveAction = {
       ...Actions.move(mockRobot.name, 'changePipette', 'left'),
       meta,
@@ -192,7 +192,7 @@ describe('moveEpic', () => {
     })
   })
 
-  test('maps successful response to MOVE_SUCCESS with disengage', () => {
+  it('maps successful response to MOVE_SUCCESS with disengage', () => {
     const action: Types.MoveAction = {
       ...Actions.move(mockRobot.name, 'changePipette', 'left', true),
       meta,
@@ -221,7 +221,7 @@ describe('moveEpic', () => {
     })
   })
 
-  test('maps failed GET /robot/positions to MOVE_FAILURE', () => {
+  it('maps failed GET /robot/positions to MOVE_FAILURE', () => {
     const action: Types.MoveAction = {
       ...Actions.move(mockRobot.name, 'changePipette', 'left', true),
       meta,
@@ -246,7 +246,7 @@ describe('moveEpic', () => {
     })
   })
 
-  test('maps failed POST /robot/move to MOVE_FAILURE', () => {
+  it('maps failed POST /robot/move to MOVE_FAILURE', () => {
     const action: Types.MoveAction = {
       ...Actions.move(mockRobot.name, 'changePipette', 'left', true),
       meta,
@@ -273,7 +273,7 @@ describe('moveEpic', () => {
     })
   })
 
-  test('maps failed POST /motors/disengage to MOVE_FAILURE', () => {
+  it('maps failed POST /motors/disengage to MOVE_FAILURE', () => {
     const action: Types.MoveAction = {
       ...Actions.move(mockRobot.name, 'changePipette', 'left', true),
       meta,

--- a/app/src/robot-controls/epic/__tests__/updateLightsEpic.test.js
+++ b/app/src/robot-controls/epic/__tests__/updateLightsEpic.test.js
@@ -50,7 +50,7 @@ describe('updateLightsEpic', () => {
     meta,
   }
 
-  test('calls POST /robot/lights', () => {
+  it('calls POST /robot/lights', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockUpdateLightsSuccess })
@@ -72,7 +72,7 @@ describe('updateLightsEpic', () => {
     })
   })
 
-  test('maps successful response to UPDATE_LIGHTS_SUCCESS', () => {
+  it('maps successful response to UPDATE_LIGHTS_SUCCESS', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockUpdateLightsSuccess })
@@ -92,7 +92,7 @@ describe('updateLightsEpic', () => {
     })
   })
 
-  test('maps failed response to UPDATE_LIGHTS_FAILURE', () => {
+  it('maps failed response to UPDATE_LIGHTS_FAILURE', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockUpdateLightsFailure })

--- a/app/src/robot-settings/__tests__/actions.test.js
+++ b/app/src/robot-settings/__tests__/actions.test.js
@@ -108,6 +108,6 @@ describe('robot settings actions', () => {
 
   SPECS.forEach(spec => {
     const { name, creator, args, expected } = spec
-    test(name, () => expect(creator(...args)).toEqual(expected))
+    it(name, () => expect(creator(...args)).toEqual(expected))
   })
 })

--- a/app/src/robot-settings/__tests__/reducer.test.js
+++ b/app/src/robot-settings/__tests__/reducer.test.js
@@ -96,7 +96,7 @@ describe('robotSettingsReducer', () => {
   SPECS.forEach(spec => {
     const { name, action, state, expected } = spec
 
-    test(name, () => {
+    it(name, () => {
       expect(robotSettingsReducer(state, action)).toEqual(expected)
     })
   })

--- a/app/src/robot-settings/__tests__/selectors.test.js
+++ b/app/src/robot-settings/__tests__/selectors.test.js
@@ -73,7 +73,7 @@ describe('robot settings selectors', () => {
   SPECS.forEach(spec => {
     const { name, selector, state, args = [], expected } = spec
 
-    test(name, () => {
+    it(name, () => {
       const result = selector(state, ...args)
       expect(result).toEqual(expected)
     })

--- a/app/src/robot-settings/epic/__tests__/clearRestartPathEpic.test.js
+++ b/app/src/robot-settings/epic/__tests__/clearRestartPathEpic.test.js
@@ -33,7 +33,7 @@ describe('clearRestartPathEpic', () => {
     jest.resetAllMocks()
   })
 
-  test('dispatches CLEAR_RESTART_PATH on robot restart', () => {
+  it('dispatches CLEAR_RESTART_PATH on robot restart', () => {
     mockGetAllRestartRequiredRobots.mockReturnValue(['a', 'b'])
     mockGetRobotAdminStatus.mockReturnValue('restarting')
 

--- a/app/src/robot-settings/epic/__tests__/fetchSettingsEpic.test.js
+++ b/app/src/robot-settings/epic/__tests__/fetchSettingsEpic.test.js
@@ -57,7 +57,7 @@ describe('fetchSettingsEpic', () => {
     meta,
   }
 
-  test('calls GET /settings', () => {
+  it('calls GET /settings', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockFetchSettingsSuccess })
@@ -78,7 +78,7 @@ describe('fetchSettingsEpic', () => {
     })
   })
 
-  test('maps successful response to FETCH_SETTINGS_SUCCESS', () => {
+  it('maps successful response to FETCH_SETTINGS_SUCCESS', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockFetchSettingsSuccess })
@@ -99,7 +99,7 @@ describe('fetchSettingsEpic', () => {
     })
   })
 
-  test('maps failed response to FETCH_SETTINGS_FAILURE', () => {
+  it('maps failed response to FETCH_SETTINGS_FAILURE', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockFetchSettingsFailure })

--- a/app/src/robot-settings/epic/__tests__/updateSettingEpic.test.js
+++ b/app/src/robot-settings/epic/__tests__/updateSettingEpic.test.js
@@ -57,7 +57,7 @@ describe('updateSettingEpic', () => {
     meta,
   }
 
-  test('calls POST /settings', () => {
+  it('calls POST /settings', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockUpdateSettingSuccess })
@@ -79,7 +79,7 @@ describe('updateSettingEpic', () => {
     })
   })
 
-  test('maps successful response to UPDATE_SETTING_SUCCESS', () => {
+  it('maps successful response to UPDATE_SETTING_SUCCESS', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockUpdateSettingSuccess })
@@ -100,7 +100,7 @@ describe('updateSettingEpic', () => {
     })
   })
 
-  test('maps failed response to UPDATE_SETTING_FAILURE', () => {
+  it('maps failed response to UPDATE_SETTING_FAILURE', () => {
     testScheduler.run(({ hot, cold, expectObservable, flush }) => {
       mockFetchRobotApi.mockReturnValue(
         cold('r', { r: Fixtures.mockUpdateSettingFailure })

--- a/app/src/robot/api-client/__tests__/create-sessions.test.js
+++ b/app/src/robot/api-client/__tests__/create-sessions.test.js
@@ -59,7 +59,7 @@ describe('RPC API client - session creation', () => {
     jest.resetAllMocks()
   })
 
-  test('calls session_manager.create on protocol:UPLOAD', () => {
+  it('calls session_manager.create on protocol:UPLOAD', () => {
     const mockProtocolFile = { name: 'protocol.py' }
     const mockSession = MockSession()
 
@@ -79,7 +79,7 @@ describe('RPC API client - session creation', () => {
     })
   })
 
-  test('calls session_manager.create_from_bundle if zip protocol', () => {
+  it('calls session_manager.create_from_bundle if zip protocol', () => {
     const mockProtocolFile = { name: 'protocol.zip', type: 'zip' }
     const mockSession = MockSession()
 
@@ -98,7 +98,7 @@ describe('RPC API client - session creation', () => {
     })
   })
 
-  test('calls create with third param if zip and create_from_bundle not available', () => {
+  it('calls create with third param if zip and create_from_bundle not available', () => {
     const mockProtocolFile = { name: 'protocol.zip', type: 'zip' }
     const mockSession = MockSession()
 
@@ -120,7 +120,7 @@ describe('RPC API client - session creation', () => {
     })
   })
 
-  test('calls create_with_extra_labware if python protocol and custom labware exist', () => {
+  it('calls create_with_extra_labware if python protocol and custom labware exist', () => {
     const mockProtocolFile = { name: 'protocol.py', type: 'python' }
     const mockSession = MockSession()
 
@@ -144,7 +144,7 @@ describe('RPC API client - session creation', () => {
     })
   })
 
-  test('calls create if custom labware but create_with_extra_labware not available', () => {
+  it('calls create if custom labware but create_with_extra_labware not available', () => {
     const mockProtocolFile = { name: 'protocol.py', type: 'python' }
     const mockSession = MockSession()
 
@@ -169,7 +169,7 @@ describe('RPC API client - session creation', () => {
     })
   })
 
-  test('calls create if custom labware but protocol is JSON', () => {
+  it('calls create if custom labware but protocol is JSON', () => {
     const mockProtocolFile = { name: 'protocol.json', type: 'json' }
     const mockSession = MockSession()
 
@@ -192,7 +192,7 @@ describe('RPC API client - session creation', () => {
     })
   })
 
-  test('dispatches session response with error if create throws', () => {
+  it('dispatches session response with error if create throws', () => {
     const mockProtocolFile = { name: 'protocol.py', type: 'python' }
 
     ProtocolSelectors.getProtocolFile.mockReturnValue(mockProtocolFile)
@@ -209,7 +209,7 @@ describe('RPC API client - session creation', () => {
     })
   })
 
-  test('dispatches helpful error response with if create throws with bundle', () => {
+  it('dispatches helpful error response with if create throws with bundle', () => {
     const mockProtocolFile = { name: 'protocol.zip', type: 'zip' }
     const mockError = Object.assign(
       new Error(

--- a/app/src/robot/test/actions.test.js
+++ b/app/src/robot/test/actions.test.js
@@ -2,7 +2,7 @@
 import { actions, actionTypes } from '../'
 
 describe('robot actions', () => {
-  test('CONNECT action', () => {
+  it('CONNECT action', () => {
     const expected = {
       type: 'robot:CONNECT',
       payload: { name: 'ot' },
@@ -12,7 +12,7 @@ describe('robot actions', () => {
     expect(actions.connect('ot')).toEqual(expected)
   })
 
-  test('CONNECT_RESPONSE action', () => {
+  it('CONNECT_RESPONSE action', () => {
     const success = {
       type: 'robot:CONNECT_RESPONSE',
       payload: { error: null, sessionCapabilities: ['create'] },
@@ -26,13 +26,13 @@ describe('robot actions', () => {
     expect(actions.connectResponse(new Error('AH'))).toEqual(failure)
   })
 
-  test('CLEAR_CONNECT_RESPONSE action', () => {
+  it('CLEAR_CONNECT_RESPONSE action', () => {
     const expected = { type: 'robot:CLEAR_CONNECT_RESPONSE' }
 
     expect(actions.clearConnectResponse()).toEqual(expected)
   })
 
-  test('DISCONNECT action', () => {
+  it('DISCONNECT action', () => {
     const expected = {
       type: 'robot:DISCONNECT',
       meta: { robotCommand: true },
@@ -41,7 +41,7 @@ describe('robot actions', () => {
     expect(actions.disconnect()).toEqual(expected)
   })
 
-  test('DISCONNECT_RESPONSE action', () => {
+  it('DISCONNECT_RESPONSE action', () => {
     const success = {
       type: 'robot:DISCONNECT_RESPONSE',
       payload: {},
@@ -50,7 +50,7 @@ describe('robot actions', () => {
     expect(actions.disconnectResponse()).toEqual(success)
   })
 
-  test('session response', () => {
+  it('session response', () => {
     const session = { state: 'READY' }
     const error = new Error('AH')
 
@@ -69,7 +69,7 @@ describe('robot actions', () => {
     expect(actions.sessionResponse(error, null, false)).toEqual(failure)
   })
 
-  test('SESSION_UPDATE action', () => {
+  it('SESSION_UPDATE action', () => {
     const update = { state: 'running', startTime: 1 }
     const expected = {
       type: 'robot:SESSION_UPDATE',
@@ -80,7 +80,7 @@ describe('robot actions', () => {
     expect(actions.sessionUpdate(update, 1234)).toEqual(expected)
   })
 
-  test('set modules reviewed action', () => {
+  it('set modules reviewed action', () => {
     expect(actions.setModulesReviewed(false)).toEqual({
       type: 'robot:SET_MODULES_REVIEWED',
       payload: false,
@@ -92,7 +92,7 @@ describe('robot actions', () => {
     })
   })
 
-  test('set deck populated action', () => {
+  it('set deck populated action', () => {
     expect(actions.setDeckPopulated(false)).toEqual({
       type: actionTypes.SET_DECK_POPULATED,
       payload: false,
@@ -104,7 +104,7 @@ describe('robot actions', () => {
     })
   })
 
-  test('move tip to front action', () => {
+  it('move tip to front action', () => {
     const expected = {
       type: actionTypes.MOVE_TO_FRONT,
       payload: { mount: 'right' },
@@ -114,7 +114,7 @@ describe('robot actions', () => {
     expect(actions.moveToFront('right')).toEqual(expected)
   })
 
-  test('move tip to front response action', () => {
+  it('move tip to front response action', () => {
     const success = {
       type: actionTypes.MOVE_TO_FRONT_RESPONSE,
       error: false,
@@ -129,7 +129,7 @@ describe('robot actions', () => {
     expect(actions.moveToFrontResponse(new Error('AH'))).toEqual(failure)
   })
 
-  test('PICKUP_AND_HOME action', () => {
+  it('PICKUP_AND_HOME action', () => {
     const action = {
       type: 'robot:PICKUP_AND_HOME',
       payload: { mount: 'left', slot: '5' },
@@ -139,7 +139,7 @@ describe('robot actions', () => {
     expect(actions.pickupAndHome('left', '5')).toEqual(action)
   })
 
-  test('PICKUP_AND_HOME response actions', () => {
+  it('PICKUP_AND_HOME response actions', () => {
     const success = {
       type: 'robot:PICKUP_AND_HOME_SUCCESS',
       payload: {},
@@ -154,7 +154,7 @@ describe('robot actions', () => {
     expect(actions.pickupAndHomeResponse(new Error('AH'))).toEqual(failure)
   })
 
-  test('DROP_TIP_AND_HOME action', () => {
+  it('DROP_TIP_AND_HOME action', () => {
     const action = {
       type: 'robot:DROP_TIP_AND_HOME',
       payload: { mount: 'right', slot: '5' },
@@ -164,7 +164,7 @@ describe('robot actions', () => {
     expect(actions.dropTipAndHome('right', '5')).toEqual(action)
   })
 
-  test('DROP_TIP_AND_HOME response actions', () => {
+  it('DROP_TIP_AND_HOME response actions', () => {
     const success = {
       type: 'robot:DROP_TIP_AND_HOME_SUCCESS',
       payload: {},
@@ -180,7 +180,7 @@ describe('robot actions', () => {
     expect(actions.dropTipAndHomeResponse(new Error('AH'))).toEqual(failure)
   })
 
-  test('CONFIRM_TIPRACK action', () => {
+  it('CONFIRM_TIPRACK action', () => {
     const action = {
       type: 'robot:CONFIRM_TIPRACK',
       payload: { mount: 'left', slot: '9' },
@@ -190,7 +190,7 @@ describe('robot actions', () => {
     expect(actions.confirmTiprack('left', '9')).toEqual(action)
   })
 
-  test('CONFIRM_TIPRACK response actions', () => {
+  it('CONFIRM_TIPRACK response actions', () => {
     const success = {
       type: 'robot:CONFIRM_TIPRACK_SUCCESS',
       payload: { tipOn: true },
@@ -206,7 +206,7 @@ describe('robot actions', () => {
     expect(actions.confirmTiprackResponse(new Error('AH'))).toEqual(failure)
   })
 
-  test('probe tip action', () => {
+  it('probe tip action', () => {
     const expected = {
       type: actionTypes.PROBE_TIP,
       payload: { mount: 'left' },
@@ -216,7 +216,7 @@ describe('robot actions', () => {
     expect(actions.probeTip('left')).toEqual(expected)
   })
 
-  test('probe tip response action', () => {
+  it('probe tip response action', () => {
     const success = {
       type: actionTypes.PROBE_TIP_RESPONSE,
       error: false,
@@ -231,7 +231,7 @@ describe('robot actions', () => {
     expect(actions.probeTipResponse(new Error('AH'))).toEqual(failure)
   })
 
-  test('CONFIRM_PROBED action', () => {
+  it('CONFIRM_PROBED action', () => {
     const expected = {
       type: 'robot:CONFIRM_PROBED',
       payload: 'left',
@@ -241,7 +241,7 @@ describe('robot actions', () => {
     expect(actions.confirmProbed('left')).toEqual(expected)
   })
 
-  test('MOVE_TO action', () => {
+  it('MOVE_TO action', () => {
     const expected = {
       type: 'robot:MOVE_TO',
       payload: { mount: 'left', slot: '3' },
@@ -251,7 +251,7 @@ describe('robot actions', () => {
     expect(actions.moveTo('left', '3')).toEqual(expected)
   })
 
-  test('MOVE_TO response actions', () => {
+  it('MOVE_TO response actions', () => {
     const success = {
       type: 'robot:MOVE_TO_SUCCESS',
       payload: {},
@@ -266,7 +266,7 @@ describe('robot actions', () => {
     expect(actions.moveToResponse(new Error('AH'))).toEqual(failure)
   })
 
-  test('JOG action', () => {
+  it('JOG action', () => {
     const expected = {
       type: 'robot:JOG',
       payload: { mount: 'left', axis: 'x', direction: -1, step: 10 },
@@ -276,7 +276,7 @@ describe('robot actions', () => {
     expect(actions.jog('left', 'x', -1, 10)).toEqual(expected)
   })
 
-  test('jog response action', () => {
+  it('jog response action', () => {
     const success = {
       type: 'robot:JOG_SUCCESS',
       payload: {},
@@ -291,7 +291,7 @@ describe('robot actions', () => {
     expect(actions.jogResponse(new Error('AH'))).toEqual(failure)
   })
 
-  test('UPDATE_OFFSET action', () => {
+  it('UPDATE_OFFSET action', () => {
     const expected = {
       type: 'robot:UPDATE_OFFSET',
       payload: { mount: 'left', slot: '2' },
@@ -301,7 +301,7 @@ describe('robot actions', () => {
     expect(actions.updateOffset('left', '2')).toEqual(expected)
   })
 
-  test('UPDATE_OFFSET response actions', () => {
+  it('UPDATE_OFFSET response actions', () => {
     const success = {
       type: 'robot:UPDATE_OFFSET_SUCCESS',
       payload: {},
@@ -316,7 +316,7 @@ describe('robot actions', () => {
     expect(actions.updateOffsetResponse(new Error('AH'))).toEqual(failure)
   })
 
-  test('confirm labware action', () => {
+  it('confirm labware action', () => {
     const expected = {
       type: actionTypes.CONFIRM_LABWARE,
       payload: { labware: '2' },
@@ -325,7 +325,7 @@ describe('robot actions', () => {
     expect(actions.confirmLabware('2')).toEqual(expected)
   })
 
-  test('run action', () => {
+  it('run action', () => {
     const expected = {
       type: actionTypes.RUN,
       meta: { robotCommand: true },
@@ -334,7 +334,7 @@ describe('robot actions', () => {
     expect(actions.run()).toEqual(expected)
   })
 
-  test('run response action', () => {
+  it('run response action', () => {
     const success = { type: actionTypes.RUN_RESPONSE, error: false }
     const failure = {
       type: actionTypes.RUN_RESPONSE,
@@ -346,7 +346,7 @@ describe('robot actions', () => {
     expect(actions.runResponse(new Error('AH'))).toEqual(failure)
   })
 
-  test('pause action', () => {
+  it('pause action', () => {
     const expected = {
       type: actionTypes.PAUSE,
       meta: { robotCommand: true },
@@ -355,7 +355,7 @@ describe('robot actions', () => {
     expect(actions.pause()).toEqual(expected)
   })
 
-  test('pause response action', () => {
+  it('pause response action', () => {
     const success = { type: actionTypes.PAUSE_RESPONSE, error: false }
     const failure = {
       type: actionTypes.PAUSE_RESPONSE,
@@ -367,7 +367,7 @@ describe('robot actions', () => {
     expect(actions.pauseResponse(new Error('AH'))).toEqual(failure)
   })
 
-  test('resume action', () => {
+  it('resume action', () => {
     const expected = {
       type: actionTypes.RESUME,
       meta: { robotCommand: true },
@@ -376,7 +376,7 @@ describe('robot actions', () => {
     expect(actions.resume()).toEqual(expected)
   })
 
-  test('resume response action', () => {
+  it('resume response action', () => {
     const success = { type: actionTypes.RESUME_RESPONSE, error: false }
     const failure = {
       type: actionTypes.RESUME_RESPONSE,
@@ -388,7 +388,7 @@ describe('robot actions', () => {
     expect(actions.resumeResponse(new Error('AHHH'))).toEqual(failure)
   })
 
-  test('cancel action', () => {
+  it('cancel action', () => {
     const expected = {
       type: actionTypes.CANCEL,
       meta: { robotCommand: true },
@@ -397,7 +397,7 @@ describe('robot actions', () => {
     expect(actions.cancel()).toEqual(expected)
   })
 
-  test('cancel response action', () => {
+  it('cancel response action', () => {
     const success = { type: actionTypes.CANCEL_RESPONSE, error: false }
     const failure = {
       type: actionTypes.CANCEL_RESPONSE,
@@ -409,14 +409,14 @@ describe('robot actions', () => {
     expect(actions.cancelResponse(new Error('AHHH'))).toEqual(failure)
   })
 
-  test('robot:REFRESH_SESSION action', () => {
+  it('robot:REFRESH_SESSION action', () => {
     expect(actions.refreshSession()).toEqual({
       type: 'robot:REFRESH_SESSION',
       meta: { robotCommand: true },
     })
   })
 
-  test('tick run time action', () => {
+  it('tick run time action', () => {
     const expected = { type: actionTypes.TICK_RUN_TIME }
 
     expect(actions.tickRunTime()).toEqual(expected)

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -130,7 +130,7 @@ describe('api client', () => {
   }
 
   describe('connect and disconnect', () => {
-    test('connect RpcClient on CONNECT message', () => {
+    it('connect RpcClient on CONNECT message', () => {
       const expectedResponse = actions.connectResponse(null, expect.any(Array))
 
       expect(RpcClient).toHaveBeenCalledTimes(0)
@@ -141,7 +141,7 @@ describe('api client', () => {
       })
     })
 
-    test('dispatch CONNECT_RESPONSE error if connection fails', () => {
+    it('dispatch CONNECT_RESPONSE error if connection fails', () => {
       const error = new Error('AHH get_root')
       const expectedResponse = actions.connectResponse(error)
 
@@ -152,7 +152,7 @@ describe('api client', () => {
       )
     })
 
-    test('send CONNECT_RESPONSE w/ capabilities from remote.session_manager', () => {
+    it('send CONNECT_RESPONSE w/ capabilities from remote.session_manager', () => {
       const expectedResponse = actions.connectResponse(null, [
         'create',
         'create_from_bundle',
@@ -166,7 +166,7 @@ describe('api client', () => {
       })
     })
 
-    test('dispatch DISCONNECT_RESPONSE if already disconnected', () => {
+    it('dispatch DISCONNECT_RESPONSE if already disconnected', () => {
       const expected = actions.disconnectResponse()
 
       return sendDisconnect().then(() =>
@@ -174,7 +174,7 @@ describe('api client', () => {
       )
     })
 
-    test('disconnects RPC client on DISCONNECT message', () => {
+    it('disconnects RPC client on DISCONNECT message', () => {
       const expected = actions.disconnectResponse()
 
       return sendConnect()
@@ -183,7 +183,7 @@ describe('api client', () => {
         .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
     })
 
-    test('disconnects RPC client on robotAdmin:RESTART message', () => {
+    it('disconnects RPC client on robotAdmin:RESTART message', () => {
       const state = {
         ...STATE,
         robot: { ...STATE.robot, connection: { connectedTo: ROBOT_NAME } },
@@ -197,7 +197,7 @@ describe('api client', () => {
     })
 
     // TODO(mc, 2018-03-01): rethink / remove this behavior
-    test('dispatch push to /run if connect to running session', () => {
+    it('dispatch push to /run if connect to running session', () => {
       const expected = push('/run')
       session.state = constants.RUNNING
 
@@ -206,7 +206,7 @@ describe('api client', () => {
       )
     })
 
-    test('dispatch push to /run if connect to paused session', () => {
+    it('dispatch push to /run if connect to paused session', () => {
       const expected = push('/run')
       session.state = constants.PAUSED
 
@@ -217,7 +217,7 @@ describe('api client', () => {
   })
 
   describe('running', () => {
-    test('calls session.run and dispatches RUN_RESPONSE success', () => {
+    it('calls session.run and dispatches RUN_RESPONSE success', () => {
       const expected = actions.runResponse()
 
       session.run.mockResolvedValue()
@@ -230,7 +230,7 @@ describe('api client', () => {
         })
     })
 
-    test('calls session.run and dispatches RUN_RESPONSE failure', () => {
+    it('calls session.run and dispatches RUN_RESPONSE failure', () => {
       const expected = actions.runResponse(new Error('AH'))
 
       session.run.mockRejectedValue(new Error('AH'))
@@ -240,7 +240,7 @@ describe('api client', () => {
         .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
     })
 
-    test('calls session.pause and dispatches PAUSE_RESPONSE success', () => {
+    it('calls session.pause and dispatches PAUSE_RESPONSE success', () => {
       const expected = actions.pauseResponse()
 
       session.pause.mockResolvedValue()
@@ -253,7 +253,7 @@ describe('api client', () => {
         })
     })
 
-    test('calls session.stop and dispatches PAUSE_RESPONSE failure', () => {
+    it('calls session.stop and dispatches PAUSE_RESPONSE failure', () => {
       const expected = actions.pauseResponse(new Error('AH'))
 
       session.pause.mockRejectedValue(new Error('AH'))
@@ -263,7 +263,7 @@ describe('api client', () => {
         .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
     })
 
-    test('calls session.resume and dispatches RESUME_RESPONSE success', () => {
+    it('calls session.resume and dispatches RESUME_RESPONSE success', () => {
       const expected = actions.resumeResponse()
 
       session.resume.mockResolvedValue()
@@ -276,7 +276,7 @@ describe('api client', () => {
         })
     })
 
-    test('calls session.resume and dispatches RESUME_RESPONSE failure', () => {
+    it('calls session.resume and dispatches RESUME_RESPONSE failure', () => {
       const expected = actions.resumeResponse(new Error('AH'))
 
       session.resume.mockRejectedValue(new Error('AH'))
@@ -286,7 +286,7 @@ describe('api client', () => {
         .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
     })
 
-    test('calls session.resume + stop and dispatches CANCEL_RESPONSE', () => {
+    it('calls session.resume + stop and dispatches CANCEL_RESPONSE', () => {
       const expected = actions.cancelResponse()
 
       session.resume.mockResolvedValue()
@@ -301,7 +301,7 @@ describe('api client', () => {
         })
     })
 
-    test('calls session.stop and dispatches CANCEL_RESPONSE failure', () => {
+    it('calls session.stop and dispatches CANCEL_RESPONSE failure', () => {
       const expected = actions.cancelResponse(new Error('AH'))
 
       session.resume.mockResolvedValue()
@@ -312,7 +312,7 @@ describe('api client', () => {
         .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
     })
 
-    test('calls session.refresh with REFRESH_SESSION', () => {
+    it('calls session.refresh with REFRESH_SESSION', () => {
       session.refresh.mockResolvedValue()
 
       return sendConnect()
@@ -320,7 +320,7 @@ describe('api client', () => {
         .then(() => expect(session.refresh).toHaveBeenCalled())
     })
 
-    test('start a timer when the run starts', () => {
+    it('start a timer when the run starts', () => {
       session.run.mockResolvedValue()
 
       return sendConnect()
@@ -350,13 +350,13 @@ describe('api client', () => {
       )
     })
 
-    test('dispatches sessionResponse on connect', () => {
+    it('dispatches sessionResponse on connect', () => {
       return sendConnect().then(() =>
         expect(dispatch).toHaveBeenCalledWith(expectedInitial)
       )
     })
 
-    test('dispatches sessionResponse on full session notification', () => {
+    it('dispatches sessionResponse on full session notification', () => {
       return sendConnect()
         .then(() => {
           dispatch.mockClear()
@@ -365,7 +365,7 @@ describe('api client', () => {
         .then(() => expect(dispatch).toHaveBeenCalledWith(expectedInitial))
     })
 
-    test('handles connnect without session', () => {
+    it('handles connnect without session', () => {
       const notExpected = actions.sessionResponse(
         null,
         expect.anything(),
@@ -379,7 +379,7 @@ describe('api client', () => {
       )
     })
 
-    test('maps api session commands and command log to commands', () => {
+    it('maps api session commands and command log to commands', () => {
       const expected = actions.sessionResponse(
         null,
         expect.objectContaining({
@@ -423,7 +423,7 @@ describe('api client', () => {
       )
     })
 
-    test('maps api instruments and instruments by mount', () => {
+    it('maps api instruments and instruments by mount', () => {
       const expected = actions.sessionResponse(
         null,
         expect.objectContaining({
@@ -473,7 +473,7 @@ describe('api client', () => {
       )
     })
 
-    test('maps api containers to labware by slot', () => {
+    it('maps api containers to labware by slot', () => {
       const expected = actions.sessionResponse(
         null,
         expect.objectContaining({
@@ -513,7 +513,7 @@ describe('api client', () => {
       )
     })
 
-    test('reconciles reported tiprack / pipette usage', () => {
+    it('reconciles reported tiprack / pipette usage', () => {
       const expected = actions.sessionResponse(
         null,
         expect.objectContaining({
@@ -586,7 +586,7 @@ describe('api client', () => {
       )
     })
 
-    test('maps api modules to modules by slot', () => {
+    it('maps api modules to modules by slot', () => {
       const expected = actions.sessionResponse(
         null,
         expect.objectContaining({
@@ -624,7 +624,7 @@ describe('api client', () => {
       )
     })
 
-    test('maps api metadata to session metadata', () => {
+    it('maps api metadata to session metadata', () => {
       const expected = actions.sessionResponse(
         null,
         expect.objectContaining({
@@ -654,7 +654,7 @@ describe('api client', () => {
       )
     })
 
-    test('sends error if received malformed session from API', () => {
+    it('sends error if received malformed session from API', () => {
       const expected = actions.sessionResponse(expect.anything(), null, false)
 
       session.commands = [{ foo: 'bar' }]
@@ -665,7 +665,7 @@ describe('api client', () => {
       )
     })
 
-    test('sends SESSION_UPDATE if session notification has lastCommand', () => {
+    it('sends SESSION_UPDATE if session notification has lastCommand', () => {
       const update = { state: 'running', startTime: 1, lastCommand: null }
       const expected = actions.sessionUpdate(update, expect.any(Number))
 
@@ -710,7 +710,7 @@ describe('api client', () => {
       }
     })
 
-    test('handles MOVE_TO_FRONT success', () => {
+    it('handles MOVE_TO_FRONT success', () => {
       const action = actions.moveToFront('left')
       const expectedResponse = actions.moveToFrontResponse()
 
@@ -726,7 +726,7 @@ describe('api client', () => {
         })
     })
 
-    test('handles MOVE_TO_FRONT failure', () => {
+    it('handles MOVE_TO_FRONT failure', () => {
       const action = actions.moveToFront('left')
       const expectedResponse = actions.moveToFrontResponse(new Error('AH'))
 
@@ -737,7 +737,7 @@ describe('api client', () => {
         .then(() => expect(dispatch).toHaveBeenCalledWith(expectedResponse))
     })
 
-    test('handles PROBE_TIP success', () => {
+    it('handles PROBE_TIP success', () => {
       const action = actions.probeTip('right')
       const expectedResponse = actions.probeTipResponse()
 
@@ -753,7 +753,7 @@ describe('api client', () => {
         })
     })
 
-    test('handles PROBE_TIP failure', () => {
+    it('handles PROBE_TIP failure', () => {
       const action = actions.probeTip('right')
       const expectedResponse = actions.probeTipResponse(new Error('AH'))
 
@@ -764,7 +764,7 @@ describe('api client', () => {
         .then(() => expect(dispatch).toHaveBeenCalledWith(expectedResponse))
     })
 
-    test('handles MOVE_TO success', () => {
+    it('handles MOVE_TO success', () => {
       const action = actions.moveTo('left', '5')
       const expectedResponse = actions.moveToResponse()
 
@@ -781,7 +781,7 @@ describe('api client', () => {
         })
     })
 
-    test('handles MOVE_TO failure', () => {
+    it('handles MOVE_TO failure', () => {
       const action = actions.moveTo('left', '5')
       const expectedResponse = actions.moveToResponse(new Error('AH'))
 
@@ -792,7 +792,7 @@ describe('api client', () => {
         .then(() => expect(dispatch).toHaveBeenCalledWith(expectedResponse))
     })
 
-    test('handles PICKUP_AND_HOME success', () => {
+    it('handles PICKUP_AND_HOME success', () => {
       const action = actions.pickupAndHome('left', '5')
       const expectedResponse = actions.pickupAndHomeResponse()
 
@@ -811,7 +811,7 @@ describe('api client', () => {
         })
     })
 
-    test('handles PICKUP_AND_HOME failure update offset', () => {
+    it('handles PICKUP_AND_HOME failure update offset', () => {
       const action = actions.pickupAndHome('left', '5')
       const expectedResponse = actions.pickupAndHomeResponse(new Error('AH'))
 
@@ -824,7 +824,7 @@ describe('api client', () => {
         .then(() => expect(dispatch).toHaveBeenCalledWith(expectedResponse))
     })
 
-    test('handles PICKUP_AND_HOME failure during pickup', () => {
+    it('handles PICKUP_AND_HOME failure during pickup', () => {
       const action = actions.pickupAndHome('left', '5')
       const expectedResponse = actions.pickupAndHomeResponse(new Error('AH'))
 
@@ -836,7 +836,7 @@ describe('api client', () => {
         .then(() => expect(dispatch).toHaveBeenCalledWith(expectedResponse))
     })
 
-    test('handles DROP_TIP_AND_HOME success', () => {
+    it('handles DROP_TIP_AND_HOME success', () => {
       const action = actions.dropTipAndHome('right', '9')
       const expectedResponse = actions.dropTipAndHomeResponse()
 
@@ -862,7 +862,7 @@ describe('api client', () => {
         })
     })
 
-    test('handles DROP_TIP_AND_HOME failure in drop_tip', () => {
+    it('handles DROP_TIP_AND_HOME failure in drop_tip', () => {
       const action = actions.dropTipAndHome('right', '9')
       const expectedResponse = actions.dropTipAndHomeResponse(new Error('AH'))
 
@@ -873,7 +873,7 @@ describe('api client', () => {
         .then(() => expect(dispatch).toHaveBeenCalledWith(expectedResponse))
     })
 
-    test('handles DROP_TIP_AND_HOME failure in home', () => {
+    it('handles DROP_TIP_AND_HOME failure in home', () => {
       const action = actions.dropTipAndHome('right', '9')
       const expectedResponse = actions.dropTipAndHomeResponse(new Error('AH'))
 
@@ -885,7 +885,7 @@ describe('api client', () => {
         .then(() => expect(dispatch).toHaveBeenCalledWith(expectedResponse))
     })
 
-    test('handles DROP_TIP_AND_HOME failure in move_to', () => {
+    it('handles DROP_TIP_AND_HOME failure in move_to', () => {
       const action = actions.dropTipAndHome('right', '9')
       const expectedResponse = actions.dropTipAndHomeResponse(new Error('AH'))
 
@@ -898,7 +898,7 @@ describe('api client', () => {
         .then(() => expect(dispatch).toHaveBeenCalledWith(expectedResponse))
     })
 
-    test('CONFIRM_TIPRACK drops tip if not last tiprack', () => {
+    it('CONFIRM_TIPRACK drops tip if not last tiprack', () => {
       const action = actions.confirmTiprack('left', '9')
       const expectedResponse = actions.confirmTiprackResponse()
 
@@ -915,7 +915,7 @@ describe('api client', () => {
         })
     })
 
-    test('CONFIRM_TIPRACK noops and keeps tip if last tiprack', () => {
+    it('CONFIRM_TIPRACK noops and keeps tip if last tiprack', () => {
       state[NAME].calibration.confirmedBySlot[5] = true
 
       const action = actions.confirmTiprack('left', '9')
@@ -931,7 +931,7 @@ describe('api client', () => {
         })
     })
 
-    test('handles CONFIRM_TIPRACK drop tip failure', () => {
+    it('handles CONFIRM_TIPRACK drop tip failure', () => {
       const action = actions.confirmTiprack('left', '9')
       const expectedResponse = actions.confirmTiprackResponse(new Error('AH'))
 
@@ -942,7 +942,7 @@ describe('api client', () => {
         .then(() => expect(dispatch).toHaveBeenCalledWith(expectedResponse))
     })
 
-    test('handles JOG success', () => {
+    it('handles JOG success', () => {
       const action = actions.jog('left', 'y', -1, 10)
       const expectedResponse = actions.jogResponse()
 
@@ -960,7 +960,7 @@ describe('api client', () => {
         })
     })
 
-    test('handles JOG failure', () => {
+    it('handles JOG failure', () => {
       const action = actions.jog('left', 'x', 1, 10)
       const expectedResponse = actions.jogResponse(new Error('AH'))
 
@@ -971,7 +971,7 @@ describe('api client', () => {
         .then(() => expect(dispatch).toHaveBeenCalledWith(expectedResponse))
     })
 
-    test('handles UPDATE_OFFSET success', () => {
+    it('handles UPDATE_OFFSET success', () => {
       const action = actions.updateOffset('left', 1)
       const expectedResponse = actions.updateOffsetResponse(null, false)
 
@@ -987,7 +987,7 @@ describe('api client', () => {
         })
     })
 
-    test('handles UPDATE_OFFSET failure', () => {
+    it('handles UPDATE_OFFSET failure', () => {
       const action = actions.updateOffset('left', 9)
       const expectedResponse = actions.updateOffsetResponse(new Error('AH'))
 

--- a/app/src/robot/test/calibration-reducer.test.js
+++ b/app/src/robot/test/calibration-reducer.test.js
@@ -19,13 +19,13 @@ const EXPECTED_INITIAL_STATE = {
 }
 
 describe('robot reducer - calibration', () => {
-  test('initial state', () => {
+  it('initial state', () => {
     const state = reducer(undefined, {})
 
     expect(state.calibration).toEqual(EXPECTED_INITIAL_STATE)
   })
 
-  test('handles robot:REFRESH_SESSION', () => {
+  it('handles robot:REFRESH_SESSION', () => {
     const state = reducer(
       { calibration: {} },
       { type: 'robot:REFRESH_SESSION' }
@@ -34,7 +34,7 @@ describe('robot reducer - calibration', () => {
     expect(state.calibration).toEqual(EXPECTED_INITIAL_STATE)
   })
 
-  test('handles DISCONNECT_RESPONSE success', () => {
+  it('handles DISCONNECT_RESPONSE success', () => {
     const expected = reducer(undefined, {}).calibration
     const state = { calibration: { dummy: 'state' } }
     const action = { type: 'robot:DISCONNECT_RESPONSE', payload: {} }
@@ -42,7 +42,7 @@ describe('robot reducer - calibration', () => {
     expect(reducer(state, action).calibration).toEqual(expected)
   })
 
-  test('handles protocol:UPLOAD', () => {
+  it('handles protocol:UPLOAD', () => {
     const expected = reducer(undefined, {}).calibration
     const state = { calibration: { dummy: 'state' } }
     const action = {
@@ -53,7 +53,7 @@ describe('robot reducer - calibration', () => {
     expect(reducer(state, action).calibration).toEqual(expected)
   })
 
-  test('handles SET_MODULES_REVIEWED action', () => {
+  it('handles SET_MODULES_REVIEWED action', () => {
     const setToTrue = { type: 'robot:SET_MODULES_REVIEWED', payload: true }
     const setToFalse = { type: 'robot:SET_MODULES_REVIEWED', payload: false }
 
@@ -68,7 +68,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles SET_DECK_POPULATED action', () => {
+  it('handles SET_DECK_POPULATED action', () => {
     const setToTrue = { type: actionTypes.SET_DECK_POPULATED, payload: true }
     const setToFalse = { type: actionTypes.SET_DECK_POPULATED, payload: false }
 
@@ -83,7 +83,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles PICKUP_AND_HOME action', () => {
+  it('handles PICKUP_AND_HOME action', () => {
     const state = {
       calibration: {
         deckPopulated: false,
@@ -113,7 +113,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles PICKUP_AND_HOME response actions', () => {
+  it('handles PICKUP_AND_HOME response actions', () => {
     const state = {
       calibration: {
         calibrationRequest: {
@@ -161,7 +161,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles DROP_TIP_AND_HOME action', () => {
+  it('handles DROP_TIP_AND_HOME action', () => {
     const state = {
       calibration: {
         calibrationRequest: {
@@ -187,7 +187,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles DROP_TIP_AND_HOME response actions', () => {
+  it('handles DROP_TIP_AND_HOME response actions', () => {
     const state = {
       calibration: {
         calibrationRequest: {
@@ -235,7 +235,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles CONFIRM_TIPRACK action', () => {
+  it('handles CONFIRM_TIPRACK action', () => {
     const state = {
       calibration: {
         calibrationRequest: {
@@ -263,7 +263,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles CONFIRM_TIPRACK response actions', () => {
+  it('handles CONFIRM_TIPRACK response actions', () => {
     const state = {
       calibration: {
         calibrationRequest: {
@@ -314,7 +314,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles MOVE_TO_FRONT action', () => {
+  it('handles MOVE_TO_FRONT action', () => {
     const state = {
       calibration: {
         deckPopulated: true,
@@ -344,7 +344,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles MOVE_TO_FRONT_RESPONSE action', () => {
+  it('handles MOVE_TO_FRONT_RESPONSE action', () => {
     const state = {
       calibration: {
         calibrationRequest: {
@@ -382,7 +382,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles PROBE_TIP action', () => {
+  it('handles PROBE_TIP action', () => {
     const state = {
       calibration: {
         calibrationRequest: {
@@ -410,7 +410,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles PROBE_TIP_RESPONSE action', () => {
+  it('handles PROBE_TIP_RESPONSE action', () => {
     const state = {
       calibration: {
         calibrationRequest: {
@@ -448,7 +448,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles CONFIRM_PROBED', () => {
+  it('handles CONFIRM_PROBED', () => {
     const state = {
       calibration: {
         probedByMount: { left: false, right: true },
@@ -464,7 +464,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles MOVE_TO action', () => {
+  it('handles MOVE_TO action', () => {
     const state = {
       calibration: {
         deckPopulated: false,
@@ -494,7 +494,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles MOVE_TO response actions', () => {
+  it('handles MOVE_TO response actions', () => {
     const state = {
       calibration: {
         calibrationRequest: {
@@ -534,7 +534,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles JOG action', () => {
+  it('handles JOG action', () => {
     const state = {
       calibration: {
         calibrationRequest: {
@@ -556,7 +556,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles JOG response actions', () => {
+  it('handles JOG response actions', () => {
     const state = {
       calibration: {
         calibrationRequest: {
@@ -595,7 +595,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles UPDATE_OFFSET action', () => {
+  it('handles UPDATE_OFFSET action', () => {
     const state = {
       calibration: {
         calibrationRequest: {
@@ -621,7 +621,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles UPDATE_OFFSET response actions', () => {
+  it('handles UPDATE_OFFSET response actions', () => {
     const state = {
       calibration: {
         calibrationRequest: {
@@ -667,7 +667,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles CONFIRM_LABWARE action', () => {
+  it('handles CONFIRM_LABWARE action', () => {
     const state = {
       calibration: {
         confirmedBySlot: {},
@@ -683,7 +683,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles CLEAR_CALIBRATION_REQUEST and robot home actions', () => {
+  it('handles CLEAR_CALIBRATION_REQUEST and robot home actions', () => {
     const state = {
       calibration: {
         calibrationRequest: {
@@ -706,7 +706,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles RETURN_TIP action', () => {
+  it('handles RETURN_TIP action', () => {
     const state = {
       calibration: {
         calibrationRequest: {
@@ -731,7 +731,7 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles RETURN_TIP_RESPONSE action', () => {
+  it('handles RETURN_TIP_RESPONSE action', () => {
     const state = {
       calibration: {
         calibrationRequest: {

--- a/app/src/robot/test/connection-reducer.test.js
+++ b/app/src/robot/test/connection-reducer.test.js
@@ -4,7 +4,7 @@ import { robotReducer as reducer } from '../'
 const getState = state => state.connection
 
 describe('robot reducer - connection', () => {
-  test('initial state', () => {
+  it('initial state', () => {
     const state = reducer(undefined, {})
 
     expect(getState(state)).toEqual({
@@ -15,7 +15,7 @@ describe('robot reducer - connection', () => {
     })
   })
 
-  test('handles CONNECT action', () => {
+  it('handles CONNECT action', () => {
     const state = {
       connection: {
         connectedTo: null,
@@ -37,7 +37,7 @@ describe('robot reducer - connection', () => {
     })
   })
 
-  test('handles CONNECT_RESPONSE success', () => {
+  it('handles CONNECT_RESPONSE success', () => {
     const state = {
       connection: {
         connectedTo: null,
@@ -56,7 +56,7 @@ describe('robot reducer - connection', () => {
     })
   })
 
-  test('handles CONNECT_RESPONSE failure', () => {
+  it('handles CONNECT_RESPONSE failure', () => {
     const state = {
       connection: {
         connectedTo: null,
@@ -82,7 +82,7 @@ describe('robot reducer - connection', () => {
     })
   })
 
-  test('handles CLEAR_CONNECT_RESPONSE action', () => {
+  it('handles CLEAR_CONNECT_RESPONSE action', () => {
     const state = {
       connection: {
         connectedTo: null,
@@ -102,7 +102,7 @@ describe('robot reducer - connection', () => {
     })
   })
 
-  test('handles DISCONNECT action', () => {
+  it('handles DISCONNECT action', () => {
     const state = {
       connection: {
         connectedTo: 'ot',
@@ -121,7 +121,7 @@ describe('robot reducer - connection', () => {
     })
   })
 
-  test('handles DISCONNECT_RESPONSE', () => {
+  it('handles DISCONNECT_RESPONSE', () => {
     const state = {
       connection: {
         connectedTo: 'ot',

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -58,13 +58,13 @@ describe('robot selectors', () => {
       }
     })
 
-    test('getConnectedRobotName', () => {
+    it('getConnectedRobotName', () => {
       expect(getConnectedRobotName(state)).toEqual('bar')
       state = setIn(state, 'robot.connection.connectedTo', 'foo')
       expect(getConnectedRobotName(state)).toEqual('foo')
     })
 
-    test('getConnectionStatus', () => {
+    it('getConnectionStatus', () => {
       state = setIn(state, 'robot.connection', {
         connectedTo: '',
         connectRequest: { inProgress: false },
@@ -95,7 +95,7 @@ describe('robot selectors', () => {
     })
   })
 
-  test('getSessionCapabilities', () => {
+  it('getSessionCapabilities', () => {
     const state = makeState({
       session: { capabilities: ['create', 'create_from_bundle'] },
     })
@@ -105,7 +105,7 @@ describe('robot selectors', () => {
     ])
   })
 
-  test('getSessionLoadInProgress', () => {
+  it('getSessionLoadInProgress', () => {
     let state = makeState({ session: { sessionRequest: { inProgress: true } } })
     expect(getSessionLoadInProgress(state)).toBe(true)
 
@@ -113,7 +113,7 @@ describe('robot selectors', () => {
     expect(getSessionLoadInProgress(state)).toBe(false)
   })
 
-  test('getUploadError', () => {
+  it('getUploadError', () => {
     let state = makeState({ session: { sessionRequest: { error: null } } })
     expect(getUploadError(state)).toBe(null)
 
@@ -123,7 +123,7 @@ describe('robot selectors', () => {
     expect(getUploadError(state)).toEqual(new Error('AH'))
   })
 
-  test('getSessionIsLoaded', () => {
+  it('getSessionIsLoaded', () => {
     let state = makeState({ session: { state: constants.LOADED } })
     expect(getSessionIsLoaded(state)).toBe(true)
 
@@ -131,7 +131,7 @@ describe('robot selectors', () => {
     expect(getSessionIsLoaded(state)).toBe(false)
   })
 
-  test('getIsReadyToRun', () => {
+  it('getIsReadyToRun', () => {
     const expectedStates = {
       loaded: true,
       running: false,
@@ -149,7 +149,7 @@ describe('robot selectors', () => {
     })
   })
 
-  test('getIsRunning', () => {
+  it('getIsRunning', () => {
     const expectedStates = {
       loaded: false,
       running: true,
@@ -166,7 +166,7 @@ describe('robot selectors', () => {
     })
   })
 
-  test('getIsPaused', () => {
+  it('getIsPaused', () => {
     const expectedStates = {
       loaded: false,
       running: false,
@@ -183,7 +183,7 @@ describe('robot selectors', () => {
     })
   })
 
-  test('getIsDone', () => {
+  it('getIsDone', () => {
     const expectedStates = {
       loaded: false,
       running: false,
@@ -200,21 +200,21 @@ describe('robot selectors', () => {
     })
   })
 
-  test('getStartTime with no start time returns null', () => {
+  it('getStartTime with no start time returns null', () => {
     const state = makeState({
       session: { startTime: null },
     })
     expect(getStartTime(state)).toBe(null)
   })
 
-  test('getStartTime returns local formatted time', () => {
+  it('getStartTime returns local formatted time', () => {
     const state = makeState({
       session: { startTime: 1582926000, remoteTimeCompensation: -6000 },
     })
     expect(getStartTime(state)).toBe(format(1582920000, 'pp'))
   })
 
-  test('getRunTime with no startTime', () => {
+  it('getRunTime with no startTime', () => {
     const state = {
       [NAME]: {
         session: {
@@ -227,7 +227,7 @@ describe('robot selectors', () => {
     expect(getRunTime(state)).toEqual('00:00:00')
   })
 
-  test('getRunTime with no remoteTimeCompensation', () => {
+  it('getRunTime with no remoteTimeCompensation', () => {
     const state = {
       [NAME]: {
         session: {
@@ -241,7 +241,7 @@ describe('robot selectors', () => {
     expect(getRunTime(state)).toEqual('00:00:00')
   })
 
-  test('getRunTime', () => {
+  it('getRunTime', () => {
     const testGetRunTime = (seconds, expected) => {
       const stateWithRunTime = {
         [NAME]: {
@@ -305,12 +305,12 @@ describe('robot selectors', () => {
       },
     })
 
-    test('getRunProgress', () => {
+    it('getRunProgress', () => {
       // leaves: 2, 3, 4; processed: 2
       expect(getRunProgress(state)).toEqual((1 / 3) * 100)
     })
 
-    test('getRunProgress with no commands', () => {
+    it('getRunProgress with no commands', () => {
       const state = makeState({
         session: { protocolCommands: [], protocolCommandsById: {} },
       })
@@ -318,7 +318,7 @@ describe('robot selectors', () => {
       expect(getRunProgress(state)).toEqual(0)
     })
 
-    test('getCommands', () => {
+    it('getCommands', () => {
       expect(getCommands(state)).toEqual([
         {
           id: 0,
@@ -389,7 +389,7 @@ describe('robot selectors', () => {
     })
 
     // TODO(mc: 2018-01-10): rethink the instrument level "calibration" prop
-    test('get pipettes', () => {
+    it('get pipettes', () => {
       expect(getPipettes(state)).toEqual([
         {
           mount: 'left',
@@ -415,7 +415,7 @@ describe('robot selectors', () => {
     })
   })
 
-  test('get calibrator mount', () => {
+  it('get calibrator mount', () => {
     const leftState = makeState({
       session: {
         pipettesByMount: {
@@ -448,7 +448,7 @@ describe('robot selectors', () => {
     expect(getCalibratorMount(rightState)).toBe('right')
   })
 
-  test('get instruments are calibrated', () => {
+  it('get instruments are calibrated', () => {
     const twoPipettesCalibrated = makeState({
       session: {
         pipettesByMount: {
@@ -512,7 +512,7 @@ describe('robot selectors', () => {
       })
     })
 
-    test('get modules by slot', () => {
+    it('get modules by slot', () => {
       expect(getModulesBySlot(state)).toEqual({
         1: {
           _id: 1,
@@ -522,7 +522,7 @@ describe('robot selectors', () => {
       })
     })
 
-    test('get modules', () => {
+    it('get modules', () => {
       expect(getModules(state)).toEqual([
         {
           _id: 1,
@@ -589,7 +589,7 @@ describe('robot selectors', () => {
       })
     })
 
-    test('get labware', () => {
+    it('get labware', () => {
       expect(getLabware(state)).toEqual([
         // multi channel tiprack should be first
         {
@@ -646,7 +646,7 @@ describe('robot selectors', () => {
       ])
     })
 
-    test('get unconfirmed tipracks', () => {
+    it('get unconfirmed tipracks', () => {
       expect(getUnconfirmedTipracks(state)).toEqual([
         {
           slot: '2',
@@ -671,7 +671,7 @@ describe('robot selectors', () => {
       ])
     })
 
-    test('get unconfirmed labware', () => {
+    it('get unconfirmed labware', () => {
       expect(getUnconfirmedLabware(state)).toEqual([
         {
           slot: '2',
@@ -705,7 +705,7 @@ describe('robot selectors', () => {
       ])
     })
 
-    test('get next labware', () => {
+    it('get next labware', () => {
       expect(getNextLabware(state)).toEqual({
         slot: '2',
         type: 'm',
@@ -742,7 +742,7 @@ describe('robot selectors', () => {
       })
     })
 
-    test('getTipracksByMount', () => {
+    it('getTipracksByMount', () => {
       expect(getTipracksByMount(state)).toEqual({
         left: {
           slot: '2',
@@ -768,7 +768,7 @@ describe('robot selectors', () => {
     })
   })
 
-  test('getDeckPopulated', () => {
+  it('getDeckPopulated', () => {
     let state = makeState({ calibration: { deckPopulated: null } })
     expect(getDeckPopulated(state)).toEqual(null)
     state = makeState({ calibration: { deckPopulated: false } })

--- a/app/src/robot/test/session-reducer.test.js
+++ b/app/src/robot/test/session-reducer.test.js
@@ -9,7 +9,7 @@ describe('robot reducer - session', () => {
   beforeAll(() => (Date.now = () => now))
   afterAll(() => (Date.now = _nowFn))
 
-  test('initial state', () => {
+  it('initial state', () => {
     const state = reducer(undefined, {})
 
     expect(state.session).toEqual({
@@ -38,7 +38,7 @@ describe('robot reducer - session', () => {
     })
   })
 
-  test('handles CONNECT_RESPONSE success', () => {
+  it('handles CONNECT_RESPONSE success', () => {
     const expected = { capabilities: ['create'] }
     const state = { session: { capabilities: [] } }
     const action = {
@@ -49,7 +49,7 @@ describe('robot reducer - session', () => {
     expect(reducer(state, action).session).toEqual(expected)
   })
 
-  test('handles CONNECT_RESPONSE failure', () => {
+  it('handles CONNECT_RESPONSE failure', () => {
     const expected = { capabilities: ['create'] }
     const state = { session: { capabilities: ['create'] } }
     const action = {
@@ -60,7 +60,7 @@ describe('robot reducer - session', () => {
     expect(reducer(state, action).session).toEqual(expected)
   })
 
-  test('handles DISCONNECT_RESPONSE success', () => {
+  it('handles DISCONNECT_RESPONSE success', () => {
     const expected = reducer(undefined, {}).session
     const state = { session: { dummy: 'state' } }
     const action = { type: 'robot:DISCONNECT_RESPONSE', payload: {} }
@@ -68,7 +68,7 @@ describe('robot reducer - session', () => {
     expect(reducer(state, action).session).toEqual(expected)
   })
 
-  test('handles protocol:UPLOAD action', () => {
+  it('handles protocol:UPLOAD action', () => {
     const initialState = reducer(undefined, {}).session
     const state = {
       session: {
@@ -90,7 +90,7 @@ describe('robot reducer - session', () => {
     })
   })
 
-  test('handles robot:REFRESH_SESSION action', () => {
+  it('handles robot:REFRESH_SESSION action', () => {
     const state = {
       session: {
         sessionRequest: { inProgress: false, error: null },
@@ -108,7 +108,7 @@ describe('robot reducer - session', () => {
     })
   })
 
-  test('handles SESSION_RESPONSE', () => {
+  it('handles SESSION_RESPONSE', () => {
     const state = {
       session: {
         sessionRequest: { inProgress: true, error: null },
@@ -135,7 +135,7 @@ describe('robot reducer - session', () => {
     })
   })
 
-  test('handles SESSION_ERROR', () => {
+  it('handles SESSION_ERROR', () => {
     const state = {
       session: {
         sessionRequest: { inProgress: true, error: null },
@@ -151,7 +151,7 @@ describe('robot reducer - session', () => {
     })
   })
 
-  test('handles SESSION_UPDATE action', () => {
+  it('handles SESSION_UPDATE action', () => {
     const state = {
       session: {
         state: 'loaded',
@@ -187,7 +187,7 @@ describe('robot reducer - session', () => {
     })
   })
 
-  test('handles RUN action', () => {
+  it('handles RUN action', () => {
     const state = {
       session: {
         runTime: now,
@@ -202,7 +202,7 @@ describe('robot reducer - session', () => {
     })
   })
 
-  test('handles RUN_RESPONSE success', () => {
+  it('handles RUN_RESPONSE success', () => {
     const state = { session: { runRequest: { inProgress: true, error: null } } }
     const action = { type: actionTypes.RUN_RESPONSE, error: false }
 
@@ -211,7 +211,7 @@ describe('robot reducer - session', () => {
     })
   })
 
-  test('handles RUN_RESPONSE failure', () => {
+  it('handles RUN_RESPONSE failure', () => {
     const state = { session: { runRequest: { inProgress: true, error: null } } }
     const action = {
       type: actionTypes.RUN_RESPONSE,
@@ -224,14 +224,14 @@ describe('robot reducer - session', () => {
     })
   })
 
-  test('handles TICK_RUN_TIME', () => {
+  it('handles TICK_RUN_TIME', () => {
     const state = { session: { runTime: 0 } }
     const action = { type: actionTypes.TICK_RUN_TIME }
 
     expect(reducer(state, action).session).toEqual({ runTime: now })
   })
 
-  test('handles PAUSE action', () => {
+  it('handles PAUSE action', () => {
     const state = {
       session: {
         pauseRequest: { inProgress: false, error: new Error('AH') },
@@ -244,7 +244,7 @@ describe('robot reducer - session', () => {
     })
   })
 
-  test('handles PAUSE_RESPONSE success', () => {
+  it('handles PAUSE_RESPONSE success', () => {
     const state = {
       session: { pauseRequest: { inProgress: true, error: null } },
     }
@@ -255,7 +255,7 @@ describe('robot reducer - session', () => {
     })
   })
 
-  test('handles PAUSE_RESPONSE failure', () => {
+  it('handles PAUSE_RESPONSE failure', () => {
     const state = {
       session: { pauseRequest: { inProgress: true, error: null } },
     }
@@ -270,7 +270,7 @@ describe('robot reducer - session', () => {
     })
   })
 
-  test('handles RESUME action', () => {
+  it('handles RESUME action', () => {
     const state = {
       session: {
         resumeRequest: { inProgress: false, error: new Error('AH') },
@@ -283,7 +283,7 @@ describe('robot reducer - session', () => {
     })
   })
 
-  test('handles RESUME_RESPONSE success', () => {
+  it('handles RESUME_RESPONSE success', () => {
     const state = {
       session: { resumeRequest: { inProgress: true, error: null } },
     }
@@ -294,7 +294,7 @@ describe('robot reducer - session', () => {
     })
   })
 
-  test('handles RESUME_RESPONSE failure', () => {
+  it('handles RESUME_RESPONSE failure', () => {
     const state = {
       session: { resumeRequest: { inProgress: true, error: null } },
     }
@@ -309,7 +309,7 @@ describe('robot reducer - session', () => {
     })
   })
 
-  test('handles CANCEL action', () => {
+  it('handles CANCEL action', () => {
     const state = {
       session: {
         cancelRequest: { inProgress: false, error: new Error('AH') },
@@ -322,7 +322,7 @@ describe('robot reducer - session', () => {
     })
   })
 
-  test('handles CANCEL_RESPONSE success', () => {
+  it('handles CANCEL_RESPONSE success', () => {
     const state = {
       session: { cancelRequest: { inProgress: true, error: null } },
     }
@@ -333,7 +333,7 @@ describe('robot reducer - session', () => {
     })
   })
 
-  test('handles CANCEL_RESPONSE failure', () => {
+  it('handles CANCEL_RESPONSE failure', () => {
     const state = {
       session: { cancelRequest: { inProgress: true, error: null } },
     }

--- a/app/src/rpc/test/client.test.js
+++ b/app/src/rpc/test/client.test.js
@@ -125,7 +125,7 @@ describe('rpc client', () => {
     RemoteObject.mockReturnValueOnce(Promise.resolve(MOCK_REMOTE))
   }
 
-  test('rejects if control message never comes', () => {
+  it('rejects if control message never comes', () => {
     jest.useFakeTimers()
 
     const result = Client(url)
@@ -138,7 +138,7 @@ describe('rpc client', () => {
     })
   })
 
-  test('connects to ws server and resolves when control is received', () => {
+  it('connects to ws server and resolves when control is received', () => {
     sendControlAndResolveRemote()
 
     return Client(url).then(client => {
@@ -152,7 +152,7 @@ describe('rpc client', () => {
     const name = 'method_name'
     const args = [1, 2, 3]
 
-    test('calls remote methods and wraps result in RemoteObject', () => {
+    it('calls remote methods and wraps result in RemoteObject', () => {
       const mockRemote = { i: 42, t: 43, v: {} }
       const mockResult = { foo: 'bar' }
       const expectedMessage = {
@@ -187,7 +187,7 @@ describe('rpc client', () => {
         })
     })
 
-    test('rejects if call nacks', () => {
+    it('rejects if call nacks', () => {
       sendControlAndResolveRemote(message => {
         const token = message.$.token
         setTimeout(() => ws.send(makeNackResponse(token, 'You done messed up')))
@@ -200,7 +200,7 @@ describe('rpc client', () => {
       })
     })
 
-    test('rejects if client errors during call', () => {
+    it('rejects if client errors during call', () => {
       sendControlAndResolveRemote(message => {
         const token = message.$.token
         const nack = makeNackResponse(token, 'You done messed up')
@@ -218,7 +218,7 @@ describe('rpc client', () => {
       })
     })
 
-    test('rejects if call is unsuccessful (string response)', () => {
+    it('rejects if call is unsuccessful (string response)', () => {
       sendControlAndResolveRemote(message => {
         const token = message.$.token
         const ack = makeAckResponse(token)
@@ -234,7 +234,7 @@ describe('rpc client', () => {
       })
     })
 
-    test('rejects if call is unsuccessful (object response)', () => {
+    it('rejects if call is unsuccessful (object response)', () => {
       sendControlAndResolveRemote(message => {
         const token = message.$.token
         const ack = makeAckResponse(token)
@@ -252,7 +252,7 @@ describe('rpc client', () => {
   })
 
   describe('resolveTypeValues', () => {
-    test('resolves cached type objects', () => {
+    it('resolves cached type objects', () => {
       sendControlAndResolveRemote()
 
       return Client(url)
@@ -260,7 +260,7 @@ describe('rpc client', () => {
         .then(values => expect(values).toEqual(REMOTE_TYPE.v))
     })
 
-    test('resolves empty object for type types', () => {
+    it('resolves empty object for type types', () => {
       sendControlAndResolveRemote()
 
       return Client(url)
@@ -268,7 +268,7 @@ describe('rpc client', () => {
         .then(values => expect(values).toEqual({}))
     })
 
-    test('calls get object by id for unknown type objects', () => {
+    it('calls get object by id for unknown type objects', () => {
       const instance = { i: 42, t: 101, v: { bar: 'baz' } }
       const type = { i: 101, t: 3, v: { baz: {} } }
       const expectedMessage = {
@@ -302,7 +302,7 @@ describe('rpc client', () => {
         })
     })
 
-    test('will not ask for a type object more than once', () => {
+    it('will not ask for a type object more than once', () => {
       const instance = { i: 42, t: 101, v: { bar: 'baz' } }
       const type = { i: 101, t: 3, v: { baz: {} } }
       let remoteCalls = 0
@@ -327,7 +327,7 @@ describe('rpc client', () => {
     })
   })
 
-  test('emits notification data wrapped in RemoteObjects', () => {
+  it('emits notification data wrapped in RemoteObjects', () => {
     const INSTANCE = { i: 32, t: 30, v: { foo: 'bar', baz: 'qux' } }
     const notification = { $: { type: NOTIFICATION }, data: INSTANCE }
     const mockRemote = { foo: 'bar', baz: 'qux' }
@@ -350,7 +350,7 @@ describe('rpc client', () => {
     })
   })
 
-  test('closes the socket', () => {
+  it('closes the socket', () => {
     sendControlAndResolveRemote()
 
     return Client(url)

--- a/app/src/rpc/test/remote-object.test.js
+++ b/app/src/rpc/test/remote-object.test.js
@@ -11,30 +11,30 @@ describe('rpc remote object factory', () => {
     }
   })
 
-  test('deserializes an int', () => {
+  it('deserializes an int', () => {
     return expect(RemoteObject(context, 42)).resolves.toBe(42)
   })
 
-  test('deserializes a string', () => {
+  it('deserializes a string', () => {
     return expect(RemoteObject(context, 'foo')).resolves.toBe('foo')
   })
 
-  test('deserializes a bool', () => {
+  it('deserializes a bool', () => {
     return expect(RemoteObject(context, true)).resolves.toBe(true)
   })
 
-  test('deserializes null', () => {
+  it('deserializes null', () => {
     return expect(RemoteObject(context, null)).resolves.toBe(null)
   })
 
-  test('deserializes an array of primitives', () => {
+  it('deserializes an array of primitives', () => {
     const source = [42, 'foo', true, null]
     const remote = RemoteObject(context, source)
 
     return expect(remote).resolves.toEqual([42, 'foo', true, null])
   })
 
-  test('deserializes an object with primitive props', () => {
+  it('deserializes an object with primitive props', () => {
     const source = { i: 1, t: 2, v: { foo: 'bar' } }
 
     context.resolveTypeValues.mockReturnValueOnce(Promise.resolve({}))
@@ -44,7 +44,7 @@ describe('rpc remote object factory', () => {
     )
   })
 
-  test('deserializes an object with remote methods from type', () => {
+  it('deserializes an object with remote methods from type', () => {
     const source = { i: 1, t: 2, v: { foo: 'bar' } }
     const typeValues = { baz: {} }
 
@@ -67,7 +67,7 @@ describe('rpc remote object factory', () => {
       })
   })
 
-  test('deserializes an object without methods if methods: false', () => {
+  it('deserializes an object without methods if methods: false', () => {
     const source = { i: 1, t: 2, v: { foo: 'bar' } }
 
     return RemoteObject(context, source, { methods: false }).then(remote => {
@@ -76,7 +76,7 @@ describe('rpc remote object factory', () => {
     })
   })
 
-  test('deserializes object props as remote objects', () => {
+  it('deserializes object props as remote objects', () => {
     const child = { i: 2, t: 100, v: { baz: 'qux' } }
     const source = { i: 1, t: 100, v: { foo: 'bar', bar: child } }
 
@@ -93,7 +93,7 @@ describe('rpc remote object factory', () => {
     })
   })
 
-  test('desrializes array of objects as remote', () => {
+  it('desrializes array of objects as remote', () => {
     const child1 = { i: 3, t: 100, v: { baz: 'qux' } }
     const child2 = { i: 2, t: 100, v: { fizz: 'buzz' } }
     const source = {
@@ -116,7 +116,7 @@ describe('rpc remote object factory', () => {
     })
   })
 
-  test('deserializes remote object with deep matching refs', () => {
+  it('deserializes remote object with deep matching refs', () => {
     const child = { i: 31, t: 30, v: { foo: 'foo' } }
     const childDup = { i: 31, t: 30, v: null }
     const parent1 = { i: 32, t: 30, v: { c: childDup } }
@@ -136,7 +136,7 @@ describe('rpc remote object factory', () => {
     })
   })
 
-  test('remote method object arg with _id,', () => {
+  it('remote method object arg with _id,', () => {
     const source = { i: 1, t: 2, v: {} }
     const typeValues = { method: {} }
 

--- a/app/src/shell/__tests__/epics.test.js
+++ b/app/src/shell/__tests__/epics.test.js
@@ -21,7 +21,7 @@ describe('shell epics', () => {
     jest.resetAllMocks()
   })
 
-  test('sendActionToShellEpic "dispatches" actions to IPC if meta.shell', () => {
+  it('sendActionToShellEpic "dispatches" actions to IPC if meta.shell', () => {
     const shellAction = { type: 'foo', meta: { shell: true } }
 
     testScheduler.run(({ hot, expectObservable }) => {
@@ -38,7 +38,7 @@ describe('shell epics', () => {
 
   // due to the use of `fromEvent`, this test doesn't work well as a marble
   // test. `toPromise` based expectation should be sufficient
-  test('catches actions from main', () => {
+  it('catches actions from main', () => {
     const shellAction = { type: 'bar' }
     const result = shellEpic(EMPTY)
       .pipe(take(1))

--- a/app/src/shell/__tests__/update.test.js
+++ b/app/src/shell/__tests__/update.test.js
@@ -34,7 +34,7 @@ describe('shell/update', () => {
 
     SPECS.forEach(spec => {
       const { name, creator, args, expected } = spec
-      test(name, () => expect(creator(...args)).toEqual(expected))
+      it(name, () => expect(creator(...args)).toEqual(expected))
     })
   })
 
@@ -110,7 +110,7 @@ describe('shell/update', () => {
 
     SPECS.forEach(spec => {
       const { name, action, initialState, expected } = spec
-      test(name, () =>
+      it(name, () =>
         expect(shellUpdateReducer(initialState, action)).toEqual(expected)
       )
     })
@@ -138,7 +138,7 @@ describe('shell/update', () => {
 
     SPECS.forEach(spec => {
       const { name, selector, state, expected } = spec
-      test(name, () => expect(selector(state)).toEqual(expected))
+      it(name, () => expect(selector(state)).toEqual(expected))
     })
   })
 })

--- a/components/src/__tests__/alerts.test.js
+++ b/components/src/__tests__/alerts.test.js
@@ -7,7 +7,7 @@ import { AlertItem } from '..'
 describe('alerts', () => {
   const onCloseClick = () => {}
 
-  test('creates an alert with close button', () => {
+  it('creates an alert with close button', () => {
     const onCloseClick = jest.fn()
     const button = Renderer.create(
       <AlertItem
@@ -22,7 +22,7 @@ describe('alerts', () => {
     expect(onCloseClick).toHaveBeenCalled()
   })
 
-  test('success alert renders correctly', () => {
+  it('success alert renders correctly', () => {
     const tree = Renderer.create(
       <AlertItem type={'success'} title={'good job!'} />
     ).toJSON()
@@ -30,7 +30,7 @@ describe('alerts', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('warning alert renders correctly', () => {
+  it('warning alert renders correctly', () => {
     const tree = Renderer.create(
       <AlertItem type={'warning'} title={'warning'} />
     ).toJSON()
@@ -38,7 +38,7 @@ describe('alerts', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('warning alert onCloseClick renders correctly', () => {
+  it('warning alert onCloseClick renders correctly', () => {
     const tree = Renderer.create(
       <AlertItem
         type={'warning'}
@@ -50,7 +50,7 @@ describe('alerts', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('warning alert with message body renders correctly', () => {
+  it('warning alert with message body renders correctly', () => {
     const tree = Renderer.create(
       <AlertItem type={'warning'} title={'warning'} onCloseClick={onCloseClick}>
         <h3>Title</h3>

--- a/components/src/__tests__/buttons.test.js
+++ b/components/src/__tests__/buttons.test.js
@@ -13,7 +13,7 @@ import {
 describe('buttons', () => {
   const onClick = () => {}
 
-  test('creates a button with props', () => {
+  it('creates a button with props', () => {
     const onClick = jest.fn()
     const button = Renderer.create(
       <Button
@@ -33,7 +33,7 @@ describe('buttons', () => {
     expect(onClick).toHaveBeenCalled()
   })
 
-  test('disabled sets onClick to undefined', () => {
+  it('disabled sets onClick to undefined', () => {
     const onClick = () => {}
     const button = Renderer.create(
       <Button onClick={onClick} disabled />
@@ -43,7 +43,7 @@ describe('buttons', () => {
     expect(button.props.onClick).toBe(undefined)
   })
 
-  test('Button renders correctly', () => {
+  it('Button renders correctly', () => {
     const tree = Renderer.create(
       <Button onClick={onClick} title="t" className="c">
         children
@@ -53,7 +53,7 @@ describe('buttons', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('Button with iconName renders correctly', () => {
+  it('Button with iconName renders correctly', () => {
     const tree = Renderer.create(
       <Button
         onClick={onClick}
@@ -68,7 +68,7 @@ describe('buttons', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('PrimaryButton renders correctly', () => {
+  it('PrimaryButton renders correctly', () => {
     const tree = Renderer.create(
       <PrimaryButton onClick={onClick} title="t" className="c">
         children
@@ -78,7 +78,7 @@ describe('buttons', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('PrimaryButton with iconName renders correctly', () => {
+  it('PrimaryButton with iconName renders correctly', () => {
     const tree = Renderer.create(
       <PrimaryButton
         onClick={onClick}
@@ -93,7 +93,7 @@ describe('buttons', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('FlatButton renders correctly', () => {
+  it('FlatButton renders correctly', () => {
     const tree = Renderer.create(
       <FlatButton onClick={onClick} title="t" className="c">
         children
@@ -103,7 +103,7 @@ describe('buttons', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('FlatButton with iconName renders correctly', () => {
+  it('FlatButton with iconName renders correctly', () => {
     const tree = Renderer.create(
       <FlatButton
         onClick={onClick}
@@ -118,7 +118,7 @@ describe('buttons', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('OutlineButton renders correctly', () => {
+  it('OutlineButton renders correctly', () => {
     const tree = Renderer.create(
       <OutlineButton onClick={onClick} title="t" className="c">
         children
@@ -128,7 +128,7 @@ describe('buttons', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('Inverted OutlineButton renders correctly', () => {
+  it('Inverted OutlineButton renders correctly', () => {
     const tree = Renderer.create(
       <OutlineButton onClick={onClick} title="t" className="c" inverted>
         children
@@ -138,7 +138,7 @@ describe('buttons', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('OutlineButton with iconName renders correctly', () => {
+  it('OutlineButton with iconName renders correctly', () => {
     const tree = Renderer.create(
       <OutlineButton
         onClick={onClick}
@@ -153,7 +153,7 @@ describe('buttons', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('IconButton renders correctly', () => {
+  it('IconButton renders correctly', () => {
     const tree = Renderer.create(
       <IconButton
         onClick={onClick}

--- a/components/src/__tests__/forms.test.js
+++ b/components/src/__tests__/forms.test.js
@@ -11,7 +11,7 @@ import {
 } from '..'
 
 describe('CheckboxField', () => {
-  test('renders correctly when unchecked', () => {
+  it('renders correctly when unchecked', () => {
     const tree = Renderer.create(
       <CheckboxField label="Check Box 1" className="foo" />
     ).toJSON()
@@ -19,7 +19,7 @@ describe('CheckboxField', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('renders correctly when checked', () => {
+  it('renders correctly when checked', () => {
     const tree = Renderer.create(
       <CheckboxField label="Check Box 1" className="foo" value />
     ).toJSON()
@@ -29,7 +29,7 @@ describe('CheckboxField', () => {
 })
 
 describe('DropdownField', () => {
-  test('renders correctly with a value', () => {
+  it('renders correctly with a value', () => {
     const tree = Renderer.create(
       <DropdownField
         className="foo"
@@ -45,7 +45,7 @@ describe('DropdownField', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('renders correctly with a falsey value', () => {
+  it('renders correctly with a falsey value', () => {
     const tree = Renderer.create(
       <DropdownField
         className="foo"
@@ -63,7 +63,7 @@ describe('DropdownField', () => {
 })
 
 describe('FormGroup', () => {
-  test('renders correctly', () => {
+  it('renders correctly', () => {
     const tree = Renderer.create(
       <FormGroup className="foo" label="This is the label">
         <div>Hey test here</div>
@@ -76,7 +76,7 @@ describe('FormGroup', () => {
 })
 
 describe('InputField', () => {
-  test('renders correctly', () => {
+  it('renders correctly', () => {
     const tree = Renderer.create(
       <InputField
         label="Input field"
@@ -91,7 +91,7 @@ describe('InputField', () => {
 })
 
 describe('RadioGroup', () => {
-  test('renders correctly with no checked value', () => {
+  it('renders correctly with no checked value', () => {
     const tree = Renderer.create(
       <RadioGroup
         options={[
@@ -105,7 +105,7 @@ describe('RadioGroup', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('renders correctly with checked value', () => {
+  it('renders correctly with checked value', () => {
     const tree = Renderer.create(
       <RadioGroup
         value="chocolate"
@@ -120,7 +120,7 @@ describe('RadioGroup', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('renders correctly inline', () => {
+  it('renders correctly inline', () => {
     const tree = Renderer.create(
       <RadioGroup
         value={'chocolate'}

--- a/components/src/__tests__/icons.test.js
+++ b/components/src/__tests__/icons.test.js
@@ -10,7 +10,7 @@ const icons = Object.keys(ICON_DATA_BY_NAME)
 
 describe('icons', () => {
   icons.forEach(icon =>
-    test(`${icon} renders correctly`, () => {
+    it(`${icon} renders correctly`, () => {
       const tree = Renderer.create(
         <Icon name={`${icon}`} className="foo" />
       ).toJSON()
@@ -21,7 +21,7 @@ describe('icons', () => {
 })
 
 describe('Notification Icon', () => {
-  test('NotificationIcon renders correctly', () => {
+  it('NotificationIcon renders correctly', () => {
     const tree = Renderer.create(
       <NotificationIcon
         name="flask-outline"

--- a/components/src/__tests__/instrument-diagram.test.js
+++ b/components/src/__tests__/instrument-diagram.test.js
@@ -4,7 +4,7 @@ import Renderer from 'react-test-renderer'
 import { InstrumentDiagram, InstrumentGroup } from '..'
 
 describe('InstrumentDiagram', () => {
-  test('Single-channel renders correctly', () => {
+  it('Single-channel renders correctly', () => {
     const tree = Renderer.create(
       <InstrumentDiagram channels={1} displayCategory="GEN1" />
     ).toJSON()
@@ -12,7 +12,7 @@ describe('InstrumentDiagram', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('Multi-channel renders correctly', () => {
+  it('Multi-channel renders correctly', () => {
     const tree = Renderer.create(
       <InstrumentDiagram channels={8} displayCategory="GEN1" />
     ).toJSON()
@@ -20,7 +20,7 @@ describe('InstrumentDiagram', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('Single-channel GEN2 renders correctly', () => {
+  it('Single-channel GEN2 renders correctly', () => {
     const tree = Renderer.create(
       <InstrumentDiagram channels={1} displayCategory="GEN2" />
     ).toJSON()
@@ -28,7 +28,7 @@ describe('InstrumentDiagram', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('Multi-channel GEN2 renders correctly', () => {
+  it('Multi-channel GEN2 renders correctly', () => {
     const tree = Renderer.create(
       <InstrumentDiagram channels={8} displayCategory="GEN2" />
     ).toJSON()
@@ -38,7 +38,7 @@ describe('InstrumentDiagram', () => {
 })
 
 describe('InstrumentGroup', () => {
-  test('Renders correctly', () => {
+  it('Renders correctly', () => {
     const tree = Renderer.create(
       <InstrumentGroup
         left={{

--- a/components/src/__tests__/lists.test.js
+++ b/components/src/__tests__/lists.test.js
@@ -6,7 +6,7 @@ import Renderer from 'react-test-renderer'
 import { SidePanelGroup, TitledList, ListItem, ListAlert } from '..'
 
 describe('TitledList', () => {
-  test('adds an h3 with the title', () => {
+  it('adds an h3 with the title', () => {
     const heading = Renderer.create(
       <TitledList title="hello" />
     ).root.findByType('h3')
@@ -15,7 +15,7 @@ describe('TitledList', () => {
     expect(heading.children).toEqual(['hello'])
   })
 
-  test('adds an optional svg icon to title', () => {
+  it('adds an optional svg icon to title', () => {
     const icon = Renderer.create(
       <TitledList title="hello" iconName="flask-outline" />
     ).root.findByType('svg')
@@ -23,13 +23,13 @@ describe('TitledList', () => {
     expect(icon).toBeDefined()
   })
 
-  test('renders TitledList without icon correctly', () => {
+  it('renders TitledList without icon correctly', () => {
     const tree = Renderer.create(<TitledList title="foo" />).toJSON()
 
     expect(tree).toMatchSnapshot()
   })
 
-  test('renders TitledList with children correctly', () => {
+  it('renders TitledList with children correctly', () => {
     const tree = Renderer.create(
       <TitledList title="foo">
         <li>Woop</li>
@@ -39,7 +39,7 @@ describe('TitledList', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('renders TitledList with onMouseEnter & onMouseLeave correctly', () => {
+  it('renders TitledList with onMouseEnter & onMouseLeave correctly', () => {
     const noop = () => {}
 
     const tree = Renderer.create(
@@ -49,7 +49,7 @@ describe('TitledList', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('renders TitledList with optional icon correctly', () => {
+  it('renders TitledList with optional icon correctly', () => {
     const tree = Renderer.create(
       <TitledList title="foo" icon="flask-outline" />
     ).toJSON()
@@ -57,7 +57,7 @@ describe('TitledList', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('renders expanded TitledList correctly', () => {
+  it('renders expanded TitledList correctly', () => {
     const tree = Renderer.create(
       <TitledList
         onCollapseToggle={e => {}}
@@ -71,7 +71,7 @@ describe('TitledList', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('renders collapsed TitledList correctly', () => {
+  it('renders collapsed TitledList correctly', () => {
     const tree = Renderer.create(
       <TitledList
         onCollapseToggle={e => {}}
@@ -88,7 +88,7 @@ describe('TitledList', () => {
 })
 
 describe('ListItem', () => {
-  test('creates a linked list item from props', () => {
+  it('creates a linked list item from props', () => {
     const linkItemProps = {
       url: '/foo/bar',
       isDisabled: false,
@@ -105,7 +105,7 @@ describe('ListItem', () => {
     expect(link.props.disabled).toBe(false)
   })
 
-  test('adds an optional svg icon as child', () => {
+  it('adds an optional svg icon as child', () => {
     const icon = Renderer.create(
       <ListItem iconName="check-circle" />
     ).root.findByType('svg')
@@ -113,7 +113,7 @@ describe('ListItem', () => {
     expect(icon).toBeDefined()
   })
 
-  test('renders ListItem with icon correctly', () => {
+  it('renders ListItem with icon correctly', () => {
     const tree = Renderer.create(
       <ListItem to="/hello" iconName="check-circle" isDisabled="false" />
     ).toJSON()
@@ -121,7 +121,7 @@ describe('ListItem', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('renders ListItem without icon correctly', () => {
+  it('renders ListItem without icon correctly', () => {
     const tree = Renderer.create(
       <ListItem to="/hello" isDisabled="false" />
     ).toJSON()
@@ -129,7 +129,7 @@ describe('ListItem', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('Side Panel Group renders correctly', () => {
+  it('Side Panel Group renders correctly', () => {
     const tree = Renderer.create(
       <SidePanelGroup title="title" iconName="flask-outline">
         children
@@ -139,7 +139,7 @@ describe('ListItem', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('Disabled Side Panel Group renders correctly', () => {
+  it('Disabled Side Panel Group renders correctly', () => {
     const tree = Renderer.create(
       <SidePanelGroup title="title" iconName="flask-outline" disabled>
         children
@@ -151,7 +151,7 @@ describe('ListItem', () => {
 })
 
 describe('ListAlert', () => {
-  test('list alert renders correctly', () => {
+  it('list alert renders correctly', () => {
     const tree = Renderer.create(<ListAlert>alert alert</ListAlert>).toJSON()
 
     expect(tree).toMatchSnapshot()

--- a/components/src/__tests__/modals.test.js
+++ b/components/src/__tests__/modals.test.js
@@ -12,7 +12,7 @@ import {
 } from '..'
 
 describe('modals', () => {
-  test('Modal has a clickable overlay', () => {
+  it('Modal has a clickable overlay', () => {
     const onCloseClick = jest.fn()
     const root = Renderer.create(
       <Modal onCloseClick={onCloseClick}>children</Modal>
@@ -24,7 +24,7 @@ describe('modals', () => {
     expect(onCloseClick).toHaveBeenCalled()
   })
 
-  test('ContinueModal has continue and cancel buttons', () => {
+  it('ContinueModal has continue and cancel buttons', () => {
     const onCancelClick = jest.fn()
     const onContinueClick = jest.fn()
     const root = Renderer.create(
@@ -46,7 +46,7 @@ describe('modals', () => {
     expect(onContinueClick).toHaveBeenCalled()
   })
 
-  test('ContinueModal calls onCancelClick on overlay click', () => {
+  it('ContinueModal calls onCancelClick on overlay click', () => {
     const onCancelClick = jest.fn()
     const onContinueClick = jest.fn()
     const root = Renderer.create(
@@ -64,7 +64,7 @@ describe('modals', () => {
     expect(onCancelClick).toHaveBeenCalled()
   })
 
-  test('Modal renders correctly', () => {
+  it('Modal renders correctly', () => {
     const tree = Renderer.create(
       <Modal onCloseClick={() => {}} className="foo">
         children
@@ -74,7 +74,7 @@ describe('modals', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('Modal renders correctly with optional heading', () => {
+  it('Modal renders correctly with optional heading', () => {
     const tree = Renderer.create(
       <Modal
         onCloseClick={() => {}}
@@ -88,7 +88,7 @@ describe('modals', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('AlertModal renders correctly', () => {
+  it('AlertModal renders correctly', () => {
     const tree = Renderer.create(
       <AlertModal
         heading={'heading'}
@@ -106,7 +106,7 @@ describe('modals', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('ContinueModal renders correctly', () => {
+  it('ContinueModal renders correctly', () => {
     const tree = Renderer.create(
       <ContinueModal onCancelClick={() => {}} onContinueClick={() => {}}>
         children
@@ -116,13 +116,13 @@ describe('modals', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('Overlay renders correctly', () => {
+  it('Overlay renders correctly', () => {
     const tree = Renderer.create(<Overlay onClick={() => {}} />).toJSON()
 
     expect(tree).toMatchSnapshot()
   })
 
-  test('ModalPage renders correctly', () => {
+  it('ModalPage renders correctly', () => {
     const tree = Renderer.create(
       <ModalPage
         titleBar={{
@@ -141,7 +141,7 @@ describe('modals', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('SpinnerModalPage renders correctly', () => {
+  it('SpinnerModalPage renders correctly', () => {
     const tree = Renderer.create(
       <SpinnerModalPage
         titleBar={{

--- a/components/src/__tests__/nav.test.js
+++ b/components/src/__tests__/nav.test.js
@@ -5,7 +5,7 @@ import Renderer from 'react-test-renderer'
 import { VerticalNavBar, NavButton, SidePanel } from '..'
 
 describe('VerticalNavBar', () => {
-  test('renders correctly', () => {
+  it('renders correctly', () => {
     const onClick = () => {}
     const tree = Renderer.create(
       <VerticalNavBar onClick={onClick} className="c">
@@ -18,7 +18,7 @@ describe('VerticalNavBar', () => {
 })
 
 describe('NavButton', () => {
-  test('creates a button with props', () => {
+  it('creates a button with props', () => {
     const onClick = jest.fn()
     const button = Renderer.create(
       <NavButton onClick={onClick} disabled={false} iconName="ot-file" />
@@ -30,7 +30,7 @@ describe('NavButton', () => {
     expect(onClick).toHaveBeenCalled()
   })
 
-  test('adds svg icon to button by name', () => {
+  it('adds svg icon to button by name', () => {
     const icon = Renderer.create(
       <NavButton iconName="ot-file" />
     ).root.findByType('svg')
@@ -38,7 +38,7 @@ describe('NavButton', () => {
     expect(icon).toBeDefined()
   })
 
-  test('renders nav button with icon correctly', () => {
+  it('renders nav button with icon correctly', () => {
     const tree = Renderer.create(
       <NavButton iconName="ot-file" disabled="false" />
     ).toJSON()
@@ -48,7 +48,7 @@ describe('NavButton', () => {
 })
 
 describe('SidePanel', () => {
-  test('renders sidebar with title', () => {
+  it('renders sidebar with title', () => {
     const heading = Renderer.create(
       <SidePanel title={'title'} />
     ).root.findByType('h2')
@@ -56,7 +56,7 @@ describe('SidePanel', () => {
     expect(heading.children).toEqual(['title'])
   })
 
-  test('renders close button when onClick is present', () => {
+  it('renders close button when onClick is present', () => {
     const onClick = jest.fn()
     const button = Renderer.create(
       <SidePanel title={'title'} onCloseClick={onClick} />
@@ -67,7 +67,7 @@ describe('SidePanel', () => {
     expect(onClick).toHaveBeenCalled()
   })
 
-  test('renders closed panel when onClick present and isOpen is false', () => {
+  it('renders closed panel when onClick present and isOpen is false', () => {
     const onClick = jest.fn()
     const panel = Renderer.create(
       <SidePanel title={'title'} isClosed="true" onCloseClick={onClick} />
@@ -76,7 +76,7 @@ describe('SidePanel', () => {
     expect(panel.props.className).toEqual('panel closed')
   })
 
-  test('renders SidePanel correctly', () => {
+  it('renders SidePanel correctly', () => {
     const onClick = jest.fn()
     const tree = Renderer.create(
       <SidePanel title={'title'} onCloseClick={onClick} isClosed="true">

--- a/components/src/__tests__/slotmap.test.js
+++ b/components/src/__tests__/slotmap.test.js
@@ -4,13 +4,13 @@ import Renderer from 'react-test-renderer'
 import { SlotMap } from '..'
 
 describe('SlotMap', () => {
-  test('renders correctly without collision warnings or errors', () => {
+  it('renders correctly without collision warnings or errors', () => {
     const tree = Renderer.create(<SlotMap occupiedSlots={['1']} />).toJSON()
 
     expect(tree).toMatchSnapshot()
   })
 
-  test('renders correctly with collision warning', () => {
+  it('renders correctly with collision warning', () => {
     const tree = Renderer.create(
       <SlotMap occupiedSlots={['1']} collisionSlots={['4']} />
     ).toJSON()
@@ -18,7 +18,7 @@ describe('SlotMap', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('renders correctly with error', () => {
+  it('renders correctly with error', () => {
     const tree = Renderer.create(
       <SlotMap occupiedSlots={['1']} isError />
     ).toJSON()
@@ -26,7 +26,7 @@ describe('SlotMap', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('renders correctly with error and collision warning', () => {
+  it('renders correctly with error and collision warning', () => {
     const tree = Renderer.create(
       <SlotMap occupiedSlots={['1']} collisionSlots={['4']} isError />
     ).toJSON()

--- a/components/src/__tests__/structure.test.js
+++ b/components/src/__tests__/structure.test.js
@@ -14,7 +14,7 @@ import {
 } from '..'
 
 describe('TitleBar', () => {
-  test('adds an h1 with the title', () => {
+  it('adds an h1 with the title', () => {
     const heading = Renderer.create(<TitleBar title="hello" />).root.findByType(
       'h1'
     )
@@ -23,7 +23,7 @@ describe('TitleBar', () => {
     expect(heading.children).toEqual(['hello'])
   })
 
-  test('adds an optional h2 with the subtitle', () => {
+  it('adds an optional h2 with the subtitle', () => {
     const heading = Renderer.create(
       <TitleBar title="hello" subtitle="world" />
     ).root.findByType('h2')
@@ -32,7 +32,7 @@ describe('TitleBar', () => {
     expect(heading.children).toEqual(['world'])
   })
 
-  test('add optional back button', () => {
+  it('add optional back button', () => {
     const onBackClick = jest.fn()
     const button = Renderer.create(
       <TitleBar title="hello" onBackClick={onBackClick} />
@@ -42,13 +42,13 @@ describe('TitleBar', () => {
     expect(onBackClick).toHaveBeenCalled()
   })
 
-  test('renders TitleBar without subtitle correctly', () => {
+  it('renders TitleBar without subtitle correctly', () => {
     const tree = Renderer.create(<TitleBar title="foo" />).toJSON()
 
     expect(tree).toMatchSnapshot()
   })
 
-  test('renders TitleBar with subtitle correctly', () => {
+  it('renders TitleBar with subtitle correctly', () => {
     const tree = Renderer.create(
       <TitleBar title="foo" subtitle="bar" />
     ).toJSON()
@@ -56,7 +56,7 @@ describe('TitleBar', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('renders TitleBar with back button correctly', () => {
+  it('renders TitleBar with back button correctly', () => {
     const tree = Renderer.create(
       <TitleBar title="foo" subtitle="bar" onBackClick={() => {}} />
     ).toJSON()
@@ -66,7 +66,7 @@ describe('TitleBar', () => {
 })
 
 describe('PageTabs', () => {
-  test('renders h3 links for each page', () => {
+  it('renders h3 links for each page', () => {
     const pages = [
       { title: 'Page1', href: '/page1', isActive: false, isDisabled: false },
       { title: 'Page2', href: '/page2', isActive: false, isDisabled: false },
@@ -88,7 +88,7 @@ describe('PageTabs', () => {
     })
   })
 
-  test('does not create a link if disabled', () => {
+  it('does not create a link if disabled', () => {
     const pages = [
       { title: 'Page1', href: '/page1', isActive: false, isDisabled: true },
     ]
@@ -102,7 +102,7 @@ describe('PageTabs', () => {
     expect(notLink.findByType('h3').children).toEqual([pages[0].title])
   })
 
-  test('adds active class if active', () => {
+  it('adds active class if active', () => {
     const pages = [
       { title: 'Page1', href: '/page1', isActive: true, isDisabled: false },
     ]
@@ -116,7 +116,7 @@ describe('PageTabs', () => {
     expect(link.props.className).toMatch(/active/)
   })
 
-  test('renders PageTabs correctly', () => {
+  it('renders PageTabs correctly', () => {
     const pages = [
       { title: 'Page1', href: '/page1', isActive: true, isDisabled: false },
       { title: 'Page2', href: '/page2', isActive: false, isDisabled: true },
@@ -133,7 +133,7 @@ describe('PageTabs', () => {
 })
 
 describe('Card', () => {
-  test('renders Card correctly', () => {
+  it('renders Card correctly', () => {
     const tree = Renderer.create(
       <Card title={'title'}>children children children</Card>
     ).toJSON()
@@ -143,14 +143,14 @@ describe('Card', () => {
 })
 
 describe('RefreshCard', () => {
-  test('calls refresh on mount', () => {
+  it('calls refresh on mount', () => {
     const refresh = jest.fn()
     Renderer.create(<RefreshCard id="foo" refresh={refresh} />)
 
     expect(refresh).toHaveBeenCalledTimes(1)
   })
 
-  test('calls refresh on id change', () => {
+  it('calls refresh on id change', () => {
     const refresh = jest.fn()
     const renderer = Renderer.create(
       <RefreshCard watch="foo" refresh={refresh} />
@@ -166,7 +166,7 @@ describe('RefreshCard', () => {
     expect(refresh).toHaveBeenCalledTimes(0)
   })
 
-  test('renders correctly', () => {
+  it('renders correctly', () => {
     const tree = Renderer.create(
       <RefreshCard watch="foo" refresh={() => {}} refreshing>
         child1 child2 child3
@@ -178,7 +178,7 @@ describe('RefreshCard', () => {
 })
 
 describe('LabeledValue', () => {
-  test('renders LabeledValue correctly', () => {
+  it('renders LabeledValue correctly', () => {
     const tree = Renderer.create(
       <LabeledValue label={'Label'} value={'Value'} />
     ).toJSON()
@@ -188,13 +188,13 @@ describe('LabeledValue', () => {
 })
 
 describe('Splash', () => {
-  test('renders correctly with no props', () => {
+  it('renders correctly with no props', () => {
     const tree = Renderer.create(<Splash />).toJSON()
 
     expect(tree).toMatchSnapshot()
   })
 
-  test('renders correctly with custom props', () => {
+  it('renders correctly with custom props', () => {
     const tree = Renderer.create(
       <Splash iconName="flask-outline" className="swag" />
     ).toJSON()
@@ -204,7 +204,7 @@ describe('Splash', () => {
 })
 
 describe('Pill', () => {
-  test('renders Pill correctly', () => {
+  it('renders Pill correctly', () => {
     const tree = Renderer.create(
       <Pill color="blue" className="foo">
         Blue
@@ -214,7 +214,7 @@ describe('Pill', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('renders Pill correctly with inverted text', () => {
+  it('renders Pill correctly with inverted text', () => {
     const tree = Renderer.create(
       <Pill color="blue" className="foo" invertTextColor>
         Blue

--- a/components/src/forms/__tests__/Select.test.js
+++ b/components/src/forms/__tests__/Select.test.js
@@ -6,13 +6,13 @@ import { shallow } from 'enzyme'
 import { Select } from '../Select'
 
 describe('Select', () => {
-  test('component renders a ReactSelect', () => {
+  it('component renders a ReactSelect', () => {
     const wrapper = shallow(<Select options={[]} />)
 
     expect(wrapper.find(ReactSelect)).toHaveLength(1)
   })
 
-  test('passes props to ReactSelect', () => {
+  it('passes props to ReactSelect', () => {
     const options = [{ value: 'foo' }, { value: 'bar' }]
     const value = options[1]
     const name = 'inputName'
@@ -38,7 +38,7 @@ describe('Select', () => {
     })
   })
 
-  test('merges in className prop', () => {
+  it('merges in className prop', () => {
     const wrapperDefault = shallow(<Select options={[]} />)
     const wrapperWithClass = shallow(
       <Select options={[]} className="something_else" />

--- a/components/src/forms/__tests__/SelectField.test.js
+++ b/components/src/forms/__tests__/SelectField.test.js
@@ -6,7 +6,7 @@ import { SelectField } from '../SelectField'
 import { Select } from '../Select'
 
 describe('SelectField', () => {
-  test('renders a Select', () => {
+  it('renders a Select', () => {
     const wrapper = shallow(
       <SelectField name="field" options={[]} value={null} />
     )
@@ -14,7 +14,7 @@ describe('SelectField', () => {
     expect(wrapper.find(Select)).toHaveLength(1)
   })
 
-  test('renders caption', () => {
+  it('renders caption', () => {
     const wrapper = shallow(
       <SelectField
         name="field"
@@ -27,7 +27,7 @@ describe('SelectField', () => {
     expect(wrapper.find('[data-hook="caption"]')).toHaveLength(1)
   })
 
-  test('passes props to Select', () => {
+  it('passes props to Select', () => {
     const id = 'id'
     const name = 'name'
     const options = [{ value: 'foo' }, { value: 'bar' }]
@@ -65,7 +65,7 @@ describe('SelectField', () => {
     })
   })
 
-  test('passes disabled to isDisabled when disabled=true', () => {
+  it('passes disabled to isDisabled when disabled=true', () => {
     const name = 'name'
     const options = [{ value: 'foo' }, { value: 'bar' }]
     const value = 'bar'
@@ -85,7 +85,7 @@ describe('SelectField', () => {
     })
   })
 
-  test('handles onChange and onBlur from Select', () => {
+  it('handles onChange and onBlur from Select', () => {
     const handleValueChange = jest.fn()
     const handleLoseFocus = jest.fn()
     const options = [{ value: 'foo' }, { value: 'bar' }]

--- a/components/src/hooks/__tests__/useInterval.test.js
+++ b/components/src/hooks/__tests__/useInterval.test.js
@@ -21,21 +21,21 @@ describe('useInterval hook', () => {
     return <span />
   }
 
-  test('delay `null` results in no calls', () => {
+  it('delay `null` results in no calls', () => {
     mount(<TestUseInterval delay={null} />)
     jest.runTimersToTime(10000)
 
     expect(callback).toHaveBeenCalledTimes(0)
   })
 
-  test('delay sets an interval', () => {
+  it('delay sets an interval', () => {
     mount(<TestUseInterval delay={2} />)
     jest.runTimersToTime(10)
 
     expect(callback).toHaveBeenCalledTimes(5)
   })
 
-  test('re-rendering with delay={null} clears the interval', () => {
+  it('re-rendering with delay={null} clears the interval', () => {
     const wrapper = mount(<TestUseInterval delay={2} />)
 
     jest.runTimersToTime(6)

--- a/components/src/hooks/__tests__/usePrevious.test.js
+++ b/components/src/hooks/__tests__/usePrevious.test.js
@@ -11,12 +11,12 @@ describe('usePrevious hook', () => {
     )
   }
 
-  test('initial previous value is `undefined', () => {
+  it('initial previous value is `undefined', () => {
     const wrapper = mount(<TestUsePrevious value="foo" />)
     expect(wrapper.html()).toEqual('<span>undefined</span>')
   })
 
-  test('saves previous values', () => {
+  it('saves previous values', () => {
     const wrapper = mount(<TestUsePrevious value="foo" />)
     wrapper.setProps({ value: 'bar' })
     expect(wrapper.html()).toEqual('<span>foo</span>')

--- a/components/src/hooks/__tests__/useTimeout.test.js
+++ b/components/src/hooks/__tests__/useTimeout.test.js
@@ -21,21 +21,21 @@ describe('useTimeouthook', () => {
     return <span />
   }
 
-  test('delay `null` results in no calls', () => {
+  it('delay `null` results in no calls', () => {
     mount(<TestUseTimeout delay={null} />)
     jest.runTimersToTime(10000)
 
     expect(callback).toHaveBeenCalledTimes(0)
   })
 
-  test('delay sets a timeout', () => {
+  it('delay sets a timeout', () => {
     mount(<TestUseTimeout delay={2} />)
     jest.runTimersToTime(3)
 
     expect(callback).toHaveBeenCalledTimes(1)
   })
 
-  test('re-rendering with delay={null} clears the interval', () => {
+  it('re-rendering with delay={null} clears the interval', () => {
     const wrapper = mount(<TestUseTimeout delay={4} />)
 
     jest.runTimersToTime(2)

--- a/components/src/instrument/__tests__/PipetteSelect.test.js
+++ b/components/src/instrument/__tests__/PipetteSelect.test.js
@@ -14,13 +14,13 @@ import { Select } from '../../forms'
 import type { PipetteNameSpecs } from '@opentrons/shared-data'
 
 describe('PipetteSelect', () => {
-  test('renders a Select', () => {
+  it('renders a Select', () => {
     const wrapper = shallow(<PipetteSelect onPipetteChange={jest.fn()} />)
 
     expect(wrapper.find(Select)).toHaveLength(1)
   })
 
-  test('passes props to Select', () => {
+  it('passes props to Select', () => {
     const tabIndex = 3
     const className = 'class'
 
@@ -40,7 +40,7 @@ describe('PipetteSelect', () => {
     })
   })
 
-  test('passes pipettes as grouped options to Select', () => {
+  it('passes pipettes as grouped options to Select', () => {
     const wrapper = shallow(<PipetteSelect onPipetteChange={jest.fn()} />)
     const pipetteSpecs: Array<PipetteNameSpecs> = getAllPipetteNames(
       'maxVolume',
@@ -62,7 +62,7 @@ describe('PipetteSelect', () => {
     ])
   })
 
-  test('can blacklist pipettes by name', () => {
+  it('can blacklist pipettes by name', () => {
     const pipetteSpecs: Array<PipetteNameSpecs> = getAllPipetteNames(
       'maxVolume',
       'channels'
@@ -89,7 +89,7 @@ describe('PipetteSelect', () => {
     ])
   })
 
-  test('maps pipetteName prop to Select value', () => {
+  it('maps pipetteName prop to Select value', () => {
     const pipetteName = 'p300_single_gen2'
     const pipetteSpecs = getPipetteNameSpecs(pipetteName)
     const expectedOption = {
@@ -107,7 +107,7 @@ describe('PipetteSelect', () => {
     expect(wrapper.find(Select).prop('value')).toEqual(expectedOption)
   })
 
-  test('allows "None" as an option', () => {
+  it('allows "None" as an option', () => {
     const expectedNone = { value: '', label: 'None' }
     const selectWrapper = shallow(
       <PipetteSelect onPipetteChange={jest.fn()} enableNoneOption />

--- a/components/src/slotmap/__tests__/SlotMap.test.js
+++ b/components/src/slotmap/__tests__/SlotMap.test.js
@@ -6,13 +6,13 @@ import { SlotMap } from '../SlotMap'
 import { Icon } from '../../icons'
 
 describe('SlotMap', () => {
-  test('component renders 11 slots', () => {
+  it('component renders 11 slots', () => {
     const wrapper = shallow(<SlotMap occupiedSlots={['1']} />)
 
     expect(wrapper.find('rect')).toHaveLength(11)
   })
 
-  test('component renders crash info icon when collision slots present', () => {
+  it('component renders crash info icon when collision slots present', () => {
     const wrapper = shallow(
       <SlotMap occupiedSlots={['1']} collisionSlots={['4']} />
     )
@@ -20,7 +20,7 @@ describe('SlotMap', () => {
     expect(wrapper.find(Icon)).toHaveLength(1)
   })
 
-  test('component applies occupied and error styles', () => {
+  it('component applies occupied and error styles', () => {
     const wrapperDefault = shallow(<SlotMap occupiedSlots={['1']} />)
     const wrapperWithError = shallow(
       <SlotMap occupiedSlots={['1']} isError={true} />

--- a/discovery-client/src/__tests__/client.test.js
+++ b/discovery-client/src/__tests__/client.test.js
@@ -22,7 +22,7 @@ describe('discovery client', () => {
     jest.clearAllMocks()
   })
 
-  test('start creates mdns browser searching for http', () => {
+  it('start creates mdns browser searching for http', () => {
     const client = createDiscoveryClient()
     const result = client.start()
 
@@ -31,7 +31,7 @@ describe('discovery client', () => {
     expect(mdns.__mockBrowser.discover).not.toHaveBeenCalled()
   })
 
-  test('mdns browser started on ready', () => {
+  it('mdns browser started on ready', () => {
     const client = createDiscoveryClient()
 
     client.start()
@@ -40,7 +40,7 @@ describe('discovery client', () => {
     expect(mdns.__mockBrowser.discover).toHaveBeenCalledTimes(1)
   })
 
-  test('stops browser on client.stop', () => {
+  it('stops browser on client.stop', () => {
     const client = createDiscoveryClient()
 
     client.start()
@@ -49,7 +49,7 @@ describe('discovery client', () => {
     expect(mdns.__mockBrowser.stop).toHaveBeenCalled()
   })
 
-  test('stops browser and creates new one on repeated client.start', () => {
+  it('stops browser and creates new one on repeated client.start', () => {
     const client = createDiscoveryClient()
 
     client.start()
@@ -60,7 +60,7 @@ describe('discovery client', () => {
     expect(mdns.__mockBrowser.stop).toHaveBeenCalledTimes(1)
   })
 
-  test('emits "service" if browser finds a service', done => {
+  it('emits "service" if browser finds a service', done => {
     const client = createDiscoveryClient()
 
     client.start()
@@ -74,7 +74,7 @@ describe('discovery client', () => {
     mdns.__mockBrowser.emit('update', MOCK_BROWSER_SERVICE)
   }, 10)
 
-  test('adds robot to client.services if browser finds a service', () => {
+  it('adds robot to client.services if browser finds a service', () => {
     const client = createDiscoveryClient()
 
     client.start()
@@ -83,7 +83,7 @@ describe('discovery client', () => {
     expect(client.candidates).toEqual([])
   })
 
-  test('new mdns service does not null out ok of existing service', () => {
+  it('new mdns service does not null out ok of existing service', () => {
     const client = createDiscoveryClient()
 
     client.services = [
@@ -108,7 +108,7 @@ describe('discovery client', () => {
     ])
   })
 
-  test('services and candidates can be prepopulated', () => {
+  it('services and candidates can be prepopulated', () => {
     const cachedServices = [MOCK_SERVICE]
     const client = createDiscoveryClient({
       services: cachedServices,
@@ -120,7 +120,7 @@ describe('discovery client', () => {
     expect(client.candidates).toEqual([{ ip: '192.168.1.43', port: 31950 }])
   })
 
-  test('candidates should be deduped by services', () => {
+  it('candidates should be deduped by services', () => {
     const client = createDiscoveryClient({
       services: [MOCK_SERVICE],
       candidates: [{ ip: MOCK_SERVICE.ip, port: 31950 }],
@@ -129,7 +129,7 @@ describe('discovery client', () => {
     expect(client.candidates).toEqual([])
   })
 
-  test('client.start should start polling with default interval 5000', () => {
+  it('client.start should start polling with default interval 5000', () => {
     const client = createDiscoveryClient({
       services: [
         {
@@ -150,7 +150,7 @@ describe('discovery client', () => {
     )
   })
 
-  test('client should have configurable poll interval', () => {
+  it('client should have configurable poll interval', () => {
     const client = createDiscoveryClient({
       pollInterval: 1000,
       candidates: [{ ip: 'foo', port: 31950 }],
@@ -165,7 +165,7 @@ describe('discovery client', () => {
     )
   })
 
-  test('client.stop should stop polling', () => {
+  it('client.stop should stop polling', () => {
     const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     poller.poll.mockReturnValueOnce({ id: 'foobar' })
@@ -174,7 +174,7 @@ describe('discovery client', () => {
     expect(poller.stop).toHaveBeenCalledWith({ id: 'foobar' }, client._logger)
   })
 
-  test('if polls come back good, oks should be flagged true from null', () => {
+  it('if polls come back good, oks should be flagged true from null', () => {
     const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     client.start()
@@ -190,7 +190,7 @@ describe('discovery client', () => {
     expect(client.services[0].serverOk).toBe(true)
   })
 
-  test('if polls come back good, oks should be flagged true from false', () => {
+  it('if polls come back good, oks should be flagged true from false', () => {
     const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     client.services[0].ok = false
@@ -207,7 +207,7 @@ describe('discovery client', () => {
     expect(client.services[0].serverOk).toBe(true)
   })
 
-  test('if API health comes back bad, ok should be flagged false from null', () => {
+  it('if API health comes back bad, ok should be flagged false from null', () => {
     const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     client.start()
@@ -219,7 +219,7 @@ describe('discovery client', () => {
     expect(client.services[0].serverOk).toBe(true)
   })
 
-  test('if API health comes back bad, ok should be flagged false from true', () => {
+  it('if API health comes back bad, ok should be flagged false from true', () => {
     const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     client.services[0].ok = true
@@ -232,7 +232,7 @@ describe('discovery client', () => {
     expect(client.services[0].serverOk).toBe(true)
   })
 
-  test('if /server health comes back bad, serverOk should be flagged false from null', () => {
+  it('if /server health comes back bad, serverOk should be flagged false from null', () => {
     const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     client.start()
@@ -247,7 +247,7 @@ describe('discovery client', () => {
     expect(client.services[0].serverOk).toBe(false)
   })
 
-  test('if /server health comes back bad, serverOk should be flagged false from true', () => {
+  it('if /server health comes back bad, serverOk should be flagged false from true', () => {
     const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     client.services[0].serverOk = true
@@ -263,7 +263,7 @@ describe('discovery client', () => {
     expect(client.services[0].serverOk).toBe(false)
   })
 
-  test('if both polls comes back bad, oks should be flagged false from null', () => {
+  it('if both polls comes back bad, oks should be flagged false from null', () => {
     const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     client.start()
@@ -275,7 +275,7 @@ describe('discovery client', () => {
     expect(client.services[0].serverOk).toBe(false)
   })
 
-  test('if both polls comes back bad, oks should be flagged false from true', () => {
+  it('if both polls comes back bad, oks should be flagged false from true', () => {
     const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     client.services[0].ok = true
@@ -289,7 +289,7 @@ describe('discovery client', () => {
     expect(client.services[0].serverOk).toBe(false)
   })
 
-  test('if names come back conflicting, prefer /server and set ok to false', () => {
+  it('if names come back conflicting, prefer /server and set ok to false', () => {
     const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     client.start()
@@ -304,7 +304,7 @@ describe('discovery client', () => {
     expect(client.services[0].serverOk).toBe(true)
   })
 
-  test('if health comes back for a candidate, it should be promoted', () => {
+  it('if health comes back for a candidate, it should be promoted', () => {
     const client = createDiscoveryClient({
       candidates: [{ ip: '192.168.1.42', port: 31950 }],
     })
@@ -329,7 +329,7 @@ describe('discovery client', () => {
     ])
   })
 
-  test('if health comes back with IP conflict, null out old services', () => {
+  it('if health comes back with IP conflict, null out old services', () => {
     const client = createDiscoveryClient()
 
     client.services = [
@@ -358,7 +358,7 @@ describe('discovery client', () => {
     ])
   })
 
-  test('if new service is added, poller is restarted', () => {
+  it('if new service is added, poller is restarted', () => {
     const client = createDiscoveryClient({
       candidates: [{ ip: '192.168.1.1', port: 31950 }],
     })
@@ -389,7 +389,7 @@ describe('discovery client', () => {
     mdns.__mockBrowser.emit('update', MOCK_BROWSER_SERVICE)
   })
 
-  test('services may be removed and removes candidates', () => {
+  it('services may be removed and removes candidates', () => {
     const client = createDiscoveryClient({
       services: [
         {
@@ -412,7 +412,7 @@ describe('discovery client', () => {
     expect(client.candidates).toEqual([])
   })
 
-  test('candidate removal restarts poll', () => {
+  it('candidate removal restarts poll', () => {
     const client = createDiscoveryClient({ services: [MOCK_SERVICE] })
 
     poller.poll.mockReturnValueOnce({ id: 1234 })
@@ -427,7 +427,7 @@ describe('discovery client', () => {
     )
   })
 
-  test('candidate removal emits removal events', done => {
+  it('candidate removal emits removal events', done => {
     const services = [
       {
         ...MOCK_SERVICE,
@@ -449,7 +449,7 @@ describe('discovery client', () => {
     client.remove('opentrons-dev')
   }, 10)
 
-  test('passes along mdns errors', () => {
+  it('passes along mdns errors', () => {
     return new Promise(resolve => {
       const mockError = new Error('AH')
       const client = createDiscoveryClient().once('error', error => {
@@ -462,7 +462,7 @@ describe('discovery client', () => {
     })
   })
 
-  test('can filter services by name', () => {
+  it('can filter services by name', () => {
     const client = createDiscoveryClient({ nameFilter: ['OPENTRONS'] })
 
     client.start()
@@ -484,7 +484,7 @@ describe('discovery client', () => {
     ])
   })
 
-  test('can filter services by ip', () => {
+  it('can filter services by ip', () => {
     const client = createDiscoveryClient({ ipFilter: ['169.254'] })
 
     client.start()
@@ -500,7 +500,7 @@ describe('discovery client', () => {
     expect(client.services.map(s => s.ip)).toEqual(['169.254.1.2'])
   })
 
-  test('can filter services by port', () => {
+  it('can filter services by port', () => {
     const client = createDiscoveryClient({ portFilter: [31950, 31951] })
 
     client.start()
@@ -521,7 +521,7 @@ describe('discovery client', () => {
     expect(client.services.map(s => s.port)).toEqual([31950, 31951])
   })
 
-  test('can add a candidate manually (with deduping)', () => {
+  it('can add a candidate manually (with deduping)', () => {
     const client = createDiscoveryClient()
     const result = client.add('localhost').add('localhost')
 
@@ -536,7 +536,7 @@ describe('discovery client', () => {
     )
   })
 
-  test('can change polling interval on the fly', () => {
+  it('can change polling interval on the fly', () => {
     const client = createDiscoveryClient({ candidates: ['localhost'] })
     const expectedCandidates = [{ ip: 'localhost', port: 31950 }]
 
@@ -558,5 +558,5 @@ describe('discovery client', () => {
     )
   })
 
-  test.todo('periodically refreshes mDNS discovery')
+  it.todo('periodically refreshes mDNS discovery')
 })

--- a/discovery-client/src/__tests__/poller.test.js
+++ b/discovery-client/src/__tests__/poller.test.js
@@ -15,12 +15,12 @@ describe('discovery poller', () => {
     fetch.__mockReset()
   })
 
-  test('returns empty poll request if no candidates', () => {
+  it('returns empty poll request if no candidates', () => {
     const request = poll([], 5000, jest.fn())
     expect(request.id).toBe(null)
   })
 
-  test('sets an interval to poll candidates evenly', () => {
+  it('sets an interval to poll candidates evenly', () => {
     poll(
       [{ ip: 'foo', port: 31950 }, { ip: 'bar', port: 31950 }],
       6000,
@@ -43,7 +43,7 @@ describe('discovery poller', () => {
     expect(setInterval).toHaveBeenCalledWith(expect.any(Function), 2000)
   })
 
-  test('will not set a subinterval smaller than 100ms', () => {
+  it('will not set a subinterval smaller than 100ms', () => {
     poll(
       [{ ip: 'foo', port: 31950 }, { ip: 'bar', port: 31950 }],
       42,
@@ -53,7 +53,7 @@ describe('discovery poller', () => {
     expect(setInterval).toHaveBeenCalledWith(expect.any(Function), 100)
   })
 
-  test('returns interval ID in request object', () => {
+  it('returns interval ID in request object', () => {
     const intervalId = 1234
     setInterval.mockReturnValueOnce(intervalId)
 
@@ -66,14 +66,14 @@ describe('discovery poller', () => {
     expect(request.id).toEqual(intervalId)
   })
 
-  test('can stop polling', () => {
+  it('can stop polling', () => {
     const request = { id: 1234 }
 
     stop(request)
     expect(clearInterval).toHaveBeenCalledWith(1234)
   })
 
-  test('calls fetch health for all candidates in an interval', () => {
+  it('calls fetch health for all candidates in an interval', () => {
     poll(
       [
         { ip: 'foo', port: 31950 },
@@ -109,7 +109,7 @@ describe('discovery poller', () => {
     )
   })
 
-  test('calls onHealth with health response if successful', done => {
+  it('calls onHealth with health response if successful', done => {
     fetch.__setMockResponse({
       ok: true,
       json: () => Promise.resolve({ name: 'foo' }),
@@ -125,7 +125,7 @@ describe('discovery poller', () => {
     jest.runTimersToTime(1000)
   }, 10)
 
-  test('calls onHealth with null response if fetch not ok', done => {
+  it('calls onHealth with null response if fetch not ok', done => {
     fetch.__setMockResponse({
       ok: false,
       json: () => Promise.resolve({ message: 'oh no!' }),
@@ -141,7 +141,7 @@ describe('discovery poller', () => {
     jest.runTimersToTime(1000)
   }, 10)
 
-  test('calls onHealth with null response if fetch rejects', done => {
+  it('calls onHealth with null response if fetch rejects', done => {
     fetch.__setMockError(new Error('failed to fetch'))
 
     poll([{ ip: 'foo', port: 31950 }], 1000, (candidate, apiRes, serverRes) => {
@@ -154,7 +154,7 @@ describe('discovery poller', () => {
     jest.runTimersToTime(1000)
   }, 10)
 
-  test('calls onHealth with null response if JSON parse rejects', done => {
+  it('calls onHealth with null response if JSON parse rejects', done => {
     fetch.__setMockResponse({
       ok: true,
       json: () => Promise.reject(new Error('oh no!')),

--- a/discovery-client/src/__tests__/service-list.test.js
+++ b/discovery-client/src/__tests__/service-list.test.js
@@ -85,7 +85,7 @@ describe('serviceList', () => {
     SPECS.forEach(spec => {
       const { name, input, expected } = spec
       const result = serviceList.createServiceList.call(null, input)
-      test(name, () => expect(result).toEqual(expected))
+      it(name, () => expect(result).toEqual(expected))
     })
   })
 
@@ -147,7 +147,7 @@ describe('serviceList', () => {
     SPECS.forEach(spec => {
       const { name, list, upsert, expected } = spec
       const result = serviceList.upsertServiceList.call(null, list, upsert)
-      test(name, () => expect(result).toEqual(expected))
+      it(name, () => expect(result).toEqual(expected))
     })
   })
 })

--- a/discovery-client/src/__tests__/service.test.js
+++ b/discovery-client/src/__tests__/service.test.js
@@ -55,7 +55,7 @@ describe('service utils', () => {
 
     SPECS.forEach(spec => {
       const { name, args, expected } = spec
-      test(name, () =>
+      it(name, () =>
         expect(service.makeService.apply(null, args)).toEqual(expected)
       )
     })
@@ -77,7 +77,7 @@ describe('service utils', () => {
 
     SPECS.forEach(spec => {
       const { name, args, expected } = spec
-      test(name, () =>
+      it(name, () =>
         expect(service.makeCandidate.apply(null, args)).toEqual(expected)
       )
     })
@@ -148,7 +148,7 @@ describe('service utils', () => {
 
     SPECS.forEach(spec => {
       const { name, args, expected } = spec
-      test(name, () =>
+      it(name, () =>
         expect(service.fromMdnsBrowser.apply(null, args)).toEqual(expected)
       )
     })
@@ -242,7 +242,7 @@ describe('service utils', () => {
 
     SPECS.forEach(spec => {
       const { name, args, expected } = spec
-      test(name, () =>
+      it(name, () =>
         expect(service.fromResponse.apply(null, args)).toEqual(expected)
       )
     })

--- a/labware-library/src/__tests__/labwareInference.test.js
+++ b/labware-library/src/__tests__/labwareInference.test.js
@@ -64,14 +64,14 @@ describe('getSpacingIfUniform', () => {
     },
   ]
   testCases.forEach(({ wells, expected, testLabel }) =>
-    test(testLabel, () =>
+    it(testLabel, () =>
       expect(getSpacingIfUniform((wells: Array<any>), 'x')).toBe(expected)
     )
   )
 })
 
 describe('getIfConsistent', () => {
-  test('deep equal', () => {
+  it('deep equal', () => {
     const items = [
       { a: 123, b: [1, 2, [3]] },
       { a: 123, b: [1, 2, [3]] },
@@ -80,7 +80,7 @@ describe('getIfConsistent', () => {
     expect(getIfConsistent(items)).toEqual(items[0])
   })
 
-  test('deep difference', () => {
+  it('deep difference', () => {
     const items = [
       { a: 123, b: [1, 2, [3]] },
       { a: 123, b: [1, 2, [999999]] },
@@ -93,7 +93,7 @@ describe('getIfConsistent', () => {
 describe('getUniqueWellProperties', () => {
   const defs = [fixture96Plate, fixtureIrregular]
   defs.forEach(def =>
-    test(def.parameters.loadName, () => {
+    it(def.parameters.loadName, () => {
       expect(getUniqueWellProperties(def)).toMatchSnapshot()
     })
   )

--- a/labware-library/src/components/App/__tests__/App.test.js
+++ b/labware-library/src/components/App/__tests__/App.test.js
@@ -8,7 +8,7 @@ import { AppComponent } from '..'
 jest.mock('../../../definitions')
 
 describe('App', () => {
-  test('component renders without definition', () => {
+  it('component renders without definition', () => {
     const tree = shallow(
       <AppComponent
         location={({ search: '' }: any)}
@@ -21,7 +21,7 @@ describe('App', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('component renders with definition', () => {
+  it('component renders with definition', () => {
     const tree = shallow(
       <AppComponent
         location={({ search: '' }: any)}

--- a/labware-library/src/components/App/__tests__/Page.test.js
+++ b/labware-library/src/components/App/__tests__/Page.test.js
@@ -8,7 +8,7 @@ import { Page } from '../Page'
 jest.mock('../../../definitions')
 
 describe('Page', () => {
-  test('component renders sidebar and content', () => {
+  it('component renders sidebar and content', () => {
     const tree = shallow(
       <Page
         scrollRef={{ current: null }}
@@ -21,7 +21,7 @@ describe('Page', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('component renders with detailPage CSS', () => {
+  it('component renders with detailPage CSS', () => {
     const tree = shallow(
       <Page
         scrollRef={{ current: null }}

--- a/labware-library/src/components/LabwareList/__tests__/LabwareList.test.js
+++ b/labware-library/src/components/LabwareList/__tests__/LabwareList.test.js
@@ -24,25 +24,25 @@ describe('LabwareList', () => {
     jest.clearAllMocks()
   })
 
-  test('component renders', () => {
+  it('component renders', () => {
     const tree = shallow(<LabwareList filters={filtersOff} />)
 
     expect(tree).toMatchSnapshot()
   })
 
-  test('renders a <ul>', () => {
+  it('renders a <ul>', () => {
     const tree = shallow(<LabwareList filters={filtersOff} />)
 
     expect(tree.find('ul')).toHaveLength(1)
   })
 
-  test('renders a LabwareCard per labware definition', () => {
+  it('renders a LabwareCard per labware definition', () => {
     const tree = shallow(<LabwareList filters={filtersOff} />)
 
     expect(tree.find(LabwareCard)).toHaveLength(getAllDefinitions().length)
   })
 
-  test('renders <NoResults> without <ul> if everything filtered out', () => {
+  it('renders <NoResults> without <ul> if everything filtered out', () => {
     getAllDefinitions.mockReturnValueOnce([])
 
     const tree = shallow(<LabwareList filters={filtersOff} />)

--- a/labware-library/src/components/LabwareList/__tests__/NoResults.test.js
+++ b/labware-library/src/components/LabwareList/__tests__/NoResults.test.js
@@ -6,7 +6,7 @@ import { shallow } from 'enzyme'
 import { NoResults } from '../NoResults'
 
 describe('NoResults', () => {
-  test('component renders', () => {
+  it('component renders', () => {
     expect(shallow(<NoResults />)).toMatchSnapshot()
   })
 })

--- a/labware-library/src/components/Nav/__tests__/Nav.test.js
+++ b/labware-library/src/components/Nav/__tests__/Nav.test.js
@@ -6,7 +6,7 @@ import { shallow } from 'enzyme'
 import { Nav } from '..'
 
 describe('Nav', () => {
-  test('component renders', () => {
+  it('component renders', () => {
     const tree = shallow(<Nav />)
 
     expect(tree).toMatchSnapshot()

--- a/labware-library/src/components/Sidebar/__tests__/FilterCategory.test.js
+++ b/labware-library/src/components/Sidebar/__tests__/FilterCategory.test.js
@@ -8,7 +8,7 @@ import { FilterCategory } from '../FilterCategory'
 jest.mock('../../../definitions')
 
 describe('FilterCategory', () => {
-  test('component renders', () => {
+  it('component renders', () => {
     const filters = { category: 'all', manufacturer: 'all' }
     const tree = shallow(<FilterCategory filters={filters} />)
 

--- a/labware-library/src/components/Sidebar/__tests__/FilterManufacturer.test.js
+++ b/labware-library/src/components/Sidebar/__tests__/FilterManufacturer.test.js
@@ -18,7 +18,7 @@ describe('FilterManufacturer', () => {
     jest.clearAllMocks()
   })
 
-  test('component renders', () => {
+  it('component renders', () => {
     getAllManufacturers.mockReturnValue(['all', 'foo', 'bar', 'baz'])
 
     const filters = { category: 'all', manufacturer: 'all' }

--- a/labware-library/src/components/Sidebar/__tests__/LabwareGuide.test.js
+++ b/labware-library/src/components/Sidebar/__tests__/LabwareGuide.test.js
@@ -6,7 +6,7 @@ import { shallow } from 'enzyme'
 import { LabwareGuide } from '../LabwareGuide'
 
 describe('LabwareGuide', () => {
-  test('component renders', () => {
+  it('component renders', () => {
     const tree = shallow(<LabwareGuide />)
 
     expect(tree).toMatchSnapshot()

--- a/labware-library/src/components/Sidebar/__tests__/Sidebar.test.js
+++ b/labware-library/src/components/Sidebar/__tests__/Sidebar.test.js
@@ -10,13 +10,13 @@ jest.mock('../../../definitions')
 describe('Sidebar', () => {
   const filters = { category: 'all', manufacturer: 'all' }
 
-  test('component renders', () => {
+  it('component renders', () => {
     const tree = shallow(<Sidebar filters={filters} />)
 
     expect(tree).toMatchSnapshot()
   })
 
-  test('renders a <nav>', () => {
+  it('renders a <nav>', () => {
     const tree = shallow(<Sidebar filters={filters} />)
 
     expect(tree.find('nav')).toHaveLength(1)

--- a/labware-library/src/components/website-navigation/__tests__/Logo.test.js
+++ b/labware-library/src/components/website-navigation/__tests__/Logo.test.js
@@ -6,13 +6,13 @@ import { shallow } from 'enzyme'
 import { Logo } from '../Logo'
 
 describe('Logo', () => {
-  test('component renders', () => {
+  it('component renders', () => {
     const tree = shallow(<Logo />)
 
     expect(tree).toMatchSnapshot()
   })
 
-  test('renders an <img>', () => {
+  it('renders an <img>', () => {
     const tree = shallow(<Logo />)
 
     expect(tree.find('img')).toHaveLength(1)

--- a/labware-library/src/components/website-navigation/__tests__/MainNav.test.js
+++ b/labware-library/src/components/website-navigation/__tests__/MainNav.test.js
@@ -6,7 +6,7 @@ import { shallow } from 'enzyme'
 import { MainNav } from '..'
 
 describe('MainNav', () => {
-  test('component renders', () => {
+  it('component renders', () => {
     const tree = shallow(<MainNav />)
 
     expect(tree).toMatchSnapshot()

--- a/labware-library/src/components/website-navigation/__tests__/NavLink.test.js
+++ b/labware-library/src/components/website-navigation/__tests__/NavLink.test.js
@@ -16,13 +16,13 @@ const linkProps = {
 }
 
 describe('NavLink', () => {
-  test('component renders', () => {
+  it('component renders', () => {
     const tree = shallow(<NavLink {...linkProps} />)
 
     expect(tree).toMatchSnapshot()
   })
 
-  test('component renders name and optional description from props', () => {
+  it('component renders name and optional description from props', () => {
     const props = {
       ...linkProps,
       description: 'some link description',
@@ -32,7 +32,7 @@ describe('NavLink', () => {
     expect(tree.find('.link_description').text()).toEqual(props.description)
   })
 
-  test('component renders conditional cta class', () => {
+  it('component renders conditional cta class', () => {
     const tree = shallow(<NavLink {...linkProps} cta={true} />)
     expect(tree.find('a').hasClass('link_cta')).toEqual(true)
   })

--- a/labware-library/src/components/website-navigation/__tests__/NavList.test.js
+++ b/labware-library/src/components/website-navigation/__tests__/NavList.test.js
@@ -6,13 +6,13 @@ import { shallow, mount } from 'enzyme'
 import { NavList } from '..'
 
 describe('NavList', () => {
-  test('component renders', () => {
+  it('component renders', () => {
     const tree = shallow(<NavList />)
 
     expect(tree).toMatchSnapshot()
   })
 
-  test('component handles state changes', () => {
+  it('component handles state changes', () => {
     const tree = shallow(<NavList />)
 
     expect(tree.state().menu).toEqual(null)
@@ -20,7 +20,7 @@ describe('NavList', () => {
     expect(tree.state().menu).toEqual('foo')
   })
 
-  test('component applies active class to nav links based on state', () => {
+  it('component applies active class to nav links based on state', () => {
     const wrapper = mount(<NavList />)
 
     // when state.menu is null, all nav links are active

--- a/labware-library/src/components/website-navigation/__tests__/SubdomainNav.test.js
+++ b/labware-library/src/components/website-navigation/__tests__/SubdomainNav.test.js
@@ -6,13 +6,13 @@ import { shallow } from 'enzyme'
 import { SubdomainNav, SUBDOMAIN_NAV_LINKS } from '..'
 
 describe('SecondaryNav', () => {
-  test('component renders', () => {
+  it('component renders', () => {
     const tree = shallow(<SubdomainNav />)
 
     expect(tree).toMatchSnapshot()
   })
 
-  test('<li> rendered match link data', () => {
+  it('<li> rendered match link data', () => {
     const tree = shallow(<SubdomainNav />)
 
     expect(tree.find('li')).toHaveLength(SUBDOMAIN_NAV_LINKS.length)

--- a/labware-library/src/labware-creator/__tests__/fieldMasks.test.js
+++ b/labware-library/src/labware-creator/__tests__/fieldMasks.test.js
@@ -4,7 +4,7 @@ import { makeMaskToDecimal, maskToInteger, maskLoadName } from '../fieldMasks'
 // TODO(Ian, 2019-07-23): some fancy util could make these tests much less verbose
 
 describe('makeMaskToDecimal', () => {
-  test('1 decimal', () => {
+  it('1 decimal', () => {
     const maskTo1Decimal = makeMaskToDecimal(1)
     expect(maskTo1Decimal('', '1')).toEqual('1')
     expect(maskTo1Decimal('1', '1.')).toEqual('1.')
@@ -23,7 +23,7 @@ describe('makeMaskToDecimal', () => {
     expect(maskTo1Decimal('.1', '.12')).toEqual('.1')
   })
 
-  test('2 decimal', () => {
+  it('2 decimal', () => {
     const maskTo2Decimal = makeMaskToDecimal(2)
     expect(maskTo2Decimal('', '1')).toEqual('1')
     expect(maskTo2Decimal('1', '1.')).toEqual('1.')
@@ -47,40 +47,40 @@ describe('makeMaskToDecimal', () => {
 })
 
 describe('maskToInteger', () => {
-  test('ignores bad chars', () => {
+  it('ignores bad chars', () => {
     expect(maskToInteger('', 'x')).toEqual('')
     expect(maskToInteger('1', 'x')).toEqual('1')
     expect(maskToInteger('1', ' ')).toEqual('1')
     expect(maskToInteger('1', '1.')).toEqual('1')
   })
 
-  test('allows [0-9]', () => {
+  it('allows [0-9]', () => {
     expect(maskToInteger('', '0')).toEqual('0')
     expect(maskToInteger('', '5')).toEqual('5')
     expect(maskToInteger('1', '12')).toEqual('12')
     expect(maskToInteger('12', '123')).toEqual('123')
   })
 
-  test('allows delete', () => {
+  it('allows delete', () => {
     expect(maskToInteger('1', '')).toEqual('')
   })
 })
 
 describe('maskLoadName', () => {
-  test('lowercases capital letters', () => {
+  it('lowercases capital letters', () => {
     expect(maskLoadName('', 'X')).toEqual('x')
     expect(maskLoadName('la', 'laB')).toEqual('lab')
   })
-  test('allows accepted chars', () => {
+  it('allows accepted chars', () => {
     expect(maskLoadName('', 'a')).toEqual('a')
     expect(maskLoadName('la', 'la_')).toEqual('la_')
     expect(maskLoadName('la', 'la.')).toEqual('la.')
   })
-  test('ignores bad chars', () => {
+  it('ignores bad chars', () => {
     expect(maskLoadName('', '-')).toEqual('')
     expect(maskLoadName('a', 'a-')).toEqual('a')
   })
-  test('allows delete', () => {
+  it('allows delete', () => {
     expect(maskLoadName('a', '')).toEqual('')
   })
 })

--- a/labware-library/src/labware-creator/__tests__/labwareDefToFields.test.js
+++ b/labware-library/src/labware-creator/__tests__/labwareDefToFields.test.js
@@ -7,7 +7,7 @@ import fixtureIrregularExample1 from '@opentrons/shared-data/labware/fixtures/2/
 jest.mock('../../definitions')
 
 describe('labwareDefToFields', () => {
-  test('fixture_96_plate', () => {
+  it('fixture_96_plate', () => {
     const def = fixture96Plate
     const result = labwareDefToFields(def)
     expect(result).toEqual({
@@ -52,7 +52,7 @@ describe('labwareDefToFields', () => {
     })
   })
 
-  test('fixture_12_trough', () => {
+  it('fixture_12_trough', () => {
     // make sure rectangular wells + single row works as expected
     const def = fixture12Trough
     const result = labwareDefToFields(def)
@@ -63,7 +63,7 @@ describe('labwareDefToFields', () => {
     expect(result).toMatchSnapshot()
   })
 
-  test('fixture_irregular_example_1 should return null (until multi-grid labware is supported in LC)', () => {
+  it('fixture_irregular_example_1 should return null (until multi-grid labware is supported in LC)', () => {
     const def = fixtureIrregularExample1
     const result = labwareDefToFields(def)
     expect(result).toEqual(null)

--- a/labware-library/src/labware-creator/__tests__/loadAndSaveIntegration.test.js
+++ b/labware-library/src/labware-creator/__tests__/loadAndSaveIntegration.test.js
@@ -26,7 +26,7 @@ describe('load and immediately save integrity test', () => {
     },
   ]
   testCases.forEach(({ inputDef, extraFields }) => {
-    test(inputDef.parameters.loadName, () => {
+    it(inputDef.parameters.loadName, () => {
       const initialRawFieldValues = labwareDefToFields(inputDef)
       // both name fields should be set to null upon import
       expect(initialRawFieldValues?.displayName).toBe(null)

--- a/protocol-designer/src/__tests__/persist.test.js
+++ b/protocol-designer/src/__tests__/persist.test.js
@@ -16,7 +16,7 @@ describe('persist', () => {
       jest.clearAllMocks()
     })
 
-    test('retrieves localStorage data by key and parses data when it exists', () => {
+    it('retrieves localStorage data by key and parses data when it exists', () => {
       const value = { test: 'some value' }
       getItemMock.mockReturnValue(JSON.stringify(value))
 
@@ -25,7 +25,7 @@ describe('persist', () => {
       expect(result).toEqual(value)
     })
 
-    test('returns undefined when localStorage could not be retrieved for key given', () => {
+    it('returns undefined when localStorage could not be retrieved for key given', () => {
       getItemMock.mockImplementation(() => {
         throw new Error('something went wrong!')
       })
@@ -50,7 +50,7 @@ describe('persist', () => {
       jest.clearAllMocks()
     })
 
-    test('adds prefix to key sets localStorage item by key', () => {
+    it('adds prefix to key sets localStorage item by key', () => {
       const value = { a: 'a', b: 'b' }
       setItemMock.mockReturnValue(undefined)
 

--- a/protocol-designer/src/components/DeckSetup/__tests__/ModuleTag.test.js
+++ b/protocol-designer/src/components/DeckSetup/__tests__/ModuleTag.test.js
@@ -44,7 +44,7 @@ const getInitialDeckSetup: JestMockFn<[BaseState], InitialDeckSetup> =
 describe('ModuleTag', () => {
   describe('ModuleStatus', () => {
     describe('magnet module', () => {
-      test('displays engaged when magent is engaged', () => {
+      it('displays engaged when magent is engaged', () => {
         const props = {
           engaged: true,
           type: MAGNETIC_MODULE_TYPE,
@@ -55,7 +55,7 @@ describe('ModuleTag', () => {
         expect(component.text()).toBe('engaged')
       })
 
-      test('displays disengaged when magnet is not engaged', () => {
+      it('displays disengaged when magnet is not engaged', () => {
         const moduleState = {
           engaged: false,
           type: MAGNETIC_MODULE_TYPE,
@@ -68,7 +68,7 @@ describe('ModuleTag', () => {
     })
 
     describe('temperature module', () => {
-      test('deactivated is shown when module is deactivated', () => {
+      it('deactivated is shown when module is deactivated', () => {
         const moduleState = {
           type: TEMPERATURE_MODULE_TYPE,
           status: TEMPERATURE_DEACTIVATED,
@@ -80,7 +80,7 @@ describe('ModuleTag', () => {
         expect(component.text()).toBe('Deactivated')
       })
 
-      test('target temperature is shown when module is at target', () => {
+      it('target temperature is shown when module is at target', () => {
         const moduleState = {
           type: TEMPERATURE_MODULE_TYPE,
           status: TEMPERATURE_AT_TARGET,
@@ -92,7 +92,7 @@ describe('ModuleTag', () => {
         expect(component.text()).toBe('45 °C')
       })
 
-      test('going to X is shown when temperature is approaching target', () => {
+      it('going to X is shown when temperature is approaching target', () => {
         const moduleState = {
           type: TEMPERATURE_MODULE_TYPE,
           status: TEMPERATURE_APPROACHING_TARGET,

--- a/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.js
+++ b/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.js
@@ -88,7 +88,7 @@ describe('FileSidebar', () => {
     }
   })
 
-  test('create new button creates new protocol', () => {
+  it('create new button creates new protocol', () => {
     const wrapper = shallow(<FileSidebar {...props} />)
     const createButton = wrapper.find(OutlineButton).at(0)
     createButton.simulate('click')
@@ -96,7 +96,7 @@ describe('FileSidebar', () => {
     expect(props.createNewFile).toHaveBeenCalled()
   })
 
-  test('import button imports saved protocol', () => {
+  it('import button imports saved protocol', () => {
     const event = { files: ['test.json'] }
 
     const wrapper = shallow(<FileSidebar {...props} />)
@@ -106,7 +106,7 @@ describe('FileSidebar', () => {
     expect(props.loadFile).toHaveBeenCalledWith(event)
   })
 
-  test('export button is disabled when canDownload is false', () => {
+  it('export button is disabled when canDownload is false', () => {
     props.canDownload = false
 
     const wrapper = shallow(<FileSidebar {...props} />)
@@ -115,7 +115,7 @@ describe('FileSidebar', () => {
     expect(downloadButton.prop('disabled')).toEqual(true)
   })
 
-  test('export button exports protocol when no errors', () => {
+  it('export button exports protocol when no errors', () => {
     props.downloadData.fileData.commands = commands
     const blob = new Blob([JSON.stringify(props.downloadData.fileData)], {
       type: 'application/json',
@@ -129,7 +129,7 @@ describe('FileSidebar', () => {
     expect(fileSaver.saveAs).toHaveBeenCalledWith(blob, 'protocol.json')
   })
 
-  test('warning modal is shown when export is clicked with no command', () => {
+  it('warning modal is shown when export is clicked with no command', () => {
     const wrapper = shallow(<FileSidebar {...props} />)
     const downloadButton = wrapper.find(PrimaryButton).at(0)
     downloadButton.simulate('click')
@@ -139,7 +139,7 @@ describe('FileSidebar', () => {
     expect(alertModal.prop('heading')).toEqual('Your protocol has no steps')
   })
 
-  test('warning modal is shown when export is clicked with unused pipette', () => {
+  it('warning modal is shown when export is clicked with unused pipette', () => {
     props.downloadData.fileData.commands = commands
     props.pipettesOnDeck = pipettesOnDeck
     props.savedStepForms = savedStepForms
@@ -160,7 +160,7 @@ describe('FileSidebar', () => {
     )
   })
 
-  test('warning modal is shown when export is clicked with unused module', () => {
+  it('warning modal is shown when export is clicked with unused module', () => {
     props.modulesOnDeck = modulesOnDeck
     props.savedStepForms = savedStepForms
     props.downloadData.fileData.commands = commands
@@ -175,7 +175,7 @@ describe('FileSidebar', () => {
     expect(alertModal.html()).toContain('Magnetic module')
   })
 
-  test('warning modal is shown when export is clicked with unused module and pipette', () => {
+  it('warning modal is shown when export is clicked with unused module and pipette', () => {
     props.modulesOnDeck = modulesOnDeck
     props.pipettesOnDeck = pipettesOnDeck
     props.savedStepForms = savedStepForms
@@ -198,7 +198,7 @@ describe('FileSidebar', () => {
     )
   })
 
-  test('blocking hint is shown when protocol contains modules', () => {
+  it('blocking hint is shown when protocol contains modules', () => {
     props.downloadData.fileData.commands = commands
     props.pipettesOnDeck = {
       pipetteLeftId: {

--- a/protocol-designer/src/components/FileSidebar/utils/__tests__/getUnusedEntities.test.js
+++ b/protocol-designer/src/components/FileSidebar/utils/__tests__/getUnusedEntities.test.js
@@ -14,7 +14,7 @@ import { TEMPERATURE_DEACTIVATED } from '../../../../constants'
 import { getUnusedEntities } from '../getUnusedEntities'
 
 describe('getUnusedEntities', () => {
-  test('pipette entities not used in steps are returned', () => {
+  it('pipette entities not used in steps are returned', () => {
     const stepForms = {
       step123: {
         pipette: 'pipette123',
@@ -46,7 +46,7 @@ describe('getUnusedEntities', () => {
     expect(result).toEqual([pipettesOnDeck.pipette456])
   })
 
-  test('module entities not used in steps are returned', () => {
+  it('module entities not used in steps are returned', () => {
     const stepForms = {
       step123: {
         moduleId: 'magnet123',

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/MagnetForm.test.js
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/MagnetForm.test.js
@@ -46,7 +46,7 @@ describe('MagnetForm', () => {
     ])
   })
 
-  test('engage height caption is displayed with proper height to decimal scale', () => {
+  it('engage height caption is displayed with proper height to decimal scale', () => {
     uiModuleSelectors.getMagnetLabwareEngageHeight.mockReturnValue('10.9444')
 
     const wrapper = render()
@@ -56,7 +56,7 @@ describe('MagnetForm', () => {
     )
   })
 
-  test('engage height caption is null when no engage height', () => {
+  it('engage height caption is null when no engage height', () => {
     uiModuleSelectors.getMagnetLabwareEngageHeight.mockReturnValue(null)
 
     const wrapper = render()

--- a/protocol-designer/src/components/modals/AnnouncementModal/__tests__/AnnouncementModal.test.js
+++ b/protocol-designer/src/components/modals/AnnouncementModal/__tests__/AnnouncementModal.test.js
@@ -23,7 +23,7 @@ describe('AnnouncementModal', () => {
     getLocalStorageItemMock.mockReturnValue(announcementKey)
   })
 
-  test('modal is not shown when announcement has been shown before', () => {
+  it('modal is not shown when announcement has been shown before', () => {
     announcementsMock.announcements = [
       {
         image: null,
@@ -38,7 +38,7 @@ describe('AnnouncementModal', () => {
     expect(wrapper.find(Modal)).toHaveLength(0)
   })
 
-  test('announcement is shown when user has not seen it before', () => {
+  it('announcement is shown when user has not seen it before', () => {
     announcementsMock.announcements = [
       {
         image: null,
@@ -55,7 +55,7 @@ describe('AnnouncementModal', () => {
     expect(modal.html()).toContain('brand new spanking feature')
   })
 
-  test('latest announcement is always shown', () => {
+  it('latest announcement is always shown', () => {
     announcementsMock.announcements = [
       {
         image: null,
@@ -78,7 +78,7 @@ describe('AnnouncementModal', () => {
     expect(modal.html()).toContain('second announcement')
   })
 
-  test('optional image component is displayed when exists', () => {
+  it('optional image component is displayed when exists', () => {
     announcementsMock.announcements = [
       {
         image: <img src="test.jpg" />,
@@ -93,7 +93,7 @@ describe('AnnouncementModal', () => {
     expect(image).toHaveLength(1)
   })
 
-  test('button click saves announcement announcementKey to localStorage and closes modal', () => {
+  it('button click saves announcement announcementKey to localStorage and closes modal', () => {
     const newAnnouncementKey = 'newFeature'
     announcementsMock.announcements = [
       {

--- a/protocol-designer/src/components/modals/EditModulesModal/__tests__/EditModulesModal.test.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/__tests__/EditModulesModal.test.js
@@ -44,7 +44,7 @@ describe('EditModulesModal', () => {
       .mockReturnValue(true)
   })
 
-  test('displays warning and disabled save button when slot is occupied by incompatible labware', () => {
+  it('displays warning and disabled save button when slot is occupied by incompatible labware', () => {
     const slot = '1'
     stepFormSelectors.getInitialDeckSetup.mockReturnValue({
       labware: {
@@ -72,7 +72,7 @@ describe('EditModulesModal', () => {
     expect(saveButton.prop('disabled')).toBe(true)
   })
 
-  test('save button is clickable and saves when slot is occupied by compatible labware', () => {
+  it('save button is clickable and saves when slot is occupied by compatible labware', () => {
     const slot = '1'
     stepFormSelectors.getInitialDeckSetup.mockReturnValue({
       labware: {
@@ -106,7 +106,7 @@ describe('EditModulesModal', () => {
     expect(props.onCloseClick).toHaveBeenCalled()
   })
 
-  test('save button saves when adding module to empty slot', () => {
+  it('save button saves when adding module to empty slot', () => {
     stepFormSelectors.getInitialDeckSetup.mockReturnValue({
       labware: {
         well: {
@@ -143,7 +143,7 @@ describe('EditModulesModal', () => {
     expect(props.onCloseClick).toHaveBeenCalled()
   })
 
-  test('move deck item when moving module to a different slot', () => {
+  it('move deck item when moving module to a different slot', () => {
     const currentSlot = '1'
     const targetSlot = '10'
     stepFormSelectors.getInitialDeckSetup.mockReturnValue({
@@ -181,7 +181,7 @@ describe('EditModulesModal', () => {
     expect(props.onCloseClick).toHaveBeenCalled()
   })
 
-  test('no warning when slot is occupied by same module', () => {
+  it('no warning when slot is occupied by same module', () => {
     stepFormSelectors.getInitialDeckSetup.mockReturnValue({
       labware: {
         well: {
@@ -207,7 +207,7 @@ describe('EditModulesModal', () => {
     expect(warning).toHaveLength(0)
   })
 
-  test('cancel calls onCloseClick to close modal', () => {
+  it('cancel calls onCloseClick to close modal', () => {
     const props = {
       moduleType: MAGNETIC_MODULE_TYPE,
       moduleId: null,
@@ -226,7 +226,7 @@ describe('EditModulesModal', () => {
     expect(props.onCloseClick).toHaveBeenCalled()
   })
 
-  test('slot dropdown is disabled when module restrictions are disabled', () => {
+  it('slot dropdown is disabled when module restrictions are disabled', () => {
     featureSelectors.getDisableModuleRestrictions = jest
       .fn()
       .mockReturnValue(true)

--- a/protocol-designer/src/components/steplist/__tests__/StepItem.test.js
+++ b/protocol-designer/src/components/steplist/__tests__/StepItem.test.js
@@ -55,7 +55,7 @@ describe('getStepItemContents', () => {
       }
     })
 
-    test('module rendered with engage when engage is true', () => {
+    it('module rendered with engage when engage is true', () => {
       const StepItemContents = getStepItemContents(magnetProps)
       const wrapper = renderWrapper(StepItemContents)
       const component = wrapper.find(ModuleStepItems)
@@ -63,7 +63,7 @@ describe('getStepItemContents', () => {
       expect(component.prop('actionText')).toEqual('engage')
     })
 
-    test('module rendered with disengage when type is disengage', () => {
+    it('module rendered with disengage when type is disengage', () => {
       magnetProps.substeps.engage = false
       const StepItemContents = getStepItemContents(magnetProps)
       const wrapper = renderWrapper(StepItemContents)
@@ -96,7 +96,7 @@ describe('getStepItemContents', () => {
       }
     })
 
-    test('module is rendered with temperature when temperature exists', () => {
+    it('module is rendered with temperature when temperature exists', () => {
       temperatureProps.substeps = {
         substepType: stepType,
         temperature: 45,
@@ -111,7 +111,7 @@ describe('getStepItemContents', () => {
       expect(component.prop('actionText')).toEqual('45 °C')
     })
 
-    test('module is rendered with deactivated when temperature is null', () => {
+    it('module is rendered with deactivated when temperature is null', () => {
       temperatureProps.substeps = {
         substepType: stepType,
         temperature: null,
@@ -150,7 +150,7 @@ describe('getStepItemContents', () => {
       }
     })
 
-    test('module is rendered with temperature', () => {
+    it('module is rendered with temperature', () => {
       awaitTemperatureProps.substeps = {
         substepType: stepType,
         temperature: 45,

--- a/protocol-designer/src/file-data/__tests__/commandsSelectors.test.js
+++ b/protocol-designer/src/file-data/__tests__/commandsSelectors.test.js
@@ -51,17 +51,17 @@ function hasAllWellKeys(result) {
 }
 
 describe('getLabwareLiquidState', () => {
-  test('no labware + no ingreds', () => {
+  it('no labware + no ingreds', () => {
     expect(getLabwareLiquidState.resultFunc({}, {})).toEqual({})
   })
 
-  test('labware + no ingreds: generate empty well keys', () => {
+  it('labware + no ingreds: generate empty well keys', () => {
     const result = getLabwareLiquidState.resultFunc({}, labwareEntities)
 
     hasAllWellKeys(result)
   })
 
-  test('selects liquids with multiple ingredient groups & multiple labware: generate all well keys', () => {
+  it('selects liquids with multiple ingredient groups & multiple labware: generate all well keys', () => {
     const result = getLabwareLiquidState.resultFunc(ingredLocs, labwareEntities)
 
     expect(result).toMatchObject(ingredLocs)
@@ -71,7 +71,7 @@ describe('getLabwareLiquidState', () => {
 })
 
 describe('getRobotStateTimeline', () => {
-  test('performs eager tip dropping', () => {
+  it('performs eager tip dropping', () => {
     const allStepArgsAndErrors = {
       a: {
         stepArgs: {

--- a/protocol-designer/src/labware-ingred/__tests__/containers.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/containers.test.js
@@ -4,7 +4,7 @@ jest.mock('../../labware-defs/utils')
 const containersInitialState = {}
 
 describe('DELETE_CONTAINER action', () => {
-  test('no-op with no containers', () => {
+  it('no-op with no containers', () => {
     expect(
       containers(containersInitialState, {
         type: 'DELETE_CONTAINER',
@@ -13,7 +13,7 @@ describe('DELETE_CONTAINER action', () => {
     ).toEqual(containersInitialState)
   })
 
-  test('no-op with nonexistent labwareId', () => {
+  it('no-op with nonexistent labwareId', () => {
     expect(
       containers(
         {
@@ -31,7 +31,7 @@ describe('DELETE_CONTAINER action', () => {
     })
   })
 
-  test('delete given labwareId', () => {
+  it('delete given labwareId', () => {
     expect(
       containers(
         {
@@ -52,7 +52,7 @@ describe('DELETE_CONTAINER action', () => {
 })
 
 describe('DUPLICATE_LABWARE action', () => {
-  test('duplicate correct labware', () => {
+  it('duplicate correct labware', () => {
     expect(
       containers(
         {

--- a/protocol-designer/src/labware-ingred/__tests__/ingredients.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/ingredients.test.js
@@ -2,7 +2,7 @@ import { ingredients, ingredLocations } from '../reducers'
 jest.mock('../../labware-defs/utils')
 
 describe('DUPLICATE_LABWARE action', () => {
-  test('duplicate ingredient locations from cloned container', () => {
+  it('duplicate ingredient locations from cloned container', () => {
     const copyLabwareAction = {
       type: 'DUPLICATE_LABWARE',
       payload: {

--- a/protocol-designer/src/labware-ingred/__tests__/selectors.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/selectors.test.js
@@ -19,7 +19,7 @@ const allIngredientsXXSingleIngred = {
 // ==============================
 
 describe('allIngredientNamesIds selector', () => {
-  test('selects names & ids from allIngredients selector result', () => {
+  it('selects names & ids from allIngredients selector result', () => {
     expect(
       selectors.allIngredientNamesIds.resultFunc(
         // flow def for resultFunc is wrong and/or resultFun isn't typeable
@@ -35,12 +35,12 @@ describe('allIngredientNamesIds selector', () => {
 })
 
 describe('allIngredientGroupFields', () => {
-  test('no ingreds - return empty obj', () => {
+  it('no ingreds - return empty obj', () => {
     // flow def for resultFunc is wrong and/or resultFun isn't typeable
     expect(selectors.allIngredientGroupFields.resultFunc(({}: any))).toEqual({})
   })
 
-  test('select fields from all ingred groups', () => {
+  it('select fields from all ingred groups', () => {
     expect(
       selectors.allIngredientGroupFields.resultFunc(
         // flow def for resultFunc is wrong and/or resultFun isn't typeable

--- a/protocol-designer/src/labware-ingred/__tests__/utils.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/utils.test.js
@@ -59,7 +59,7 @@ describe('getNextNickname', () => {
   ]
 
   testCases.forEach(({ desc, allNicknames, proposed, expected }) => {
-    test(desc, () => {
+    it(desc, () => {
       const result = getNextNickname(allNicknames, proposed)
       expect(result).toEqual(expected)
     })

--- a/protocol-designer/src/load-file/__tests__/proceduresMatchSnapshots.test.js
+++ b/protocol-designer/src/load-file/__tests__/proceduresMatchSnapshots.test.js
@@ -37,7 +37,7 @@ const fixtures = [
 
 // TODO(IL, 2020-02-28): restore these tests, maybe as e2e. See #5123
 describe('snapshot integration test: JSON protocol fixture to procedures', () => {
-  test.todo('TODO')
+  it.todo('TODO')
   fixtures.forEach(({ testName, inputFile, expectedProcedure }) => {
     // test.todo(testName, () => {
     //   const store = configureStore()

--- a/protocol-designer/src/load-file/migration/__tests__/1_1_0.test.js
+++ b/protocol-designer/src/load-file/migration/__tests__/1_1_0.test.js
@@ -14,7 +14,7 @@ import {
 
 describe('renameOrderedSteps', () => {
   const migratedFile = renameOrderedSteps(oldProtocol)
-  test('removes orderedSteps key', () => {
+  it('removes orderedSteps key', () => {
     expect(oldProtocol['designer-application'].data.orderedSteps).not.toEqual(
       undefined
     )
@@ -23,7 +23,7 @@ describe('renameOrderedSteps', () => {
     )
   })
 
-  test('adds orderedStepIds key and value', () => {
+  it('adds orderedStepIds key and value', () => {
     const oldOrderedStepsIds =
       oldProtocol['designer-application'].data.orderedSteps
     expect(oldProtocol['designer-application'].data.orderedStepIds).toEqual(
@@ -34,7 +34,7 @@ describe('renameOrderedSteps', () => {
     )
   })
 
-  test('the rest of file should be unaltered', () => {
+  it('the rest of file should be unaltered', () => {
     const oldWithout = {
       ...oldProtocol,
       'designer-application': {
@@ -61,7 +61,7 @@ describe('renameOrderedSteps', () => {
 
 describe('addInitialDeckSetupStep', () => {
   const migratedFile = addInitialDeckSetupStep(oldProtocol)
-  test('adds savedStepForm key', () => {
+  it('adds savedStepForm key', () => {
     expect(
       oldProtocol['designer-application'].data.savedStepForms[
         INITIAL_DECK_SETUP_STEP_ID
@@ -85,19 +85,19 @@ describe('addInitialDeckSetupStep', () => {
       migratedFile['designer-application'].data.savedStepForms[
         INITIAL_DECK_SETUP_STEP_ID
       ]
-    test('is correct stepType', () => {
+    it('is correct stepType', () => {
       expect(deckSetupStepForm.stepType).toEqual(wellFormedSetupStep.stepType)
     })
-    test('has correct id value', () => {
+    it('has correct id value', () => {
       expect(deckSetupStepForm.id).toEqual(wellFormedSetupStep.id)
     })
-    test('constructs labware location update object', () => {
+    it('constructs labware location update object', () => {
       expect(deckSetupStepForm.labwareLocationUpdate).toEqual({
         ...wellFormedSetupStep.labwareLocationUpdate,
         ...mapValues(oldProtocol.labware, l => l.slot),
       })
     })
-    test('constructs pipette location update object', () => {
+    it('constructs pipette location update object', () => {
       expect(deckSetupStepForm.pipetteLocationUpdate).toEqual({
         ...wellFormedSetupStep.pipetteLocationUpdate,
         ...mapValues(oldProtocol.pipettes, p => p.mount),
@@ -195,7 +195,7 @@ describe('updateStepFormKeys', () => {
       },
     }
     const migratedFile = updateStepFormKeys(stubbedTCDStepsFile)
-    test('deprecates all indicated field names', () => {
+    it('deprecates all indicated field names', () => {
       each(TCD_DEPRECATED_FIELD_NAMES, fieldName => {
         each(
           stubbedTCDStepsFile['designer-application'].data.savedStepForms,
@@ -211,7 +211,7 @@ describe('updateStepFormKeys', () => {
         )
       })
     })
-    test('creates non-existent new fields', () => {
+    it('creates non-existent new fields', () => {
       const oldFields =
         stubbedTCDStepsFile['designer-application'].data.savedStepForms['1']
       const addedFields = {
@@ -278,7 +278,7 @@ describe('updateStepFormKeys', () => {
       },
     }
     const migratedFile = updateStepFormKeys(stubbedMixStepFile)
-    test('deprecates all indicated field names', () => {
+    it('deprecates all indicated field names', () => {
       each(MIX_DEPRECATED_FIELD_NAMES, fieldName => {
         each(
           stubbedMixStepFile['designer-application'].data.savedStepForms,
@@ -290,7 +290,7 @@ describe('updateStepFormKeys', () => {
         )
       })
     })
-    test('creates non-existent new fields', () => {
+    it('creates non-existent new fields', () => {
       const oldFields =
         stubbedMixStepFile['designer-application'].data.savedStepForms['1']
       const addedFields = {
@@ -328,37 +328,37 @@ describe('replaceTCDStepsWithMoveLiquidStep', () => {
   const migratedFile = replaceTCDStepsWithMoveLiquidStep(oldProtocol)
   each(oldStepForms, (stepForm, stepId) => {
     if (stepForm.stepType === 'transfer') {
-      test('transfer stepType changes into moveLiquid', () => {
+      it('transfer stepType changes into moveLiquid', () => {
         expect(
           migratedFile['designer-application'].data.savedStepForms[stepId]
             .stepType
         ).toEqual('moveLiquid')
       })
-      test('transfer stepType always receives single path', () => {
+      it('transfer stepType always receives single path', () => {
         expect(
           migratedFile['designer-application'].data.savedStepForms[stepId].path
         ).toEqual('single')
       })
     } else if (stepForm.stepType === 'consolidate') {
-      test('consolidate stepType changes into moveLiquid', () => {
+      it('consolidate stepType changes into moveLiquid', () => {
         expect(
           migratedFile['designer-application'].data.savedStepForms[stepId]
             .stepType
         ).toEqual('moveLiquid')
       })
-      test('consolidate stepType always receives multiAspirate path', () => {
+      it('consolidate stepType always receives multiAspirate path', () => {
         expect(
           migratedFile['designer-application'].data.savedStepForms[stepId].path
         ).toEqual('multiAspirate')
       })
     } else if (stepForm.stepType === 'distribute') {
-      test('distribute stepType changes into moveLiquid', () => {
+      it('distribute stepType changes into moveLiquid', () => {
         expect(
           migratedFile['designer-application'].data.savedStepForms[stepId]
             .stepType
         ).toEqual('moveLiquid')
       })
-      test('distribute stepType always receives multiAspirate or single path', () => {
+      it('distribute stepType always receives multiAspirate or single path', () => {
         expect(
           migratedFile['designer-application'].data.savedStepForms[stepId].path
         ).toMatch(/multiDispense|single/)

--- a/protocol-designer/src/load-file/migration/__tests__/3_0_0.test.js
+++ b/protocol-designer/src/load-file/migration/__tests__/3_0_0.test.js
@@ -5,7 +5,7 @@ jest.mock('../../../labware-defs/utils')
 jest.mock('../utils/v1LabwareModelToV2Def')
 
 describe('migrate to 3.0.0', () => {
-  test('snapshot test', () => {
+  it('snapshot test', () => {
     const result = migrateFile(example_1_1_0)
     expect(result).toMatchSnapshot()
   })

--- a/protocol-designer/src/load-file/migration/__tests__/index.test.js
+++ b/protocol-designer/src/load-file/migration/__tests__/index.test.js
@@ -11,21 +11,21 @@ describe('runs appropriate migrations for version', () => {
     '1.2.0': 'fake migration to 1.2.0',
     '1.1.0': 'fake migration to 1.1.0',
   }
-  test('does not run migration if only patch number is larger', () => {
+  it('does not run migration if only patch number is larger', () => {
     const migrationsToRun = getMigrationVersionsToRunFromVersion(
       stubbedMigrationByVersion,
       '1.1.2'
     )
     expect(migrationsToRun).toEqual(['1.2.0', '1.3.0', '2.0.0', '6.3.0'])
   })
-  test('does not run migration if only patch version is identical', () => {
+  it('does not run migration if only patch version is identical', () => {
     const migrationsToRun = getMigrationVersionsToRunFromVersion(
       stubbedMigrationByVersion,
       '1.1.0'
     )
     expect(migrationsToRun).toEqual(['1.2.0', '1.3.0', '2.0.0', '6.3.0'])
   })
-  test('runs all migrations if supplied version is lower than all', () => {
+  it('runs all migrations if supplied version is lower than all', () => {
     const migrationsToRun = getMigrationVersionsToRunFromVersion(
       stubbedMigrationByVersion,
       '0.0.5'
@@ -38,7 +38,7 @@ describe('runs appropriate migrations for version', () => {
       '6.3.0',
     ])
   })
-  test('runs no migrations if supplied version is higher than all', () => {
+  it('runs no migrations if supplied version is higher than all', () => {
     const migrationsToRun = getMigrationVersionsToRunFromVersion(
       stubbedMigrationByVersion,
       '8.9.5'

--- a/protocol-designer/src/step-forms/test/reducers.test.js
+++ b/protocol-designer/src/step-forms/test/reducers.test.js
@@ -18,7 +18,7 @@ import type { DeckSlot } from '../../types'
 jest.mock('../../labware-defs/utils')
 
 describe('steps reducer', () => {
-  test('initial add step', () => {
+  it('initial add step', () => {
     const state = {}
     const action = {
       type: 'ADD_STEP',
@@ -33,7 +33,7 @@ describe('steps reducer', () => {
     })
   })
 
-  test('second add step', () => {
+  it('second add step', () => {
     const state = {
       '333': {
         id: '333',
@@ -59,7 +59,7 @@ describe('steps reducer', () => {
 })
 
 describe('orderedStepIds reducer', () => {
-  test('initial add step', () => {
+  it('initial add step', () => {
     const state = []
     const action = {
       type: 'ADD_STEP',
@@ -68,7 +68,7 @@ describe('orderedStepIds reducer', () => {
     expect(orderedStepIds(state, action)).toEqual(['123'])
   })
 
-  test('second add step', () => {
+  it('second add step', () => {
     const state = ['123']
     const action = {
       type: 'ADD_STEP',
@@ -149,7 +149,7 @@ describe('orderedStepIds reducer', () => {
     ]
 
     testCases.forEach(({ label, payload, expected }) => {
-      test(label, () => {
+      it(label, () => {
         const action = {
           type: 'REORDER_SELECTED_STEP',
           payload,
@@ -161,7 +161,7 @@ describe('orderedStepIds reducer', () => {
 })
 
 describe('labwareInvariantProperties reducer', () => {
-  test('replace custom labware def', () => {
+  it('replace custom labware def', () => {
     const prevState = {
       labwareIdA1: { labwareDefURI: 'foo/a/1' },
       labwareIdA2: { labwareDefURI: 'foo/a/1' },
@@ -200,7 +200,7 @@ describe('moduleInvariantProperties reducer', () => {
     }
   })
 
-  test('create module', () => {
+  it('create module', () => {
     const newModuleData = {
       id: newId,
       slot: '3',
@@ -221,7 +221,7 @@ describe('moduleInvariantProperties reducer', () => {
     })
   })
 
-  test('edit module (change its model)', () => {
+  it('edit module (change its model)', () => {
     const newModel = 'someDifferentModel'
     const result = moduleInvariantProperties(prevState, {
       type: 'EDIT_MODULE',
@@ -232,7 +232,7 @@ describe('moduleInvariantProperties reducer', () => {
     })
   })
 
-  test('delete module', () => {
+  it('delete module', () => {
     const result = moduleInvariantProperties(prevState, {
       type: 'DELETE_MODULE',
       payload: { id: existingModuleId },
@@ -298,7 +298,7 @@ describe('savedStepForms reducer: initial deck setup step', () => {
     ]
 
     testCases.forEach(({ testName, action }) => {
-      test(testName, () => {
+      it(testName, () => {
         const prevRootState = makePrevRootState({
           labwareLocationUpdate: {
             [existingLabwareId]: '1',
@@ -542,7 +542,7 @@ describe('savedStepForms reducer: initial deck setup step', () => {
         expectedLabwareLocations,
         expectedModuleLocations,
       }) => {
-        test(testName, () => {
+        it(testName, () => {
           const prevRootState = makePrevRootState(makeStateArgs)
           const action = moveDeckItem(sourceSlot, destSlot)
           const result = savedStepForms(prevRootState, action)
@@ -562,7 +562,7 @@ describe('savedStepForms reducer: initial deck setup step', () => {
     )
   })
 
-  test('delete labware -> removes labware from initial deck setup step', () => {
+  it('delete labware -> removes labware from initial deck setup step', () => {
     const labwareToDeleteId = '__labwareToDelete'
     const prevRootState = makePrevRootState({
       labwareLocationUpdate: {
@@ -580,7 +580,7 @@ describe('savedStepForms reducer: initial deck setup step', () => {
     })
   })
 
-  test('delete pipettes -> removes pipette(s) from initial deck setup step', () => {
+  it('delete pipettes -> removes pipette(s) from initial deck setup step', () => {
     const leftPipetteId = '__leftPipette'
     const rightPipetteId = '__rightPipette'
     const prevRootState = makePrevRootState({
@@ -638,7 +638,7 @@ describe('savedStepForms reducer: initial deck setup step', () => {
           expectedLabwareLocations,
           expectedModuleLocations,
         }) => {
-          test(testName, () => {
+          it(testName, () => {
             const action = {
               type: 'CREATE_MODULE',
               payload: {
@@ -718,7 +718,7 @@ describe('savedStepForms reducer: initial deck setup step', () => {
       ]
 
       testCases.forEach(({ testName, action, expectedModuleId }) => {
-        test(testName, () => {
+        it(testName, () => {
           const result = savedStepForms(prevRootStateWithMagStep, action)
           expect(result.mag_step_form_id.moduleId).toBe(expectedModuleId)
         })
@@ -772,7 +772,7 @@ describe('savedStepForms reducer: initial deck setup step', () => {
         expectedLabwareLocations,
         expectedModuleLocations,
       }) => {
-        test(testName, () => {
+        it(testName, () => {
           const action = { type: 'DELETE_MODULE', payload: { id: moduleId } }
           const prevRootState = makePrevRootState(makeStateArgs)
           const result = savedStepForms(prevRootState, action)
@@ -846,7 +846,7 @@ describe('savedStepForms reducer: initial deck setup step', () => {
     ]
 
     testCases.forEach(({ testName, step }) => {
-      test(testName, () => {
+      it(testName, () => {
         const result = savedStepForms(getPrevRootStateWithStep(step), action)
         expect(result[stepId]).toEqual({ ...step, moduleId: null })
       })

--- a/protocol-designer/src/step-forms/test/utils.test.js
+++ b/protocol-designer/src/step-forms/test/utils.test.js
@@ -2,10 +2,10 @@
 import { getIdsInRange } from '../utils'
 
 describe('getIdsInRange', () => {
-  test('gets id in array of length 1', () => {
+  it('gets id in array of length 1', () => {
     expect(getIdsInRange(['X'], 'X', 'X')).toEqual(['X'])
   })
-  test('gets ids in array of length > 1', () => {
+  it('gets ids in array of length > 1', () => {
     const orderedIds = ['T', 'E', 'S', 'TTT', 'C', 'A', 'SSS', 'EEE']
     // includes first element
     expect(getIdsInRange(orderedIds, 'T', 'C')).toEqual([

--- a/protocol-designer/src/step-generation/__tests__/aspirate.test.js
+++ b/protocol-designer/src/step-generation/__tests__/aspirate.test.js
@@ -30,7 +30,7 @@ describe('aspirate', () => {
     }
   })
 
-  test('aspirate normally (with tip)', () => {
+  it('aspirate normally (with tip)', () => {
     const params = {
       ...flowRateAndOffsets,
       pipette: DEFAULT_PIPETTE,
@@ -48,7 +48,7 @@ describe('aspirate', () => {
     ])
   })
 
-  test('aspirate with volume > tip max volume should throw error', () => {
+  it('aspirate with volume > tip max volume should throw error', () => {
     invariantContext.pipetteEntities[
       DEFAULT_PIPETTE
     ].tiprackDefURI = getLabwareDefURI(fixture_tiprack_10_ul)
@@ -75,7 +75,7 @@ describe('aspirate', () => {
     })
   })
 
-  test('aspirate with volume > pipette max volume should throw error', () => {
+  it('aspirate with volume > pipette max volume should throw error', () => {
     // NOTE: assigning p300 to a 1000uL tiprack is nonsense, just for this test
     invariantContext.pipetteEntities[
       DEFAULT_PIPETTE
@@ -103,7 +103,7 @@ describe('aspirate', () => {
     })
   })
 
-  test('aspirate with invalid pipette ID should return error', () => {
+  it('aspirate with invalid pipette ID should return error', () => {
     const result = aspirate(
       {
         ...flowRateAndOffsets,
@@ -119,7 +119,7 @@ describe('aspirate', () => {
     expectTimelineError(getErrorResult(result).errors, 'PIPETTE_DOES_NOT_EXIST')
   })
 
-  test('aspirate with no tip should return error', () => {
+  it('aspirate with no tip should return error', () => {
     const result = aspirate(
       {
         ...flowRateAndOffsets,
@@ -138,7 +138,7 @@ describe('aspirate', () => {
     })
   })
 
-  test('aspirate from nonexistent labware should return error', () => {
+  it('aspirate from nonexistent labware should return error', () => {
     const result = aspirate(
       {
         ...flowRateAndOffsets,

--- a/protocol-designer/src/step-generation/__tests__/awaitTemperature.test.js
+++ b/protocol-designer/src/step-generation/__tests__/awaitTemperature.test.js
@@ -35,7 +35,7 @@ describe('awaitTemperature', () => {
     robotState = stateAndContext.robotState
   })
 
-  test('temperature module id exists and temp status is approaching temp', () => {
+  it('temperature module id exists and temp status is approaching temp', () => {
     const temperature = 20
     const args = {
       module: temperatureModuleId,
@@ -63,7 +63,7 @@ describe('awaitTemperature', () => {
     const result = awaitTemperature(args, invariantContext, previousRobotState)
     expect(result).toEqual(expected)
   })
-  test('returns missing module error when module id does not exist', () => {
+  it('returns missing module error when module id does not exist', () => {
     const temperature = 42
     const args = {
       module: 'someNonexistentModuleId',
@@ -74,7 +74,7 @@ describe('awaitTemperature', () => {
     const result = awaitTemperature(args, invariantContext, robotState)
     expect(result).toEqual(missingModuleError)
   })
-  test('returns missing module error when module id is null', () => {
+  it('returns missing module error when module id is null', () => {
     const temperature = 42
     const args = {
       module: null,
@@ -85,7 +85,7 @@ describe('awaitTemperature', () => {
     const result = awaitTemperature(args, invariantContext, robotState)
     expect(result).toEqual(missingModuleError)
   })
-  test('returns awaitTemperature command creator when temperature module already at target temp and awaiting that same temp', () => {
+  it('returns awaitTemperature command creator when temperature module already at target temp and awaiting that same temp', () => {
     const temperature = 42
     const args = {
       module: temperatureModuleId,
@@ -112,7 +112,7 @@ describe('awaitTemperature', () => {
     const result = awaitTemperature(args, invariantContext, previousRobotState)
     expect(result).toEqual(expected)
   })
-  test('returns missing temperature step error when temperature module already at target temp and awaiting different temp', () => {
+  it('returns missing temperature step error when temperature module already at target temp and awaiting different temp', () => {
     const temperature = 80
     const args = {
       module: temperatureModuleId,
@@ -130,7 +130,7 @@ describe('awaitTemperature', () => {
     const result = awaitTemperature(args, invariantContext, previousRobotState)
     expect(result).toEqual(missingTemperatureStep)
   })
-  test('returns missing temperature step error when prev temp state is DEACTIVATED', () => {
+  it('returns missing temperature step error when prev temp state is DEACTIVATED', () => {
     const temperature = 80
     const args = {
       module: temperatureModuleId,

--- a/protocol-designer/src/step-generation/__tests__/blowout.test.js
+++ b/protocol-designer/src/step-generation/__tests__/blowout.test.js
@@ -31,7 +31,7 @@ describe('blowout', () => {
     }
   })
 
-  test('blowout with tip', () => {
+  it('blowout with tip', () => {
     const result = blowout(params, invariantContext, robotStateWithTip)
 
     const res = getSuccessResult(result)
@@ -43,7 +43,7 @@ describe('blowout', () => {
     ])
   })
 
-  test('blowout with invalid pipette ID should throw error', () => {
+  it('blowout with invalid pipette ID should throw error', () => {
     const result = blowout(
       {
         ...params,
@@ -56,7 +56,7 @@ describe('blowout', () => {
     expectTimelineError(getErrorResult(result).errors, 'PIPETTE_DOES_NOT_EXIST')
   })
 
-  test('blowout with invalid labware ID should throw error', () => {
+  it('blowout with invalid labware ID should throw error', () => {
     const result = blowout(
       {
         ...params,
@@ -73,7 +73,7 @@ describe('blowout', () => {
     })
   })
 
-  test('blowout with no tip should throw error', () => {
+  it('blowout with no tip should throw error', () => {
     const result = blowout(params, invariantContext, initialRobotState)
 
     const res = getErrorResult(result)

--- a/protocol-designer/src/step-generation/__tests__/blowoutUtil.test.js
+++ b/protocol-designer/src/step-generation/__tests__/blowoutUtil.test.js
@@ -39,7 +39,7 @@ describe('blowoutUtil', () => {
     curryCommandCreator.mockReturnValue('return value from blowout')
   })
 
-  test('blowoutUtil curries blowout with source well params', () => {
+  it('blowoutUtil curries blowout with source well params', () => {
     blowoutUtil({
       ...blowoutArgs,
       blowoutLocation: SOURCE_WELL_BLOWOUT_DESTINATION,
@@ -54,7 +54,7 @@ describe('blowoutUtil', () => {
     })
   })
 
-  test('blowoutUtil curries blowout with dest plate params', () => {
+  it('blowoutUtil curries blowout with dest plate params', () => {
     blowoutUtil({
       ...blowoutArgs,
       blowoutLocation: DEST_WELL_BLOWOUT_DESTINATION,
@@ -69,7 +69,7 @@ describe('blowoutUtil', () => {
     })
   })
 
-  test('blowoutUtil curries blowout with an arbitrary labware Id', () => {
+  it('blowoutUtil curries blowout with an arbitrary labware Id', () => {
     blowoutUtil({
       ...blowoutArgs,
       blowoutLocation: TROUGH_LABWARE,
@@ -84,7 +84,7 @@ describe('blowoutUtil', () => {
     })
   })
 
-  test('blowoutUtil returns an empty array if not given a blowoutLocation', () => {
+  it('blowoutUtil returns an empty array if not given a blowoutLocation', () => {
     const result = blowoutUtil({ ...blowoutArgs, blowoutLocation: null })
     expect(curryCommandCreator).not.toHaveBeenCalled()
     expect(result).toEqual([])

--- a/protocol-designer/src/step-generation/__tests__/consolidate.test.js
+++ b/protocol-designer/src/step-generation/__tests__/consolidate.test.js
@@ -82,7 +82,7 @@ beforeEach(() => {
 })
 
 describe('consolidate single-channel', () => {
-  test('Minimal single-channel: A1 A2 to B1, 50uL with p300', () => {
+  it('Minimal single-channel: A1 A2 to B1, 50uL with p300', () => {
     const data = {
       ...mixinArgs,
       sourceWells: ['A1', 'A2'],
@@ -101,7 +101,7 @@ describe('consolidate single-channel', () => {
     ])
   })
 
-  test('Single-channel with exceeding pipette max: A1 A2 A3 A4 to B1, 150uL with p300', () => {
+  it('Single-channel with exceeding pipette max: A1 A2 A3 A4 to B1, 150uL with p300', () => {
     // TODO Ian 2018-05-03 is this a duplicate of exceeding max with changeTip="once"???
     const data = {
       ...mixinArgs,
@@ -123,7 +123,7 @@ describe('consolidate single-channel', () => {
     ])
   })
 
-  test('Single-channel with exceeding pipette max: with changeTip="always"', () => {
+  it('Single-channel with exceeding pipette max: with changeTip="always"', () => {
     const data = {
       ...mixinArgs,
       volume: 150,
@@ -146,7 +146,7 @@ describe('consolidate single-channel', () => {
     ])
   })
 
-  test('Single-channel with exceeding pipette max: with changeTip="once"', () => {
+  it('Single-channel with exceeding pipette max: with changeTip="once"', () => {
     const data = {
       ...mixinArgs,
       volume: 150,
@@ -167,7 +167,7 @@ describe('consolidate single-channel', () => {
     ])
   })
 
-  test('Single-channel with exceeding pipette max: with changeTip="never"', () => {
+  it('Single-channel with exceeding pipette max: with changeTip="never"', () => {
     const data = {
       ...mixinArgs,
       volume: 150,
@@ -187,7 +187,7 @@ describe('consolidate single-channel', () => {
     ])
   })
 
-  test('mix on aspirate should mix before aspirate in first well of chunk only, and tip position bound to labware', () => {
+  it('mix on aspirate should mix before aspirate in first well of chunk only, and tip position bound to labware', () => {
     const data = {
       ...mixinArgs,
       volume: 100,
@@ -221,7 +221,7 @@ describe('consolidate single-channel', () => {
     ])
   })
 
-  test('mix on aspirate', () => {
+  it('mix on aspirate', () => {
     const data = {
       ...mixinArgs,
       volume: 125,
@@ -279,7 +279,7 @@ describe('consolidate single-channel', () => {
     ])
   })
 
-  test('mix after dispense', () => {
+  it('mix after dispense', () => {
     const data = {
       ...mixinArgs,
       volume: 100,
@@ -312,7 +312,7 @@ describe('consolidate single-channel', () => {
     ])
   })
 
-  test('mix after dispense with blowout to trash: first mix, then blowout', () => {
+  it('mix after dispense with blowout to trash: first mix, then blowout', () => {
     const data = {
       ...mixinArgs,
       volume: 100,
@@ -349,7 +349,7 @@ describe('consolidate single-channel', () => {
     ])
   })
 
-  test('"pre-wet tip" should aspirate and dispense consolidate volume from first well of each chunk', () => {
+  it('"pre-wet tip" should aspirate and dispense consolidate volume from first well of each chunk', () => {
     // TODO LATER Ian 2018-02-13 Should it be 2/3 max volume instead?
     const data = {
       ...mixinArgs,
@@ -393,7 +393,7 @@ describe('consolidate single-channel', () => {
     ])
   })
 
-  test('touchTip after aspirate should touch tip after every aspirate command', () => {
+  it('touchTip after aspirate should touch tip after every aspirate command', () => {
     const data = {
       ...mixinArgs,
       volume: 150,
@@ -428,7 +428,7 @@ describe('consolidate single-channel', () => {
     ])
   })
 
-  test('touchTip after dispense should touch tip after dispense on destination well', () => {
+  it('touchTip after dispense should touch tip after dispense on destination well', () => {
     const data = {
       ...mixinArgs,
       volume: 150,
@@ -460,7 +460,7 @@ describe('consolidate single-channel', () => {
     ])
   })
 
-  test('invalid pipette ID should return error', () => {
+  it('invalid pipette ID should return error', () => {
     const data = {
       ...mixinArgs,
       sourceWells: ['A1', 'A2'],
@@ -476,7 +476,7 @@ describe('consolidate single-channel', () => {
     expect(res.errors[0].type).toEqual('PIPETTE_DOES_NOT_EXIST')
   })
 
-  test.todo('air gap') // TODO Ian 2018-04-05 determine air gap behavior
+  it.todo('air gap') // TODO Ian 2018-04-05 determine air gap behavior
 })
 
 describe('consolidate multi-channel', () => {
@@ -512,7 +512,7 @@ describe('consolidate multi-channel', () => {
     ...getFlowRateAndOffsetParams(),
   }
 
-  test('simple multi-channel: cols A1 A2 A3 A4 to col A12', () => {
+  it('simple multi-channel: cols A1 A2 A3 A4 to col A12', () => {
     const data = {
       ...args,
       volume: 140,
@@ -534,7 +534,7 @@ describe('consolidate multi-channel', () => {
   })
 
   // TODO Ian 2018-03-14: address different multi-channel layouts of plates
-  test.todo('multi-channel 384 plate: cols A1 B1 A2 B2 to 96-plate col A12')
+  it.todo('multi-channel 384 plate: cols A1 B1 A2 B2 to 96-plate col A12')
 
-  test.todo('multi-channel trough A1 A2 A3 A4 to 96-plate A12')
+  it.todo('multi-channel trough A1 A2 A3 A4 to 96-plate A12')
 })

--- a/protocol-designer/src/step-generation/__tests__/deactivateTemperature.test.js
+++ b/protocol-designer/src/step-generation/__tests__/deactivateTemperature.test.js
@@ -66,7 +66,7 @@ describe('deactivateTemperature', () => {
   ]
 
   testCases.forEach(({ expected, moduleId, testName }) => {
-    test(testName, () => {
+    it(testName, () => {
       const args = { module: moduleId, commandCreatorFnName }
       const result = deactivateTemperature(args, invariantContext, robotState)
       expect(result).toEqual(expected)

--- a/protocol-designer/src/step-generation/__tests__/delay.test.js
+++ b/protocol-designer/src/step-generation/__tests__/delay.test.js
@@ -21,7 +21,7 @@ beforeEach(() => {
 })
 
 describe('delay indefinitely', () => {
-  test('...', () => {
+  it('...', () => {
     const robotInitialState = getRobotInitialState()
     const message = 'delay indefinitely message'
 
@@ -49,7 +49,7 @@ describe('delay indefinitely', () => {
 })
 
 describe('delay for a given time', () => {
-  test('...', () => {
+  it('...', () => {
     const robotInitialState = getRobotInitialState()
     const message = 'delay 95.5 secs message'
 

--- a/protocol-designer/src/step-generation/__tests__/disengageMagnet.test.js
+++ b/protocol-designer/src/step-generation/__tests__/disengageMagnet.test.js
@@ -26,7 +26,7 @@ describe('engageMagnet', () => {
       moduleState: { type: MAGNETIC_MODULE_TYPE, engaged: false },
     }
   })
-  test('creates engage magnet command', () => {
+  it('creates engage magnet command', () => {
     const module = moduleId
     const result = disengageMagnet(
       { commandCreatorFnName, module },

--- a/protocol-designer/src/step-generation/__tests__/dispense.test.js
+++ b/protocol-designer/src/step-generation/__tests__/dispense.test.js
@@ -33,7 +33,7 @@ describe('dispense', () => {
         flowRate: 6,
       }
     })
-    test('dispense normally (with tip)', () => {
+    it('dispense normally (with tip)', () => {
       const result = dispense(params, invariantContext, robotStateWithTip)
 
       expect(getSuccessResult(result).commands).toEqual([
@@ -44,7 +44,7 @@ describe('dispense', () => {
       ])
     })
 
-    test('dispensing without tip should throw error', () => {
+    it('dispensing without tip should throw error', () => {
       const result = dispense(params, invariantContext, initialRobotState)
 
       const res = getErrorResult(result)
@@ -54,7 +54,7 @@ describe('dispense', () => {
       })
     })
 
-    test('dispense to nonexistent labware should throw error', () => {
+    it('dispense to nonexistent labware should throw error', () => {
       const result = dispense(
         {
           ...params,

--- a/protocol-designer/src/step-generation/__tests__/dispenseUpdateLiquidState.test.js
+++ b/protocol-designer/src/step-generation/__tests__/dispenseUpdateLiquidState.test.js
@@ -36,7 +36,7 @@ function getUpdatedLiquidState(params, initialLiquidState) {
 }
 
 describe('...single-channel pipette', () => {
-  test('fully dispense single ingredient into empty well, with explicit volume', () => {
+  it('fully dispense single ingredient into empty well, with explicit volume', () => {
     const initialLiquidState = merge(
       {},
       createEmptyLiquidState(invariantContext),
@@ -74,7 +74,7 @@ describe('...single-channel pipette', () => {
     })
   })
 
-  test('fully dispense single ingredient into empty well, with useFullVolume', () => {
+  it('fully dispense single ingredient into empty well, with useFullVolume', () => {
     const initialLiquidState = merge(
       {},
       createEmptyLiquidState(invariantContext),
@@ -115,7 +115,7 @@ describe('...single-channel pipette', () => {
     })
   })
 
-  test('dispense ingred 1 into well containing ingreds 1 & 2', () => {
+  it('dispense ingred 1 into well containing ingreds 1 & 2', () => {
     const initialLiquidState = merge(
       {},
       createEmptyLiquidState(invariantContext),
@@ -164,7 +164,7 @@ describe('...single-channel pipette', () => {
     })
   })
 
-  test('dispense ingred 1 & 2 into well containing 2 & 3', () => {
+  it('dispense ingred 1 & 2 into well containing 2 & 3', () => {
     const initialLiquidState = merge(
       {},
       createEmptyLiquidState(invariantContext),
@@ -216,7 +216,7 @@ describe('...single-channel pipette', () => {
     })
   })
 
-  test('partially dispense ingred 1 & 2 into well containing 2 & 3', () => {
+  it('partially dispense ingred 1 & 2 into well containing 2 & 3', () => {
     const initialLiquidState = merge(
       {},
       createEmptyLiquidState(invariantContext),
@@ -269,9 +269,7 @@ describe('...single-channel pipette', () => {
   })
 
   describe('handle air in pipette tips', () => {
-    test.todo(
-      'TODO(IL 2018-03-16): deal with air (especially regarding air gap)'
-    )
+    it.todo('TODO(IL 2018-03-16): deal with air (especially regarding air gap)')
   })
 })
 
@@ -344,7 +342,7 @@ describe('...8-channel pipette', () => {
 
     tests.forEach(({ labwareType, def, expectedLabwareMatch }) =>
       // make sourcePlateId a different labware def each time
-      test(labwareType, () => {
+      it(labwareType, () => {
         let customInvariantContext = makeContext()
         customInvariantContext.labwareEntities.sourcePlateId = {
           id: SOURCE_LABWARE,

--- a/protocol-designer/src/step-generation/__tests__/distribute.test.js
+++ b/protocol-designer/src/step-generation/__tests__/distribute.test.js
@@ -70,7 +70,7 @@ beforeEach(() => {
 })
 
 describe('distribute: minimal example', () => {
-  test('single channel; 60uL from A1 -> A2, A3; no tip pickup', () => {
+  it('single channel; 60uL from A1 -> A2, A3; no tip pickup', () => {
     const distributeArgs = {
       ...mixinArgs,
       sourceWell: 'A1',
@@ -94,7 +94,7 @@ describe('distribute: minimal example', () => {
 })
 
 describe('tip handling for multiple distribute chunks', () => {
-  test('changeTip: "once"', () => {
+  it('changeTip: "once"', () => {
     const distributeArgs: DistributeArgs = {
       ...mixinArgs,
       sourceWell: 'A1',
@@ -126,7 +126,7 @@ describe('tip handling for multiple distribute chunks', () => {
     ])
   })
 
-  test('changeTip: "always"', () => {
+  it('changeTip: "always"', () => {
     const distributeArgs: DistributeArgs = {
       ...mixinArgs,
       sourceWell: 'A1',
@@ -160,7 +160,7 @@ describe('tip handling for multiple distribute chunks', () => {
     ])
   })
 
-  test('changeTip: "never" with carried-over tip', () => {
+  it('changeTip: "never" with carried-over tip', () => {
     // NOTE: this has been used as BASE CASE for the "advanced settings" tests
     const distributeArgs: DistributeArgs = {
       ...mixinArgs,
@@ -188,7 +188,7 @@ describe('tip handling for multiple distribute chunks', () => {
     ])
   })
 
-  test('changeTip: "never" should fail with no initial tip', () => {
+  it('changeTip: "never" should fail with no initial tip', () => {
     const distributeArgs: DistributeArgs = {
       ...mixinArgs,
       sourceWell: 'A1',
@@ -212,7 +212,7 @@ describe('tip handling for multiple distribute chunks', () => {
 })
 
 describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position', () => {
-  test('mix before aspirate, then aspirate disposal volume', () => {
+  it('mix before aspirate, then aspirate disposal volume', () => {
     // NOTE this also tests "uneven final chunk" eg A6 in [A2 A3 | A4 A5 | A6]
     // which is especially relevant to disposal volume
     const distributeArgs: DistributeArgs = {
@@ -268,7 +268,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
   })
 
   // TODO(IL, 2020-02-28): pre-wet volume is not implemented for distribute! #5122
-  test.todo('pre-wet tip')
+  it.todo('pre-wet tip')
   // (() => {
   //   const distributeArgs: DistributeArgs = {
   //     ...mixinArgs,
@@ -306,7 +306,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
   //   ])
   // })
 
-  test('touch tip after aspirate', () => {
+  it('touch tip after aspirate', () => {
     const distributeArgs: DistributeArgs = {
       ...mixinArgs,
       sourceWell: 'A1',
@@ -337,7 +337,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
     ])
   })
 
-  test('touch tip after dispense', () => {
+  it('touch tip after dispense', () => {
     const distributeArgs: DistributeArgs = {
       ...mixinArgs,
       sourceWell: 'A1',
@@ -370,7 +370,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
     ])
   })
 
-  test('mix before aspirate w/ disposal vol', () => {
+  it('mix before aspirate w/ disposal vol', () => {
     const volume = 130
     const disposalVolume = 20
     const disposalLabware = SOURCE_LABWARE
@@ -430,7 +430,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
 })
 
 describe('invalid input + state errors', () => {
-  test('invalid pipette ID should throw error', () => {
+  it('invalid pipette ID should throw error', () => {
     const distributeArgs: DistributeArgs = {
       ...mixinArgs,
       sourceWell: 'A1',
@@ -455,7 +455,7 @@ describe('invalid input + state errors', () => {
 })
 
 describe('distribute volume exceeds pipette max volume', () => {
-  test(`no disposal volume`, () => {
+  it(`no disposal volume`, () => {
     const changeTip = 'once'
     const distributeArgs: DistributeArgs = {
       ...mixinArgs,
@@ -478,7 +478,7 @@ describe('distribute volume exceeds pipette max volume', () => {
     expect(res.errors[0].type).toEqual('PIPETTE_VOLUME_EXCEEDED')
   })
 
-  test(`with disposal volume`, () => {
+  it(`with disposal volume`, () => {
     const changeTip = 'once'
     const distributeArgs: DistributeArgs = {
       ...mixinArgs,

--- a/protocol-designer/src/step-generation/__tests__/dropAllTips.test.js
+++ b/protocol-designer/src/step-generation/__tests__/dropAllTips.test.js
@@ -41,7 +41,7 @@ function expectNoTipsRemaining(
 }
 
 describe('drop all tips', () => {
-  test('should do nothing with no pipettes', () => {
+  it('should do nothing with no pipettes', () => {
     initialRobotState.pipettes = {}
     initialRobotState.tipState.pipettes = {}
 
@@ -51,14 +51,14 @@ describe('drop all tips', () => {
     expectNoTipsRemaining(initialRobotState, invariantContext, res)
   })
 
-  test('should do nothing with pipette that does not have tips', () => {
+  it('should do nothing with pipette that does not have tips', () => {
     const result = dropAllTips(null, invariantContext, initialRobotState)
     const res = getSuccessResult(result)
     expect(res.commands).toHaveLength(0)
     expectNoTipsRemaining(initialRobotState, invariantContext, res)
   })
 
-  test('should drop tips of one pipette that has them, and not one without', () => {
+  it('should drop tips of one pipette that has them, and not one without', () => {
     initialRobotState.tipState.pipettes = {
       [p300SingleId]: true,
       [p300MultiId]: false,
@@ -72,7 +72,7 @@ describe('drop all tips', () => {
     expectNoTipsRemaining(initialRobotState, invariantContext, res)
   })
 
-  test('should drop tips for both pipettes, with 2 pipettes that have tips', () => {
+  it('should drop tips for both pipettes, with 2 pipettes that have tips', () => {
     initialRobotState.tipState.pipettes = {
       [p300SingleId]: true,
       [p300MultiId]: true,

--- a/protocol-designer/src/step-generation/__tests__/dropTip.test.js
+++ b/protocol-designer/src/step-generation/__tests__/dropTip.test.js
@@ -32,7 +32,7 @@ describe('dropTip', () => {
   }
 
   describe('replaceTip: single channel', () => {
-    test('drop tip if there is a tip', () => {
+    it('drop tip if there is a tip', () => {
       const result = dropTip(
         { pipette: DEFAULT_PIPETTE },
         invariantContext,
@@ -51,7 +51,7 @@ describe('dropTip', () => {
       ])
     })
 
-    test('no tip on pipette, ignore dropTip', () => {
+    it('no tip on pipette, ignore dropTip', () => {
       const initialRobotState = makeRobotState({
         singleHasTips: false,
         multiHasTips: true,
@@ -67,7 +67,7 @@ describe('dropTip', () => {
   })
 
   describe('Multi-channel dropTip', () => {
-    test('drop tip if there is a tip', () => {
+    it('drop tip if there is a tip', () => {
       const result = dropTip(
         { pipette: 'p300MultiId' },
         invariantContext,
@@ -86,7 +86,7 @@ describe('dropTip', () => {
       ])
     })
 
-    test('no tip on pipette, ignore dropTip', () => {
+    it('no tip on pipette, ignore dropTip', () => {
       const initialRobotState = makeRobotState({
         singleHasTips: true,
         multiHasTips: false,

--- a/protocol-designer/src/step-generation/__tests__/engageMagnet.test.js
+++ b/protocol-designer/src/step-generation/__tests__/engageMagnet.test.js
@@ -26,7 +26,7 @@ describe('engageMagnet', () => {
       moduleState: { type: MAGNETIC_MODULE_TYPE, engaged: false },
     }
   })
-  test('creates engage magnet command', () => {
+  it('creates engage magnet command', () => {
     const module = moduleId
     const engageHeight = 2
     const result = engageMagnet(

--- a/protocol-designer/src/step-generation/__tests__/fixtureGeneration.test.js
+++ b/protocol-designer/src/step-generation/__tests__/fixtureGeneration.test.js
@@ -3,10 +3,10 @@ import { createEmptyLiquidState } from '../utils'
 import { makeContext, makeState } from '../__fixtures__'
 
 describe('snapshot tests', () => {
-  test('makeContext', () => {
+  it('makeContext', () => {
     expect(makeContext()).toMatchSnapshot()
   })
-  test('makeState', () => {
+  it('makeState', () => {
     expect(
       makeState({
         invariantContext: makeContext(),
@@ -21,7 +21,7 @@ describe('snapshot tests', () => {
       })
     ).toMatchSnapshot()
   })
-  test('createEmptyLiquidState', () => {
+  it('createEmptyLiquidState', () => {
     expect(createEmptyLiquidState(makeContext())).toMatchSnapshot()
   })
 })

--- a/protocol-designer/src/step-generation/__tests__/forAspirate.test.js
+++ b/protocol-designer/src/step-generation/__tests__/forAspirate.test.js
@@ -42,7 +42,7 @@ describe('...single-channel pipette', () => {
     }
   })
   describe('...fresh tip', () => {
-    test('aspirate from single-ingredient well', () => {
+    it('aspirate from single-ingredient well', () => {
       robotState.liquidState.labware[labwareId].A1 = {
         ingred1: {
           volume: 200,
@@ -71,7 +71,7 @@ describe('...single-channel pipette', () => {
       })
     })
 
-    test('aspirate everything + air from a single-ingredient well', () => {
+    it('aspirate everything + air from a single-ingredient well', () => {
       // aspirate 300 from well with 200, leaving 100 of air
       robotState.liquidState.labware[labwareId].A1 = {
         ingred1: {
@@ -103,7 +103,7 @@ describe('...single-channel pipette', () => {
       })
     })
 
-    test('aspirate from two-ingredient well', () => {
+    it('aspirate from two-ingredient well', () => {
       robotState.liquidState.labware[labwareId].A1 = {
         ingred1: { volume: 200 },
         ingred2: { volume: 100 },
@@ -133,7 +133,7 @@ describe('...single-channel pipette', () => {
       })
     })
 
-    test('aspirate everything + air from two-ingredient well', () => {
+    it('aspirate everything + air from two-ingredient well', () => {
       robotState.liquidState.labware[labwareId].A1 = {
         ingred1: { volume: 60 },
         ingred2: { volume: 70 },
@@ -168,7 +168,7 @@ describe('...single-channel pipette', () => {
   })
 
   describe('...tip already containing liquid', () => {
-    test('aspirate from single-ingredient well', () => {
+    it('aspirate from single-ingredient well', () => {
       robotState.liquidState.labware[labwareId].A1 = {
         ingred1: { volume: 200 },
       }
@@ -213,7 +213,7 @@ describe('...8-channel pipette', () => {
     }
   })
 
-  test('aspirate from single-ingredient set of wells (96-flat)', () => {
+  it('aspirate from single-ingredient set of wells (96-flat)', () => {
     // A1 and B1 have 1 ingred of different volumes, rest of column 1 is empty
     robotState.liquidState.labware[labwareId] = {
       ...robotState.liquidState.labware[labwareId],
@@ -255,7 +255,7 @@ describe('...8-channel pipette', () => {
     })
   })
 
-  test('aspirate everything + air from single-ingredient wells (96-flat)', () => {
+  it('aspirate everything + air from single-ingredient wells (96-flat)', () => {
     // A1 and B1 have 1 ingred of different volumes, rest of column 1 is empty
     robotState.liquidState.labware[labwareId] = {
       ...robotState.liquidState.labware[labwareId],
@@ -332,7 +332,7 @@ describe('8-channel trough', () => {
       expectedWarnings,
       expectedWellContents,
     }) =>
-      test(`aspirate from single-ingredient common well (trough-12row): ${testName}`, () => {
+      it(`aspirate from single-ingredient common well (trough-12row): ${testName}`, () => {
         robotState.liquidState.labware[labwareId] = {
           ...robotState.liquidState.labware[labwareId],
           A1: initialWellContents,
@@ -364,5 +364,5 @@ describe('8-channel trough', () => {
       })
   )
 
-  test.todo('aspirate from 384 plate starting from B row') // TODO
+  it.todo('aspirate from 384 plate starting from B row') // TODO
 })

--- a/protocol-designer/src/step-generation/__tests__/forBlowout.test.js
+++ b/protocol-designer/src/step-generation/__tests__/forBlowout.test.js
@@ -29,7 +29,7 @@ beforeEach(() => {
 
 describe('Blowout command', () => {
   describe('liquid tracking', () => {
-    test('blowout updates with max volume of pipette', () => {
+    it('blowout updates with max volume of pipette', () => {
       robotStateWithTip.liquidState.pipettes.p300SingleId['0'] = {
         ingred1: { volume: 150 },
       }

--- a/protocol-designer/src/step-generation/__tests__/forDropTip.test.js
+++ b/protocol-designer/src/step-generation/__tests__/forDropTip.test.js
@@ -35,7 +35,7 @@ describe('dropTip', () => {
   }
 
   describe('replaceTip: single channel', () => {
-    test('drop tip if there is a tip', () => {
+    it('drop tip if there is a tip', () => {
       const prevRobotState = makeRobotState({
         singleHasTips: true,
         multiHasTips: true,
@@ -58,11 +58,11 @@ describe('dropTip', () => {
     })
 
     // TODO: IL 2019-11-20
-    test.todo('no tip on pipette')
+    it.todo('no tip on pipette')
   })
 
   describe('Multi-channel dropTip', () => {
-    test('drop tip when there are tips', () => {
+    it('drop tip when there are tips', () => {
       const prevRobotState = makeRobotState({
         singleHasTips: true,
         multiHasTips: true,
@@ -86,7 +86,7 @@ describe('dropTip', () => {
   })
 
   describe('liquid tracking', () => {
-    test('dropTip uses full volume when transfering tip to trash', () => {
+    it('dropTip uses full volume when transfering tip to trash', () => {
       const prevRobotState = makeRobotState({
         singleHasTips: true,
         multiHasTips: true,

--- a/protocol-designer/src/step-generation/__tests__/forPickUpTip.test.js
+++ b/protocol-designer/src/step-generation/__tests__/forPickUpTip.test.js
@@ -32,7 +32,7 @@ beforeEach(() => {
 })
 
 describe('tip tracking', () => {
-  test('single-channel', () => {
+  it('single-channel', () => {
     const params = { pipette: p300SingleId, labware: tiprack1Id, well: 'A1' }
 
     const result = forPickUpTip(params, invariantContext, initialRobotState)
@@ -54,7 +54,7 @@ describe('tip tracking', () => {
     )
   })
 
-  test('multi-channel', () => {
+  it('multi-channel', () => {
     const params = {
       pipette: p300MultiId,
       labware: 'tiprack1Id',
@@ -78,5 +78,5 @@ describe('tip tracking', () => {
   })
 
   // TODO: Ian 2019-11-20 eventually should generate warning (or error?)
-  test.todo('multi-channel, missing tip in specified row')
+  it.todo('multi-channel, missing tip in specified row')
 })

--- a/protocol-designer/src/step-generation/__tests__/glue.test.js
+++ b/protocol-designer/src/step-generation/__tests__/glue.test.js
@@ -148,7 +148,7 @@ beforeEach(() => {
 })
 
 describe('reduceCommandCreators', () => {
-  test('basic command creators', () => {
+  it('basic command creators', () => {
     const initialState: any = { count: 0 }
     const result: any = reduceCommandCreators(
       [
@@ -168,7 +168,7 @@ describe('reduceCommandCreators', () => {
     })
   })
 
-  test('error in a command short-circuits the command creation pipeline', () => {
+  it('error in a command short-circuits the command creation pipeline', () => {
     const initialState: any = { count: 5 }
     const result = reduceCommandCreators(
       [
@@ -190,7 +190,7 @@ describe('reduceCommandCreators', () => {
     })
   })
 
-  test('warnings accumulate in a flat array across the command chain', () => {
+  it('warnings accumulate in a flat array across the command chain', () => {
     const initialState: any = { count: 5 }
     const result = reduceCommandCreators(
       [
@@ -217,7 +217,7 @@ describe('reduceCommandCreators', () => {
 })
 
 describe('commandCreatorsTimeline', () => {
-  test('any errors short-circuit the timeline chain', () => {
+  it('any errors short-circuit the timeline chain', () => {
     const initialState: any = { count: 5 }
     const result = commandCreatorsTimeline(
       [
@@ -255,7 +255,7 @@ describe('commandCreatorsTimeline', () => {
     })
   })
 
-  test('warnings are indexed in an indexed command chain', () => {
+  it('warnings are indexed in an indexed command chain', () => {
     const initialState: any = { count: 5 }
 
     const result = commandCreatorsTimeline(

--- a/protocol-designer/src/step-generation/__tests__/mix.test.js
+++ b/protocol-designer/src/step-generation/__tests__/mix.test.js
@@ -56,7 +56,7 @@ describe('mix: change tip', () => {
     wells: ['A1', 'B1', 'C1'],
     changeTip,
   })
-  test('changeTip="always"', () => {
+  it('changeTip="always"', () => {
     const args = makeArgs('always')
     const result = mix(args, invariantContext, robotStateWithTip)
     const res = getSuccessResult(result)
@@ -73,7 +73,7 @@ describe('mix: change tip', () => {
     )
   })
 
-  test('changeTip="once"', () => {
+  it('changeTip="once"', () => {
     const args = makeArgs('once')
     const result = mix(args, invariantContext, robotStateWithTip)
     const res = getSuccessResult(result)
@@ -89,7 +89,7 @@ describe('mix: change tip', () => {
     ])
   })
 
-  test('changeTip="never"', () => {
+  it('changeTip="never"', () => {
     const args = makeArgs('never')
     const result = mix(args, invariantContext, robotStateWithTip)
     const res = getSuccessResult(result)
@@ -110,7 +110,7 @@ describe('mix: advanced options', () => {
   const times = 2
   const blowoutLabwareId = DEST_LABWARE
 
-  test('flow rate', () => {
+  it('flow rate', () => {
     const args = {
       ...mixinArgs,
       volume,
@@ -131,7 +131,7 @@ describe('mix: advanced options', () => {
     ])
   })
 
-  test('touch tip (after each dispense)', () => {
+  it('touch tip (after each dispense)', () => {
     const args: MixArgs = {
       ...mixinArgs,
       volume,
@@ -157,7 +157,7 @@ describe('mix: advanced options', () => {
     )
   })
 
-  test('blowout', () => {
+  it('blowout', () => {
     const args: MixArgs = {
       ...mixinArgs,
       volume,
@@ -185,7 +185,7 @@ describe('mix: advanced options', () => {
     )
   })
 
-  test('touch tip after blowout', () => {
+  it('touch tip after blowout', () => {
     const args: MixArgs = {
       ...mixinArgs,
       volume,
@@ -227,7 +227,7 @@ describe('mix: errors', () => {
       wells: ['A1', 'A2'],
     }
   })
-  test('invalid labware', () => {
+  it('invalid labware', () => {
     const args: MixArgs = {
       ...errorArgs,
       labware: 'invalidLabwareId',
@@ -240,7 +240,7 @@ describe('mix: errors', () => {
     })
   })
 
-  test('invalid pipette', () => {
+  it('invalid pipette', () => {
     const args: MixArgs = {
       ...errorArgs,
       pipette: 'invalidPipetteId',
@@ -254,6 +254,6 @@ describe('mix: errors', () => {
   })
 
   // TODO Ian 2018-05-08
-  test.todo('"times" arg non-integer')
-  test.todo('"times" arg negative')
+  it.todo('"times" arg non-integer')
+  it.todo('"times" arg negative')
 })

--- a/protocol-designer/src/step-generation/__tests__/replaceTip.test.js
+++ b/protocol-designer/src/step-generation/__tests__/replaceTip.test.js
@@ -26,7 +26,7 @@ describe('replaceTip', () => {
   })
 
   describe('replaceTip: single channel', () => {
-    test('Single-channel: first tip', () => {
+    it('Single-channel: first tip', () => {
       const result = replaceTip(
         { pipette: p300SingleId },
         invariantContext,
@@ -37,7 +37,7 @@ describe('replaceTip', () => {
       expect(res.commands).toEqual([pickUpTipHelper(0)])
     })
 
-    test('Single-channel: second tip B1', () => {
+    it('Single-channel: second tip B1', () => {
       const result = replaceTip(
         { pipette: p300SingleId },
         invariantContext,
@@ -59,7 +59,7 @@ describe('replaceTip', () => {
       expect(res.commands).toEqual([pickUpTipHelper(1)])
     })
 
-    test('Single-channel: ninth tip (next column)', () => {
+    it('Single-channel: ninth tip (next column)', () => {
       const initialTestRobotState = merge({}, initialRobotState, {
         tipState: {
           tipracks: {
@@ -81,7 +81,7 @@ describe('replaceTip', () => {
       expect(res.commands).toEqual([pickUpTipHelper('A2')])
     })
 
-    test('Single-channel: pipette already has tip, so tip will be replaced.', () => {
+    it('Single-channel: pipette already has tip, so tip will be replaced.', () => {
       const initialTestRobotState = merge({}, initialRobotState, {
         tipState: {
           tipracks: {
@@ -105,7 +105,7 @@ describe('replaceTip', () => {
       expect(res.commands).toEqual([dropTipHelper('A1'), pickUpTipHelper('B1')])
     })
 
-    test('Single-channel: used all tips in first rack, move to second rack', () => {
+    it('Single-channel: used all tips in first rack, move to second rack', () => {
       const initialTestRobotState = merge({}, initialRobotState, {
         tipState: {
           tipracks: {
@@ -130,7 +130,7 @@ describe('replaceTip', () => {
   })
 
   describe('replaceTip: multi-channel', () => {
-    test('multi-channel, all tipracks have tips', () => {
+    it('multi-channel, all tipracks have tips', () => {
       const result = replaceTip(
         { pipette: p300MultiId },
         invariantContext,
@@ -143,7 +143,7 @@ describe('replaceTip', () => {
       ])
     })
 
-    test('multi-channel, missing tip in first row', () => {
+    it('multi-channel, missing tip in first row', () => {
       const robotStateWithTipA1Missing = {
         ...initialRobotState,
         tipState: {
@@ -166,7 +166,7 @@ describe('replaceTip', () => {
       ])
     })
 
-    test('Multi-channel: pipette already has tip, so tip will be replaced.', () => {
+    it('Multi-channel: pipette already has tip, so tip will be replaced.', () => {
       const robotStateWithTipsOnMulti = {
         ...initialRobotState,
         tipState: {

--- a/protocol-designer/src/step-generation/__tests__/robotStateSelectors.test.js
+++ b/protocol-designer/src/step-generation/__tests__/robotStateSelectors.test.js
@@ -21,7 +21,7 @@ beforeEach(() => {
 })
 
 describe('sortLabwareBySlot', () => {
-  test('sorts all labware by slot', () => {
+  it('sorts all labware by slot', () => {
     const labwareState = {
       six: {
         slot: '6',
@@ -44,7 +44,7 @@ describe('sortLabwareBySlot', () => {
     ])
   })
 
-  test('with no labware, return empty array', () => {
+  it('with no labware, return empty array', () => {
     const labwareState = {}
     expect(sortLabwareBySlot(labwareState)).toEqual([])
   })
@@ -80,7 +80,7 @@ describe('_getNextTip', () => {
       robotState,
     })
   }
-  test('empty tiprack should return null', () => {
+  it('empty tiprack should return null', () => {
     const channels = [1, 8]
     channels.forEach(channel => {
       const result = getNextTipHelper(channel, { ...getTiprackTipstate(false) })
@@ -88,12 +88,12 @@ describe('_getNextTip', () => {
     })
   })
 
-  test('full tiprack should start at A1', () => {
+  it('full tiprack should start at A1', () => {
     const result = getNextTipHelper(1, { ...getTiprackTipstate(true) })
     expect(result).toEqual('A1')
   })
 
-  test('missing A1, go to B1', () => {
+  it('missing A1, go to B1', () => {
     const result = getNextTipHelper(1, {
       ...getTiprackTipstate(true),
       A1: false,
@@ -101,7 +101,7 @@ describe('_getNextTip', () => {
     expect(result).toEqual('B1')
   })
 
-  test('missing A1 and B1, go to C1', () => {
+  it('missing A1 and B1, go to C1', () => {
     const result = getNextTipHelper(1, {
       ...getTiprackTipstate(true),
       A1: false,
@@ -110,7 +110,7 @@ describe('_getNextTip', () => {
     expect(result).toEqual('C1')
   })
 
-  test('missing first column, go to A2', () => {
+  it('missing first column, go to A2', () => {
     const result = getNextTipHelper(1, {
       ...getTiprackTipstate(true),
       ...getTipColumn(1, false),
@@ -118,7 +118,7 @@ describe('_getNextTip', () => {
     expect(result).toEqual('A2')
   })
 
-  test('missing a few random tips, go to lowest col, then lowest row', () => {
+  it('missing a few random tips, go to lowest col, then lowest row', () => {
     const result = getNextTipHelper(1, {
       ...getTiprackTipstate(true),
       ...getTipColumn(1, false),
@@ -130,7 +130,7 @@ describe('_getNextTip', () => {
 })
 
 describe('getNextTiprack - single-channel', () => {
-  test('single tiprack, missing A1', () => {
+  it('single tiprack, missing A1', () => {
     const robotState = makeState({
       invariantContext,
       labwareLocations: {
@@ -149,7 +149,7 @@ describe('getNextTiprack - single-channel', () => {
     expect(result && result.well).toEqual('B1')
   })
 
-  test('single tiprack, empty, should return null', () => {
+  it('single tiprack, empty, should return null', () => {
     const robotState = makeState({
       invariantContext,
       pipetteLocations: { p300SingleId: { mount: 'left' } },
@@ -161,7 +161,7 @@ describe('getNextTiprack - single-channel', () => {
     expect(result).toEqual(null)
   })
 
-  test('multiple tipracks, all full, should return the filled tiprack in the lowest slot', () => {
+  it('multiple tipracks, all full, should return the filled tiprack in the lowest slot', () => {
     const robotState = makeState({
       invariantContext,
       pipetteLocations: { p300SingleId: { mount: 'left' } },
@@ -177,7 +177,7 @@ describe('getNextTiprack - single-channel', () => {
     expect(result && result.well).toEqual('A1')
   })
 
-  test('multiple tipracks, some partially full, should return the filled tiprack in the lowest slot', () => {
+  it('multiple tipracks, some partially full, should return the filled tiprack in the lowest slot', () => {
     let robotState = makeState({
       invariantContext,
       pipetteLocations: { p300SingleId: { mount: 'left' } },
@@ -196,7 +196,7 @@ describe('getNextTiprack - single-channel', () => {
     expect(result && result.well).toEqual('B1')
   })
 
-  test('multiple tipracks, all empty, should return null', () => {
+  it('multiple tipracks, all empty, should return null', () => {
     let robotState = makeState({
       invariantContext,
       pipetteLocations: { p300SingleId: { mount: 'left' } },
@@ -213,7 +213,7 @@ describe('getNextTiprack - single-channel', () => {
 })
 
 describe('getNextTiprack - 8-channel', () => {
-  test('single tiprack, totally full', () => {
+  it('single tiprack, totally full', () => {
     let robotState = makeState({
       invariantContext,
       pipetteLocations: { p300SingleId: { mount: 'left' } },
@@ -229,7 +229,7 @@ describe('getNextTiprack - 8-channel', () => {
     expect(result && result.well).toEqual('A1')
   })
 
-  test('single tiprack, partially full', () => {
+  it('single tiprack, partially full', () => {
     let robotState = makeState({
       invariantContext,
       pipetteLocations: { p300SingleId: { mount: 'left' } },
@@ -250,7 +250,7 @@ describe('getNextTiprack - 8-channel', () => {
     expect(result && result.well).toEqual('A3')
   })
 
-  test('single tiprack, empty, should return null', () => {
+  it('single tiprack, empty, should return null', () => {
     let robotState = makeState({
       invariantContext,
       pipetteLocations: { p300SingleId: { mount: 'left' } },
@@ -264,7 +264,7 @@ describe('getNextTiprack - 8-channel', () => {
     expect(result).toEqual(null)
   })
 
-  test('single tiprack, a well missing from each column, should return null', () => {
+  it('single tiprack, a well missing from each column, should return null', () => {
     let robotState = makeState({
       invariantContext,
       pipetteLocations: { p300SingleId: { mount: 'left' } },
@@ -294,7 +294,7 @@ describe('getNextTiprack - 8-channel', () => {
     expect(result).toEqual(null)
   })
 
-  test('multiple tipracks, all full, should return the filled tiprack in the lowest slot', () => {
+  it('multiple tipracks, all full, should return the filled tiprack in the lowest slot', () => {
     const robotState = makeState({
       invariantContext,
       pipetteLocations: { p300SingleId: { mount: 'left' } },
@@ -311,7 +311,7 @@ describe('getNextTiprack - 8-channel', () => {
     expect(result && result.well).toEqual('A1')
   })
 
-  test('multiple tipracks, some partially full, should return the filled tiprack in the lowest slot', () => {
+  it('multiple tipracks, some partially full, should return the filled tiprack in the lowest slot', () => {
     let robotState = makeState({
       invariantContext,
       pipetteLocations: { p300SingleId: { mount: 'left' } },
@@ -366,7 +366,7 @@ describe('getNextTiprack - 8-channel', () => {
     expect(result && result.well).toEqual('A2')
   })
 
-  test('multiple tipracks, all empty, should return null', () => {
+  it('multiple tipracks, all empty, should return null', () => {
     const robotState = makeState({
       invariantContext,
       pipetteLocations: { p300SingleId: { mount: 'left' } },
@@ -387,7 +387,7 @@ describe('getNextTiprack - 8-channel', () => {
 })
 
 describe('getModuleState', () => {
-  test('returns the state for specified module', () => {
+  it('returns the state for specified module', () => {
     const magModuleId = 'magdeck123'
     const magModuleState = {
       type: MAGNETIC_MODULE_TYPE,

--- a/protocol-designer/src/step-generation/__tests__/setTemperature.test.js
+++ b/protocol-designer/src/step-generation/__tests__/setTemperature.test.js
@@ -69,7 +69,7 @@ describe('setTemperature', () => {
   ]
 
   testCases.forEach(({ expected, moduleId, testName }) => {
-    test(testName, () => {
+    it(testName, () => {
       const args = { module: moduleId, targetTemperature, commandCreatorFnName }
       const result = setTemperature(args, invariantContext, robotState)
       expect(result).toEqual(expected)

--- a/protocol-designer/src/step-generation/__tests__/temperatureUpdates.test.js
+++ b/protocol-designer/src/step-generation/__tests__/temperatureUpdates.test.js
@@ -49,7 +49,7 @@ beforeEach(() => {
 })
 
 describe('forSetTemperature', () => {
-  test('module status is set to approaching and temp is set to target', () => {
+  it('module status is set to approaching and temp is set to target', () => {
     const params = {
       module: temperatureModuleId,
       temperature: temperature,
@@ -68,7 +68,7 @@ describe('forSetTemperature', () => {
     })
   })
 
-  test('module temp is changed to new target temp when already active', () => {
+  it('module temp is changed to new target temp when already active', () => {
     const newTemperature = 55
     const params = {
       module: temperatureModuleId,
@@ -99,7 +99,7 @@ describe('forSetTemperature', () => {
 })
 
 describe('forDeactivateTemperature', () => {
-  test('module status is deactivated and no temperature is set', () => {
+  it('module status is deactivated and no temperature is set', () => {
     const params = {
       module: temperatureModuleId,
     }
@@ -116,7 +116,7 @@ describe('forDeactivateTemperature', () => {
     })
   })
 
-  test('no effect when temp module is not active', () => {
+  it('no effect when temp module is not active', () => {
     const params = {
       module: temperatureModuleId,
     }
@@ -136,7 +136,7 @@ describe('forDeactivateTemperature', () => {
 
 describe('forAwaitTemperature', () => {
   ;[TEMPERATURE_AT_TARGET, TEMPERATURE_APPROACHING_TARGET].forEach(status => {
-    test(`update status to 'at target' when previous status is ${status} and the given target temp matches the previous target temp`, () => {
+    it(`update status to 'at target' when previous status is ${status} and the given target temp matches the previous target temp`, () => {
       const params = {
         module: temperatureModuleId,
         temperature: temperature,
@@ -169,7 +169,7 @@ describe('forAwaitTemperature', () => {
     })
   })
 
-  test(`keep status at 'appraoching target temperature' when actively approaching target`, () => {
+  it(`keep status at 'appraoching target temperature' when actively approaching target`, () => {
     const params = {
       module: temperatureModuleId,
       temperature: 55,

--- a/protocol-designer/src/step-generation/__tests__/touchTip.test.js
+++ b/protocol-designer/src/step-generation/__tests__/touchTip.test.js
@@ -22,7 +22,7 @@ describe('touchTip', () => {
     robotStateWithTip = getRobotStateWithTipStandard(invariantContext)
   })
 
-  test('touchTip with tip, specifying offsetFromBottomMm', () => {
+  it('touchTip with tip, specifying offsetFromBottomMm', () => {
     const result = touchTip(
       {
         pipette: DEFAULT_PIPETTE,
@@ -48,7 +48,7 @@ describe('touchTip', () => {
     ])
   })
 
-  test('touchTip with invalid pipette ID should throw error', () => {
+  it('touchTip with invalid pipette ID should throw error', () => {
     const result = touchTip(
       {
         pipette: 'badPipette',
@@ -64,7 +64,7 @@ describe('touchTip', () => {
     expectTimelineError(res.errors, 'PIPETTE_DOES_NOT_EXIST')
   })
 
-  test('touchTip with no tip should throw error', () => {
+  it('touchTip with no tip should throw error', () => {
     const result = touchTip(
       {
         pipette: DEFAULT_PIPETTE,

--- a/protocol-designer/src/step-generation/__tests__/transfer.test.js
+++ b/protocol-designer/src/step-generation/__tests__/transfer.test.js
@@ -68,7 +68,7 @@ describe('pick up tip if no tip on pipette', () => {
   const changeTipOptions = ['once', 'always']
 
   changeTipOptions.forEach(changeTip => {
-    test(`...${changeTip}`, () => {
+    it(`...${changeTip}`, () => {
       noTipArgs = {
         ...noTipArgs,
         changeTip,
@@ -81,7 +81,7 @@ describe('pick up tip if no tip on pipette', () => {
     })
   })
 
-  test('...never (should not pick up tip, and fail)', () => {
+  it('...never (should not pick up tip, and fail)', () => {
     noTipArgs = {
       ...noTipArgs,
       changeTip: 'never',
@@ -199,7 +199,7 @@ describe('single transfer exceeding pipette max', () => {
     }
   })
 
-  test('changeTip="once"', () => {
+  it('changeTip="once"', () => {
     transferArgs = {
       ...transferArgs,
       changeTip: 'once',
@@ -220,7 +220,7 @@ describe('single transfer exceeding pipette max', () => {
     ])
   })
 
-  test('changeTip="always"', () => {
+  it('changeTip="always"', () => {
     transferArgs = {
       ...transferArgs,
       changeTip: 'always',
@@ -257,7 +257,7 @@ describe('single transfer exceeding pipette max', () => {
     ])
   })
 
-  test('changeTip="perSource"', () => {
+  it('changeTip="perSource"', () => {
     transferArgs = {
       ...transferArgs,
       sourceWells: ['A1', 'A1', 'A2'],
@@ -295,7 +295,7 @@ describe('single transfer exceeding pipette max', () => {
     ])
   })
 
-  test('changeTip="perDest"', () => {
+  it('changeTip="perDest"', () => {
     // NOTE: same wells as perSource test
     transferArgs = {
       ...transferArgs,
@@ -335,7 +335,7 @@ describe('single transfer exceeding pipette max', () => {
     ])
   })
 
-  test('changeTip="never"', () => {
+  it('changeTip="never"', () => {
     transferArgs = {
       ...transferArgs,
       changeTip: 'never',
@@ -361,7 +361,7 @@ describe('single transfer exceeding pipette max', () => {
     ])
   })
 
-  test('split up volume without going below pipette min', () => {
+  it('split up volume without going below pipette min', () => {
     transferArgs = {
       ...transferArgs,
       volume: 629,
@@ -405,7 +405,7 @@ describe('advanced options', () => {
     }
   })
   describe('...aspirate options', () => {
-    test('pre-wet tip should aspirate and dispense transfer volume from source well of each subtransfer', () => {
+    it('pre-wet tip should aspirate and dispense transfer volume from source well of each subtransfer', () => {
       advArgs = {
         ...advArgs,
         volume: 350,
@@ -431,7 +431,7 @@ describe('advanced options', () => {
       ])
     })
 
-    test('touchTip after aspirate should touchTip on each source well, for every aspirate', () => {
+    it('touchTip after aspirate should touchTip on each source well, for every aspirate', () => {
       advArgs = {
         ...advArgs,
         volume: 350,
@@ -451,7 +451,7 @@ describe('advanced options', () => {
       ])
     })
 
-    test('touchTip after dispense should touchTip on each dest well, for every dispense', () => {
+    it('touchTip after dispense should touchTip on each dest well, for every dispense', () => {
       advArgs = {
         ...advArgs,
         volume: 350,
@@ -471,7 +471,7 @@ describe('advanced options', () => {
       ])
     })
 
-    test('mix before aspirate', () => {
+    it('mix before aspirate', () => {
       advArgs = {
         ...advArgs,
         volume: 350,
@@ -510,11 +510,11 @@ describe('advanced options', () => {
       ])
     })
 
-    test.todo('air gap => ???') // TODO determine behavior
+    it.todo('air gap => ???') // TODO determine behavior
   })
 
   describe('...dispense options', () => {
-    test('mix after dispense', () => {
+    it('mix after dispense', () => {
       advArgs = {
         ...advArgs,
         volume: 350,

--- a/protocol-designer/src/step-generation/__tests__/updateMagneticModule.test.js
+++ b/protocol-designer/src/step-generation/__tests__/updateMagneticModule.test.js
@@ -38,7 +38,7 @@ beforeEach(() => {
 })
 
 describe('forEngageMagnet', () => {
-  test('engages magnetic module when it was unengaged', () => {
+  it('engages magnetic module when it was unengaged', () => {
     const params = { module: moduleId, engageHeight: 10 }
 
     const result = forEngageMagnet(
@@ -53,7 +53,7 @@ describe('forEngageMagnet', () => {
     })
   })
 
-  test('no effect on magnetic module "engaged" state when already engaged', () => {
+  it('no effect on magnetic module "engaged" state when already engaged', () => {
     const params = { module: moduleId, engageHeight: 11 }
 
     const result = forEngageMagnet(params, invariantContext, engagedRobotState)
@@ -66,7 +66,7 @@ describe('forEngageMagnet', () => {
 })
 
 describe('forDisengageMagnet', () => {
-  test('unengages magnetic module when it was engaged', () => {
+  it('unengages magnetic module when it was engaged', () => {
     const params = { module: moduleId }
 
     const result = forDisengageMagnet(
@@ -81,7 +81,7 @@ describe('forDisengageMagnet', () => {
     })
   })
 
-  test('no effect on magnetic module "engaged" state when already disengaged', () => {
+  it('no effect on magnetic module "engaged" state when already disengaged', () => {
     const params = { module: moduleId }
 
     const result = forDisengageMagnet(

--- a/protocol-designer/src/step-generation/__tests__/utils.test.js
+++ b/protocol-designer/src/step-generation/__tests__/utils.test.js
@@ -33,21 +33,21 @@ describe('splitLiquid', () => {
     ingred2: { volume: 300 },
   }
 
-  test('simple split with 1 ingredient in source', () => {
+  it('simple split with 1 ingredient in source', () => {
     expect(splitLiquid(60, singleIngred)).toEqual({
       source: { ingred1: { volume: 40 } },
       dest: { ingred1: { volume: 60 } },
     })
   })
 
-  test('get 0 volume in source when you split it all', () => {
+  it('get 0 volume in source when you split it all', () => {
     expect(splitLiquid(100, singleIngred)).toEqual({
       source: { ingred1: { volume: 0 } },
       dest: { ingred1: { volume: 100 } },
     })
   })
 
-  test('split with 2 ingredients in source', () => {
+  it('split with 2 ingredients in source', () => {
     expect(splitLiquid(20, twoIngred)).toEqual({
       source: {
         ingred1: { volume: 95 },
@@ -60,7 +60,7 @@ describe('splitLiquid', () => {
     })
   })
 
-  test('split all with 2 ingredients', () => {
+  it('split all with 2 ingredients', () => {
     expect(splitLiquid(400, twoIngred)).toEqual({
       source: {
         ingred1: { volume: 0 },
@@ -70,7 +70,7 @@ describe('splitLiquid', () => {
     })
   })
 
-  test('taking out 0 volume results in same source, empty dest', () => {
+  it('taking out 0 volume results in same source, empty dest', () => {
     expect(splitLiquid(0, twoIngred)).toEqual({
       source: twoIngred,
       dest: {
@@ -80,7 +80,7 @@ describe('splitLiquid', () => {
     })
   })
 
-  test('split with 2 ingreds, one has 0 vol', () => {
+  it('split with 2 ingreds, one has 0 vol', () => {
     expect(
       splitLiquid(50, {
         ingred1: { volume: 200 },
@@ -98,7 +98,7 @@ describe('splitLiquid', () => {
     })
   })
 
-  test('split with 2 ingredients, floating-point volume', () => {
+  it('split with 2 ingredients, floating-point volume', () => {
     expect(
       splitLiquid(
         1000 / 3, // ~333.33
@@ -116,21 +116,21 @@ describe('splitLiquid', () => {
     })
   })
 
-  test('splitting with no ingredients in source just splits "air"', () => {
+  it('splitting with no ingredients in source just splits "air"', () => {
     expect(splitLiquid(100, {})).toEqual({
       source: {},
       dest: { [AIR]: { volume: 100 } },
     })
   })
 
-  test('splitting with 0 volume in source just splits "air"', () => {
+  it('splitting with 0 volume in source just splits "air"', () => {
     expect(splitLiquid(100, { ingred1: { volume: 0 } })).toEqual({
       source: { ingred1: { volume: 0 } },
       dest: { [AIR]: { volume: 100 } },
     })
   })
 
-  test('splitting with excessive volume leaves "air" in dest', () => {
+  it('splitting with excessive volume leaves "air" in dest', () => {
     expect(
       splitLiquid(100, { ingred1: { volume: 50 }, ingred2: { volume: 20 } })
     ).toEqual({
@@ -144,14 +144,14 @@ describe('splitLiquid', () => {
   })
 
   // TODO Ian 2018-03-19 figure out what to do with air warning reporting
-  test.todo('splitting with air in source should do something (throw error???)')
+  it.todo('splitting with air in source should do something (throw error???)')
   // expect(() =>
   // splitLiquid(50, { ingred1: { volume: 100 }, [AIR]: { volume: 20 } })
   // ).toThrow(/source cannot contain air/)
 })
 
 describe('mergeLiquid', () => {
-  test('merge ingreds 1 2 with 2 3 to get 1 2 3', () => {
+  it('merge ingreds 1 2 with 2 3 to get 1 2 3', () => {
     expect(
       mergeLiquid(
         {
@@ -170,7 +170,7 @@ describe('mergeLiquid', () => {
     })
   })
 
-  test('merge ingreds 3 with 1 2 to get 1 2 3', () => {
+  it('merge ingreds 3 with 1 2 to get 1 2 3', () => {
     expect(
       mergeLiquid(
         {
@@ -190,7 +190,7 @@ describe('mergeLiquid', () => {
 })
 
 describe('repeatArray', () => {
-  test('repeat array of objects', () => {
+  it('repeat array of objects', () => {
     expect(repeatArray([{ a: 1 }, { b: 2 }, { c: 3 }], 3)).toEqual([
       { a: 1 },
       { b: 2 },
@@ -204,7 +204,7 @@ describe('repeatArray', () => {
     ])
   })
 
-  test('repeat array of arrays', () => {
+  it('repeat array of arrays', () => {
     expect(repeatArray([[1, 2], [3, 4]], 4)).toEqual([
       [1, 2],
       [3, 4],

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultEngageHeight/__tests__/getNextDefautEngageHeight.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultEngageHeight/__tests__/getNextDefautEngageHeight.test.js
@@ -11,7 +11,7 @@ describe('getNextDefaultEngageHeight', () => {
     ]
 
     testCases.forEach(({ testMsg, expected }) => {
-      test(testMsg, () => {
+      it(testMsg, () => {
         const savedForms = {}
         const orderedStepIds = []
 
@@ -44,7 +44,7 @@ describe('getNextDefaultEngageHeight', () => {
     ]
 
     testCases.forEach(({ testMsg, orderedStepIds, expected }) => {
-      test(testMsg, () => {
+      it(testMsg, () => {
         const savedForms = {
           e: {
             id: 'moduleId',

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultMagnetAction/__tests__/getNextDefaultModuleAction.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultMagnetAction/__tests__/getNextDefaultModuleAction.test.js
@@ -11,7 +11,7 @@ describe('getNextDefaultMagnetAction', () => {
     ]
 
     testCases.forEach(({ testMsg, expected }) => {
-      test(testMsg, () => {
+      it(testMsg, () => {
         const savedForms = {}
         const orderedStepIds = []
 
@@ -37,7 +37,7 @@ describe('getNextDefaultMagnetAction', () => {
     ]
 
     testCases.forEach(({ testMsg, orderedStepIds, expected }) => {
-      test(testMsg, () => {
+      it(testMsg, () => {
         const savedForms = {
           e: { id: 'moduleId', stepType: 'magnet', magnetAction: 'engage' },
           d: { id: 'moduleId', stepType: 'magnet', magnetAction: 'disengage' },

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/__tests__/getNextDefaultModuleId.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/__tests__/getNextDefaultModuleId.test.js
@@ -68,7 +68,7 @@ describe('getNextDefaultTemperatureModuleId', () => {
     ]
 
     testCases.forEach(({ testMsg, equippedModulesById, expected }) => {
-      test(testMsg, () => {
+      it(testMsg, () => {
         const savedForms = {}
         const orderedStepIds = []
 
@@ -173,7 +173,7 @@ describe('getNextDefaultTemperatureModuleId', () => {
         orderedStepIds = [],
         expected,
       }) => {
-        test(testMsg, () => {
+        it(testMsg, () => {
           const result = getNextDefaultTemperatureModuleId(
             savedForms,
             orderedStepIds,

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultPipetteId/test/getNextDefaultPipetteId.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultPipetteId/test/getNextDefaultPipetteId.test.js
@@ -20,7 +20,7 @@ describe('getNextDefaultPipetteId', () => {
     ]
 
     testCases.forEach(({ testMsg, equippedPipettesById, expected }) => {
-      test(testMsg, () => {
+      it(testMsg, () => {
         const savedForms = {}
         const orderedStepIds = []
 
@@ -65,7 +65,7 @@ describe('getNextDefaultPipetteId', () => {
     ]
 
     testCases.forEach(({ testMsg, orderedStepIds, expected }) => {
-      test(testMsg, () => {
+      it(testMsg, () => {
         const savedForms = {
           a: { pipette: 'pipetteId_A' },
           b: { pipette: 'pipetteId_B' },

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/makeConditionalFieldUpdater.test.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/makeConditionalFieldUpdater.test.js
@@ -13,16 +13,16 @@ describe('makeConditionalPatchUpdater', () => {
     },
   ]
   const updateForFood = makeConditionalPatchUpdater(foodUpdateMap)
-  test('unhandled key field values case', () => {
+  it('unhandled key field values case', () => {
     expect(updateForFood('blorg', 'zvvvvvvargh', { spam: 'blah' })).toEqual({})
   })
-  test('no dependent fields cases', () => {
+  it('no dependent fields cases', () => {
     expect(updateForFood('apple', 'banana', {})).toEqual({})
     expect(
       updateForFood('apple', 'banana', { nonUpdatedField: 'foo' })
     ).toEqual({})
   })
-  test('avoid updating fields that should not get updated', () => {
+  it('avoid updating fields that should not get updated', () => {
     // all values in update don't need secondary update
     expect(
       updateForFood('apple', 'banana', {
@@ -40,7 +40,7 @@ describe('makeConditionalPatchUpdater', () => {
       })
     ).toEqual({ color: 'yellow' })
   })
-  test('update multiple fields together correctly', () => {
+  it('update multiple fields together correctly', () => {
     expect(
       updateForFood('apple', 'banana', {
         color: 'red',

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/mix.test.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/mix.test.js
@@ -34,11 +34,11 @@ describe('no-op cases should pass through the patch unchanged', () => {
     blah: 'blaaah',
   }
 
-  test('empty patch', () => {
+  it('empty patch', () => {
     const patch = {}
     expect(handleFormHelper(patch, minimalBaseForm)).toBe(patch)
   })
-  test('patch with unhandled field', () => {
+  it('patch with unhandled field', () => {
     const patch = { fooField: 123 }
     expect(handleFormHelper(patch, minimalBaseForm)).toBe(patch)
   })
@@ -55,17 +55,17 @@ describe('well selection should update', () => {
     }
   })
 
-  test('pipette cleared', () => {
+  it('pipette cleared', () => {
     const patch = { pipette: null }
     expect(handleFormHelper(patch, form)).toEqual({ ...patch, wells: [] })
   })
 
-  test('pipette single -> multi', () => {
+  it('pipette single -> multi', () => {
     const patch = { pipette: 'pipetteMultiId' }
     expect(handleFormHelper(patch, form)).toEqual({ ...patch, wells: [] })
   })
 
-  test('pipette multi -> single', () => {
+  it('pipette multi -> single', () => {
     const multiChForm = {
       ...form,
       pipette: 'pipetteMultiId',
@@ -78,7 +78,7 @@ describe('well selection should update', () => {
     })
   })
 
-  test('select single-well labware', () => {
+  it('select single-well labware', () => {
     const patch = { labware: 'trashId' }
     expect(handleFormHelper(patch, form)).toEqual({
       ...patch,
@@ -87,7 +87,7 @@ describe('well selection should update', () => {
     })
   })
 
-  test('select labware with multiple wells', () => {
+  it('select labware with multiple wells', () => {
     const trashLabwareForm = { ...form, labware: 'trashId' }
     const patch = { labware: 'plateId' }
     expect(handleFormHelper(patch, trashLabwareForm)).toEqual({

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
@@ -46,18 +46,18 @@ describe('no-op cases should pass through the patch unchanged', () => {
     dispense_wells: ['B1'],
   }
 
-  test('empty patch', () => {
+  it('empty patch', () => {
     const patch = {}
     expect(handleFormHelper(patch, minimalBaseForm)).toBe(patch)
   })
-  test('patch with unhandled field', () => {
+  it('patch with unhandled field', () => {
     const patch = { fooField: 123 }
     expect(handleFormHelper(patch, minimalBaseForm)).toBe(patch)
   })
 })
 
 describe('path should update...', () => {
-  test('if there is no path in base form', () => {
+  it('if there is no path in base form', () => {
     const patch = {}
     expect(handleFormHelper(patch, { blah: 'blaaah' })).toEqual({
       path: 'single',
@@ -66,7 +66,7 @@ describe('path should update...', () => {
   describe('if path is multi and volume*2 exceeds pipette/tip capacity', () => {
     const multiPaths = ['multiAspirate', 'multiDispense']
     multiPaths.forEach(path => {
-      test(`path ${path} → single`, () => {
+      it(`path ${path} → single`, () => {
         // volume is updated, existing path was multi
         // NOTE: 6 exceeds multi-well capacity of P10 (cannot fit 2 wells)
         const result2 = handleFormHelper(
@@ -87,7 +87,7 @@ describe('path should update...', () => {
     const cases = [['perSource', 'multiAspirate'], ['perDest', 'multiDispense']]
 
     cases.forEach(([changeTip, badPath]) => {
-      test(`"${changeTip}" selected: path → single`, () => {
+      it(`"${changeTip}" selected: path → single`, () => {
         const patch = { changeTip }
         const result = handleFormHelper({ ...patch, path: badPath }, {})
         expect(result.path).toEqual('single')
@@ -113,14 +113,14 @@ describe('disposal volume should update...', () => {
   describe('should not remove valid decimal', () => {
     const testCases = ['.', '0.', '.1', '1.', '']
     testCases.forEach(disposalVolume_volume => {
-      test(`input is ${disposalVolume_volume}`, () => {
+      it(`input is ${disposalVolume_volume}`, () => {
         const result = handleFormHelper({ disposalVolume_volume }, form)
         expect(result.disposalVolume_volume).toBe(disposalVolume_volume)
       })
     })
   })
 
-  test('when path is changed: multiDispense → single', () => {
+  it('when path is changed: multiDispense → single', () => {
     const result = handleFormHelper({ path: 'single' }, form)
     expect(result).toEqual({
       path: 'single',
@@ -129,7 +129,7 @@ describe('disposal volume should update...', () => {
     })
   })
 
-  test('when volume is raised but disposal vol is still in capacity, do not change (noop case)', () => {
+  it('when volume is raised but disposal vol is still in capacity, do not change (noop case)', () => {
     const patch = { volume: '2.5' }
     const result = handleFormHelper(patch, form)
     expect(result).toEqual(patch)
@@ -137,7 +137,7 @@ describe('disposal volume should update...', () => {
 
   describe('when volume is raised so that disposal vol must be exactly zero, clear/zero disposal volume fields', () => {
     const volume = '5' // 5 + 5 = 10 which is P10 capacity ==> max disposal volume is zero
-    test('when form is newly changed to multiDispense: clear the disposal vol + dispense_mix_* fields', () => {
+    it('when form is newly changed to multiDispense: clear the disposal vol + dispense_mix_* fields', () => {
       const patch = { path: 'multiDispense' }
       const result = handleFormHelper(patch, {
         ...form,
@@ -154,7 +154,7 @@ describe('disposal volume should update...', () => {
       })
     })
 
-    test('when form was multiDispense already: set to zero', () => {
+    it('when form was multiDispense already: set to zero', () => {
       const patch = { volume }
       const result = handleFormHelper(patch, form)
       expect(result).toEqual({
@@ -164,7 +164,7 @@ describe('disposal volume should update...', () => {
     })
   })
 
-  test('when volume is raised past disposal volume, lower disposal volume', () => {
+  it('when volume is raised past disposal volume, lower disposal volume', () => {
     const result = handleFormHelper({ volume: '4.6' }, form)
     expect(result).toEqual({
       volume: '4.6',
@@ -172,12 +172,12 @@ describe('disposal volume should update...', () => {
     })
   })
 
-  test('clamp excessive disposal volume to max', () => {
+  it('clamp excessive disposal volume to max', () => {
     const result = handleFormHelper({ disposalVolume_volume: '9999' }, form)
     expect(result).toEqual({ disposalVolume_volume: '6' })
   })
 
-  test('when disposal volume is a negative number, set to zero', () => {
+  it('when disposal volume is a negative number, set to zero', () => {
     const result = handleFormHelper({ disposalVolume_volume: '-2' }, form)
     expect(result).toEqual({ disposalVolume_volume: '0' })
   })
@@ -185,7 +185,7 @@ describe('disposal volume should update...', () => {
   describe('mix fields should clear...', () => {
     // NOTE: path --> multiDispense handled in "when form is newly changed to multiDispense" test above
 
-    test('when path is changed to multiAspirate, clear aspirate mix fields', () => {
+    it('when path is changed to multiAspirate, clear aspirate mix fields', () => {
       const form = {
         path: 'single',
         aspirate_wells: ['A1', 'A2'],
@@ -226,7 +226,7 @@ describe('disposal volume should update...', () => {
 
     testCases.forEach(({ prevPath, nextPath, incompatible }) => {
       const patch = { path: nextPath }
-      test(`when changing path ${prevPath} → ${nextPath}, arbitrary labware still allowed`, () => {
+      it(`when changing path ${prevPath} → ${nextPath}, arbitrary labware still allowed`, () => {
         const result = updatePatchBlowoutFields(patch, {
           path: prevPath,
           blowout_location: 'someKindaTrashLabwareIdHere',
@@ -234,7 +234,7 @@ describe('disposal volume should update...', () => {
         expect(result).toEqual(patch)
       })
 
-      test(`when changing path ${prevPath} → ${nextPath}, ${incompatible} reset to trashId`, () => {
+      it(`when changing path ${prevPath} → ${nextPath}, ${incompatible} reset to trashId`, () => {
         const result = updatePatchBlowoutFields(patch, {
           path: prevPath,
           blowout_location: incompatible,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/moveLiquidFormToArgs.test.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/moveLiquidFormToArgs.test.js
@@ -87,7 +87,7 @@ describe('move liquid step form -> command creator args', () => {
     }
   })
 
-  test('moveLiquidFormToArgs calls getOrderedWells correctly', () => {
+  it('moveLiquidFormToArgs calls getOrderedWells correctly', () => {
     moveLiquidFormToArgs(hydratedForm)
 
     expect(getOrderedWells).toHaveBeenCalledTimes(2)
@@ -105,7 +105,7 @@ describe('move liquid step form -> command creator args', () => {
     )
   })
 
-  test('moveLiquid form with 1:1 single transfer translated to args', () => {
+  it('moveLiquid form with 1:1 single transfer translated to args', () => {
     const result = moveLiquidFormToArgs(hydratedForm)
 
     expect(result).toMatchObject({
@@ -160,7 +160,7 @@ describe('move liquid step form -> command creator args', () => {
       expectedArgsChecked,
       expectedArgsUnchecked,
     }) => {
-      test(`${checkboxField} toggles dependent fields`, () => {
+      it(`${checkboxField} toggles dependent fields`, () => {
         expect(
           moveLiquidFormToArgs({
             ...hydratedForm,
@@ -196,7 +196,7 @@ describe('move liquid step form -> command creator args', () => {
       // remember the blowout/disposalVolume checkboxes are false by default!
     }
 
-    test('disposal volume works when checkbox true', () => {
+    it('disposal volume works when checkbox true', () => {
       const result = moveLiquidFormToArgs({
         ...hydratedForm,
         fields: {
@@ -213,7 +213,7 @@ describe('move liquid step form -> command creator args', () => {
       })
     })
 
-    test('disposal volume fields ignored when checkbox false', () => {
+    it('disposal volume fields ignored when checkbox false', () => {
       const result = moveLiquidFormToArgs({
         ...hydratedForm,
         fields: {
@@ -230,7 +230,7 @@ describe('move liquid step form -> command creator args', () => {
       })
     })
 
-    test('disposal volume overrides blowout', () => {
+    it('disposal volume overrides blowout', () => {
       const result = moveLiquidFormToArgs({
         ...hydratedForm,
         fields: {
@@ -248,7 +248,7 @@ describe('move liquid step form -> command creator args', () => {
       })
     })
 
-    test('fallback to blowout when disposal volume unchecked', () => {
+    it('fallback to blowout when disposal volume unchecked', () => {
       const result = moveLiquidFormToArgs({
         ...hydratedForm,
         fields: {
@@ -266,7 +266,7 @@ describe('move liquid step form -> command creator args', () => {
       })
     })
 
-    test('blowout in source', () => {
+    it('blowout in source', () => {
       const result = moveLiquidFormToArgs({
         ...hydratedForm,
         fields: {
@@ -284,7 +284,7 @@ describe('move liquid step form -> command creator args', () => {
       })
     })
 
-    test('blowout in dest', () => {
+    it('blowout in dest', () => {
       const result = moveLiquidFormToArgs({
         ...hydratedForm,
         fields: {
@@ -305,7 +305,7 @@ describe('move liquid step form -> command creator args', () => {
 })
 
 describe('getMixData', () => {
-  test('return null if checkbox field is false', () => {
+  it('return null if checkbox field is false', () => {
     expect(
       getMixData(
         { checkboxField: false, volumeField: 30, timesField: 2 },
@@ -316,7 +316,7 @@ describe('getMixData', () => {
     ).toBe(null)
   })
 
-  test('return null if either number fields <= 0 / null', () => {
+  it('return null if either number fields <= 0 / null', () => {
     const cases = [[0, 5], [null, 5], [10, 0], [10, null]]
 
     cases.forEach(testCase => {
@@ -336,7 +336,7 @@ describe('getMixData', () => {
     })
   })
 
-  test('return volume & times if checkbox is checked', () => {
+  it('return volume & times if checkbox is checked', () => {
     expect(
       getMixData(
         { checkboxField: true, volumeField: 30, timesField: 2 },

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/pauseFormToArgs.test.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/pauseFormToArgs.test.js
@@ -6,7 +6,7 @@ import {
 import { pauseFormToArgs } from '../pauseFormToArgs'
 
 describe('pauseFormToArgs', () => {
-  test('returns awaitTemperature command creator when form specifies pause until temp', () => {
+  it('returns awaitTemperature command creator when form specifies pause until temp', () => {
     const formData = {
       stepType: 'pause',
       id: 'test_id',
@@ -23,7 +23,7 @@ describe('pauseFormToArgs', () => {
     }
     expect(pauseFormToArgs(formData)).toEqual(expected)
   })
-  test('returns delay command creator when form specifies pause until resume', () => {
+  it('returns delay command creator when form specifies pause until resume', () => {
     const formData = {
       stepType: 'pause',
       id: 'test_id',
@@ -46,7 +46,7 @@ describe('pauseFormToArgs', () => {
     expect(pauseFormToArgs(formData)).toEqual(expected)
   })
 
-  test('returns delay command creator when form specifies pause until time', () => {
+  it('returns delay command creator when form specifies pause until time', () => {
     const formData = {
       stepType: 'pause',
       id: 'test_id',

--- a/protocol-designer/src/steplist/test/generateSubsteps.test.js
+++ b/protocol-designer/src/steplist/test/generateSubsteps.test.js
@@ -36,7 +36,7 @@ describe('generateSubsteps', () => {
     })
   })
 
-  test('null is returned when no robotState', () => {
+  it('null is returned when no robotState', () => {
     robotState = null
     const stepArgsAndErrors = {
       stepArgs: {
@@ -81,7 +81,7 @@ describe('generateSubsteps', () => {
       },
     },
   ].forEach(({ testName, args }) => {
-    test(testName, () => {
+    it(testName, () => {
       const result = generateSubsteps(
         args,
         invariantContext,
@@ -94,7 +94,7 @@ describe('generateSubsteps', () => {
     })
   })
 
-  test('delay command returns pause substep data', () => {
+  it('delay command returns pause substep data', () => {
     const stepArgsAndErrors = {
       errors: {},
       stepArgs: {
@@ -310,7 +310,7 @@ describe('generateSubsteps', () => {
         },
       },
     ].forEach(({ testName, stepArgs, expected }) => {
-      test(testName, () => {
+      it(testName, () => {
         const stepArgsAndErrors = {
           errors: {},
           stepArgs: { ...sharedArgs, ...stepArgs },
@@ -329,7 +329,7 @@ describe('generateSubsteps', () => {
     })
   })
 
-  test('mix command returns substep data', () => {
+  it('mix command returns substep data', () => {
     const stepArgsAndErrors = {
       stepArgs: {
         name: 'testing',
@@ -484,7 +484,7 @@ describe('generateSubsteps', () => {
     expect(result).toEqual(expected)
   })
 
-  test('engageMagnet returns substep data with engage = true', () => {
+  it('engageMagnet returns substep data with engage = true', () => {
     const stepArgsAndErrors = {
       errors: {},
       stepArgs: {
@@ -511,7 +511,7 @@ describe('generateSubsteps', () => {
     })
   })
 
-  test('disengageMagnet returns substep data with engage = false', () => {
+  it('disengageMagnet returns substep data with engage = false', () => {
     const stepArgsAndErrors = {
       errors: {},
       stepArgs: {
@@ -538,7 +538,7 @@ describe('generateSubsteps', () => {
     })
   })
 
-  test('setTemperature returns substep data with temperature', () => {
+  it('setTemperature returns substep data with temperature', () => {
     const stepArgsAndErrors = {
       errors: {},
       stepArgs: {
@@ -566,7 +566,7 @@ describe('generateSubsteps', () => {
     })
   })
 
-  test('setTemperature returns temperature when 0', () => {
+  it('setTemperature returns temperature when 0', () => {
     const stepArgsAndErrors = {
       errors: {},
       stepArgs: {
@@ -594,7 +594,7 @@ describe('generateSubsteps', () => {
     })
   })
 
-  test('deactivateTemperature returns substep data with null temp', () => {
+  it('deactivateTemperature returns substep data with null temp', () => {
     const stepArgsAndErrors = {
       errors: {},
       stepArgs: {
@@ -621,7 +621,7 @@ describe('generateSubsteps', () => {
     })
   })
 
-  test('null is returned when no matching command', () => {
+  it('null is returned when no matching command', () => {
     const stepArgsAndErrors = {
       errors: {},
       stepArgs: {

--- a/protocol-designer/src/steplist/test/mergeSubstepsFns.test.js
+++ b/protocol-designer/src/steplist/test/mergeSubstepsFns.test.js
@@ -216,7 +216,7 @@ describe('mergeSubstepRowsSingleChannel', () => {
     },
   ]
   testCases.forEach(({ testName, showDispenseVol, substepRows, expected }) =>
-    test(testName, () => {
+    it(testName, () => {
       const result = mergeSubstepRowsSingleChannel({
         substepRows,
         showDispenseVol,
@@ -259,7 +259,7 @@ describe('mergeSubstepRowsMultiChannel', () => {
     },
   ]
   testCases.forEach(({ testName, isMixStep, showDispenseVol, substepRows }) =>
-    test(testName, () => {
+    it(testName, () => {
       const channels = 8
       const result = mergeSubstepRowsMultiChannel({
         channels,

--- a/protocol-designer/src/steplist/test/mergeWhen.test.js
+++ b/protocol-designer/src/steplist/test/mergeWhen.test.js
@@ -6,21 +6,21 @@ function concat(a: string, b: string): string {
 }
 
 describe('mergeWhen', () => {
-  test('empty array input', () => {
+  it('empty array input', () => {
     ;[true, false].forEach(shouldSplit => {
       const result = mergeWhen([], (current, next) => shouldSplit, concat)
       expect(result).toEqual([])
     })
   })
 
-  test('single array input', () => {
+  it('single array input', () => {
     ;[true, false].forEach(shouldSplit => {
       const result2 = mergeWhen(['a'], (current, next) => shouldSplit, concat)
       expect(result2).toEqual(['a'])
     })
   })
 
-  test('single array uses alternative when predicate is false', () => {
+  it('single array uses alternative when predicate is false', () => {
     const result = mergeWhen(
       ['a'],
       (current, next) => false,
@@ -30,17 +30,17 @@ describe('mergeWhen', () => {
     expect(result).toEqual(['A'])
   })
 
-  test('always merge', () => {
+  it('always merge', () => {
     const result = mergeWhen(['1', '2', '3'], (current, next) => true, concat)
     expect(result).toEqual(['12', '3'])
   })
 
-  test('never split', () => {
+  it('never split', () => {
     const result = mergeWhen(['1', '2', '3'], (current, next) => false, concat)
     expect(result).toEqual(['1', '2', '3'])
   })
 
-  test('predicate true on index=0 only', () => {
+  it('predicate true on index=0 only', () => {
     const result = mergeWhen(
       ['1', '2', '3'],
       (current, next) => current === 1,
@@ -49,7 +49,7 @@ describe('mergeWhen', () => {
     expect(result).toEqual(['1', '2', '3'])
   })
 
-  test('merge at end', () => {
+  it('merge at end', () => {
     const result = mergeWhen(
       ['1', '2', '3'],
       (current, next) => current === '3',
@@ -58,7 +58,7 @@ describe('mergeWhen', () => {
     expect(result).toEqual(['1', '2', '3'])
   })
 
-  test('merge when "a*" before "b*"', () => {
+  it('merge when "a*" before "b*"', () => {
     const result = mergeWhen(
       ['a1', 'a2', 'b3', 'a4', 'b5', 'b6', 'a7', 'b8'],
       (prev: string, current: string) =>

--- a/protocol-designer/src/steplist/test/orderWells.test.js
+++ b/protocol-designer/src/steplist/test/orderWells.test.js
@@ -34,7 +34,7 @@ describe('orderWells', () => {
       },
     }
     orderTuples.forEach(tuple => {
-      test(`first ${tuple[0]} then ${tuple[1]}`, () => {
+      it(`first ${tuple[0]} then ${tuple[1]}`, () => {
         expect(orderWells(regularOrdering, ...tuple)).toEqual(
           regularAnswerMap[tuple[0]][tuple[1]]
         )
@@ -69,7 +69,7 @@ describe('orderWells', () => {
     }
 
     orderTuples.forEach(tuple => {
-      test(`first ${tuple[0]} then ${tuple[1]}`, () => {
+      it(`first ${tuple[0]} then ${tuple[1]}`, () => {
         expect(orderWells(irregularOrdering, ...tuple)).toEqual(
           irregularAnswerMap[tuple[0]][tuple[1]]
         )

--- a/protocol-designer/src/steplist/test/substeps.test.js
+++ b/protocol-designer/src/steplist/test/substeps.test.js
@@ -22,14 +22,14 @@
 
 describe('substep timeline', () => {
   describe('substepTimelineSingleChannel', () => {
-    test('returns empty array if initial timeline frame has errors', () => {})
+    it('returns empty array if initial timeline frame has errors', () => {})
   })
   describe('substepTimelineMultiChannel', () => {
-    test('returns empty array if initial timeline frame has errors', () => {})
+    it('returns empty array if initial timeline frame has errors', () => {})
   })
 
   describe('_getNewActiveTips', () => {
-    test('gets params of last pickUpTip command in an array of commands', () => {})
-    test('returns null when there were no pickUpTip commands', () => {})
+    it('gets params of last pickUpTip command in an array of commands', () => {})
+    it('returns null when there were no pickUpTip commands', () => {})
   })
 })

--- a/protocol-designer/src/top-selectors/well-contents/__tests__/getSelectedWellsCommonValues.test.js
+++ b/protocol-designer/src/top-selectors/well-contents/__tests__/getSelectedWellsCommonValues.test.js
@@ -20,7 +20,7 @@ beforeEach(() => {
 })
 
 describe('getSelectedWellsCommonValues', () => {
-  test('labware id not in ingredientLocations', () => {
+  it('labware id not in ingredientLocations', () => {
     const selectedWells = { A1: null }
     const selectedLabwareId = 'badLabwareId'
 
@@ -33,7 +33,7 @@ describe('getSelectedWellsCommonValues', () => {
     expect(result.ingredientId).toBe(null)
   })
 
-  test('no selected labware', () => {
+  it('no selected labware', () => {
     const selectedWells = { A1: null }
     const selectedLabwareId = null
 
@@ -46,7 +46,7 @@ describe('getSelectedWellsCommonValues', () => {
     expect(result.ingredientId).toBe(null)
   })
 
-  test('all selected wells same ingred: return ingred group id', () => {
+  it('all selected wells same ingred: return ingred group id', () => {
     const selectedWells = { A1: null, A2: null }
 
     const result = getSelectedWellsCommonValues.resultFunc(
@@ -58,7 +58,7 @@ describe('getSelectedWellsCommonValues', () => {
     expect(result.ingredientId).toBe('ingred1')
   })
 
-  test('2 well different ingreds: return null', () => {
+  it('2 well different ingreds: return null', () => {
     const selectedWells = { A2: null, A3: null }
 
     const result = getSelectedWellsCommonValues.resultFunc(
@@ -70,7 +70,7 @@ describe('getSelectedWellsCommonValues', () => {
     expect(result.ingredientId).toBe(null)
   })
 
-  test('2 well one empty: return null', () => {
+  it('2 well one empty: return null', () => {
     const selectedWells = { A2: null, A6: null }
 
     const result = getSelectedWellsCommonValues.resultFunc(
@@ -82,7 +82,7 @@ describe('getSelectedWellsCommonValues', () => {
     expect(result.ingredientId).toBe(null)
   })
 
-  test('1 well mixed ingreds: return null', () => {
+  it('1 well mixed ingreds: return null', () => {
     const selectedWells = { A4: null }
 
     const result = getSelectedWellsCommonValues.resultFunc(

--- a/protocol-designer/src/top-selectors/well-contents/__tests__/getWellContentsAllLabware.test.js
+++ b/protocol-designer/src/top-selectors/well-contents/__tests__/getWellContentsAllLabware.test.js
@@ -58,12 +58,12 @@ describe('getWellContentsAllLabware', () => {
     )
   })
 
-  test('containers have expected number of wells', () => {
+  it('containers have expected number of wells', () => {
     expect(Object.keys(singleIngredResult.container1Id).length).toEqual(96)
     expect(Object.keys(singleIngredResult.container2Id).length).toEqual(96)
   })
 
-  test('selects well contents of all labware (for Plate props)', () => {
+  it('selects well contents of all labware (for Plate props)', () => {
     expect(singleIngredResult).toMatchObject({
       FIXED_TRASH_ID: {
         A1: defaultWellContents,
@@ -98,7 +98,7 @@ describe('getWellContentsAllLabware', () => {
     })
   })
 
-  test('no selected wells when labwareId is not selected', () => {
+  it('no selected wells when labwareId is not selected', () => {
     const result = getWellContentsAllLabware.resultFunc(
       labwareEntities,
       ingredsByLabwareXXSingleIngred,

--- a/protocol-designer/src/ui/labware/__tests__/selectors.test.js
+++ b/protocol-designer/src/ui/labware/__tests__/selectors.test.js
@@ -34,10 +34,10 @@ describe('labware selectors', () => {
     }
   })
   describe('getDisposalLabwareOptions', () => {
-    test('returns an empty list when labware is NOT provided', () => {
+    it('returns an empty list when labware is NOT provided', () => {
       expect(getDisposalLabwareOptions.resultFunc([], names)).toEqual([])
     })
-    test('returns empty list when trash is NOT present', () => {
+    it('returns empty list when trash is NOT present', () => {
       const labwareEntities = {
         ...tipracks,
       }
@@ -45,7 +45,7 @@ describe('labware selectors', () => {
         getDisposalLabwareOptions.resultFunc(labwareEntities, names)
       ).toEqual([])
     })
-    test('filters out labware that is NOT trash when one trash bin present', () => {
+    it('filters out labware that is NOT trash when one trash bin present', () => {
       const labwareEntities = {
         ...tipracks,
         ...trash,
@@ -55,7 +55,7 @@ describe('labware selectors', () => {
         getDisposalLabwareOptions.resultFunc(labwareEntities, names)
       ).toEqual([{ name: 'Trash', value: 'trashId' }])
     })
-    test('filters out labware that is NOT trash when multiple trash bins present', () => {
+    it('filters out labware that is NOT trash when multiple trash bins present', () => {
       const trash2 = {
         trashId2: {
           def: { ...fixture_trash },

--- a/protocol-designer/src/ui/steps/actions/__tests__/actions.test.js
+++ b/protocol-designer/src/ui/steps/actions/__tests__/actions.test.js
@@ -23,7 +23,7 @@ describe('steps actions', () => {
       })
     })
 
-    test('action is created to populate form with default engage height to scale when engage magnet step', () => {
+    it('action is created to populate form with default engage height to scale when engage magnet step', () => {
       const magnetModule = 'magnet123'
       const magnetAction = 'engage'
       uiModulesSelectors.getSingleMagneticModuleId = jest
@@ -53,7 +53,7 @@ describe('steps actions', () => {
       ])
     })
 
-    test('action is created to populate form with null default engage height when engage magnet step with labware with no engage height', () => {
+    it('action is created to populate form with null default engage height when engage magnet step with labware with no engage height', () => {
       const magnetModule = 'magnet123'
       const magnetAction = 'engage'
       uiModulesSelectors.getSingleMagneticModuleId = jest

--- a/protocol-designer/src/ui/steps/test/reducers.test.js
+++ b/protocol-designer/src/ui/steps/test/reducers.test.js
@@ -6,7 +6,7 @@ jest.mock('../../../labware-defs/utils')
 const { collapsedSteps, selectedItem } = _allReducers
 
 describe('collapsedSteps reducer', () => {
-  test('add step', () => {
+  it('add step', () => {
     const state = {}
     const action = {
       type: 'ADD_STEP',
@@ -17,7 +17,7 @@ describe('collapsedSteps reducer', () => {
     })
   })
 
-  test('toggle step on->off', () => {
+  it('toggle step on->off', () => {
     const state = {
       '1': true,
       '2': false,
@@ -36,7 +36,7 @@ describe('collapsedSteps reducer', () => {
     })
   })
 
-  test('toggle step off-> on', () => {
+  it('toggle step off-> on', () => {
     const state = {
       '1': true,
       '2': false,
@@ -57,7 +57,7 @@ describe('collapsedSteps reducer', () => {
 })
 
 describe('selectedItem reducer', () => {
-  test('select step', () => {
+  it('select step', () => {
     const stepId = '123'
     const action = {
       type: 'SELECT_STEP',
@@ -69,7 +69,7 @@ describe('selectedItem reducer', () => {
     })
   })
 
-  test('select terminal item', () => {
+  it('select terminal item', () => {
     const terminalId = 'test'
     const action = {
       type: 'SELECT_TERMINAL_ITEM',

--- a/protocol-designer/src/ui/steps/test/selectors.test.js
+++ b/protocol-designer/src/ui/steps/test/selectors.test.js
@@ -24,7 +24,7 @@ describe('getHoveredStepLabware', () => {
     }
   })
 
-  test('no labware is returned when no hovered step', () => {
+  it('no labware is returned when no hovered step', () => {
     const stepArgs = {
       commandCreatorFnName: mixCommand,
       labware,
@@ -41,7 +41,7 @@ describe('getHoveredStepLabware', () => {
     expect(result).toEqual([])
   })
 
-  test('no labware is returned when step is not found', () => {
+  it('no labware is returned when step is not found', () => {
     const stepArgs = {
       commandCreatorFnName: mixCommand,
       labware,
@@ -58,7 +58,7 @@ describe('getHoveredStepLabware', () => {
     expect(result).toEqual([])
   })
 
-  test('no labware is returned when no step arguments', () => {
+  it('no labware is returned when no step arguments', () => {
     const stepArgs = null
     const argsByStepId = createArgsForStepId(hoveredStepId, stepArgs)
 
@@ -71,7 +71,7 @@ describe('getHoveredStepLabware', () => {
     expect(result).toEqual([])
   })
   ;['consolidate', 'distribute', 'transfer'].forEach(command => {
-    test(`source and destination labware is returned when ${command}`, () => {
+    it(`source and destination labware is returned when ${command}`, () => {
       const sourceLabware = 'test tube'
       const stepArgs = {
         commandCreatorFnName: command,
@@ -90,7 +90,7 @@ describe('getHoveredStepLabware', () => {
     })
   })
 
-  test('labware is returned when command is mix', () => {
+  it('labware is returned when command is mix', () => {
     const stepArgs = {
       commandCreatorFnName: mixCommand,
       labware,
@@ -133,7 +133,7 @@ describe('getHoveredStepLabware', () => {
       }
     })
 
-    test('labware on module is returned when module id exists', () => {
+    it('labware on module is returned when module id exists', () => {
       utils.getLabwareOnModule = jest.fn().mockReturnValue({ id: labware })
       const stepArgs = {
         commandCreatorFnName: setTempCommand,
@@ -150,7 +150,7 @@ describe('getHoveredStepLabware', () => {
       expect(result).toEqual([labware])
     })
 
-    test('no labware is returned when no labware on module', () => {
+    it('no labware is returned when no labware on module', () => {
       utils.getLabwareOnModule = jest.fn().mockReturnValue(null)
       const stepArgs = {
         commandCreatorFnName: setTempCommand,

--- a/shared-data/js/__tests__/deckSchemas.test.js
+++ b/shared-data/js/__tests__/deckSchemas.test.js
@@ -21,7 +21,7 @@ describe('validate deck defs and fixtures', () => {
   const v1Fixtures = glob.sync(v1FixtureGlob)
   v1Fixtures.forEach(fixturePath => {
     const fixtureDef = require(fixturePath)
-    test('fixture validates against v1 schema', () => {
+    it('fixture validates against v1 schema', () => {
       const valid = validateV1Schema(fixtureDef)
       const validationErrors = validateV1Schema.errors
       if (validationErrors) {
@@ -38,7 +38,7 @@ describe('validate deck defs and fixtures', () => {
   const v2Fixtures = glob.sync(v2FixtureGlob)
   v2Fixtures.forEach(fixturePath => {
     const fixtureDef = require(fixturePath)
-    test('fixture validates against v2 schema', () => {
+    it('fixture validates against v2 schema', () => {
       const valid = validateV2Schema(fixtureDef)
       const validationErrors = validateV2Schema.errors
       if (validationErrors) {
@@ -55,7 +55,7 @@ describe('validate deck defs and fixtures', () => {
   const v1Defs = glob.sync(v1DefGlob)
   v1Defs.forEach(defPath => {
     const deckDef = require(defPath)
-    test('deck validates against v1 schema', () => {
+    it('deck validates against v1 schema', () => {
       const valid = validateV1Schema(deckDef)
       const validationErrors = validateV1Schema.errors
       if (validationErrors) {
@@ -72,7 +72,7 @@ describe('validate deck defs and fixtures', () => {
   const v2Defs = glob.sync(v2DefGlob)
   v2Defs.forEach(defPath => {
     const deckDef = require(defPath)
-    test('deck validates against v2 schema', () => {
+    it('deck validates against v2 schema', () => {
       const valid = validateV2Schema(deckDef)
       const validationErrors = validateV2Schema.errors
       if (validationErrors) {

--- a/shared-data/js/__tests__/getWellNamePerMultiTip.test.js
+++ b/shared-data/js/__tests__/getWellNamePerMultiTip.test.js
@@ -9,7 +9,7 @@ import { getWellNamePerMultiTip } from '../helpers/getWellNamePerMultiTip'
 describe('96 plate', () => {
   const labware = fixture_96_plate
 
-  test('A1 => column 1', () => {
+  it('A1 => column 1', () => {
     expect(getWellNamePerMultiTip(labware, 'A1')).toEqual([
       'A1',
       'B1',
@@ -22,7 +22,7 @@ describe('96 plate', () => {
     ])
   })
 
-  test('A2 => column 2', () => {
+  it('A2 => column 2', () => {
     expect(getWellNamePerMultiTip(labware, 'A2')).toEqual([
       'A2',
       'B2',
@@ -35,7 +35,7 @@ describe('96 plate', () => {
     ])
   })
 
-  test('B1 => null (cannot access with 8-channel)', () => {
+  it('B1 => null (cannot access with 8-channel)', () => {
     expect(getWellNamePerMultiTip(labware, 'B1')).toEqual(null)
   })
 })
@@ -43,7 +43,7 @@ describe('96 plate', () => {
 describe('384 plate', () => {
   const labware = fixture_384_plate
 
-  test('A1 => column 1 ACEGIKMO', () => {
+  it('A1 => column 1 ACEGIKMO', () => {
     expect(getWellNamePerMultiTip(labware, 'A1')).toEqual([
       'A1',
       'C1',
@@ -56,7 +56,7 @@ describe('384 plate', () => {
     ])
   })
 
-  test('A2 => column 2 ACEGIKMO', () => {
+  it('A2 => column 2 ACEGIKMO', () => {
     expect(getWellNamePerMultiTip(labware, 'A2')).toEqual([
       'A2',
       'C2',
@@ -69,7 +69,7 @@ describe('384 plate', () => {
     ])
   })
 
-  test('B1 => column 1 BDFHJLNP', () => {
+  it('B1 => column 1 BDFHJLNP', () => {
     expect(getWellNamePerMultiTip(labware, 'B1')).toEqual([
       'B1',
       'D1',
@@ -82,7 +82,7 @@ describe('384 plate', () => {
     ])
   })
 
-  test('C1 => null (cannot access with 8-channel)', () => {
+  it('C1 => null (cannot access with 8-channel)', () => {
     expect(getWellNamePerMultiTip(labware, 'C1')).toEqual(null)
   })
 })
@@ -90,7 +90,7 @@ describe('384 plate', () => {
 describe('Fixed trash', () => {
   const labware = fixture_trash
 
-  test('A1 => all tips in A1', () => {
+  it('A1 => all tips in A1', () => {
     expect(getWellNamePerMultiTip(labware, 'A1')).toEqual([
       'A1',
       'A1',
@@ -103,14 +103,14 @@ describe('Fixed trash', () => {
     ])
   })
 
-  test('A2 => null (well does not exist)', () => {
+  it('A2 => null (well does not exist)', () => {
     expect(getWellNamePerMultiTip(labware, 'A2')).toEqual(null)
   })
 })
 
 describe('tube rack 2mL', () => {
   const labware = fixture_24_tuberack
-  test('tube rack 2mL not accessible by 8-channel (return null)', () => {
+  it('tube rack 2mL not accessible by 8-channel (return null)', () => {
     ;['A1', 'A2', 'B1', 'B2'].forEach(well => {
       expect(getWellNamePerMultiTip(labware, 'A1')).toEqual(null)
     })
@@ -120,7 +120,7 @@ describe('tube rack 2mL', () => {
 describe('12 channel trough', () => {
   const labware = fixture_12_trough
 
-  test('A1 => all tips in A1', () => {
+  it('A1 => all tips in A1', () => {
     expect(getWellNamePerMultiTip(labware, 'A1')).toEqual([
       'A1',
       'A1',
@@ -133,7 +133,7 @@ describe('12 channel trough', () => {
     ])
   })
 
-  test('A2 => all tips in A2', () => {
+  it('A2 => all tips in A2', () => {
     expect(getWellNamePerMultiTip(labware, 'A2')).toEqual([
       'A2',
       'A2',
@@ -146,7 +146,7 @@ describe('12 channel trough', () => {
     ])
   })
 
-  test('B1 => null (well does not exist)', () => {
+  it('B1 => null (well does not exist)', () => {
     expect(getWellNamePerMultiTip(labware, 'B1')).toEqual(null)
   })
 })

--- a/shared-data/js/__tests__/labwareDefQuirks.test.js
+++ b/shared-data/js/__tests__/labwareDefQuirks.test.js
@@ -20,7 +20,7 @@ describe('check quirks for all labware defs', () => {
   })
   labwarePaths.forEach(labwarePath => {
     const defname = path.basename(path.dirname(labwarePath))
-    test(`${defname} has valid quirks`, () => {
+    it(`${defname} has valid quirks`, () => {
       const labwareDef = require(labwarePath)
       const quirks = labwareDef.parameters.quirks || []
       // we want to test that the quirks in the def are a subset of validQuirks,

--- a/shared-data/js/__tests__/labwareDefSchemaV1.test.js
+++ b/shared-data/js/__tests__/labwareDefSchemaV1.test.js
@@ -15,7 +15,7 @@ const ajv = new Ajv({
 const validate = ajv.compile(labwareSchemaV1)
 
 describe('test the schema against a minimalist fixture', () => {
-  test('...', () => {
+  it('...', () => {
     const minimalLabwareDef = {
       metadata: {
         name: 'test-labware',
@@ -42,7 +42,7 @@ describe('test the schema against a minimalist fixture', () => {
     expect(valid).toBe(true)
   })
 
-  test('fail on bad labware', () => {
+  it('fail on bad labware', () => {
     const badDef = {
       metadata: { name: 'bad' },
       ordering: ['A1'], // array of strings not array of arrays
@@ -63,7 +63,7 @@ describe('test the schema against a minimalist fixture', () => {
 describe('test schemas of all definitions', () => {
   const labwarePaths = glob.sync(DEFINITIONS_GLOB_PATTERN, GLOB_OPTIONS)
 
-  test('got at least 1 labware definition file', () => {
+  it('got at least 1 labware definition file', () => {
     // Make sure definitions path didn't break, which would give you false positives
     expect(labwarePaths.length).toBeGreaterThan(0)
   })
@@ -71,14 +71,14 @@ describe('test schemas of all definitions', () => {
   labwarePaths.forEach(labwarePath => {
     const filename = path.parse(labwarePath).name
     const labwareDef = require(labwarePath)
-    test(filename, () => {
+    it(filename, () => {
       const valid = validate(labwareDef)
       const validationErrors = validate.errors
 
       expect(validationErrors).toBe(null)
       expect(valid).toBe(true)
     })
-    test(`file name matches metadata.name: ${filename}`, () => {
+    it(`file name matches metadata.name: ${filename}`, () => {
       expect(labwareDef.metadata.name).toEqual(filename)
     })
   })

--- a/shared-data/js/__tests__/labwareDefSchemaV2.test.js
+++ b/shared-data/js/__tests__/labwareDefSchemaV2.test.js
@@ -38,7 +38,7 @@ describe('fail on bad labware', () => {
 
 describe('test schemas of all opentrons definitions', () => {
   const labwarePaths = glob.sync(definitionsGlobPath)
-  test(`path to definitions OK`, () => {
+  it(`path to definitions OK`, () => {
     // Make sure definitions path didn't break, which would give you false positives
     expect(labwarePaths.length).toBeGreaterThan(0)
   })
@@ -46,22 +46,22 @@ describe('test schemas of all opentrons definitions', () => {
   labwarePaths.forEach(labwarePath => {
     const filename = path.parse(labwarePath).base
     const labwareDef = require(labwarePath)
-    test(`${filename} validates against schema`, () => {
+    it(`${filename} validates against schema`, () => {
       const valid = validate(labwareDef)
       const validationErrors = validate.errors
 
       expect(validationErrors).toBe(null)
       expect(valid).toBe(true)
     })
-    test(`file name matches version: ${labwarePath}`, () => {
+    it(`file name matches version: ${labwarePath}`, () => {
       expect(`${labwareDef.version}`).toEqual(path.basename(filename, '.json'))
     })
-    test(`parent dir matches loadName: ${labwarePath}`, () => {
+    it(`parent dir matches loadName: ${labwarePath}`, () => {
       expect(labwareDef.parameters.loadName).toEqual(
         path.basename(path.dirname(labwarePath))
       )
     })
-    test(`namespace is "opentrons": ${labwarePath}`, () => {
+    it(`namespace is "opentrons": ${labwarePath}`, () => {
       expect(labwareDef.namespace).toEqual('opentrons')
     })
   })
@@ -70,7 +70,7 @@ describe('test schemas of all opentrons definitions', () => {
 describe('test schemas of all v2 labware fixtures', () => {
   const labwarePaths = glob.sync(fixturesGlobPath)
 
-  test(`path to fixtures OK`, () => {
+  it(`path to fixtures OK`, () => {
     // Make sure fixtures path didn't break, which would give you false positives
     expect(labwarePaths.length).toBeGreaterThan(0)
   })
@@ -78,19 +78,19 @@ describe('test schemas of all v2 labware fixtures', () => {
   labwarePaths.forEach(labwarePath => {
     const filename = path.parse(labwarePath).base
     const labwareDef = require(labwarePath)
-    test(`${filename} validates against schema`, () => {
+    it(`${filename} validates against schema`, () => {
       const valid = validate(labwareDef)
       const validationErrors = validate.errors
 
       expect(validationErrors).toBe(null)
       expect(valid).toBe(true)
     })
-    test(`fixture file name matches loadName: ${labwarePath}`, () => {
+    it(`fixture file name matches loadName: ${labwarePath}`, () => {
       expect(labwareDef.parameters.loadName).toEqual(
         path.basename(filename, '.json')
       )
     })
-    test(`namespace is "fixture": ${labwarePath}`, () => {
+    it(`namespace is "fixture": ${labwarePath}`, () => {
       expect(labwareDef.namespace).toEqual('fixture')
     })
   })

--- a/shared-data/js/__tests__/moduleAccessors.test.js
+++ b/shared-data/js/__tests__/moduleAccessors.test.js
@@ -20,15 +20,15 @@ import {
 describe('all valid models work', () => {
   MODULE_MODELS.forEach(model => {
     const loadedDef = getModuleDef2(model)
-    test('ensure valid models load', () => {
+    it('ensure valid models load', () => {
       expect(loadedDef).not.toBeNull()
       expect(loadedDef?.model).toEqual(model)
     })
-    test('valid models have valid module types', () => {
+    it('valid models have valid module types', () => {
       expect(getModuleTypeFromModuleModel(model)).toEqual(loadedDef.moduleType)
       expect(MODULE_TYPES).toContain(getModuleTypeFromModuleModel(model))
     })
-    test('valid modules have display names that match the def', () => {
+    it('valid modules have display names that match the def', () => {
       expect(getModuleDisplayName(model)).toEqual(loadedDef.displayName)
     })
   })

--- a/shared-data/js/__tests__/moduleSpecsSchema.test.js
+++ b/shared-data/js/__tests__/moduleSpecsSchema.test.js
@@ -22,7 +22,7 @@ beforeAll(() => {
 })
 
 describe('validate all module specs with schema', () => {
-  test('ensure V1 module specs match the V1 JSON schema', () => {
+  it('ensure V1 module specs match the V1 JSON schema', () => {
     const valid = validateModuleSpecsV1(moduleSpecsV1)
     const validationErrors = validateModuleSpecsV1.errors
 
@@ -33,14 +33,14 @@ describe('validate all module specs with schema', () => {
   MODULE_PATHS.forEach(modulePath => {
     const filename = path.parse(modulePath).name
     const moduleDef = require(modulePath)
-    test(`${filename} validates against schema`, () => {
+    it(`${filename} validates against schema`, () => {
       const valid = validateModuleSpecsV2(moduleDef)
       const validationErrors = validateModuleSpecsV2.errors
       expect(validationErrors).toBe(null)
       expect(valid).toBe(true)
     })
   })
-  test('validate each module specs model matches its filename', () => {
+  it('validate each module specs model matches its filename', () => {
     MODULE_PATHS.forEach(modulePath => {
       const filename = path.parse(modulePath).name
       const moduleDef = require(modulePath)

--- a/shared-data/js/__tests__/pipetteSpecSchemas.test.js
+++ b/shared-data/js/__tests__/pipetteSpecSchemas.test.js
@@ -13,7 +13,7 @@ const validateNameSpecs = ajv.compile(nameSpecsSchema)
 const validateModelSpecs = ajv.compile(modelSpecsSchema)
 
 describe('validate pipette specs with JSON schemas', () => {
-  test('ensure all pipette *NAME* specs match name JSON schema', () => {
+  it('ensure all pipette *NAME* specs match name JSON schema', () => {
     const valid = validateNameSpecs(pipetteNameSpecs)
     const validationErrors = validateNameSpecs.errors
 
@@ -25,7 +25,7 @@ describe('validate pipette specs with JSON schemas', () => {
     expect(valid).toBe(true)
   })
 
-  test('ensure all pipette *MODEL* specs match model JSON schema', () => {
+  it('ensure all pipette *MODEL* specs match model JSON schema', () => {
     const valid = validateModelSpecs(pipetteModelSpecs)
     const validationErrors = validateModelSpecs.errors
 
@@ -39,7 +39,7 @@ describe('validate pipette specs with JSON schemas', () => {
 })
 
 describe('model -> name referencing', () => {
-  test('ensure all pipette model specs reference a valid pipette name', () => {
+  it('ensure all pipette model specs reference a valid pipette name', () => {
     const modelKeys = Object.keys(pipetteModelSpecs.config)
     const nameKeys = Object.keys(pipetteNameSpecs)
 

--- a/shared-data/js/__tests__/pipettes.test.js
+++ b/shared-data/js/__tests__/pipettes.test.js
@@ -44,14 +44,14 @@ const PIPETTE_MODELS = [
 describe('pipette data accessors', () => {
   describe('getPipetteNameSpecs', () => {
     PIPETTE_NAMES.forEach(name =>
-      test(`name ${name} snapshot`, () =>
+      it(`name ${name} snapshot`, () =>
         expect(getPipetteNameSpecs(name)).toMatchSnapshot())
     )
   })
 
   describe('getPipetteModelSpecs', () => {
     PIPETTE_MODELS.forEach(model =>
-      test(`model ${model} snapshot`, () =>
+      it(`model ${model} snapshot`, () =>
         expect(getPipetteModelSpecs(model)).toMatchSnapshot())
     )
   })

--- a/shared-data/js/__tests__/protocolSchemaV4.test.js
+++ b/shared-data/js/__tests__/protocolSchemaV4.test.js
@@ -27,7 +27,7 @@ const validateProtocol = ajv.compile(protocolSchema)
 
 describe('validate v4 protocol fixtures under JSON schema', () => {
   protocolFixtures.forEach(protocolPath => {
-    test(path.basename(protocolPath), () => {
+    it(path.basename(protocolPath), () => {
       const protocol = require(protocolPath)
       const valid = validateProtocol(protocol)
       const validationErrors = validateProtocol.errors
@@ -42,7 +42,7 @@ describe('validate v4 protocol fixtures under JSON schema', () => {
 })
 
 describe('ensure bad protocol data fails validation', () => {
-  test('$otSharedSchema is required to be "#/protocol/schemas/4"', () => {
+  it('$otSharedSchema is required to be "#/protocol/schemas/4"', () => {
     expect(validateProtocol(omit(simpleV4Fixture, '$otSharedSchema'))).toBe(
       false
     )
@@ -54,14 +54,14 @@ describe('ensure bad protocol data fails validation', () => {
     ).toBe(false)
   })
 
-  test('schemaVersion is required to be 4', () => {
+  it('schemaVersion is required to be 4', () => {
     expect(validateProtocol(omit(simpleV4Fixture, 'schemaVersion'))).toBe(false)
     expect(validateProtocol({ ...simpleV4Fixture, schemaVersion: 3 })).toBe(
       false
     )
   })
 
-  test('reject bad values in "pipettes" objects', () => {
+  it('reject bad values in "pipettes" objects', () => {
     const badPipettes = {
       missingKeys: {},
       missingName: { mount: 'left' },
@@ -87,7 +87,7 @@ describe('ensure bad protocol data fails validation', () => {
     })
   })
 
-  test('reject bad values in "labware" objects', () => {
+  it('reject bad values in "labware" objects', () => {
     const badLabware = {
       noSlot: { definitionId: 'defId' },
       noDefId: { slot: '1' },
@@ -111,7 +111,7 @@ describe('ensure bad protocol data fails validation', () => {
     })
   })
 
-  test('reject bad values in "modules" objects', () => {
+  it('reject bad values in "modules" objects', () => {
     const badModules = {
       badModuleType: { slot: '1', moduleType: 'fake' },
       noSlot: { moduleType: 'thermocycler' },

--- a/shared-data/js/__tests__/sortWells.test.js
+++ b/shared-data/js/__tests__/sortWells.test.js
@@ -2,7 +2,7 @@
 import { sortWells } from '../helpers'
 
 describe('sortWells', () => {
-  test('single letters', () => {
+  it('single letters', () => {
     const input = ['A12', 'A2', 'B1', 'B12', 'A1']
     const expected = ['A1', 'B1', 'A2', 'A12', 'B12']
     const result = [...input].sort(sortWells)
@@ -10,7 +10,7 @@ describe('sortWells', () => {
   })
 
   // just in case we get a 1536-well plate
-  test('double letters', () => {
+  it('double letters', () => {
     const input = [
       'AB12',
       'A12',

--- a/shared-data/js/__tests__/splitWellsOnColumn.test.js
+++ b/shared-data/js/__tests__/splitWellsOnColumn.test.js
@@ -1,15 +1,15 @@
 import { splitWellsOnColumn } from '../helpers'
 
 describe('test splitWellsOnColumn', () => {
-  test('empty array', () => {
+  it('empty array', () => {
     expect(splitWellsOnColumn([])).toEqual([])
   })
 
-  test('one value', () => {
+  it('one value', () => {
     expect(splitWellsOnColumn(['A1'])).toEqual([['A1']])
   })
 
-  test('sort multi-digit wels', () => {
+  it('sort multi-digit wels', () => {
     expect(splitWellsOnColumn(['A1', 'B2', 'C2', 'D3', 'X10', 'X11'])).toEqual([
       ['A1'],
       ['B2', 'C2'],

--- a/shared-data/js/helpers/__tests__/volume.test.js
+++ b/shared-data/js/helpers/__tests__/volume.test.js
@@ -85,6 +85,6 @@ describe('volume helpers', () => {
   ]
 
   SPECS.forEach(s => {
-    test(s.name, () => expect(s.func(...s.input)).toEqual(s.expected))
+    it(s.name, () => expect(s.func(...s.input)).toEqual(s.expected))
   })
 })

--- a/shared-data/js/helpers/__tests__/wellSets.test.js
+++ b/shared-data/js/helpers/__tests__/wellSets.test.js
@@ -10,7 +10,7 @@ describe('getWellSetForMultichannel (integration test)', () => {
     const helpers = makeWellSetHelpers()
     getWellSetForMultichannel = helpers.getWellSetForMultichannel
   })
-  test('96-flat', () => {
+  it('96-flat', () => {
     const labwareDef = fixture_96_plate
     expect(getWellSetForMultichannel(labwareDef, 'A1')).toEqual([
       'A1',
@@ -57,12 +57,12 @@ describe('getWellSetForMultichannel (integration test)', () => {
     ])
   })
 
-  test('invalid well', () => {
+  it('invalid well', () => {
     const labwareDef = fixture_96_plate
     expect(getWellSetForMultichannel(labwareDef, 'A13')).toBeFalsy()
   })
 
-  test('trough-12row', () => {
+  it('trough-12row', () => {
     const labwareDef = fixture_12_trough
     expect(getWellSetForMultichannel(labwareDef, 'A1')).toEqual([
       'A1',
@@ -87,7 +87,7 @@ describe('getWellSetForMultichannel (integration test)', () => {
     ])
   })
 
-  test('384-plate', () => {
+  it('384-plate', () => {
     const labwareDef = fixture_384_plate
     expect(getWellSetForMultichannel(labwareDef, 'C1')).toEqual([
       'A1',

--- a/shared-data/js/labwareTools/__tests__/createDefaultDisplayName.test.js
+++ b/shared-data/js/labwareTools/__tests__/createDefaultDisplayName.test.js
@@ -96,7 +96,7 @@ describe('createDefaultDisplayName', () => {
   ]
 
   testCases.forEach(({ testName, args, expected }) => {
-    test(testName, () => {
+    it(testName, () => {
       expect(createDefaultDisplayName(args)).toEqual(expected)
     })
   })

--- a/shared-data/js/labwareTools/__tests__/createIrregularLabware.test.js
+++ b/shared-data/js/labwareTools/__tests__/createIrregularLabware.test.js
@@ -21,7 +21,7 @@ const exampleLabware1 = {
 }
 
 describe('test helper functions', () => {
-  test('Well name generated correctly', () => {
+  it('Well name generated correctly', () => {
     const grid = { row: 2, column: 2 }
     const gridStart = [
       { rowStart: 'A', colStart: '1', rowStride: 1, colStride: 2 },
@@ -41,7 +41,7 @@ describe('test helper functions', () => {
     })
   })
 
-  test('XYZ generates correctly for each grid', () => {
+  it('XYZ generates correctly for each grid', () => {
     const grid = { row: 1, column: 5 }
     const offset = { x: 1, y: 0.5, z: 55.5 }
     const spacing = [{ row: 10, column: 10 }, { row: 5, column: 14 }]
@@ -129,17 +129,17 @@ describe('test createIrregularLabware function', () => {
     labware1 = createIrregularLabware(labware1Args)
   })
 
-  test('irregular ordering generates as expected', () => {
+  it('irregular ordering generates as expected', () => {
     const keyList = Object.keys(labware1.wells)
     const generatedOrdering = splitWellsOnColumn(keyList.sort(sortWells))
     expect(labware1.ordering).toEqual(generatedOrdering)
   })
 
-  test('check labware matches fixture', () => {
+  it('check labware matches fixture', () => {
     expect(labware1).toEqual(exampleLabware1)
   })
 
-  test('labware loadName generated correctly for multi-grid labware', () => {
+  it('labware loadName generated correctly for multi-grid labware', () => {
     const loadName = _generateIrregularLoadName({
       grid: [{ row: 3, column: 2 }, { row: 1, column: 4 }],
       well: [
@@ -163,7 +163,7 @@ describe('test createIrregularLabware function', () => {
     expect(loadName).toEqual('somebrand_10_wellplate_6x400ul_4x2000ul')
   })
 
-  test('labware loadName generated correctly for multi-grid labware in other units', () => {
+  it('labware loadName generated correctly for multi-grid labware in other units', () => {
     const loadName = _generateIrregularLoadName({
       grid: [{ row: 3, column: 2 }],
       well: [{ depth: 20, shape: 'circular', totalLiquidVolume: 4000 }],
@@ -176,7 +176,7 @@ describe('test createIrregularLabware function', () => {
     expect(loadName).toEqual('somebrand_6_wellplate_6x4ml')
   })
 
-  test('failing to validate against labware schema throws w/o "strict"', () => {
+  it('failing to validate against labware schema throws w/o "strict"', () => {
     const args = {
       ...labware1Args,
       // negative y offset should fail schema validation by making well `y` negative

--- a/shared-data/js/labwareTools/__tests__/createLabware.test.js
+++ b/shared-data/js/labwareTools/__tests__/createLabware.test.js
@@ -67,16 +67,16 @@ describe('createLabware', () => {
     jest.clearAllMocks()
   })
 
-  test('snapshot tests', () => {
+  it('snapshot tests', () => {
     expect(labware1).toEqual(exampleLabware1)
     expect(labware2).toEqual(exampleLabware2)
   })
 
-  test('ordering generates as expected', () => {
+  it('ordering generates as expected', () => {
     expect(exampleLabware2.ordering).toEqual(labware2.ordering)
   })
 
-  test('well XYZ generates correctly', () => {
+  it('well XYZ generates correctly', () => {
     const spacing = { row: 10, column: 10 }
     const grid = { row: 3, column: 2 }
 
@@ -113,7 +113,7 @@ describe('createLabware', () => {
     })
   })
 
-  test('failing to validate against labware schema throws w/o "strict"', () => {
+  it('failing to validate against labware schema throws w/o "strict"', () => {
     const args = {
       ...labware2Args,
       // this spacing should make negative well `y` value and fail schema validation


### PR DESCRIPTION
## overview

As per previous discussions, this switches Jest "test" to "it" so we can do more BDD-style test names eg `it(should do the thing when activated)`

## changelog

Big diff but this is just:

- add the lint rule `'jest/consistent-test-it': 'error',`
- run eslint auto-fix

## review requests

1. Any objections to this rule change?
2. I used the default version of the rule, described [here](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/consistent-test-it.md#default-configuration). This allows `it` and not `test` inside a `describe` block, and allows `test` but not `it` on the top level outside a `describe`. I'm not really sure why you would want to use it/test outside a describe block? If we also add the `require-top-level-describe` rule, no top-level test/it would be allowed anyway. (This rule would require code changes to one test file so I'd want to do it in a follow-up PR if we do it, but it's not hard to do.). Thoughts about that?