### PR TITLE
chore(*): include all vscode configs in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,4 +108,4 @@ calibrations/
 *.ipynb
 
 # local IDE configs
-*/.vscode
+**/.vscode


### PR DESCRIPTION
## overview

Vscode configs were getting tracked by git depending in where they live. I assume we don't want that, so voila. 