### PR TITLE
feat(protocol-designer): allow custom labware on modules

### DIFF
--- a/protocol-designer/src/components/DeckSetup/DeckSetup.js
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.js
@@ -16,13 +16,16 @@ import {
 import { getDeckDefinitions } from '@opentrons/components/src/deck/getDeckDefinitions'
 import { PSEUDO_DECK_SLOTS, GEN_ONE_MULTI_PIPETTES } from '../../constants'
 import type { TerminalItemId } from '../../steplist'
-import { getLabwareIsCompatible } from '../../utils/labwareModuleCompatibility'
+import {
+  getLabwareIsCompatible,
+  getLabwareIsCustom,
+} from '../../utils/labwareModuleCompatibility'
+import { selectors as labwareDefSelectors } from '../../labware-defs'
 import {
   getModuleVizDims,
   inferModuleOrientationFromSlot,
 } from './getModuleVizDims'
 
-import { selectors as labwareDefSelectors } from '../../labware-defs'
 import { selectors as featureFlagSelectors } from '../../feature-flags'
 import { getSlotsBlockedBySpanning, getSlotIsEmpty } from '../../step-forms'
 import { BrowseLabwareModal } from '../labware'
@@ -121,8 +124,14 @@ export const getSwapBlocked = (args: {
   const destModuleType: ?ModuleRealType =
     modulesById[hoveredLabware.slot]?.type || null
 
-  const draggedLabwareIsCustom = customLabwares[draggedLabware.labwareDefURI]
-  const hoveredLabwareIsCustom = customLabwares[hoveredLabware.labwareDefURI]
+  const draggedLabwareIsCustom = getLabwareIsCustom(
+    customLabwares,
+    draggedLabware
+  )
+  const hoveredLabwareIsCustom = getLabwareIsCustom(
+    customLabwares,
+    hoveredLabware
+  )
 
   // dragging custom labware to module gives not compat error
   const labwareSourceToDestBlocked = sourceModuleType
@@ -139,7 +148,7 @@ export const getSwapBlocked = (args: {
 
 // TODO IL 2020-01-12: to support dynamic labware/module movement during a protocol,
 // don't use initialDeckSetup here. Use some version of timelineFrameForActiveItem
-export const DeckSetupContents = (props: ContentsProps) => {
+const DeckSetupContents = (props: ContentsProps) => {
   const {
     initialDeckSetup,
     deckSlotsById,
@@ -154,7 +163,6 @@ export const DeckSetupContents = (props: ContentsProps) => {
   // hovered over**. The intrinsic state of `react-dnd` is not designed to handle that.
   // So we need to use our own state here to determine
   // whether swapping will be blocked due to labware<>module compat:
-
   const [hoveredLabware, setHoveredLabware] = useState<?LabwareOnDeckType>(null)
   const [draggedLabware, setDraggedLabware] = useState<?LabwareOnDeckType>(null)
 

--- a/protocol-designer/src/components/DeckSetup/DeckSetup.js
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.js
@@ -111,10 +111,15 @@ export const getSwapBlocked = (args: {
   hoveredLabware: ?LabwareOnDeckType,
   draggedLabware: ?LabwareOnDeckType,
   modulesById: $PropertyType<InitialDeckSetup, 'modules'>,
-  customLabwares: LabwareDefByDefURI,
+  customLabwareDefs: LabwareDefByDefURI,
 }): boolean => {
-  const { hoveredLabware, draggedLabware, modulesById, customLabwares } = args
-
+  const {
+    hoveredLabware,
+    draggedLabware,
+    modulesById,
+    customLabwareDefs,
+  } = args
+  console.log('hovered ', hoveredLabware, modulesById)
   if (!hoveredLabware || !draggedLabware) {
     return false
   }
@@ -125,11 +130,11 @@ export const getSwapBlocked = (args: {
     modulesById[hoveredLabware.slot]?.type || null
 
   const draggedLabwareIsCustom = getLabwareIsCustom(
-    customLabwares,
+    customLabwareDefs,
     draggedLabware
   )
   const hoveredLabwareIsCustom = getLabwareIsCustom(
-    customLabwares,
+    customLabwareDefs,
     hoveredLabware
   )
 
@@ -166,15 +171,16 @@ const DeckSetupContents = (props: ContentsProps) => {
   const [hoveredLabware, setHoveredLabware] = useState<?LabwareOnDeckType>(null)
   const [draggedLabware, setDraggedLabware] = useState<?LabwareOnDeckType>(null)
 
-  const customLabwares = useSelector(
+  const customLabwareDefs = useSelector(
     labwareDefSelectors.getCustomLabwareDefsByURI
   )
   const swapBlocked = getSwapBlocked({
     hoveredLabware,
     draggedLabware,
     modulesById: initialDeckSetup.modules,
-    customLabwares,
+    customLabwareDefs,
   })
+
   const handleHoverEmptySlot = useCallback(() => setHoveredLabware(null), [])
 
   const slotsBlockedBySpanning = getSlotsBlockedBySpanning(

--- a/protocol-designer/src/components/DeckSetup/DeckSetup.js
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.js
@@ -104,7 +104,7 @@ const getModuleSlotDefs = (
   )
 }
 
-const getSwapBlocked = (args: {
+export const getSwapBlocked = (args: {
   hoveredLabware: ?LabwareOnDeckType,
   draggedLabware: ?LabwareOnDeckType,
   modulesById: $PropertyType<InitialDeckSetup, 'modules'>,
@@ -123,6 +123,7 @@ const getSwapBlocked = (args: {
 
   const draggedLabwareIsCustom = customLabwares[draggedLabware.labwareDefURI]
   const hoveredLabwareIsCustom = customLabwares[hoveredLabware.labwareDefURI]
+
   // dragging custom labware to module gives not compat error
   const labwareSourceToDestBlocked = sourceModuleType
     ? !getLabwareIsCompatible(hoveredLabware.def, sourceModuleType) &&
@@ -138,7 +139,7 @@ const getSwapBlocked = (args: {
 
 // TODO IL 2020-01-12: to support dynamic labware/module movement during a protocol,
 // don't use initialDeckSetup here. Use some version of timelineFrameForActiveItem
-const DeckSetupContents = (props: ContentsProps) => {
+export const DeckSetupContents = (props: ContentsProps) => {
   const {
     initialDeckSetup,
     deckSlotsById,

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.js
@@ -7,16 +7,18 @@ import { connect } from 'react-redux'
 import { DropTarget } from 'react-dnd'
 import noop from 'lodash/noop'
 import { i18n } from '../../../localization'
-import { getLabwareIsCompatible } from '../../../utils/labwareModuleCompatibility'
+import {
+  getLabwareIsCompatible,
+  getLabwareIsCustom,
+} from '../../../utils/labwareModuleCompatibility'
 import { BlockedSlot } from './BlockedSlot'
 import {
   openAddLabwareModal,
   moveDeckItem,
 } from '../../../labware-ingred/actions'
+import { selectors as labwareDefSelectors } from '../../../labware-defs'
 import { START_TERMINAL_ITEM_ID, type TerminalItemId } from '../../../steplist'
 import { DND_TYPES } from './constants'
-
-import { selectors as labwareDefSelectors } from '../../../labware-defs'
 
 import type { DeckSlot, ThunkDispatch, BaseState } from '../../../types'
 import type { LabwareDefByDefURI } from '../../../labware-defs'
@@ -29,7 +31,7 @@ import styles from './LabwareOverlays.css'
 
 type DNDP = {|
   isOver: boolean,
-  connectDropTarget: Node => Node | null,
+  connectDropTarget: Node => Node,
   draggedItem: ?{ labwareOnDeck: LabwareOnDeck },
 |}
 type OP = {|
@@ -61,8 +63,9 @@ export const SlotControlsComponent = (props: Props) => {
   if (selectedTerminalItemId !== START_TERMINAL_ITEM_ID) return null
 
   const draggedDef = draggedItem?.labwareOnDeck?.def
-  const isCustomLabware =
-    draggedItem && customLabwares[draggedItem.labwareOnDeck.labwareDefURI]
+  const isCustomLabware = draggedItem
+    ? getLabwareIsCustom(customLabwares, draggedItem.labwareOnDeck)
+    : false
 
   let slotBlocked: string | null = null
   if (
@@ -141,8 +144,10 @@ const slotTarget = {
 
     if (moduleType != null && draggedDef != null) {
       // this is a module slot, prevent drop if the dragged labware is not compatible
-      const isCustomLabware =
-        props.customLabwares[draggedItem.labwareOnDeck.labwareDefURI]
+      const isCustomLabware = getLabwareIsCustom(
+        props.customLabwares,
+        draggedItem.labwareOnDeck
+      )
 
       return getLabwareIsCompatible(draggedDef, moduleType) || isCustomLabware
     }

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.js
@@ -29,7 +29,7 @@ import styles from './LabwareOverlays.css'
 
 type DNDP = {|
   isOver: boolean,
-  connectDropTarget: Node => mixed,
+  connectDropTarget: Node => Node | null,
   draggedItem: ?{ labwareOnDeck: LabwareOnDeck },
 |}
 type OP = {|
@@ -47,7 +47,7 @@ type SP = {|
 |}
 type Props = {| ...OP, ...DP, ...DNDP, ...SP |}
 
-const SlotControlsComponent = (props: Props) => {
+export const SlotControlsComponent = (props: Props) => {
   const {
     slot,
     addLabware,

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.js
@@ -45,7 +45,7 @@ type DP = {|
   moveDeckItem: (DeckSlot, DeckSlot) => mixed,
 |}
 type SP = {|
-  customLabwares: LabwareDefByDefURI,
+  customLabwareDefs: LabwareDefByDefURI,
 |}
 type Props = {| ...OP, ...DP, ...DNDP, ...SP |}
 
@@ -58,13 +58,13 @@ export const SlotControlsComponent = (props: Props) => {
     connectDropTarget,
     moduleType,
     draggedItem,
-    customLabwares,
+    customLabwareDefs,
   } = props
   if (selectedTerminalItemId !== START_TERMINAL_ITEM_ID) return null
 
   const draggedDef = draggedItem?.labwareOnDeck?.def
   const isCustomLabware = draggedItem
-    ? getLabwareIsCustom(customLabwares, draggedItem.labwareOnDeck)
+    ? getLabwareIsCustom(customLabwareDefs, draggedItem.labwareOnDeck)
     : false
 
   let slotBlocked: string | null = null
@@ -114,7 +114,7 @@ export const SlotControlsComponent = (props: Props) => {
 
 const mapStateToProps = (state: BaseState): SP => {
   return {
-    customLabwares: labwareDefSelectors.getCustomLabwareDefsByURI(state),
+    customLabwareDefs: labwareDefSelectors.getCustomLabwareDefsByURI(state),
   }
 }
 
@@ -145,7 +145,7 @@ const slotTarget = {
     if (moduleType != null && draggedDef != null) {
       // this is a module slot, prevent drop if the dragged labware is not compatible
       const isCustomLabware = getLabwareIsCustom(
-        props.customLabwares,
+        props.customLabwareDefs,
         draggedItem.labwareOnDeck
       )
 

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/__tests__/SlotControls.test.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/__tests__/SlotControls.test.js
@@ -1,0 +1,102 @@
+// @flow
+
+import React from 'react'
+import { shallow } from 'enzyme'
+import fixture_96_plate_def from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
+import * as labwareModuleCompatibility from '../../../../utils/labwareModuleCompatibility'
+import { SlotControlsComponent } from '../SlotControls'
+import { START_TERMINAL_ITEM_ID } from '../../../../steplist'
+import { BlockedSlot } from '../BlockedSlot'
+
+import type { LabwareDefinition2, ModuleRealType } from '@opentrons/shared-data'
+
+jest.mock('../../../../utils/labwareModuleCompatibility')
+
+const getLabwareIsCompatibleMock: JestMockFn<
+  [LabwareDefinition2, ModuleRealType],
+  boolean
+> = labwareModuleCompatibility.getLabwareIsCompatible
+
+describe('SlotControlsComponent', () => {
+  let props
+  beforeEach(() => {
+    const slot = {
+      id: 'deckSlot1',
+      position: [1, 2, 3],
+      boundingBox: {
+        xDimension: 10,
+        yDimension: 20,
+        zDimension: 40,
+      },
+      displayName: 'slot 1',
+      compatibleModules: ['magdeck'],
+    }
+
+    const labwareOnDeck = {
+      labwareDefURI: 'fixture/fixture_96_plate',
+      id: 'plate123',
+      slot: '3',
+      def: fixture_96_plate_def,
+    }
+
+    props = {
+      slot,
+      addLabware: jest.fn(),
+      moveDeckItem: jest.fn(),
+      selectedTerminalItemId: START_TERMINAL_ITEM_ID,
+      isOver: true,
+      connectDropTarget: el => <svg>{el}</svg>,
+      moduleType: 'magneticModuleType',
+      draggedItem: {
+        labwareOnDeck,
+      },
+      customLabwares: {},
+    }
+  })
+
+  it('renders nothing when not start terminal item', () => {
+    props.selectedTerminalItemId = '__end__'
+
+    const wrapper = shallow(<SlotControlsComponent {...props} />)
+
+    expect(wrapper.get(0)).toBeNull()
+  })
+
+  it('gives a slot blocked warning when dragged noncustom and incompatible labware is over a module slot with labware', () => {
+    getLabwareIsCompatibleMock.mockReturnValue(false)
+
+    const wrapper = shallow(<SlotControlsComponent {...props} />)
+    const blockedSlot = wrapper.find(BlockedSlot)
+
+    expect(blockedSlot.prop('message')).toBe(
+      'MODULE_INCOMPATIBLE_SINGLE_LABWARE'
+    )
+  })
+
+  it('displays place here when dragged compatible labware is hovered over slot with labware', () => {
+    getLabwareIsCompatibleMock.mockReturnValue(true)
+
+    const wrapper = shallow(<SlotControlsComponent {...props} />)
+
+    expect(wrapper.render().text()).toContain('Place Here')
+  })
+
+  it('displays place here when dragged labware is custom and hovered over another labware on module slot', () => {
+    props.customLabwares = {
+      'fixture/fixture_96_plate': fixture_96_plate_def,
+    }
+
+    const wrapper = shallow(<SlotControlsComponent {...props} />)
+
+    expect(wrapper.render().text()).toContain('Place Here')
+  })
+
+  it('displays add labware when slot is empty and compatible', () => {
+    props.isOver = false
+    getLabwareIsCompatibleMock.mockReturnValue(true)
+
+    const wrapper = shallow(<SlotControlsComponent {...props} />)
+
+    expect(wrapper.render().text()).toContain('Add Labware')
+  })
+})

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/__tests__/SlotControls.test.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/__tests__/SlotControls.test.js
@@ -4,21 +4,12 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import fixture_96_plate_def from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
 import * as labwareModuleCompatibility from '../../../../utils/labwareModuleCompatibility'
-import { SlotControlsComponent } from '../SlotControls'
 import { START_TERMINAL_ITEM_ID } from '../../../../steplist'
+import { SlotControlsComponent } from '../SlotControls'
 import { BlockedSlot } from '../BlockedSlot'
 
-import type { LabwareDefinition2, ModuleRealType } from '@opentrons/shared-data'
-
-jest.mock('../../../../utils/labwareModuleCompatibility')
-
-const getLabwareIsCompatibleMock: JestMockFn<
-  [LabwareDefinition2, ModuleRealType],
-  boolean
-> = labwareModuleCompatibility.getLabwareIsCompatible
-
 describe('SlotControlsComponent', () => {
-  let props
+  let props, getLabwareIsCompatibleSpy
   beforeEach(() => {
     const slot = {
       id: 'deckSlot1',
@@ -52,6 +43,15 @@ describe('SlotControlsComponent', () => {
       },
       customLabwares: {},
     }
+
+    getLabwareIsCompatibleSpy = jest.spyOn(
+      labwareModuleCompatibility,
+      'getLabwareIsCompatible'
+    )
+  })
+
+  afterEach(() => {
+    getLabwareIsCompatibleSpy.mockClear()
   })
 
   it('renders nothing when not start terminal item', () => {
@@ -63,7 +63,7 @@ describe('SlotControlsComponent', () => {
   })
 
   it('gives a slot blocked warning when dragged noncustom and incompatible labware is over a module slot with labware', () => {
-    getLabwareIsCompatibleMock.mockReturnValue(false)
+    getLabwareIsCompatibleSpy.mockReturnValue(false)
 
     const wrapper = shallow(<SlotControlsComponent {...props} />)
     const blockedSlot = wrapper.find(BlockedSlot)
@@ -74,7 +74,7 @@ describe('SlotControlsComponent', () => {
   })
 
   it('displays place here when dragged compatible labware is hovered over slot with labware', () => {
-    getLabwareIsCompatibleMock.mockReturnValue(true)
+    getLabwareIsCompatibleSpy.mockReturnValue(true)
 
     const wrapper = shallow(<SlotControlsComponent {...props} />)
 
@@ -93,7 +93,7 @@ describe('SlotControlsComponent', () => {
 
   it('displays add labware when slot is empty and compatible', () => {
     props.isOver = false
-    getLabwareIsCompatibleMock.mockReturnValue(true)
+    getLabwareIsCompatibleSpy.mockReturnValue(true)
 
     const wrapper = shallow(<SlotControlsComponent {...props} />)
 

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/__tests__/SlotControls.test.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/__tests__/SlotControls.test.js
@@ -2,7 +2,8 @@
 
 import React from 'react'
 import { shallow } from 'enzyme'
-import fixture_96_plate_def from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
+import fixture_96_plate from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
+import { MAGNETIC_MODULE_TYPE } from '@opentrons/shared-data'
 import * as labwareModuleCompatibility from '../../../../utils/labwareModuleCompatibility'
 import { START_TERMINAL_ITEM_ID } from '../../../../steplist'
 import { SlotControlsComponent } from '../SlotControls'
@@ -27,7 +28,7 @@ describe('SlotControlsComponent', () => {
       labwareDefURI: 'fixture/fixture_96_plate',
       id: 'plate123',
       slot: '3',
-      def: fixture_96_plate_def,
+      def: fixture_96_plate,
     }
 
     props = {
@@ -37,11 +38,11 @@ describe('SlotControlsComponent', () => {
       selectedTerminalItemId: START_TERMINAL_ITEM_ID,
       isOver: true,
       connectDropTarget: el => <svg>{el}</svg>,
-      moduleType: 'magneticModuleType',
+      moduleType: MAGNETIC_MODULE_TYPE,
       draggedItem: {
         labwareOnDeck,
       },
-      customLabwares: {},
+      customLabwareDefs: {},
     }
 
     getLabwareIsCompatibleSpy = jest.spyOn(
@@ -82,8 +83,8 @@ describe('SlotControlsComponent', () => {
   })
 
   it('displays place here when dragged labware is custom and hovered over another labware on module slot', () => {
-    props.customLabwares = {
-      'fixture/fixture_96_plate': fixture_96_plate_def,
+    props.customLabwareDefs = {
+      'fixture/fixture_96_plate': fixture_96_plate,
     }
 
     const wrapper = shallow(<SlotControlsComponent {...props} />)
@@ -91,9 +92,8 @@ describe('SlotControlsComponent', () => {
     expect(wrapper.render().text()).toContain('Place Here')
   })
 
-  it('displays add labware when slot is empty and compatible', () => {
+  it('displays add labware when slot is empty', () => {
     props.isOver = false
-    getLabwareIsCompatibleSpy.mockReturnValue(true)
 
     const wrapper = shallow(<SlotControlsComponent {...props} />)
 

--- a/protocol-designer/src/components/DeckSetup/__tests__/DeckSetup.test.js
+++ b/protocol-designer/src/components/DeckSetup/__tests__/DeckSetup.test.js
@@ -2,16 +2,8 @@
 
 import fixture_96_plate_def from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
 import fixture_24_tuberack_def from '@opentrons/shared-data/labware/fixtures/2/fixture_24_tuberack.json'
-import { getSwapBlocked } from '../DeckSetup'
 import * as labwareModuleCompatibility from '../../../utils/labwareModuleCompatibility'
-import type { LabwareDefinition2, ModuleRealType } from '@opentrons/shared-data'
-
-jest.mock('../../../utils/labwareModuleCompatibility')
-
-const getLabwareIsCompatibleMock: JestMockFn<
-  [LabwareDefinition2, ModuleRealType],
-  boolean
-> = labwareModuleCompatibility.getLabwareIsCompatible
+import { getSwapBlocked } from '../DeckSetup'
 
 describe('DeckSetup', () => {
   describe('getSwapBlocked', () => {
@@ -27,6 +19,18 @@ describe('DeckSetup', () => {
       slot: '4',
       def: fixture_24_tuberack_def,
     }
+
+    let getLabwareIsCompatibleSpy
+    beforeEach(() => {
+      getLabwareIsCompatibleSpy = jest.spyOn(
+        labwareModuleCompatibility,
+        'getLabwareIsCompatible'
+      )
+    })
+
+    afterEach(() => {
+      getLabwareIsCompatibleSpy.mockClear()
+    })
 
     it('is not blocked when there is no labware in slot', () => {
       const args = {
@@ -56,7 +60,7 @@ describe('DeckSetup', () => {
 
     it('is not blocked when dragged labware to swap on module is custom', () => {
       fixture_24_tuberack.slot = 'magnet123'
-      getLabwareIsCompatibleMock.mockReturnValue(false)
+      getLabwareIsCompatibleSpy.mockReturnValue(false)
       const args = {
         hoveredLabware: fixture_24_tuberack,
         draggedLabware: fixture_96_plate,
@@ -84,7 +88,7 @@ describe('DeckSetup', () => {
 
     it('is blocked when dragged labware to swap is not custom and not compatible', () => {
       fixture_24_tuberack.slot = 'magnet123'
-      getLabwareIsCompatibleMock.mockReturnValue(false)
+      getLabwareIsCompatibleSpy.mockReturnValue(false)
       const args = {
         hoveredLabware: fixture_24_tuberack,
         draggedLabware: fixture_96_plate,
@@ -110,7 +114,7 @@ describe('DeckSetup', () => {
 
     it('is not blocked when both labwares are compatible', () => {
       fixture_24_tuberack.slot = 'magnet123'
-      getLabwareIsCompatibleMock.mockReturnValue(true)
+      getLabwareIsCompatibleSpy.mockReturnValue(true)
       const args = {
         hoveredLabware: fixture_24_tuberack,
         draggedLabware: fixture_96_plate,

--- a/protocol-designer/src/components/DeckSetup/__tests__/DeckSetup.test.js
+++ b/protocol-designer/src/components/DeckSetup/__tests__/DeckSetup.test.js
@@ -1,0 +1,137 @@
+// @flow
+
+import fixture_96_plate_def from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
+import fixture_24_tuberack_def from '@opentrons/shared-data/labware/fixtures/2/fixture_24_tuberack.json'
+import { getSwapBlocked } from '../DeckSetup'
+import * as labwareModuleCompatibility from '../../../utils/labwareModuleCompatibility'
+import type { LabwareDefinition2, ModuleRealType } from '@opentrons/shared-data'
+
+jest.mock('../../../utils/labwareModuleCompatibility')
+
+const getLabwareIsCompatibleMock: JestMockFn<
+  [LabwareDefinition2, ModuleRealType],
+  boolean
+> = labwareModuleCompatibility.getLabwareIsCompatible
+
+describe('DeckSetup', () => {
+  describe('getSwapBlocked', () => {
+    const fixture_96_plate = {
+      labwareDefURI: 'fixture/fixture_96_plate',
+      id: 'plate123',
+      slot: '3',
+      def: fixture_96_plate_def,
+    }
+    const fixture_24_tuberack = {
+      labwareDefURI: 'fixture/fixtures_24_tuberack',
+      id: 'tuberack098',
+      slot: '4',
+      def: fixture_24_tuberack_def,
+    }
+
+    it('is not blocked when there is no labware in slot', () => {
+      const args = {
+        hoveredLabware: null,
+        draggedLabware: fixture_96_plate,
+        modulesById: {},
+        customLabwares: {},
+      }
+
+      const isBlocked = getSwapBlocked(args)
+
+      expect(isBlocked).toEqual(false)
+    })
+
+    it('is not blocked when no dragged labware', () => {
+      const args = {
+        hoveredLabware: fixture_96_plate,
+        draggedLabware: null,
+        modulesById: {},
+        customLabwares: {},
+      }
+
+      const isBlocked = getSwapBlocked(args)
+
+      expect(isBlocked).toEqual(false)
+    })
+
+    it('is not blocked when dragged labware to swap on module is custom', () => {
+      fixture_24_tuberack.slot = 'magnet123'
+      getLabwareIsCompatibleMock.mockReturnValue(false)
+      const args = {
+        hoveredLabware: fixture_24_tuberack,
+        draggedLabware: fixture_96_plate,
+        modulesById: {
+          magnet123: {
+            id: 'magnet123',
+            type: 'magneticModuleType',
+            model: 'GEN1',
+            moduleState: {
+              type: 'magneticModuleType',
+              engaged: false,
+            },
+            slot: '1',
+          },
+        },
+        customLabwares: {
+          'fixture/fixture_96_plate': fixture_96_plate_def,
+        },
+      }
+
+      const isBlocked = getSwapBlocked(args)
+
+      expect(isBlocked).toEqual(false)
+    })
+
+    it('is blocked when dragged labware to swap is not custom and not compatible', () => {
+      fixture_24_tuberack.slot = 'magnet123'
+      getLabwareIsCompatibleMock.mockReturnValue(false)
+      const args = {
+        hoveredLabware: fixture_24_tuberack,
+        draggedLabware: fixture_96_plate,
+        modulesById: {
+          magnet123: {
+            id: 'magnet123',
+            type: 'magneticModuleType',
+            model: 'GEN1',
+            moduleState: {
+              type: 'magneticModuleType',
+              engaged: false,
+            },
+            slot: '1',
+          },
+        },
+        customLabwares: {},
+      }
+
+      const isBlocked = getSwapBlocked(args)
+
+      expect(isBlocked).toEqual(true)
+    })
+
+    it('is not blocked when both labwares are compatible', () => {
+      fixture_24_tuberack.slot = 'magnet123'
+      getLabwareIsCompatibleMock.mockReturnValue(true)
+      const args = {
+        hoveredLabware: fixture_24_tuberack,
+        draggedLabware: fixture_96_plate,
+        modulesById: {
+          magnet123: {
+            id: 'magnet123',
+            type: 'magneticModuleType',
+            model: 'GEN1',
+            moduleState: {
+              type: 'magneticModuleType',
+              engaged: false,
+            },
+            slot: '1',
+          },
+        },
+        customLabwares: {},
+      }
+
+      const isBlocked = getSwapBlocked(args)
+
+      expect(isBlocked).toEqual(false)
+    })
+  })
+})

--- a/protocol-designer/src/utils/__tests__/labwareModuleCompatibility.test.js
+++ b/protocol-designer/src/utils/__tests__/labwareModuleCompatibility.test.js
@@ -1,0 +1,29 @@
+import fixture_96_plate_def from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
+import { getLabwareIsCustom } from '../labwareModuleCompatibility'
+
+describe('labwareModuleCompatibility', () => {
+  describe('getLabwareIsCustom', () => {
+    const labwareOnDeck = {
+      labwareDefURI: 'fixture/fixture_96_plate',
+      id: 'abcef123',
+      slot: '3',
+      def: fixture_96_plate_def,
+    }
+
+    it('returns true when labware is inside custom labwares obj', () => {
+      const customLabwares = {
+        'fixture/fixture_96_plate': fixture_96_plate_def,
+      }
+
+      const labwareIsCustom = getLabwareIsCustom(customLabwares, labwareOnDeck)
+
+      expect(labwareIsCustom).toEqual(true)
+    })
+
+    it('returns false when labware is not inside custom labwares obj', () => {
+      const labwareIsCustom = getLabwareIsCustom({}, labwareOnDeck)
+
+      expect(labwareIsCustom).toEqual(false)
+    })
+  })
+})

--- a/protocol-designer/src/utils/labwareModuleCompatibility.js
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.js
@@ -7,7 +7,8 @@ import {
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import type { LabwareDefinition2, ModuleRealType } from '@opentrons/shared-data'
-
+import type { LabwareDefByDefURI } from '../labware-defs'
+import type { LabwareOnDeck } from '../step-forms'
 // NOTE: this does not distinguish btw versions. Standard labware only (assumes namespace is 'opentrons')
 const COMPATIBLE_LABWARE_WHITELIST_BY_MODULE_TYPE: {
   [ModuleRealType]: $ReadOnlyArray<string>,
@@ -60,4 +61,11 @@ export const getLabwareIsCompatible = (
   const whitelist =
     COMPATIBLE_LABWARE_WHITELIST_BY_MODULE_TYPE[moduleType] || []
   return whitelist.includes(def.parameters.loadName)
+}
+
+export const getLabwareIsCustom = (
+  customLabwares: LabwareDefByDefURI,
+  labwareOnDeck: LabwareOnDeck
+): boolean => {
+  return labwareOnDeck.labwareDefURI in customLabwares
 }


### PR DESCRIPTION
## overview
Closes #4910 by removing restrictions when placing custom labware on modules

## changelog
- Add checks for custom labware in relevant functions
- Add tests

## review requests
https://github.com/Opentrons/opentrons/issues/4910 - acceptance criteria here
This was tested with the python api but feel free to test it yourself.

**Swapping labware**
1. Create a custom labware using labware creator
2. Create a new protocol with a magnet and temperature module
3. On the deck view, click on the modules to add a new labware
4. Select upload custom labware and upload your labware
5. Select the custom labware as the labware to place on the magnet and temperature module
- [ ] There should be no errors and labware should be placed on top of the modules
6. Add magnet and temperature compatible labwares to the deck in empty slots
7. Swap the custom labware on the magnet module with the magnet compatible labware
- [ ] Labware should be swapped with no issue
8. Swap the custom labware on the temperature module with the temperature compatible labware
- [ ] Labware should be swapped with no issue
9. Swap the labware back until both temperature and magnet modules both have custom labware on them again
10. Add a tube rack (this is incompatible with the magnet and temperature modules)  to an empty slot on the deck
11. Try to swap the tube rack with the custom labware on both modules
- [ ] Incompatible labware should not be swapped
12. Drag the labware from the modules to empty slots
13. Drag them back to the module
- [ ] This should be allowed


**Adding steps**
**Labware is not magnet compatible**
Add a magnet engage step
- [ ] There is no recommended engage height and no recommended label

**Labware is magnet compatible and has an engage height**
Add a magnet engage step
- [ ] The recommended engage height is filled out in the form with the recommended label specifying the engage height below it

**Temperature steps**
Add a set temperature step
- [ ] There are no errors

Add a deactivate step
- [ ] There are no errors
