### PR TITLE
fix(app): accept mixed-case extensions for protocols and custom labware

### DIFF
--- a/app-shell/src/labware/__tests__/definitions.test.js
+++ b/app-shell/src/labware/__tests__/definitions.test.js
@@ -39,7 +39,7 @@ describe('labware directory utilities', () => {
       ).rejects.toThrow(/no such file/)
     })
 
-    test('returns paths to JSON files in directory', () => {
+    test('returns paths to *.json files in directory', () => {
       const dir = makeEmptyDir()
 
       return Promise.all([
@@ -75,6 +75,22 @@ describe('labware directory utilities', () => {
             path.join(nested, 'a.json'),
           ])
         })
+    })
+
+    test('returns paths to *.JSON files in directory', () => {
+      const dir = makeEmptyDir()
+
+      return Promise.all([
+        fs.writeJson(path.join(dir, 'a.JSON'), { name: 'a' }),
+        fs.writeJson(path.join(dir, 'b.JSON'), { name: 'b' }),
+        fs.writeJson(path.join(dir, 'c.JSON'), { name: 'c' }),
+      ]).then(() => {
+        return expect(readLabwareDirectory(dir)).resolves.toEqual([
+          path.join(dir, 'a.JSON'),
+          path.join(dir, 'b.JSON'),
+          path.join(dir, 'c.JSON'),
+        ])
+      })
     })
   })
 

--- a/app-shell/src/labware/definitions.js
+++ b/app-shell/src/labware/definitions.js
@@ -6,6 +6,8 @@ import { shell } from 'electron'
 import type { Dirent } from '../types'
 import type { UncheckedLabwareFile } from '@opentrons/app/src/custom-labware/types'
 
