### PR TITLE
refactor(robot-server, api): add /pipettes endpoint and tests

### DIFF
--- a/robot-server/robot_server/service/main.py
+++ b/robot-server/robot_server/service/main.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI
 from starlette.responses import JSONResponse
 from starlette.requests import Request
 from .routers import health, networking, control, settings, deck_calibration, \
-    modules
+    modules, pipettes
 from .models import V1BasicResponse
 from .exceptions import V1HandlerError
 
@@ -31,6 +31,8 @@ app.include_router(router=deck_calibration.router,
                    tags=["deckCalibration"])
 app.include_router(router=modules.router,
                    tags=["modules"])
+app.include_router(router=pipettes.router,
+                   tags=["pipettes"])
 
 
 @app.exception_handler(V1HandlerError)

--- a/robot-server/robot_server/service/models/control.py
+++ b/robot-server/robot_server/service/models/control.py
@@ -5,58 +5,6 @@ from enum import Enum
 from pydantic import BaseModel, Field
 
 
-class AttachedPipette(BaseModel):
-    """Pipette (if any) attached to the mount"""
-    model: typing.Optional[str] = \
-        Field(...,
-              description="The model of the attached pipette. These are snake "
-                          "case as in the Protocol API. This includes the full"
-                          " version string")
-    name: typing.Optional[str] = \
-        Field(...,
-              description="The name of the attached pipette - the model "
-                          "without the version string")
-    tip_length: typing.Optional[float] = \
-        Field(...,
-              description="The default tip length for this pipette, if "
-                          "attached")
-    mount_axis: str = \
-        Field(...,
-              description="The axis that moves this pipette up and down")
-    plunger_axis: str = \
-        Field(...,
-              description="The axis that moves this pipette's plunger")
-    id: typing.Optional[str] = \
-        Field(...,
-              description="The serial number of the attached pipette")
-
-
-class Pipette(BaseModel):
-    """None"""
-    left: AttachedPipette
-    right: AttachedPipette
-
-    class Config:
-        schema_extra = {"example": {
-            "left": {
-                "model": "p300_single_v1.5",
-                "name": "p300_single",
-                "tip_length": 51.7,
-                "mount_axis": "z",
-                "plunger_axis": "b",
-                "id": "P3HS12123041"
-            },
-            "right": {
-                "model": None,
-                "name": None,
-                "tip_length": None,
-                "mount_axis": "a",
-                "plunger_axis": "c",
-                "id": None
-            }
-        }}
-
-
 class EngagedMotor(BaseModel):
     """Engaged motor"""
     enabled: bool = Field(..., description="Is engine enabled")

--- a/robot-server/robot_server/service/models/pipettes.py
+++ b/robot-server/robot_server/service/models/pipettes.py
@@ -1,0 +1,55 @@
+import typing
+
+from pydantic import BaseModel, Field
+
+
+class AttachedPipette(BaseModel):
+    """Pipette (if any) attached to the mount"""
+    model: typing.Optional[str] = \
+        Field(...,
+              description="The model of the attached pipette. These are snake "
+                          "case as in the Protocol API. This includes the full"
+                          " version string")
+    name: typing.Optional[str] = \
+        Field(...,
+              description="The name of the attached pipette - the model "
+                          "without the version string")
+    tip_length: typing.Optional[float] = \
+        Field(...,
+              description="The default tip length for this pipette, if "
+                          "attached")
+    mount_axis: str = \
+        Field(...,
+              description="The axis that moves this pipette up and down")
+    plunger_axis: str = \
+        Field(...,
+              description="The axis that moves this pipette's plunger")
+    id: typing.Optional[str] = \
+        Field(...,
+              description="The serial number of the attached pipette")
+
+
+class Pipette(BaseModel):
+    """None"""
+    left: AttachedPipette
+    right: AttachedPipette
+
+    class Config:
+        schema_extra = {"example": {
+            "left": {
+                "model": "p300_single_v1.5",
+                "name": "p300_single",
+                "tip_length": 51.7,
+                "mount_axis": "z",
+                "plunger_axis": "b",
+                "id": "P3HS12123041"
+            },
+            "right": {
+                "model": None,
+                "name": None,
+                "tip_length": None,
+                "mount_axis": "a",
+                "plunger_axis": "c",
+                "id": None
+            }
+        }}

--- a/robot-server/robot_server/service/routers/control.py
+++ b/robot-server/robot_server/service/routers/control.py
@@ -35,20 +35,6 @@ async def post_picture_capture() -> StreamingResponse:
     )
 
 
-@router.get("/pipettes",
-            description="Get the pipettes currently attached",
-            summary="This endpoint lists properties of the pipettes currently "
-                    "attached to the robot like name, model, and mount. It "
-                    "queries a cached value unless the refresh query parameter"
-                    " is set to true, in which case it will actively scan for "
-                    "pipettes. This requires disabling the pipette motors "
-                    "(which is done automatically) and therefore should only "
-                    "be done through user intent",
-            response_model=control.Pipette)
-async def get_pipettes(refresh: bool) -> control.Pipette:
-    raise HTTPException(HTTPStatus.NOT_IMPLEMENTED, "not implemented")
-
-
 @router.get("/motors/engaged",
             description="Query which motors are engaged and holding",
             response_model=control.EngagedMotors)

