### PR TITLE
feat(protocol-designer): add warning modal switching mag model

### DIFF
--- a/protocol-designer/src/components/modals/EditModulesModal/MagneticModuleWarningModalContent.css
+++ b/protocol-designer/src/components/modals/EditModulesModal/MagneticModuleWarningModalContent.css
@@ -1,0 +1,25 @@
+@import '@opentrons/components';
+
+.content {
+  margin-bottom: 2rem;
+
+  & strong {
+    font-weight: var(--fw-semibold);
+  }
+}
+
+.bullet_list {
+  padding-bottom: 1rem;
+  padding-left: 3rem;
+
+  & li div {
+    font-weight: var(--fw-semibold);
+    padding-bottom: 0.5rem;
+  }
+
+  & li ul li {
+    font-weight: var(--fw-regular);
+    list-style-type: none;
+    padding-bottom: 0.5rem;
+  }
+}

--- a/protocol-designer/src/components/modals/EditModulesModal/MagneticModuleWarningModalContent.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/MagneticModuleWarningModalContent.js
@@ -1,0 +1,37 @@
+// @flow
+import * as React from 'react'
+import styles from './MagneticModuleWarningModalContent.css'
+
+export const MagneticModuleWarningModalContent = () => (
+  <div className={styles.content}>
+    <p>
+      Switching between GEN1 and GEN2 Magnetic Modules{' '}
+      <strong>will clear all non-default engage heights</strong> from existing
+      magnet steps because they do not use the same units.
+    </p>
+
+    <ul className={styles.bullet_list}>
+      <li>
+        <div>Converting engage height from GEN1 to GEN2</div>
+        <ul>
+          <li>Divide your engage height by 2</li>
+        </ul>
+      </li>
+      <li>
+        <div>Converting engage height from GEN2 to GEN1</div>
+        <ul>
+          <li>Multiply your engage height by 2</li>
+        </ul>
+      </li>
+    </ul>
+
+    <p>
+      You may also need to <strong>alter the time you pause</strong> while your
+      magnet is engaged.
+    </p>
+    <p>
+      Read more about the difference between GEN1 and GEN2 magnetic modules
+      here.{/* TODO IMMEDIATELY add KnowledgeBaseLink */}
+    </p>
+  </div>
+)

--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -1,11 +1,12 @@
 // @flow
