### PR TITLE
feat(protocol-designer): add border to module tag when hovering over step

### DIFF
--- a/protocol-designer/src/components/DeckSetup/ModuleTag.css
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.css
@@ -4,7 +4,7 @@
   width: 100%;
   background-color: var(--c-plate-bg);
   color: var(--c-font-dark);
-  padding: 0.3rem 0.113rem 0 0.113rem;
+  padding: 0.3rem 0.1rem 0 0.1rem;
   border: 3px solid transparent;
 }
 
@@ -22,6 +22,20 @@
   text-transform: capitalize;
 }
 
-.highlighted_border_div {
-  border: 3px solid var(--c-highlight);
+.highlighted_border_left_none {
+  border-top: 3px;
+  border-bottom: 3px;
+  border-right: 3px;
+  border-left: 0;
+  border-style: solid;
+  border-color: var(--c-highlight);
+}
+
+.highlighted_border_right_none {
+  border-top: 3px;
+  border-bottom: 3px;
+  border-left: 3px;
+  border-right: 0;
+  border-style: solid;
+  border-color: var(--c-highlight);
 }

--- a/protocol-designer/src/components/DeckSetup/ModuleTag.css
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.css
@@ -20,3 +20,7 @@
 .module_status_line {
   text-transform: capitalize;
 }
+
+.highlighted_border_div {
+  box-shadow: inset 0 0 0 3px var(--c-highlight);
+}

--- a/protocol-designer/src/components/DeckSetup/ModuleTag.css
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.css
@@ -23,19 +23,19 @@
 }
 
 .highlighted_border_left_none {
-  border-top: 3px;
-  border-bottom: 3px;
   border-right: 3px;
-  border-left: 0;
-  border-style: solid;
-  border-color: var(--c-highlight);
+  border-left: 3px transparent;
 }
 
 .highlighted_border_right_none {
+  border-left: 3px;
+  border-right: 3px transparent;
+}
+
+.highlighted_border_left_none,
+.highlighted_border_right_none {
   border-top: 3px;
   border-bottom: 3px;
-  border-left: 3px;
-  border-right: 0;
   border-style: solid;
   border-color: var(--c-highlight);
 }

--- a/protocol-designer/src/components/DeckSetup/ModuleTag.css
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.css
@@ -4,7 +4,8 @@
   width: 100%;
   background-color: var(--c-plate-bg);
   color: var(--c-font-dark);
-  padding: 0.3rem 0.3rem 0 0.3rem;
+  padding: 0.3rem 0.113rem 0 0.113rem;
+  border: 3px solid transparent;
 }
 
 .module_info_line {
@@ -22,5 +23,5 @@
 }
 
 .highlighted_border_div {
-  box-shadow: inset 0 0 0 3px var(--c-highlight);
+  border: 3px solid var(--c-highlight);
 }

--- a/protocol-designer/src/components/DeckSetup/ModuleTag.js
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.js
@@ -17,6 +17,8 @@ import {
   TEMPERATURE_APPROACHING_TARGET,
   TEMPERATURE_DEACTIVATED,
 } from '../../constants'
+import * as uiSelectors from '../../ui/steps'
+import { getLabwareOnModule } from '../../ui/modules/utils'
 import { getModuleVizDims } from './getModuleVizDims'
 import styles from './ModuleTag.css'
 import type { ModuleOrientation } from '../../types'
