### PR TITLE
feat(protocol-designer): Enable magnetic and temperature module support

### DIFF
--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -32,7 +32,6 @@ export type Props = {|
   goToNextPage: () => mixed,
   saveFileMetadata: FileMetadataFields => mixed,
   swapPipettes: () => mixed,
-  modulesEnabled: ?boolean,
   thermocyclerEnabled: ?boolean,
   modules: ModulesForEditModulesCard,
 |}
@@ -207,13 +206,11 @@ export class FilePage extends React.Component<Props, State> {
           </div>
         </Card>
 
-        {this.props.modulesEnabled && (
-          <EditModulesCard
-            modules={modules}
-            thermocyclerEnabled={this.props.thermocyclerEnabled}
-            openEditModuleModal={this.handleEditModule}
-          />
-        )}
+        <EditModulesCard
+          modules={modules}
+          thermocyclerEnabled={this.props.thermocyclerEnabled}
+          openEditModuleModal={this.handleEditModule}
+        />
 
         <div className={modalStyles.button_row}>
           <PrimaryButton

--- a/protocol-designer/src/components/StepCreationButton.js
+++ b/protocol-designer/src/components/StepCreationButton.js
@@ -2,7 +2,6 @@
 import * as React from 'react'
 import { connect } from 'react-redux'
 import cx from 'classnames'
-import without from 'lodash/without'
 import { HoverTooltip, PrimaryButton } from '@opentrons/components'
 import {
   MAGNETIC_MODULE_TYPE,
@@ -11,7 +10,6 @@ import {
 } from '@opentrons/shared-data'
 import { i18n } from '../localization'
 import { actions as stepsActions } from '../ui/steps'
-import { selectors as featureFlagSelectors } from '../feature-flags'
 import {
   selectors as stepFormSelectors,
   getIsModuleOnDeck,
@@ -21,7 +19,6 @@ import type { BaseState, ThunkDispatch } from '../types'
 import styles from './listButtons.css'
 
 type SP = {|
-  modulesEnabled: ?boolean,
   isStepTypeEnabled: {
     [moduleType: StepType]: boolean,
   },
@@ -59,10 +56,6 @@ class StepCreationButtonComponent extends React.Component<Props, State> {
       'temperature',
       'thermocycler',
     ]
-    const moduleSteps = ['magnet', 'temperature', 'thermocycler']
-    const filteredSteps = this.props.modulesEnabled
-      ? supportedSteps
-      : without(supportedSteps, ...moduleSteps)
     const { isStepTypeEnabled } = this.props
 
     return (
@@ -76,7 +69,7 @@ class StepCreationButtonComponent extends React.Component<Props, State> {
 
         <div className={styles.buttons_popover}>
           {this.state.expanded &&
-            filteredSteps.map(stepType => {
+            supportedSteps.map(stepType => {
               const disabled = !isStepTypeEnabled[stepType]
               const tooltipMessage = disabled
                 ? i18n.t(`tooltip.disabled_module_step`)
@@ -116,7 +109,6 @@ class StepCreationButtonComponent extends React.Component<Props, State> {
 const mapSTP = (state: BaseState): SP => {
   const modules = stepFormSelectors.getInitialDeckSetup(state).modules
   return {
-    modulesEnabled: featureFlagSelectors.getEnableModules(state),
     isStepTypeEnabled: {
       moveLiquid: true,
       mix: true,

--- a/protocol-designer/src/components/StepEditForm/forms/PauseForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/PauseForm.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import cx from 'classnames'
 import { useSelector } from 'react-redux'
 import { selectors as uiModuleSelectors } from '../../../ui/modules'
-import { selectors as featureFlagSelectors } from '../../../feature-flags'
+
 import { FormGroup, HoverTooltip } from '@opentrons/components'
 import { i18n } from '../../../localization'
 import {
@@ -27,7 +27,6 @@ type PauseFormProps = { focusHandlers: FocusHandlers }
 export const PauseForm = (props: PauseFormProps): React.Element<'div'> => {
   const { focusHandlers } = props
 
-  const modulesEnabled = useSelector(featureFlagSelectors.getEnableModules)
   const moduleLabwareOptions = useSelector(
     uiModuleSelectors.getTemperatureLabwareOptions
   )
@@ -117,66 +116,65 @@ export const PauseForm = (props: PauseFormProps): React.Element<'div'> => {
               />
             </div>
           </ConditionalOnField>
-          {modulesEnabled && (
-            <HoverTooltip
-              placement="bottom"
-              tooltipComponent={
-                pauseUntilTempEnabled ? null : pauseUntilTempTooltip
-              }
-            >
-              {hoverTooltipHandlers => (
-                <div {...hoverTooltipHandlers}>
-                  <div className={styles.checkbox_row}>
-                    <RadioGroupField
-                      className={cx({
-                        [styles.disabled]: !pauseUntilTempEnabled,
-                      })}
-                      name="pauseForAmountOfTime"
-                      options={[
-                        {
-                          name: i18n.t(
-                            'form.step_edit_form.field.pauseForAmountOfTime.options.untilTemperature'
-                          ),
-                          value: PAUSE_UNTIL_TEMP,
-                        },
-                      ]}
-                      {...focusHandlers}
-                    />
-                  </div>
-                  <ConditionalOnField
-                    name={'pauseForAmountOfTime'}
-                    condition={val => val === PAUSE_UNTIL_TEMP}
-                  >
-                    <div className={styles.form_row}>
-                      <FormGroup
-                        label={i18n.t(
-                          'form.step_edit_form.field.moduleActionLabware.label'
-                        )}
-                      >
-                        <StepFormDropdown
-                          {...focusHandlers}
-                          name="moduleId"
-                          options={moduleLabwareOptions}
-                        />
-                      </FormGroup>
-                      <FormGroup
-                        label={i18n.t(
-                          'form.step_edit_form.field.pauseTemperature.label'
-                        )}
-                      >
-                        <TextField
-                          name="pauseTemperature"
-                          className={styles.small_field}
-                          units={i18n.t('application.units.degrees')}
-                          {...focusHandlers}
-                        />
-                      </FormGroup>
-                    </div>
-                  </ConditionalOnField>
+
+          <HoverTooltip
+            placement="bottom"
+            tooltipComponent={
+              pauseUntilTempEnabled ? null : pauseUntilTempTooltip
+            }
+          >
+            {hoverTooltipHandlers => (
+              <div {...hoverTooltipHandlers}>
+                <div className={styles.checkbox_row}>
+                  <RadioGroupField
+                    className={cx({
+                      [styles.disabled]: !pauseUntilTempEnabled,
+                    })}
+                    name="pauseForAmountOfTime"
+                    options={[
+                      {
+                        name: i18n.t(
+                          'form.step_edit_form.field.pauseForAmountOfTime.options.untilTemperature'
+                        ),
+                        value: PAUSE_UNTIL_TEMP,
+                      },
+                    ]}
+                    {...focusHandlers}
+                  />
                 </div>
-              )}
-            </HoverTooltip>
-          )}
+                <ConditionalOnField
+                  name={'pauseForAmountOfTime'}
+                  condition={val => val === PAUSE_UNTIL_TEMP}
+                >
+                  <div className={styles.form_row}>
+                    <FormGroup
+                      label={i18n.t(
+                        'form.step_edit_form.field.moduleActionLabware.label'
+                      )}
+                    >
+                      <StepFormDropdown
+                        {...focusHandlers}
+                        name="moduleId"
+                        options={moduleLabwareOptions}
+                      />
+                    </FormGroup>
+                    <FormGroup
+                      label={i18n.t(
+                        'form.step_edit_form.field.pauseTemperature.label'
+                      )}
+                    >
+                      <TextField
+                        name="pauseTemperature"
+                        className={styles.small_field}
+                        units={i18n.t('application.units.degrees')}
+                        {...focusHandlers}
+                      />
+                    </FormGroup>
+                  </div>
+                </ConditionalOnField>
+              </div>
+            )}
+          </HoverTooltip>
         </div>
         <div className={styles.section_column}>
           <div className={styles.form_row}>

--- a/protocol-designer/src/components/modals/EditPipettesModal/index.js
+++ b/protocol-designer/src/components/modals/EditPipettesModal/index.js
@@ -28,7 +28,6 @@ type SP = {|
   initialPipetteValues: FormPipettesByMount,
   _prevPipettes: { [pipetteId: string]: PipetteOnDeck },
   _orderedStepIds: Array<StepIdType>,
-  modulesEnabled: ?boolean,
   thermocyclerEnabled: ?boolean,
   moduleRestrictionsDisabled: ?boolean,
 |}
@@ -44,7 +43,6 @@ const mapSTP = (state: BaseState): SP => {
     initialPipetteValues: initialPipettes,
     _prevPipettes: stepFormSelectors.getInitialDeckSetup(state).pipettes, // TODO: Ian 2019-01-02 when multi-step editing is supported, don't use initial deck state. Instead, show the pipettes available for the selected step range
     _orderedStepIds: stepFormSelectors.getOrderedStepIds(state),
-    modulesEnabled: featureFlagSelectors.getEnableModules(state),
     thermocyclerEnabled: featureFlagSelectors.getEnableThermocycler(state),
     moduleRestrictionsDisabled: featureFlagSelectors.getDisableModuleRestrictions(
       state

--- a/protocol-designer/src/components/modals/FilePipettesModal/__tests__/index.test.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/__tests__/index.test.js
@@ -57,7 +57,6 @@ describe('FilePipettesModal', () => {
       hideModal: false,
       onCancel: jest.fn(),
       onSave: jest.fn(),
-      modulesEnabled: true,
       thermocyclerEnabled: true,
       moduleRestrictionsDisabled: false,
     }
@@ -97,12 +96,10 @@ describe('FilePipettesModal', () => {
       expect(pipetteFields.prop('touched')).toBeNull()
     })
 
-    it('does not render ModuleFields when modules are not enabled', () => {
-      props.modulesEnabled = false
-
+    it('renders ModuleFields', () => {
       const moduleFields = renderFormComponent(props).find(ModuleFields)
 
-      expect(moduleFields).toHaveLength(0)
+      expect(moduleFields).toHaveLength(1)
     })
 
     it('does not render ModuleFields when editing pipettes and showModulesFields is false', () => {

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.js
@@ -71,7 +71,6 @@ export type Props = {|
     pipettes: Array<PipetteFieldsData>,
     modules: Array<ModuleCreationArgs>,
   |}) => mixed,
-  modulesEnabled: ?boolean,
   thermocyclerEnabled: ?boolean,
   moduleRestrictionsDisabled: ?boolean,
 |}
@@ -345,28 +344,27 @@ export class FilePipettesModal extends React.Component<Props, State> {
                           onSetFieldTouched={setFieldTouched}
                         />
 
-                        {this.props.modulesEnabled &&
-                          this.props.showModulesFields && (
-                            <div className={styles.protocol_modules_group}>
-                              <h2 className={styles.new_file_modal_title}>
-                                {i18n.t(
-                                  'modal.new_protocol.title.PROTOCOL_MODULES'
-                                )}
-                              </h2>
-                              <ModuleFields
-                                errors={errors.modulesByType ?? null}
-                                values={visibleModules}
-                                thermocyclerEnabled={
-                                  this.props.thermocyclerEnabled
-                                }
-                                onFieldChange={handleChange}
-                                onSetFieldValue={setFieldValue}
-                                onBlur={handleBlur}
-                                touched={touched.modulesByType ?? null}
-                                onSetFieldTouched={setFieldTouched}
-                              />
-                            </div>
-                          )}
+                        {this.props.showModulesFields && (
+                          <div className={styles.protocol_modules_group}>
+                            <h2 className={styles.new_file_modal_title}>
+                              {i18n.t(
+                                'modal.new_protocol.title.PROTOCOL_MODULES'
+                              )}
+                            </h2>
+                            <ModuleFields
+                              errors={errors.modulesByType ?? null}
+                              values={visibleModules}
+                              thermocyclerEnabled={
+                                this.props.thermocyclerEnabled
+                              }
+                              onFieldChange={handleChange}
+                              onSetFieldValue={setFieldValue}
+                              onBlur={handleBlur}
+                              touched={touched.modulesByType ?? null}
+                              onSetFieldTouched={setFieldTouched}
+                            />
+                          </div>
+                        )}
                         {showCrashInfoBox && !moduleRestrictionsDisabled && (
                           <CrashInfoBox
                             showDiagram

--- a/protocol-designer/src/components/modals/NewFileModal/index.js
+++ b/protocol-designer/src/components/modals/NewFileModal/index.js
@@ -29,7 +29,6 @@ type OP = {|
 type SP = {|
   hideModal: $PropertyType<Props, 'hideModal'>,
   _hasUnsavedChanges: ?boolean,
-  modulesEnabled: ?boolean,
   thermocyclerEnabled: ?boolean,
   moduleRestrictionsDisabled: ?boolean,
 |}
@@ -49,7 +48,6 @@ function mapStateToProps(state: BaseState): SP {
   return {
     hideModal: !selectors.getNewProtocolModal(state),
     _hasUnsavedChanges: loadFileSelectors.getHasUnsavedChanges(state),
-    modulesEnabled: featureFlagSelectors.getEnableModules(state),
     thermocyclerEnabled: featureFlagSelectors.getEnableThermocycler(state),
     moduleRestrictionsDisabled: featureFlagSelectors.getDisableModuleRestrictions(
       state
@@ -113,7 +111,6 @@ function mapDispatchToProps(dispatch: ThunkDispatch<*>): DP {
 function mergeProps(stateProps: SP, dispatchProps: DP, ownProps: OP): Props {
   return {
     ...ownProps,
-    modulesEnabled: stateProps.modulesEnabled,
     thermocyclerEnabled: stateProps.thermocyclerEnabled,
     moduleRestrictionsDisabled: stateProps.moduleRestrictionsDisabled,
     showModulesFields: true,

--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -19,7 +19,6 @@ type SP = {|
   instruments: $PropertyType<Props, 'instruments'>,
   formValues: $PropertyType<Props, 'formValues'>,
   _initialDeckSetup: InitialDeckSetup,
-  modulesEnabled: ?boolean,
   thermocyclerEnabled: ?boolean,
   modules: $PropertyType<Props, 'modules'>,
 |}
@@ -30,7 +29,6 @@ const mapStateToProps = (state: BaseState): SP => {
     instruments: stepFormSelectors.getPipettesForInstrumentGroup(state),
     modules: stepFormSelectors.getModulesForEditModulesCard(state),
     _initialDeckSetup: stepFormSelectors.getInitialDeckSetup(state),
-    modulesEnabled: featureFlagSelectors.getEnableModules(state),
     thermocyclerEnabled: featureFlagSelectors.getEnableThermocycler(state),
   }
 }

--- a/protocol-designer/src/feature-flags/reducers.js
+++ b/protocol-designer/src/feature-flags/reducers.js
@@ -19,7 +19,6 @@ import type { Action } from '../types'
 // initial value is only relevant matters if there is no persisted value already)
 const initialFlags: Flags = {
   PRERELEASE_MODE: process.env.OT_PD_PRERELEASE_MODE === '1' || false,
-  OT_PD_ENABLE_MODULES: process.env.OT_PD_ENABLE_MODULES === '1' || false,
   OT_PD_DISABLE_MODULE_RESTRICTIONS:
     process.env.OT_PD_DISABLE_MODULE_RESTRICTIONS === '1' || false,
   OT_PD_ENABLE_MULTI_GEN2_PIPETTES:

--- a/protocol-designer/src/feature-flags/selectors.js
+++ b/protocol-designer/src/feature-flags/selectors.js
@@ -9,11 +9,6 @@ export const getEnabledPrereleaseMode: Selector<?boolean> = createSelector(
   flags => flags.PRERELEASE_MODE
 )
 
-export const getEnableModules: Selector<?boolean> = createSelector(
-  getFeatureFlagData,
-  flags => flags.OT_PD_ENABLE_MODULES
-)
-
 export const getDisableModuleRestrictions: Selector<?boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_DISABLE_MODULE_RESTRICTIONS

--- a/protocol-designer/src/feature-flags/types.js
+++ b/protocol-designer/src/feature-flags/types.js
@@ -7,12 +7,12 @@
 export const DEPRECATED_FLAGS = [
   'OT_PD_SHOW_UPLOAD_CUSTOM_LABWARE_BUTTON',
   'OT_PD_ENABLE_GEN2_PIPETTES',
+  'OT_PD_ENABLE_MODULES',
 ]
 
 // union of feature flag string constant IDs
 export type FlagTypes =
   | 'PRERELEASE_MODE'
-  | 'OT_PD_ENABLE_MODULES'
   | 'OT_PD_DISABLE_MODULE_RESTRICTIONS'
   | 'OT_PD_ENABLE_MULTI_GEN2_PIPETTES'
   | 'OT_PD_ENABLE_THERMOCYCLER'
@@ -20,6 +20,7 @@ export type FlagTypes =
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: Array<FlagTypes> = [
   'OT_PD_ENABLE_MULTI_GEN2_PIPETTES',
+  'OT_PD_DISABLE_MODULE_RESTRICTIONS',
 ]
 
 export type Flags = $Shape<{|

--- a/protocol-designer/src/load-file/actions.js
+++ b/protocol-designer/src/load-file/actions.js
@@ -1,6 +1,5 @@
 // @flow
 import { migration } from './migration'
-import { selectors as featureFlagSelectors } from '../feature-flags'
 import type { PDProtocolFile } from '../file-types'
 import type { GetState, ThunkAction, ThunkDispatch } from '../types'
 import type {
@@ -51,22 +50,11 @@ export const loadProtocolFile = (
       const result = ((readEvent.currentTarget: any): FileReader).result
       let parsedProtocol: ?PDProtocolFile
 
-      const modulesEnabled = featureFlagSelectors.getEnableModules(getState())
-
       try {
         parsedProtocol = JSON.parse(((result: any): string))
-        // Protect production PD from weird states you could get from loading a JSON ~v4 protocol with modules
-        if ('modules' in parsedProtocol && !modulesEnabled) {
-          dispatch(
-            fileError(
-              'INVALID_JSON_FILE',
-              'This protocol appears to contain modules. This is not yet supported in PD.'
-            )
-          )
-        } else {
-          // TODO LATER Ian 2018-05-18 validate file with JSON Schema here
-          dispatch(loadFileAction(parsedProtocol))
-        }
+
+        // TODO LATER Ian 2018-05-18 validate file with JSON Schema here
+        dispatch(loadFileAction(parsedProtocol))
       } catch (error) {
         console.error(error)
         fileError('INVALID_JSON_FILE', error.message)


### PR DESCRIPTION
## overview

🥁 This closes #4968 by removing the enable modules in PD FF, and promoting disable module restrictions to a user facing experimental setting.

## changelog

- feat(protocol-designer): Enable magnetic and temperature module support

## review requests

Please really run this one to ground. 
Quadruple check:
- [ ] New file modal
- [ ] File settings page
- [ ] Deck Map
- [ ] Step creation button
- [ ] Imports and Exports
- [ ] Settings page FFs

## risk assessment

Modules in PD only