### PR TITLE
refactor(robot-server): port log endpoints and add tests

### DIFF
--- a/api/src/opentrons/system/log_control.py
+++ b/api/src/opentrons/system/log_control.py
@@ -7,7 +7,6 @@ This is the implementation of the endpoints in
 import asyncio
 import logging
 import subprocess
-import syslog
 from typing import Tuple
 
 
@@ -15,17 +14,6 @@ LOG = logging.getLogger(__name__)
 
 MAX_RECORDS = 100000
 DEFAULT_RECORDS = 50000
-
-_SYSLOG_PRIORITY_TO_NAME = {
-    syslog.LOG_EMERG: 'emergency',
-    syslog.LOG_CRIT: 'critical',
-    syslog.LOG_ERR: 'error',
-    syslog.LOG_WARNING: 'warning',
-    syslog.LOG_INFO: 'info',
-    syslog.LOG_DEBUG: 'debug',
-    syslog.LOG_ALERT: 'alert',
-    syslog.LOG_NOTICE: 'notice'
-}
 
 
 async def get_records_dumb(selector: str, records: int,

--- a/api/src/opentrons/system/log_control.py
+++ b/api/src/opentrons/system/log_control.py
@@ -14,6 +14,7 @@ from typing import Tuple
 LOG = logging.getLogger(__name__)
 
 MAX_RECORDS = 100000
+DEFAULT_RECORDS = 50000
 
 _SYSLOG_PRIORITY_TO_NAME = {
     syslog.LOG_EMERG: 'emergency',

--- a/robot-server/robot_server/service/main.py
+++ b/robot-server/robot_server/service/main.py
@@ -9,7 +9,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
 
 from .routers import health, networking, control, settings, deck_calibration, \
-    modules, pipettes, motors, camera, item
+    modules, pipettes, motors, camera, item, logs
 from .models.json_api.errors import \
     transform_validation_error_to_json_api_errors, \
     transform_http_exception_to_json_api_errors
@@ -49,6 +49,8 @@ app.include_router(router=camera.router,
 # once response work is implemented in new route handlers
 app.include_router(router=item.router,
                    tags=["item"])
+app.include_router(router=logs.router,
+                   tags=["logs"])
 
 
 @app.exception_handler(V1HandlerError)

--- a/robot-server/robot_server/service/models/logs.py
+++ b/robot-server/robot_server/service/models/logs.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+class LogIdentifier(str, Enum):
+    """Identifier of the log"""
+    api = "api.log"
+    serial = "serial.log"
+
+
+class LogFormat(str, Enum):
+    """Format to use for log records"""
+    text = "text"
+    json = "json"

--- a/robot-server/robot_server/service/models/settings.py
+++ b/robot-server/robot_server/service/models/settings.py
@@ -1,7 +1,8 @@
 import typing
 from enum import Enum
 
-from pydantic import BaseModel, Field, create_model
+from typing import Optional
+from pydantic import BaseModel, Field, create_model, validator
 from opentrons.server.endpoints.settings import _common_settings_reset_options
 
 
@@ -45,23 +46,14 @@ class LogLevels(str, Enum):
 
 
 class LogLevel(BaseModel):
-    """None"""
-    log_level: LogLevels = \
+    log_level: Optional[LogLevels] = \
         Field(...,
               description="The value to set (conforming to Python "
                           "log levels)")
 
-
-class LogIdentifier(str, Enum):
-    """Identifier of the log"""
-    api = "api.log"
-    serial = "serial.log"
-
-
-class LogFormat(str, Enum):
-    """Format to use for log records"""
-    text = "text"
-    json = "json"
+    @validator('log_level', pre=True)
+    def lower_case_log_keys(cls, value):
+        return value if value is None else LogLevels(value.lower())
 
 
 class FactoryResetOption(BaseModel):

--- a/robot-server/robot_server/service/routers/logs.py
+++ b/robot-server/robot_server/service/routers/logs.py
@@ -10,7 +10,7 @@ router = APIRouter()
 @router.get("/logs/{log_identifier}", description="Get logs from the robot.")
 async def get_logs(
     log_identifier: LogIdentifier,
-    format: LogFormat = Query('text', title="Log format type"),
+    format: LogFormat = Query(LogFormat.text, title="Log format type"),
     records: int = Query(
         log_control.DEFAULT_RECORDS, title="Number of records to retrieve",
         gt=0, le=log_control.MAX_RECORDS
@@ -20,7 +20,7 @@ async def get_logs(
     if log_identifier == LogIdentifier.api:
         identifier = 'opentrons-api'
 
-    modes = {"json": "json", "text": "short"}
+    modes = {LogFormat.json: "json", LogFormat.text: "short"}
     format_type = modes[format]
     output = await log_control.get_records_dumb(
         identifier, records, format_type

--- a/robot-server/robot_server/service/routers/logs.py
+++ b/robot-server/robot_server/service/routers/logs.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Query
+
+from opentrons.system import log_control
+from robot_server.service.models.logs import LogIdentifier, \
+    LogFormat
+
+router = APIRouter()
+
+
+@router.get("/logs/{log_identifier}", description="Get logs from the robot.")
+async def get_logs(
+    log_identifier: LogIdentifier,
+    format: LogFormat = Query('text', title="Log format type"),
+    records: int = Query(
+        log_control.DEFAULT_RECORDS, title="Number of records to retrieve",
+        gt=0, le=log_control.MAX_RECORDS
+    ),
+) -> str:
+    identifier = 'opentrons-api-serial'
+    if log_identifier == LogIdentifier.api:
+        identifier = 'opentrons-api'
+
+    modes = {"json": "json", "text": "short"}
+    format_type = modes[format]
+    output = await log_control.get_records_dumb(
+        identifier, records, format_type
+    )
+    return output.decode("utf-8")

--- a/robot-server/tests/service/routers/test_logs.py
+++ b/robot-server/tests/service/routers/test_logs.py
@@ -1,8 +1,7 @@
 import pytest
 from unittest.mock import patch
 
-MAX_RECORDS = 100000
-DEFAULT_RECORDS = 50000
+from opentrons.system.log_control import MAX_RECORDS, DEFAULT_RECORDS
 
 
 def test_get_serial_log_with_defaults(api_client):

--- a/robot-server/tests/service/routers/test_logs.py
+++ b/robot-server/tests/service/routers/test_logs.py
@@ -1,7 +1,8 @@
 import pytest
 from unittest.mock import patch
 
-from opentrons.system.log_control import MAX_RECORDS, DEFAULT_RECORDS
+MAX_RECORDS = 100000
+DEFAULT_RECORDS = 50000
 
 
 def test_get_serial_log_with_defaults(api_client):

--- a/robot-server/tests/service/routers/test_logs.py
+++ b/robot-server/tests/service/routers/test_logs.py
@@ -1,0 +1,154 @@
+import pytest
+from unittest.mock import patch
+
+from opentrons.system.log_control import MAX_RECORDS, DEFAULT_RECORDS
+
+
+def test_get_serial_log_with_defaults(api_client):
+    logs = '{"serial": "serial logs"}'
+    res_bytes = logs.encode('utf-8')
+    expected = res_bytes.decode('utf-8')
+
+    async def mock_get_records_dumb(identifier, records, format_type):
+        return res_bytes
+
+    with patch("opentrons.system.log_control.get_records_dumb") as m:
+        m.side_effect = mock_get_records_dumb
+        response = api_client.get("/logs/serial.log")
+        body = response.json()
+        assert response.status_code == 200
+        assert body == expected
+        m.assert_called_once_with(
+            "opentrons-api-serial", DEFAULT_RECORDS, "short"
+        )
+
+
+@pytest.mark.parametrize(
+    "format_param, records_param, mode_param",
+    [
+        ("json", MAX_RECORDS - 1, "json"),
+        ("text", MAX_RECORDS - 1, "short"),
+        ("json", 1, "json"),
+        ("text", 1, "short")
+    ]
+)
+def test_get_serial_log_with_params(
+    api_client, format_param, records_param, mode_param
+):
+    logs = '{"serial": "serial logs"}'
+    res_bytes = logs.encode('utf-8')
+    expected = res_bytes.decode('utf-8')
+
+    async def mock_get_records_dumb(identifier, records, mode):
+        return res_bytes
+
+    with patch("opentrons.system.log_control.get_records_dumb") as m:
+        m.side_effect = mock_get_records_dumb
+        response = api_client.get(
+            f"/logs/serial.log?format={format_param}&records={records_param}"
+        )
+        body = response.json()
+        assert response.status_code == 200
+        assert body == expected
+        m.assert_called_once_with(
+            "opentrons-api-serial", records_param, mode_param
+        )
+
+
+@pytest.mark.parametrize(
+    "format_param, records_param",
+    [
+        ("json", 0),
+        ("text", MAX_RECORDS + 1),
+        ("invalid", MAX_RECORDS - 1)
+    ]
+)
+def test_get_serial_log_with_invalid_params(
+    api_client, format_param, records_param
+):
+    logs = '{"serial": "serial logs"}'
+    res_bytes = logs.encode('utf-8')
+
+    async def mock_get_records_dumb(identifier, records, format_type):
+        return res_bytes
+
+    with patch("opentrons.system.log_control.get_records_dumb") as m:
+        m.side_effect = mock_get_records_dumb
+        response = api_client.get(
+            f"/logs/serial.log?format={format_param}&records={records_param}"
+        )
+        assert response.status_code == 422
+        m.assert_not_called()
+
+
+def test_get_api_log_with_defaults(api_client):
+    logs = '{"api": "application programing interface logs"}'
+    res_bytes = logs.encode('utf-8')
+    expected = res_bytes.decode('utf-8')
+
+    async def mock_get_records_dumb(identifier, records, format_type):
+        return res_bytes
+
+    with patch("opentrons.system.log_control.get_records_dumb") as m:
+        m.side_effect = mock_get_records_dumb
+        response = api_client.get("/logs/api.log")
+        body = response.json()
+        assert response.status_code == 200
+        assert body == expected
+        m.assert_called_once_with("opentrons-api", DEFAULT_RECORDS, "short")
+
+
+@pytest.mark.parametrize(
+    "format_param, records_param, mode_param",
+    [
+        ("json", MAX_RECORDS - 1, "json"),
+        ("text", MAX_RECORDS - 1, "short"),
+        ("json", 1, "json"),
+        ("text", 1, "short")
+    ]
+)
+def test_get_api_log_with_params(
+    api_client, format_param, records_param, mode_param
+):
+    logs = '{"api": "application programing interface logs"}'
+    res_bytes = logs.encode('utf-8')
+    expected = res_bytes.decode('utf-8')
+
+    async def mock_get_records_dumb(identifier, records, format_type):
+        return res_bytes
+
+    with patch("opentrons.system.log_control.get_records_dumb") as m:
+        m.side_effect = mock_get_records_dumb
+        response = api_client.get(
+            f"/logs/api.log?format={format_param}&records={records_param}"
+        )
+        body = response.json()
+        assert response.status_code == 200
+        assert body == expected
+        m.assert_called_once_with("opentrons-api", records_param, mode_param)
+
+
+@pytest.mark.parametrize(
+    "format_param, records_param",
+    [
+        ("json", 0),
+        ("text", MAX_RECORDS + 1),
+        ("invalid", MAX_RECORDS - 1)
+    ]
+)
+def test_get_api_log_with_invalid_params(
+    api_client, format_param, records_param
+):
+    logs = '{"api": "application programing interface logs"}'
+    res_bytes = logs.encode('utf-8')
+
+    async def mock_get_records_dumb(identifier, records, format_type):
+        return res_bytes
+
+    with patch("opentrons.system.log_control.get_records_dumb") as m:
+        m.side_effect = mock_get_records_dumb
+        response = api_client.get(
+            f"/logs/api.log?format={format_param}&records={records_param}"
+        )
+        assert response.status_code == 422
+        m.assert_not_called()

--- a/robot-server/tests/service/routers/test_settings.py
+++ b/robot-server/tests/service/routers/test_settings.py
@@ -1,0 +1,87 @@
+import pytest
+from unittest.mock import patch
+
+
+# TDOD(isk: 3/20/20): test validation errors after refactor
+# return {message: string}
+@pytest.mark.parametrize(
+    "log_level, syslog_level, expected_message",
+    [
+        (
+            "error",
+            "err",
+            {"message": "Upstreaming log level changed to error"}
+        ), (
+            "ERROR",
+            "err",
+            {"message": "Upstreaming log level changed to error"}
+        ), (
+            "warning",
+            "warning",
+            {"message": "Upstreaming log level changed to warning"}
+        ), (
+            "WARNING",
+            "warning",
+            {"message": "Upstreaming log level changed to warning"}
+        ), (
+            "info",
+            "info",
+            {"message": "Upstreaming log level changed to info"}
+        ), (
+            "INFO",
+            "info",
+            {"message": "Upstreaming log level changed to info"}
+        ), (
+            "debug",
+            "debug",
+            {"message": "Upstreaming log level changed to debug"}
+        ), (
+            "DEBUG",
+            "debug",
+            {"message": "Upstreaming log level changed to debug"}
+        ), (
+            None,
+            "emerg",
+            {"message": "Upstreaming logs disabled"}
+        ), (
+            None,
+            "emerg",
+            {"message": "Upstreaming logs disabled"}
+        )
+    ]
+)
+def test_post_log_level_upstream(
+    api_client,
+    log_level,
+    syslog_level,
+    expected_message
+):
+    async def mock_set_syslog_level(syslog_level):
+        return (0, "stdout", "stderr")
+
+    with patch("opentrons.system.log_control.set_syslog_level") as m:
+        m.side_effect = mock_set_syslog_level
+        response = api_client.post(
+            "/settings/log_level/upstream", json={"log_level": log_level}
+        )
+        body = response.json()
+        assert response.status_code == 200
+        assert body == expected_message
+        m.assert_called_once_with(syslog_level)
+
+
+def test_post_log_level_upstream_fails_reload(api_client):
+    log_level = "debug"
+
+    async def mock_set_syslog_level(syslog_level):
+        return (1, "stdout", "stderr")
+
+    with patch("opentrons.system.log_control.set_syslog_level") as m:
+        m.side_effect = mock_set_syslog_level
+        response = api_client.post(
+            "/settings/log_level/upstream", json={"log_level": log_level}
+        )
+        body = response.json()
+        assert response.status_code == 500
+        assert body == {"message": "Could not reload config: stdout stderr"}
+        m.assert_called_once_with(log_level)


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

Implement the endpoints in `/endpoints/logs.py` in robot-server's fastapi app

closes #5142

## changelog

- port endpoints/logs.py routes. logs model and routes file
- refactor route routes/settings
- port/added tests from aiohttp into fastapi

## risk assessment

<!--
  Carefully go over your pull request and look at the other parts of the
  codebase it may affect. Look for the possibility, even if you think it's
  small, that your change may affect some other part of the system - for
  instance, changing return tip behavior in protocol may also change the
  behavior of labware calibration.

  Identify the other parts of the system your codebase may affect, so that in
  addition to your own review and testing, other people who may not have
  the system internalized as much as you can focus their attention and testing
  there.
-->

Very low. These changes all live behind a feature flag which is not enabled.