### PR TITLE
feat(shared-data): correct existing labware defs engageHeight

### DIFF
--- a/protocol-designer/src/ui/modules/selectors.js
+++ b/protocol-designer/src/ui/modules/selectors.js
@@ -6,6 +6,7 @@ import {
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
+  MAGNETIC_MODULE_V1,
 } from '@opentrons/shared-data'
 import mapValues from 'lodash/mapValues'
 import { selectors as stepFormSelectors } from '../../step-forms'
@@ -139,9 +140,19 @@ export const getMagnetLabwareEngageHeight: Selector<
   stepFormSelectors.getInitialDeckSetup,
   getSingleMagneticModuleId,
   (initialDeckSetup, magnetModuleId) => {
-    const labware =
-      magnetModuleId && getLabwareOnModule(initialDeckSetup, magnetModuleId)
-    return (labware && getLabwareDefaultEngageHeight(labware.def)) || null
+    if (magnetModuleId == null) return null
+
+    const moduleModel = initialDeckSetup.modules[magnetModuleId]?.model
+    const labware = getLabwareOnModule(initialDeckSetup, magnetModuleId)
+    const engageHeightMm = labware
+      ? getLabwareDefaultEngageHeight(labware.def)
+      : null
+
+    if (engageHeightMm != null && moduleModel === MAGNETIC_MODULE_V1) {
+      // convert to 'short mm' units for GEN1
+      return engageHeightMm / 2
+    }
+    return engageHeightMm
   }
 )
 

--- a/protocol-designer/src/ui/modules/selectors.js
+++ b/protocol-designer/src/ui/modules/selectors.js
@@ -150,7 +150,7 @@ export const getMagnetLabwareEngageHeight: Selector<
 
     if (engageHeightMm != null && moduleModel === MAGNETIC_MODULE_V1) {
       // convert to 'short mm' units for GEN1
-      return engageHeightMm / 2
+      return engageHeightMm * 2
     }
     return engageHeightMm
   }

--- a/shared-data/js/constants.js
+++ b/shared-data/js/constants.js
@@ -55,7 +55,9 @@ export const MODULE_MODELS: Array<ModuleModel> = [
   ...THERMOCYCLER_MODULE_MODELS,
 ]
 