-import * as React from 'react'
+import React, { useState } from 'react'
 import cx from 'classnames'
 import { useSelector, useDispatch } from 'react-redux'
 import { Formik } from 'formik'
 import * as Yup from 'yup'
 import {
   THERMOCYCLER_MODULE_TYPE,
+  MAGNETIC_MODULE_TYPE,
   type ModuleModel,
 } from '@opentrons/shared-data'
 import {
@@ -34,6 +35,8 @@ import { i18n } from '../../../localization'
 import { getLabwareIsCompatible } from '../../../utils/labwareModuleCompatibility'
 import { PDAlert } from '../../alerts/PDAlert'
 import { isModuleWithCollisionIssue } from '../../modules'
+import { useBlockingHint } from '../../Hints/useBlockingHint'
+import { MagneticModuleWarningModalContent } from './MagneticModuleWarningModalContent'
 import modalStyles from '../modal.css'
 import styles from './EditModules.css'
 import type { FormikProps } from 'formik/@flow-typed'
@@ -58,7 +61,7 @@ type EditModulesProps = {
   onCloseClick: () => mixed,
 }
 
-export function EditModulesModal(props: EditModulesProps) {
+export const EditModulesModal = (props: EditModulesProps) => {
   const { moduleType, onCloseClick } = props
 
   const _initialDeckSetup = useSelector(stepFormSelectors.getInitialDeckSetup)
@@ -82,24 +85,62 @@ export function EditModulesModal(props: EditModulesProps) {
   )
   const dispatch = useDispatch()
 
-  const onSaveClick = (values: EditModulesState) => {
+  const [
+    enqueuedModuleModel,
+    setEnqueuedModuleModel,
+  ] = useState<null | ModuleModel>(null)
+
+  const editModule = (selectedModel: ModuleModel) => {
+    if (moduleOnDeck?.id != null) {
+      dispatch(
+        stepFormActions.editModule({
+          id: moduleOnDeck.id,
+          model: selectedModel,
+        })
+      )
+    } else {
+      console.error(
+        `cannot edit module without module id. This shouldn't be able to happen`
+      )
+    }
+  }
+  const moduleChangeModal = useBlockingHint({
+    hintKey: 'change_magnet_module_model',
+    handleCancel: () => {
+      setEnqueuedModuleModel(null)
+    },
+    handleContinue: () => {
+      if (enqueuedModuleModel) {
+        editModule(enqueuedModuleModel)
+      } else {
+        console.error('no enqueuedModuleModel, could not edit module')
+      }
+      setEnqueuedModuleModel(null)
+      onCloseClick()
+    },
+    content: <MagneticModuleWarningModalContent />,
+    enabled: enqueuedModuleModel != null,
+  })
+
+  const onSaveClick = (values: EditModulesState): void => {
     const { selectedModel, selectedSlot } = values
 
     // validator from formik should never let onSaveClick be called
     // this case might never be true but still need to handle for flow
-    if (!selectedModel) return null
+    if (!selectedModel) return
 
     if (moduleOnDeck) {
       // disabled if something lives in the slot selected in local state
       // if previous moduleOnDeck.model is different, edit module
       if (moduleOnDeck.model !== selectedModel) {
-        moduleOnDeck.id &&
-          dispatch(
-            stepFormActions.editModule({
-              id: moduleOnDeck.id,
-              model: selectedModel,
-            })
-          )
+        if (moduleOnDeck.type === MAGNETIC_MODULE_TYPE) {
+          // we're changing Magnetic Module's model, show the blocking hint modal
+          setEnqueuedModuleModel(selectedModel)
+          // bail out of the rest of the submit (avoid onCloseClick call)
+          return
+        } else {
+          editModule(selectedModel)
+        }
       }
       // if previous moduleOnDeck.slot is different than state, move deck item
       if (selectedSlot && moduleOnDeck.slot !== selectedSlot) {
@@ -115,6 +156,8 @@ export function EditModulesModal(props: EditModulesProps) {
         })
       )
     }
+
+    // only close modal if there's no blocking hints enqueued
     onCloseClick()
   }
 
@@ -127,156 +170,161 @@ export function EditModulesModal(props: EditModulesProps) {
   )
 
   return (
-    <Modal
-      heading={heading}
-      className={cx(modalStyles.modal, styles.edit_module_modal)}
-      contentsClassName={styles.modal_contents}
-    >
-      <Formik
-        enableReinitialize
-        initialValues={initialValues}
-        onSubmit={onSaveClick}
-        validationSchema={validationSchema}
+    moduleChangeModal || (
+      <Modal
+        heading={heading}
+        className={cx(modalStyles.modal, styles.edit_module_modal)}
+        contentsClassName={styles.modal_contents}
       >
-        {({
-          handleChange,
-          handleSubmit,
-          errors,
-          setFieldValue,
-          touched,
-          values,
-          handleBlur,
-        }: FormikProps<EditModulesState>) => {
-          const { selectedSlot, selectedModel } = values
+        <Formik
+          enableReinitialize
+          initialValues={initialValues}
+          onSubmit={onSaveClick}
+          validationSchema={validationSchema}
+        >
+          {({
+            handleChange,
+            handleSubmit,
+            errors,
+            setFieldValue,
+            touched,
+            values,
+            handleBlur,
+          }: FormikProps<EditModulesState>) => {
+            const { selectedSlot, selectedModel } = values
 
-          const slotIsEmpty =
-            !slotsBlockedBySpanning.includes(selectedSlot) &&
-            (getSlotIsEmpty(_initialDeckSetup, selectedSlot) ||
-              previousModuleSlot === selectedSlot)
+            const slotIsEmpty =
+              !slotsBlockedBySpanning.includes(selectedSlot) &&
+              (getSlotIsEmpty(_initialDeckSetup, selectedSlot) ||
+                previousModuleSlot === selectedSlot)
 
-          let hasSlotOrIncompatibleError = true
-          if (slotIsEmpty) {
-            hasSlotOrIncompatibleError = false
-          } else {
-            const labwareOnSlot = getLabwareOnSlot(
-              _initialDeckSetup,
-              selectedSlot
-            )
-            const labwareIsCompatible =
-              labwareOnSlot &&
-              getLabwareIsCompatible(labwareOnSlot.def, moduleType)
+            let hasSlotOrIncompatibleError = true
+            if (slotIsEmpty) {
+              hasSlotOrIncompatibleError = false
+            } else {
+              const labwareOnSlot = getLabwareOnSlot(
+                _initialDeckSetup,
+                selectedSlot
+              )
+              const labwareIsCompatible =
+                labwareOnSlot &&
+                getLabwareIsCompatible(labwareOnSlot.def, moduleType)
 
-            hasSlotOrIncompatibleError = !labwareIsCompatible
-          }
-
-          const occupiedSlotError = hasSlotOrIncompatibleError
-            ? `Slot ${selectedSlot} is occupied by another module or by labware incompatible with this module. Remove module or labware from the slot in order to continue.`
-            : null
-
-          const moduleHasCollisionIssue =
-            selectedModel && !isModuleWithCollisionIssue(selectedModel)
-          const enableSlotSelection =
-            disabledModuleRestriction || moduleHasCollisionIssue
-
-          const handleModelChange = (
-            e: SyntheticInputEvent<HTMLSelectElement>
-          ): void => {
-            handleChange(e)
-            // TODO(IL, 2020-03-27): can't make Flow understand that dropdown values are ModuleModel type
-            let value: ModuleModel | null = (e.target.value: any) || null
-
-            // reset slot if user switches from module with no collision issue
-            // to one that does have collision issues
-            if (
-              value &&
-              (!disabledModuleRestriction && isModuleWithCollisionIssue(value))
-            ) {
-              setFieldValue('selectedSlot', supportedModuleSlot)
+              hasSlotOrIncompatibleError = !labwareIsCompatible
             }
-          }
 
-          return (
-            <>
-              {hasSlotOrIncompatibleError && (
-                <PDAlert
-                  alertType="warning"
-                  title={i18n.t('alert.module_placement.SLOT_OCCUPIED.title')}
-                  description={''}
-                />
-              )}
-              <form>
-                <div className={styles.form_row}>
-                  <FormGroup label="Model*" className={styles.option_model}>
-                    <DropdownField
-                      tabIndex={0}
-                      options={MODELS_FOR_MODULE_TYPE[moduleType]}
-                      name="selectedModel"
-                      value={selectedModel}
-                      onChange={handleModelChange}
-                      onBlur={handleBlur}
-                      error={
-                        touched.selectedModel && errors && errors.selectedModel
-                          ? errors.selectedModel
-                          : null
-                      }
-                    />
-                  </FormGroup>
-                  {showSlotOption && (
-                    <>
-                      <HoverTooltip
-                        placement="top"
-                        tooltipComponent={slotOptionTooltip}
-                      >
-                        {hoverTooltipHandlers => (
-                          <div
-                            {...hoverTooltipHandlers}
-                            className={styles.option_slot}
-                          >
-                            <FormGroup label="Position">
-                              <DropdownField
-                                tabIndex={1}
-                                options={getAllModuleSlotsByType(moduleType)}
-                                name="selectedSlot"
-                                value={selectedSlot}
-                                disabled={!enableSlotSelection}
-                                onChange={handleChange}
-                                error={occupiedSlotError}
-                              />
-                            </FormGroup>
-                          </div>
-                        )}
-                      </HoverTooltip>
-                      <div className={styles.slot_map_container}>
-                        {selectedSlot && (
-                          <SlotMap
-                            occupiedSlots={[`${selectedSlot}`]}
-                            isError={Boolean(occupiedSlotError)}
-                          />
-                        )}
-                      </div>
-                    </>
-                  )}
-                </div>
-                <div className={modalStyles.button_row}>
-                  <OutlineButton
-                    className={styles.button_margin}
-                    onClick={onCloseClick}
-                  >
-                    {i18n.t('button.cancel')}
-                  </OutlineButton>
-                  <OutlineButton
-                    className={styles.button_margin}
-                    disabled={hasSlotOrIncompatibleError}
-                    onClick={handleSubmit}
-                  >
-                    {i18n.t('button.save')}
-                  </OutlineButton>
-                </div>
-              </form>
-            </>
-          )
-        }}
-      </Formik>
-    </Modal>
+            const occupiedSlotError = hasSlotOrIncompatibleError
+              ? `Slot ${selectedSlot} is occupied by another module or by labware incompatible with this module. Remove module or labware from the slot in order to continue.`
+              : null
+
+            const moduleHasCollisionIssue =
+              selectedModel && !isModuleWithCollisionIssue(selectedModel)
+            const enableSlotSelection =
+              disabledModuleRestriction || moduleHasCollisionIssue
+
+            const handleModelChange = (
+              e: SyntheticInputEvent<HTMLSelectElement>
+            ): void => {
+              handleChange(e)
+              // TODO(IL, 2020-03-27): can't make Flow understand that dropdown values are ModuleModel type
+              let value: ModuleModel | null = (e.target.value: any) || null
+
+              // reset slot if user switches from module with no collision issue
+              // to one that does have collision issues
+              if (
+                value &&
+                (!disabledModuleRestriction &&
+                  isModuleWithCollisionIssue(value))
+              ) {
+                setFieldValue('selectedSlot', supportedModuleSlot)
+              }
+            }
+
+            return (
+              <>
+                {hasSlotOrIncompatibleError && (
+                  <PDAlert
+                    alertType="warning"
+                    title={i18n.t('alert.module_placement.SLOT_OCCUPIED.title')}
+                    description={''}
+                  />
+                )}
+                <form>
+                  <div className={styles.form_row}>
+                    <FormGroup label="Model*" className={styles.option_model}>
+                      <DropdownField
+                        tabIndex={0}
+                        options={MODELS_FOR_MODULE_TYPE[moduleType]}
+                        name="selectedModel"
+                        value={selectedModel}
+                        onChange={handleModelChange}
+                        onBlur={handleBlur}
+                        error={
+                          touched.selectedModel &&
+                          errors &&
+                          errors.selectedModel
+                            ? errors.selectedModel
+                            : null
+                        }
+                      />
+                    </FormGroup>
+                    {showSlotOption && (
+                      <>
+                        <HoverTooltip
+                          placement="top"
+                          tooltipComponent={slotOptionTooltip}
+                        >
+                          {hoverTooltipHandlers => (
+                            <div
+                              {...hoverTooltipHandlers}
+                              className={styles.option_slot}
+                            >
+                              <FormGroup label="Position">
+                                <DropdownField
+                                  tabIndex={1}
+                                  options={getAllModuleSlotsByType(moduleType)}
+                                  name="selectedSlot"
+                                  value={selectedSlot}
+                                  disabled={!enableSlotSelection}
+                                  onChange={handleChange}
+                                  error={occupiedSlotError}
+                                />
+                              </FormGroup>
+                            </div>
+                          )}
+                        </HoverTooltip>
+                        <div className={styles.slot_map_container}>
+                          {selectedSlot && (
+                            <SlotMap
+                              occupiedSlots={[`${selectedSlot}`]}
+                              isError={Boolean(occupiedSlotError)}
+                            />
+                          )}
+                        </div>
+                      </>
+                    )}
+                  </div>
+                  <div className={modalStyles.button_row}>
+                    <OutlineButton
+                      className={styles.button_margin}
+                      onClick={onCloseClick}
+                    >
+                      {i18n.t('button.cancel')}
+                    </OutlineButton>
+                    <OutlineButton
+                      className={styles.button_margin}
+                      disabled={hasSlotOrIncompatibleError}
+                      onClick={handleSubmit}
+                    >
+                      {i18n.t('button.save')}
+                    </OutlineButton>
+                  </div>
+                </form>
+              </>
+            )
+          }}
+        </Formik>
+      </Modal>
+    )
   )
 }

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -31,6 +31,9 @@
     "export_v4_protocol": {
       "title": "Robot requirements for running module inclusive JSON protocols",
       "body": "This protocol utilizes modules and can only run on app and robot server version 3.17 or higher. Please ensure your OT-2 is updated to the correct version."
+    },
+    "change_magnet_module_model": {
+      "title": "All existing engage heights will be cleared"
     }
   },
   "timeline": {

--- a/protocol-designer/src/tutorial/index.js
+++ b/protocol-designer/src/tutorial/index.js
@@ -11,6 +11,7 @@ type HintKey =
   // blocking hints
   | 'custom_labware_with_modules'
   | 'export_v4_protocol'
+  | 'change_magnet_module_model'
 
 export { actions, rootReducer, selectors }
 


### PR DESCRIPTION
## overview

Closes #5251

Note that it's not specified in the ticket that the warning modal is a Blocking Hint. Confirmed w Morgan that it is.

## changelog

- add blocking hint to edit modules modal, in the case that you're changing the model of an existing magnetic module

## review requests

Be careful because even when you leave "Don't show me again" unchecked, PD won't show you the same blocking hint twice in the same session. By design, you have to refresh PD to see the hint a second time. (And if you do check "Don't show me again", you have to reset hints on the Settings page and also restart PD!)

- [ ] Adding any module from the file page works normally (no modal)
- [ ] Editing a temp module's model -> no modal
- [ ] Editing a magnetic module's slot -> no modal
- [ ] Editing a magnetic module's model -> modal!
- [ ] Modal matches design in linked ticket

## risk assessment

just PD