### PR TITLE
feat(protocol-designer): allow user to select module model when adding or editing modules

### DIFF
--- a/protocol-designer/src/components/modals/EditModulesModal/__tests__/EditModulesModal.test.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/__tests__/EditModulesModal.test.js
@@ -6,12 +6,14 @@ import { mount } from 'enzyme'
 import { OutlineButton, DropdownField } from '@opentrons/components'
 import {
   MAGNETIC_MODULE_TYPE,
+  MAGNETIC_MODULE_V2,
+  MAGNETIC_MODULE_V1,
+  TEMPERATURE_MODULE_V1,
   TEMPERATURE_MODULE_TYPE,
   type LabwareDefinition2,
   type ModuleRealType,
 } from '@opentrons/shared-data'
 import fixture_96_plate from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate'
-import { DEFAULT_MODEL_FOR_MODULE_TYPE } from '../../../../constants'
 import {
   selectors as stepFormSelectors,
   type InitialDeckSetup,
@@ -20,6 +22,7 @@ import { selectors as featureSelectors } from '../../../../feature-flags'
 import * as stepFormActions from '../../../../step-forms/actions'
 import { getLabwareIsCompatible } from '../../../../utils/labwareModuleCompatibility'
 import * as labwareIngredActions from '../../../../labware-ingred/actions'
+import { SUPPORTED_MODULE_SLOTS } from '../../../../modules'
 import { PDAlert } from '../../../alerts/PDAlert'
 import { EditModulesModal } from '../'
 
@@ -42,6 +45,10 @@ const getDisableModuleRestrictionsMock: JestMockFn<[BaseState], ?boolean> =
   featureSelectors.getDisableModuleRestrictions
 
 describe('EditModulesModal', () => {
+  const slotDropdownName = 'selectedSlot'
+  const modelDropdownName = 'selectedModel'
+  const modelDropdownSelector = `select[name="${modelDropdownName}"]`
+  const slotDropdownSelector = `select[name="${slotDropdownName}"]`
   let mockStore
   function render(props) {
     return mount(
@@ -51,12 +58,38 @@ describe('EditModulesModal', () => {
     )
   }
 
+  function simulateRunAllAsyncEvents() {
+    return new Promise(resolve => setTimeout(resolve, 0))
+  }
+
+  let magneticModule, emptyDeckState, addMagneticModuleProps
   beforeEach(() => {
     jest.clearAllMocks()
     mockStore = {
       dispatch: jest.fn(),
       subscribe: jest.fn(),
       getState: () => ({}),
+    }
+
+    magneticModule = {
+      id: 'magnet123',
+      slot: '3',
+      type: MAGNETIC_MODULE_TYPE,
+      model: MAGNETIC_MODULE_V1,
+      moduleState: {
+        engaged: false,
+        type: MAGNETIC_MODULE_TYPE,
+      },
+    }
+    emptyDeckState = {
+      labware: {},
+      modules: {},
+      pipettes: {},
+    }
+    addMagneticModuleProps = {
+      moduleType: MAGNETIC_MODULE_TYPE,
+      moduleId: null,
+      onCloseClick: jest.fn(),
     }
 
     getDisableModuleRestrictionsMock.mockReturnValue(true)
@@ -75,23 +108,20 @@ describe('EditModulesModal', () => {
       pipettes: {},
     })
     getLabwareIsCompatibleMock.mockReturnValue(false)
-    const props = {
-      moduleType: MAGNETIC_MODULE_TYPE,
-      moduleId: null,
-      onCloseClick: jest.fn(),
-    }
 
-    const wrapper = render(props)
+    const wrapper = render(addMagneticModuleProps)
     const saveButton = wrapper.find(OutlineButton).at(1)
-    const slotDropdown = wrapper.find('.option_slot select')
-    slotDropdown.simulate('change', { target: { value: slot } })
+    const slotDropdown = wrapper.find(slotDropdownSelector)
+    slotDropdown.simulate('change', {
+      target: { name: slotDropdownName, value: slot },
+    })
     const warning = wrapper.find(PDAlert)
 
     expect(warning).toHaveLength(1)
     expect(saveButton.prop('disabled')).toBe(true)
   })
 
-  it('save button is clickable and saves when slot is occupied by compatible labware', () => {
+  it('save button is clickable and saves when model is selected and slot is occupied by compatible labware', async () => {
     const slot = '1'
     getInitialDeckSetupMock.mockReturnValue({
       labware: {
@@ -104,44 +134,37 @@ describe('EditModulesModal', () => {
       pipettes: {},
     })
     getLabwareIsCompatibleMock.mockReturnValue(true)
-    const props = {
-      moduleType: MAGNETIC_MODULE_TYPE,
-      moduleId: null,
-      onCloseClick: jest.fn(),
-    }
 
-    const wrapper = render(props)
+    const wrapper = render(addMagneticModuleProps)
+    const slotDropdown = wrapper.find(slotDropdownSelector)
+    slotDropdown.simulate('change', {
+      target: { name: slotDropdownName, value: slot },
+    })
+    const modelDropdown = wrapper.find(modelDropdownSelector)
+    modelDropdown.simulate('change', {
+      target: { name: modelDropdownName, value: MAGNETIC_MODULE_V1 },
+    })
     const saveButton = wrapper.find(OutlineButton).at(1)
-    const slotDropdown = wrapper.find('.option_slot select')
-    slotDropdown.simulate('change', { target: { value: slot } })
     saveButton.simulate('click')
+    await simulateRunAllAsyncEvents()
     const warning = wrapper.find(PDAlert)
 
     expect(warning).toHaveLength(0)
     expect(stepFormActions.createModule).toHaveBeenCalledWith({
       slot,
       type: MAGNETIC_MODULE_TYPE,
-      model: DEFAULT_MODEL_FOR_MODULE_TYPE[MAGNETIC_MODULE_TYPE],
+      model: MAGNETIC_MODULE_V1,
     })
-    expect(props.onCloseClick).toHaveBeenCalled()
+    expect(addMagneticModuleProps.onCloseClick).toHaveBeenCalled()
   })
 
-  it('save button saves when adding module to empty slot', () => {
+  it('save button saves when adding module to empty slot', async () => {
     getInitialDeckSetupMock.mockReturnValue({
       labware: {
         well96Id: fixture_96_plate,
       },
       modules: {
-        magnet123: {
-          id: 'magnet123',
-          slot: '3',
-          type: 'magneticModuleType',
-          model: 'magneticModuleV1',
-          moduleState: {
-            engaged: false,
-            type: 'magneticModuleType',
-          },
-        },
+        magnet123: magneticModule,
       },
       pipettes: {},
     })
@@ -150,27 +173,34 @@ describe('EditModulesModal', () => {
       moduleId: null,
       onCloseClick: jest.fn(),
     }
-    const newSlot = '10'
+    const newSlot = '9'
 
     const wrapper = render(props)
     const saveButton = wrapper.find(OutlineButton).at(1)
-    const slotDropdown = wrapper.find('.option_slot select')
-    slotDropdown.simulate('change', { target: { value: newSlot } })
+    const slotDropdown = wrapper.find(slotDropdownSelector)
+    slotDropdown.simulate('change', {
+      target: { name: slotDropdownName, value: newSlot },
+    })
+    const modelDropdown = wrapper.find(modelDropdownSelector)
+    modelDropdown.simulate('change', {
+      target: { name: 'selectedModel', value: TEMPERATURE_MODULE_V1 },
+    })
     saveButton.simulate('click')
+    await simulateRunAllAsyncEvents()
     const warning = wrapper.find(PDAlert)
 
     expect(warning).toHaveLength(0)
     expect(stepFormActions.createModule).toHaveBeenCalledWith({
       slot: newSlot,
       type: TEMPERATURE_MODULE_TYPE,
-      model: DEFAULT_MODEL_FOR_MODULE_TYPE[TEMPERATURE_MODULE_TYPE],
+      model: TEMPERATURE_MODULE_V1,
     })
     expect(props.onCloseClick).toHaveBeenCalled()
   })
 
-  it('move deck item when moving module to a different slot', () => {
+  it('move deck item when moving module to a different slot', async () => {
     const currentSlot = '1'
-    const targetSlot = '10'
+    const targetSlot = '9'
     getInitialDeckSetupMock.mockReturnValue({
       labware: {
         wellId: {
@@ -180,14 +210,8 @@ describe('EditModulesModal', () => {
       },
       modules: {
         magnet123: {
-          id: 'magnet123',
+          ...magneticModule,
           slot: currentSlot,
-          type: 'magneticModuleType',
-          model: 'magneticModuleV1',
-          moduleState: {
-            engaged: false,
-            type: 'magneticModuleType',
-          },
         },
       },
       pipettes: {},
@@ -201,9 +225,12 @@ describe('EditModulesModal', () => {
 
     const wrapper = render(props)
     const saveButton = wrapper.find(OutlineButton).at(1)
-    const slotDropdown = wrapper.find('.option_slot select')
-    slotDropdown.simulate('change', { target: { value: targetSlot } })
+    const slotDropdown = wrapper.find(slotDropdownSelector)
+    slotDropdown.simulate('change', {
+      target: { name: slotDropdownName, value: targetSlot },
+    })
     saveButton.simulate('click')
+    await simulateRunAllAsyncEvents()
     const warning = wrapper.find(PDAlert)
 
     expect(warning).toHaveLength(0)
@@ -223,16 +250,7 @@ describe('EditModulesModal', () => {
         },
       },
       modules: {
-        magnet123: {
-          id: 'magnet123',
-          slot: '3',
-          type: 'magneticModuleType',
-          model: 'magneticModuleV1',
-          moduleState: {
-            engaged: false,
-            type: 'magneticModuleType',
-          },
-        },
+        magnet123: magneticModule,
       },
       pipettes: {},
     })
@@ -249,44 +267,103 @@ describe('EditModulesModal', () => {
   })
 
   it('cancel calls onCloseClick to close modal', () => {
-    const props = {
-      moduleType: MAGNETIC_MODULE_TYPE,
-      moduleId: null,
-      onCloseClick: jest.fn(),
-    }
-    getInitialDeckSetupMock.mockReturnValue({
-      labware: {},
-      modules: {},
-      pipettes: {},
-    })
+    getInitialDeckSetupMock.mockReturnValue(emptyDeckState)
 
-    const wrapper = render(props)
-
+    const wrapper = render(addMagneticModuleProps)
     const cancelButton = wrapper.find(OutlineButton).at(0)
     cancelButton.simulate('click')
-    expect(props.onCloseClick).toHaveBeenCalled()
+
+    expect(addMagneticModuleProps.onCloseClick).toHaveBeenCalled()
   })
 
-  it('slot dropdown is disabled when module restrictions are disabled', () => {
+  it('slot dropdown is disabled when module restrictions are enabled', () => {
+    getDisableModuleRestrictionsMock.mockReturnValue(false)
+    getInitialDeckSetupMock.mockReturnValue(emptyDeckState)
+
+    const wrapper = render(addMagneticModuleProps)
+
+    expect(wrapper.find(slotDropdownSelector).prop('disabled')).toBe(true)
+  })
+
+  it('allows slot options when module restrictions are disabled', () => {
     getDisableModuleRestrictionsMock.mockReturnValue(true)
-    const props = {
-      moduleType: MAGNETIC_MODULE_TYPE,
-      moduleId: null,
-      onCloseClick: jest.fn(),
-    }
-    getInitialDeckSetupMock.mockReturnValue({
-      labware: {},
-      modules: {},
-      pipettes: {},
+    getInitialDeckSetupMock.mockReturnValue(emptyDeckState)
+
+    const wrapper = render(addMagneticModuleProps)
+
+    expect(wrapper.find(slotDropdownSelector).prop('disabled')).toBe(false)
+  })
+
+  it('allows slot options when modules do not have collisions', () => {
+    getDisableModuleRestrictionsMock.mockReturnValue(false)
+    getInitialDeckSetupMock.mockReturnValue(emptyDeckState)
+
+    const wrapper = render(addMagneticModuleProps)
+    const modelDropdown = wrapper.find(modelDropdownSelector)
+    modelDropdown.simulate('change', {
+      target: { name: modelDropdownName, value: MAGNETIC_MODULE_V2 },
     })
 
-    const wrapper = render(props)
+    expect(wrapper.find(slotDropdownSelector).prop('disabled')).toBe(false)
+  })
+
+  it('has error when clicking save button when no model is selected', async () => {
+    getInitialDeckSetupMock.mockReturnValue(emptyDeckState)
+
+    const wrapper = render(addMagneticModuleProps)
+    const saveButton = wrapper.find(OutlineButton).at(1)
+    saveButton.simulate('click')
+    await simulateRunAllAsyncEvents()
+    wrapper.update()
 
     expect(
       wrapper
-        .find('.option_slot')
         .find(DropdownField)
-        .prop('disabled')
-    ).toBe(false)
+        .filter({ name: modelDropdownName })
+        .prop('error')
+    ).toBe('This field is required')
+  })
+
+  it('only allows default slot if module has collision issue and module restrictions are enabled', () => {
+    getDisableModuleRestrictionsMock.mockReturnValue(false)
+    getInitialDeckSetupMock.mockReturnValue(emptyDeckState)
+
+    const wrapper = render(addMagneticModuleProps)
+    const modelDropdown = wrapper.find(modelDropdownSelector)
+    modelDropdown.simulate('change', {
+      target: { name: modelDropdownName, value: MAGNETIC_MODULE_V1 },
+    })
+    const slotDropdown = wrapper.find(slotDropdownSelector)
+
+    expect(slotDropdown.prop('disabled')).toBe(true)
+    expect(slotDropdown.prop('value')).toBe(
+      SUPPORTED_MODULE_SLOTS[MAGNETIC_MODULE_TYPE][0].value
+    )
+  })
+
+  it('resets the slot to default when switching from module without collision issue to one that does', async () => {
+    getDisableModuleRestrictionsMock.mockReturnValue(false)
+    getInitialDeckSetupMock.mockReturnValue(emptyDeckState)
+
+    const wrapper = render(addMagneticModuleProps)
+    const modelDropdown = wrapper.find(modelDropdownSelector)
+    modelDropdown.simulate('change', {
+      target: { name: modelDropdownName, value: MAGNETIC_MODULE_V2 },
+    })
+    const slotDropdown = wrapper.find(slotDropdownSelector)
+    slotDropdown.simulate('change', {
+      target: { name: slotDropdownName, value: '9' },
+    })
+    modelDropdown.simulate('change', {
+      target: { name: modelDropdownName, value: MAGNETIC_MODULE_V1 },
+    })
+    await simulateRunAllAsyncEvents()
+    wrapper.update()
+    const updatedSlotDropdown = wrapper.find(slotDropdownSelector)
+
+    expect(updatedSlotDropdown.prop('disabled')).toBe(true)
+    expect(updatedSlotDropdown.prop('value')).toBe(
+      SUPPORTED_MODULE_SLOTS[MAGNETIC_MODULE_TYPE][0].value
+    )
   })
 })

--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -6,8 +6,8 @@ import { Formik } from 'formik'
 import * as Yup from 'yup'
 import {
   THERMOCYCLER_MODULE_TYPE,
-  type ModuleModel,
   MODULE_MODELS,
+  type ModuleModel,
 } from '@opentrons/shared-data'
 import {
   Modal,
@@ -34,11 +34,10 @@ import { MODELS_FOR_MODULE_TYPE } from '../../../constants'
 import { i18n } from '../../../localization'
 import { getLabwareIsCompatible } from '../../../utils/labwareModuleCompatibility'
 import { PDAlert } from '../../alerts/PDAlert'
+import { isModuleWithCollisionIssue } from '../../modules'
 import modalStyles from '../modal.css'
 import styles from './EditModules.css'
 import type { ModuleRealType } from '@opentrons/shared-data'
-
-import { isModuleWithCollisionIssue } from '../../modules'
 
 const validationSchema = Yup.object().shape({
   selectedModel: Yup.string()
@@ -76,10 +75,9 @@ export function EditModulesModal(props: EditModulesProps) {
   const disabledModuleRestriction = useSelector(
     featureFlagSelectors.getDisableModuleRestrictions
   )
-
   const dispatch = useDispatch()
 
-  let onSaveClick = values => {
+  const onSaveClick = values => {
     const { selectedModel, selectedSlot } = values
 
     if (module) {
@@ -158,8 +156,7 @@ export function EditModulesModal(props: EditModulesProps) {
 
             hasSlotOrIncompatibleError = !labwareIsCompatible
           }
-          console.log(touched)
-          console.log(errors)
+
           const occupiedSlotError = hasSlotOrIncompatibleError
             ? `Slot ${selectedSlot} is occupied by another module or by labware incompatible with this module. Remove module or labware from the slot in order to continue.`
             : null
@@ -181,6 +178,7 @@ export function EditModulesModal(props: EditModulesProps) {
             if (modelValueIndex >= 0) {
               value = MODULE_MODELS[modelValueIndex]
             }
+
             // reset slot if user switches from module with no collision issue
             // to one that does have collision issues
             if (

--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -143,7 +143,6 @@ export function EditModulesModal(props: EditModulesProps) {
           touched,
           values,
           handleBlur,
-          setFieldTouched,
         }: FormikProps<EditModulesState>) => {
           const { selectedSlot, selectedModel } = values
 

--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -37,6 +37,7 @@ import { PDAlert } from '../../alerts/PDAlert'
 import { isModuleWithCollisionIssue } from '../../modules'
 import modalStyles from '../modal.css'
 import styles from './EditModules.css'
+import type { FormikProps } from 'formik/@flow-typed'
 import type { ModuleRealType } from '@opentrons/shared-data'
 
 const validationSchema = Yup.object().shape({
@@ -45,6 +46,11 @@ const validationSchema = Yup.object().shape({
     .required('This field is required'),
   selectedSlot: Yup.string().required(),
 })
+
+type EditModulesState = {
+  selectedModel: ModuleModel | null,
+  selectedSlot: string,
+}
 
 type EditModulesProps = {
   moduleType: ModuleRealType,
@@ -79,6 +85,10 @@ export function EditModulesModal(props: EditModulesProps) {
 
   const onSaveClick = values => {
     const { selectedModel, selectedSlot } = values
+
+    // validator from formik should never let onSaveClick be called
+    // this case might never be true but still need to handle for flow
+    if (!selectedModel) return null
 
     if (module) {
       // disabled if something lives in the slot selected in local state
@@ -134,7 +144,7 @@ export function EditModulesModal(props: EditModulesProps) {
           values,
           handleBlur,
           setFieldTouched,
-        }) => {
+        }: FormikProps<EditModulesState>) => {
           const { selectedSlot, selectedModel } = values
 
           const slotIsEmpty =

--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -2,7 +2,13 @@
 import * as React from 'react'
 import cx from 'classnames'
 import { useSelector, useDispatch } from 'react-redux'
-import { THERMOCYCLER_MODULE_TYPE } from '@opentrons/shared-data'
+import { Formik } from 'formik'
+import * as Yup from 'yup'
+import {
+  THERMOCYCLER_MODULE_TYPE,
+  type ModuleModel,
+  MODULE_MODELS,
+} from '@opentrons/shared-data'
 import {
   Modal,
   OutlineButton,
@@ -24,16 +30,22 @@ import {
   SUPPORTED_MODULE_SLOTS,
   getAllModuleSlotsByType,
 } from '../../../modules'
-import {
-  MODELS_FOR_MODULE_TYPE,
-  DEFAULT_MODEL_FOR_MODULE_TYPE,
-} from '../../../constants'
+import { MODELS_FOR_MODULE_TYPE } from '../../../constants'
 import { i18n } from '../../../localization'
 import { getLabwareIsCompatible } from '../../../utils/labwareModuleCompatibility'
 import { PDAlert } from '../../alerts/PDAlert'
 import modalStyles from '../modal.css'
 import styles from './EditModules.css'
 import type { ModuleRealType } from '@opentrons/shared-data'
+
+import { isModuleWithCollisionIssue } from '../../modules'
+
+const validationSchema = Yup.object().shape({
+  selectedModel: Yup.string()
+    .nullable()
+    .required('This field is required'),
+  selectedSlot: Yup.string().required(),
+})
 
 type EditModulesProps = {
   moduleType: ModuleRealType,
@@ -44,68 +56,33 @@ type EditModulesProps = {
 
 export function EditModulesModal(props: EditModulesProps) {
   const { moduleType, onCloseClick } = props
-  const _initialDeckSetup = useSelector(stepFormSelectors.getInitialDeckSetup)
 
+  const _initialDeckSetup = useSelector(stepFormSelectors.getInitialDeckSetup)
   const module = props.moduleId
     ? _initialDeckSetup.modules[props.moduleId]
     : null
+  const supportedModuleSlot = SUPPORTED_MODULE_SLOTS[moduleType][0].value
 
-  const [selectedSlot, setSelectedSlot] = React.useState<string>(
-    module?.slot || SUPPORTED_MODULE_SLOTS[moduleType][0].value
-  )
-
-  const [selectedModel, setSelectedModel] = React.useState<string>(
-    module?.model || DEFAULT_MODEL_FOR_MODULE_TYPE[moduleType]
-  )
+  const initialValues = {
+    selectedSlot: module?.slot || supportedModuleSlot,
+    selectedModel: module?.model || null,
+  }
 
   const slotsBlockedBySpanning = getSlotsBlockedBySpanning(_initialDeckSetup)
   const previousModuleSlot = module && module.slot
 
-  const slotIsEmpty =
-    !slotsBlockedBySpanning.includes(selectedSlot) &&
-    (getSlotIsEmpty(_initialDeckSetup, selectedSlot) ||
-      previousModuleSlot === selectedSlot)
-
-  let hasSlotOrIncompatibleError = true
-  if (slotIsEmpty) {
-    hasSlotOrIncompatibleError = false
-  } else {
-    const labwareOnSlot = getLabwareOnSlot(_initialDeckSetup, selectedSlot)
-    const labwareIsCompatible =
-      labwareOnSlot && getLabwareIsCompatible(labwareOnSlot.def, moduleType)
-
-    hasSlotOrIncompatibleError = !labwareIsCompatible
-  }
-
   const showSlotOption = moduleType !== THERMOCYCLER_MODULE_TYPE
 
-  const enableSlotSelection = useSelector(
+  const disabledModuleRestriction = useSelector(
     featureFlagSelectors.getDisableModuleRestrictions
   )
 
-  const occupiedSlotError = hasSlotOrIncompatibleError
-    ? `Slot ${selectedSlot} is occupied by another module or by labware incompatible with this module. Remove module or labware from the slot in order to continue.`
-    : null
-
   const dispatch = useDispatch()
 
-  const handleSlotChange = (e: SyntheticInputEvent<*>) =>
-    setSelectedSlot(e.target.value)
-  const handleModelChange = (e: SyntheticInputEvent<*>) =>
-    setSelectedModel(e.target.value)
+  let onSaveClick = values => {
+    const { selectedModel, selectedSlot } = values
 
-  let onSaveClick = () => {
-    dispatch(
-      stepFormActions.createModule({
-        slot: selectedSlot,
-        type: moduleType,
-        model: selectedModel,
-      })
-    )
-    onCloseClick()
-  }
-  if (module) {
-    onSaveClick = () => {
+    if (module) {
       // disabled if something lives in the slot selected in local state
       // if previous module.model is different, edit module
       if (module.model !== selectedModel) {
@@ -118,9 +95,18 @@ export function EditModulesModal(props: EditModulesProps) {
       if (selectedSlot && module.slot !== selectedSlot) {
         module.slot && dispatch(moveDeckItem(module.slot, selectedSlot))
       }
-      onCloseClick()
+    } else {
+      dispatch(
+        stepFormActions.createModule({
+          slot: selectedSlot,
+          type: moduleType,
+          model: selectedModel,
+        })
+      )
     }
+    onCloseClick()
   }
+
   const heading = i18n.t(`modules.module_long_names.${moduleType}`)
 
   const slotOptionTooltip = (
@@ -128,75 +114,165 @@ export function EditModulesModal(props: EditModulesProps) {
       {i18n.t('tooltip.edit_module_modal.slot_selection')}
     </div>
   )
+
   return (
     <Modal
       heading={heading}
       className={cx(modalStyles.modal, styles.edit_module_modal)}
       contentsClassName={styles.modal_contents}
     >
-      {hasSlotOrIncompatibleError && (
-        <PDAlert
-          alertType="warning"
-          title={i18n.t('alert.module_placement.SLOT_OCCUPIED.title')}
-          description={''}
-        />
-      )}
-      <form>
-        <div className={styles.form_row}>
-          <FormGroup label="Model" className={styles.option_model}>
-            <DropdownField
-              tabIndex={0}
-              options={MODELS_FOR_MODULE_TYPE[moduleType]}
-              value={selectedModel}
-              onChange={handleModelChange}
-            />
-          </FormGroup>
-          {showSlotOption && (
-            <>
-              <HoverTooltip
-                placement="top"
-                tooltipComponent={slotOptionTooltip}
-              >
-                {hoverTooltipHandlers => (
-                  <div {...hoverTooltipHandlers} className={styles.option_slot}>
-                    <FormGroup label="Position">
-                      <DropdownField
-                        tabIndex={1}
-                        options={getAllModuleSlotsByType(moduleType)}
-                        value={selectedSlot}
-                        disabled={!enableSlotSelection}
-                        onChange={handleSlotChange}
-                        error={occupiedSlotError}
-                      />
-                    </FormGroup>
-                  </div>
-                )}
-              </HoverTooltip>
-              <div className={styles.slot_map_container}>
-                {selectedSlot && (
-                  <SlotMap
-                    occupiedSlots={[`${selectedSlot}`]}
-                    isError={Boolean(occupiedSlotError)}
-                  />
-                )}
-              </div>
-            </>
-          )}
-        </div>
-      </form>
+      <Formik
+        enableReinitialize
+        initialValues={initialValues}
+        onSubmit={onSaveClick}
+        validationSchema={validationSchema}
+      >
+        {({
+          handleChange,
+          handleSubmit,
+          errors,
+          setFieldValue,
+          touched,
+          values,
+          handleBlur,
+          setFieldTouched,
+        }) => {
+          const { selectedSlot, selectedModel } = values
 
-      <div className={modalStyles.button_row}>
-        <OutlineButton className={styles.button_margin} onClick={onCloseClick}>
-          {i18n.t('button.cancel')}
-        </OutlineButton>
-        <OutlineButton
-          className={styles.button_margin}
-          disabled={hasSlotOrIncompatibleError}
-          onClick={onSaveClick}
-        >
-          {i18n.t('button.save')}
-        </OutlineButton>
-      </div>
+          const slotIsEmpty =
+            !slotsBlockedBySpanning.includes(selectedSlot) &&
+            (getSlotIsEmpty(_initialDeckSetup, selectedSlot) ||
+              previousModuleSlot === selectedSlot)
+
+          let hasSlotOrIncompatibleError = true
+          if (slotIsEmpty) {
+            hasSlotOrIncompatibleError = false
+          } else {
+            const labwareOnSlot = getLabwareOnSlot(
+              _initialDeckSetup,
+              selectedSlot
+            )
+            const labwareIsCompatible =
+              labwareOnSlot &&
+              getLabwareIsCompatible(labwareOnSlot.def, moduleType)
+
+            hasSlotOrIncompatibleError = !labwareIsCompatible
+          }
+          console.log(touched)
+          console.log(errors)
+          const occupiedSlotError = hasSlotOrIncompatibleError
+            ? `Slot ${selectedSlot} is occupied by another module or by labware incompatible with this module. Remove module or labware from the slot in order to continue.`
+            : null
+
+          const moduleHasCollisionIssue =
+            selectedModel && !isModuleWithCollisionIssue(selectedModel)
+          const enableSlotSelection =
+            disabledModuleRestriction || moduleHasCollisionIssue
+
+          function handleModelChange(
+            e: SyntheticInputEvent<HTMLSelectElement>
+          ) {
+            handleChange(e)
+
+            // to handle flow issue with calling isModuleWithCollisionIssue on
+            // e.target.value since it is a string at runtime
+            let value: ModuleModel | null = null
+            const modelValueIndex = MODULE_MODELS.indexOf(e.target.value)
+            if (modelValueIndex >= 0) {
+              value = MODULE_MODELS[modelValueIndex]
+            }
+            // reset slot if user switches from module with no collision issue
+            // to one that does have collision issues
+            if (
+              value &&
+              (!disabledModuleRestriction && isModuleWithCollisionIssue(value))
+            ) {
+              setFieldValue('selectedSlot', supportedModuleSlot)
+            }
+          }
+
+          return (
+            <>
+              {hasSlotOrIncompatibleError && (
+                <PDAlert
+                  alertType="warning"
+                  title={i18n.t('alert.module_placement.SLOT_OCCUPIED.title')}
+                  description={''}
+                />
+              )}
+              <form>
+                <div className={styles.form_row}>
+                  <FormGroup label="Model*" className={styles.option_model}>
+                    <DropdownField
+                      tabIndex={0}
+                      options={MODELS_FOR_MODULE_TYPE[moduleType]}
+                      name="selectedModel"
+                      value={selectedModel}
+                      onChange={handleModelChange}
+                      onBlur={handleBlur}
+                      error={
+                        touched.selectedModel && errors && errors.selectedModel
+                          ? errors.selectedModel
+                          : null
+                      }
+                    />
+                  </FormGroup>
+                  {showSlotOption && (
+                    <>
+                      <HoverTooltip
+                        placement="top"
+                        tooltipComponent={slotOptionTooltip}
+                      >
+                        {hoverTooltipHandlers => (
+                          <div
+                            {...hoverTooltipHandlers}
+                            className={styles.option_slot}
+                          >
+                            <FormGroup label="Position">
+                              <DropdownField
+                                tabIndex={1}
+                                options={getAllModuleSlotsByType(moduleType)}
+                                name="selectedSlot"
+                                value={selectedSlot}
+                                disabled={!enableSlotSelection}
+                                onChange={handleChange}
+                                error={occupiedSlotError}
+                              />
+                            </FormGroup>
+                          </div>
+                        )}
+                      </HoverTooltip>
+                      <div className={styles.slot_map_container}>
+                        {selectedSlot && (
+                          <SlotMap
+                            occupiedSlots={[`${selectedSlot}`]}
+                            isError={Boolean(occupiedSlotError)}
+                          />
+                        )}
+                      </div>
+                    </>
+                  )}
+                </div>
+                <div className={modalStyles.button_row}>
+                  <OutlineButton
+                    className={styles.button_margin}
+                    onClick={onCloseClick}
+                  >
+                    {i18n.t('button.cancel')}
+                  </OutlineButton>
+                  <OutlineButton
+                    className={styles.button_margin}
+                    disabled={hasSlotOrIncompatibleError}
+                    onClick={handleSubmit}
+                  >
+                    {i18n.t('button.save')}
+                  </OutlineButton>
+                </div>
+              </form>
+            </>
+          )
+        }}
+      </Formik>
     </Modal>
   )
 }


### PR DESCRIPTION
## overview
closes #5188 by enabling the dropdown for model selection

## changelog
- Migrate form to formik to handle errors and validation
- enable dropdown for model selection and handle slot select disabled depending on what model and flag is selected
- fix previous tests and added additional tests to cover new feature

## review requests
Regression testing mostly to make sure nothing broke when moving to formik.
Make sure the disable module warnings flag is off.

**Editing/Adding module**
- [ ] When adding a module, the form should have no default module in dropdown
- [ ] The slot is always defaulted to the default slot
- [ ] Clicking save with no model will display an error message underneath the model selection
- [ ] Selecting GEN1 does not allow you to switch slots
- [ ] Selecting GEN2 opens the slot dropdown and you can select any slot with no warnings
- [ ] Switching the model from GEN2 back to GEN1 will switch the slot position back to the default slot for GEN 1

**Compatible labware**
- [ ] Adding a module to a slot where a compatible labware does not give any errors
- [ ] Adding a module to a slot where an incompatible labware is gives an error
- [ ] Adding a gen 2 module to a slot where a module already exists gives an error 

## risk assessment
Low - should only affect pd but the correct model for the modules should be in the json file when exported