### PR TITLE
refactor(robot-server): robot server port settings to fastapi

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -341,7 +341,8 @@ def get_setting_with_env_overload(setting_name):
     if env_name in os.environ:
         return os.environ[env_name].lower() in {'1', 'true', 'on'}
     else:
-        return get_adv_setting(setting_name) is True
+        s = get_adv_setting(setting_name)
+        return s.value is True if s is not None else False
 
 
 _SETTINGS_RESTART_REQUIRED = False

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -19,7 +19,9 @@ SettingsMap = Dict[str, Optional[bool]]
 
 
 class SettingException(Exception):
-    pass
+    def __init__(self, message, error):
+        super(Exception, self).__init__(message)
+        self.error = error
 
 
 class SettingsData(NamedTuple):
@@ -89,7 +91,8 @@ class DisableLogIntegrationSettingDefinition(SettingDefinition):
                     f"Could not set log control: {code}: stdout={stdout}"
                     f" stderr={stderr}")
                 raise SettingException(
-                    f'Failed to set log upstreaming: {code}'
+                    f'Failed to set log upstreaming: {code}',
+                    'log-config-failure'
                 )
         super().on_change(value)
 

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -417,7 +417,7 @@ def list_mutable_configs(pipette_id: str) -> Dict[str, Any]:
     if pipette_id in known_pipettes():
         config = load_config_dict(pipette_id)
     else:
-        log.info('Pipette id %s not found', pipette_id)
+        log.info(f'Pipette id {pipette_id} not found')
         return cfg
 
     for key in config:

--- a/api/src/opentrons/config/reset.py
+++ b/api/src/opentrons/config/reset.py
@@ -1,0 +1,91 @@
+import logging
+import os
+import shutil
+from enum import Enum
+from typing import NamedTuple, Dict, Set
+
+from opentrons.config import (robot_configs as rc,
+                              IS_ROBOT)
+from opentrons.data_storage import database as db
+from opentrons.protocol_api import labware
+
+DATA_BOOT_D = '/data/boot.d'
+
+log = logging.getLogger(__name__)
+
+
+class UnrecognizedOption(Exception):
+    pass
+
+
+class CommonResetOption(NamedTuple):
+    name: str
+    description: str
+
+
+class ResetOptionId(str, Enum):
+    """The available reset options"""
+    tip_probe = 'tipProbe'
+    labware_calibration = 'labwareCalibration'
+    boot_scripts = 'bootScripts'
+
+
+_common_settings_reset_options = {
+    ResetOptionId.tip_probe:
+        CommonResetOption(
+            name='Pipette Calibration',
+            description='Clear pipette offset and tip length calibration'
+        ),
+    ResetOptionId.labware_calibration:
+        CommonResetOption(
+            name='Labware Calibration',
+            description='Clear labware calibration and Protocol API v1 custom labware (created with labware.create())'   # noqa(E501)
+        ),
+    ResetOptionId.boot_scripts:
+        CommonResetOption(
+            name='Boot Scripts',
+            description='Clear custom boot scripts'
+        ),
+}
+
+
+def reset_options() -> Dict[ResetOptionId, CommonResetOption]:
+    return _common_settings_reset_options
+
+
+def reset(options: Set[ResetOptionId]) -> None:
+    """
+    Execute a reset of the requested parts of the user configuration.
+
+    :param options: the parts to reset
+    """
+    log.info("Reset requested for %s", options)
+    if ResetOptionId.tip_probe in options:
+        reset_tip_probe()
+
+    if ResetOptionId.labware_calibration in options:
+        reset_labware_calibration()
+
+    if ResetOptionId.boot_scripts in options:
+        reset_boot_scripts()
+
+
+def reset_boot_scripts():
+    if IS_ROBOT:
+        if os.path.exists(DATA_BOOT_D):
+            shutil.rmtree(DATA_BOOT_D)
+    else:
+        log.debug('Not on pi, not removing %s', DATA_BOOT_D)
+
+
+def reset_labware_calibration():
+    labware.clear_calibrations()
+    db.reset()
+
+
+def reset_tip_probe():
+    config = rc.load()
+    config = config._replace(
+        instrument_offset=rc.build_fallback_instrument_offset({}))
+    config.tip_length.clear()
+    rc.save_robot_settings(config)

--- a/api/src/opentrons/config/reset.py
+++ b/api/src/opentrons/config/reset.py
@@ -2,6 +2,7 @@ import logging
 import os
 import shutil
 from enum import Enum
