### PR TITLE
test(protocol-designer): fix failing cypress tests following addition of announcement modal

### DIFF
--- a/protocol-designer/cypress/integration/newProtocol.spec.js
+++ b/protocol-designer/cypress/integration/newProtocol.spec.js
@@ -5,6 +5,12 @@ describe('Desktop Navigation', () => {
   })
 
   describe('the setup form', () => {
+    it('displays the announcement modal and clicks "GOT IT!" to close it', () => {
+      cy.get('button')
+        .contains('Got It!')
+        .click()
+    })
+
     it('clicks the "CREATE NEW" button', () => {
       cy.get('button')
         .contains('Create New')

--- a/protocol-designer/cypress/integration/settings.spec.js
+++ b/protocol-designer/cypress/integration/settings.spec.js
@@ -3,6 +3,12 @@ describe('The Settings Page', () => {
     cy.visit('/')
   })
 
+  it('displays the announcement modal and clicks "GOT IT!" to close it', () => {
+    cy.get('button')
+      .contains('Got It!')
+      .click()
+  })
+
   it('contains a working settings button', () => {
     cy.get("button[class*='navbar__tab__']")
       .contains('Settings')


### PR DESCRIPTION
## overview
The cypress end to end tests were failing since we added the modal and the cypress couldn't access some of the buttons covered by the announcement modal.

## changelog
- Added relevant tests to close announcement modal so tests can continue

## review requests
- Run the e2e tests for protocol designer. They should no longer be failing. There should be no more errors saying element was covered by modal overlay.