### PR TITLE
fix(protocol-designer): Only show slot access warnings for Gen1 modules

### DIFF
--- a/protocol-designer/src/components/DeckSetup/DeckSetup.js
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.js
@@ -10,13 +10,15 @@ import {
 } from '@opentrons/components'
 import {
   getLabwareHasQuirk,
-  MAGNETIC_MODULE_V1,
-  TEMPERATURE_MODULE_V1,
   type DeckSlot as DeckDefSlot,
   type ModuleRealType,
 } from '@opentrons/shared-data'
 import { getDeckDefinitions } from '@opentrons/components/src/deck/getDeckDefinitions'
-import { PSEUDO_DECK_SLOTS, GEN_ONE_MULTI_PIPETTES } from '../../constants'
+import {
+  PSEUDO_DECK_SLOTS,
+  GEN_ONE_MULTI_PIPETTES,
+  MODULES_WITH_COLLISION_ISSUES,
+} from '../../constants'
 import type { TerminalItemId } from '../../steplist'
 import {
   getLabwareIsCompatible,
@@ -213,14 +215,14 @@ const DeckSetupContents = (props: ContentsProps) => {
         (allModules.some(
           moduleOnDeck =>
             moduleOnDeck.slot === '1' &&
-            moduleOnDeck.model.includes(MAGNETIC_MODULE_V1)
+            MODULES_WITH_COLLISION_ISSUES.includes(moduleOnDeck.model)
         ) &&
           deckSlotsById?.['4']) ||
           null,
         (allModules.some(
           moduleOnDeck =>
             moduleOnDeck.slot === '3' &&
-            moduleOnDeck.model.includes(TEMPERATURE_MODULE_V1)
+            MODULES_WITH_COLLISION_ISSUES.includes(moduleOnDeck.model)
         ) &&
           deckSlotsById?.['6']) ||
           null,

--- a/protocol-designer/src/components/DeckSetup/DeckSetup.js
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.js
@@ -10,6 +10,8 @@ import {
 } from '@opentrons/components'
 import {
   getLabwareHasQuirk,
+  MAGNETIC_MODULE_V1,
+  TEMPERATURE_MODULE_V1,
   type DeckSlot as DeckDefSlot,
   type ModuleRealType,
 } from '@opentrons/shared-data'
@@ -210,13 +212,15 @@ const DeckSetupContents = (props: ContentsProps) => {
     ? compact([
         (allModules.some(
           moduleOnDeck =>
-            moduleOnDeck.slot === '1' && moduleOnDeck.model.includes('V1')
+            moduleOnDeck.slot === '1' &&
+            moduleOnDeck.model.includes(MAGNETIC_MODULE_V1)
         ) &&
           deckSlotsById?.['4']) ||
           null,
         (allModules.some(
           moduleOnDeck =>
-            moduleOnDeck.slot === '3' && moduleOnDeck.model.includes('V1')
+            moduleOnDeck.slot === '3' &&
+            moduleOnDeck.model.includes(TEMPERATURE_MODULE_V1)
         ) &&
           deckSlotsById?.['6']) ||
           null,

--- a/protocol-designer/src/components/DeckSetup/DeckSetup.js
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.js
@@ -208,10 +208,16 @@ const DeckSetupContents = (props: ContentsProps) => {
   // NOTE: naively hard-coded to show warning north of slots 1 or 3 when occupied by any module
   let multichannelWarningSlots: Array<DeckDefSlot> = showGen1MultichannelCollisionWarnings
     ? compact([
-        (allModules.some(moduleOnDeck => moduleOnDeck.slot === '1') &&
+        (allModules.some(
+          moduleOnDeck =>
+            moduleOnDeck.slot === '1' && moduleOnDeck.model.includes('V1')
+        ) &&
           deckSlotsById?.['4']) ||
           null,
-        (allModules.some(moduleOnDeck => moduleOnDeck.slot === '3') &&
+        (allModules.some(
+          moduleOnDeck =>
+            moduleOnDeck.slot === '3' && moduleOnDeck.model.includes('V1')
+        ) &&
           deckSlotsById?.['6']) ||
           null,
       ])


### PR DESCRIPTION
## overview

This PR closes #5309 by disabling deckmap slot warnings for GEN2 Modules only

## changelog

- fix(protocol-designer): Only show slot access warnings for Gen1 modules

## review requests

Make sure disable module restrictions FF is OFF
Make a protocol with GEN1 modules and a GEN1 8-Channel Pipette
- [ ] 8-channel access warnings render in Slot 4 and Slot 6

Change the magnetic module to GEN2
- [ ] 8-channel access warnings render in Slot 6 only
- [ ] No warning in Slot 4

Change the temperature module to GEN2
- [ ] No warnings in any slots

## risk assessment

Slow. PD deckmap only