+from pathlib import Path
 from typing import NamedTuple, Dict, Set
 
 from opentrons.config import (robot_configs as rc,
@@ -9,7 +10,7 @@ from opentrons.config import (robot_configs as rc,
 from opentrons.data_storage import database as db
 from opentrons.protocol_api import labware
 
-DATA_BOOT_D = '/data/boot.d'
+DATA_BOOT_D = Path('/data/boot.d')
 
 log = logging.getLogger(__name__)
 
@@ -75,7 +76,7 @@ def reset_boot_scripts():
         if os.path.exists(DATA_BOOT_D):
             shutil.rmtree(DATA_BOOT_D)
     else:
-        log.debug('Not on pi, not removing %s', DATA_BOOT_D)
+        log.debug(f'Not on pi, not removing {DATA_BOOT_D}')
 
 
 def reset_labware_calibration():

--- a/api/src/opentrons/server/endpoints/settings.py
+++ b/api/src/opentrons/server/endpoints/settings.py
@@ -184,7 +184,8 @@ async def modify_pipette_settings(request: web.Request) -> web.Response:
     data = await request.json()
     fields = data.get('fields', {})
     # Convert fields to dict of field name to value
-    fields = {k: v.get('value') for k, v in fields.items()}
+    fields = {k: None if v is None else v.get('value')
+              for k, v in fields.items()}
     if fields:
         try:
             pc.override(fields=fields, pipette_id=pipette_id)

--- a/api/src/opentrons/server/endpoints/settings.py
+++ b/api/src/opentrons/server/endpoints/settings.py
@@ -71,7 +71,7 @@ async def set_advanced_setting(request: web.Request) -> web.Response:
     log.info(f'set_advanced_setting: {key} -> {value}')
 
     try:
-        advs.set_adv_setting(key, value)
+        await advs.set_adv_setting(key, value)
     except ValueError as e:
         log.warning(f'set_advanced_setting: bad request: {key} invalid')
         return web.json_response({

--- a/api/src/opentrons/server/endpoints/settings.py
+++ b/api/src/opentrons/server/endpoints/settings.py
@@ -40,13 +40,7 @@ def _get_adv_settings_response() -> Dict[
                    List[Dict[str, Union[str, bool, None]]]]]:
     data = advs.get_all_adv_settings()
 
-    def _should_show(setting_dict):
-        if not setting_dict['show_if']:
-            return True
-        return advs.get_setting_with_env_overload(setting_dict['show_if'][0])\
-            == setting_dict['show_if'][1]
-
-    if _SETTINGS_RESTART_REQUIRED:
+    if advs.restart_required():
         links = {'restart': '/server/restart'}
     else:
         links = {}
@@ -54,9 +48,14 @@ def _get_adv_settings_response() -> Dict[
     return {
         'links': links,
         'settings': [
-            {k: v for k, v in setting.items() if k != 'show_if'}
-            for setting in data.values()
-            if _should_show(setting)]}
+            {"id":s.definition.id,
+            "old_id": s.definition.old_id,
+            "title": s.definition.title,
+            "description": s.definition.description,
+            "restart_required": s.definition.restart_required
+             } for s in data.values()
+        ]
+    }
 
 
 async def set_advanced_setting(request: web.Request) -> web.Response:

--- a/api/src/opentrons/server/endpoints/settings.py
+++ b/api/src/opentrons/server/endpoints/settings.py
@@ -162,14 +162,7 @@ async def available_resets(request: web.Request) -> web.Response:
 async def pipette_settings(request: web.Request) -> web.Response:
     res = {}
     for pipette_id in pc.known_pipettes():
-        whole_config = pc.load_config_dict(pipette_id)
-        res[pipette_id] = {
-            'info': {
-                'name': whole_config.get('name'),
-                'model': whole_config.get('model')
-            },
-            'fields': pc.list_mutable_configs(pipette_id=pipette_id)
-        }
+        res[pipette_id] = _make_pipette_response_body(pipette_id)
     return web.json_response(res, status=200)
 
 
@@ -179,6 +172,11 @@ async def pipette_settings_id(request: web.Request) -> web.Response:
         return web.json_response(
             {'message': '{} is not a valid pipette id'.format(pipette_id)},
             status=404)
+    res = _make_pipette_response_body(pipette_id)
+    return web.json_response(res, status=200)
+
+
+def _make_pipette_response_body(pipette_id):
     whole_config = pc.load_config_dict(pipette_id)
     res = {
         'info': {
@@ -187,7 +185,7 @@ async def pipette_settings_id(request: web.Request) -> web.Response:
         },
         'fields': pc.list_mutable_configs(pipette_id)
     }
-    return web.json_response(res, status=200)
+    return res
 
 
 async def modify_pipette_settings(request: web.Request) -> web.Response:

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -97,11 +97,11 @@ def test_save_and_clear_config(mock_config, sync_hardware, loop):
     hardware.config.gantry_calibration[0][3] = 0
 
 
-def test_new_deck_points():
+async def test_new_deck_points():
     # Checks that the correct deck calibration points are being used
     # if feature_flag is set (or not)
 
-    advs.set_adv_setting('deckCalibrationDots', True)
+    await advs.set_adv_setting('deckCalibrationDots', True)
     calibration_points = get_calibration_points()
     expected_points1 = expected_points()
     # Check that old calibration points are used in cli
@@ -113,7 +113,7 @@ def test_new_deck_points():
     assert expected_points1['2'] == (380.87, 6.0)
     assert expected_points1['3'] == (12.13, 261.0)
 
-    advs.set_adv_setting('deckCalibrationDots', False)
+    await advs.set_adv_setting('deckCalibrationDots', False)
     calibration_points2 = get_calibration_points()
     expected_points2 = expected_points()
     # Check that new calibration points are used

--- a/api/tests/opentrons/config/test_advanced_settings.py
+++ b/api/tests/opentrons/config/test_advanced_settings.py
@@ -1,0 +1,112 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from opentrons.config import advanced_settings, CONFIG
+
+
+@pytest.fixture
+def mock_settings_values():
+    return {
+        "disableHomeOnBoot": True,
+        "useOldAspirationFunctions": False,
+        "useFastApi": False,
+        "useProtocolApi2": True
+    }
+
+
+@pytest.fixture
+def mock_settings_version():
+    return 1
+
+
+@pytest.fixture
+def mock_read_settings_file(mock_settings_values, mock_settings_version):
+    with patch("opentrons.config.advanced_settings._read_settings_file") as p:
+        p.return_value = \
+            advanced_settings.SettingsData(
+                settings_map=mock_settings_values,
+                version=mock_settings_version)
+        yield p
+
+
+@pytest.fixture
+def mock_write_settings_file():
+    with patch("opentrons.config.advanced_settings._write_settings_file") as p:
+        yield p
+
+
+@pytest.fixture
+def restore_restart_required():
+    yield
+    advanced_settings._SETTINGS_RESTART_REQUIRED = False
+
+
+def test_get_advanced_setting_not_found(mock_read_settings_file):
+    assert advanced_settings.get_adv_setting("unknown") is None
+
+
+def test_get_advanced_setting_found(mock_read_settings_file,
+                                    mock_settings_values):
+    for k, v in mock_settings_values.items():
+        s = advanced_settings.get_adv_setting(k)
+        assert s.value == v
+        assert s.definition == \
+            advanced_settings.settings_by_id[k]
+
+
+def test_get_all_adv_settings(mock_read_settings_file,
+                              mock_settings_values):
+    s = advanced_settings.get_all_adv_settings()
+    assert s.keys() == mock_settings_values.keys()
+    for k, v in s.items():
+        assert v.value == mock_settings_values[k]
+        assert v.definition == \
+            advanced_settings.settings_by_id[k]
+
+
+def test_get_all_adv_settings_empty(mock_read_settings_file):
+    mock_read_settings_file.return_value = advanced_settings.SettingsData({}, 1)
+    s = advanced_settings.get_all_adv_settings()
+    assert s == {}
+
+
+def test_set_adv_setting(mock_read_settings_file,
+                         mock_settings_values,
+                         mock_write_settings_file,
+                         mock_settings_version,
+                         restore_restart_required):
+    for k, v in mock_settings_values.items():
+        # Toggle the advanced setting
+        advanced_settings.set_adv_setting(k, not v)
+        mock_write_settings_file.assert_called_with(
+            # Only the current key is toggled
+            {nk: nv if nk != k else not v for nk, nv in mock_settings_values.items()},
+            mock_settings_version,
+            CONFIG['feature_flags_file']
+        )
+
+
+def test_set_adv_setting_unknown(mock_read_settings_file,
+                                 mock_write_settings_file):
+    mock_read_settings_file.return_value = advanced_settings.SettingsData({}, 1)
+    with pytest.raises(ValueError, match="is not recognized"):
+        advanced_settings.set_adv_setting("no", False)
+
+
+def test_on_change_called(mock_read_settings_file,
+                          mock_settings_values,
+                          mock_write_settings_file,
+                          restore_restart_required):
+    _id = 'useProtocolApi2'
+    with patch(
+        "opentrons.config.advanced_settings.SettingDefinition.on_change"
+    ) as m:
+        advanced_settings.set_adv_setting(_id, True)
+        m.assert_called_once_with(True)
+
+
+def test_restart_required(restore_restart_required):
+    assert advanced_settings.restart_required() is False
+    _id = 'useFastApi'
+    advanced_settings.set_adv_setting(_id, True)
+    assert advanced_settings.restart_required() is True

--- a/api/tests/opentrons/config/test_advanced_settings.py
+++ b/api/tests/opentrons/config/test_advanced_settings.py
@@ -113,3 +113,21 @@ def test_restart_required(restore_restart_required):
     _id = 'useFastApi'
     advanced_settings.set_adv_setting(_id, True)
     assert advanced_settings.restart_required() is True
+
+
+def test_get_setting_use_env_overload(mock_read_settings_file,
+                                      mock_settings_values):
+    with patch("os.environ",
+               new={
+                   "OT_API_FF_useProtocolApi2": "FALSE"
+               }):
+        v = advanced_settings.get_setting_with_env_overload("useProtocolApi2")
+        assert v is not mock_settings_values['useProtocolApi2']
+
+
+def test_get_setting_with_env_overload(mock_read_settings_file,
+                                       mock_settings_values):
+    with patch("os.environ",
+               new={}):
+        v = advanced_settings.get_setting_with_env_overload("useProtocolApi2")
+        assert v is mock_settings_values['useProtocolApi2']

--- a/api/tests/opentrons/config/test_advanced_settings.py
+++ b/api/tests/opentrons/config/test_advanced_settings.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from opentrons.config import advanced_settings, CONFIG
 
@@ -65,7 +65,8 @@ def test_get_all_adv_settings(mock_read_settings_file,
 
 
 def test_get_all_adv_settings_empty(mock_read_settings_file):
-    mock_read_settings_file.return_value = advanced_settings.SettingsData({}, 1)
+    mock_read_settings_file.return_value = \
+        advanced_settings.SettingsData({}, 1)
     s = advanced_settings.get_all_adv_settings()
     assert s == {}
 
@@ -80,7 +81,8 @@ def test_set_adv_setting(mock_read_settings_file,
         advanced_settings.set_adv_setting(k, not v)
         mock_write_settings_file.assert_called_with(
             # Only the current key is toggled
-            {nk: nv if nk != k else not v for nk, nv in mock_settings_values.items()},
+            {nk: nv if nk != k else not v
+             for nk, nv in mock_settings_values.items()},
             mock_settings_version,
             CONFIG['feature_flags_file']
         )
@@ -88,7 +90,8 @@ def test_set_adv_setting(mock_read_settings_file,
 
 def test_set_adv_setting_unknown(mock_read_settings_file,
                                  mock_write_settings_file):
-    mock_read_settings_file.return_value = advanced_settings.SettingsData({}, 1)
+    mock_read_settings_file.return_value = \
+        advanced_settings.SettingsData({}, 1)
     with pytest.raises(ValueError, match="is not recognized"):
         advanced_settings.set_adv_setting("no", False)
 

--- a/api/tests/opentrons/config/test_reset.py
+++ b/api/tests/opentrons/config/test_reset.py
@@ -1,0 +1,92 @@
+import json
+import os
+from collections import namedtuple
+from unittest.mock import patch, MagicMock
+import pytest
+from opentrons.config import reset
+
+
+@pytest.fixture
+def mock_reset_boot_scripts():
+    with patch("opentrons.config.reset.reset_boot_scripts") as m:
+        yield m
+
+
+@pytest.fixture
+def mock_reset_labware_calibration():
+    with patch("opentrons.config.reset.reset_labware_calibration") as m:
+        yield m
+
+
+@pytest.fixture
+def mock_reset_tip_probe():
+    with patch("opentrons.config.reset.reset_tip_probe") as m:
+        yield m
+
+
+@pytest.fixture()
+def mock_db():
+    with patch("opentrons.config.reset.db") as m:
+        yield m
+
+
+@pytest.fixture()
+def mock_labware():
+    with patch("opentrons.config.reset.labware") as m:
+        yield m
+
+
+@pytest.fixture()
+def mock_robot_config():
+    with patch("opentrons.config.reset.rc") as m:
+        yield m
+
+
+def test_reset_empty_set(mock_reset_boot_scripts,
+                         mock_reset_labware_calibration,
+                         mock_reset_tip_probe):
+    reset.reset(set())
+    mock_reset_labware_calibration.assert_not_called()
+    mock_reset_boot_scripts.assert_not_called()
+    mock_reset_tip_probe.assert_not_called()
+
+
+def test_reset_all_set(mock_reset_boot_scripts,
+                       mock_reset_labware_calibration,
+                       mock_reset_tip_probe):
+    reset.reset({reset.ResetOptionId.boot_scripts,
+                 reset.ResetOptionId.tip_probe,
+                 reset.ResetOptionId.labware_calibration})
+    mock_reset_labware_calibration.assert_called_once()
+    mock_reset_boot_scripts.assert_called_once()
+    mock_reset_tip_probe.assert_called_once()
+
+
+def test_labware_calibration_reset(mock_db, mock_labware):
+    reset.reset_labware_calibration()
+    # Check side effecting function calls
+    mock_db.reset.assert_called_once()
+    mock_labware.clear_calibrations.assert_called_once()
+
+
+def test_tip_probe_reset(mock_robot_config):
+    # Create a named tuple of the robot_config fields we care about
+    FakeRobotConfig = namedtuple("FakeRobotConfig",
+                                 ["instrument_offset", "tip_length"])
+    # Instantiate with None and a mock.
+    obj = FakeRobotConfig(None, MagicMock())
+    # Mock out build_fallback_instrument_offset
+    mock_robot_config.build_fallback_instrument_offset.return_value = 100
+    # Mock out load to return our fake robot config
+    mock_robot_config.load.return_value = obj
+
+    # Call the test function
+    reset.reset_tip_probe()
+
+    # Check the side effects
+    obj.tip_length.clear.assert_called_once_with()
+
+    mock_robot_config.save_robot_settings.assert_called_once_with(
+        FakeRobotConfig(100,
+                        obj.tip_length))
+

--- a/api/tests/opentrons/config/test_reset.py
+++ b/api/tests/opentrons/config/test_reset.py
@@ -1,5 +1,3 @@
-import json
-import os
 from collections import namedtuple
 from unittest.mock import patch, MagicMock
 import pytest
@@ -89,4 +87,3 @@ def test_tip_probe_reset(mock_robot_config):
     mock_robot_config.save_robot_settings.assert_called_once_with(
         FakeRobotConfig(100,
                         obj.tip_length))
-

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -169,24 +169,25 @@ def wifi_keys_tempdir():
 
 # -------feature flag fixtures-------------
 @pytest.fixture
-def calibrate_bottom_flag():
-    config.advanced_settings.set_adv_setting('calibrateToBottom', True)
+async def calibrate_bottom_flag():
+    await config.advanced_settings.set_adv_setting('calibrateToBottom', True)
     yield
-    config.advanced_settings.set_adv_setting('calibrateToBottom', False)
+    await config.advanced_settings.set_adv_setting('calibrateToBottom', False)
 
 
 @pytest.fixture
-def short_trash_flag():
-    config.advanced_settings.set_adv_setting('shortFixedTrash', True)
+async def short_trash_flag():
+    await config.advanced_settings.set_adv_setting('shortFixedTrash', True)
     yield
-    config.advanced_settings.set_adv_setting('shortFixedTrash', False)
+    await config.advanced_settings.set_adv_setting('shortFixedTrash', False)
 
 
 @pytest.fixture
-def old_aspiration(monkeypatch):
-    config.advanced_settings.set_adv_setting('useOldAspirationFunctions', True)
+async def old_aspiration(monkeypatch):
+    await config.advanced_settings.set_adv_setting(
+        'useOldAspirationFunctions', True)
     yield
-    config.advanced_settings.set_adv_setting(
+    await config.advanced_settings.set_adv_setting(
         'useOldAspirationFunctions', False)
 
 

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -3,14 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from opentrons.server import endpoints
 from opentrons.config.reset import ResetOptionId
-
-
-@pytest.fixture
-def restore_restart_required():
-    yield
-    endpoints.settings._SETTINGS_RESTART_REQUIRED = False
 
 
 def validate_response_body(body):

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -1,12 +1,11 @@
 import json
-import os
 from unittest.mock import patch
 
 import pytest
 
 from opentrons.server import endpoints
 from opentrons.config import pipette_config
-from opentrons import config, types
+from opentrons import types
 from opentrons.config.reset import ResetOptionId
 
 

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -4,8 +4,6 @@ from unittest.mock import patch
 import pytest
 
 from opentrons.server import endpoints
-from opentrons.config import pipette_config
-from opentrons import types
 from opentrons.config.reset import ResetOptionId
 
 
@@ -13,41 +11,6 @@ from opentrons.config.reset import ResetOptionId
 def restore_restart_required():
     yield
     endpoints.settings._SETTINGS_RESTART_REQUIRED = False
-
-
-@pytest.fixture
-async def attached_pipettes(async_client, request):
-    """ Fixture the robot to have attached pipettes
-
-    Mark the node with
-    'attach_left_model': model_name for left (default: p300_single_v1)
-    'attach_right_model': model_name for right (default: p50_multi_v1)
-    'attach_left_id': id for left (default: 'abc123')
-    'attach_right_id': id for right (default: 'acbcd123')
-
-    Returns the model by mount style dict of
-    {'left': {'name': str, 'model': str, 'id': str}, 'right'...}
-    """
-    def marker_with_default(marker: str, default: str) -> str:
-        return request.node.get_closest_marker(marker) or default
-    left_mod = marker_with_default('attach_left_model', 'p300_multi_v1')
-    left_name = left_mod.split('_v')[0]
-    right_mod = marker_with_default('attach_right_model', 'p50_multi_v1')
-    right_name = right_mod.split('_v')[0]
-    left_id = marker_with_default('attach_left_id', 'abc123')
-    right_id = marker_with_default('attach_right_id', 'abcd123')
-    hw = async_client.app['com.opentrons.hardware']
-    hw._backend._attached_instruments = {
-        types.Mount.RIGHT: {
-            'model': right_mod, 'id': right_id, 'name': right_name
-        },
-        types.Mount.LEFT: {
-            'model': left_mod, 'id': left_id, 'name': left_name
-            }
-    }
-    await hw.cache_instruments()
-    return {k.name.lower(): v
-            for k, v in hw._backend._attached_instruments.items()}
 
 
 def validate_response_body(body):
@@ -141,102 +104,141 @@ async def test_reset_invalid_option(async_client, mock_reset):
     assert 'aksgjajhadjasl' in body['message']
 
 
-async def test_receive_pipette_settings(async_client, attached_pipettes):
+@pytest.fixture
+def mock_pipette_data():
+    return {
+        'p1': {
+            'info': {
+                'name': 'p1_name',
+                'model': 'p1_model',
+            },
+            'fields': {
+                'pickUpCurrent': {
+                    'units': 'mm',
+                    'type': 'float',
+                    'min': 0.0,
+                    'max': 2.0,
+                    'default': 1.0,
+                    'value': 0.5,
+                },
+                'quirks': {
+                    'dropTipShake': True
+                }
+            }
+        },
+        'p2': {
+            'info': {
+                'name': 'p2_name',
+                'model': 'p2_model',
+            },
+            'fields': {
+                'pickUpIncrement': {
+                    'units': 'inch',
+                    'type': 'int',
+                    'min': 0,
+                    'max': 2,
+                    'default': 1.,
+                    'value': 2,
+                }
+            }
+        }
+    }
 
-    test_id = attached_pipettes['left']['id']
+
+@pytest.fixture
+def mock_pipette_config(mock_pipette_data):
+    with patch("opentrons.server.endpoints.settings.pc") as p:
+        p.known_pipettes.return_value = list(mock_pipette_data.keys())
+        p.load_config_dict.side_effect = \
+            lambda id: mock_pipette_data[id]['info']
+        p.list_mutable_configs.side_effect = \
+            lambda pipette_id: mock_pipette_data[pipette_id]['fields']
+        yield p
+
+
+async def test_receive_pipette_settings(async_client,
+                                        mock_pipette_config,
+                                        mock_pipette_data):
     resp = await async_client.get('/settings/pipettes')
-    body = await resp.json()
-    assert test_id in body
-    assert body[test_id]['fields'] == pipette_config.list_mutable_configs(
-        pipette_id=test_id)
+    assert resp.status == 200
+    assert await resp.json() == mock_pipette_data
 
 
-async def test_receive_pipette_settings_one_pipette(
-        async_client, attached_pipettes):
-    # This will check that sending a known pipette id works,
-    # and sending an unknown one does not
-    test_id = attached_pipettes['left']['id']
-    resp = await async_client.get('/settings/pipettes/{}'.format(test_id))
-    body = await resp.json()
-    assert body['fields'] == pipette_config.list_mutable_configs(
-        pipette_id=test_id)
-
+async def test_receive_pipette_settings_unknown(async_client,
+                                                mock_pipette_config,
+                                                mock_pipette_data):
     # Non-existent pipette id and get 404
-    resp = await async_client.get(
-        '/settings/pipettes/{}'.format('wannabepipette'))
+    resp = await async_client.get('/settings/pipettes/wannabepipette')
     assert resp.status == 404
 
 
-async def test_modify_pipette_settings(async_client, attached_pipettes):
-    # This test will check that setting modified pipette configs
-    # works as expected
+async def test_receive_pipette_settings_found(async_client,
+                                              mock_pipette_config,
+                                              mock_pipette_data):
+    resp = await async_client.get('/settings/pipettes/p1')
+    assert resp.status == 200
+    assert await resp.json() == mock_pipette_data['p1']
+
+
+async def test_modify_pipette_settings_call_override(async_client,
+                                                     mock_pipette_config,
+                                                     mock_pipette_data):
+    pipette_id = 'p1'
     changes = {
         'fields': {
-            'pickUpCurrent': {'value': 1}
+            'pickUpCurrent': {'value': 1},
+            'otherField': {'value': True},
+            'noneField': {'value': None}
         }
     }
-
-    no_changes = {
-        'fields': {
-            'pickUpCurrent': {'value': 1}
-        }
-    }
-
-    test_id = attached_pipettes['left']['id']
-    # Check data has not been changed yet
-    resp = await async_client.get('/settings/pipettes/{}'.format(test_id))
-    body = await resp.json()
-    assert body['fields']['pickUpCurrent'] == \
-        pipette_config.list_mutable_configs(
-            pipette_id=test_id)['pickUpCurrent']
 
     # Check that data is changed and matches the changes specified
     resp = await async_client.patch(
-        '/settings/pipettes/{}'.format(test_id),
+        f'/settings/pipettes/{pipette_id}',
         json=changes)
+    mock_pipette_config.override.assert_called_once_with(
+        fields={'pickUpCurrent': 1, 'otherField': True, 'noneField': None},
+        pipette_id=pipette_id)
     patch_body = await resp.json()
     assert resp.status == 200
-    check = await async_client.get('/settings/pipettes/{}'.format(test_id))
-    body = await check.json()
-    assert body['fields'] == patch_body['fields']
+    assert patch_body == {'fields': mock_pipette_data[pipette_id]['fields']}
 
-    # Check that None reverts a setting to default
-    changes2 = {
-        'fields': {
-            'pickUpCurrent': None
-        }
-    }
+
+@pytest.mark.parametrize(argnames=["body"],
+                         argvalues=[
+                             [{}],
+                             [{'fields': {}}]
+                         ])
+async def test_modify_pipette_settings_do_not_call_override(
+        async_client, mock_pipette_config, mock_pipette_data, body):
+    pipette_id = 'p1'
+
     resp = await async_client.patch(
-        '/settings/pipettes/{}'.format(test_id),
-        json=changes2)
+        f'/settings/pipettes/{pipette_id}',
+        json=body)
+    mock_pipette_config.override.assert_not_called()
+    patch_body = await resp.json()
     assert resp.status == 200
-    check = await async_client.get('/settings/pipettes/{}'.format(test_id))
-    body = await check.json()
-    assert body['fields']['pickUpCurrent']['value'] == \
-        pipette_config.list_mutable_configs(
-            pipette_id=test_id)['pickUpCurrent']['default']
+    assert patch_body == {'fields': mock_pipette_data[pipette_id]['fields']}
 
-    # check no fields returns no changes
+
+async def test_modify_pipette_settings_failure(async_client,
+                                               mock_pipette_config):
+    test_id = 'p1'
+
+    def mock_override(pipette_id, fields):
+        raise ValueError("Failed!")
+
+    mock_pipette_config.override.side_effect = mock_override
+
     resp = await async_client.patch(
-        '/settings/pipettes/{}'.format(test_id),
-        json=no_changes)
-    body = await resp.json()
-    assert body['fields'] == pipette_config.list_mutable_configs(test_id)
-    assert resp.status == 200
-
-
-async def test_incorrect_modify_pipette_settings(
-        async_client, attached_pipettes):
-    out_of_range = {
-        'fields': {
-            'pickUpCurrent': {'value': 1000}
-        }
-    }
-    # check over max fails
-    resp = await async_client.patch(
-        '/settings/pipettes/{}'.format(attached_pipettes['left']['id']),
-        json=out_of_range)
+        f'/settings/pipettes/{test_id}',
+        json={'fields': {'a': {'value': 1}}})
+    mock_pipette_config.override.assert_called_once_with(pipette_id=test_id,
+                                                         fields={'a': 1})
+    patch_body = await resp.json()
     assert resp.status == 412
+    assert patch_body == {'message': "Failed!"}
 
 
 async def test_set_log_level(mock_config, async_client):
@@ -250,7 +252,7 @@ async def test_set_log_level(mock_config, async_client):
                                    json={'log_level': 'oafajhshda'})
     assert resp.status == 400
     body = await resp.json()
-    assert 'message'in body
+    assert 'message' in body
     conf = hardware.config
     assert conf.log_level != 'ERROR'
     resp = await async_client.post('/settings/log_level/local',

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -181,7 +181,8 @@ async def test_modify_pipette_settings_call_override(async_client,
         'fields': {
             'pickUpCurrent': {'value': 1},
             'otherField': {'value': True},
-            'noneField': {'value': None}
+            'noneField': {'value': None},
+            'otherNoneField': None
         }
     }
 
@@ -190,7 +191,8 @@ async def test_modify_pipette_settings_call_override(async_client,
         f'/settings/pipettes/{pipette_id}',
         json=changes)
     mock_pipette_config.override.assert_called_once_with(
-        fields={'pickUpCurrent': 1, 'otherField': True, 'noneField': None},
+        fields={'pickUpCurrent': 1, 'otherField': True,
+                'noneField': None, 'otherNoneField': None},
         pipette_id=pipette_id)
     patch_body = await resp.json()
     assert resp.status == 200

--- a/robot-server/robot_server/service/models/settings.py
+++ b/robot-server/robot_server/service/models/settings.py
@@ -178,5 +178,5 @@ class PipetteUpdateField(BaseModel):
 
 
 class PipetteSettingsUpdate(BaseModel):
-    setting_fields: typing.Dict[str, PipetteUpdateField] = \
-        Field(..., alias="fields")
+    setting_fields: typing.Optional[typing.Dict[str, PipetteUpdateField]] = \
+        Field(None, alias="fields")

--- a/robot-server/robot_server/service/models/settings.py
+++ b/robot-server/robot_server/service/models/settings.py
@@ -153,7 +153,7 @@ PipetteSettingsFields = create_model(
         if conf != 'quirks'
     }
 )
-PipetteSettingsField.__doc__ = "The fields of the pipette settings"
+PipetteSettingsFields.__doc__ = "The fields of the pipette settings"
 
 
 class PipetteSettings(BaseModel):

--- a/robot-server/robot_server/service/models/settings.py
+++ b/robot-server/robot_server/service/models/settings.py
@@ -1,8 +1,7 @@
-import typing
 from enum import Enum
 import logging
 
-from typing import Optional
+from typing import Optional, List, Dict, Any, Union
 
 from pydantic import BaseModel, Field, create_model, validator
 
@@ -31,7 +30,7 @@ class AdvancedSetting(BaseModel):
         Field(...,
               description="Whether a robot restart is required to make this "
                           "change take effect")
-    value: typing.Optional[bool] =\
+    value: Optional[bool] =\
         Field(...,
               description="Whether the setting is off by previous user choice"
                           " (false), true by user choice (true), or off and "
@@ -48,7 +47,7 @@ class Links(BaseModel):
 
 class AdvancedSettingsResponse(BaseModel):
     """A dump of advanced settings and suitable links for next action"""
-    settings: typing.List[AdvancedSetting]
+    settings: List[AdvancedSetting]
     links: Links
 
 
@@ -105,10 +104,10 @@ class FactoryResetOption(BaseModel):
 
 class FactoryResetOptions(BaseModel):
     """Available values to reset as factory reset"""
-    options: typing.List[FactoryResetOption]
+    options: List[FactoryResetOption]
 
 
-RobotConfigs = typing.Dict[str, typing.Any]
+RobotConfigs = Dict[str, Any]
 
 
 class PipetteSettingsFieldType(str, Enum):
@@ -149,7 +148,7 @@ class PipetteSettingsInfo(BaseModel):
 
 
 class BasePipetteSettingFields(BaseModel):
-    quirks: typing.Dict[str, bool] = \
+    quirks: Dict[str, bool] = \
         Field(None,
               description="Quirks are behavioral changes associated with "
                           "pipettes. For instance, some models of pipette "
@@ -188,11 +187,11 @@ class PipetteSettings(BaseModel):
         fields = {'setting_fields': 'fields'}
 
 
-MultiPipetteSettings = typing.Dict[str, PipetteSettings]
+MultiPipetteSettings = Dict[str, PipetteSettings]
 
 
 class PipetteUpdateField(BaseModel):
-    value: typing.Union[None, bool, float] = \
+    value: Union[None, bool, float] = \
         Field(...,
               description="Boolean if the format if this is a quirk.  The "
                           "format if this is not a quirk. Must be between max "
@@ -200,5 +199,5 @@ class PipetteUpdateField(BaseModel):
 
 
 class PipetteSettingsUpdate(BaseModel):
-    setting_fields: typing.Optional[typing.Dict[str, PipetteUpdateField]] = \
+    setting_fields: Optional[Dict[str, Optional[PipetteUpdateField]]] = \
         Field(None, alias="fields")

--- a/robot-server/robot_server/service/models/settings.py
+++ b/robot-server/robot_server/service/models/settings.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from opentrons.config.pipette_config import MUTABLE_CONFIGS
 from pydantic import BaseModel, Field, create_model, validator
-from opentrons.server.endpoints.settings import _common_settings_reset_options
+from opentrons.config.reset import ResetOptionId
 
 
 class AdvancedSetting(BaseModel):
@@ -59,7 +59,7 @@ class LogLevel(BaseModel):
 
 
 class FactoryResetOption(BaseModel):
-    id: str = \
+    id: ResetOptionId = \
         Field(..., description="A short machine-readable id for the setting")
     name: str = \
         Field(..., description="A short human-readable name for the setting")
@@ -71,17 +71,6 @@ class FactoryResetOption(BaseModel):
 class FactoryResetOptions(BaseModel):
     """Available values to reset as factory reset"""
     options: typing.List[FactoryResetOption]
-
-
-FactoryResetCommands = create_model("FactoryResetCommands",
-                                    __config__=None,
-                                    __base__=None,
-                                    __module__=None,
-                                    __validators__=None,
-                                    **{x['id']: (typing.Optional[bool], None)
-                                       for x in _common_settings_reset_options}
-                                    )
-FactoryResetCommands.__doc__ = "The specific elements of robot data to reset"
 
 
 RobotConfigs = typing.Dict[str, typing.Any]

--- a/robot-server/robot_server/service/models/settings.py
+++ b/robot-server/robot_server/service/models/settings.py
@@ -15,7 +15,7 @@ class AdvancedSetting(BaseModel):
     id: str = \
         Field(...,
               description="The machine-readable property ID")
-    old_id: str = \
+    old_id: Optional[str] = \
         Field(...,
               description="The ID by which the property used to be known; not"
                           " useful now and may contain spaces or hyphens")
@@ -38,7 +38,29 @@ class AdvancedSetting(BaseModel):
                           "has never been altered (null)")
 
 
-AdvancedSettings = typing.List[AdvancedSetting]
+class Links(BaseModel):
+    restart: Optional[str] = Field(
+        None,
+        description="A URI to POST to restart the robot. If this is present,"
+                    " it must be requested for any settings changes to take "
+                    "effect")
+
+
+class AdvancedSettingsResponse(BaseModel):
+    """A dump of advanced settings and suitable links for next action"""
+    settings: typing.List[AdvancedSetting]
+    links: Links
+
+
+class AdvancedSettingRequest(BaseModel):
+    """Configure the setting to change and the new value"""
+    id: str = Field(
+        ...,
+        description="The ID of the setting to change (something returned by"
+                    " GET /settings)")
+    value: Optional[bool] = Field(
+        None,
+        description="The new value to set. If null, reset to default")
 
 
 class LogLevels(str, Enum):

--- a/robot-server/robot_server/service/models/settings.py
+++ b/robot-server/robot_server/service/models/settings.py
@@ -98,7 +98,7 @@ class PipetteSettingsField(BaseModel):
     units: str = \
         Field(None,
               description="The physical units this value is in (e.g. mm, uL)")
-    type: PipetteSettingsFieldType = None
+    type: Optional[PipetteSettingsFieldType]
     min: float = \
         Field(...,
               description="The minimum acceptable value of the property")
@@ -143,19 +143,25 @@ class BasePipetteSettingFields(BaseModel):
 # generated from pipette_config module. It's derived from an object with the
 # 'quirks` member.
 PipetteSettingsFields = create_model(
-    'PipetteSettingsFields', __base__=BasePipetteSettingFields, **{
+    'PipetteSettingsFields',
+    __base__=BasePipetteSettingFields,
+    __config__=None,
+    __module__=None,
+    __validators__=None,
+    **{
         conf: (PipetteSettingsField, None) for conf in MUTABLE_CONFIGS
         if conf != 'quirks'
     }
 )
+PipetteSettingsField.__doc__ = "The fields of the pipette settings"
 
 
 class PipetteSettings(BaseModel):
     info: PipetteSettingsInfo
-    setting_fields: PipetteSettingsFields = \
-        Field(...,
-              alias="fields",
-              description="The fields of the pipette settings")
+    setting_fields: PipetteSettingsFields   # type: ignore
+
+    class Config:
+        fields = {'setting_fields': 'fields'}
 
 
 MultiPipetteSettings = typing.Dict[str, PipetteSettings]

--- a/robot-server/robot_server/service/models/settings.py
+++ b/robot-server/robot_server/service/models/settings.py
@@ -1,10 +1,12 @@
 import typing
 from enum import Enum
+import logging
 
 from typing import Optional
 
-from opentrons.config.pipette_config import MUTABLE_CONFIGS
 from pydantic import BaseModel, Field, create_model, validator
+
+from opentrons.config.pipette_config import MUTABLE_CONFIGS
 from opentrons.config.reset import ResetOptionId
 
 
@@ -41,15 +43,26 @@ AdvancedSettings = typing.List[AdvancedSetting]
 
 class LogLevels(str, Enum):
     """Valid log levels"""
-    debug = "debug"
-    info = "info"
-    warning = "warning"
-    error = "error"
+    def __new__(cls, value, level):
+        obj = str.__new__(cls, value)
+        obj._value_ = value
+        obj._level_id = level
+        return obj
+
+    debug = ("debug", logging.DEBUG)
+    info = ("info", logging.INFO)
+    warning = ("warning", logging.WARNING)
+    error = ("error", logging.ERROR)
+
+    @property
+    def level_id(self):
+        """The log level id as defined in logging lib"""
+        return self._level_id
 
 
 class LogLevel(BaseModel):
-    log_level: Optional[LogLevels] = \
-        Field(...,
+    log_level: LogLevels = \
+        Field(None,
               description="The value to set (conforming to Python "
                           "log levels)")
 

--- a/robot-server/robot_server/service/routers/settings.py
+++ b/robot-server/robot_server/service/routers/settings.py
@@ -92,7 +92,7 @@ async def post_log_level_local(
     await hardware.update_config(log_level=level_name)  # type: ignore
     robot_configs.save_robot_settings(hardware.config)  # type: ignore
 
-    return V1BasicResponse(message=f'log_level set to {log_level}')
+    return V1BasicResponse(message=f'log_level set to {level}')
 
 
 @router.post("/settings/log_level/upstream",

--- a/robot-server/robot_server/service/routers/settings.py
+++ b/robot-server/robot_server/service/routers/settings.py
@@ -31,7 +31,7 @@ async def post_settings(update: AdvancedSettingRequest)\
         -> AdvancedSettingsResponse:
     """Update advanced setting (feature flag)"""
     try:
-        advanced_settings.set_adv_setting(update.id, update.value)
+        await advanced_settings.set_adv_setting(update.id, update.value)
     except ValueError as e:
         raise V1HandlerError(message=str(e),
                              status_code=HTTPStatus.BAD_REQUEST)

--- a/robot-server/robot_server/service/routers/settings.py
+++ b/robot-server/robot_server/service/routers/settings.py
@@ -13,7 +13,7 @@ from robot_server.service.exceptions import V1HandlerError
 from robot_server.service.models.settings import AdvancedSettings, LogLevel, \
     LogLevels, FactoryResetOptions, FactoryResetCommands, PipetteSettings, \
     PipetteSettingsUpdate, RobotConfigs, MultiPipetteSettings, \
-    PipetteSettingsInfo, PipetteSettingsField, PipetteSettingsFields
+    PipetteSettingsInfo, PipetteSettingsFields
 
 log = logging.getLogger(__name__)
 

--- a/robot-server/robot_server/service/routers/settings.py
+++ b/robot-server/robot_server/service/routers/settings.py
@@ -1,9 +1,11 @@
 import logging
 from http import HTTPStatus
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
+from opentrons.hardware_control import HardwareAPILike
 
 from opentrons.system import log_control
 
+from robot_server.service.dependencies import get_hardware
 from robot_server.service.models import V1BasicResponse
 from robot_server.service.exceptions import V1HandlerError
 from robot_server.service.models.settings import AdvancedSettings, LogLevel, \
@@ -94,8 +96,9 @@ async def post_settings_reset_options(
 @router.get("/settings/robot",
             description="Get the current robot config",
             response_model=RobotConfigs)
-async def get_robot_settings() -> RobotConfigs:
-    raise HTTPException(HTTPStatus.NOT_IMPLEMENTED, "not implemented")
+async def get_robot_settings(
+        hardware: HardwareAPILike = Depends(get_hardware)) -> RobotConfigs:
+    return hardware.config._asdict()  # type: ignore
 
 
 @router.get("/settings/pipettes",

--- a/robot-server/robot_server/service/routers/settings.py
+++ b/robot-server/robot_server/service/routers/settings.py
@@ -25,7 +25,8 @@ router = APIRouter()
 
 @router.post("/settings",
              description="Change an advanced setting (feature flag)",
-             response_model=AdvancedSettingsResponse)
+             response_model=AdvancedSettingsResponse,
+             response_model_exclude_unset=True)
 async def post_settings(update: AdvancedSettingRequest)\
         -> AdvancedSettingsResponse:
     """Update advanced setting (feature flag)"""
@@ -44,7 +45,8 @@ async def post_settings(update: AdvancedSettingRequest)\
 @router.get("/settings",
             description="Get a list of available advanced settings (feature "
                         "flags) and their values",
-            response_model=AdvancedSettingsResponse)
+            response_model=AdvancedSettingsResponse,
+            response_model_exclude_unset=True)
 async def get_settings() -> AdvancedSettingsResponse:
     """Get advanced setting (feature flags)"""
     return _create_settings_response()

--- a/robot-server/robot_server/service/routers/settings.py
+++ b/robot-server/robot_server/service/routers/settings.py
@@ -224,7 +224,8 @@ async def patch_pipette_setting(
 
     # Convert fields to dict of field name to value
     fields = settings_update.setting_fields or {}
-    field_values = {k: v.value for k, v in fields.items()}
+    field_values = {k: None if v is None else v.value
+                    for k, v in fields.items()}
     if field_values:
         try:
             pipette_config.override(fields=field_values, pipette_id=pipette_id)

--- a/robot-server/tests/service/routers/test_settings.py
+++ b/robot-server/tests/service/routers/test_settings.py
@@ -276,14 +276,22 @@ def test_set_log_level_invalid(api_client, body,
                                    "expected_log_level",
                                    "expected_log_level_name"],
                          argvalues=[
-                             [{'log_level': 'debug'}, logging.DEBUG, "DEBUG"],
-                             [{'log_level': 'deBug'}, logging.DEBUG, "DEBUG"],
-                             [{'log_level': 'info'}, logging.INFO, "INFO"],
-                             [{'log_level': 'INFO'}, logging.INFO, "INFO"],
-                             [{'log_level': 'warning'}, logging.WARNING, "WARNING"],
-                             [{'log_level': 'warninG'}, logging.WARNING, "WARNING"],
-                             [{'log_level': 'error'}, logging.ERROR, "ERROR"],
-                             [{'log_level': 'ERROR'}, logging.ERROR, "ERROR"],
+                             [{'log_level': 'debug'},
+                              logging.DEBUG, "DEBUG"],
+                             [{'log_level': 'deBug'},
+                              logging.DEBUG, "DEBUG"],
+                             [{'log_level': 'info'},
+                              logging.INFO, "INFO"],
+                             [{'log_level': 'INFO'},
+                              logging.INFO, "INFO"],
+                             [{'log_level': 'warning'},
+                              logging.WARNING, "WARNING"],
+                             [{'log_level': 'warninG'},
+                              logging.WARNING, "WARNING"],
+                             [{'log_level': 'error'},
+                              logging.ERROR, "ERROR"],
+                             [{'log_level': 'ERROR'},
+                              logging.ERROR, "ERROR"],
                          ])
 def test_set_log_level(api_client, hardware_log_level,
                        mock_robot_configs, mock_logging_set_level,
@@ -291,5 +299,6 @@ def test_set_log_level(api_client, hardware_log_level,
     resp = api_client.post('/settings/log_level/local', json=body)
     assert resp.status_code == 200
     mock_logging_set_level.assert_called_once_with(expected_log_level)
-    hardware_log_level.update_config.assert_called_once_with(log_level=expected_log_level_name)
+    hardware_log_level.update_config.assert_called_once_with(
+        log_level=expected_log_level_name)
     mock_robot_configs.save_robot_settings.assert_called_once()

--- a/robot-server/tests/service/routers/test_settings.py
+++ b/robot-server/tests/service/routers/test_settings.py
@@ -388,6 +388,9 @@ def mock_restart_required():
 @pytest.fixture
 def mock_set_adv_setting():
     with patch("robot_server.service.routers.settings.advanced_settings.set_adv_setting") as p:  # noqa: E501
+        async def f(i, v):
+            pass
+        p.side_effect = f
         yield p
 
 

--- a/robot-server/tests/service/routers/test_settings.py
+++ b/robot-server/tests/service/routers/test_settings.py
@@ -111,13 +111,16 @@ def mock_pipette_data():
                 'model': 'p1_model',
             },
             'fields': {
-                'p1': {
+                'pickUpCurrent': {
                     'units': 'mm',
                     'type': 'float',
                     'min': 0.0,
                     'max': 2.0,
                     'default': 1.0,
                     'value': 0.5,
+                },
+                'quirks': {
+                    'dropTipShake': True
                 }
             }
         },
@@ -127,7 +130,7 @@ def mock_pipette_data():
                 'model': 'p2_model',
             },
             'fields': {
-                'p2': {
+                'pickUpIncrement': {
                     'units': 'inch',
                     'type': 'int',
                     'min': 0,

--- a/robot-server/tests/service/routers/test_settings.py
+++ b/robot-server/tests/service/routers/test_settings.py
@@ -191,7 +191,8 @@ def test_modify_pipette_settings_call_override(api_client,
         'fields': {
             'pickUpCurrent': {'value': 1},
             'otherField': {'value': True},
-            'noneField': {'value': None}
+            'noneField': {'value': None},
+            'otherNoneField': None
         }
     }
 
@@ -200,7 +201,8 @@ def test_modify_pipette_settings_call_override(api_client,
         f'/settings/pipettes/{pipette_id}',
         json=changes)
     mock_pipette_config.override.assert_called_once_with(
-        fields={'pickUpCurrent': 1, 'otherField': True, 'noneField': None},
+        fields={'pickUpCurrent': 1, 'otherField': True,
+                'noneField': None, 'otherNoneField': None},
         pipette_id=pipette_id)
     patch_body = resp.json()
     assert resp.status_code == 200


### PR DESCRIPTION
## overview

These endpoints are implemented in fastapi:

`GET /settings/robot`
`GET /settings/pipettes`
`GET /settings/pipettes/{pipette_id}`
`PATCH /settings/pipettes/{pipette_id}`
`POST /settings/reset`
`GET /settings/reset/options`
`POST /settings/log_level/local`
`GET /settings`
`POST /settings`

To do this I moved a lot of logic from `opentrons.server.endpoints.settings` into other modules.

## changelog

- The model of pipette config spells out exact field names.
- Refactor `opentrons.server.endpoints.settings`: 
    - Move reset logic to it's own module in `opentrons.config`
    - Move pipette config override logic out of handler and into `opentrons.config.pipette_config`
- Refactor `opentrons.config.advanced_settings`:
    - Make Setting object a namedtuple of SettingDefinition (what used to be Setting) and the value. A dict of id to Setting is returned in the get functions. 
    - SettingDefinition has an on_change function for side effects (like restart_required handling)
    - Create special SettingDefinition for the log aggregator. 

## review requests

The settings endpoints are tricky to port and need some attention on the aiohttp side.
I've tested the fastapi side on my raspberry pi using the `/docs` endpoint as well as the Opentrons app. 

## risk assessment

High risk. This involved refactoring the settings endoints on the aiohttp side as well.

closes #5144 
