### PR TITLE
feat(robot-server): add formatted json responses and error handling

### DIFF
--- a/robot-server/robot_server/service/main.py
+++ b/robot-server/robot_server/service/main.py
@@ -41,6 +41,8 @@ app.include_router(router=modules.router,
                    tags=["modules"])
 app.include_router(router=pipettes.router,
                    tags=["pipettes"])
+# TODO(isk: 3/18/20): this is an example route, remove item route and model
+# once response work is implemented in new route handlers
 app.include_router(router=item.router,
                    tags=["item"])
 

--- a/robot-server/robot_server/service/main.py
+++ b/robot-server/robot_server/service/main.py
@@ -1,9 +1,18 @@
 from opentrons import __version__
 from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
+
 from starlette.responses import JSONResponse
 from starlette.requests import Request
+from starlette.exceptions import HTTPException as StarletteHTTPException
+# https://github.com/encode/starlette/blob/master/starlette/status.py
+from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
+
 from .routers import health, networking, control, settings, deck_calibration, \
-    modules, pipettes
+    modules, pipettes, item
+from .models.json_api.errors import \
+    transform_validation_error_to_json_api_errors, \
+    transform_http_exception_to_json_api_errors
 from .models import V1BasicResponse
 from .exceptions import V1HandlerError
 
@@ -17,7 +26,6 @@ app = FastAPI(
                 "`patternProperties` behavior.",
     version=__version__
 )
-
 
 app.include_router(router=health.router,
                    tags=["health"])
@@ -33,6 +41,8 @@ app.include_router(router=modules.router,
                    tags=["modules"])
 app.include_router(router=pipettes.router,
                    tags=["pipettes"])
+app.include_router(router=item.router,
+                   tags=["item"])
 
 
 @app.exception_handler(V1HandlerError)
@@ -41,3 +51,31 @@ async def v1_exception_handler(request: Request, exc: V1HandlerError):
         status_code=exc.status_code,
         content=V1BasicResponse(message=exc.message).dict()
     )
+
+
+@app.exception_handler(RequestValidationError)
+async def custom_request_validation_exception_handler(
+    request: Request,
+    exception: RequestValidationError
+) -> JSONResponse:
+    errors = transform_validation_error_to_json_api_errors(
+        HTTP_422_UNPROCESSABLE_ENTITY, exception
+    ).dict(exclude_unset=True)
+    return JSONResponse(
+        status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+        content=errors,
+     )
+
+
+@app.exception_handler(StarletteHTTPException)
+async def custom_http_exception_handler(
+    request: Request,
+    exception: StarletteHTTPException
+) -> JSONResponse:
+    errors = transform_http_exception_to_json_api_errors(
+        exception
+    ).dict(exclude_unset=True)
+    return JSONResponse(
+        status_code=exception.status_code,
+        content=errors,
+     )

--- a/robot-server/robot_server/service/models/item.py
+++ b/robot-server/robot_server/service/models/item.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+from dataclasses import dataclass
+from uuid import uuid4
+
+
+@dataclass
+class ItemData:
+    name: str
+    quantity: int
+    price: float
+    id: str = str(uuid4().hex)
+
+
+class Item(BaseModel):
+    name: str
+    quantity: int
+    price: float

--- a/robot-server/robot_server/service/models/json_api/errors.py
+++ b/robot-server/robot_server/service/models/json_api/errors.py
@@ -1,0 +1,92 @@
+from typing import Optional, List, Dict
+from pydantic import BaseModel, Field
+
+from .resource_links import ResourceLinks
+
+
+class ErrorSource(BaseModel):
+    pointer: Optional[str] = \
+        Field(None,
+              description="a JSON Pointer [RFC6901] to the associated"
+                          " entity in the request document.")
+    parameter: Optional[str] = \
+        Field(None,
+              description="a string indicating which URI query parameter"
+                          " caused the error.")
+
+
+class Error(BaseModel):
+    """https://jsonapi.org/format/#error-objects"""
+    id: Optional[str] = \
+        Field(None,
+              description="a unique identifier for this particular"
+                          " occurrence of the problem.")
+    links: Optional[ResourceLinks] = \
+        Field(None,
+              description="a link that leads to further details about"
+                          " this particular occurrence of the problem.")
+    status: Optional[str] = \
+        Field(None,
+              description="the HTTP status code applicable to this problem,"
+                          " expressed as a string value.")
+    code: Optional[str] = \
+        Field(None,
+              description="an application-specific error code, expressed"
+                          " as a string value.")
+    title: Optional[str] = \
+        Field(None,
+              description="a short, human-readable summary of the problem"
+                          " that SHOULD NOT change from occurrence"
+                          " to occurrence of the problem, except for"
+                          " purposes of localization.")
+    detail: Optional[str] = \
+        Field(None,
+              description="a human-readable explanation specific to this"
+                          " occurrence of the problem. Like title, this"
+                          " field’s value can be localized.")
+    source: Optional[ErrorSource] = \
+        Field(None,
+              description="an object containing references to the source of"
+                          " the error, optionally including pointer"
+                          " or parameter fields.")
+    meta: Optional[Dict] = \
+        Field(None,
+              description="a meta object containing non-standard"
+                          " meta-information about the error.")
+
+
+class ErrorResponse(BaseModel):
+    errors: List[Error] = \
+        Field(...,
+              description="a list containing one of more error objects.")
+
+
+# Note(isk: 3/13/20): object marshalling for http exceptions
+# (these errors come back differently than validation errors).
+# e.g. invalid json in request body
+def transform_http_exception_to_json_api_errors(exception) -> ErrorResponse:
+    request_error = Error(
+        status=exception.status_code,
+        detail=exception.detail,
+        title='Bad Request'
+    )
+    return ErrorResponse(errors=[request_error])
+
+
+# Note(isk: 3/13/20): object marshalling for validation errors.
+# format pydantic validation errors to expected json:api response shape.
+def transform_validation_error_to_json_api_errors(
+    status_code,
+    exception
+) -> ErrorResponse:
+    def transform_error(error):
+        return Error(
+            status=status_code,
+            detail=error.get('msg'),
+            source=ErrorSource(pointer='/' + '/'.join(error['loc'])),
+            title=error.get('type')
+        )
+
+    return ErrorResponse(
+        errors=[transform_error(error) for error in exception.errors()]
+    )

