### PR TITLE
fix(api): exec protocol contents in module mode

### DIFF
--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -3,7 +3,7 @@ import inspect
 import logging
 import traceback
 import sys
-from typing import Any, Callable
+from typing import Any, Callable, Dict
 
 from opentrons.drivers.smoothie_drivers.driver_3_0 import SmoothieAlarm
 
@@ -91,9 +91,8 @@ def _find_protocol_error(tb, proto_name):
 
 def _run_python(
         proto: PythonProtocol, context: ProtocolContext):
-    new_locs = locals()
-    new_globs = globals()
-    exec(proto.contents, new_globs, new_locs)
+    new_globs: Dict[Any, Any] = {}
+    exec(proto.contents, new_globs)
     # If the protocol is written correctly, it will have defined a function
     # like run(context: ProtocolContext). If so, that function is now in the
     # current scope.
@@ -102,12 +101,13 @@ def _run_python(
     else:
         filename = proto.filename or '<protocol>'
     try:
-        _runfunc_ok(new_locs.get('run'))
+        _runfunc_ok(new_globs.get('run'))
     except SyntaxError as se:
         raise MalformedProtocolError(str(se))
-    new_globs.update(new_locs)
+
+    new_globs['__context'] = context
     try:
-        exec('run(context)', new_globs, new_locs)
+        exec('run(__context)', new_globs)
     except (SmoothieAlarm, asyncio.CancelledError, ExecutionCancelledError):
         # this is a protocol cancel and shouldn't have special logging
         raise

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -165,6 +165,7 @@ class ProtocolContext(CommandPublisher):
         """ Finalize and clean up the protocol context. """
         if self._unsubscribe_commands:
             self._unsubscribe_commands()
+            self._unsubscribe_commands = None
 
     def __del__(self):
         if getattr(self, '_unsubscribe_commands', None):


### PR DESCRIPTION
if you give exec() separate locals and globals, it executes the provided
data as if embedded in a class definition which we very much do not want
- we want it to be executed as if in just a file, which of course it is.
This makes scoping work the same as it does when people write their
protocols and expect them to work.

While we're at it, call the argument we feed to the protocol's run
method something a little less likely to collide.

Closes #4982
Closes #4981

## Risk assessment

Should be minor - narrowly scoped change and easy to check since it happens in `opentrons_simulate`. 

## Testing
This protocol:

```python
metadata = {"apiLevel": "2.1"}

deck_clearance = 0.5
calibration_cross_coordinates = [(x, y, deck_clearance) for x, y in [
    (12.13, 9.0),
    (380.87, 9.0),
    (12.13, 348.5)
]]

def run(protocol):
    protocol.comment(str(calibration_cross_coordinates))

print(calibration_cross_coordinates) # Output something as a sanity check when running as a Python script.
```

should now execute without errors