### PR TITLE
feat(protocol-designer): clear out engageHeight

### DIFF
--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -110,12 +110,10 @@ export const unsavedForm = (
     case 'POPULATE_FORM':
       return action.payload
     case 'CANCEL_STEP_FORM':
-      return unsavedFormInitialState
     case 'SELECT_TERMINAL_ITEM':
-      return unsavedFormInitialState
     case 'SAVE_STEP_FORM':
-      return unsavedFormInitialState
     case 'DELETE_STEP':
+    case 'EDIT_MODULE':
       return unsavedFormInitialState
     case 'SUBSTITUTE_STEP_FORM_PIPETTES': {
       // only substitute unsaved step form if its ID is in the start-end range
@@ -183,6 +181,7 @@ type SavedStepFormsActions =
   | DuplicateLabwareAction
   | SwapSlotContentsAction
   | ReplaceCustomLabwareDef
+  | EditModuleAction
 
 export const savedStepForms = (
   rootState: RootState,
@@ -280,6 +279,24 @@ export const savedStepForms = (
           return { ...savedForm, moduleId }
         }
 
+        return savedForm
+      })
+    }
+    case 'EDIT_MODULE': {
+      const moduleId = action.payload.id
+      return mapValues(savedStepForms, (savedForm: FormData, formId) => {
+        if (
+          savedForm.stepType === 'magnet' &&
+          savedForm.moduleId === moduleId
+        ) {
+          // null out engageHeight if magnet step's module has been edited
+          const blankEngageHeight = getDefaultsForStepType('magnet')
+            .engageHeight
+          return {
+            ...savedForm,
+            engageHeight: blankEngageHeight,
+          }
+        }
         return savedForm
       })
     }


### PR DESCRIPTION
## overview

Clear out `engageHeight` from MAGNET steps when magnetic module model is
edited.

Closes #5225

I also cover an unspecified case where if you have a form open (thus in `unsavedForm` reducer state) and edit a module, that open form will just close without changes instead of doing something smarter

Also, I figured EDIT_MODULES shouldn't affect magnet steps that somehow aren't using the same `moduleId` as the edited module.

## changelog

* add tests for uncovered unsavedForm reducer

## review requests

- [ ] This is mostly code / test review b/c the UI to change module models isn't in yet
- [ ] One might argue that this form change should go thru `handleFormChange` as a best practice. I'm open to that, but IMO we should figure out #5247 first because this form isn't working right.
- [ ] You can test with redux devtools. You need to know the unique ID of your mag module, then dispatch:

```js
{
    type: 'EDIT_MODULE',
    payload: {
        id: "magnetic module ID here", 
        model: "magneticModuleV2"
    }
}
```

NOTE: you might notice that opening a Magnet > Disengage step shows "engage" being selected. That's not new in this PR, it's #5247 

## risk assessment

Definitely PD-only, shouldn't interfere with other PD work unless it's specifically engageHeight