### PR TITLE
fix(app): use containers and instruments to set RPC pipette tip rack list

### DIFF
--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -513,6 +513,79 @@ describe('api client', () => {
       )
     })
 
+    test('reconciles reported tiprack / pipette usage', () => {
+      const expected = actions.sessionResponse(
+        null,
+        expect.objectContaining({
+          pipettesByMount: {
+            left: {
+              _id: 123,
+              mount: 'left',
+              name: 'p200',
+              channels: 1,
+              tipRacks: [789],
+              requestedAs: 'bar',
+            },
+            right: {
+              _id: 456,
+              mount: 'right',
+              name: 'p50',
+              channels: 8,
+              tipRacks: [789],
+              requestedAs: 'foo',
+            },
+          },
+          labwareBySlot: {
+            1: {
+              _id: 789,
+              slot: '1',
+              name: 'a',
+              type: 'tiprack',
+              isTiprack: true,
+              calibratorMount: 'left',
+            },
+          },
+        }),
+        false
+      )
+
+      session.instruments = [
+        {
+          _id: 456,
+          mount: 'right',
+          name: 'p50',
+          channels: 8,
+          tip_racks: [],
+          requested_as: 'foo',
+        },
+        {
+          _id: 123,
+          mount: 'left',
+          name: 'p200',
+          channels: 1,
+          tip_racks: [],
+          requested_as: 'bar',
+        },
+      ]
+
+      session.containers = [
+        {
+          _id: 789,
+          slot: '1',
+          name: 'a',
+          type: 'tiprack',
+          instruments: [
+            { mount: 'left', channels: 1 },
+            { mount: 'right', channels: 8 },
+          ],
+        },
+      ]
+
+      return sendConnect().then(() =>
+        expect(dispatch).toHaveBeenCalledWith(expected)
+      )
+    })
+
     test('maps api modules to modules by slot', () => {
       const expected = actions.sessionResponse(
         null,


### PR DESCRIPTION
## overview

This works PR works around a "bug" from the RPC API in PAPIv1 (Existing expected bahavior? Who really knows?) that was discovered by an internal user.

A pipette may be reported to the app to use no tip racks even if a tip rack object used in the protocol reports usage by that same pipette. E.g. the session can come back with:

- RPC Session
    - "Instruments" list
        - Some pipette
            - Tip racks list: []
    - "Containers" list
        - Some tip rack
            - Pipettes list: [ "Some pipette" ]

This appears to happen if one constructs the pipettes without using the `tip_racks` argument of the constructor in PAPIv1. To work around this issue, the app will now build the tip rack usage list from both the RPC instruments _and_ the RPC containers, instead of just the instruments.

## changelog

- fix(app): use containers and instruments to set RPC pipette tip rack list

## review requests

To test, upload a Protocol API v1 protocol that does not use the `tip_racks` argument of the pipette constructors, but makes various `pick_up_tip` and `return_tip` calls

- [ ] Pipette is available for tip probe
    - i.e. it is not greyed out saying "This pipette is not used in this protocol"

The added functionality is covered by unit tests, but is a very old, un-typed part of the app's source code.