### PR TITLE
fix(app): alignment in thermocycler card cycle info

### DIFF
--- a/app/src/components/ModuleLiveStatusCards/ThermocyclerCard.js
+++ b/app/src/components/ModuleLiveStatusCards/ThermocyclerCard.js
@@ -1,16 +1,16 @@
 // @flow
 import * as React from 'react'
-import { addSeconds, format } from 'date-fns'
 import cx from 'classnames'
 import { LabeledValue } from '@opentrons/components'
 import { getModuleDisplayName } from '@opentrons/shared-data'
 
+import type { ThermocyclerModule, ModuleCommand } from '../../modules/types'
+import { formatSeconds } from '../../robot/selectors' // TODO: move helper from robot selector to helper file
 import { TemperatureControl, TemperatureData } from '../ModuleControls'
+
 import { StatusCard } from './StatusCard'
 import { StatusItem } from './StatusItem'
 import styles from './styles.css'
-
-import type { ThermocyclerModule, ModuleCommand } from '../../modules/types'
 
 const TimeRemaining = ({
   holdTime,
@@ -23,10 +23,7 @@ const TimeRemaining = ({
     className={cx(styles.inline_labeled_value, styles.time_remaining_wrapper)}
   >
     <p className={styles.time_remaining_label}>Time remaining for step:</p>
-    <p>
-      {// convert duration to seconds from epoch (midnight), then format
-      format(addSeconds(0, holdTime ?? 0), 'HH:mm:ss')}
-    </p>
+    <p>{formatSeconds(holdTime ?? 0)}</p>
   </span>
 )
 
@@ -146,18 +143,18 @@ export const ThermocyclerCard = ({
         />
       </div>
       {/* {executingProfile && ( */}
-        <CycleInfo
-          holdTime={50}
-          totalCycleCount={2}
-          currentCycleIndex={1}
-          totalStepCount={30}
-          currentStepIndex={4}
-        />
+      <CycleInfo
+        holdTime={50}
+        totalCycleCount={2}
+        currentCycleIndex={1}
+        totalStepCount={30}
+        currentStepIndex={4}
+      />
       {/* )} */}
       {/* {holdTime != null && holdTime > 0 && !executingProfile && ( */}
-        <div className={styles.card_row}>
-          <TimeRemaining holdTime={holdTime} title="Hold time remaining:" />
-        </div>
+      <div className={styles.card_row}>
+        <TimeRemaining holdTime={holdTime} title="Hold time remaining:" />
+      </div>
       {/* )} */}
     </StatusCard>
   )

--- a/app/src/components/ModuleLiveStatusCards/ThermocyclerCard.js
+++ b/app/src/components/ModuleLiveStatusCards/ThermocyclerCard.js
@@ -142,20 +142,20 @@ export const ThermocyclerCard = ({
           target={lidTarget}
         />
       </div>
-      {/* {executingProfile && ( */}
-      <CycleInfo
-        holdTime={50}
-        totalCycleCount={2}
-        currentCycleIndex={1}
-        totalStepCount={30}
-        currentStepIndex={4}
-      />
-      {/* )} */}
-      {/* {holdTime != null && holdTime > 0 && !executingProfile && ( */}
-      <div className={styles.card_row}>
-        <TimeRemaining holdTime={holdTime} title="Hold time remaining:" />
-      </div>
-      {/* )} */}
+      {executingProfile && (
+        <CycleInfo
+          holdTime={50}
+          totalCycleCount={2}
+          currentCycleIndex={1}
+          totalStepCount={30}
+          currentStepIndex={4}
+        />
+      )}
+      {holdTime != null && holdTime > 0 && !executingProfile && (
+        <div className={styles.card_row}>
+          <TimeRemaining holdTime={holdTime} title="Hold time remaining:" />
+        </div>
+      )}
     </StatusCard>
   )
 }

--- a/app/src/components/ModuleLiveStatusCards/ThermocyclerCard.js
+++ b/app/src/components/ModuleLiveStatusCards/ThermocyclerCard.js
@@ -144,11 +144,11 @@ export const ThermocyclerCard = ({
       </div>
       {executingProfile && (
         <CycleInfo
-          holdTime={50}
-          totalCycleCount={2}
-          currentCycleIndex={1}
-          totalStepCount={30}
-          currentStepIndex={4}
+          holdTime={holdTime}
+          totalCycleCount={totalCycleCount}
+          currentCycleIndex={currentCycleIndex}
+          totalStepCount={totalStepCount}
+          currentStepIndex={currentStepIndex}
         />
       )}
       {holdTime != null && holdTime > 0 && !executingProfile && (

--- a/app/src/components/ModuleLiveStatusCards/ThermocyclerCard.js
+++ b/app/src/components/ModuleLiveStatusCards/ThermocyclerCard.js
@@ -53,19 +53,31 @@ const CycleInfo = ({
     return null
   }
   return (
-    <div className={styles.card_row}>
-      <LabeledValue
-        label="Cycle #"
-        className={styles.compact_labeled_value}
-        value={`${currentCycleIndex} / ${totalCycleCount}`}
-      />
-      <LabeledValue
-        label="Step #"
-        className={styles.compact_labeled_value}
-        value={`${currentStepIndex} / ${totalStepCount}`}
-      />
-      <TimeRemaining holdTime={holdTime} title="Time remaining for step:" />
-    </div>
+    <>
+      <div className={styles.card_row}>
+        <div className={styles.cycle_info_wrapper}>
+          <div className={styles.cycle_info_counts}>
+            <LabeledValue
+              label="Cycle #"
+              className={cx(
+                styles.compact_labeled_value,
+                styles.cycle_data_item
+              )}
+              value={`${currentCycleIndex} / ${totalCycleCount}`}
+            />
+            <LabeledValue
+              label="Step #"
+              className={cx(
+                styles.compact_labeled_value,
+                styles.cycle_data_item
+              )}
+              value={`${currentStepIndex} / ${totalStepCount}`}
+            />
+          </div>
+          <TimeRemaining holdTime={holdTime} title="Time remaining for step:" />
+        </div>
+      </div>
+    </>
   )
 }
 
@@ -133,20 +145,20 @@ export const ThermocyclerCard = ({
           target={lidTarget}
         />
       </div>
-      {executingProfile && (
+      {/* {executingProfile && ( */}
         <CycleInfo
-          holdTime={holdTime}
-          totalCycleCount={totalCycleCount}
-          currentCycleIndex={currentCycleIndex}
-          totalStepCount={totalStepCount}
-          currentStepIndex={currentStepIndex}
+          holdTime={50}
+          totalCycleCount={2}
+          currentCycleIndex={1}
+          totalStepCount={30}
+          currentStepIndex={4}
         />
-      )}
-      {holdTime != null && holdTime > 0 && !executingProfile && (
+      {/* )} */}
+      {/* {holdTime != null && holdTime > 0 && !executingProfile && ( */}
         <div className={styles.card_row}>
           <TimeRemaining holdTime={holdTime} title="Hold time remaining:" />
         </div>
-      )}
+      {/* )} */}
     </StatusCard>
   )
 }

--- a/app/src/components/ModuleLiveStatusCards/styles.css
+++ b/app/src/components/ModuleLiveStatusCards/styles.css
@@ -46,6 +46,7 @@ updated component library cards after redesign/refactor
   max-width: 7rem;
 }
 
+.cycle_data_item,
 .temp_data_item {
   flex: 1 1 0;
 }
@@ -71,4 +72,15 @@ updated component library cards after redesign/refactor
 
 .status_item_wrapper {
   flex: 1 1 0;
+}
+
+.cycle_info_wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.cycle_info_counts {
+  display: flex;
+  flex-direction: row;
 }

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -213,15 +213,18 @@ export const getRunSeconds = createSelector(
 )
 
 // $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
+export function formatSeconds(runSeconds: number): string {
+  const hours = padStart(`${Math.floor(runSeconds / 3600)}`, 2, '0')
+  const minutes = padStart(`${Math.floor(runSeconds / 60) % 60}`, 2, '0')
+  const seconds = padStart(`${runSeconds % 60}`, 2, '0')
+
+  return `${hours}:${minutes}:${seconds}`
+}
+
+// $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
 export const getRunTime = createSelector(
   getRunSeconds,
-  (runSeconds): string => {
-    const hours = padStart(`${Math.floor(runSeconds / 3600)}`, 2, '0')
-    const minutes = padStart(`${Math.floor(runSeconds / 60) % 60}`, 2, '0')
-    const seconds = padStart(`${runSeconds % 60}`, 2, '0')
-
-    return `${hours}:${minutes}:${seconds}`
-  }
+  formatSeconds
 )
 
 export function getCalibrationRequest(state: State) {

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -212,7 +212,6 @@ export const getRunSeconds = createSelector(
   }
 )
 
-// $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
 export function formatSeconds(runSeconds: number): string {
   const hours = padStart(`${Math.floor(runSeconds / 3600)}`, 2, '0')
   const minutes = padStart(`${Math.floor(runSeconds / 60) % 60}`, 2, '0')


### PR DESCRIPTION
This PR fixes an alignment issue within the Thermocycler's run card cycle info.

The Time remaining should be on a new row beneath the cycle and step counts, but they were all scrunching together.

This also repairs a regression in formatting the time remaining, that was introduced in the shift away from moment in #5127 .  For instance, ten seconds remaining was displaying as 19:00:10 and it should correctly display as 00:00:10.