@@ -93,6 +95,14 @@ const ModuleTagComponent = (props: Props) => {
     timelineFrame.robotState.modules[props.id]?.moduleState
   const moduleType: ?* = moduleEntity?.type
 
+  const hoveredLabwares = useSelector(uiSelectors.getHoveredStepLabware)
+  const initialDeck = useSelector(stepFormSelectors.getInitialDeckSetup)
+  const moduleLabware = getLabwareOnModule(initialDeck, props.id)
+
+  const isHoveredModuleStep = moduleLabware
+    ? hoveredLabwares[0] === moduleLabware.id
+    : false
+
   if (moduleType == null || moduleState == null) {
     // this should never happen, but better to have an empty tag than to whitescreen
     console.error(
@@ -117,7 +127,9 @@ const ModuleTagComponent = (props: Props) => {
       height={TAG_HEIGHT}
       width={TAG_WIDTH}
       innerDivProps={{
-        className: styles.module_info_tag,
+        className: cx(styles.module_info_tag, {
+          [styles.highlighted_border_div]: isHoveredModuleStep,
+        }),
       }}
     >
       <div className={cx(styles.module_info_type, styles.module_info_line)}>

--- a/protocol-designer/src/components/DeckSetup/ModuleTag.js
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.js
@@ -127,7 +127,6 @@ const ModuleTagComponent = (props: Props) => {
       y={props.y + childYOffset + (STD_SLOT_Y_DIM - TAG_HEIGHT) / 2}
       height={TAG_HEIGHT}
       width={TAG_WIDTH}
-      className={styles.highlight}
       innerDivProps={{
         className: cx(styles.module_info_tag, {
           [styles.highlighted_border_right_none]:

--- a/protocol-designer/src/components/DeckSetup/ModuleTag.js
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.js
@@ -99,9 +99,10 @@ const ModuleTagComponent = (props: Props) => {
   const initialDeck = useSelector(stepFormSelectors.getInitialDeckSetup)
   const moduleLabware = getLabwareOnModule(initialDeck, props.id)
 
-  const isHoveredModuleStep = moduleLabware
-    ? hoveredLabwares[0] === moduleLabware.id
-    : false
+  const isHoveredModuleStep =
+    moduleLabware && hoveredLabwares.length
+      ? hoveredLabwares[0] === moduleLabware.id
+      : false
 
   if (moduleType == null || moduleState == null) {
     // this should never happen, but better to have an empty tag than to whitescreen

--- a/protocol-designer/src/components/DeckSetup/ModuleTag.js
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.js
@@ -103,6 +103,10 @@ const ModuleTagComponent = (props: Props) => {
     moduleLabware && hoveredLabwares.length
       ? hoveredLabwares[0] === moduleLabware.id
       : false
+  const highlightedBorderClass =
+    isHoveredModuleStep && props.orientation === 'left'
+      ? 'highlighted_border_right_none'
+      : 'highlighted_border_left_none'
 
   if (moduleType == null || moduleState == null) {
     // this should never happen, but better to have an empty tag than to whitescreen
@@ -127,9 +131,13 @@ const ModuleTagComponent = (props: Props) => {
       y={props.y + childYOffset + (STD_SLOT_Y_DIM - TAG_HEIGHT) / 2}
       height={TAG_HEIGHT}
       width={TAG_WIDTH}
+      className={styles.highlight}
       innerDivProps={{
         className: cx(styles.module_info_tag, {
-          [styles.highlighted_border_div]: isHoveredModuleStep,
+          [styles.highlighted_border_right_none]:
+            isHoveredModuleStep && props.orientation === 'left',
+          [styles.highlighted_border_left_none]:
+            isHoveredModuleStep && props.orientation === 'right',
         }),
       }}
     >

--- a/protocol-designer/src/components/DeckSetup/ModuleTag.js
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.js
@@ -103,10 +103,6 @@ const ModuleTagComponent = (props: Props) => {
     moduleLabware && hoveredLabwares.length
       ? hoveredLabwares[0] === moduleLabware.id
       : false
-  const highlightedBorderClass =
-    isHoveredModuleStep && props.orientation === 'left'
-      ? 'highlighted_border_right_none'
-      : 'highlighted_border_left_none'
 
   if (moduleType == null || moduleState == null) {
     // this should never happen, but better to have an empty tag than to whitescreen

--- a/protocol-designer/src/components/DeckSetup/__tests__/ModuleTag.test.js
+++ b/protocol-designer/src/components/DeckSetup/__tests__/ModuleTag.test.js
@@ -197,7 +197,7 @@ describe('ModuleTag', () => {
 
       expect(
         wrapper.find('RobotCoordsForeignDiv').prop('innerDivProps').className
-      ).toContain('highlighted_border_div')
+      ).toContain('highlighted_border_right_none')
     })
 
     it('does not add a border when the step is not a module step', () => {
@@ -205,7 +205,7 @@ describe('ModuleTag', () => {
 
       expect(
         wrapper.find('RobotCoordsForeignDiv').prop('innerDivProps').className
-      ).not.toContain('highlighted_border_div')
+      ).not.toContain('highlighted_border_right_none')
     })
 
     it('does not add a border when no labware on module', () => {
@@ -215,7 +215,7 @@ describe('ModuleTag', () => {
 
       expect(
         wrapper.find('RobotCoordsForeignDiv').prop('innerDivProps').className
-      ).not.toContain('highlighted_border_div')
+      ).not.toContain('highlighted_border_right_none')
     })
   })
 })

--- a/protocol-designer/src/components/DeckSetup/__tests__/ModuleTag.test.js
+++ b/protocol-designer/src/components/DeckSetup/__tests__/ModuleTag.test.js
@@ -2,6 +2,7 @@
 import {
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
+  TEMPERATURE_MODULE_V1,
 } from '@opentrons/shared-data'
 import React from 'react'
 import { Provider } from 'react-redux'
@@ -106,13 +107,14 @@ describe('ModuleTag', () => {
   })
 
   describe('ModuleTagComponent', () => {
+    const moduleId = 'abcdef'
     let store, props
     beforeEach(() => {
       props = {
         x: 1,
         y: 2,
         orientation: 'left',
-        id: 'abcdef',
+        id: moduleId,
       }
 
       store = {
@@ -147,44 +149,13 @@ describe('ModuleTag', () => {
         },
         warnings: [],
       })
-
       getModuleEntitiesMock.mockReturnValue({
         abcdef: {
-          id: 'abcdef',
-          type: 'temperatureModuleType',
-          model: 'GEN1',
+          id: moduleId,
+          type: TEMPERATURE_MODULE_TYPE,
+          model: TEMPERATURE_MODULE_V1,
         },
       })
-
-      getHoveredStepLabwareMock.mockReturnValue(['labwareId'])
-    })
-
-    it('adds a border when the step is is a module step type', () => {
-      getInitialDeckSetup.mockReturnValue({
-        labware: {
-          labwareId: {
-            id: 'labwareId',
-            slot: 'abcdef',
-            labwareDefURI: 'url',
-            def: fixture_tiprack_10_ul,
-          },
-        },
-        pipettes: {},
-        modules: {},
-      })
-
-      const wrapper = mount(
-        <Provider store={store}>
-          <ModuleTag {...props} />
-        </Provider>
-      )
-
-      expect(
-        wrapper.find('RobotCoordsForeignDiv').prop('innerDivProps').className
-      ).toContain('highlighted_border_div')
-    })
-
-    it('does not add a border when the step is not a module step and labware is not on the module', () => {
       getInitialDeckSetup.mockReturnValue({
         labware: {
           labwareId: {
@@ -197,12 +168,50 @@ describe('ModuleTag', () => {
         pipettes: {},
         modules: {},
       })
+      getHoveredStepLabwareMock.mockReturnValue(['labwareId'])
+    })
 
-      const wrapper = mount(
+    function render() {
+      return mount(
         <Provider store={store}>
           <ModuleTag {...props} />
         </Provider>
       )
+    }
+
+    it('adds a border when the step is is a module step type', () => {
+      getInitialDeckSetup.mockReturnValue({
+        labware: {
+          labwareId: {
+            id: 'labwareId',
+            slot: moduleId,
+            labwareDefURI: 'url',
+            def: fixture_tiprack_10_ul,
+          },
+        },
+        pipettes: {},
+        modules: {},
+      })
+
+      const wrapper = render()
+
+      expect(
+        wrapper.find('RobotCoordsForeignDiv').prop('innerDivProps').className
+      ).toContain('highlighted_border_div')
+    })
+
+    it('does not add a border when the step is not a module step', () => {
+      const wrapper = render()
+
+      expect(
+        wrapper.find('RobotCoordsForeignDiv').prop('innerDivProps').className
+      ).not.toContain('highlighted_border_div')
+    })
+
+    it('does not add a border when no labware on module', () => {
+      getHoveredStepLabwareMock.mockReturnValue([])
+
+      const wrapper = render()
 
       expect(
         wrapper.find('RobotCoordsForeignDiv').prop('innerDivProps').className

--- a/protocol-designer/src/components/DeckSetup/__tests__/ModuleTag.test.js
+++ b/protocol-designer/src/components/DeckSetup/__tests__/ModuleTag.test.js
@@ -4,74 +4,209 @@ import {
   TEMPERATURE_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import React from 'react'
-import { render } from 'enzyme'
-import { ModuleStatus } from '../ModuleTag'
+import { Provider } from 'react-redux'
+import { render, mount } from 'enzyme'
+import fixture_tiprack_10_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_10_ul.json'
 import {
   TEMPERATURE_APPROACHING_TARGET,
   TEMPERATURE_AT_TARGET,
   TEMPERATURE_DEACTIVATED,
 } from '../../../constants'
+import { ModuleStatus, ModuleTag } from '../ModuleTag'
 
-describe('ModuleStatus', () => {
-  describe('magnet module', () => {
-    test('displays engaged when magent is engaged', () => {
-      const props = {
-        engaged: true,
-        type: MAGNETIC_MODULE_TYPE,
-      }
+import * as timelineFramesSelectors from '../../../top-selectors/timelineFrames'
+import { selectors as stepFormSelectors } from '../../../step-forms'
+import * as uiSelectors from '../../../ui/steps'
 
-      const component = render(<ModuleStatus moduleState={props} />)
+import type { BaseState } from '../../../types'
+import type { CommandsAndRobotState } from '../../../step-generation'
+import type { ModuleEntities, InitialDeckSetup } from '../../../step-forms'
 
-      expect(component.text()).toBe('engaged')
+jest.mock('../../../ui/steps')
+jest.mock('../../../top-selectors/timelineFrames')
+jest.mock('../../../step-forms')
+
+const timelineFrameBeforeActiveItemMock: JestMockFn<
+  [BaseState],
+  CommandsAndRobotState
+> = timelineFramesSelectors.timelineFrameBeforeActiveItem
+
+const getModuleEntitiesMock: JestMockFn<[BaseState], ModuleEntities> =
+  stepFormSelectors.getModuleEntities
+
+const getHoveredStepLabwareMock: JestMockFn<[BaseState], Array<string>> =
+  uiSelectors.getHoveredStepLabware
+
+const getInitialDeckSetup: JestMockFn<[BaseState], InitialDeckSetup> =
+  stepFormSelectors.getInitialDeckSetup
+
+describe('ModuleTag', () => {
+  describe('ModuleStatus', () => {
+    describe('magnet module', () => {
+      test('displays engaged when magent is engaged', () => {
+        const props = {
+          engaged: true,
+          type: MAGNETIC_MODULE_TYPE,
+        }
+
+        const component = render(<ModuleStatus moduleState={props} />)
+
+        expect(component.text()).toBe('engaged')
+      })
+
+      test('displays disengaged when magnet is not engaged', () => {
+        const moduleState = {
+          engaged: false,
+          type: MAGNETIC_MODULE_TYPE,
+        }
+
+        const component = render(<ModuleStatus moduleState={moduleState} />)
+
+        expect(component.text()).toBe('disengaged')
+      })
     })
 
-    test('displays disengaged when magnet is not engaged', () => {
-      const moduleState = {
-        engaged: false,
-        type: MAGNETIC_MODULE_TYPE,
-      }
+    describe('temperature module', () => {
+      test('deactivated is shown when module is deactivated', () => {
+        const moduleState = {
+          type: TEMPERATURE_MODULE_TYPE,
+          status: TEMPERATURE_DEACTIVATED,
+          targetTemperature: null,
+        }
 
-      const component = render(<ModuleStatus moduleState={moduleState} />)
+        const component = render(<ModuleStatus moduleState={moduleState} />)
 
-      expect(component.text()).toBe('disengaged')
+        expect(component.text()).toBe('Deactivated')
+      })
+
+      test('target temperature is shown when module is at target', () => {
+        const moduleState = {
+          type: TEMPERATURE_MODULE_TYPE,
+          status: TEMPERATURE_AT_TARGET,
+          targetTemperature: 45,
+        }
+
+        const component = render(<ModuleStatus moduleState={moduleState} />)
+
+        expect(component.text()).toBe('45 °C')
+      })
+
+      test('going to X is shown when temperature is approaching target', () => {
+        const moduleState = {
+          type: TEMPERATURE_MODULE_TYPE,
+          status: TEMPERATURE_APPROACHING_TARGET,
+          targetTemperature: 45,
+        }
+
+        const component = render(<ModuleStatus moduleState={moduleState} />)
+
+        expect(component.text()).toBe('Going to 45 °C')
+      })
     })
   })
 
-  describe('temperature module', () => {
-    test('deactivated is shown when module is deactivated', () => {
-      const moduleState = {
-        type: TEMPERATURE_MODULE_TYPE,
-        status: TEMPERATURE_DEACTIVATED,
-        targetTemperature: null,
+  describe('ModuleTagComponent', () => {
+    let store, props
+    beforeEach(() => {
+      props = {
+        x: 1,
+        y: 2,
+        orientation: 'left',
+        id: 'abcdef',
       }
 
-      const component = render(<ModuleStatus moduleState={moduleState} />)
+      store = {
+        subscribe: jest.fn(),
+        dispatch: jest.fn(),
+        getState: () => ({}),
+      }
 
-      expect(component.text()).toBe('Deactivated')
+      timelineFrameBeforeActiveItemMock.mockReturnValue({
+        commands: [],
+        robotState: {
+          labware: {},
+          liquidState: {
+            pipettes: {},
+            labware: {},
+          },
+          pipettes: {},
+          tipState: {
+            tipracks: {},
+            pipettes: {},
+          },
+          modules: {
+            abcdef: {
+              slot: '3',
+              moduleState: {
+                type: TEMPERATURE_MODULE_TYPE,
+                status: TEMPERATURE_DEACTIVATED,
+                targetTemperature: null,
+              },
+            },
+          },
+        },
+        warnings: [],
+      })
+
+      getModuleEntitiesMock.mockReturnValue({
+        abcdef: {
+          id: 'abcdef',
+          type: 'temperatureModuleType',
+          model: 'GEN1',
+        },
+      })
+
+      getHoveredStepLabwareMock.mockReturnValue(['labwareId'])
     })
 
-    test('target temperature is shown when module is at target', () => {
-      const moduleState = {
-        type: TEMPERATURE_MODULE_TYPE,
-        status: TEMPERATURE_AT_TARGET,
-        targetTemperature: 45,
-      }
+    it('adds a border when the step is is a module step type', () => {
+      getInitialDeckSetup.mockReturnValue({
+        labware: {
+          labwareId: {
+            id: 'labwareId',
+            slot: 'abcdef',
+            labwareDefURI: 'url',
+            def: fixture_tiprack_10_ul,
+          },
+        },
+        pipettes: {},
+        modules: {},
+      })
 
-      const component = render(<ModuleStatus moduleState={moduleState} />)
+      const wrapper = mount(
+        <Provider store={store}>
+          <ModuleTag {...props} />
+        </Provider>
+      )
 
-      expect(component.text()).toBe('45 °C')
+      expect(
+        wrapper.find('RobotCoordsForeignDiv').prop('innerDivProps').className
+      ).toContain('highlighted_border_div')
     })
 
-    test('going to X is shown when temperature is approaching target', () => {
-      const moduleState = {
-        type: TEMPERATURE_MODULE_TYPE,
-        status: TEMPERATURE_APPROACHING_TARGET,
-        targetTemperature: 45,
-      }
+    it('does not add a border when the step is not a module step and labware is not on the module', () => {
+      getInitialDeckSetup.mockReturnValue({
+        labware: {
+          labwareId: {
+            id: 'labwareId',
+            slot: '3',
+            labwareDefURI: 'url',
+            def: fixture_tiprack_10_ul,
+          },
+        },
+        pipettes: {},
+        modules: {},
+      })
 
-      const component = render(<ModuleStatus moduleState={moduleState} />)
+      const wrapper = mount(
+        <Provider store={store}>
+          <ModuleTag {...props} />
+        </Provider>
+      )
 
-      expect(component.text()).toBe('Going to 45 °C')
+      expect(
+        wrapper.find('RobotCoordsForeignDiv').prop('innerDivProps').className
+      ).not.toContain('highlighted_border_div')
     })
   })
 })

--- a/protocol-designer/src/components/DeckSetup/__tests__/ModuleTag.test.js
+++ b/protocol-designer/src/components/DeckSetup/__tests__/ModuleTag.test.js
@@ -174,7 +174,9 @@ describe('ModuleTag', () => {
     function render() {
       return mount(
         <Provider store={store}>
-          <ModuleTag {...props} />
+          <svg>
+            <ModuleTag {...props} />
+          </svg>
         </Provider>
       )
     }


### PR DESCRIPTION
## overview
Closes #5110 by adding the highlighted border around the module label when hovering over module steps in the timeline.

![module-tag-highlight](https://user-images.githubusercontent.com/18384699/75818371-bdc3e200-5d66-11ea-8f50-39f86fa172f7.png)

## changelog
- Update styling for tag - border adds a bit more space to the tag
- Tag is also now highlighted along with the labware
- Updated test file - added extra describe block to separate out two components in the file

## review requests

1. Hovering over module step with labware
2. Create a new protocol with a module
3. The tag on the deck should not be highlighted
4. Add labware to the module on the deck
5. Add the same labware to another slot
6. Add some steps (transfers, mixes) to the labware not on the module
7. Add a module step
8. Hover over the transfer/mix steps
- [ ] The tag should not be highlighted
9. Hover over the module step
- [ ] The tag should be highlighted
10. Try removing the labware on the deck
- [ ] The tag should not be highlighted
