### PR TITLE
refactor(robot-server): add /motors endpoints and tests

### DIFF
--- a/robot-server/robot_server/service/main.py
+++ b/robot-server/robot_server/service/main.py
@@ -9,7 +9,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
 
 from .routers import health, networking, control, settings, deck_calibration, \
-    modules, pipettes, item
+    modules, pipettes, motors, item
 from .models.json_api.errors import \
     transform_validation_error_to_json_api_errors, \
     transform_http_exception_to_json_api_errors
@@ -41,6 +41,8 @@ app.include_router(router=modules.router,
                    tags=["modules"])
 app.include_router(router=pipettes.router,
                    tags=["pipettes"])
+app.include_router(router=motors.router,
+                   tags=["motors"])
 # TODO(isk: 3/18/20): this is an example route, remove item route and model
 # once response work is implemented in new route handlers
 app.include_router(router=item.router,

--- a/robot-server/robot_server/service/models/control.py
+++ b/robot-server/robot_server/service/models/control.py
@@ -5,40 +5,6 @@ from enum import Enum
 from pydantic import BaseModel, Field
 
 
-class EngagedMotor(BaseModel):
-    """Engaged motor"""
-    enabled: bool = Field(..., description="Is engine enabled")
-
-
-class EngagedMotors(BaseModel):
-    """Which motors are engaged"""
-    x: EngagedMotor
-    y: EngagedMotor
-    z: EngagedMotor
-    a: EngagedMotor
-    b: EngagedMotor
-    c: EngagedMotor
-
-    class Config:
-        schema_extra = {"example": {
-            "x": {"enabled": False},
-            "y": {"enabled": True},
-            "z": {"enabled": False},
-            "a": {"enabled": True},
-            "b": {"enabled": False},
-            "c": {"enabled": True}
-        }}
-
-
-class MotorName(str, Enum):
-    x = "x"
-    y = "y"
-    z = "z"
-    a = "a"
-    b = "b"
-    c = "c"
-
-
 class MotionTarget(str, Enum):
     """
     What should be moved. If mount, move the nominal position of the mount;

--- a/robot-server/robot_server/service/models/json_api/errors.py
+++ b/robot-server/robot_server/service/models/json_api/errors.py
@@ -83,7 +83,8 @@ def transform_validation_error_to_json_api_errors(
         return Error(
             status=status_code,
             detail=error.get('msg'),
-            source=ErrorSource(pointer='/' + '/'.join(error['loc'])),
+            source=ErrorSource(pointer='/' + '/'.join(
+                str(node) for node in error['loc'])),
             title=error.get('type')
         )
 

--- a/robot-server/robot_server/service/models/motors.py
+++ b/robot-server/robot_server/service/models/motors.py
@@ -1,0 +1,47 @@
+from enum import Enum
+
+import typing
+from pydantic import BaseModel, Field, validator
+
+
+class EngagedMotor(BaseModel):
+    """Engaged motor"""
+    enabled: bool = Field(..., description="Is engine enabled")
+
+
+class EngagedMotors(BaseModel):
+    """Which motors are engaged"""
+    x: EngagedMotor
+    y: EngagedMotor
+    z: EngagedMotor
+    a: EngagedMotor
+    b: EngagedMotor
+    c: EngagedMotor
+
+    class Config:
+        schema_extra = {"example": {
+            "x": {"enabled": False},
+            "y": {"enabled": True},
+            "z": {"enabled": False},
+            "a": {"enabled": True},
+            "b": {"enabled": False},
+            "c": {"enabled": True}
+        }}
+
+
+class MotorName(str, Enum):
+    x = "x"
+    y = "y"
+    z = "z"
+    a = "a"
+    b = "b"
+    c = "c"
+
+
+class Axes(BaseModel):
+    """A list of motor axes to disengage"""
+    axes: typing.List[MotorName]
+
+    @validator('axes', pre=True)
+    def lower_case_motor_name(cls, v):
+        return [m.lower() for m in v]

--- a/robot-server/robot_server/service/models/motors.py
+++ b/robot-server/robot_server/service/models/motors.py
@@ -1,7 +1,21 @@
 from enum import Enum
 
 import typing
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, validator, create_model
+
+from opentrons.hardware_control import types
+
+
+class MotorName(str, Enum):
+    # opentrons.hardware_control.types.Axis as an int enum. We need this to
+    # be a string enum of the keys in Axis. We will use _ignore_ and vars a la
+    # https://docs.python.org/3/library/enum.html#timeperiod to
+    # dynamically create an enum with the same keys as Axis but whose values
+    # are also the keys. (ie X=0 becomes  X='X')
+    _ignore_ = "MotorName _current_axis"
+    MotorName = vars()
+    for _current_axis in types.Axis:
+        MotorName[_current_axis.name] = _current_axis.name.lower()
 
 
 class EngagedMotor(BaseModel):
@@ -9,33 +23,18 @@ class EngagedMotor(BaseModel):
     enabled: bool = Field(..., description="Is engine enabled")
 
 
-class EngagedMotors(BaseModel):
-    """Which motors are engaged"""
-    x: EngagedMotor
-    y: EngagedMotor
-    z: EngagedMotor
-    a: EngagedMotor
-    b: EngagedMotor
-    c: EngagedMotor
-
-    class Config:
-        schema_extra = {"example": {
-            "x": {"enabled": False},
-            "y": {"enabled": True},
-            "z": {"enabled": False},
-            "a": {"enabled": True},
-            "b": {"enabled": False},
-            "c": {"enabled": True}
-        }}
-
-
-class MotorName(str, Enum):
-    x = "x"
-    y = "y"
-    z = "z"
-    a = "a"
-    b = "b"
-    c = "c"
+# Dynamically create the Engaged motors. It has one EngagedMotor per MotorName
+EngagedMotors = create_model(
+    "EngagedMotors",
+    __config__=None,
+    __base__=None,
+    __module__=None,
+    __validators__=None,
+    **{
+        motor.value: (EngagedMotor, ...) for motor in MotorName
+    }
+)
+EngagedMotors.__doc__ = "Which motors are engaged"
 
 
 class Axes(BaseModel):

--- a/robot-server/robot_server/service/routers/control.py
+++ b/robot-server/robot_server/service/routers/control.py
@@ -1,4 +1,3 @@
-import typing
 from http import HTTPStatus
 from starlette.responses import StreamingResponse
 from fastapi import APIRouter, Query, HTTPException
@@ -33,21 +32,6 @@ async def post_picture_capture() -> StreamingResponse:
         status_code=HTTPStatus.OK,
         media_type="image/png"
     )
-
-
-@router.get("/motors/engaged",
-            description="Query which motors are engaged and holding",
-            response_model=control.EngagedMotors)
-async def get_engaged_motors() -> control.EngagedMotors:
-    raise HTTPException(HTTPStatus.NOT_IMPLEMENTED, "not implemented")
-
-
-@router.post("/motors/disengage",
-             description="Disengage a motor or set of motors",
-             response_model=V1BasicResponse)
-async def post_disengage_motors(motors: typing.List[control.MotorName]) \
-        -> V1BasicResponse:
-    raise HTTPException(HTTPStatus.NOT_IMPLEMENTED, "not implemented")
 
 
 @router.get("/robot/positions",

--- a/robot-server/robot_server/service/routers/motors.py
+++ b/robot-server/robot_server/service/routers/motors.py
@@ -1,0 +1,42 @@
+from fastapi import APIRouter, Depends
+from opentrons.hardware_control import HardwareAPILike
+from opentrons.hardware_control.types import Axis
+from pydantic import ValidationError
+
+from robot_server.service.dependencies import get_hardware
+from robot_server.service.exceptions import V1HandlerError
+from robot_server.service.models import motors as model, V1BasicResponse
+
+
+router = APIRouter()
+
+
+@router.get("/motors/engaged",
+            description="Query which motors are engaged and holding",
+            response_model=model.EngagedMotors
+            )
+async def get_engaged_motors(hardware: HardwareAPILike = Depends(get_hardware)
+                             ) -> model.EngagedMotors:
+
+    try:
+        engaged_axes = hardware.engaged_axes    # type: ignore
+        axes_dict = {str(k).lower(): model.EngagedMotor(enabled=v)
+                     for k, v in engaged_axes.items()}
+        return model.EngagedMotors(**axes_dict)
+    except ValidationError as e:
+        raise V1HandlerError(500, str(e))
+
+
+@router.post("/motors/disengage",
+             description="Disengage a motor or set of motors",
+             response_model=V1BasicResponse)
+async def post_disengage_motors(
+        axes: model.Axes,
+        hardware: HardwareAPILike = Depends(get_hardware)) \
+        -> V1BasicResponse:
+
+    input_axes = [Axis[ax.upper()] for ax in axes.axes]
+    await hardware.disengage_axes(input_axes)    # type: ignore
+    return V1BasicResponse(
+        message="Disengaged axes: {}".format(', '.join(axes.axes))
+    )

--- a/robot-server/robot_server/service/routers/motors.py
+++ b/robot-server/robot_server/service/routers/motors.py
@@ -16,8 +16,7 @@ router = APIRouter()
             response_model=model.EngagedMotors
             )
 async def get_engaged_motors(hardware: HardwareAPILike = Depends(get_hardware)
-                             ) -> model.EngagedMotors:
-
+                             ) -> model.EngagedMotors:  # type: ignore
     try:
         engaged_axes = hardware.engaged_axes    # type: ignore
         axes_dict = {str(k).lower(): model.EngagedMotor(enabled=v)

--- a/robot-server/tests/service/routers/test_motors.py
+++ b/robot-server/tests/service/routers/test_motors.py
@@ -1,0 +1,91 @@
+from opentrons.hardware_control.types import Axis
+import pytest
+
+
+def test_engage_axes(api_client, hardware):
+    hardware.engaged_axes = {
+        "x": True,
+        "y": True,
+        "z": True,
+        "a": True,
+        "b": True,
+        "c": True
+    }
+
+    res0 = api_client.get('/motors/engaged')
+    result0 = res0.json()
+    assert res0.status_code == 200
+    assert result0 == {
+        "x": {"enabled": True},
+        "y": {"enabled": True},
+        "z": {"enabled": True},
+        "a": {"enabled": True},
+        "b": {"enabled": True},
+        "c": {"enabled": True}
+    }
+
+
+def test_engage_invalid_axes(api_client, hardware):
+    hardware.engaged_axes = {
+        "B": True,
+        "D": True,
+        "z": True,
+        "a": True,
+        "b": True,
+        "c": True
+    }
+
+    res0 = api_client.get('/motors/engaged')
+    assert res0.status_code == 500
+
+
+@pytest.fixture
+def hardware_with_disengage_axes(hardware):
+    async def mock_disengage_axes(*args, **kwargs):
+        pass
+
+    hardware.disengage_axes.side_effect = mock_disengage_axes
+    return hardware
+
+
+def test_disengage_axes(api_client, hardware_with_disengage_axes):
+    postres = api_client.post(
+        '/motors/disengage', json={'axes': ['x', 'b']})
+
+    hardware_with_disengage_axes.disengage_axes.assert_called_once_with(
+        [Axis.X, Axis.B])
+
+    assert postres.status_code == 200
+    assert postres.json() == {"message": "Disengaged axes: x, b"}
+
+
+def test_disengage_axes_case_insensitive(api_client,
+                                         hardware_with_disengage_axes):
+
+    postres = api_client.post(
+        '/motors/disengage', json={'axes': ['Y', 'A']})
+
+    hardware_with_disengage_axes.disengage_axes.assert_called_once_with(
+        [Axis.Y, Axis.A])
+
+    assert postres.status_code == 200
+    assert postres.json() == {"message": "Disengaged axes: y, a"}
+
+
+def test_disengage_invalid_axes(api_client, hardware_with_disengage_axes):
+    postres = api_client.post(
+        '/motors/disengage', json={'axes': ['u']})
+
+    hardware_with_disengage_axes.disengage_axes.assert_not_called()
+
+    assert postres.status_code == 422
+
+
+def test_disengage_no_axes(api_client, hardware_with_disengage_axes):
+    postres = api_client.post(
+        '/motors/disengage', json={'axes': []})
+
+    hardware_with_disengage_axes.disengage_axes.assert_called_once_with([])
+
+    assert postres.status_code == 200
+    assert postres.json() == {"message": "Disengaged axes: "}


### PR DESCRIPTION
## overview

Implement the `/motors` endpoints in robot-server's fastapi app

## changelog
- separate the the motor models and routes from control into their own module
- port tests from aiohttp into fastapi. 
- separate the tests into smaller tests.
- implement the endpoints

## review requests

The ticket is to port the endpoint and unit tests.
I do not have a robot to test this on, so not 100% it will work on a robot.

## risk assessment

Very low. These changes all live behind a feature flag which is not enabled.


closes #5192 