-// offset added to parameters.agneticModuleEngageHeight for displaying reccomended height in PD
+// offset added to parameters.magneticModuleEngageHeight to convert older labware
+// definitions from "distance from home switch" to "distance from labware bottom"
+// Note: this is in actual mm, not "short mm" :)
 export const ENGAGE_HEIGHT_OFFSET = -4
 
 export const MODULE_TYPES = [

--- a/shared-data/js/constants.js
+++ b/shared-data/js/constants.js
@@ -55,11 +55,6 @@ export const MODULE_MODELS: Array<ModuleModel> = [
   ...THERMOCYCLER_MODULE_MODELS,
 ]
 
-// offset added to parameters.magneticModuleEngageHeight to convert older labware
-// definitions from "distance from home switch" to "distance from labware bottom"
-// Note: this is in actual mm, not "short mm" :)
-export const ENGAGE_HEIGHT_OFFSET = -4
-
 export const MODULE_TYPES = [
   TEMPERATURE_MODULE_TYPE,
   MAGNETIC_MODULE_TYPE,

--- a/shared-data/js/getLabware.js
+++ b/shared-data/js/getLabware.js
@@ -4,9 +4,9 @@ import mapValues from 'lodash/mapValues'
 // TODO: Ian 2019-06-04 remove the shared-data build process for labware v1
 import definitions from '../build/labware.json'
 import {
-  SLOT_RENDER_HEIGHT,
   FIXED_TRASH_RENDER_HEIGHT,
-  ENGAGE_HEIGHT_OFFSET,
+  OPENTRONS_LABWARE_NAMESPACE,
+  SLOT_RENDER_HEIGHT,
 } from './constants'
 import type {
   LabwareDefinition1,
@@ -62,12 +62,17 @@ const _SHORT_MM_LABWARE_DEF_LOADNAMES = [
   'nest_96_wellplate_100ul_pcr_full_skirt',
   'usascientific_96_wellplate_2.4ml_deep',
 ]
+// offset added to parameters.magneticModuleEngageHeight to convert older labware
+// definitions from "distance from home switch" to "distance from labware bottom"
+// Note: this is in actual mm, not "short mm" :)
+const ENGAGE_HEIGHT_OFFSET = -4
+
 export function getLabwareDefaultEngageHeight(
   labwareDef: LabwareDefinition2
 ): number | null {
   if (
-    labwareDef.namespace === 'opentrons' &&
-    labwareDef.parameters.loadName in _SHORT_MM_LABWARE_DEF_LOADNAMES
+    labwareDef.namespace === OPENTRONS_LABWARE_NAMESPACE &&
+    _SHORT_MM_LABWARE_DEF_LOADNAMES.includes(labwareDef.parameters.loadName)
   ) {
     const rawEngageHeight: ?number =
       labwareDef.parameters.magneticModuleEngageHeight

--- a/shared-data/js/getLabware.js
+++ b/shared-data/js/getLabware.js
@@ -70,18 +70,16 @@ const ENGAGE_HEIGHT_OFFSET = -4
 export function getLabwareDefaultEngageHeight(
   labwareDef: LabwareDefinition2
 ): number | null {
+  const rawEngageHeight: ?number =
+    labwareDef.parameters.magneticModuleEngageHeight
   if (
     labwareDef.namespace === OPENTRONS_LABWARE_NAMESPACE &&
     _SHORT_MM_LABWARE_DEF_LOADNAMES.includes(labwareDef.parameters.loadName)
   ) {
-    const rawEngageHeight: ?number =
-      labwareDef.parameters.magneticModuleEngageHeight
     return rawEngageHeight == null
       ? null
-      : rawEngageHeight * 2 + ENGAGE_HEIGHT_OFFSET
+      : rawEngageHeight / 2 + ENGAGE_HEIGHT_OFFSET
   }
-  const rawEngageHeight: ?number =
-    labwareDef.parameters.magneticModuleEngageHeight
   return rawEngageHeight == null ? null : rawEngageHeight
 }
 

--- a/shared-data/js/getLabware.js
+++ b/shared-data/js/getLabware.js
@@ -48,12 +48,36 @@ export function getIsTiprack(labwareDef: LabwareDefinition2): boolean {
   return labwareDef.parameters.isTiprack
 }
 
+// NOTE: these labware definitions in _SHORT_MM_LABWARE_DEF_LOADNAMES
+// were written in "short mm" = 0.5mm, but
+// we will write all future definitions in actual mm.
+// These whitelisted labware also have engage heights measured from home switch
+// instead of from labware bottom, which is why we add ENGAGE_HEIGHT_OFFSET.
+//
+// Ideally instead of using this whitelist, we would publish a new version
+// of these definitions with corrected labware heights. However, we don't
+// support labware versioning well enough yet.
+const _SHORT_MM_LABWARE_DEF_LOADNAMES = [
+  'biorad_96_wellplate_200ul_pcr',
+  'nest_96_wellplate_100ul_pcr_full_skirt',
+  'usascientific_96_wellplate_2.4ml_deep',
+]
 export function getLabwareDefaultEngageHeight(
   labwareDef: LabwareDefinition2
 ): number | null {
+  if (
+    labwareDef.namespace === 'opentrons' &&
+    labwareDef.parameters.loadName in _SHORT_MM_LABWARE_DEF_LOADNAMES
+  ) {
+    const rawEngageHeight: ?number =
+      labwareDef.parameters.magneticModuleEngageHeight
+    return rawEngageHeight == null
+      ? null
+      : rawEngageHeight * 2 + ENGAGE_HEIGHT_OFFSET
+  }
   const rawEngageHeight: ?number =
     labwareDef.parameters.magneticModuleEngageHeight
-  return rawEngageHeight == null ? null : rawEngageHeight + ENGAGE_HEIGHT_OFFSET
+  return rawEngageHeight == null ? null : rawEngageHeight
 }
 
 /* Render Helpers */


### PR DESCRIPTION
## overview

Closes #5226

## changelog

* existing 3 labware defs should be output in real mm from labware bottom

## review requests

- The 3 labware that use engageHeight should have their PD suggested defaults equal to `((original_number_in_def * 2) - 4) / 2`. For GEN2 magnetic module, the final `/ 2` shouldn't happen, for GEN1, it should.

For the 1 recommended magnetic module labware, `for nest_96_wellplate_100ul_pcr_full_skirt`, both default value and "Recommended: __" caption should be:
- [ ] GEN2: 6 real mm
- [ ] GEN1: 12 short mm

FYI, the math is:
```
20 short mm from def for nest_96_wellplate_100ul_pcr_full_skirt
= 10 real mm from switch
Do -4 real mm to translate "from switch" to "from labware bottom"
= 6 real mm

GEN2: 6 real mm
GEN1: 12 short mm (6*2)
```

## risk assessment

Shouldn't interfere with anything outside on engageHeight use in PD. But it WILL mess up creating engage magnet steps in PD with default values until we do #5230, because the min/max values we have aren't right; default values won't be valid until we fix the range. However this issue is blocking #5230 too.