### PR TITLE
feat(protocol-designer): use different ranges for gen1 vs gen2 engageHeight

### DIFF
--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -88,8 +88,10 @@ export const DEFAULT_MM_BLOWOUT_OFFSET_FROM_TOP = 0
 export const DEFAULT_WELL_ORDER_FIRST_OPTION: 't2b' = 't2b'
 export const DEFAULT_WELL_ORDER_SECOND_OPTION: 'l2r' = 'l2r'
 
-export const MIN_ENGAGE_HEIGHT = -4
-export const MAX_ENGAGE_HEIGHT = 16
+export const MIN_ENGAGE_HEIGHT_V1 = -5
+export const MAX_ENGAGE_HEIGHT_V1 = 40
+export const MIN_ENGAGE_HEIGHT_V2 = -4
+export const MAX_ENGAGE_HEIGHT_V2 = 19
 
 export const MIN_TEMP_MODULE_TEMP = 0
 export const MAX_TEMP_MODULE_TEMP = 95

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -390,9 +390,9 @@ function _getHydratedForm(
   // Consider nesting all additional fields under 'hydrated' key,
   // following what we're doing with 'module'.
   // See #3161
-  hydratedForm.hydrated = {}
+  hydratedForm.meta = {}
   if (rawForm?.moduleId != null) {
-    hydratedForm.hydrated.module = getModuleEntity(
+    hydratedForm.meta.module = getModuleEntity(
       invariantContext,
       rawForm.moduleId
     )

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -56,6 +56,7 @@ import type {
   LabwareEntities,
   MagneticModuleState,
   ModuleOnDeck,
+  ModuleEntity,
   ModuleEntities,
   ModulesForEditModulesCard,
   PipetteEntities,
@@ -370,14 +371,32 @@ const getOrderedSavedForms: Selector<Array<FormData>> = createSelector(
   }
 )
 
-// TODO: Ian 2019-01-25 type with hydrated form type
+const getModuleEntity = (state: InvariantContext, id: string): ModuleEntity => {
+  return state.moduleEntities[id]
+}
+
+// TODO: Ian 2019-01-25 type with hydrated form type, see #3161
 function _getHydratedForm(
-  rawForm: FormData,
+  rawForm: ?FormData,
   invariantContext: InvariantContext
 ) {
   const hydratedForm = mapValues(rawForm, (value, name) =>
     hydrateField(invariantContext, name, value)
   )
+  // TODO(IL, 2020-03-23): separate hydrated/denormalized fields from the other fields.
+  // It's confusing that pipette is an ID string before this,
+  // but a PipetteEntity object after this.
+  // For `moduleId` field, it would be surprising to be a ModuleEntity!
+  // Consider nesting all additional fields under 'hydrated' key,
+  // following what we're doing with 'module'.
+  // See #3161
+  hydratedForm.hydrated = {}
+  if (rawForm?.moduleId != null) {
+    hydratedForm.hydrated.module = getModuleEntity(
+      invariantContext,
+      rawForm.moduleId
+    )
+  }
   return hydratedForm
 }
 

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -16,12 +16,7 @@ import {
   type ValueMasker,
   type ValueCaster,
 } from './processing'
-import {
-  MIN_ENGAGE_HEIGHT,
-  MAX_ENGAGE_HEIGHT,
-  MIN_TEMP_MODULE_TEMP,
-  MAX_TEMP_MODULE_TEMP,
-} from '../../constants'
+import { MIN_TEMP_MODULE_TEMP, MAX_TEMP_MODULE_TEMP } from '../../constants'
 import type { StepFieldName } from '../../form-types'
 import type { LabwareEntity, PipetteEntity } from '../../step-forms'
 import type { InvariantContext } from '../../step-generation'
@@ -128,10 +123,6 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
   },
   magnetAction: { getErrors: composeErrors(requiredField) },
   engageHeight: {
-    getErrors: composeErrors(
-      minFieldValue(MIN_ENGAGE_HEIGHT),
-      maxFieldValue(MAX_ENGAGE_HEIGHT)
-    ),
     maskValue: composeMaskers(maskToFloat),
     castValue: Number,
   },

--- a/protocol-designer/src/steplist/formLevel/errors.js
+++ b/protocol-designer/src/steplist/formLevel/errors.js
@@ -223,7 +223,7 @@ export const engageHeightRangeExceeded = (
   fields: HydratedFormData
 ): FormError | null => {
   const { magnetAction, engageHeight } = fields
-  const module = fields.hydrated?.module
+  const module = fields.meta?.module
   const model = module?.model
 
   if (magnetAction === 'engage') {

--- a/protocol-designer/src/steplist/formLevel/index.js
+++ b/protocol-designer/src/steplist/formLevel/index.js
@@ -8,6 +8,7 @@ import {
   wellRatioMoveLiquid,
   magnetActionRequired,
   engageHeightRequired,
+  engageHeightRangeExceeded,
   type FormError,
   moduleIdRequired,
   targetTemperatureRequired,
@@ -17,7 +18,6 @@ import {
   belowPipetteMinimumVolume,
   maxDispenseWellVolume,
   minDisposalVolume,
-  engageHeightRangeExceeded,
   temperatureRangeExceeded,
   type FormWarning,
   type FormWarningType,
@@ -66,9 +66,9 @@ const stepFormHelperMap: { [StepType]: FormHelpers } = {
     getErrors: composeErrors(
       magnetActionRequired,
       engageHeightRequired,
-      moduleIdRequired
+      moduleIdRequired,
+      engageHeightRangeExceeded
     ),
-    getWarnings: composeWarnings(engageHeightRangeExceeded),
   },
   temperature: {
     getErrors: composeErrors(targetTemperatureRequired, moduleIdRequired),

--- a/protocol-designer/src/steplist/formLevel/warnings.js
+++ b/protocol-designer/src/steplist/formLevel/warnings.js
@@ -1,12 +1,7 @@
 // @flow
 import * as React from 'react'
 import { getWellTotalVolume } from '@opentrons/shared-data'
-import {
-  MIN_ENGAGE_HEIGHT,
-  MAX_ENGAGE_HEIGHT,
-  MIN_TEMP_MODULE_TEMP,
-  MAX_TEMP_MODULE_TEMP,
-} from '../../constants'
+import { MIN_TEMP_MODULE_TEMP, MAX_TEMP_MODULE_TEMP } from '../../constants'
 import { KnowledgeBaseLink } from '../../components/KnowledgeBaseLink'
 import type { FormError } from './errors'
 /*******************
@@ -17,8 +12,6 @@ export type FormWarningType =
   | 'BELOW_PIPETTE_MINIMUM_VOLUME'
   | 'OVER_MAX_WELL_VOLUME'
   | 'BELOW_MIN_DISPOSAL_VOLUME'
-  | 'ENGAGE_HEIGHT_MIN_EXCEEDED'
-  | 'ENGAGE_HEIGHT_MAX_EXCEEDED'
   | 'TEMPERATURE_MIN_EXCEEDED'
   | 'TEMPERATURE_MAX_EXCEEDED'
   | 'PAUSE_TEMPERATURE_MIN_EXCEEDED'
@@ -51,16 +44,6 @@ const FORM_WARNINGS: { [FormWarningType]: FormWarning } = {
       </React.Fragment>
     ),
     dependentFields: ['disposalVolume_volume', 'pipette'],
-  },
-  ENGAGE_HEIGHT_MIN_EXCEEDED: {
-    type: 'ENGAGE_HEIGHT_MIN_EXCEEDED',
-    title: 'Specified distance is below module minimum',
-    dependentFields: ['magnetAction', 'engageHeight'],
-  },
-  ENGAGE_HEIGHT_MAX_EXCEEDED: {
-    type: 'ENGAGE_HEIGHT_MAX_EXCEEDED',
-    title: 'Specified distance is above module maximum',
-    dependentFields: ['magnetAction', 'engageHeight'],
   },
   TEMPERATURE_MIN_EXCEEDED: {
     type: 'TEMPERATURE_MIN_EXCEEDED',
@@ -127,18 +110,6 @@ export const minDisposalVolume = (fields: HydratedFormData): ?FormWarning => {
   if (isUnselected) return FORM_WARNINGS.BELOW_MIN_DISPOSAL_VOLUME
   const isBelowMin = disposalVolume_volume < pipette.spec.minVolume
   return isBelowMin ? FORM_WARNINGS.BELOW_MIN_DISPOSAL_VOLUME : null
-}
-
-export const engageHeightRangeExceeded = (
-  fields: HydratedFormData
-): ?FormWarning => {
-  const { magnetAction, engageHeight } = fields
-  if (magnetAction === 'engage' && engageHeight < MIN_ENGAGE_HEIGHT) {
-    return FORM_WARNINGS.ENGAGE_HEIGHT_MIN_EXCEEDED
-  } else if (magnetAction === 'engage' && engageHeight > MAX_ENGAGE_HEIGHT) {
-    return FORM_WARNINGS.ENGAGE_HEIGHT_MAX_EXCEEDED
-  }
-  return null
 }
 
 export const temperatureRangeExceeded = (


### PR DESCRIPTION
## overview

Closes #5230

## changelog

- Introduces `meta` field to HydratedFormData

## review requests

Note: the existing "form hydration" stuff works on the fields `pipette` and `labware`. A raw/non-hydrated FormData will have `pipette: string` b/c it's the ID, then after being "hydrated" it will be HydratedFormData with `pipette: PipetteEntity`.

For 2 reasons, I want to start nesting the results of hydration in some field, I'm calling it `meta` but I'm open to other suggestions eg `context` or `hydrated` or whatever. This would be instead of the existing "form hydration" mechanism of converting the types of some certain fields
1. Much easier to type well once we finally get to typing FormData / HydratedFormData in #3161 (right now FormData is mostly any-typed and HydratedFormData is entirely any-typed, which has been causing problems for a while)
2. `moduleId` field has the word "id" in it, it would be very confusing if hydration made it `{moduleId: ModuleEntity}` and it's a hassle to refactor PD to make it `module`...
3. IMO just feels cleaner and easier to understand if `FormData -> HydratedFormData` conversion just adds a `meta` key rather than replace the types of select keys

We have the ticket #3161 to address this.

- [ ] With a GEN1 module, allowed engageHeight range should be -5 to 40 (these are "short mm" fyi)
- [ ] With a GEN2 module, allowed engageHeight range should be -4 to 19 (these are real mm fyi)

## risk assessment

Limited to PD, might affect other engageHeight / FormData stuff