### PR TITLE
fix(protocol-designer): rename 'module' variables to something else

### DIFF
--- a/protocol-designer/src/components/DeckSetup/DeckSetup.js
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.js
@@ -74,16 +74,17 @@ const VIEWBOX_WIDTH = 520
 const VIEWBOX_HEIGHT = 414
 
 const getSlotDefForModuleSlot = (
-  module: ModuleOnDeck,
+  moduleOnDeck: ModuleOnDeck,
   deckSlots: { [slotId: string]: DeckDefSlot }
 ): DeckDefSlot => {
-  const parentSlotDef = deckSlots[module.slot] || PSEUDO_DECK_SLOTS[module.slot]
-  const moduleOrientation = inferModuleOrientationFromSlot(module.slot)
-  const moduleData = getModuleVizDims(moduleOrientation, module.type)
+  const parentSlotDef =
+    deckSlots[moduleOnDeck.slot] || PSEUDO_DECK_SLOTS[moduleOnDeck.slot]
+  const moduleOrientation = inferModuleOrientationFromSlot(moduleOnDeck.slot)
+  const moduleData = getModuleVizDims(moduleOrientation, moduleOnDeck.type)
 
   return {
     ...parentSlotDef,
-    id: module.id,
+    id: moduleOnDeck.id,
     position: [
       parentSlotDef.position[0] + moduleData.childXOffset,
       parentSlotDef.position[1] + moduleData.childYOffset,
@@ -94,7 +95,7 @@ const getSlotDefForModuleSlot = (
       yDimension: moduleData.childYDimension,
       zDimension: 0,
     },
-    displayName: `Slot of ${module.type} in slot ${module.slot}`,
+    displayName: `Slot of ${moduleOnDeck.type} in slot ${moduleOnDeck.slot}`,
   }
 }
 
@@ -102,8 +103,8 @@ const getModuleSlotDefs = (
   initialDeckSetup: InitialDeckSetup,
   deckSlots: { [slotId: string]: DeckDefSlot }
 ): Array<DeckDefSlot> => {
-  return values(initialDeckSetup.modules).map((module: ModuleOnDeck) =>
-    getSlotDefForModuleSlot(module, deckSlots)
+  return values(initialDeckSetup.modules).map((moduleOnDeck: ModuleOnDeck) =>
+    getSlotDefForModuleSlot(moduleOnDeck, deckSlots)
   )
 }
 
@@ -207,10 +208,10 @@ const DeckSetupContents = (props: ContentsProps) => {
   // NOTE: naively hard-coded to show warning north of slots 1 or 3 when occupied by any module
   let multichannelWarningSlots: Array<DeckDefSlot> = showGen1MultichannelCollisionWarnings
     ? compact([
-        (allModules.some(module => module.slot === '1') &&
+        (allModules.some(moduleOnDeck => moduleOnDeck.slot === '1') &&
           deckSlotsById?.['4']) ||
           null,
-        (allModules.some(module => module.slot === '3') &&
+        (allModules.some(moduleOnDeck => moduleOnDeck.slot === '3') &&
           deckSlotsById?.['6']) ||
           null,
       ])
@@ -219,10 +220,14 @@ const DeckSetupContents = (props: ContentsProps) => {
   return (
     <>
       {/* all modules */}
-      {allModules.map(module => {
-        const slot = moduleParentSlots.find(slot => slot.id === module.slot)
+      {allModules.map(moduleOnDeck => {
+        const slot = moduleParentSlots.find(
+          slot => slot.id === moduleOnDeck.slot
+        )
         if (!slot) {
-          console.warn(`no slot ${module.slot} for module ${module.id}`)
+          console.warn(
+            `no slot ${moduleOnDeck.slot} for module ${moduleOnDeck.id}`
+          )
           return null
         }
 
@@ -235,14 +240,14 @@ const DeckSetupContents = (props: ContentsProps) => {
               x={moduleX}
               y={moduleY}
               orientation={orientation}
-              module={module}
+              module={moduleOnDeck}
               slotName={slot.id}
             />
             <ModuleTag
               x={moduleX}
               y={moduleY}
               orientation={orientation}
-              id={module.id}
+              id={moduleOnDeck.id}
             />
           </React.Fragment>
         )

--- a/protocol-designer/src/components/FileSidebar/FileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.js
@@ -81,7 +81,9 @@ function getWarningContent({
     .map(pipette => `${pipette.mount} ${pipette.spec.displayName}`)
     .join(' and ')
   const modulesDetails = modulesWithoutStep
-    .map(module => i18n.t(`modules.module_long_names.${module.type}`))
+    .map(moduleOnDeck =>
+      i18n.t(`modules.module_long_names.${moduleOnDeck.type}`)
+    )
     .join(' and ')
 
   if (pipettesWithoutStep.length && modulesWithoutStep.length) {

--- a/protocol-designer/src/components/LabwareSelectionModal/index.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/index.js
@@ -36,7 +36,9 @@ function mapStateToProps(state: BaseState): SP {
     moduleId => modulesById[moduleId]
   )
   const parentModule =
-    (slot != null && initialModules.find(module => module.id === slot)) || null
+    (slot != null &&
+      initialModules.find(moduleOnDeck => moduleOnDeck.id === slot)) ||
+    null
 
   return {
     customLabwareDefs: labwareDefSelectors.getCustomLabwareDefsByURI(state),

--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -93,9 +93,12 @@ export function EditModulesModal(props: EditModulesProps) {
       // disabled if something lives in the slot selected in local state
       // if previous moduleOnDeck.model is different, edit module
       if (moduleOnDeck.model !== selectedModel) {
-        module.id &&
+        moduleOnDeck.id &&
           dispatch(
-            stepFormActions.editModule({ id: module.id, model: selectedModel })
+            stepFormActions.editModule({
+              id: moduleOnDeck.id,
+              model: selectedModel,
+            })
           )
       }
       // if previous moduleOnDeck.slot is different than state, move deck item

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.js
@@ -161,10 +161,10 @@ export class FilePipettesModal extends React.Component<Props, State> {
     modules: FormModulesByType,
     moduleType: ModuleRealType
   ) => {
-    const module = modules[moduleType]
+    const formModule = modules[moduleType]
     const crashableModuleOnDeck =
-      module.onDeck && module.model
-        ? isModuleWithCollisionIssue(module.model)
+      formModule.onDeck && formModule.model
+        ? isModuleWithCollisionIssue(formModule.model)
         : false
 
     return crashableModuleOnDeck
@@ -205,14 +205,14 @@ export class FilePipettesModal extends React.Component<Props, State> {
     const moduleTypes: Array<ModuleRealType> = Object.keys(values.modulesByType)
     const modules: Array<ModuleCreationArgs> = moduleTypes.reduce(
       (acc, moduleType) => {
-        const module = values.modulesByType[moduleType]
-        return module?.onDeck
+        const formModule = values.modulesByType[moduleType]
+        return formModule?.onDeck
           ? [
               ...acc,
               {
                 type: moduleType,
-                model: module.model || '',
-                slot: module.slot,
+                model: formModule.model || '',
+                slot: formModule.slot,
               },
             ]
           : acc

--- a/protocol-designer/src/components/modals/NewFileModal/index.js
+++ b/protocol-designer/src/components/modals/NewFileModal/index.js
@@ -94,7 +94,9 @@ function mapDispatchToProps(dispatch: ThunkDispatch<*>): DP {
       )
 
       // create modules
-      modules.forEach(module => dispatch(stepFormActions.createModule(module)))
+      modules.forEach(moduleArgs =>
+        dispatch(stepFormActions.createModule(moduleArgs))
+      )
 
       // auto-generate tipracks for pipettes
       const newTiprackModels: Array<string> = uniq(

--- a/protocol-designer/src/components/modules/EditModulesCard.js
+++ b/protocol-designer/src/components/modules/EditModulesCard.js
@@ -74,7 +74,7 @@ export function EditModulesCard(props: Props) {
             return (
               <ModuleRow
                 type={moduleType}
-                module={moduleData}
+                moduleOnDeck={moduleData}
                 showCollisionWarnings={warningsEnabled}
                 key={i}
                 openEditModuleModal={openEditModuleModal}

--- a/protocol-designer/src/components/modules/ModuleRow.js
+++ b/protocol-designer/src/components/modules/ModuleRow.js
@@ -21,19 +21,19 @@ import styles from './styles.css'
 import type { ModuleRealType } from '@opentrons/shared-data'
 import type { ModuleOnDeck } from '../../step-forms'
 
-type Props = {
-  module?: ModuleOnDeck,
+type Props = {|
+  moduleOnDeck?: ModuleOnDeck,
   showCollisionWarnings?: boolean,
   type: ModuleRealType,
   openEditModuleModal: (moduleType: ModuleRealType, moduleId?: string) => mixed,
-}
+|}
 
 export function ModuleRow(props: Props) {
-  const { module, openEditModuleModal, showCollisionWarnings } = props
-  const type: ModuleRealType = module?.type || props.type
+  const { moduleOnDeck, openEditModuleModal, showCollisionWarnings } = props
+  const type: ModuleRealType = moduleOnDeck?.type || props.type
 
-  const model = module?.model
-  const slot = module?.slot
+  const model = moduleOnDeck?.model
+  const slot = moduleOnDeck?.slot
 
   /*
   TODO (ka 2020-2-3): This logic is very specific to this individual implementation
@@ -88,15 +88,16 @@ export function ModuleRow(props: Props) {
     moduleId?: string
   ) => () => openEditModuleModal(moduleType, moduleId)
 
-  const addRemoveText = module ? 'remove' : 'add'
+  const addRemoveText = moduleOnDeck ? 'remove' : 'add'
 
   const dispatch = useDispatch()
 
-  const handleAddOrRemove = module
-    ? () => dispatch(stepFormActions.deleteModule(module.id))
+  const handleAddOrRemove = moduleOnDeck
+    ? () => dispatch(stepFormActions.deleteModule(moduleOnDeck.id))
     : setCurrentModule(type)
 
-  const handleEditModule = module && setCurrentModule(type, module.id)
+  const handleEditModule =
+    moduleOnDeck && setCurrentModule(type, moduleOnDeck.id)
 
   return (
     <div>
@@ -141,7 +142,7 @@ export function ModuleRow(props: Props) {
           )}
         </div>
         <div className={styles.modules_button_group}>
-          {module && (
+          {moduleOnDeck && (
             <OutlineButton
               className={styles.module_button}
               onClick={handleEditModule}

--- a/protocol-designer/src/components/modules/__tests__/EditModulesCard.test.js
+++ b/protocol-designer/src/components/modules/__tests__/EditModulesCard.test.js
@@ -180,7 +180,7 @@ describe('EditModulesCard', () => {
         .props()
     ).toEqual({
       type: MAGNETIC_MODULE_TYPE,
-      module: crashableMagneticModule,
+      moduleOnDeck: crashableMagneticModule,
       showCollisionWarnings: true,
       openEditModuleModal: props.openEditModuleModal,
     })

--- a/protocol-designer/src/components/modules/__tests__/ModuleRow.test.js
+++ b/protocol-designer/src/components/modules/__tests__/ModuleRow.test.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react'
 import { mount } from 'enzyme'
 import { Provider } from 'react-redux'
@@ -48,7 +49,7 @@ describe('ModuleRow', () => {
 
   it('displays crash warning tooltip when module is crashable and in slot 1', () => {
     const props = {
-      module: magneticModule,
+      moduleOnDeck: magneticModule,
       showCollisionWarnings: true,
       type: MAGNETIC_MODULE_TYPE,
       openEditModuleModal: jest.fn(),
@@ -63,7 +64,7 @@ describe('ModuleRow', () => {
   it('displays crash warning tooltip when module is crashable and in slot 3', () => {
     magneticModule.slot = '3'
     const props = {
-      module: magneticModule,
+      moduleOnDeck: magneticModule,
       showCollisionWarnings: true,
       type: MAGNETIC_MODULE_TYPE,
       openEditModuleModal: jest.fn(),
@@ -78,7 +79,7 @@ describe('ModuleRow', () => {
   it('does not display crash warning tooltip when module is not crashable regardless of slot', () => {
     magneticModule.model = MAGNETIC_MODULE_V2
     const props = {
-      module: magneticModule,
+      moduleOnDeck: magneticModule,
       showCollisionWarnings: true,
       type: MAGNETIC_MODULE_TYPE,
       openEditModuleModal: jest.fn(),
@@ -92,7 +93,7 @@ describe('ModuleRow', () => {
 
   it('does not display warning tooltip when showCollisionWarnings is false', () => {
     const props = {
-      module: magneticModule,
+      moduleOnDeck: magneticModule,
       showCollisionWarnings: false,
       type: MAGNETIC_MODULE_TYPE,
       openEditModuleModal: jest.fn(),
@@ -120,7 +121,7 @@ describe('ModuleRow', () => {
   it('displays the correct module diagram for the selected module model', () => {
     magneticModule.model = MAGNETIC_MODULE_V2
     const props = {
-      module: magneticModule,
+      moduleOnDeck: magneticModule,
       showCollisionWarnings: true,
       type: MAGNETIC_MODULE_TYPE,
       openEditModuleModal: jest.fn(),
@@ -135,7 +136,7 @@ describe('ModuleRow', () => {
 
   it('displays the correct module model and slot when it is added to protocol', () => {
     const props = {
-      module: magneticModule,
+      moduleOnDeck: magneticModule,
       showCollisionWarnings: true,
       type: MAGNETIC_MODULE_TYPE,
       openEditModuleModal: jest.fn(),
@@ -172,7 +173,7 @@ describe('ModuleRow', () => {
   describe('buttons', () => {
     it('opens edit modal when module is added', () => {
       const props = {
-        module: magneticModule,
+        moduleOnDeck: magneticModule,
         showCollisionWarnings: true,
         type: MAGNETIC_MODULE_TYPE,
         openEditModuleModal: jest.fn(),
@@ -211,7 +212,7 @@ describe('ModuleRow', () => {
 
     it('removes module when module has been added', () => {
       const props = {
-        module: magneticModule,
+        moduleOnDeck: magneticModule,
         showCollisionWarnings: true,
         type: MAGNETIC_MODULE_TYPE,
         openEditModuleModal: jest.fn(),

--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -130,9 +130,9 @@ export const createFile: Selector<PDProtocolFile> = createSelector(
 
     const modules: { [moduleId: string]: FileModule } = mapValues(
       moduleEntities,
-      (module: ModuleEntity, moduleId: string): FileModule => ({
+      (moduleEntity: ModuleEntity, moduleId: string): FileModule => ({
         slot: initialRobotState.modules[moduleId].slot,
-        model: module.model,
+        model: moduleEntity.model,
       })
     )
 

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -201,27 +201,27 @@ const _getInitialDeckSetup = (
     modules: mapValues(
       moduleLocations,
       (slot: DeckSlot, moduleId: string): ModuleOnDeck => {
-        const module = moduleEntities[moduleId]
-        if (module.type === MAGNETIC_MODULE_TYPE) {
+        const moduleEntity = moduleEntities[moduleId]
+        if (moduleEntity.type === MAGNETIC_MODULE_TYPE) {
           return {
-            id: module.id,
-            model: module.model,
+            id: moduleEntity.id,
+            model: moduleEntity.model,
             type: MAGNETIC_MODULE_TYPE,
             slot,
             moduleState: MAGNETIC_MODULE_INITIAL_STATE,
           }
-        } else if (module.type === TEMPERATURE_MODULE_TYPE) {
+        } else if (moduleEntity.type === TEMPERATURE_MODULE_TYPE) {
           return {
-            id: module.id,
-            model: module.model,
+            id: moduleEntity.id,
+            model: moduleEntity.model,
             type: TEMPERATURE_MODULE_TYPE,
             slot,
             moduleState: TEMPERATURE_MODULE_INITIAL_STATE,
           }
         } else {
           return {
-            id: module.id,
-            model: module.model,
+            id: moduleEntity.id,
+            model: moduleEntity.model,
             type: THERMOCYCLER_MODULE_TYPE,
             slot,
             moduleState: THERMOCYCLER_MODULE_INITIAL_STATE,

--- a/protocol-designer/src/step-forms/utils.js
+++ b/protocol-designer/src/step-forms/utils.js
@@ -96,9 +96,9 @@ export const getSlotsBlockedBySpanning = (
   // NOTE: Ian 2019-10-25 dumb heuristic since there's only one case this can happen now
   if (
     values(initialDeckSetup.modules).some(
-      (module: ModuleOnDeck) =>
-        module.type === THERMOCYCLER_MODULE_TYPE &&
-        module.slot === SPAN7_8_10_11_SLOT
+      (moduleOnDeck: ModuleOnDeck) =>
+        moduleOnDeck.type === THERMOCYCLER_MODULE_TYPE &&
+        moduleOnDeck.slot === SPAN7_8_10_11_SLOT
     )
   ) {
     return ['7', '8', '10', '11']
@@ -126,7 +126,7 @@ export const getSlotIsEmpty = (
   return (
     [
       ...values(initialDeckSetup.modules).filter(
-        (module: ModuleOnDeck) => module.slot === slot
+        (moduleOnDeck: ModuleOnDeck) => moduleOnDeck.slot === slot
       ),
       ...values(initialDeckSetup.labware).filter(
         (labware: LabwareOnDeckType) => labware.slot === slot

--- a/protocol-designer/src/steplist/formLevel/errors.js
+++ b/protocol-designer/src/steplist/formLevel/errors.js
@@ -223,8 +223,8 @@ export const engageHeightRangeExceeded = (
   fields: HydratedFormData
 ): FormError | null => {
   const { magnetAction, engageHeight } = fields
-  const module = fields.meta?.module
-  const model = module?.model
+  const moduleEntity = fields.meta?.module
+  const model = moduleEntity?.model
 
   if (magnetAction === 'engage') {
     if (model === MAGNETIC_MODULE_V1) {

--- a/protocol-designer/src/ui/labware/selectors.js
+++ b/protocol-designer/src/ui/labware/selectors.js
@@ -38,10 +38,10 @@ export const getLabwareOptions: Selector<Options> = createSelector(
     reduce(
       labwareEntities,
       (acc: Options, l: LabwareEntity, labwareId: string): Options => {
-        const module = getModuleUnderLabware(initialDeckSetup, labwareId)
-        const prefix = module
+        const moduleOnDeck = getModuleUnderLabware(initialDeckSetup, labwareId)
+        const prefix = moduleOnDeck
           ? i18n.t(
-              `form.step_edit_form.field.moduleLabwarePrefix.${module.type}`
+              `form.step_edit_form.field.moduleLabwarePrefix.${moduleOnDeck.type}`
             )
           : null
         const nickName = prefix

--- a/protocol-designer/src/ui/modules/selectors.js
+++ b/protocol-designer/src/ui/modules/selectors.js
@@ -26,7 +26,7 @@ export const getLabwareNamesByModuleId: Selector<{
   stepFormSelectors.getInitialDeckSetup,
   getLabwareNicknamesById,
   (initialDeckSetup, nicknamesById) =>
-    mapValues(initialDeckSetup.modules, (module, moduleId) => {
+    mapValues(initialDeckSetup.modules, (_, moduleId) => {
       const labware = getLabwareOnModule(initialDeckSetup, moduleId)
       return labware
         ? {

--- a/protocol-designer/src/ui/modules/utils.js
+++ b/protocol-designer/src/ui/modules/utils.js
@@ -14,7 +14,7 @@ export function getModuleOnDeckByType(
   type: ModuleRealType
 ): ?ModuleOnDeck {
   return values(initialDeckSetup.modules).find(
-    (module: ModuleOnDeck) => module.type === type
+    (moduleOnDeck: ModuleOnDeck) => moduleOnDeck.type === type
   )
 }
 
@@ -32,8 +32,8 @@ export function getModuleUnderLabware(
   labwareId: string
 ): ?ModuleOnDeck {
   return values(initialDeckSetup.modules).find(
-    (module: ModuleOnDeck) =>
-      initialDeckSetup.labware[labwareId]?.slot === module.id
+    (moduleOnDeck: ModuleOnDeck) =>
+      initialDeckSetup.labware[labwareId]?.slot === moduleOnDeck.id
   )
 }
 
@@ -42,23 +42,24 @@ export function getModuleLabwareOptions(
   nicknamesById: { [labwareId: string]: string },
   type: ModuleRealType
 ): Options {
-  const module = getModuleOnDeckByType(initialDeckSetup, type)
-  const labware = module && getLabwareOnModule(initialDeckSetup, module.id)
+  const moduleOnDeck = getModuleOnDeckByType(initialDeckSetup, type)
+  const labware =
+    moduleOnDeck && getLabwareOnModule(initialDeckSetup, moduleOnDeck.id)
   const prefix = i18n.t(`form.step_edit_form.field.moduleLabwarePrefix.${type}`)
   let options = []
-  if (module) {
+  if (moduleOnDeck) {
     if (labware) {
       options = [
         {
           name: `${prefix} ${nicknamesById[labware.id]}`,
-          value: module.id,
+          value: moduleOnDeck.id,
         },
       ]
     } else {
       options = [
         {
           name: `${prefix} No labware on module`,
-          value: module.id,
+          value: moduleOnDeck.id,
         },
       ]
     }
@@ -71,7 +72,8 @@ export function getModuleHasLabware(
   initialDeckSetup: InitialDeckSetup,
   type: ModuleRealType
 ): boolean {
-  const module = getModuleOnDeckByType(initialDeckSetup, type)
-  const labware = module && getLabwareOnModule(initialDeckSetup, module.id)
-  return Boolean(module) && Boolean(labware)
+  const moduleOnDeck = getModuleOnDeckByType(initialDeckSetup, type)
+  const labware =
+    moduleOnDeck && getLabwareOnModule(initialDeckSetup, moduleOnDeck.id)
+  return Boolean(moduleOnDeck) && Boolean(labware)
 }


### PR DESCRIPTION
## overview

We had a lot of `const module = ...` or `mapValues(modules, module => ...` etc, which is usually fine. But since `module` is a reserved word with a global Flow type, you can do things like `if (module)` or `return module.id` even if there is no `const module = ...` around. So if you're declaring a variable called `module` at the top of a fn and using it at the bottom, and then delete or change `module` at the top, you might not get linting errors about your missing variable.

This silly problem led me to get really confused for 15 mins working on a PR with `module`

This PR should be purely a refactor, changing uses of local `module` variables to something else like `moduleOnDeck` or `moduleEntity` etc.

I wish there was a linting rule where you can't assign `module` (or use it as an arg name `const myFn = (module) => {...}`) but I didn't see anything in eslint (?!?)

### UPDATE

This is a fix, not a refactor, b/c in `protocol-designer/src/components/modals/EditModulesModal/index.js` it's using the global `module` and was making a bug where editing the module and saving it would whitescreen PR, which is a bug I introduced while refactoring #5284 (I think I renamed `module -> moduleOnDeck` but missed some `module` and got no linting error so thought it was good :stuck_out_tongue_closed_eyes:)

## changelog

* rename variables called `module` to something else

## review requests

- [ ] Code review
- [ ] Editing modules should work OK
- For later: linting rule to cement this?

## risk assessment

wide-scope refactor across PD, but if tests pass and code review OK it should be low-risk?