--- a/robot-server/robot_server/service/models/json_api/factory.py
+++ b/robot-server/robot_server/service/models/json_api/factory.py
@@ -1,7 +1,7 @@
 from typing import Type, Any, Tuple
 
-from .request import JsonApiRequest, RequestModel
-from .response import JsonApiResponse, ResponseModel
+from .request import json_api_request, RequestModel
+from .response import json_api_response, ResponseModel
 
 
 def generate_json_api_models(
@@ -11,6 +11,8 @@ def generate_json_api_models(
     list_response: bool = False
 ) -> Tuple[Type[RequestModel], Type[ResponseModel]]:
     return (
-        JsonApiRequest(type_string, attributes_model),
-        JsonApiResponse(type_string, attributes_model, use_list=list_response),
+        json_api_request(type_string, attributes_model),
+        json_api_response(
+            type_string, attributes_model, use_list=list_response
+        ),
     )

--- a/robot-server/robot_server/service/models/json_api/factory.py
+++ b/robot-server/robot_server/service/models/json_api/factory.py
@@ -1,0 +1,16 @@
+from typing import Type, Any, Tuple
+
+from .request import JsonApiRequest, RequestModel
+from .response import JsonApiResponse, ResponseModel
+
+
+def generate_json_api_models(
+    type_string: str,
+    attributes_model: Any,
+    *,
+    list_response: bool = False
+) -> Tuple[Type[RequestModel], Type[ResponseModel]]:
+    return (
+        JsonApiRequest(type_string, attributes_model),
+        JsonApiResponse(type_string, attributes_model, use_list=list_response),
+    )

--- a/robot-server/robot_server/service/models/json_api/request.py
+++ b/robot-server/robot_server/service/models/json_api/request.py
@@ -41,7 +41,7 @@ class RequestModel(GenericModel, Generic[DataT]):
 
 
 # Note(isk: 3/13/20): formats and returns request model
-def JsonApiRequest(
+def json_api_request(
     type_string: str,
     attributes_model: Any
 ) -> Type[RequestModel]:

--- a/robot-server/robot_server/service/models/json_api/request.py
+++ b/robot-server/robot_server/service/models/json_api/request.py
@@ -1,0 +1,55 @@
+from typing import Generic, TypeVar, Optional, Any, Type
+from typing_extensions import Literal
+from pydantic import Field
+from pydantic.generics import GenericModel
+
+TypeT = TypeVar('TypeT')
+AttributesT = TypeVar('AttributesT')
+
+
+class RequestDataModel(GenericModel, Generic[TypeT, AttributesT]):
+    """
+    """
+    id: Optional[str] = \
+        Field(None,
+              description="id member represents a resource object and is not"
+                          " required when the resource object originates at"
+                          " the client and represents a new resource to be"
+                          " created on the server.")
+    type: TypeT = \
+        Field(...,
+              description="type member is used to describe resource objects"
+                          " that share common attributes.")
+    attributes: AttributesT = \
+        Field(...,
+              description="an attributes object representing some of the"
+                          " resource’s data.")
+
+
+DataT = TypeVar('DataT', bound=RequestDataModel)
+
+
+class RequestModel(GenericModel, Generic[DataT]):
+    """
+    """
+    data: DataT = \
+        Field(...,
+              description="the document’s 'primary data'")
+
+    def attributes(self):
+        return self.data.attributes
+
+
+# Note(isk: 3/13/20): formats and returns request model
+def JsonApiRequest(
+    type_string: str,
+    attributes_model: Any
+) -> Type[RequestModel]:
+    request_data_model = RequestDataModel[
+        Literal[type_string],    # type: ignore
+        attributes_model,    # type: ignore
+    ]
+    request_data_model.__name__ = f'RequestData[{type_string}]'
+    request_model = RequestModel[request_data_model]
+    request_model.__name__ = f'Request[{type_string}]'
+    return request_model

--- a/robot-server/robot_server/service/models/json_api/resource_links.py
+++ b/robot-server/robot_server/service/models/json_api/resource_links.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel, Field
+
+
+class ResourceLinks(BaseModel):
+    """https://jsonapi.org/format/#document-links"""
+    self: str = \
+        Field(...,
+              description="the link that generated the current"
+                          " response document.")

--- a/robot-server/robot_server/service/models/json_api/response.py
+++ b/robot-server/robot_server/service/models/json_api/response.py
@@ -1,0 +1,99 @@
+from typing import Generic, TypeVar, Optional, List, \
+    Dict, Any, Type, get_type_hints
+from typing_extensions import Literal
+from pydantic import Field
+from pydantic.generics import GenericModel
+
+from .resource_links import ResourceLinks
+
+TypeT = TypeVar('TypeT', bound=str)
+AttributesT = TypeVar('AttributesT')
+
+
+class ResponseDataModel(GenericModel, Generic[TypeT, AttributesT]):
+    """
+    """
+    id: str = \
+        Field(...,
+              description="id member represents a resource object.")
+    type: TypeT = \
+        Field(...,
+              description="type member is used to describe resource objects"
+                          " that share common attributes.")
+    attributes: AttributesT = \
+        Field({},
+              description="an attributes object representing some of the"
+                          " resource’s data.")
+
+    # Note(isk: 3/13/20): Need this to validate attribute default
+    # see here: https://pydantic-docs.helpmanual.io/usage/model_config/
+    class Config:
+        validate_all = True
+
+
+DataT = TypeVar('DataT', bound=ResponseDataModel)
+
+
+class ResponseModel(GenericModel, Generic[DataT]):
+    """
+    """
+    meta: Optional[Dict] = \
+        Field(None,
+              description="a meta object that contains non-standard"
+                          " meta-information.")
+    data: DataT = \
+        Field(...,
+              description="the document’s 'primary data'")
+    links: Optional[ResourceLinks] = \
+        Field(None,
+              description="a links object related to the primary data.")
+
+    # Note(isk: 3/13/20): resource_object for object marshalling.
+    # This class method is for formating the data object response
+    @classmethod
+    def resource_object(
+        cls,
+        *,
+        id: str,
+        attributes: Optional[Dict] = None,
+    ) -> ResponseDataModel:
+        # Note(isk: 3/13/20): get_type_hints returns a dictionary containing
+        # type hints for the class object.
+        data_type = get_type_hints(cls)['data']
+        # Note(isk: 3/13/20): check if '__origin__' attribute on data object is
+        # a list, if not return None.
+        if getattr(data_type, '__origin__', None) is list:
+            data_type = data_type.__args__[0]
+        # Note(isk: 3/13/20): get type name from data object
+        # using get_type_hints
+        typename = get_type_hints(data_type)['type'].__args__[0]
+        return data_type(
+            id=id,
+            type=typename,
+            attributes=attributes or {},
+        )
+
+
+# Note(isk: 3/13/20): returns response based on whether
+# the data object is a list or not
+def JsonApiResponse(
+    type_string: str,
+    attributes_model: Any,
+    *,
+    use_list: bool = False
+) -> Type[ResponseModel]:
+    response_data_model = ResponseDataModel[
+        Literal[type_string],    # type: ignore
+        attributes_model,    # type: ignore
+    ]
+    if use_list:
+        response_data_model = List[response_data_model]    # type: ignore
+        response_data_model.__name__ = f'ListResponseData[{type_string}]'
+        response_model_list = ResponseModel[response_data_model]
+        response_model_list.__name__ = f'ListResponse[{type_string}]'
+        return response_model_list
+    else:
+        response_data_model.__name__ = f'ResponseData[{type_string}]'
+        response_model = ResponseModel[response_data_model]
+        response_model.__name__ = f'Response[{type_string}]'
+        return response_model

--- a/robot-server/robot_server/service/models/json_api/response.py
+++ b/robot-server/robot_server/service/models/json_api/response.py
@@ -76,7 +76,7 @@ class ResponseModel(GenericModel, Generic[DataT]):
 
 # Note(isk: 3/13/20): returns response based on whether
 # the data object is a list or not
-def JsonApiResponse(
+def json_api_response(
     type_string: str,
     attributes_model: Any,
     *,

--- a/robot-server/robot_server/service/routers/item.py
+++ b/robot-server/robot_server/service/routers/item.py
@@ -1,0 +1,63 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import ValidationError
+
+from robot_server.service.models.item import Item, ItemData
+from robot_server.service.models.json_api.factory import \
+    generate_json_api_models
+from robot_server.service.models.json_api.errors import ErrorResponse
+# https://github.com/encode/starlette/blob/master/starlette/status.py
+from starlette.status import HTTP_400_BAD_REQUEST, \
+    HTTP_422_UNPROCESSABLE_ENTITY
+
+router = APIRouter()
+
+ITEM_TYPE_NAME = "item"
+ItemRequest, ItemResponse = generate_json_api_models(ITEM_TYPE_NAME, Item)
+
+
+@router.get("/items/{item_id}",
+            description="Get an individual item by it's ID",
+            summary="Get an individual item",
+            response_model=ItemResponse,
+            response_model_exclude_unset=True,
+            responses={
+                HTTP_422_UNPROCESSABLE_ENTITY: {"model": ErrorResponse},
+            })
+async def get_item(item_id: str) -> ItemResponse:    # type: ignore
+    try:
+        # NOTE(isk: 3/10/20): mock DB / robot response
+        item = Item(name="apple", quantity=10, price=1.20)
+        data = ItemResponse.resource_object(id=item_id, attributes=vars(item))
+        return ItemResponse(data=data, links={"self": f'/items/{item_id}'})
+    except ValidationError as e:
+        raise HTTPException(
+            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=e
+        )
+
+
+@router.post("/items",
+             description="Create an item",
+             summary="Create an item via post route",
+             response_model=ItemResponse,
+             response_model_exclude_unset=True,
+             responses={
+                 HTTP_400_BAD_REQUEST: {"model": ErrorResponse},
+                 HTTP_422_UNPROCESSABLE_ENTITY: {"model": ErrorResponse},
+             })
+async def create_item(
+    item_request: ItemRequest    # type: ignore
+) -> ItemResponse:    # type: ignore
+    try:
+        attributes = item_request.attributes().dict()    # type: ignore
+        # NOTE(isk: 3/10/20): mock DB / robot response
+        item = ItemData(**attributes)
+        data = ItemResponse.resource_object(id=item.id, attributes=vars(item))
+        return ItemResponse(data=data, links={"self": f'/items/{item.id}'})
+    except ValidationError as e:
+        raise HTTPException(
+                status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=e
+        )
+    except Exception as e:
+        raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=e)

--- a/robot-server/robot_server/service/routers/item.py
+++ b/robot-server/robot_server/service/routers/item.py
@@ -16,7 +16,7 @@ ItemRequest, ItemResponse = generate_json_api_models(ITEM_TYPE_NAME, Item)
 
 
 @router.get("/items/{item_id}",
-            description="Get an individual item by it's ID",
+            description="Get an individual item by its ID",
             summary="Get an individual item",
             response_model=ItemResponse,
             response_model_exclude_unset=True,

--- a/robot-server/tests/service/helpers.py
+++ b/robot-server/tests/service/helpers.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel
+from dataclasses import dataclass
+from uuid import uuid4
+
+from robot_server.service.models.json_api.request import JsonApiRequest
+
+
+@dataclass
+class ItemData:
+    name: str
+    quantity: int
+    price: float
+    id: str = str(uuid4().hex)
+
+
+class ItemModel(BaseModel):
+    name: str
+    quantity: int
+    price: float
+
+
+item_type_name = 'item'
+ItemRequest = JsonApiRequest(item_type_name, ItemModel)

--- a/robot-server/tests/service/helpers.py
+++ b/robot-server/tests/service/helpers.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel
 from dataclasses import dataclass
 from uuid import uuid4
 
-from robot_server.service.models.json_api.request import JsonApiRequest
+from robot_server.service.models.json_api.request import json_api_request
 
 
 @dataclass
@@ -20,4 +20,4 @@ class ItemModel(BaseModel):
 
 
 item_type_name = 'item'
-ItemRequest = JsonApiRequest(item_type_name, ItemModel)
+ItemRequest = json_api_request(item_type_name, ItemModel)

--- a/robot-server/tests/service/models/json_api/test_errors.py
+++ b/robot-server/tests/service/models/json_api/test_errors.py
@@ -1,0 +1,84 @@
+from functools import reduce
+
+import pytest
+from pytest import raises
+from pydantic import ValidationError
+from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
+
+from robot_server.service.models.json_api.errors import ErrorResponse, \
+    transform_validation_error_to_json_api_errors
+
+from tests.service.helpers import ItemRequest
+
+
+def errors_wrapper(d):
+    return {'errors': [d]}
+
+
+valid_error_objects = [
+    {'id': 'abc123'},
+    {'status': '404'},
+    {'code': '1005'},
+    {'title': 'Something went wrong'},
+    {'detail': "oh wow, there's a few things we messed up there"},
+    {'meta': {'num_errors_today': 10000}},
+    {'links': {'self': '/my/error-info?code=1005'}},
+    {'source': {'pointer': '/data/attributes/price'}},
+]
+
+valid_error_responses = map(errors_wrapper, valid_error_objects)
+
+
+@pytest.mark.parametrize('error_response', valid_error_responses)
+def test_valid_error_response_fields(error_response):
+    validated = ErrorResponse(**error_response)
+    assert validated.dict(exclude_unset=True) == error_response
+
+
+error_with_all_fields = reduce(
+    lambda acc, d: {**acc, **d}, valid_error_objects, {}
+)
+
+
+def test_error_response_with_all_fields():
+    error_response = errors_wrapper(error_with_all_fields)
+    validated = ErrorResponse(**error_response)
+    assert validated.dict(exclude_unset=True) == error_response
+
+
+def test_empty_error_response_valid():
+    error_response = {'errors': []}
+    validated = ErrorResponse(**error_response)
+    assert validated.dict(exclude_unset=True) == error_response
+
+
+def test_transform_validation_error_to_json_api_errors():
+    with raises(ValidationError) as e:
+        ItemRequest(**{
+            'data': {
+                'type': 'invalid'
+            }
+        })
+    assert transform_validation_error_to_json_api_errors(
+        HTTP_422_UNPROCESSABLE_ENTITY,
+        e.value
+    ).dict(exclude_unset=True) == {
+        'errors': [
+            {
+                'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
+                'detail': "unexpected value; permitted: 'item'",
+                'source': {
+                    'pointer': '/data/type'
+                },
+                'title': 'value_error.const'
+            },
+            {
+                'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
+                'detail': 'field required',
+                'source': {
+                    'pointer': '/data/attributes'
+                },
+                'title': 'value_error.missing'
+            },
+        ]
+    }

--- a/robot-server/tests/service/models/json_api/test_factory.py
+++ b/robot-server/tests/service/models/json_api/test_factory.py
@@ -1,0 +1,34 @@
+from typing import List
+from typing_extensions import Literal
+
+from robot_server.service.models.json_api.factory import \
+    generate_json_api_models
+from robot_server.service.models.json_api.request import RequestModel, \
+    RequestDataModel
+from robot_server.service.models.json_api.response import ResponseModel, \
+    ResponseDataModel
+from tests.service.helpers import ItemModel
+
+
+def test_json_api_model():
+    ItemRequest, ItemResponse = generate_json_api_models('item', ItemModel)
+    assert ItemRequest == RequestModel[
+        RequestDataModel[Literal['item'], ItemModel]
+    ]
+    assert ItemResponse == ResponseModel[
+        ResponseDataModel[Literal['item'], ItemModel]
+    ]
+
+
+def test_json_api_model__list_response():
+    ItemRequest, ItemResponse = generate_json_api_models(
+        'item',
+        ItemModel,
+        list_response=True
+    )
+    assert ItemRequest == RequestModel[
+        RequestDataModel[Literal['item'], ItemModel]
+    ]
+    assert ItemResponse == ResponseModel[
+        List[ResponseDataModel[Literal['item'], ItemModel]]
+    ]

--- a/robot-server/tests/service/models/json_api/test_request.py
+++ b/robot-server/tests/service/models/json_api/test_request.py
@@ -1,0 +1,137 @@
+from pytest import raises
+
+from pydantic import ValidationError
+
+from robot_server.service.models.json_api.request import JsonApiRequest
+from tests.service.helpers import ItemModel
+
+
+def test_attributes_as_dict():
+    DictRequest = JsonApiRequest('item', dict)
+    obj_to_validate = {
+        'data': {'type': 'item', 'attributes': {}}
+    }
+    my_request_obj = DictRequest(**obj_to_validate)
+    assert my_request_obj.dict() == {
+        'data': {
+            'type': 'item',
+            'attributes': {},
+            'id': None,
+        }
+    }
+
+
+def test_attributes_as_item_model():
+    ItemRequest = JsonApiRequest('item', ItemModel)
+    obj_to_validate = {
+        'data': {
+            'type': 'item',
+            'attributes': {
+                'name': 'apple',
+                'quantity': 10,
+                'price': 1.20
+            },
+            'id': None,
+        }
+    }
+    my_request_obj = ItemRequest(**obj_to_validate)
+    assert my_request_obj.dict() == obj_to_validate
+
+
+def test_attributes_as_item_model__empty_dict():
+    ItemRequest = JsonApiRequest('item', ItemModel)
+    obj_to_validate = {
+        'data': {
+            'type': 'item',
+            'attributes': {}
+        }
+    }
+    with raises(ValidationError) as e:
+        ItemRequest(**obj_to_validate)
+
+    assert e.value.errors() == [
+        {
+            'loc': ('data', 'attributes', 'name'),
+            'msg': 'field required',
+            'type': 'value_error.missing'
+        }, {
+            'loc': ('data', 'attributes', 'quantity'),
+            'msg': 'field required',
+            'type': 'value_error.missing'
+        }, {
+            'loc': ('data', 'attributes', 'price'),
+            'msg': 'field required',
+            'type': 'value_error.missing'
+        }
+    ]
+
+
+def test_type_invalid_string():
+    MyRequest = JsonApiRequest('item', dict)
+    obj_to_validate = {
+        'data': {'type': 'not_an_item', 'attributes': {}}
+    }
+    with raises(ValidationError) as e:
+        MyRequest(**obj_to_validate)
+
+    assert e.value.errors() == [
+        {
+            'loc': ('data', 'type'),
+            'msg': "unexpected value; permitted: 'item'",
+            'type': 'value_error.const',
+            'ctx': {'given': 'not_an_item', 'permitted': ('item',)},
+        },
+    ]
+
+
+def test_attributes_required():
+    MyRequest = JsonApiRequest('item', dict)
+    obj_to_validate = {
+        'data': {'type': 'item', 'attributes': None}
+    }
+    with raises(ValidationError) as e:
+        MyRequest(**obj_to_validate)
+
+    assert e.value.errors() == [
+        {
+            'loc': ('data', 'attributes'),
+            'msg': 'none is not an allowed value',
+            'type': 'type_error.none.not_allowed'
+        },
+    ]
+
+
+def test_data_required():
+    MyRequest = JsonApiRequest('item', dict)
+    obj_to_validate = {
+        'data': None
+    }
+    with raises(ValidationError) as e:
+        MyRequest(**obj_to_validate)
+
+    assert e.value.errors() == [
+        {
+            'loc': ('data',),
+            'msg': 'none is not an allowed value',
+            'type': 'type_error.none.not_allowed'
+        },
+    ]
+
+
+def test_request_with_id():
+    MyRequest = JsonApiRequest('item', dict)
+    obj_to_validate = {
+        'data': {
+            'type': 'item',
+            'attributes': {},
+            'id': 'abc123'
+        },
+    }
+    my_request_obj = MyRequest(**obj_to_validate)
+    assert my_request_obj.dict() == {
+        'data': {
+            'type': 'item',
+            'attributes': {},
+            'id': 'abc123'
+        },
+    }

--- a/robot-server/tests/service/models/json_api/test_request.py
+++ b/robot-server/tests/service/models/json_api/test_request.py
@@ -2,12 +2,12 @@ from pytest import raises
 
 from pydantic import ValidationError
 
-from robot_server.service.models.json_api.request import JsonApiRequest
+from robot_server.service.models.json_api.request import json_api_request
 from tests.service.helpers import ItemModel
 
 
 def test_attributes_as_dict():
-    DictRequest = JsonApiRequest('item', dict)
+    DictRequest = json_api_request('item', dict)
     obj_to_validate = {
         'data': {'type': 'item', 'attributes': {}}
     }
@@ -22,7 +22,7 @@ def test_attributes_as_dict():
 
 
 def test_attributes_as_item_model():
-    ItemRequest = JsonApiRequest('item', ItemModel)
+    ItemRequest = json_api_request('item', ItemModel)
     obj_to_validate = {
         'data': {
             'type': 'item',
@@ -39,7 +39,7 @@ def test_attributes_as_item_model():
 
 
 def test_attributes_as_item_model__empty_dict():
-    ItemRequest = JsonApiRequest('item', ItemModel)
+    ItemRequest = json_api_request('item', ItemModel)
     obj_to_validate = {
         'data': {
             'type': 'item',
@@ -67,7 +67,7 @@ def test_attributes_as_item_model__empty_dict():
 
 
 def test_type_invalid_string():
-    MyRequest = JsonApiRequest('item', dict)
+    MyRequest = json_api_request('item', dict)
     obj_to_validate = {
         'data': {'type': 'not_an_item', 'attributes': {}}
     }
@@ -85,7 +85,7 @@ def test_type_invalid_string():
 
 
 def test_attributes_required():
-    MyRequest = JsonApiRequest('item', dict)
+    MyRequest = json_api_request('item', dict)
     obj_to_validate = {
         'data': {'type': 'item', 'attributes': None}
     }
@@ -102,7 +102,7 @@ def test_attributes_required():
 
 
 def test_data_required():
-    MyRequest = JsonApiRequest('item', dict)
+    MyRequest = json_api_request('item', dict)
     obj_to_validate = {
         'data': None
     }
@@ -119,7 +119,7 @@ def test_data_required():
 
 
 def test_request_with_id():
-    MyRequest = JsonApiRequest('item', dict)
+    MyRequest = json_api_request('item', dict)
     obj_to_validate = {
         'data': {
             'type': 'item',

--- a/robot-server/tests/service/models/json_api/test_resource_links.py
+++ b/robot-server/tests/service/models/json_api/test_resource_links.py
@@ -1,0 +1,35 @@
+from pytest import raises
+
+from pydantic import BaseModel, ValidationError
+from robot_server.service.models.json_api.resource_links import ResourceLinks
+
+
+class ThingWithLink(BaseModel):
+    links: ResourceLinks
+
+
+def test_follows_structure():
+    structure_to_validate = {
+        'links': {
+            'self': '/items/1',
+        }
+    }
+    validated = ThingWithLink(**structure_to_validate)
+    assert validated.dict() == structure_to_validate
+
+
+def test_must_be_self_key_with_string_value():
+    invalid_structure_to_validate = {
+        'invalid': {
+            'key': 'value',
+        }
+    }
+    with raises(ValidationError) as e:
+        ThingWithLink(**invalid_structure_to_validate)
+    assert e.value.errors() == [
+        {
+            'loc': ('links',),
+            'msg': 'field required',
+            'type': 'value_error.missing'
+        }
+    ]

--- a/robot-server/tests/service/models/json_api/test_response.py
+++ b/robot-server/tests/service/models/json_api/test_response.py
@@ -1,0 +1,328 @@
+from pytest import raises
+from pydantic import BaseModel, ValidationError
+
+from robot_server.service.models.json_api.response import JsonApiResponse
+from tests.service.helpers import ItemModel, ItemData
+
+
+def test_attributes_as_dict():
+    MyResponse = JsonApiResponse('item', dict)
+    obj_to_validate = {
+        'data': {'id': '123', 'type': 'item', 'attributes': {}},
+    }
+    my_response_object = MyResponse(**obj_to_validate)
+    assert my_response_object.dict() == {
+        'meta': None,
+        'links': None,
+        'data': {
+            'id': '123',
+            'type': 'item',
+            'attributes': {},
+        }
+    }
+
+
+def test_missing_attributes_dict():
+    MyResponse = JsonApiResponse('item', dict)
+    obj_to_validate = {
+        'data': {'id': '123', 'type': 'item'}
+    }
+    my_response_object = MyResponse(**obj_to_validate)
+    assert my_response_object.dict() == {
+        'meta': None,
+        'links': None,
+        'data': {
+            'id': '123',
+            'type': 'item',
+            'attributes': {},
+        }
+    }
+
+
+def test_missing_attributes_empty_model():
+    class EmptyModel(BaseModel):
+        pass
+
+    MyResponse = JsonApiResponse('item', EmptyModel)
+    obj_to_validate = {
+        'data': {'id': '123', 'type': 'item'}
+    }
+    my_response_object = MyResponse(**obj_to_validate)
+    assert my_response_object.dict() == {
+        'meta': None,
+        'links': None,
+        'data': {
+            'id': '123',
+            'type': 'item',
+            'attributes': {},
+        }
+    }
+    assert isinstance(my_response_object.data.attributes, EmptyModel)
+
+
+def test_attributes_as_item_model():
+    ItemResponse = JsonApiResponse('item', ItemModel)
+    obj_to_validate = {
+        'meta': None,
+        'links': None,
+        'data': {
+            'id': '123',
+            'type': 'item',
+            'attributes': {
+                'name': 'apple',
+                'quantity': 10,
+                'price': 1.20
+            }
+        }
+    }
+    my_response_obj = ItemResponse(**obj_to_validate)
+    assert my_response_obj.dict() == {
+        'meta': None,
+        'links': None,
+        'data': {
+            'id': '123',
+            'type': 'item',
+            'attributes': {
+                'name': 'apple',
+                'quantity': 10,
+                'price': 1.20,
+            }
+        }
+    }
+
+
+def test_list_item_model():
+    ItemResponse = JsonApiResponse('item', ItemModel, use_list=True)
+    obj_to_validate = {
+        'meta': None,
+        'links': None,
+        'data': [
+            {
+                'id': '123',
+                'type': 'item',
+                'attributes': {
+                    'name': 'apple',
+                    'quantity': 10,
+                    'price': 1.20
+                },
+            },
+            {
+                'id': '321',
+                'type': 'item',
+                'attributes': {
+                    'name': 'banana',
+                    'quantity': 20,
+                    'price': 2.34
+                },
+            },
+        ],
+    }
+    my_response_obj = ItemResponse(**obj_to_validate)
+    assert my_response_obj.dict() == {
+        'meta': None,
+        'links': None,
+        'data': [
+            {
+                'id': '123',
+                'type': 'item',
+                'attributes': {
+                    'name': 'apple',
+                    'quantity': 10,
+                    'price': 1.20,
+                },
+            },
+            {
+                'id': '321',
+                'type': 'item',
+                'attributes': {
+                    'name': 'banana',
+                    'quantity': 20,
+                    'price': 2.34,
+                },
+            },
+        ],
+    }
+
+
+def test_type_invalid_string():
+    MyResponse = JsonApiResponse('item', dict)
+    obj_to_validate = {
+        'data': {'id': '123', 'type': 'not_an_item', 'attributes': {}}
+    }
+    with raises(ValidationError) as e:
+        MyResponse(**obj_to_validate)
+
+    assert e.value.errors() == [
+        {
+            'loc': ('data', 'type'),
+            'msg': "unexpected value; permitted: 'item'",
+            'type': 'value_error.const',
+            'ctx': {'given': 'not_an_item', 'permitted': ('item',)},
+        },
+    ]
+
+
+def test_attributes_required():
+    ItemResponse = JsonApiResponse('item', ItemModel)
+    obj_to_validate = {
+        'data': {'id': '123', 'type': 'item', 'attributes': None}
+    }
+    with raises(ValidationError) as e:
+        ItemResponse(**obj_to_validate)
+
+    assert e.value.errors() == [
+        {
+            'loc': ('data', 'attributes'),
+            'msg': 'none is not an allowed value',
+            'type': 'type_error.none.not_allowed',
+        },
+    ]
+
+
+def test_attributes_as_item_model__empty_dict():
+    ItemResponse = JsonApiResponse('item', ItemModel)
+    obj_to_validate = {
+        'data': {
+            'id': '123',
+            'type': 'item',
+            'attributes': {}
+        }
+    }
+    with raises(ValidationError) as e:
+        ItemResponse(**obj_to_validate)
+
+    assert e.value.errors() == [
+        {
+            'loc': ('data', 'attributes', 'name'),
+            'msg': 'field required',
+            'type': 'value_error.missing'
+        }, {
+            'loc': ('data', 'attributes', 'quantity'),
+            'msg': 'field required',
+            'type': 'value_error.missing'
+        }, {
+            'loc': ('data', 'attributes', 'price'),
+            'msg': 'field required',
+            'type': 'value_error.missing'
+        },
+    ]
+
+
+def test_resource_object_constructor():
+    ItemResponse = JsonApiResponse('item', ItemModel)
+    item = ItemModel(name='pear', price=1.2, quantity=10)
+    document = ItemResponse.resource_object(
+        id='abc123',
+        attributes=item
+    ).dict()
+
+    assert document == {
+        'id': 'abc123',
+        'type': 'item',
+        'attributes': {
+            'name': 'pear',
+            'price': 1.2,
+            'quantity': 10,
+        }
+    }
+
+
+def test_resource_object_constructor__no_attributes():
+    IdentifierResponse = JsonApiResponse('item', dict)
+    document = IdentifierResponse.resource_object(id='abc123').dict()
+
+    assert document == {
+        'id': 'abc123',
+        'type': 'item',
+        'attributes': {},
+    }
+
+
+def test_resource_object_constructor__with_list_response():
+    ItemResponse = JsonApiResponse('item', ItemModel, use_list=True)
+    item = ItemModel(name='pear', price=1.2, quantity=10)
+    document = ItemResponse.resource_object(
+        id='abc123',
+        attributes=item
+    ).dict()
+
+    assert document == {
+        'id': 'abc123',
+        'type': 'item',
+        'attributes': {
+            'name': 'pear',
+            'price': 1.2,
+            'quantity': 10,
+        }
+    }
+
+
+def test_response_constructed_with_resource_object():
+    ItemResponse = JsonApiResponse('item', ItemModel)
+    item = ItemModel(name='pear', price=1.2, quantity=10)
+    data = ItemResponse.resource_object(
+        id='abc123',
+        attributes=item
+    ).dict()
+
+    assert ItemResponse(data=data).dict() == {
+        'meta': None,
+        'links': None,
+        "data": {
+            'id': 'abc123',
+            "type": 'item',
+            "attributes": {
+                'name': 'pear',
+                'price': 1.2,
+                'quantity': 10,
+            },
+        }
+    }
+
+
+def test_response_constructed_with_resource_object__list():
+    ItemResponse = JsonApiResponse('item', ItemModel, use_list=True)
+    items = [
+        ItemData(id=1, name='apple', price=1.5, quantity=3),
+        ItemData(id=2, name='pear', price=1.2, quantity=10),
+        ItemData(id=3, name='orange', price=2.2, quantity=5)
+    ]
+    response = ItemResponse(
+        data=[
+            ItemResponse.resource_object(id=item.id, attributes=vars(item))
+            for item in items
+        ]
+    )
+    assert response.dict() == {
+        'meta': None,
+        'links': None,
+        'data': [
+            {
+                'id': '1',
+                'type': 'item',
+                'attributes': {
+                    'name': 'apple',
+                    'price': 1.5,
+                    'quantity': 3,
+                },
+            },
+            {
+                'id': '2',
+                'type': 'item',
+                'attributes': {
+                    'name': 'pear',
+                    'price': 1.2,
+                    'quantity': 10,
+                },
+            },
+            {
+                'id': '3',
+                'type': 'item',
+                'attributes': {
+                    'name': 'orange',
+                    'price': 2.2,
+                    'quantity': 5,
+                },
+            },
+        ]
+    }

--- a/robot-server/tests/service/models/json_api/test_response.py
+++ b/robot-server/tests/service/models/json_api/test_response.py
@@ -1,12 +1,12 @@
 from pytest import raises
 from pydantic import BaseModel, ValidationError
 
-from robot_server.service.models.json_api.response import JsonApiResponse
+from robot_server.service.models.json_api.response import json_api_response
 from tests.service.helpers import ItemModel, ItemData
 
 
 def test_attributes_as_dict():
-    MyResponse = JsonApiResponse('item', dict)
+    MyResponse = json_api_response('item', dict)
     obj_to_validate = {
         'data': {'id': '123', 'type': 'item', 'attributes': {}},
     }
@@ -23,7 +23,7 @@ def test_attributes_as_dict():
 
 
 def test_missing_attributes_dict():
-    MyResponse = JsonApiResponse('item', dict)
+    MyResponse = json_api_response('item', dict)
     obj_to_validate = {
         'data': {'id': '123', 'type': 'item'}
     }
@@ -43,7 +43,7 @@ def test_missing_attributes_empty_model():
     class EmptyModel(BaseModel):
         pass
 
-    MyResponse = JsonApiResponse('item', EmptyModel)
+    MyResponse = json_api_response('item', EmptyModel)
     obj_to_validate = {
         'data': {'id': '123', 'type': 'item'}
     }
@@ -61,7 +61,7 @@ def test_missing_attributes_empty_model():
 
 
 def test_attributes_as_item_model():
-    ItemResponse = JsonApiResponse('item', ItemModel)
+    ItemResponse = json_api_response('item', ItemModel)
     obj_to_validate = {
         'meta': None,
         'links': None,
@@ -92,7 +92,7 @@ def test_attributes_as_item_model():
 
 
 def test_list_item_model():
-    ItemResponse = JsonApiResponse('item', ItemModel, use_list=True)
+    ItemResponse = json_api_response('item', ItemModel, use_list=True)
     obj_to_validate = {
         'meta': None,
         'links': None,
@@ -145,7 +145,7 @@ def test_list_item_model():
 
 
 def test_type_invalid_string():
-    MyResponse = JsonApiResponse('item', dict)
+    MyResponse = json_api_response('item', dict)
     obj_to_validate = {
         'data': {'id': '123', 'type': 'not_an_item', 'attributes': {}}
     }
@@ -163,7 +163,7 @@ def test_type_invalid_string():
 
 
 def test_attributes_required():
-    ItemResponse = JsonApiResponse('item', ItemModel)
+    ItemResponse = json_api_response('item', ItemModel)
     obj_to_validate = {
         'data': {'id': '123', 'type': 'item', 'attributes': None}
     }
@@ -180,7 +180,7 @@ def test_attributes_required():
 
 
 def test_attributes_as_item_model__empty_dict():
-    ItemResponse = JsonApiResponse('item', ItemModel)
+    ItemResponse = json_api_response('item', ItemModel)
     obj_to_validate = {
         'data': {
             'id': '123',
@@ -209,7 +209,7 @@ def test_attributes_as_item_model__empty_dict():
 
 
 def test_resource_object_constructor():
-    ItemResponse = JsonApiResponse('item', ItemModel)
+    ItemResponse = json_api_response('item', ItemModel)
     item = ItemModel(name='pear', price=1.2, quantity=10)
     document = ItemResponse.resource_object(
         id='abc123',
@@ -228,7 +228,7 @@ def test_resource_object_constructor():
 
 
 def test_resource_object_constructor__no_attributes():
-    IdentifierResponse = JsonApiResponse('item', dict)
+    IdentifierResponse = json_api_response('item', dict)
     document = IdentifierResponse.resource_object(id='abc123').dict()
 
     assert document == {
@@ -239,7 +239,7 @@ def test_resource_object_constructor__no_attributes():
 
 
 def test_resource_object_constructor__with_list_response():
-    ItemResponse = JsonApiResponse('item', ItemModel, use_list=True)
+    ItemResponse = json_api_response('item', ItemModel, use_list=True)
     item = ItemModel(name='pear', price=1.2, quantity=10)
     document = ItemResponse.resource_object(
         id='abc123',
@@ -258,7 +258,7 @@ def test_resource_object_constructor__with_list_response():
 
 
 def test_response_constructed_with_resource_object():
-    ItemResponse = JsonApiResponse('item', ItemModel)
+    ItemResponse = json_api_response('item', ItemModel)
     item = ItemModel(name='pear', price=1.2, quantity=10)
     data = ItemResponse.resource_object(
         id='abc123',
@@ -281,7 +281,7 @@ def test_response_constructed_with_resource_object():
 
 
 def test_response_constructed_with_resource_object__list():
-    ItemResponse = JsonApiResponse('item', ItemModel, use_list=True)
+    ItemResponse = json_api_response('item', ItemModel, use_list=True)
     items = [
         ItemData(id=1, name='apple', price=1.5, quantity=3),
         ItemData(id=2, name='pear', price=1.2, quantity=10),

--- a/robot-server/tests/service/routers/test_item.py
+++ b/robot-server/tests/service/routers/test_item.py
@@ -1,0 +1,86 @@
+from starlette.status import HTTP_200_OK, HTTP_422_UNPROCESSABLE_ENTITY
+
+from tests.service.helpers import ItemData
+
+
+def test_get_item(api_client):
+    item_id = "1"
+    response = api_client.get(f'items/{item_id}')
+    assert response.status_code == HTTP_200_OK
+    assert response.json() == {
+        "data": {
+            "id": item_id,
+            "type": 'item',
+            "attributes": {
+                "name": "apple",
+                "quantity": 10,
+                "price": 1.2
+            },
+        },
+        "links": {
+            "self": f'/items/{item_id}',
+        }
+    }
+
+
+def test_create_item(api_client):
+    data = {"name": "apple", "quantity": 10, "price": 1.20}
+    item = ItemData(**data)
+    response = api_client.post(
+        "/items",
+        json={"data": {"type": "item", "attributes": vars(item)}}
+    )
+    # NOTE(isk: 3/11/20): We don't have the id until the resource is created
+    response_id = response.json().get("data", {}).get('id')
+    assert response.status_code == HTTP_200_OK
+    assert response.json() == {
+        "data": {
+            "id": response_id,
+            "type": 'item',
+            "attributes": {
+                "name": item.name,
+                "quantity": item.quantity,
+                "price": item.price
+            },
+        },
+        "links": {
+            "self": f'/items/{response_id}',
+        }
+    }
+
+
+def test_create_item_with_attribute_validation_error(api_client):
+    response = api_client.post(
+        "/items",
+        json={
+            "data": {
+                "type": "item",
+                "attributes": {}
+            }
+        }
+    )
+    assert response.status_code == HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.json() == {
+      'errors': [{
+          'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
+          'title': 'value_error.missing',
+          'detail': 'field required',
+          'source': {
+            'pointer': '/body/item_request/data/attributes/name',
+          }
+      }, {
+          'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
+          'title': 'value_error.missing',
+          'detail': 'field required',
+          'source': {
+            'pointer': '/body/item_request/data/attributes/quantity',
+          }
+      }, {
+          'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
+          'title': 'value_error.missing',
+          'detail': 'field required',
+          'source': {
+            'pointer': '/body/item_request/data/attributes/price',
+          }
+      }]
+    }


### PR DESCRIPTION
Adds formatted json responses and error handling in FastAPI framework

closes #4636 

<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->

In the `robot-server` project:
- run `OT_API_FF_useFastApi=TRUE make dev`

You should be able to visit `/docs` route on localhost.  This will allow you to review the swagger interactive docs. The two endpoints these changes affect are the placeholder endpoints `/items` and `/items/{item_id}`

- [ ] Make sure 200 responses are returned as expected
- [ ] Test error responses when JSON is invalid structure
- [ ] Test error responses when there is a model validation error

Please add comments around any additions you would like to see, this is a first pass at solidifying some structure based on the JSON:API spec but we can change and add as we see fit.

Still todo:
- [ ] Need to fixup types!
- [ ] Add an endpoint that returns multiple resources
- [ ] Determine how the meta object will be formatted
- [ ] Add a convenience method for formatting link responses 