### PR TITLE
fix(protocol-designer): fix bug with selecting magnet > disengage step

### DIFF
--- a/protocol-designer/src/ui/steps/actions/actions.js
+++ b/protocol-designer/src/ui/steps/actions/actions.js
@@ -142,7 +142,7 @@ export const selectStep = (
   }
 
   // auto-select magnetic module if it exists (assumes no more than 1 magnetic module)
-  if (formData && formData.stepType === 'magnet') {
+  if (newStepType === 'magnet') {
     const moduleId = uiModulesSelectors.getSingleMagneticModuleId(state)
     const magnetAction = getNextDefaultMagnetAction(
       stepFormSelectors.getSavedStepForms(state),
@@ -166,6 +166,11 @@ export const selectStep = (
     // recommended value is null when no labware found on module
     const engageHeight = prevEngageHeight || stringDefaultEngageHeight
     formData = { ...formData, moduleId, magnetAction, engageHeight }
+  } else if (formData?.stepType === 'magnet') {
+    // handle case for pristine-never-saved Magnet step:
+    // it needs the moduleId field populated, bc that field has no UI
+    const moduleId = uiModulesSelectors.getSingleMagneticModuleId(state)
+    formData = { ...formData, moduleId }
   }
 
   dispatch({


### PR DESCRIPTION
## overview

Closes #5247

The problem was that existing magnet steps were being treated the same as just-newly-created magnet steps. The desired behavior for just-newly-created steps 

## review requests

- [ ] Create a disengage step, save it, click off it to another step, select it again. It should still be a "disengage" in the form. Saving the re-opened form shouldn't make changes to the form (you can look at Redux state)
- [ ] You can create a magnet step, click off without saving, reselect, fill it out, and save it successfully
- [ ] Autofilling last entered engage height number if the previous step was disengage should still work w/o regression

- Ideas for tests? I thought about refactoring the `if (newStepType === 'magnet') {...} else if (formData?.stepType === 'magnet') {...}` into a function that could be tested on its own, but I'm not very motivated to put work into the pristine-never-saved form stuff since we're going to strip it out :/

## risk assessment

PD only, shouldn't affect PRs in flight