### PR TITLE
refactor(api): create a method that will initialize api.

### DIFF
--- a/api/src/opentrons/server/__init__.py
+++ b/api/src/opentrons/server/__init__.py
@@ -127,8 +127,7 @@ def init(hardware: 'HardwareAPILike' = None,
 def run(hardware: 'HardwareAPILike',
         hostname=None,
         port=None,
-        path=None,
-        loop=None):
+        path=None):
     """
     The arguments are not all optional. Either a path or hostname+port should
     be specified; you have to specify one.


### PR DESCRIPTION
## overview

This is a mild refactor to support migration to robot_server. .

The robot_server will serve as the entrypoint to the http server. It will use the opentrons.api package to interact with the robot. Robot server needs to initialize the api, not unlike what we do in `opentrons.main`. This defines that initialize method that will be used by api and robot_server. Eventually main and server.main will be removed from the api sub project.
