### PR TITLE
fix(protocol-designer): fix module substep text styling

### DIFF
--- a/protocol-designer/src/components/DeckSetup/__tests__/ModuleTag.test.js
+++ b/protocol-designer/src/components/DeckSetup/__tests__/ModuleTag.test.js
@@ -77,7 +77,7 @@ describe('ModuleTag', () => {
 
         const component = render(<ModuleStatus moduleState={moduleState} />)
 
-        expect(component.text()).toBe('Deactivated')
+        expect(component.text()).toBe('deactivated')
       })
 
       it('target temperature is shown when module is at target', () => {

--- a/protocol-designer/src/components/steplist/StepItem.css
+++ b/protocol-designer/src/components/steplist/StepItem.css
@@ -70,10 +70,6 @@
   font-size: var(--fs-body-1);
   font-weight: var(--fw-semibold);
 
-  & span {
-    margin-right: 0.5rem;
-  }
-
   &:last-child {
     padding-bottom: 1.25rem;
   }
@@ -82,6 +78,7 @@
 .module_substep_value {
   text-align: right;
   flex: 0.5;
+  text-transform: capitalize;
 }
 
 /* Multi-channel row representing a single channel */

--- a/protocol-designer/src/localization/en/modules.json
+++ b/protocol-designer/src/localization/en/modules.json
@@ -19,7 +19,7 @@
   "status": {
     "engaged": "engaged",
     "disengaged": "disengaged",
-    "deactivated": "Deactivated"
+    "deactivated": "deactivated"
   },
   "actions": {
     "action": "action",


### PR DESCRIPTION
## overview

Closes #5305 

## changelog

## review requests

See linked issue for screenshots + Zeplin link

- [ ] Type style matches design for both engage & disengage in Magnet step substeps
- [ ] Temperature substeps (degrees C and Deactivated) should continue to appear correct

## risk assessment

just PD copy styling