### PR TITLE
fix(protocol-designer): Hide CrashInfoBox when module restrictions disabled

### DIFF
--- a/protocol-designer/src/components/modals/EditPipettesModal/index.js
+++ b/protocol-designer/src/components/modals/EditPipettesModal/index.js
@@ -30,6 +30,7 @@ type SP = {|
   _orderedStepIds: Array<StepIdType>,
   modulesEnabled: ?boolean,
   thermocyclerEnabled: ?boolean,
+  moduleRestrictionsDisabled: ?boolean,
 |}
 
 type OP = {|
@@ -45,6 +46,9 @@ const mapSTP = (state: BaseState): SP => {
     _orderedStepIds: stepFormSelectors.getOrderedStepIds(state),
     modulesEnabled: featureFlagSelectors.getEnableModules(state),
     thermocyclerEnabled: featureFlagSelectors.getEnableThermocycler(state),
+    moduleRestrictionsDisabled: featureFlagSelectors.getDisableModuleRestrictions(
+      state
+    ),
   }
 }
 

--- a/protocol-designer/src/components/modals/FilePipettesModal/__tests__/index.test.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/__tests__/index.test.js
@@ -59,6 +59,7 @@ describe('FilePipettesModal', () => {
       onSave: jest.fn(),
       modulesEnabled: true,
       thermocyclerEnabled: true,
+      moduleRestrictionsDisabled: false,
     }
   })
 
@@ -256,6 +257,19 @@ describe('FilePipettesModal', () => {
 
       props.initialPipetteValues = initialPipetteValues
       props.initialModuleValues = initialModuleValues
+
+      const wrapper = renderFormComponent(props)
+
+      expect(wrapper.find(CrashInfoBox)).toHaveLength(0)
+    })
+
+    it('does not display crash info when module restrictions disabled', () => {
+      initialPipetteValues.left = crashablePipette
+      initialModuleValues[MAGNETIC_MODULE_TYPE] = crashableMagnet
+
+      props.initialPipetteValues = initialPipetteValues
+      props.initialModuleValues = initialModuleValues
+      props.moduleRestrictionsDisabled = true
 
       const wrapper = renderFormComponent(props)
 

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.js
@@ -73,6 +73,7 @@ export type Props = {|
   |}) => mixed,
   modulesEnabled: ?boolean,
   thermocyclerEnabled: ?boolean,
+  moduleRestrictionsDisabled: ?boolean,
 |}
 
 const initialFormState: FormState = {
@@ -245,7 +246,7 @@ export class FilePipettesModal extends React.Component<Props, State> {
 
   render() {
     if (this.props.hideModal) return null
-    const { showProtocolFields } = this.props
+    const { showProtocolFields, moduleRestrictionsDisabled } = this.props
 
     return (
       <React.Fragment>
@@ -366,7 +367,7 @@ export class FilePipettesModal extends React.Component<Props, State> {
                               />
                             </div>
                           )}
-                        {showCrashInfoBox && (
+                        {showCrashInfoBox && !moduleRestrictionsDisabled && (
                           <CrashInfoBox
                             showDiagram
                             magnetOnDeck={hasCrashableMagnetModuleSelected}

--- a/protocol-designer/src/components/modals/NewFileModal/index.js
+++ b/protocol-designer/src/components/modals/NewFileModal/index.js
@@ -31,6 +31,7 @@ type SP = {|
   _hasUnsavedChanges: ?boolean,
   modulesEnabled: ?boolean,
   thermocyclerEnabled: ?boolean,
+  moduleRestrictionsDisabled: ?boolean,
 |}
 
 type DP = {|
@@ -50,6 +51,9 @@ function mapStateToProps(state: BaseState): SP {
     _hasUnsavedChanges: loadFileSelectors.getHasUnsavedChanges(state),
     modulesEnabled: featureFlagSelectors.getEnableModules(state),
     thermocyclerEnabled: featureFlagSelectors.getEnableThermocycler(state),
+    moduleRestrictionsDisabled: featureFlagSelectors.getDisableModuleRestrictions(
+      state
+    ),
   }
 }
 
@@ -111,6 +115,7 @@ function mergeProps(stateProps: SP, dispatchProps: DP, ownProps: OP): Props {
     ...ownProps,
     modulesEnabled: stateProps.modulesEnabled,
     thermocyclerEnabled: stateProps.thermocyclerEnabled,
+    moduleRestrictionsDisabled: stateProps.moduleRestrictionsDisabled,
     showModulesFields: true,
     hideModal: stateProps.hideModal,
     onCancel: dispatchProps.onCancel,


### PR DESCRIPTION
## overview

closes #5276 by fixing a bug where crash info box was rendering when module restrictions were disabled.

## changelog

- fix(protocol-designer): Hide CrashInfoBox when module restrictions disabled
- refactor: Add test for hidden crash info box

## review requests

Make sure module restrictions FF is OFF
Make a protocol with a Gen1 Multi and a magnetic module
- [ ] Crash info box should render in new file modal
- [ ] Crash info box should render in file settings page

Make sure module restrictions FF is ON
Make a protocol with a Gen1 Multi and a magnetic module
- [ ] Crash info box should NOT render in new file modal
- [ ] Crash info box should NOT render in file settings page

## risk assessment

Low, should only affect PD new file modal, but please double check all crash info warnings render when they should in new file modal and file settings page.