--- a/robot-server/robot_server/service/routers/pipettes.py
+++ b/robot-server/robot_server/service/routers/pipettes.py
@@ -1,0 +1,62 @@
+import typing
+from fastapi import APIRouter, Query, Depends
+from opentrons.hardware_control import HardwareAPILike
+from opentrons.hardware_control.types import Axis
+
+from robot_server.service.dependencies import get_hardware
+from robot_server.service.models import pipettes
+
+
+router = APIRouter()
+
+
+@router.get("/pipettes",
+            description="Get the pipettes currently attached",
+            summary="This endpoint lists properties of the pipettes currently "
+                    "attached to the robot like name, model, and mount. It "
+                    "queries a cached value unless the refresh query parameter"
+                    " is set to true, in which case it will actively scan for "
+                    "pipettes. This requires disabling the pipette motors "
+                    "(which is done automatically) and therefore should only "
+                    "be done through user intent",
+            response_model=pipettes.Pipette)
+async def get_pipettes(
+        refresh: typing.Optional[bool] = Query(
+            False,
+            description="If true, actively scan for attached pipettes. Note:"
+                        " this requires  disabling the pipette motors and"
+                        " should only be done when no  protocol is running "
+                        "and you know  it won't cause a problem"),
+        hardware: HardwareAPILike = Depends(get_hardware))\
+        -> pipettes.Pipette:
+    """
+    Query robot for model strings on 'left' and 'right' mounts, and return a
+    dict with the results keyed by mount. By default, this endpoint provides
+    cached values, which will not interrupt a running session. WARNING: if the
+    caller supplies the "refresh=true" query parameter, this method will
+    interrupt a sequence of Smoothie operations that are in progress, such as a
+    protocol run.
+
+    If a pipette is "uncommissioned" (e.g.: does not have a model string
+    written to on-board memory), or if no pipette is present, the corresponding
+    mount will report `'model': null`
+    """
+    if refresh is True:
+        await hardware.cache_instruments()     # type: ignore
+
+    attached = hardware.attached_instruments   # type: ignore
+
+    def make_pipette(mount, o):
+        return pipettes.AttachedPipette(
+            model=o.get('model'),
+            name=o.get('name'),
+            id=o.get('pipette_id'),
+            mount_axis=str(Axis.by_mount(mount)).lower(),
+            plunger_axis=str(Axis.of_plunger(mount)).lower(),
+            tip_length=o.get('tip_length', 0) if o.get('model') else None
+        )
+
+    e = {mount.name.lower(): make_pipette(mount, data)
+         for mount, data in attached.items()}
+
+    return pipettes.Pipette(**e)

--- a/robot-server/tests/service/routers/test_pipettes.py
+++ b/robot-server/tests/service/routers/test_pipettes.py
@@ -1,0 +1,75 @@
+import pytest
+from opentrons import types
+
+
+@pytest.fixture
+def attached_pipettes():
+    test_model = 'p300_multi_v1'
+    test_name = 'p300_multi'
+    test_id = '123abc'
+
+    return {
+        types.Mount.RIGHT: {'model': test_model,
+                            'pipette_id': test_id,
+                            'name': test_name,
+                            'tip_length': 123},
+        types.Mount.LEFT: {'model': test_model,
+                           'pipette_id': test_id,
+                           'name': test_name,
+                           'tip_length': 321}
+    }
+
+
+def test_get_pipettes(api_client, hardware, attached_pipettes):
+    hardware.attached_instruments = attached_pipettes
+    expected = {
+        'left': {
+            'model': attached_pipettes[types.Mount.LEFT]['model'],
+            'name': attached_pipettes[types.Mount.LEFT]['name'],
+            'tip_length': 321,
+            'mount_axis': 'z',
+            'plunger_axis': 'b',
+            'id': attached_pipettes[types.Mount.LEFT]['pipette_id']
+        },
+        'right': {
+            'model': attached_pipettes[types.Mount.RIGHT]['model'],
+            'name': attached_pipettes[types.Mount.RIGHT]['name'],
+            'tip_length': 123,
+            'mount_axis': 'a',
+            'plunger_axis': 'c',
+            'id': attached_pipettes[types.Mount.RIGHT]['pipette_id']
+        }
+    }
+
+    resp = api_client.get('/pipettes')
+
+    body = resp.json()
+    assert resp.status_code == 200
+    assert body == expected
+
+
+def test_get_pipettes_refresh_true(api_client, hardware, attached_pipettes):
+    """Test that cache instruments is called when refresh is true"""
+    hardware.attached_instruments = attached_pipettes
+
+    async def mock_cache_instruments():
+        pass
+
+    hardware.cache_instruments.side_effect = mock_cache_instruments
+
+    resp = api_client.get('/pipettes?refresh=true')
+
+    hardware.cache_instruments.assert_called_once()
+
+    assert resp.status_code == 200
+
+
+def test_get_pipettes_refresh_false(api_client, hardware, attached_pipettes):
+    """Test that cache instruments is not called when refresh is false"""
+    hardware.attached_instruments = attached_pipettes
+
+    resp = api_client.get('/pipettes?refresh=false')
+
+    hardware.cache_instruments.assert_not_called()
+
+    assert resp.status_code == 200


### PR DESCRIPTION
## overview

Implements the `GET  /pipettes` endpoint in robot-server's fastapi.

## changelog

port tests from api
implement endpoint business logic

## review requests


## risk assessment

Very low risk. This only impacts code that is not executed on the robot at the moment.

closes #5145 
