### PR TITLE
refactor(api): Add in a GET request for calibration check session

### DIFF
--- a/api/src/opentrons/server/endpoints/calibration/check.py
+++ b/api/src/opentrons/server/endpoints/calibration/check.py
@@ -49,8 +49,8 @@ async def get_session(request):
         return web.json_response(text=response.json(), status=200)
     else:
         response = {
-            "message": "No check session exists. Please create one.",
-            "links": {"POST": "/calibration/check/session"}}
+            "message": f"No {session_type} session exists. Please create one.",
+            "links": {"createSession": f"/calibration/{session_type}/session"}}
         return web.json_response(response, status=404)
 
 
@@ -80,8 +80,8 @@ async def create_session(request):
         return web.json_response(text=response.json(), status=201)
     else:
         response = {
-            "message": "A check session exists. Please delete to proceed.",
-            "links": {"DELETE": "/calibration/check/session"}}
+            "message": f"A {session_type} session exists. Please delete to proceed.",
+            "links": {"deleteSession": f"/calibration/{session_type}/session"}}
         return web.json_response(response, status=409)
 
 

--- a/api/src/opentrons/server/endpoints/calibration/check.py
+++ b/api/src/opentrons/server/endpoints/calibration/check.py
@@ -80,7 +80,8 @@ async def create_session(request):
         return web.json_response(text=response.json(), status=201)
     else:
         response = {
-            "message": f"A {session_type} session exists. Please delete to proceed.",
+            "message": f"A {session_type} session exists."
+                       "Please delete to proceed.",
             "links": {"deleteSession": f"/calibration/{session_type}/session"}}
         return web.json_response(response, status=409)
 

--- a/api/src/opentrons/server/endpoints/calibration/check.py
+++ b/api/src/opentrons/server/endpoints/calibration/check.py
@@ -29,9 +29,29 @@ def _format_status(
     status = CalibrationSessionStatus(
         instruments=instruments,
         currentStep=current,
-        nextSteps=links,
-        sessionToken=session.token)
+        nextSteps=links)
     return status
+
+
+async def get_session(request):
+    """
+    GET /calibration/check/session
+
+    If a session exists, this endpoint will return the current status.
+
+    Otherwise, this endpoint will return a 404 with links to the post request.
+    """
+    session_type = request.match_info['type']
+    session_storage = request.app['com.opentrons.session_manager']
+    current_session = session_storage.sessions.get(session_type)
+    if current_session:
+        response = _format_status(current_session, request.app.router)
+        return web.json_response(text=response.json(), status=200)
+    else:
+        response = {
+            "message": "No check session exists. Please create one.",
+            "links": {"POST": "/calibration/check/session"}}
+        return web.json_response(response, status=404)
 
 
 async def create_session(request):
@@ -59,8 +79,10 @@ async def create_session(request):
         response = _format_status(new_session, request.app.router)
         return web.json_response(text=response.json(), status=201)
     else:
-        response = _format_status(current_session, request.app.router)
-        return web.json_response(text=response.json(), status=200)
+        response = {
+            "message": "A check session exists. Please delete to proceed.",
+            "links": {"DELETE": "/calibration/check/session"}}
+        return web.json_response(response, status=409)
 
 
 async def delete_session(request):

--- a/api/src/opentrons/server/endpoints/calibration/models.py
+++ b/api/src/opentrons/server/endpoints/calibration/models.py
@@ -41,7 +41,6 @@ class CalibrationSessionStatus(BaseModel):
     currentStep: str = Field(..., description="Current step of session")
     nextSteps: Dict[str, Dict[str, str]] =\
         Field(..., description="Next Available Step in Session")
-    sessionToken: UUID4 = Field(..., description="Session token")
 
     class Config:
         json_encoders = {UUID4: convert_uuid}
@@ -71,8 +70,7 @@ class CalibrationSessionStatus(BaseModel):
                         "links": {
                             "specifyLabware": ""
                         }
-                    },
-                    "sessionToken": "FakeUUIDHex"
+                    }
 
                 }
             ]

--- a/api/src/opentrons/server/endpoints/calibration/session.py
+++ b/api/src/opentrons/server/endpoints/calibration/session.py
@@ -32,7 +32,6 @@ class SessionManager:
 class CalibrationSession:
     """Class that controls state of the current deck calibration session"""
     def __init__(self, hardware: ThreadManager):
-        self.token = uuid4()
         self._pipettes = self._key_by_uuid(hardware.get_attached_instruments())
         self._hardware = hardware
 

--- a/api/src/opentrons/server/http.py
+++ b/api/src/opentrons/server/http.py
@@ -98,6 +98,8 @@ class HTTPServer(object):
         )
         self.app.router.add_get(
             '/settings/robot', settings.get_robot_settings)
+        self.app.router.add_get(
+            '/calibration/{type}/session', check.get_session)
         self.app.router.add_post(
             '/calibration/{type}/session', check.create_session)
         self.app.router.add_delete(

--- a/api/tests/opentrons/server/test_calibration_session.py
+++ b/api/tests/opentrons/server/test_calibration_session.py
@@ -22,25 +22,31 @@ async def test_start_session(async_client, test_setup):
     assert resp.status == 201
     text = await resp.json()
     assert list(text.keys()) ==\
-        ["instruments", "currentStep", "nextSteps", "sessionToken"]
+        ["instruments", "currentStep", "nextSteps"]
     assert text["currentStep"] == "sessionStart"
     assert text["nextSteps"] == {"links": {"specifyLabware": ""}}
 
+    resp = await async_client.post('/calibration/check/session')
+    assert resp.status == 409
+
 
 async def test_check_session(async_client, test_setup):
+    resp = await async_client.get('/calibration/check/session')
+    assert resp.status == 404
+
     resp = await async_client.post('/calibration/check/session')
     assert resp.status == 201
     text = await resp.json()
 
-    resp = await async_client.post('/calibration/check/session')
-    text2 = await resp.json()
+    resp = await async_client.get('/calibration/check/session')
     assert resp.status == 200
+    text2 = await resp.json()
+    assert text == text2
 
-    assert text["sessionToken"] == text2["sessionToken"]
-    assert list(text.keys()) ==\
-        ["instruments", "currentStep", "nextSteps", "sessionToken"]
-    assert text["currentStep"] == "sessionStart"
-    assert text["nextSteps"] == {"links": {"specifyLabware": ""}}
+    assert list(text2.keys()) ==\
+        ["instruments", "currentStep", "nextSteps"]
+    assert text2["currentStep"] == "sessionStart"
+    assert text2["nextSteps"] == {"links": {"specifyLabware": ""}}
 
 
 async def test_delete_session(async_client, async_server, test_setup):


### PR DESCRIPTION
## Overview

This PR refactors the POST request in the calibration check session flow. Previously, the POST request would return a status if a session had already been created. Now there is a GET request which returns that information.

## changelog

- If a session already exists, the POST request will return a 409
- A GET request was added back in. If no session exists it will return a 404, otherwise it will return a 200 + the status.

## review requests

HTTP structure look OK? Anything missing and/or should be removed?

## risk assessment

- Ensure the behavior/status response structure still remains the same.
