### PR TITLE
refactor(api,robot-server): Robot server port camera fast api

### DIFF
--- a/api/src/opentrons/server/endpoints/control.py
+++ b/api/src/opentrons/server/endpoints/control.py
@@ -1,8 +1,8 @@
 import asyncio
 import functools
-import os
 import json
 import logging
+from pathlib import Path
 from aiohttp import web
 
 try:
@@ -488,8 +488,8 @@ async def set_rail_lights(request):
 
 
 async def take_picture(request):
-    filename = os.path.join(
-        request.app['com.opentrons.response_file_tempdir'], 'picture.jpg')
+    filename = Path(request.app['com.opentrons.response_file_tempdir'])
+    filename = filename.joinpath('picture.jpg')
 
     try:
         await camera.take_picture(filename, request.loop)

--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+from pathlib import Path
 from opentrons.config import IS_OSX
 
 
@@ -7,7 +8,7 @@ class CameraException(Exception):
     pass
 
 
-async def take_picture(filename: str,
+async def take_picture(filename: Path,
                        loop: asyncio.AbstractEventLoop = None):
     """
     Take a picture and save it to filename
@@ -17,11 +18,10 @@ async def take_picture(filename: str,
     :return: None
     :raises: CameraException
     """
-    if os.path.exists(filename):
-        try:
-            os.remove(filename)
-        except OSError:
-            pass
+    try:
+        os.remove(filename)
+    except OSError:
+        pass
 
     cmd = 'ffmpeg -f video4linux2 -s 640x480 -i /dev/video0 -ss 0:0:1 -frames 1'  # NOQA
 
@@ -40,5 +40,5 @@ async def take_picture(filename: str,
 
     if proc.returncode != 0:
         raise CameraException(res)
-    if not os.path.exists(filename):
+    if not filename.exists():
         raise CameraException('picture not saved')

--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -1,0 +1,44 @@
+import asyncio
+import os
+from opentrons.config import IS_OSX
+
+
+class CameraException(Exception):
+    pass
+
+
+async def take_picture(filename: str,
+                       loop: asyncio.AbstractEventLoop = None):
+    """
+    Take a picture and save it to filename
+
+    :param filename: Name of file to save picture to
+    :param loop: optional loop to use
+    :return: None
+    :raises: CameraException
+    """
+    if os.path.exists(filename):
+        try:
+            os.remove(filename)
+        except OSError:
+            pass
+
+    cmd = 'ffmpeg -f video4linux2 -s 640x480 -i /dev/video0 -ss 0:0:1 -frames 1'  # NOQA
+
+    if IS_OSX:
+        # Purely for development on macos
+        cmd = 'ffmpeg -f avfoundation -framerate 1  -s 640x480  -i "0" -ss 0:0:1 -frames 1'  # NOQA
+
+    proc = await asyncio.create_subprocess_shell(
+        f'{cmd} {filename}',
+        stderr=asyncio.subprocess.PIPE,
+        loop=loop or asyncio.get_event_loop())
+
+    res = await proc.stderr.read()  # type: ignore
+    res = res.decode().strip()
+    await proc.wait()
+
+    if proc.returncode != 0:
+        raise CameraException(res)
+    if not os.path.exists(filename):
+        raise CameraException('picture not saved')

--- a/robot-server/robot_server/service/routers/camera.py
+++ b/robot-server/robot_server/service/routers/camera.py
@@ -1,10 +1,18 @@
+import logging
+import os
+import tempfile
 from http import HTTPStatus
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from starlette.responses import StreamingResponse
+from opentrons.system import camera
 
+
+log = logging.getLogger(__name__)
 
 router = APIRouter()
+
+JPG = "image/jpg"
 
 
 @router.post("/camera/picture",
@@ -12,13 +20,24 @@ router = APIRouter()
                          "and return it",
              responses={
                  HTTPStatus.OK: {
-                     "content": {"image/png": {}},
+                     "content": {JPG: {}},
                      "description": "The image"
                  }
              })
 async def post_picture_capture() -> StreamingResponse:
-    return StreamingResponse(
-        content=iter([]),
-        status_code=HTTPStatus.OK,
-        media_type="image/png"
-    )
+    """Take a picture"""
+    filename = tempfile.mktemp(suffix=".jpg")
+    try:
+        await camera.take_picture(filename)
+        log.info("Image taken at %s", filename)
+        return StreamingResponse(open(filename, 'rb'), media_type=JPG)
+    except camera.CameraException as e:
+        raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                            detail=str(e))
+    finally:
+        try:
+            if os.path.exists(filename):
+                log.info("Deleting image at %s", filename)
+                os.remove(filename)
+        except OSError:
+            pass

--- a/robot-server/robot_server/service/routers/camera.py
+++ b/robot-server/robot_server/service/routers/camera.py
@@ -4,6 +4,7 @@ import tempfile
 from http import HTTPStatus
 
 from fastapi import APIRouter, HTTPException
+from starlette.background import BackgroundTask
 from starlette.responses import StreamingResponse
 from opentrons.system import camera
 
@@ -27,17 +28,24 @@ JPG = "image/jpg"
 async def post_picture_capture() -> StreamingResponse:
     """Take a picture"""
     filename = tempfile.mktemp(suffix=".jpg")
+
     try:
         await camera.take_picture(filename)
         log.info("Image taken at %s", filename)
-        return StreamingResponse(open(filename, 'rb'), media_type=JPG)
+        return StreamingResponse(open(filename, 'rb'),
+                                 media_type=JPG,
+                                 background=BackgroundTask(func=_cleanup,
+                                                           filename=filename))
     except camera.CameraException as e:
         raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
                             detail=str(e))
