### PR TITLE
fix(robot-server): fix failure in fw_version reading in health endpoint.

### DIFF
--- a/robot-server/robot_server/service/routers/health.py
+++ b/robot-server/robot_server/service/routers/health.py
@@ -28,7 +28,7 @@ async def get_health(
     # This conditional handles the case where we have just changed the
     # use protocol api v2 feature flag, so it does not match the type
     # of hardware we're actually using.
-    fw_version = await hardware.fw_version  # type: ignore
+    fw_version = hardware.fw_version  # type: ignore
     if inspect.isawaitable(fw_version):
         fw_version = await fw_version
 


### PR DESCRIPTION
## overview

Fix bug that only revealed itself when `fw_version` stopped being an awaitable.
