### PR TITLE
fix(robot-server): fix typing_extensions bug

### DIFF
--- a/robot-server/robot_server/service/models/json_api/__init__.py
+++ b/robot-server/robot_server/service/models/json_api/__init__.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+# TODO(isk: 3/24/20): remove this enum and replace with typing.Literal
+# after migration to python 3.8
+class ResourceTypes(str, Enum):
+    """Resource object types"""
+    item = "item"

--- a/robot-server/robot_server/service/models/json_api/factory.py
+++ b/robot-server/robot_server/service/models/json_api/factory.py
@@ -2,17 +2,18 @@ from typing import Type, Any, Tuple
 
 from .request import json_api_request, RequestModel
 from .response import json_api_response, ResponseModel
+from . import ResourceTypes
 
 
 def generate_json_api_models(
-    type_string: str,
+    resource_type: ResourceTypes,
     attributes_model: Any,
     *,
     list_response: bool = False
 ) -> Tuple[Type[RequestModel], Type[ResponseModel]]:
     return (
-        json_api_request(type_string, attributes_model),
+        json_api_request(resource_type, attributes_model),
         json_api_response(
-            type_string, attributes_model, use_list=list_response
+            resource_type, attributes_model, use_list=list_response
         ),
     )

--- a/robot-server/robot_server/service/models/json_api/request.py
+++ b/robot-server/robot_server/service/models/json_api/request.py
@@ -1,13 +1,13 @@
 from typing import Generic, TypeVar, Optional, Any, Type
-from typing_extensions import Literal
 from pydantic import Field
 from pydantic.generics import GenericModel
 
-TypeT = TypeVar('TypeT')
+from . import ResourceTypes
+
 AttributesT = TypeVar('AttributesT')
 
 
-class RequestDataModel(GenericModel, Generic[TypeT, AttributesT]):
+class RequestDataModel(GenericModel, Generic[AttributesT]):
     """
     """
     id: Optional[str] = \
@@ -16,7 +16,7 @@ class RequestDataModel(GenericModel, Generic[TypeT, AttributesT]):
                           " required when the resource object originates at"
                           " the client and represents a new resource to be"
                           " created on the server.")
-    type: TypeT = \
+    type: ResourceTypes = \
         Field(...,
               description="type member is used to describe resource objects"
                           " that share common attributes.")
@@ -42,13 +42,11 @@ class RequestModel(GenericModel, Generic[DataT]):
 
 # Note(isk: 3/13/20): formats and returns request model
 def json_api_request(
-    type_string: str,
+    resource_type: ResourceTypes,
     attributes_model: Any
 ) -> Type[RequestModel]:
-    request_data_model = RequestDataModel[
-        Literal[type_string],    # type: ignore
-        attributes_model,    # type: ignore
-    ]
+    type_string = resource_type.value
+    request_data_model = RequestDataModel[attributes_model]    # type: ignore
     request_data_model.__name__ = f'RequestData[{type_string}]'
     request_model = RequestModel[request_data_model]
     request_model.__name__ = f'Request[{type_string}]'

--- a/robot-server/robot_server/service/routers/item.py
+++ b/robot-server/robot_server/service/routers/item.py
@@ -5,14 +5,16 @@ from robot_server.service.models.item import Item, ItemData
 from robot_server.service.models.json_api.factory import \
     generate_json_api_models
 from robot_server.service.models.json_api.errors import ErrorResponse
+from robot_server.service.models.json_api import ResourceTypes
+
 # https://github.com/encode/starlette/blob/master/starlette/status.py
 from starlette.status import HTTP_400_BAD_REQUEST, \
     HTTP_422_UNPROCESSABLE_ENTITY
 
 router = APIRouter()
 