+const JSON_EXT_RE = /\.json$/i
+
 export function readLabwareDirectory(dir: string): Promise<Array<string>> {
   const absoluteName = e => path.join(dir, e.name)
 
@@ -13,7 +15,7 @@ export function readLabwareDirectory(dir: string): Promise<Array<string>> {
     .readdir(dir, { withFileTypes: true })
     .then((entries: Array<Dirent>) => {
       const jsonFiles = entries
-        .filter(e => e.isFile() && e.name.endsWith('.json'))
+        .filter(e => e.isFile() && JSON_EXT_RE.test(e.name))
         .map(absoluteName)
 
       const getNestedFiles = Promise.all(

--- a/app-shell/src/labware/definitions.js
+++ b/app-shell/src/labware/definitions.js
@@ -6,7 +6,7 @@ import { shell } from 'electron'
 import type { Dirent } from '../types'
 import type { UncheckedLabwareFile } from '@opentrons/app/src/custom-labware/types'
 
-const JSON_EXT_RE = /\.json$/i
+const RE_JSON_EXT = /\.json$/i
 
 export function readLabwareDirectory(dir: string): Promise<Array<string>> {
   const absoluteName = e => path.join(dir, e.name)
@@ -15,7 +15,7 @@ export function readLabwareDirectory(dir: string): Promise<Array<string>> {
     .readdir(dir, { withFileTypes: true })
     .then((entries: Array<Dirent>) => {
       const jsonFiles = entries
-        .filter(e => e.isFile() && JSON_EXT_RE.test(e.name))
+        .filter(e => e.isFile() && RE_JSON_EXT.test(e.name))
         .map(absoluteName)
 
       const getNestedFiles = Promise.all(

--- a/app/src/protocol/__tests__/reducer.test.js
+++ b/app/src/protocol/__tests__/reducer.test.js
@@ -44,7 +44,7 @@ describe('protocolReducer', () => {
       },
     },
     {
-      name: 'handles robot:SESSION_RESPONSE with JSON protocol',
+      name: 'handles robot:SESSION_RESPONSE with .json protocol',
       action: {
         type: 'robot:SESSION_RESPONSE',
         payload: { name: 'foo.json', protocolText: '{"metadata": {}}' },
@@ -61,7 +61,7 @@ describe('protocolReducer', () => {
       },
     },
     {
-      name: 'handles robot:SESSION_RESPONSE with Python protocol metadata',
+      name: 'handles robot:SESSION_RESPONSE with .py protocol',
       action: {
         type: 'robot:SESSION_RESPONSE',
         payload: {
@@ -74,6 +74,44 @@ describe('protocolReducer', () => {
       expectedState: {
         file: {
           name: 'foo.py',
+          type: 'python',
+          lastModified: null,
+        },
+        contents: '# foo.py',
+        data: { metadata: { protocolName: 'foo' } },
+      },
+    },
+    {
+      name: 'handles robot:SESSION_RESPONSE with .JSON protocol',
+      action: {
+        type: 'robot:SESSION_RESPONSE',
+        payload: { name: 'foo.JSON', protocolText: '{"metadata": {}}' },
+      },
+      initialState: { file: null, contents: null, data: null },
+      expectedState: {
+        file: {
+          name: 'foo.JSON',
+          type: 'json',
+          lastModified: null,
+        },
+        contents: '{"metadata": {}}',
+        data: { metadata: {} },
+      },
+    },
+    {
+      name: 'handles robot:SESSION_RESPONSE with .PY protocol',
+      action: {
+        type: 'robot:SESSION_RESPONSE',
+        payload: {
+          name: 'foo.PY',
+          protocolText: '# foo.py',
+          metadata: { protocolName: 'foo' },
+        },
+      },
+      initialState: { file: null, contents: null, data: null },
+      expectedState: {
+        file: {
+          name: 'foo.PY',
           type: 'python',
           lastModified: null,
         },

--- a/app/src/protocol/constants.js
+++ b/app/src/protocol/constants.js
@@ -1,0 +1,6 @@
+// @flow
+
+// protocol types
+export const TYPE_JSON: 'json' = 'json'
+export const TYPE_PYTHON: 'python' = 'python'
+export const TYPE_ZIP: 'zip' = 'zip'

--- a/app/src/protocol/index.js
+++ b/app/src/protocol/index.js
@@ -15,6 +15,7 @@ import type {
   InvalidProtocolFileAction,
 } from './types'
 
+export * from './constants'
 export * from './selectors'
 
 const BUNDLE_UPLOAD_DISABLED =

--- a/app/src/protocol/protocol-data.js
+++ b/app/src/protocol/protocol-data.js
@@ -1,15 +1,20 @@
 // @flow
 // functions for parsing protocol files
 import { createLogger } from '../logger'
+import { TYPE_JSON, TYPE_PYTHON, TYPE_ZIP } from './constants'
 
 import type { ProtocolFile, ProtocolData, ProtocolType } from './types'
 
 const log = createLogger(__filename)
 
+const RE_JSON_EXT = /\.json$/i
+const RE_PY_EXT = /\.py$/i
+const RE_ZIP_EXT = /\.zip$/i
+
 export function filenameToType(filename: string): ProtocolType | null {
-  if (filename.endsWith('.json')) return 'json'
-  if (filename.endsWith('.py')) return 'python'
-  if (filename.endsWith('.zip')) return 'zip'
+  if (RE_JSON_EXT.test(filename)) return TYPE_JSON
+  if (RE_PY_EXT.test(filename)) return TYPE_PYTHON
+  if (RE_ZIP_EXT.test(filename)) return TYPE_ZIP
   return null
 }
 
@@ -44,15 +49,15 @@ export function parseProtocolData(
 }
 
 export function fileIsPython(file: ProtocolFile): boolean {
-  return file.type === 'python' || file.type == null
+  return file.type === TYPE_PYTHON || file.type == null
 }
 
 export function fileIsJson(file: ProtocolFile): boolean {
-  return file.type === 'json'
+  return file.type === TYPE_JSON
 }
 
 export function fileIsBundle(file: ProtocolFile): boolean {
-  return file.type === 'zip'
+  return file.type === TYPE_ZIP
 }
 
 export function fileIsBinary(file: ProtocolFile): boolean {

--- a/app/src/protocol/types.js
+++ b/app/src/protocol/types.js
@@ -3,6 +3,8 @@
 import type { ProtocolFile as SchemaV1ProtocolFile } from '@opentrons/shared-data/protocol/flowTypes/schemaV1'
 import type { ProtocolFile as SchemaV3ProtocolFile } from '@opentrons/shared-data/protocol/flowTypes/schemaV3'
 
+import typeof { TYPE_JSON, TYPE_PYTHON, TYPE_ZIP } from './constants'
+
 // data may be a full JSON protocol or just a metadata dict from Python
 export type ProtocolData =
   | SchemaV1ProtocolFile<{}>
@@ -10,7 +12,7 @@ export type ProtocolData =
   | { metadata: $PropertyType<SchemaV1ProtocolFile<{}>, 'metadata'> }
 // NOTE: add union of additional versions after schema is bumped
 
-export type ProtocolType = 'json' | 'python' | 'zip'
+export type ProtocolType = TYPE_JSON | TYPE_PYTHON | TYPE_ZIP
 
 export type ProtocolFile = {
   name: string,


### PR DESCRIPTION
## overview

This PR fixes an embarrassing mistake in the app's filename handling for custom labware and protocols: it expects all file extensions to be lowercase

Fixes #5151

## changelog

- fix(app): accept mixed-case extensions for protocols and custom labware

## review requests

- [ ] Uploading `whatever-labware.JSON` as custom labware works
- [ ] Uploading `whatever-protocol.JSON` as a protocol works
