### PR TITLE
fix(robot-server): cannot import log control

### DIFF
--- a/robot-server/robot_server/service/routers/settings.py
+++ b/robot-server/robot_server/service/routers/settings.py
@@ -1,6 +1,5 @@
 from http import HTTPStatus
 from fastapi import APIRouter, HTTPException, Query
-from opentrons.system import log_control
 
 from robot_server.service.models import V1ErrorMessage
 from robot_server.service.models.settings import AdvancedSettings, LogLevel, \
@@ -96,5 +95,5 @@ async def get_logs(syslog_identifier: LogIdentifier,
                                         description="Number of records to "
                                                     "retrieve",
                                         gt=0,
-                                        le=log_control.MAX_RECORDS)) -> str:
+                                        le=100000)) -> str:
     raise HTTPException(HTTPStatus.NOT_IMPLEMENTED, "not implemented")


### PR DESCRIPTION
## overview

Cannot import log control on non-linux machines. I was importing it to get the max number of log records to return in the get_log API. 


