### PR TITLE
feat(protocol-designer): allow selection of gen 2 modules and use formik

### DIFF
--- a/flow-typed/npm/formik_v2.x.x.js
+++ b/flow-typed/npm/formik_v2.x.x.js
@@ -47,7 +47,7 @@ declare module 'formik/@flow-typed' {
     ): void,
     setFieldError(fieldName: $Keys<Values>, message: string): void,
     setFieldTouched(
-      fieldName: $Keys<Values>,
+      fieldName: string,
       isTouched?: boolean,
       shouldValidate?: boolean
     ): void,

--- a/protocol-designer/src/components/DeckSetup/DeckSetup.js
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.js
@@ -119,7 +119,6 @@ export const getSwapBlocked = (args: {
     modulesById,
     customLabwareDefs,
   } = args
-  console.log('hovered ', hoveredLabware, modulesById)
   if (!hoveredLabware || !draggedLabware) {
     return false
   }

--- a/protocol-designer/src/components/modals/FilePipettesModal/FilePipettesModal.css
+++ b/protocol-designer/src/components/modals/FilePipettesModal/FilePipettesModal.css
@@ -31,7 +31,8 @@
 }
 
 .new_file_modal_contents {
-  position: relative;
+  /* override the position relative of default modal style to allow another modal's overlay to take up entire space */
+  position: static;
   border-radius: 0;
   margin: 0;
   height: 100%;

--- a/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.js
@@ -2,27 +2,113 @@
 import * as React from 'react'
 import cx from 'classnames'
 import { CheckboxField, DropdownField, FormGroup } from '@opentrons/components'
+import {
+  MAGNETIC_MODULE_V1,
+  MAGNETIC_MODULE_V2,
+  TEMPERATURE_MODULE_V1,
+  TEMPERATURE_MODULE_V2,
+  THERMOCYCLER_MODULE_V1,
+  type ModuleRealType,
+} from '@opentrons/shared-data'
 import { i18n } from '../../../localization'
 import { DEFAULT_MODEL_FOR_MODULE_TYPE } from '../../../constants'
 import { ModuleDiagram } from '../../modules'
 
 import styles from './FilePipettesModal.css'
 
-import type { ModuleRealType } from '@opentrons/shared-data'
 import type { FormModulesByType } from '../../../step-forms'
 
 type Props = {|
+  // TODO 2020-3-20 use formik typing here after we update the def in flow-typed
+  errors:
+    | null
+    | string
+    | {|
+        magneticModuleType?: {
+          model: string,
+        },
+        temperatureModuleType?: {
+          model: string,
+        },
+        thermocyclerModuleType?: {
+          model: string,
+        },
+      |},
+  touched:
+    | null
+    | boolean
+    | {
+        magneticModuleType?: {
+          model: boolean,
+        },
+        temperatureModuleType?: {
+          model: boolean,
+        },
+        thermocyclerModuleType?: {
+          model: boolean,
+        },
+      },
   values: FormModulesByType,
   thermocyclerEnabled: ?boolean,
-  onFieldChange: (type: ModuleRealType, value: boolean) => mixed,
+  onFieldChange: (
+    event: SyntheticInputEvent<HTMLSelectElement | HTMLInputElement>
+  ) => mixed,
+  onSetFieldValue: (field: string, value: string | null) => void,
+  onSetFieldTouched: (field: string, touched: boolean) => void,
+  onBlur: (event: SyntheticFocusEvent<HTMLSelectElement>) => mixed,
 |}
 
+const moduleOptionNamePrefix = 'modules.model_display_name.'
+const modulesAndModels = {
+  magneticModuleType: [
+    {
+      name: i18n.t(`${moduleOptionNamePrefix}${MAGNETIC_MODULE_V1}`),
+      value: MAGNETIC_MODULE_V1,
+    },
+    {
+      name: i18n.t(`${moduleOptionNamePrefix}${MAGNETIC_MODULE_V2}`),
+      value: MAGNETIC_MODULE_V2,
+    },
+  ],
+  temperatureModuleType: [
+    {
+      name: i18n.t(`${moduleOptionNamePrefix}${TEMPERATURE_MODULE_V1}`),
+      value: TEMPERATURE_MODULE_V1,
+    },
+    {
+      name: i18n.t(`${moduleOptionNamePrefix}${TEMPERATURE_MODULE_V2}`),
+      value: TEMPERATURE_MODULE_V2,
+    },
+  ],
+  thermocyclerModuleType: [
+    {
+      name: i18n.t(`${moduleOptionNamePrefix}${THERMOCYCLER_MODULE_V1}`),
+      value: THERMOCYCLER_MODULE_V1,
+    },
+  ],
+}
+
 export function ModuleFields(props: Props) {
-  const { onFieldChange, values, thermocyclerEnabled } = props
+  const {
+    onFieldChange,
+    onSetFieldValue,
+    onSetFieldTouched,
+    onBlur,
+    values,
+    thermocyclerEnabled,
+    errors,
+    touched,
+  } = props
   const modules = Object.keys(values)
   const handleOnDeckChange = (type: ModuleRealType) => (
     e: SyntheticInputEvent<HTMLInputElement>
-  ) => onFieldChange(type, e.currentTarget.checked || false)
+  ) => {
+    const targetToClear = `modulesByType.${type}.model`
+
+    onFieldChange(e)
+    onSetFieldValue(targetToClear, null)
+    onSetFieldTouched(targetToClear, false)
+  }
 
   const className = cx(styles.modules_row, {
     [styles.hide_thermo]: !thermocyclerEnabled,
@@ -31,37 +117,49 @@ export function ModuleFields(props: Props) {
   return (
     <div className={className}>
       {modules.map((moduleType, i) => {
+        const moduleTypeAccessor = `modulesByType.${moduleType}`
         const label = i18n.t(`modules.module_display_names.${moduleType}`)
         const defaultModel = DEFAULT_MODEL_FOR_MODULE_TYPE[moduleType]
+        const selectedModel = values[moduleType].model
+
         return (
           <div className={styles.module_form_group} key={`${moduleType}`}>
             <CheckboxField
               label={label}
+              name={`${moduleTypeAccessor}.onDeck`}
               value={values[moduleType].onDeck}
               onChange={handleOnDeckChange(moduleType)}
               tabIndex={i}
             />
-            <ModuleDiagram type={moduleType} model={defaultModel} />
-            {/*
-              TODO (ka 2019-10-22): This field is disabled until Gen 2 Modules are available
-              - onChange returns null because onChange is required by DropdownFields
-            */}
+
+            <ModuleDiagram
+              type={moduleType}
+              model={selectedModel ?? defaultModel}
+            />
+
             <div className={styles.module_model}>
               {values[moduleType].onDeck && (
-                <FormGroup label="Model">
+                <FormGroup label="Model*">
                   <DropdownField
+                    error={
+                      // TODO JF 2020-3-19 allow dropdowns to take error
+                      // components from formik so we avoid manually doing this
+                      touched &&
+                      typeof touched !== 'boolean' &&
+                      touched[moduleType] &&
+                      touched[moduleType].model &&
+                      errors !== null &&
+                      typeof errors !== 'string' &&
+                      errors[moduleType]
+                        ? errors[moduleType].model
+                        : null
+                    }
                     tabIndex={i}
-                    options={[
-                      {
-                        name: i18n.t(
-                          `modules.model_display_name.${defaultModel}`
-                        ),
-                        value: defaultModel,
-                      },
-                    ]}
-                    value={defaultModel}
-                    disabled
-                    onChange={() => null}
+                    name={`${moduleTypeAccessor}.model`}
+                    options={modulesAndModels[moduleType]}
+                    value={selectedModel}
+                    onChange={onFieldChange}
+                    onBlur={onBlur}
                   />
                 </FormGroup>
               )}

--- a/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.js
@@ -2,20 +2,16 @@
 import * as React from 'react'
 import cx from 'classnames'
 import { CheckboxField, DropdownField, FormGroup } from '@opentrons/components'
-import {
-  MAGNETIC_MODULE_V1,
-  MAGNETIC_MODULE_V2,
-  TEMPERATURE_MODULE_V1,
-  TEMPERATURE_MODULE_V2,
-  THERMOCYCLER_MODULE_V1,
-  type ModuleRealType,
-} from '@opentrons/shared-data'
 import { i18n } from '../../../localization'
-import { DEFAULT_MODEL_FOR_MODULE_TYPE } from '../../../constants'
+import {
+  DEFAULT_MODEL_FOR_MODULE_TYPE,
+  MODELS_FOR_MODULE_TYPE,
+} from '../../../constants'
 import { ModuleDiagram } from '../../modules'
 
 import styles from './FilePipettesModal.css'
 
+import type { ModuleRealType } from '@opentrons/shared-data'
 import type { FormModulesByType } from '../../../step-forms'
 
 type Props = {|
@@ -57,36 +53,6 @@ type Props = {|
   onSetFieldTouched: (field: string, touched: boolean) => void,
   onBlur: (event: SyntheticFocusEvent<HTMLSelectElement>) => mixed,
 |}
-
-const moduleOptionNamePrefix = 'modules.model_display_name.'
-const modulesAndModels = {
-  magneticModuleType: [
-    {
-      name: i18n.t(`${moduleOptionNamePrefix}${MAGNETIC_MODULE_V1}`),
-      value: MAGNETIC_MODULE_V1,
-    },
-    {
-      name: i18n.t(`${moduleOptionNamePrefix}${MAGNETIC_MODULE_V2}`),
-      value: MAGNETIC_MODULE_V2,
-    },
-  ],
-  temperatureModuleType: [
-    {
-      name: i18n.t(`${moduleOptionNamePrefix}${TEMPERATURE_MODULE_V1}`),
-      value: TEMPERATURE_MODULE_V1,
-    },
-    {
-      name: i18n.t(`${moduleOptionNamePrefix}${TEMPERATURE_MODULE_V2}`),
-      value: TEMPERATURE_MODULE_V2,
-    },
-  ],
-  thermocyclerModuleType: [
-    {
-      name: i18n.t(`${moduleOptionNamePrefix}${THERMOCYCLER_MODULE_V1}`),
-      value: THERMOCYCLER_MODULE_V1,
-    },
-  ],
-}
 
 export function ModuleFields(props: Props) {
   const {
@@ -156,7 +122,7 @@ export function ModuleFields(props: Props) {
                     }
                     tabIndex={i}
                     name={`${moduleTypeAccessor}.model`}
-                    options={modulesAndModels[moduleType]}
+                    options={MODELS_FOR_MODULE_TYPE[moduleType]}
                     value={selectedModel}
                     onChange={onFieldChange}
                     onBlur={onBlur}

--- a/protocol-designer/src/components/modals/FilePipettesModal/__tests__/ModuleFields.test.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/__tests__/ModuleFields.test.js
@@ -1,0 +1,148 @@
+// @flow
+
+import React from 'react'
+import { shallow } from 'enzyme'
+import {
+  MAGNETIC_MODULE_V2,
+  THERMOCYCLER_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  MAGNETIC_MODULE_TYPE,
+} from '@opentrons/shared-data'
+import { CheckboxField } from '@opentrons/components'
+import { DEFAULT_MODEL_FOR_MODULE_TYPE } from '../../../../constants'
+import { ModuleDiagram } from '../../../modules'
+import { ModuleFields } from '../ModuleFields'
+
+describe('ModuleFields', () => {
+  let magnetModuleOnDeck,
+    temperatureModuleNotOnDeck,
+    thermocyclerModuleNotOnDeck,
+    props
+  beforeEach(() => {
+    magnetModuleOnDeck = {
+      onDeck: true,
+      slot: '1',
+      model: MAGNETIC_MODULE_V2,
+    }
+    temperatureModuleNotOnDeck = {
+      onDeck: false,
+      slot: '2',
+      model: null,
+    }
+    thermocyclerModuleNotOnDeck = {
+      onDeck: false,
+      slot: '9',
+      model: null,
+    }
+
+    props = {
+      values: {
+        [MAGNETIC_MODULE_TYPE]: magnetModuleOnDeck,
+        [TEMPERATURE_MODULE_TYPE]: temperatureModuleNotOnDeck,
+        [THERMOCYCLER_MODULE_TYPE]: thermocyclerModuleNotOnDeck,
+      },
+      thermocyclerEnabled: false,
+      onFieldChange: jest.fn(),
+      onSetFieldValue: jest.fn(),
+      onSetFieldTouched: jest.fn(),
+      onBlur: jest.fn(),
+      touched: null,
+      errors: null,
+    }
+  })
+  it('renders a module selection element for every module', () => {
+    const wrapper = shallow(<ModuleFields {...props} />)
+
+    expect(wrapper.find(CheckboxField)).toHaveLength(3)
+  })
+
+  it('adds module to protocol when checkbox is selected and resets the model field', () => {
+    const checkboxTargetName = `modulesByType.${TEMPERATURE_MODULE_TYPE}.onDeck`
+    const targetToClear = `modulesByType.${TEMPERATURE_MODULE_TYPE}.model`
+    const expectedEvent = {
+      target: {
+        name: checkboxTargetName,
+        value: true,
+      },
+    }
+
+    const wrapper = shallow(<ModuleFields {...props} />)
+    const temperatureSelectChange = wrapper
+      .find({ name: checkboxTargetName })
+      .prop('onChange')
+    temperatureSelectChange(expectedEvent)
+
+    expect(props.onFieldChange).toHaveBeenCalledWith(expectedEvent)
+    expect(props.onSetFieldValue).toHaveBeenCalledWith(targetToClear, null)
+    expect(props.onSetFieldTouched).toHaveBeenCalledWith(targetToClear, false)
+  })
+
+  it('displays model select when module is selected and selects the model for the module', () => {
+    const magnetModelName = `modulesByType.${MAGNETIC_MODULE_TYPE}.model`
+    const expectedEvent = {
+      target: {
+        name: magnetModelName,
+        value: MAGNETIC_MODULE_V2,
+      },
+    }
+
+    const wrapper = shallow(<ModuleFields {...props} />)
+    const magnetModelSelect = wrapper.find({
+      name: magnetModelName,
+    })
+    magnetModelSelect.prop('onChange')(expectedEvent)
+
+    expect(magnetModelSelect).toHaveLength(1)
+    expect(props.onFieldChange).toHaveBeenCalledWith(expectedEvent)
+  })
+
+  it('displays an error for model select when select has been touched but no selection was made', () => {
+    const propsWithErrors = {
+      ...props,
+      touched: {
+        [MAGNETIC_MODULE_TYPE]: {
+          model: true,
+        },
+      },
+      errors: {
+        [MAGNETIC_MODULE_TYPE]: {
+          model: 'required',
+        },
+      },
+    }
+    const magnetModelSelectName = `modulesByType.${MAGNETIC_MODULE_TYPE}.model`
+
+    const wrapper = shallow(<ModuleFields {...propsWithErrors} />)
+    const magnetModelSelect = wrapper.find({ name: magnetModelSelectName })
+
+    expect(magnetModelSelect.prop('error')).toEqual('required')
+  })
+
+  it('displays a default module img when no model has been selected', () => {
+    const wrapper = shallow(<ModuleFields {...props} />)
+    const temperatureModuleDiagramProps = wrapper
+      .find(ModuleDiagram)
+      .filter({ type: TEMPERATURE_MODULE_TYPE })
+      .props()
+
+    expect(temperatureModuleDiagramProps).toEqual({
+      type: TEMPERATURE_MODULE_TYPE,
+      model: DEFAULT_MODEL_FOR_MODULE_TYPE[TEMPERATURE_MODULE_TYPE],
+    })
+  })
+
+  it('displays specific module img when model has been selected', () => {
+    props.values[MAGNETIC_MODULE_TYPE].model = MAGNETIC_MODULE_V2
+
+    const wrapper = shallow(<ModuleFields {...props} />)
+    const magnetModuleDiagramProps = wrapper
+      .find(ModuleDiagram)
+      .filter({ type: MAGNETIC_MODULE_TYPE })
+      .props()
+
+    expect(magnetModuleDiagramProps).toEqual({
+      type: MAGNETIC_MODULE_TYPE,
+      model: MAGNETIC_MODULE_V2,
+    })
+  })
+})

--- a/protocol-designer/src/components/modals/FilePipettesModal/__tests__/PipetteFields.test.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/__tests__/PipetteFields.test.js
@@ -1,0 +1,179 @@
+// @flow
+
+import React from 'react'
+import { Provider } from 'react-redux'
+import { mount } from 'enzyme'
+import { PipetteSelect, DropdownField } from '@opentrons/components'
+import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_300_ul.json'
+import fixture_tiprack_1000_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_1000_ul.json'
+import { getEnableMultiGEN2Pipettes } from '../../../../feature-flags/selectors'
+import { getOnlyLatestDefs } from '../../../../labware-defs/utils'
+import { PipetteFields } from '../PipetteFields'
+import { TiprackDiagram } from '../TiprackDiagram'
+import { PipetteDiagram } from '../PipetteDiagram'
+
+import type { LabwareDefByDefURI } from '../../../../labware-defs'
+import type { BaseState } from '../../../../types'
+
+jest.mock('../../../../feature-flags/selectors')
+jest.mock('../../../../labware-defs/utils.js')
+jest.mock('../TiprackDiagram')
+
+const getEnableMultiGEN2PipettesMock: JestMockFn<
+  [BaseState],
+  ?boolean
+> = getEnableMultiGEN2Pipettes
+const getOnlyLatestDefsMock: JestMockFn<
+  [],
+  LabwareDefByDefURI
+> = getOnlyLatestDefs
+
+describe('PipetteFields', () => {
+  const leftPipetteKey = 'pipettesByMount.left'
+  const leftTiprackKey = `${leftPipetteKey}.tiprackDefURI`
+  const leftPipetteName = `${leftPipetteKey}.pipetteName`
+  const rightPipetteKey = 'pipettesByMount.left'
+  const rightTiprackKey = `${rightPipetteKey}.tiprackDefURI`
+  const unselectedPipette = {
+    pipetteName: '',
+    tiprackDefURI: '',
+  }
+
+  let props, leftPipette, rightPipette, store
+  beforeEach(() => {
+    store = {
+      dispatch: jest.fn(),
+      subscribe: jest.fn(),
+      getState: () => ({}),
+    }
+
+    leftPipette = {
+      pipetteName: 'p300',
+      tiprackDefURI: 'tiprack_300',
+    }
+    rightPipette = {
+      pipetteName: 'p1000',
+      tiprackDefURI: 'tiprack_1000',
+    }
+    props = {
+      onFieldChange: jest.fn(),
+      onSetFieldValue: jest.fn(),
+      onSetFieldTouched: jest.fn(),
+      onBlur: jest.fn(),
+      initialTabIndex: 1,
+      values: {
+        left: leftPipette,
+        right: rightPipette,
+      },
+      errors: null,
+      touched: null,
+    }
+
+    getEnableMultiGEN2PipettesMock.mockReturnValue(true)
+    getOnlyLatestDefsMock.mockReturnValue({
+      tiprack_300: fixture_tiprack_300_ul,
+      tiprack_1000: fixture_tiprack_1000_ul,
+    })
+  })
+
+  function render(props) {
+    return mount(
+      <Provider store={store}>
+        <PipetteFields {...props} />
+      </Provider>
+    )
+  }
+
+  it('renders a selection for left and right pipette with disabled tiprack select', () => {
+    props.values.left = unselectedPipette
+    props.values.right = unselectedPipette
+
+    const wrapper = render(props)
+
+    expect(wrapper.find(PipetteSelect)).toHaveLength(2)
+    expect(
+      wrapper
+        .find(DropdownField)
+        .filter({ name: leftTiprackKey })
+        .prop('disabled')
+    ).toBe(true)
+    expect(
+      wrapper
+        .find(DropdownField)
+        .filter({ name: rightTiprackKey })
+        .prop('disabled')
+    ).toBe(true)
+  })
+
+  it('selects a pipette and clears tiprack fields that has been touched', () => {
+    props.values.left = unselectedPipette
+
+    const wrapper = render(props)
+    const leftPipette = wrapper.find(PipetteSelect).at(0)
+
+    leftPipette.prop('onPipetteChange')('p50')
+
+    expect(props.onSetFieldTouched).toHaveBeenCalledWith(leftTiprackKey, false)
+    expect(props.onSetFieldValue.mock.calls).toEqual([
+      [leftPipetteName, 'p50'],
+      [leftTiprackKey, null],
+    ])
+  })
+
+  it('undisables tiprack selection when a pipette is selected', () => {
+    props.values.left.tiprackDefURI = ''
+
+    const wrapper = render(props)
+
+    expect(
+      wrapper
+        .find(DropdownField)
+        .filter({ name: leftTiprackKey })
+        .prop('disabled')
+    ).toBe(false)
+  })
+
+  it('selects a tiprack for the pipette', () => {
+    props.values.left.tiprackDefURI = ''
+    const event = {
+      target: {
+        name: leftTiprackKey,
+        value: 'tiprack_300',
+      },
+    }
+
+    const wrapper = render(props)
+    const leftTiprackSelect = wrapper
+      .find(DropdownField)
+      .filter({ name: leftTiprackKey })
+    leftTiprackSelect.prop('onChange')(event)
+
+    expect(props.onFieldChange).toHaveBeenCalledWith(event)
+  })
+
+  it('renders tiprack diagrams for selected tipracks', () => {
+    props.values.left = unselectedPipette
+
+    const wrapper = render(props)
+    const tiprackDiagrams = wrapper.find(TiprackDiagram)
+
+    expect(tiprackDiagrams).toHaveLength(2)
+    expect(tiprackDiagrams.at(0).props()).toEqual({
+      definitionURI: '',
+    })
+    expect(tiprackDiagrams.at(1).props()).toEqual({
+      definitionURI: 'tiprack_1000',
+    })
+  })
+
+  it('displays pipette diagrams for selected pipettes', () => {
+    const wrapper = render(props)
+    const pipetteDiagram = wrapper.find(PipetteDiagram)
+
+    expect(pipetteDiagram).toHaveLength(1)
+    expect(pipetteDiagram.props()).toEqual({
+      leftPipette: leftPipette.pipetteName,
+      rightPipette: rightPipette.pipetteName,
+    })
+  })
+})

--- a/protocol-designer/src/components/modals/FilePipettesModal/__tests__/index.test.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/__tests__/index.test.js
@@ -143,19 +143,37 @@ describe('FilePipettesModal', () => {
       expect(saveButton.prop('disabled')).toBe(true)
     })
 
-    it('is not disabled when pipette is selected', () => {
+    it('is not disabled when pipette is selected', async () => {
       props.initialPipetteValues = initialPipetteValues
+      props.initialModuleValues = initialModuleValues
 
-      const wrapper = shallow(<FilePipettesModal {...props} />)
-        .find(Formik)
-        .dive()
+      const wrapper = renderFormComponent(props)
       const saveButton = wrapper
         .find(OutlineButton)
         .filterWhere(n => n.render().text() === 'save')
-
+      saveButton.simulate('click')
       // issue #823 in enzyme where simulate events are sync so we cannot test
-      // the btn click -> component handleSubmit properly here
+      // the btn click -> component handleSubmit properly here since formik submit is async
+      await new Promise(resolve => setTimeout(resolve, 0))
+
       expect(saveButton.prop('disabled')).toBe(false)
+      expect(props.onSave).toHaveBeenCalledWith({
+        modules: [
+          {
+            type: MAGNETIC_MODULE_TYPE,
+            model: MAGNETIC_MODULE_V1,
+            slot: initialModuleValues[MAGNETIC_MODULE_TYPE].slot,
+          },
+        ],
+        newProtocolFields: { name: '' },
+        pipettes: [
+          {
+            mount: 'left',
+            name: initialPipetteValues.left.pipetteName,
+            tiprackDefURI: initialPipetteValues.left.tiprackDefURI,
+          },
+        ],
+      })
     })
 
     it('closes the modal when clicking cancel button', () => {

--- a/protocol-designer/src/components/modals/FilePipettesModal/__tests__/index.test.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/__tests__/index.test.js
@@ -1,0 +1,279 @@
+// @flow
+
+import React from 'react'
+import { Formik } from 'formik'
+import { shallow } from 'enzyme'
+import {
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+  MAGNETIC_MODULE_V1,
+  MAGNETIC_MODULE_V2,
+} from '@opentrons/shared-data'
+import { Modal, InputField, OutlineButton } from '@opentrons/components'
+import { i18n } from '../../../../localization'
+import { CrashInfoBox } from '../../../modules'
+import { StepChangesConfirmModal } from '../../EditPipettesModal/StepChangesConfirmModal'
+import { PipetteFields } from '../PipetteFields'
+import { ModuleFields } from '../ModuleFields'
+import { FilePipettesModal, type Props } from '../'
+
+describe('FilePipettesModal', () => {
+  const tiprackDefURI = 'tiprack_300'
+  let props: Props, initialPipetteValues, initialModuleValues
+  beforeEach(() => {
+    initialPipetteValues = {
+      left: {
+        pipetteName: 'p300',
+        tiprackDefURI,
+      },
+      right: {
+        pipetteName: '',
+        tiprackDefURI: null,
+      },
+    }
+
+    initialModuleValues = {
+      [MAGNETIC_MODULE_TYPE]: {
+        onDeck: true,
+        slot: '1',
+        model: MAGNETIC_MODULE_V1,
+      },
+      [TEMPERATURE_MODULE_TYPE]: {
+        onDeck: false,
+        slot: '',
+        model: null,
+      },
+      [THERMOCYCLER_MODULE_TYPE]: {
+        onDeck: false,
+        slot: '',
+        model: null,
+      },
+    }
+
+    props = {
+      showProtocolFields: true,
+      showModulesFields: true,
+      hideModal: false,
+      onCancel: jest.fn(),
+      onSave: jest.fn(),
+      modulesEnabled: true,
+      thermocyclerEnabled: true,
+    }
+  })
+
+  function renderFormComponent(props) {
+    return shallow(<FilePipettesModal {...props} />)
+      .find(Formik)
+      .dive()
+  }
+
+  it('does not display modal when hideModal prop', () => {
+    props.hideModal = true
+
+    const wrapper = shallow(<FilePipettesModal {...props} />)
+
+    expect(wrapper.find(Modal)).toHaveLength(0)
+  })
+
+  describe('rendered fields', () => {
+    it('renders InputField with name and default value', () => {
+      const form = renderFormComponent(props)
+      const protocolNameField = form.find(InputField)
+
+      expect(protocolNameField.prop('name')).toEqual('fields.name')
+      expect(protocolNameField.prop('value')).toEqual('')
+    })
+
+    it('renders PipetteFields with props', () => {
+      const pipetteFields = renderFormComponent(props).find(PipetteFields)
+
+      expect(pipetteFields.prop('values')).toEqual({
+        left: { pipetteName: '', tiprackDefURI: null },
+        right: { pipetteName: '', tiprackDefURI: null },
+      })
+      expect(pipetteFields.prop('errors')).toBeNull()
+      expect(pipetteFields.prop('touched')).toBeNull()
+    })
+
+    it('does not render ModuleFields when modules are not enabled', () => {
+      props.modulesEnabled = false
+
+      const moduleFields = renderFormComponent(props).find(ModuleFields)
+
+      expect(moduleFields).toHaveLength(0)
+    })
+
+    it('does not render ModuleFields when editing pipettes and showModulesFields is false', () => {
+      props.showModulesFields = false
+
+      const moduleFields = renderFormComponent(props).find(ModuleFields)
+
+      expect(moduleFields).toHaveLength(0)
+    })
+
+    it('renders ModuleFields with props when modules are enabled', () => {
+      const moduleFields = renderFormComponent(props).find(ModuleFields)
+
+      expect(moduleFields).toHaveLength(1)
+      expect(moduleFields.prop('errors')).toBeNull()
+      expect(moduleFields.prop('touched')).toBeNull()
+    })
+
+    it('renders fields with values from props when exists', () => {
+      props.initialPipetteValues = initialPipetteValues
+      props.initialModuleValues = initialModuleValues
+
+      const wrapper = renderFormComponent(props)
+      const moduleFields = wrapper.find(ModuleFields)
+      const pipetteFields = wrapper.find(PipetteFields)
+
+      expect(moduleFields.prop('values')).toEqual(props.initialModuleValues)
+      expect(moduleFields.prop('thermocyclerEnabled')).toBe(true)
+      expect(pipetteFields.prop('values')).toEqual(props.initialPipetteValues)
+    })
+  })
+
+  describe('form buttons', () => {
+    it('does not allow save btn to be clicked when no pipette selected', () => {
+      const saveButton = renderFormComponent(props)
+        .find(OutlineButton)
+        .filterWhere(n => n.render().text() === 'save')
+
+      expect(saveButton.prop('disabled')).toBe(true)
+    })
+
+    it('is not disabled when pipette is selected', () => {
+      props.initialPipetteValues = initialPipetteValues
+
+      const wrapper = shallow(<FilePipettesModal {...props} />)
+        .find(Formik)
+        .dive()
+      const saveButton = wrapper
+        .find(OutlineButton)
+        .filterWhere(n => n.render().text() === 'save')
+
+      // issue #823 in enzyme where simulate events are sync so we cannot test
+      // the btn click -> component handleSubmit properly here
+      expect(saveButton.prop('disabled')).toBe(false)
+    })
+
+    it('closes the modal when clicking cancel button', () => {
+      const cancel = renderFormComponent(props)
+        .find(OutlineButton)
+        .filterWhere(n => n.render().text() === 'cancel')
+      cancel.simulate('click')
+
+      expect(props.onCancel).toHaveBeenCalled()
+    })
+  })
+
+  describe('step changes confirm modal', () => {
+    it('displays edit confirmation when editing pipettes', () => {
+      const wrapper = shallow(<FilePipettesModal {...props} />)
+      wrapper.setState({
+        showEditPipetteConfirmation: true,
+      })
+
+      expect(
+        wrapper
+          .find(Formik)
+          .dive()
+          .find(StepChangesConfirmModal)
+      ).toHaveLength(1)
+    })
+
+    it('does not display edit confirmation when new protocol', () => {
+      expect(
+        renderFormComponent(props).find(StepChangesConfirmModal)
+      ).toHaveLength(0)
+    })
+  })
+
+  describe('render', () => {
+    const crashableMagnet = {
+      onDeck: true,
+      slot: '1',
+      model: MAGNETIC_MODULE_V1,
+    }
+    const nonCrashableMagnet = {
+      onDeck: true,
+      slot: '1',
+      model: MAGNETIC_MODULE_V2,
+    }
+    const crashablePipette = {
+      pipetteName: 'p300_multi',
+      tiprackDefURI,
+    }
+    const noncrashablePipette = {
+      pipetteName: 'p300',
+      tiprackDefURI,
+    }
+
+    it('displays crash info box when crashable modules used with crashable pipettes', () => {
+      initialModuleValues[MAGNETIC_MODULE_TYPE] = crashableMagnet
+      props.initialModuleValues = initialModuleValues
+      initialPipetteValues.left = crashablePipette
+      props.initialPipetteValues = initialPipetteValues
+
+      const wrapper = renderFormComponent(props)
+
+      expect(wrapper.find(CrashInfoBox)).toHaveLength(1)
+    })
+
+    it('does not display crash info when noncrashable modules used with crashable pipettes', () => {
+      initialPipetteValues.left = crashablePipette
+      props.initialPipetteValues = initialPipetteValues
+      initialModuleValues[MAGNETIC_MODULE_TYPE] = nonCrashableMagnet
+      props.initialModuleValues = initialModuleValues
+
+      const wrapper = renderFormComponent(props)
+
+      expect(wrapper.find(CrashInfoBox)).toHaveLength(0)
+    })
+
+    it('does not display crash info when noncrashable pipettes', () => {
+      initialPipetteValues.left = noncrashablePipette
+      initialModuleValues[MAGNETIC_MODULE_TYPE] = crashableMagnet
+
+      props.initialPipetteValues = initialPipetteValues
+      props.initialModuleValues = initialModuleValues
+
+      const wrapper = renderFormComponent(props)
+
+      expect(wrapper.find(CrashInfoBox)).toHaveLength(0)
+    })
+
+    it('displays heading for new protocol when creating new protocol', () => {
+      props.showProtocolFields = true
+
+      const wrapper = shallow(<FilePipettesModal {...props} />)
+        .find(Formik)
+        .dive()
+      const newProtocolHeader = wrapper
+        .find('h2')
+        .filterWhere(
+          n =>
+            n.render().text() ===
+            i18n.t('modal.new_protocol.title.PROTOCOL_FILE')
+        )
+
+      expect(newProtocolHeader).toHaveLength(1)
+    })
+
+    it('displays edit pipettes title when editing pipettes', () => {
+      props.showProtocolFields = false
+
+      const wrapper = shallow(<FilePipettesModal {...props} />)
+        .find(Formik)
+        .dive()
+      const editPipettesHeader = wrapper
+        .find('h2')
+        .filterWhere(
+          n => n.render().text() === i18n.t('modal.edit_pipettes.title')
+        )
+
+      expect(editPipettesHeader).toHaveLength(1)
+    })
+  })
+})

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.js
@@ -23,7 +23,7 @@ import { SPAN7_8_10_11_SLOT } from '../../../constants'
 import { StepChangesConfirmModal } from '../EditPipettesModal/StepChangesConfirmModal'
 import { ModuleFields } from './ModuleFields'
 import { PipetteFields } from './PipetteFields'
-import { CrashInfoBox } from '../../modules'
+import { CrashInfoBox, isModuleWithCollisionIssue } from '../../modules'
 import styles from './FilePipettesModal.css'
 import formStyles from '../../forms/forms.css'
 import modalStyles from '../modal.css'
@@ -34,12 +34,10 @@ import type {
   PipetteOnDeck,
   FormPipette,
   FormPipettesByMount,
-  // FormModule,
   FormModulesByType,
 } from '../../../step-forms'
 import type { FormikProps } from 'formik/@flow-typed'
 
-import { isModuleWithCollisionIssue } from '../../modules/utils'
 type PipetteFieldsData = $Diff<
   PipetteOnDeck,
   {| id: mixed, spec: mixed, tiprackLabwareDef: mixed |}
@@ -275,7 +273,6 @@ export class FilePipettesModal extends React.Component<Props, State> {
                   touched,
                   values,
                   handleBlur,
-                  setValues,
                   setFieldTouched,
                 }: FormikProps<FormState>) => {
                   const { left, right } = values.pipettesByMount

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.js
@@ -4,21 +4,19 @@ import reduce from 'lodash/reduce'
 import omit from 'lodash/omit'
 import * as React from 'react'
 import cx from 'classnames'
+import { Formik } from 'formik'
+import * as Yup from 'yup'
 import { getIsCrashablePipetteSelected } from '../../../step-forms'
 import {
   Modal,
   FormGroup,
   InputField,
   OutlineButton,
-  type Mount,
 } from '@opentrons/components'
 import {
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
-  MAGNETIC_MODULE_V1,
-  TEMPERATURE_MODULE_V1,
-  THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
 import { i18n } from '../../../localization'
 import { SPAN7_8_10_11_SLOT } from '../../../constants'
@@ -36,10 +34,12 @@ import type {
   PipetteOnDeck,
   FormPipette,
   FormPipettesByMount,
-  FormModule,
+  // FormModule,
   FormModulesByType,
 } from '../../../step-forms'
+import type { FormikProps } from 'formik/@flow-typed'
 
+import { isModuleWithCollisionIssue } from '../../modules/utils'
 type PipetteFieldsData = $Diff<
   PipetteOnDeck,
   {| id: mixed, spec: mixed, tiprackLabwareDef: mixed |}
@@ -51,20 +51,23 @@ type ModuleCreationArgs = {|
   slot: DeckSlot,
 |}
 
-type State = {|
+type FormState = {|
   fields: NewProtocolFields,
   pipettesByMount: FormPipettesByMount,
-  showEditPipetteConfirmation: boolean,
   modulesByType: FormModulesByType,
 |}
 
-type Props = {|
+type State = {|
+  showEditPipetteConfirmation: boolean,
+|}
+
+export type Props = {|
   showProtocolFields?: ?boolean,
   showModulesFields?: ?boolean,
   hideModal?: boolean,
   onCancel: () => mixed,
-  initialPipetteValues?: $PropertyType<State, 'pipettesByMount'>,
-  initialModuleValues?: $PropertyType<State, 'modulesByType'>,
+  initialPipetteValues?: $PropertyType<FormState, 'pipettesByMount'>,
+  initialModuleValues?: $PropertyType<FormState, 'modulesByType'>,
   onSave: ({|
     newProtocolFields: NewProtocolFields,
     pipettes: Array<PipetteFieldsData>,
@@ -74,9 +77,8 @@ type Props = {|
   thermocyclerEnabled: ?boolean,
 |}
 
-const initialState: State = {
+const initialFormState: FormState = {
   fields: { name: '' },
-  showEditPipetteConfirmation: false,
   pipettesByMount: {
     left: { pipetteName: '', tiprackDefURI: null },
     right: { pipetteName: '', tiprackDefURI: null },
@@ -84,94 +86,102 @@ const initialState: State = {
   modulesByType: {
     [MAGNETIC_MODULE_TYPE]: {
       onDeck: false,
-      model: MAGNETIC_MODULE_V1,
+      model: null,
       slot: '1',
     },
     [TEMPERATURE_MODULE_TYPE]: {
       onDeck: false,
-      model: TEMPERATURE_MODULE_V1,
+      model: null,
       slot: '3',
     },
     [THERMOCYCLER_MODULE_TYPE]: {
       onDeck: false,
-      model: THERMOCYCLER_MODULE_V1,
+      model: null,
       slot: SPAN7_8_10_11_SLOT,
     },
   },
 }
 
+const pipetteValidationShape = Yup.object().shape({
+  pipetteName: Yup.string().nullable(),
+  tiprackDefURI: Yup.string()
+    .nullable()
+    .when('pipetteName', {
+      is: val => Boolean(val),
+      then: Yup.string().required('Required'),
+      otherwise: null,
+    }),
+})
+const moduleValidationShape = Yup.object().shape({
+  onDeck: Yup.boolean().default(false),
+  model: Yup.string()
+    .nullable()
+    .when('onDeck', {
+      is: true,
+      then: Yup.string().required('Required'),
+      otherwise: null,
+    }),
+  slot: Yup.string(),
+})
+
+const validationSchema = Yup.object().shape({
+  fields: Yup.object().shape({
+    name: Yup.string(),
+  }),
+  pipettesByMount: Yup.object()
+    .shape({
+      left: pipetteValidationShape,
+      right: pipetteValidationShape,
+    })
+    .test('pipette-is-required', 'a pipette is required', value =>
+      Object.keys(value).some(val => value[val].pipetteName)
+    ),
+  modulesByType: Yup.object().shape({
+    [MAGNETIC_MODULE_TYPE]: moduleValidationShape,
+    [TEMPERATURE_MODULE_TYPE]: moduleValidationShape,
+    [THERMOCYCLER_MODULE_TYPE]: moduleValidationShape,
+  }),
+})
+
 // TODO: Ian 2019-03-15 use i18n for labels
 export class FilePipettesModal extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
+
     this.state = {
-      ...initialState,
-      pipettesByMount: {
-        ...initialState.pipettesByMount,
-        ...props.initialPipetteValues,
-      },
-      modulesByType: {
-        ...initialState.modulesByType,
-        ...props.initialModuleValues,
-      },
+      showEditPipetteConfirmation: false,
     }
   }
 
   componentDidUpdate(prevProps: Props) {
-    // reset form state when modal is hidden
     if (!prevProps.hideModal && this.props.hideModal)
-      this.setState(initialState)
+      this.setState({ showEditPipetteConfirmation: false })
   }
 
-  getCrashableModuleSelected = (modules: FormModulesByType) => {
-    return (
-      modules[MAGNETIC_MODULE_TYPE].onDeck ||
-      modules[TEMPERATURE_MODULE_TYPE].onDeck
-    )
-  }
-
-  handlePipetteFieldsChange = (
-    mount: Mount,
-    fieldName: $Keys<FormPipette>,
-    value: string | null
+  getCrashableModuleSelected = (
+    modules: FormModulesByType,
+    moduleType: ModuleRealType
   ) => {
-    let nextMountState: $Shape<FormPipette> = {}
-    nextMountState[fieldName] = value
-    if (fieldName === 'pipetteName') {
-      nextMountState.tiprackDefURI = null
-    }
+    const module = modules[moduleType]
+    const crashableModuleOnDeck =
+      module.onDeck && module.model
+        ? isModuleWithCollisionIssue(module.model)
+        : false
 
-    // TODO(IL, 2020-02-24): consider using an immutable type to this.state
-    // to make this less precarious, see #5073
-    const stateUpdate = { pipettesByMount: { ...this.state.pipettesByMount } }
-    stateUpdate.pipettesByMount[mount] = {
-      ...this.state.pipettesByMount[mount],
-      ...nextMountState,
-    }
-
-    this.setState(stateUpdate)
+    return crashableModuleOnDeck
   }
 
-  handleModuleOnDeckChange = (type: ModuleRealType, value: boolean) => {
-    let nextMountState: $Shape<FormModule> = { onDeck: value }
+  handleSubmit = (values: FormState) => {
+    const { showProtocolFields } = this.props
+    const { showEditPipetteConfirmation } = this.state
 
-    // TODO(IL, 2020-02-24): consider using an immutable type to this.state
-    // to make this less precarious, see #5073
-    const stateUpdate = { modulesByType: { ...this.state.modulesByType } }
-    stateUpdate.modulesByType[type] = {
-      ...this.state.modulesByType[type],
-      ...nextMountState,
+    if (!showProtocolFields && !showEditPipetteConfirmation) {
+      return this.showEditPipetteConfirmationModal()
     }
-    this.setState(stateUpdate)
-  }
 
-  handleNameChange = (e: SyntheticInputEvent<*>) =>
-    this.setState({ fields: { ...this.state.fields, name: e.target.value } })
-
-  handleSubmit = () => {
-    const newProtocolFields = this.state.fields
+    const newProtocolFields = values.fields
     const pipettes = reduce(
-      this.state.pipettesByMount,
+      values.pipettesByMount,
       (acc, formPipette: FormPipette, mount): Array<PipetteFieldsData> => {
         assert(mount === 'left' || mount === 'right', `invalid mount: ${mount}`) // this is mostly for flow
         return formPipette &&
@@ -193,16 +203,18 @@ export class FilePipettesModal extends React.Component<Props, State> {
 
     // NOTE: this is extra-explicit for flow. Reduce fns won't cooperate
     // with enum-typed key like `{[ModuleRealType]: ___}`
-    const moduleTypes: Array<ModuleRealType> = Object.keys(
-      this.state.modulesByType
-    )
+    const moduleTypes: Array<ModuleRealType> = Object.keys(values.modulesByType)
     const modules: Array<ModuleCreationArgs> = moduleTypes.reduce(
       (acc, moduleType) => {
-        const module = this.state.modulesByType[moduleType]
+        const module = values.modulesByType[moduleType]
         return module?.onDeck
           ? [
               ...acc,
-              { type: moduleType, model: module.model, slot: module.slot },
+              {
+                type: moduleType,
+                model: module.model || '',
+                slot: module.slot,
+              },
             ]
           : acc
       },
@@ -219,31 +231,23 @@ export class FilePipettesModal extends React.Component<Props, State> {
     this.setState({ showEditPipetteConfirmation: false })
   }
 
+  getInitialValues = () => {
+    return {
+      ...initialFormState,
+      pipettesByMount: {
+        ...initialFormState.pipettesByMount,
+        ...this.props.initialPipetteValues,
+      },
+      modulesByType: {
+        ...initialFormState.modulesByType,
+        ...this.props.initialModuleValues,
+      },
+    }
+  }
+
   render() {
     if (this.props.hideModal) return null
     const { showProtocolFields } = this.props
-
-    const { name } = this.state.fields
-    const { left, right } = this.state.pipettesByMount
-
-    const pipetteSelectionIsValid =
-      // at least one must not be none (empty string)
-      left.pipetteName || right.pipetteName
-
-    // if pipette selected, corresponding tiprack type also selected
-    const tiprackSelectionIsValid =
-      (left.pipetteName ? Boolean(left.tiprackDefURI) : true) &&
-      (right.pipetteName ? Boolean(right.tiprackDefURI) : true)
-
-    const canSubmit = pipetteSelectionIsValid && tiprackSelectionIsValid
-
-    const showCrashInfoBox =
-      getIsCrashablePipetteSelected(this.state.pipettesByMount) &&
-      this.getCrashableModuleSelected(this.state.modulesByType)
-
-    const visibleModules = this.props.thermocyclerEnabled
-      ? this.state.modulesByType
-      : omit(this.state.modulesByType, THERMOCYCLER_MODULE_TYPE)
 
     return (
       <React.Fragment>
@@ -256,98 +260,156 @@ export class FilePipettesModal extends React.Component<Props, State> {
         >
           <div className={modalStyles.scrollable_modal_wrapper}>
             <div className={modalStyles.scrollable_modal_scroll}>
-              <form
-                onSubmit={() => {
-                  canSubmit && this.handleSubmit()
-                }}
+              <Formik
+                enableReinitialize
+                initialValues={this.getInitialValues()}
+                onSubmit={this.handleSubmit}
+                validationSchema={validationSchema}
+                validateOnChange={false}
               >
-                {showProtocolFields && (
-                  <div className={styles.protocol_file_group}>
-                    <h2 className={styles.new_file_modal_title}>
-                      {i18n.t('modal.new_protocol.title.PROTOCOL_FILE')}
-                    </h2>
-                    <FormGroup className={formStyles.stacked_row} label="Name">
-                      <InputField
-                        autoFocus
-                        tabIndex={1}
-                        placeholder={i18n.t(
-                          'form.generic.default_protocol_name'
+                {({
+                  handleChange,
+                  handleSubmit,
+                  errors,
+                  setFieldValue,
+                  touched,
+                  values,
+                  handleBlur,
+                  setValues,
+                  setFieldTouched,
+                }: FormikProps<FormState>) => {
+                  const { left, right } = values.pipettesByMount
+
+                  const pipetteSelectionIsValid =
+                    // at least one must not be none (empty string)
+                    left.pipetteName || right.pipetteName
+
+                  const hasCrashableMagnetModuleSelected = this.getCrashableModuleSelected(
+                    values.modulesByType,
+                    MAGNETIC_MODULE_TYPE
+                  )
+                  const hasCrashableTemperatureModuleSelected = this.getCrashableModuleSelected(
+                    values.modulesByType,
+                    TEMPERATURE_MODULE_TYPE
+                  )
+                  const showCrashInfoBox =
+                    getIsCrashablePipetteSelected(values.pipettesByMount) &&
+                    (hasCrashableMagnetModuleSelected ||
+                      hasCrashableTemperatureModuleSelected)
+
+                  const visibleModules = this.props.thermocyclerEnabled
+                    ? values.modulesByType
+                    : omit(values.modulesByType, THERMOCYCLER_MODULE_TYPE)
+
+                  return (
+                    <>
+                      <form onSubmit={handleSubmit}>
+                        {showProtocolFields && (
+                          <div className={styles.protocol_file_group}>
+                            <h2 className={styles.new_file_modal_title}>
+                              {i18n.t('modal.new_protocol.title.PROTOCOL_FILE')}
+                            </h2>
+                            <FormGroup
+                              className={formStyles.stacked_row}
+                              label="Name"
+                            >
+                              <InputField
+                                autoFocus
+                                tabIndex={1}
+                                placeholder={i18n.t(
+                                  'form.generic.default_protocol_name'
+                                )}
+                                name="fields.name"
+                                value={values.fields.name}
+                                onChange={handleChange}
+                                onBlur={handleBlur}
+                              />
+                            </FormGroup>
+                          </div>
                         )}
-                        value={name}
-                        onChange={this.handleNameChange}
-                      />
-                    </FormGroup>
-                  </div>
-                )}
 
-                <h2 className={styles.new_file_modal_title}>
-                  {showProtocolFields
-                    ? i18n.t('modal.new_protocol.title.PROTOCOL_PIPETTES')
-                    : i18n.t('modal.edit_pipettes.title')}
-                </h2>
+                        <h2 className={styles.new_file_modal_title}>
+                          {showProtocolFields
+                            ? i18n.t(
+                                'modal.new_protocol.title.PROTOCOL_PIPETTES'
+                              )
+                            : i18n.t('modal.edit_pipettes.title')}
+                        </h2>
 
-                <PipetteFields
-                  initialTabIndex={1}
-                  values={this.state.pipettesByMount}
-                  onFieldChange={this.handlePipetteFieldsChange}
-                />
+                        <PipetteFields
+                          initialTabIndex={1}
+                          values={values.pipettesByMount}
+                          onFieldChange={handleChange}
+                          onSetFieldValue={setFieldValue}
+                          onBlur={handleBlur}
+                          errors={errors.pipettesByMount ?? null}
+                          touched={touched.pipettesByMount ?? null}
+                          onSetFieldTouched={setFieldTouched}
+                        />
 
-                {this.props.modulesEnabled && this.props.showModulesFields && (
-                  <div className={styles.protocol_modules_group}>
-                    <h2 className={styles.new_file_modal_title}>
-                      {i18n.t('modal.new_protocol.title.PROTOCOL_MODULES')}
-                    </h2>
-                    <ModuleFields
-                      values={visibleModules}
-                      thermocyclerEnabled={this.props.thermocyclerEnabled}
-                      onFieldChange={this.handleModuleOnDeckChange}
-                    />
-                  </div>
-                )}
-              </form>
+                        {this.props.modulesEnabled &&
+                          this.props.showModulesFields && (
+                            <div className={styles.protocol_modules_group}>
+                              <h2 className={styles.new_file_modal_title}>
+                                {i18n.t(
+                                  'modal.new_protocol.title.PROTOCOL_MODULES'
+                                )}
+                              </h2>
+                              <ModuleFields
+                                errors={errors.modulesByType ?? null}
+                                values={visibleModules}
+                                thermocyclerEnabled={
+                                  this.props.thermocyclerEnabled
+                                }
+                                onFieldChange={handleChange}
+                                onSetFieldValue={setFieldValue}
+                                onBlur={handleBlur}
+                                touched={touched.modulesByType ?? null}
+                                onSetFieldTouched={setFieldTouched}
+                              />
+                            </div>
+                          )}
+                        {showCrashInfoBox && (
+                          <CrashInfoBox
+                            showDiagram
+                            magnetOnDeck={hasCrashableMagnetModuleSelected}
+                            temperatureOnDeck={
+                              hasCrashableTemperatureModuleSelected
+                            }
+                          />
+                        )}
+                        <div className={modalStyles.button_row}>
+                          <OutlineButton
+                            onClick={this.props.onCancel}
+                            tabIndex={7}
+                            className={styles.button}
+                          >
+                            {i18n.t('button.cancel')}
+                          </OutlineButton>
+                          <OutlineButton
+                            disabled={!pipetteSelectionIsValid}
+                            onClick={handleSubmit}
+                            tabIndex={6}
+                            className={styles.button}
+                          >
+                            {i18n.t('button.save')}
+                          </OutlineButton>
+                        </div>
+                      </form>
 
-              {showCrashInfoBox && (
-                <CrashInfoBox
-                  showDiagram
-                  magnetOnDeck={
-                    this.state.modulesByType[MAGNETIC_MODULE_TYPE].onDeck
-                  }
-                  temperatureOnDeck={
-                    this.state.modulesByType[TEMPERATURE_MODULE_TYPE].onDeck
-                  }
-                />
-              )}
-
-              <div className={modalStyles.button_row}>
-                <OutlineButton
-                  onClick={this.props.onCancel}
-                  tabIndex={7}
-                  className={styles.button}
-                >
-                  {i18n.t('button.cancel')}
-                </OutlineButton>
-                <OutlineButton
-                  onClick={
-                    showProtocolFields
-                      ? this.handleSubmit
-                      : this.showEditPipetteConfirmationModal
-                  }
-                  disabled={!canSubmit}
-                  tabIndex={6}
-                  className={styles.button}
-                >
-                  {i18n.t('button.save')}
-                </OutlineButton>
-              </div>
+                      {this.state.showEditPipetteConfirmation && (
+                        <StepChangesConfirmModal
+                          onCancel={this.handleCancel}
+                          onConfirm={handleSubmit}
+                        />
+                      )}
+                    </>
+                  )
+                }}
+              </Formik>
             </div>
           </div>
         </Modal>
-        {this.state.showEditPipetteConfirmation && (
-          <StepChangesConfirmModal
-            onCancel={this.handleCancel}
-            onConfirm={this.handleSubmit}
-          />
-        )}
       </React.Fragment>
     )
   }

--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -7,9 +7,9 @@ import {
   THERMOCYCLER_MODULE_TYPE,
   THERMOCYCLER,
   MAGNETIC_MODULE_V1,
-  // MAGNETIC_MODULE_V2,
+  MAGNETIC_MODULE_V2,
   TEMPERATURE_MODULE_V1,
-  // TEMPERATURE_MODULE_V2,
+  TEMPERATURE_MODULE_V2,
   THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
 import { i18n } from './localization'
@@ -115,8 +115,10 @@ export const MODELS_FOR_MODULE_TYPE: {
       // downcast required because the module models are now enums rather than strings
       value: (MAGNETIC_MODULE_V1: string),
     },
-    // TODO: IL 2019-01-31 enable this to support Magnetic Module GEN2 in PD
-    // { name: i18n.t(`modules.model_display_name.${MAGNETIC_MODULE_V2}`), value: MAGNETIC_MODULE_V2 },
+    {
+      name: i18n.t(`modules.model_display_name.${MAGNETIC_MODULE_V2}`),
+      value: MAGNETIC_MODULE_V2,
+    },
   ],
   [TEMPERATURE_MODULE_TYPE]: [
     {
@@ -124,8 +126,10 @@ export const MODELS_FOR_MODULE_TYPE: {
       // downcast required because the module models are now enums rather than strings
       value: (TEMPERATURE_MODULE_V1: string),
     },
-    // TODO: IL 2019-01-31 enable this to support Temperature Module GEN2 in PD
-    // { name: i18n.t(`modules.model_display_name.${TEMPERATURE_MODULE_V2}`, value: TEMPERATURE_MODULE_V2 },
+    {
+      name: i18n.t(`modules.model_display_name.${TEMPERATURE_MODULE_V2}`),
+      value: TEMPERATURE_MODULE_V2,
+    },
   ],
   [THERMOCYCLER_MODULE_TYPE]: [
     {

--- a/protocol-designer/src/step-forms/types.js
+++ b/protocol-designer/src/step-forms/types.js
@@ -50,7 +50,7 @@ export type PipetteEntities = {
 // =========== MODULES ========
 export type FormModule = {|
   onDeck: boolean,
-  model: ModuleModel,
+  model: ModuleModel | null,
   slot: DeckSlot,
 |}
 


### PR DESCRIPTION
## overview
This PR closes #5150 and part of #5189 by enabling the model dropdown when creating a new protocol so users can select their model for their module.

## changelog
- Use formik to handle the FilePipettesModal state and errors
- crash warnings only show up for gen 1 modules
- Added unit tests (was annoying to test the modal with formik, might be a good idea to refactor out the form so its easier to unit test)

## review requests
The errors for the dropdowns are currently very ugly. After talking with Ian, we thought it would be a good idea to allow Dropdown components to accept a react node for error props instead of just a string since we use formik in multiple places and we could use the form error components to our advantage so we don't have to manage the errors ourselves - #5283 

Same goes for the flow typing for pipettesByMount and modulesByType - flow type for formik will need to be updated but it will take some major flow-fu (recursion!) to get it done so I manually typed the errors and touched object for now. Or if you guys have any better ideas, would appreciate it!

http://sandbox.designer.opentrons.com/pd_gen2-mods-new-protocol/

A lot of this is just regression testing to make sure nothing broke when changing to formik

**New protocol**
- [ ] Creating a protocol without a pipette has a disabled button
- [ ] Saving with a pipette but no tipracks will give a required error at the tiprack dropdown
- [ ] Removing a pipette clears the tiprack error and allow you to save
- [ ] Swapping pipettes clears the tiprack
- [ ] Selecting a model does not show the model dropdown with a default model
- [ ] Saving with a model but no model will give a required error at the model dropdown
- [ ] Removing a module clears the model
- [ ] Selecting model drop from dropdown displays proper mode image
- [ ] Please do some mixing and matching where you add and remove modules and pipettes and swap them around. Errors should show up properly and not for wrong modules or tiprack sides.
- [ ] After creating a protocol, click on edit under the pipettes section should pop up the edit pipettes modal - this is the same component so we have to test this, too
- [ ] Removing a tiprack from a pipette and saving should show the same required error
- [ ] Do the same swapping and changing of pipettes here and make sure nothing is broken
- [ ] Clicking save should pop up the confirmation modal
- [ ] The modal should cover the edit pipettes modal and the overlay should cover that entire section
- [ ] Clicking save should save your changes and take you back to the file page

**Crash images**
- [ ] Selecting a GEN1 module with a GEN1 8 channel pipette should display the crash image along with text warning about the selected module and GEN1 pipettes
- [ ] Select both GEN1 modules, this should display both both images and the text should say mention both modules
- [ ] Removing the modules or changing to GEN2 pipettes will make the crash images disappear

## risk assessment
Low? As long as all the fields are properly being saved in the json.