-ITEM_TYPE_NAME = "item"
-ItemRequest, ItemResponse = generate_json_api_models(ITEM_TYPE_NAME, Item)
+ITEM_TYPE = ResourceTypes.item
+ItemRequest, ItemResponse = generate_json_api_models(ITEM_TYPE, Item)
 
 
 @router.get("/items/{item_id}",

--- a/robot-server/tests/service/helpers.py
+++ b/robot-server/tests/service/helpers.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from uuid import uuid4
 
 from robot_server.service.models.json_api.request import json_api_request
+from robot_server.service.models.json_api import ResourceTypes
 
 
 @dataclass
@@ -19,5 +20,5 @@ class ItemModel(BaseModel):
     price: float
 
 
-item_type_name = 'item'
-ItemRequest = json_api_request(item_type_name, ItemModel)
+item_type = ResourceTypes.item
+ItemRequest = json_api_request(item_type, ItemModel)

--- a/robot-server/tests/service/models/json_api/test_errors.py
+++ b/robot-server/tests/service/models/json_api/test_errors.py
@@ -66,11 +66,12 @@ def test_transform_validation_error_to_json_api_errors():
         'errors': [
             {
                 'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
-                'detail': "unexpected value; permitted: 'item'",
+                'detail': "value is not a valid enumeration member; permitted:"
+                          " 'item'",
                 'source': {
                     'pointer': '/data/type'
                 },
-                'title': 'value_error.const'
+                'title': 'type_error.enum'
             },
             {
                 'status': str(HTTP_422_UNPROCESSABLE_ENTITY),

--- a/robot-server/tests/service/models/json_api/test_factory.py
+++ b/robot-server/tests/service/models/json_api/test_factory.py
@@ -1,5 +1,4 @@
 from typing import List
-from typing_extensions import Literal
 
 from robot_server.service.models.json_api.factory import \
     generate_json_api_models
@@ -7,28 +6,31 @@ from robot_server.service.models.json_api.request import RequestModel, \
     RequestDataModel
 from robot_server.service.models.json_api.response import ResponseModel, \
     ResponseDataModel
+from robot_server.service.models.json_api import ResourceTypes
 from tests.service.helpers import ItemModel
+
+ITEM_TYPE = ResourceTypes.item
 
 
 def test_json_api_model():
-    ItemRequest, ItemResponse = generate_json_api_models('item', ItemModel)
+    ItemRequest, ItemResponse = generate_json_api_models(ITEM_TYPE, ItemModel)
     assert ItemRequest == RequestModel[
-        RequestDataModel[Literal['item'], ItemModel]
+        RequestDataModel[ItemModel]
     ]
     assert ItemResponse == ResponseModel[
-        ResponseDataModel[Literal['item'], ItemModel]
+        ResponseDataModel[ItemModel]
     ]
 
 
 def test_json_api_model__list_response():
     ItemRequest, ItemResponse = generate_json_api_models(
-        'item',
+        ITEM_TYPE,
         ItemModel,
         list_response=True
     )
     assert ItemRequest == RequestModel[
-        RequestDataModel[Literal['item'], ItemModel]
+        RequestDataModel[ItemModel]
     ]
     assert ItemResponse == ResponseModel[
-        List[ResponseDataModel[Literal['item'], ItemModel]]
+        List[ResponseDataModel[ItemModel]]
     ]

--- a/robot-server/tests/service/models/json_api/test_request.py
+++ b/robot-server/tests/service/models/json_api/test_request.py
@@ -3,11 +3,15 @@ from pytest import raises
 from pydantic import ValidationError
 
 from robot_server.service.models.json_api.request import json_api_request
+from robot_server.service.models.json_api import ResourceTypes
 from tests.service.helpers import ItemModel
 
 
+ITEM_TYPE = ResourceTypes.item
+
+
 def test_attributes_as_dict():
-    DictRequest = json_api_request('item', dict)
+    DictRequest = json_api_request(ITEM_TYPE, dict)
     obj_to_validate = {
         'data': {'type': 'item', 'attributes': {}}
     }
@@ -22,7 +26,7 @@ def test_attributes_as_dict():
 
 
 def test_attributes_as_item_model():
-    ItemRequest = json_api_request('item', ItemModel)
+    ItemRequest = json_api_request(ITEM_TYPE, ItemModel)
     obj_to_validate = {
         'data': {
             'type': 'item',
@@ -39,7 +43,7 @@ def test_attributes_as_item_model():
 
 
 def test_attributes_as_item_model__empty_dict():
-    ItemRequest = json_api_request('item', ItemModel)
+    ItemRequest = json_api_request(ITEM_TYPE, ItemModel)
     obj_to_validate = {
         'data': {
             'type': 'item',
@@ -67,7 +71,7 @@ def test_attributes_as_item_model__empty_dict():
 
 
 def test_type_invalid_string():
-    MyRequest = json_api_request('item', dict)
+    MyRequest = json_api_request(ITEM_TYPE, dict)
     obj_to_validate = {
         'data': {'type': 'not_an_item', 'attributes': {}}
     }
@@ -77,15 +81,16 @@ def test_type_invalid_string():
     assert e.value.errors() == [
         {
             'loc': ('data', 'type'),
-            'msg': "unexpected value; permitted: 'item'",
-            'type': 'value_error.const',
-            'ctx': {'given': 'not_an_item', 'permitted': ('item',)},
+            'msg': "value is not a valid enumeration member;"
+                   " permitted: 'item'",
+            'type': 'type_error.enum',
+            'ctx': {'enum_values': [ITEM_TYPE]},
         },
     ]
 
 
 def test_attributes_required():
-    MyRequest = json_api_request('item', dict)
+    MyRequest = json_api_request(ITEM_TYPE, dict)
     obj_to_validate = {
         'data': {'type': 'item', 'attributes': None}
     }
@@ -102,7 +107,7 @@ def test_attributes_required():
 
 
 def test_data_required():
-    MyRequest = json_api_request('item', dict)
+    MyRequest = json_api_request(ITEM_TYPE, dict)
     obj_to_validate = {
         'data': None
     }
@@ -119,7 +124,7 @@ def test_data_required():
 
 
 def test_request_with_id():
-    MyRequest = json_api_request('item', dict)
+    MyRequest = json_api_request(ITEM_TYPE, dict)
     obj_to_validate = {
         'data': {
             'type': 'item',

--- a/robot-server/tests/service/models/json_api/test_response.py
+++ b/robot-server/tests/service/models/json_api/test_response.py
@@ -2,11 +2,15 @@ from pytest import raises
 from pydantic import BaseModel, ValidationError
 
 from robot_server.service.models.json_api.response import json_api_response
+from robot_server.service.models.json_api import ResourceTypes
 from tests.service.helpers import ItemModel, ItemData
 
 
+ITEM_TYPE = ResourceTypes.item
+
+
 def test_attributes_as_dict():
-    MyResponse = json_api_response('item', dict)
+    MyResponse = json_api_response(ITEM_TYPE, dict)
     obj_to_validate = {
         'data': {'id': '123', 'type': 'item', 'attributes': {}},
     }
@@ -23,7 +27,7 @@ def test_attributes_as_dict():
 
 
 def test_missing_attributes_dict():
-    MyResponse = json_api_response('item', dict)
+    MyResponse = json_api_response(ITEM_TYPE, dict)
     obj_to_validate = {
         'data': {'id': '123', 'type': 'item'}
     }
@@ -43,7 +47,7 @@ def test_missing_attributes_empty_model():
     class EmptyModel(BaseModel):
         pass
 
-    MyResponse = json_api_response('item', EmptyModel)
+    MyResponse = json_api_response(ITEM_TYPE, EmptyModel)
     obj_to_validate = {
         'data': {'id': '123', 'type': 'item'}
     }
@@ -61,7 +65,7 @@ def test_missing_attributes_empty_model():
 
 
 def test_attributes_as_item_model():
-    ItemResponse = json_api_response('item', ItemModel)
+    ItemResponse = json_api_response(ITEM_TYPE, ItemModel)
     obj_to_validate = {
         'meta': None,
         'links': None,
@@ -92,7 +96,7 @@ def test_attributes_as_item_model():
 
 
 def test_list_item_model():
-    ItemResponse = json_api_response('item', ItemModel, use_list=True)
+    ItemResponse = json_api_response(ITEM_TYPE, ItemModel, use_list=True)
     obj_to_validate = {
         'meta': None,
         'links': None,
@@ -145,7 +149,7 @@ def test_list_item_model():
 
 
 def test_type_invalid_string():
-    MyResponse = json_api_response('item', dict)
+    MyResponse = json_api_response(ITEM_TYPE, dict)
     obj_to_validate = {
         'data': {'id': '123', 'type': 'not_an_item', 'attributes': {}}
     }
@@ -155,15 +159,16 @@ def test_type_invalid_string():
     assert e.value.errors() == [
         {
             'loc': ('data', 'type'),
-            'msg': "unexpected value; permitted: 'item'",
-            'type': 'value_error.const',
-            'ctx': {'given': 'not_an_item', 'permitted': ('item',)},
+            'msg': "value is not a valid enumeration member;"
+                   " permitted: 'item'",
+            'type': 'type_error.enum',
+            'ctx': {'enum_values': [ITEM_TYPE]},
         },
     ]
 
 
 def test_attributes_required():
-    ItemResponse = json_api_response('item', ItemModel)
+    ItemResponse = json_api_response(ITEM_TYPE, ItemModel)
     obj_to_validate = {
         'data': {'id': '123', 'type': 'item', 'attributes': None}
     }
@@ -180,7 +185,7 @@ def test_attributes_required():
 
 
 def test_attributes_as_item_model__empty_dict():
-    ItemResponse = json_api_response('item', ItemModel)
+    ItemResponse = json_api_response(ITEM_TYPE, ItemModel)
     obj_to_validate = {
         'data': {
             'id': '123',
@@ -209,7 +214,7 @@ def test_attributes_as_item_model__empty_dict():
 
 
 def test_resource_object_constructor():
-    ItemResponse = json_api_response('item', ItemModel)
+    ItemResponse = json_api_response(ITEM_TYPE, ItemModel)
     item = ItemModel(name='pear', price=1.2, quantity=10)
     document = ItemResponse.resource_object(
         id='abc123',
@@ -228,7 +233,7 @@ def test_resource_object_constructor():
 
 
 def test_resource_object_constructor__no_attributes():
-    IdentifierResponse = json_api_response('item', dict)
+    IdentifierResponse = json_api_response(ITEM_TYPE, dict)
     document = IdentifierResponse.resource_object(id='abc123').dict()
 
     assert document == {
@@ -239,7 +244,7 @@ def test_resource_object_constructor__no_attributes():
 
 
 def test_resource_object_constructor__with_list_response():
-    ItemResponse = json_api_response('item', ItemModel, use_list=True)
+    ItemResponse = json_api_response(ITEM_TYPE, ItemModel, use_list=True)
     item = ItemModel(name='pear', price=1.2, quantity=10)
     document = ItemResponse.resource_object(
         id='abc123',
@@ -258,7 +263,7 @@ def test_resource_object_constructor__with_list_response():
 
 
 def test_response_constructed_with_resource_object():
-    ItemResponse = json_api_response('item', ItemModel)
+    ItemResponse = json_api_response(ITEM_TYPE, ItemModel)
     item = ItemModel(name='pear', price=1.2, quantity=10)
     data = ItemResponse.resource_object(
         id='abc123',
@@ -281,7 +286,7 @@ def test_response_constructed_with_resource_object():
 
 
 def test_response_constructed_with_resource_object__list():
-    ItemResponse = json_api_response('item', ItemModel, use_list=True)
+    ItemResponse = json_api_response(ITEM_TYPE, ItemModel, use_list=True)
     items = [
         ItemData(id=1, name='apple', price=1.5, quantity=3),
         ItemData(id=2, name='pear', price=1.2, quantity=10),


### PR DESCRIPTION
fix `typing_extensions` bug by removing Literal type and subsequently the library

closes #5275

<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

See here: https://github.com/Opentrons/opentrons/issues/5275

Introduced a bug when importing `Literal` type from `typing_extensions` which is only used in development. Python 3.8 supports `Literal` types, so we can revert changes at a later date.

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->

## risk assessment

<!--
  Carefully go over your pull request and look at the other parts of the
  codebase it may affect. Look for the possibility, even if you think it's
  small, that your change may affect some other part of the system - for
  instance, changing return tip behavior in protocol may also change the
  behavior of labware calibration.

  Identify the other parts of the system your codebase may affect, so that in
  addition to your own review and testing, other people who may not have
  the system internalized as much as you can focus their attention and testing
  there.
-->
