### PR TITLE
fix(robot-server): unavailable is a valid network connection state

### DIFF
--- a/robot-server/robot_server/service/models/networking.py
+++ b/robot-server/robot_server/service/models/networking.py
@@ -17,6 +17,7 @@ class ConnectionState(str, Enum):
     connected = "connected"
     connecting = "connecting"
     disconnected = "disconnected"
+    unavailable = "unavailable"
 
 
 class ConnectionType(str, Enum):

--- a/robot-server/robot_server/service/routers/networking.py
+++ b/robot-server/robot_server/service/routers/networking.py
@@ -36,7 +36,7 @@ async def get_networking_status() -> NetworkingStatus:
         log.debug("Interfaces: %s", interfaces)
         return NetworkingStatus(status=connectivity, interfaces=interfaces)
     except (subprocess.CalledProcessError, FileNotFoundError, ValueError) as e:
-        log.error("Failed calling nmcli")
+        log.exception("Failed calling nmcli")
         raise HTTPException(HTTPStatus.INTERNAL_SERVER_ERROR, str(e))
 
 


### PR DESCRIPTION
## overview

Bug fix in fastapi handling of `/network/status`

## changelog

Added `unavailable` to `ConnectionState` enum. It is a valid state returned by nmcli.

## risk assessment

None. Behind a feature flag