### PR TITLE
refactor(protocol-designer): Update pause item substep messaging

### DIFF
--- a/protocol-designer/src/components/steplist/ModuleStepItems.js
+++ b/protocol-designer/src/components/steplist/ModuleStepItems.js
@@ -23,7 +23,7 @@ export const ModuleStepItems = (props: Props) => (
     {props.message && (
       <PDListItem className="step-item-message">{props.message}</PDListItem>
     )}
-    <li className={styles.module_substep_header}>
+    <li className={styles.substep_header}>
       <span>{i18n.t(`modules.module_long_names.${props.moduleType}`)}</span>
       <span>{props.action}</span>
     </li>

--- a/protocol-designer/src/components/steplist/ModuleStepItems.js
+++ b/protocol-designer/src/components/steplist/ModuleStepItems.js
@@ -20,15 +20,12 @@ type Props = {|
 
 export const ModuleStepItems = (props: Props) => (
   <>
-    {props.message && (
-      <PDListItem className="step-item-message">{props.message}</PDListItem>
-    )}
     <li className={styles.substep_header}>
       <span>{i18n.t(`modules.module_long_names.${props.moduleType}`)}</span>
       <span>{props.action}</span>
     </li>
     <PDListItem
-      className={cx(styles.step_subitem_column_header, styles.emphasized_cell)}
+      className={cx(styles.step_subitem_column_header, styles.substep_content)}
     >
       <HoverTooltip
         portal={Portal}
@@ -50,5 +47,10 @@ export const ModuleStepItems = (props: Props) => (
       </HoverTooltip>
       <span className={styles.module_substep_value}>{props.actionText}</span>
     </PDListItem>
+    {props.message && (
+      <PDListItem className={cx(styles.substep_content, 'step-item-message')}>
+        &quot;{props.message}&quot;
+      </PDListItem>
+    )}
   </>
 )

--- a/protocol-designer/src/components/steplist/PauseStepItems.js
+++ b/protocol-designer/src/components/steplist/PauseStepItems.js
@@ -22,7 +22,7 @@ export function PauseStepItems(props: Props) {
           <li className={styles.substep_header}>
             <span>Pause for Time</span>
           </li>
-          <li className={styles.pause_content}>
+          <li className={styles.substep_content}>
             <span>
               {hours} {i18n.t('application.units.hours')}
             </span>
@@ -42,7 +42,7 @@ export function PauseStepItems(props: Props) {
         </>
       )}
       {message && (
-        <li className={styles.pause_content}>&quot;{message}&quot;</li>
+        <li className={styles.substep_content}>&quot;{message}&quot;</li>
       )}
     </>
   )

--- a/protocol-designer/src/components/steplist/PauseStepItems.js
+++ b/protocol-designer/src/components/steplist/PauseStepItems.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import { i18n } from '../../localization'
-import { PDListItem } from '../lists'
+import styles from './StepItem.css'
 import type { PauseArgs } from '../../step-generation'
 type Props = {
   pauseArgs: PauseArgs,
@@ -15,25 +15,35 @@ export function PauseStepItems(props: Props) {
   }
   const { message, wait } = pauseArgs
   const { hours, minutes, seconds } = pauseArgs.meta
-
   return (
-    <React.Fragment>
-      {message && <PDListItem>{message}</PDListItem>}
-      {wait !== true && (
-        <PDListItem>
-          <span>
-            {hours} {i18n.t('application.units.hours')}
-          </span>
-          <span>
-            {minutes} {i18n.t('application.units.minutes')}
-          </span>
-          <span>
-            {seconds} {i18n.t('application.units.seconds')}
-          </span>
-          <span />
-          <span />
-        </PDListItem>
+    <>
+      {wait !== true ? (
+        <>
+          <li className={styles.substep_header}>
+            <span>Pause for Time</span>
+          </li>
+          <li className={styles.pause_content}>
+            <span>
+              {hours} {i18n.t('application.units.hours')}
+            </span>
+            <span>
+              {minutes} {i18n.t('application.units.minutes')}
+            </span>
+            <span>
+              {seconds} {i18n.t('application.units.seconds')}
+            </span>
+          </li>
+        </>
+      ) : (
+        <>
+          <li className={styles.substep_header}>
+            <span>Pause Until Told to Resume</span>
+          </li>
+        </>
       )}
-    </React.Fragment>
+      {message && (
+        <li className={styles.pause_content}>&quot;{message}&quot;</li>
+      )}
+    </>
   )
 }

--- a/protocol-designer/src/components/steplist/StepItem.css
+++ b/protocol-designer/src/components/steplist/StepItem.css
@@ -52,12 +52,30 @@
   }
 }
 
-.module_substep_header {
+.substep_header {
   display: flex;
   margin: 0.5rem 0.5rem 0 0.5rem;
   font-size: var(--fs-caption);
   text-transform: uppercase;
   justify-content: space-between;
+}
+
+.pause_content {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 0.5rem;
+  padding-bottom: 0;
+  font-size: var(--fs-body-1);
+  font-weight: var(--fw-semibold);
+
+  & span {
+    margin-right: 0.5rem;
+  }
+
+  &:last-child {
+    padding-bottom: 1.25rem;
+  }
 }
 
 .module_substep_value {

--- a/protocol-designer/src/components/steplist/StepItem.css
+++ b/protocol-designer/src/components/steplist/StepItem.css
@@ -60,10 +60,11 @@
   justify-content: space-between;
 }
 
-.pause_content {
+.substep_content {
   display: flex;
   justify-content: flex-start;
   align-items: center;
+  min-height: 1.5rem;
   padding: 0.5rem;
   padding-bottom: 0;
   font-size: var(--fs-body-1);

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -163,7 +163,7 @@ export function getStepItemContents(stepItemProps: StepItemProps) {
         labwareDisplayName={substeps.labwareDisplayName}
         labwareNickname={substeps.labwareNickname}
         message={substeps.message}
-        action={i18n.t(`modules.actions.await_temperature`)}
+        action={i18n.t('modules.actions.await_temperature')}
         actionText={temperature}
         moduleType={TEMPERATURE_MODULE_TYPE}
       />

--- a/protocol-designer/src/components/steplist/__tests__/StepItem.test.js
+++ b/protocol-designer/src/components/steplist/__tests__/StepItem.test.js
@@ -162,7 +162,7 @@ describe('getStepItemContents', () => {
       const wrapper = renderWrapper(Component)
       const component = wrapper.find(ModuleStepItems)
       expect(component).toHaveLength(1)
-      expect(component.prop('action')).toEqual('temperature')
+      expect(component.prop('action')).toEqual('pause until')
       expect(component.prop('actionText')).toEqual('45 °C')
     })
   })

--- a/protocol-designer/src/localization/en/modules.json
+++ b/protocol-designer/src/localization/en/modules.json
@@ -26,6 +26,6 @@
     "go_to": "go to",
     "engage": "engage",
     "disengage": "disengage",
-    "await_temperature": "temperature"
+    "await_temperature": "pause until"
   }
 }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.js
@@ -24,6 +24,7 @@ export const pauseFormToArgs = (
         commandCreatorFnName: 'awaitTemperature',
         temperature,
         module: formData.moduleId,
+        message,
       }
     case PAUSE_UNTIL_TIME:
       return {

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/pauseFormToArgs.test.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/pauseFormToArgs.test.js
@@ -12,11 +12,13 @@ describe('pauseFormToArgs', () => {
       id: 'test_id',
       pauseForAmountOfTime: PAUSE_UNTIL_TEMP,
       pauseTemperature: '20',
+      pauseMessage: 'pause message',
       moduleId: 'some_id',
     }
     const expected = {
       commandCreatorFnName: 'awaitTemperature',
       temperature: 20,
+      message: 'pause message',
       module: 'some_id',
     }
     expect(pauseFormToArgs(formData)).toEqual(expected)


### PR DESCRIPTION
## overview

closes #5116. See ticket for text/style updates.

<img width="299" alt="Screen Shot 2020-03-03 at 10 09 53 AM" src="https://user-images.githubusercontent.com/3430313/75793547-8260ed80-5d3d-11ea-9c1f-a86f8b3928e2.png">


## changelog

- refactor(protocol-designer): Update pause item substep messaging and styles

## review requests

Make a protocol with a temperature module
Add a set temp step
- [ ] Temperare step timeline action should read `GO TO`

Add a pause until temperature step
- [ ] Temperare step timeline action should read `PAUSE UNTIL`

Add a pause until told to resume step with a message
- [ ] Substep header should now exist and read `PAUSE UNTIL TOLD TO RESUME`
- [ ] Message should render below in bold quoted text

Add a pause for an amount of time step and a message
- [ ] Substep header should now exist and read `PAUSE FOR TIME`
- [ ] Bold hours minutes and seconds should render below (slightly more condensed than before)
- [ ] Message should render directly below in bold quoted text
- [ ] All substep value rows should be evenly spaced 