-    finally:
-        try:
-            if os.path.exists(filename):
-                log.info("Deleting image at %s", filename)
-                os.remove(filename)
-        except OSError:
-            pass
+
+
+def _cleanup(filename: str) -> None:
+    """Clean up after sending the response"""
+    try:
+        if os.path.exists(filename):
+            log.info("Deleting image at %s", filename)
+            os.remove(filename)
+    except OSError:
+        pass

--- a/robot-server/robot_server/service/routers/camera.py
+++ b/robot-server/robot_server/service/routers/camera.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import tempfile
+from pathlib import Path
 from http import HTTPStatus
 
 from fastapi import APIRouter, HTTPException
@@ -27,7 +28,7 @@ JPG = "image/jpg"
              })
 async def post_picture_capture() -> StreamingResponse:
     """Take a picture"""
-    filename = tempfile.mktemp(suffix=".jpg")
+    filename = Path(tempfile.mktemp(suffix=".jpg"))
 
     try:
         await camera.take_picture(filename)
@@ -44,8 +45,7 @@ async def post_picture_capture() -> StreamingResponse:
 def _cleanup(filename: str) -> None:
     """Clean up after sending the response"""
     try:
-        if os.path.exists(filename):
-            log.info("Deleting image at %s", filename)
-            os.remove(filename)
+        log.info("Deleting image at %s", filename)
+        os.remove(filename)
     except OSError:
         pass

--- a/robot-server/tests/service/routers/test_camera.py
+++ b/robot-server/tests/service/routers/test_camera.py
@@ -1,0 +1,44 @@
+import os
+from unittest.mock import patch
+import pytest
+from opentrons.system import camera
+
+
+@pytest.fixture
+def mock_take_picture():
+    with patch("robot_server.service.routers.camera.camera.take_picture",
+               spec=camera.take_picture) as m:
+        yield m
+
+
+def test_camera_exception(mock_take_picture, api_client):
+    async def raise_it(filename, loop=None):
+        raise camera.CameraException("No")
+
+    mock_take_picture.side_effect = raise_it
+
+    res = api_client.post("/camera/picture")
+    assert res.status_code == 500
+
+
+def test_camera_success(mock_take_picture, api_client):
+    """
+    Test that we return the contents of the file we direct camera to write
+    image to.
+    """
+    state = {}
+
+    async def fake_picture(filename, loop=None):
+        # Save the filename
+        state['filename'] = filename
+        # Write some junk to the file
+        with open(filename, "wb") as f:
+            f.write(b"test image")
+
+    mock_take_picture.side_effect = fake_picture
+
+    res = api_client.post("/camera/picture")
+    assert res.status_code == 200
+    assert res.content == b"test image"
+    # Make sure the tempfile was deleted
+    assert os.path.exists(state['filename']) is False


### PR DESCRIPTION
## overview

Implement camera endpoint in fastapi

## changelog

- move ffmpeg call out of `server/endpoints/control.py` to `/system/camera.py`
- add ffmpeg command line for development on mac.
- use stderr to get results from ffmpeg. they ain't in stdout.
- use return code to determine failure/success of call to ffmpeg.
- implement post_take_picture in robot_server.
- add tests.

## review requests

I tested this on my mac. I don't have a robot. Both the fastapi and aiohttp versions work.  Returning an image from my mac's camera. The fastapi UI renders the image.

## risk assessment

Moderate. There's a change to the aiohttp handler.

closes #5223 