### PR TITLE
fix(protocol-designer): add field level validation for magnetic module engage height

### DIFF
--- a/protocol-designer/src/components/LiquidPlacementForm/LiquidPlacementForm.js
+++ b/protocol-designer/src/components/LiquidPlacementForm/LiquidPlacementForm.js
@@ -88,7 +88,8 @@ export class LiquidPlacementForm extends React.Component<Props> {
     const value: ?string = e.currentTarget.value
     const masked = fieldProcessors.composeMaskers(
       fieldProcessors.maskToFloat,
-      fieldProcessors.onlyPositiveNumbers
+      fieldProcessors.onlyPositiveNumbers,
+      fieldProcessors.trimDecimals(1)
     )(value)
     setFieldValue('volume', masked)
   }

--- a/protocol-designer/src/steplist/fieldLevel/errors.js
+++ b/protocol-designer/src/steplist/fieldLevel/errors.js
@@ -13,6 +13,7 @@ export type FieldError =
   | 'NON_ZERO'
   | 'UNDER_RANGE_MINIMUM'
   | 'OVER_RANGE_MAXIMUM'
+  | 'NOT_A_REAL_NUMBER'
 
 const FIELD_ERRORS: { [FieldError]: string } = {
   REQUIRED: 'This field is required',
@@ -20,6 +21,7 @@ const FIELD_ERRORS: { [FieldError]: string } = {
   NON_ZERO: 'Must be greater than zero',
   UNDER_RANGE_MINIMUM: 'Min is',
   OVER_RANGE_MAXIMUM: 'Max is',
+  NOT_A_REAL_NUMBER: 'Must be a real number',
 }
 
 // TODO: test these
@@ -52,6 +54,9 @@ export const maxFieldValue = (maximum: number): ErrorChecker => (
   Number(value) <= maximum
     ? null
     : `${FIELD_ERRORS.OVER_RANGE_MAXIMUM} ${maximum}`
+
+export const realNumber: ErrorChecker = (value: mixed) =>
+  isNaN(Number(value)) ? FIELD_ERRORS.NOT_A_REAL_NUMBER : null
 
 /*******************
  **     Helpers    **

--- a/protocol-designer/src/steplist/fieldLevel/errors.js
+++ b/protocol-designer/src/steplist/fieldLevel/errors.js
@@ -21,7 +21,7 @@ const FIELD_ERRORS: { [FieldError]: string } = {
   NON_ZERO: 'Must be greater than zero',
   UNDER_RANGE_MINIMUM: 'Min is',
   OVER_RANGE_MAXIMUM: 'Max is',
-  NOT_A_REAL_NUMBER: 'Must be a real number',
+  NOT_A_REAL_NUMBER: 'Must be a number',
 }
 
 // TODO: test these

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -86,7 +86,11 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
     castValue: Number,
   },
   dispense_mix_volume: {
-    maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
+    maskValue: composeMaskers(
+      maskToFloat,
+      onlyPositiveNumbers,
+      trimDecimals(1)
+    ),
     castValue: Number,
   },
   dispense_mmFromBottom: {

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -132,7 +132,12 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
   },
   volume: {
     getErrors: composeErrors(requiredField, nonZero),
-    maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers, defaultTo(0)),
+    maskValue: composeMaskers(
+      maskToFloat,
+      onlyPositiveNumbers,
+      defaultTo(0),
+      trimDecimals(1)
+    ),
     castValue: Number,
   },
   wells: {
@@ -142,7 +147,7 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
   magnetAction: { getErrors: composeErrors(requiredField) },
   engageHeight: {
     getErrors: composeErrors(realNumber),
-    maskValue: composeMaskers(maskToFloat),
+    maskValue: composeMaskers(maskToFloat, trimDecimals(1)),
     castValue: Number,
   },
   setTemperature: { getErrors: composeErrors(requiredField) },

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -135,8 +135,8 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
     maskValue: composeMaskers(
       maskToFloat,
       onlyPositiveNumbers,
-      defaultTo(0),
-      trimDecimals(1)
+      trimDecimals(1),
+      defaultTo(0)
     ),
     castValue: Number,
   },

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -6,6 +6,7 @@ import {
   composeErrors,
   minFieldValue,
   maxFieldValue,
+  realNumber,
 } from './errors'
 import {
   maskToInteger,
@@ -128,6 +129,7 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
   },
   magnetAction: { getErrors: composeErrors(requiredField) },
   engageHeight: {
+    getErrors: composeErrors(realNumber),
     maskValue: composeMaskers(maskToFloat),
     castValue: Number,
   },

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -13,6 +13,7 @@ import {
   onlyPositiveNumbers,
   defaultTo,
   composeMaskers,
+  trimDecimals,
   type ValueMasker,
   type ValueCaster,
 } from './processing'
@@ -45,7 +46,11 @@ type StepFieldHelpers = {|
 |}
 const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
   aspirate_airGap_volume: {
-    maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
+    maskValue: composeMaskers(
+      maskToFloat,
+      onlyPositiveNumbers,
+      trimDecimals(1)
+    ),
     castValue: Number,
   },
   aspirate_labware: {

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -101,7 +101,11 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
     maskValue: defaultTo([]),
   },
   disposalVolume_volume: {
-    maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
+    maskValue: composeMaskers(
+      maskToFloat,
+      onlyPositiveNumbers,
+      trimDecimals(1)
+    ),
     castValue: Number,
   },
   labware: {

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -63,7 +63,11 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
     castValue: Number,
   },
   aspirate_mix_volume: {
-    maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
+    maskValue: composeMaskers(
+      maskToFloat,
+      onlyPositiveNumbers,
+      trimDecimals(1)
+    ),
     castValue: Number,
   },
   aspirate_mmFromBottom: {

--- a/protocol-designer/src/steplist/fieldLevel/processing.js
+++ b/protocol-designer/src/steplist/fieldLevel/processing.js
@@ -22,6 +22,13 @@ export const maskToFloat = (rawValue: mixed): string =>
     ? rawValue.replace(/[^-/.0-9]/g, '')
     : String(rawValue)
 
+export const trimDecimals = (decimals: number = DEFAULT_DECIMAL_PLACES) => (
+  rawValue: mixed
+): string => {
+  const trimRegex = new RegExp(`(\\d*[.]{1}\\d{${decimals}})(\\d*)`)
+  return String(rawValue).replace(trimRegex, (match, group1) => group1)
+}
+
 /*********************
  **  Value Limiters  **
  **********************/
@@ -33,13 +40,6 @@ export const onlyPositiveNumbers = (value: mixed) =>
   value !== null && !Number.isNaN(value) && Number(value) >= 0 ? value : null
 export const defaultTo = (defaultValue: mixed) => (value: mixed) =>
   value === null || Number.isNaN(value) ? defaultValue : value
-
-export const trimDecimals = (decimals: number = DEFAULT_DECIMAL_PLACES) => (
-  rawValue: mixed
-): string => {
-  const trimRegex = new RegExp(`(\\d*[.]{1}\\d{${decimals}})(\\d*)`)
-  return String(rawValue).replace(trimRegex, (match, group1) => group1)
-}
 
 /*******************
  **     Helpers    **

--- a/protocol-designer/src/steplist/fieldLevel/processing.js
+++ b/protocol-designer/src/steplist/fieldLevel/processing.js
@@ -15,18 +15,12 @@ export const maskToInteger = (rawValue: mixed): mixed => {
   return rawNumericValue
 }
 
-const DEFAULT_DECIMAL_PLACES = 1
+const DEFAULT_DECIMAL_PLACES: number = 1
 
-export const maskToFloat = (rawValue: mixed): ?mixed => {
-  const rawNumericValue =
-    typeof rawValue === 'string'
-      ? rawValue.replace(/[^-/.0-9]/g, '')
-      : String(rawValue)
-  const trimRegex = new RegExp(
-    `(\\d*[.]{1}\\d{${DEFAULT_DECIMAL_PLACES}})(\\d*)`
-  )
-  return rawNumericValue.replace(trimRegex, (match, group1) => group1)
-}
+export const maskToFloat = (rawValue: mixed): string =>
+  typeof rawValue === 'string'
+    ? rawValue.replace(/[^-/.0-9]/g, '')
+    : String(rawValue)
 
 /*********************
  **  Value Limiters  **

--- a/protocol-designer/src/steplist/fieldLevel/processing.js
+++ b/protocol-designer/src/steplist/fieldLevel/processing.js
@@ -7,7 +7,7 @@ export type ValueCaster = (value: mixed) => mixed
  **********************/
 
 // Mask to number now allows for 0 and negative numbers, for decimals use maskToFloat
-export const maskToInteger = (rawValue: mixed): mixed => {
+export const maskToInteger = (rawValue: mixed): string => {
   const rawNumericValue =
     typeof rawValue === 'string'
       ? rawValue.replace(/[^-0-9]/g, '')

--- a/protocol-designer/src/steplist/fieldLevel/processing.js
+++ b/protocol-designer/src/steplist/fieldLevel/processing.js
@@ -34,6 +34,13 @@ export const onlyPositiveNumbers = (value: mixed) =>
 export const defaultTo = (defaultValue: mixed) => (value: mixed) =>
   value === null || Number.isNaN(value) ? defaultValue : value
 
+export const trimDecimals = (decimals: number = DEFAULT_DECIMAL_PLACES) => (
+  rawValue: mixed
+): string => {
+  const trimRegex = new RegExp(`(\\d*[.]{1}\\d{${decimals}})(\\d*)`)
+  return String(rawValue).replace(trimRegex, (match, group1) => group1)
+}
+
 /*******************
  **     Helpers    **
  ********************/

--- a/protocol-designer/src/steplist/fieldLevel/processing.js
+++ b/protocol-designer/src/steplist/fieldLevel/processing.js
@@ -37,7 +37,7 @@ export const trimDecimals = (decimals: number = DEFAULT_DECIMAL_PLACES) => (
 // For the sake of simplicity and flow happiness, they are equipped to deal with parameters of type `mixed`
 
 export const onlyPositiveNumbers = (value: mixed) =>
-  value !== null && !Number.isNaN(value) && Number(value) >= 0 ? value : null
+  value !== null && !Number.isNaN(value) && Number(value) >= 0 ? value : ''
 export const defaultTo = (defaultValue: mixed) => (value: mixed) =>
   value === null || Number.isNaN(value) ? defaultValue : value
 

--- a/protocol-designer/src/steplist/fieldLevel/test/processing.test.js
+++ b/protocol-designer/src/steplist/fieldLevel/test/processing.test.js
@@ -1,0 +1,43 @@
+import { maskToFloat, trimDecimals } from '../processing'
+
+describe('Value Casters', () => {
+  describe('maskToFloat', () => {
+    it('returns string representation of integer when the input is an integer', () => {
+      expect(maskToFloat(1)).toBe('1')
+      expect(maskToFloat('1')).toBe('1')
+      expect(maskToFloat(109213097)).toBe('109213097')
+      expect(maskToFloat('109213097')).toBe('109213097')
+      expect(maskToFloat(-12837)).toBe('-12837')
+      expect(maskToFloat('-12837')).toBe('-12837')
+    })
+    it('does not truncate decimals', () => {
+      expect(maskToFloat(0.00001)).toBe('0.00001')
+      expect(maskToFloat('0.00001')).toBe('0.00001')
+      expect(maskToFloat(21.0123)).toBe('21.0123')
+      expect(maskToFloat('21.0123')).toBe('21.0123')
+      expect(maskToFloat(-9211.0987)).toBe('-9211.0987')
+      expect(maskToFloat('-9211.0987')).toBe('-9211.0987')
+    })
+  })
+
+  describe('trimDecimals', () => {
+    it('removes one decimal', () => {
+      const trimByOne = trimDecimals(1)
+      expect(trimByOne(0.00001)).toBe('0.0')
+      expect(trimByOne('0.00001')).toBe('0.0')
+      expect(trimByOne(21.123)).toBe('21.1')
+      expect(trimByOne('21.123')).toBe('21.1')
+      expect(trimByOne(-9211.987)).toBe('-9211.9')
+      expect(trimByOne('-9211.987')).toBe('-9211.9')
+    })
+    it('removes two decimals', () => {
+      const trimByTwo = trimDecimals(2)
+      expect(trimByTwo(0.00001)).toBe('0.00')
+      expect(trimByTwo('0.00001')).toBe('0.00')
+      expect(trimByTwo(21.123)).toBe('21.12')
+      expect(trimByTwo('21.123')).toBe('21.12')
+      expect(trimByTwo(-9211.987)).toBe('-9211.98')
+      expect(trimByTwo('-9211.987')).toBe('-9211.98')
+    })
+  })
+})


### PR DESCRIPTION
## overview
This PR closes #5274 by adding field level validation for magnetic module engage height text input. 

Along the way, I also refactored the `maskToFloat` input masker to just mask to float, and added an additional masker to trim decimals (previously `maskToFloat` was doing both) 

## changelog
refactor `maskToFloat` to just mask to float
change signature for `maskToInt`
add 'trimDecimals' masker
add field level validation for magnetic module engage height
## review requests
- code review 
- make sure you **CANNOT** submit non-numbered values into the `engage height` field

Because of the refactor I did, the following fields were affected, but shouldn't have changed. The expected behavior is that they should mask floats, and only allow one decimal place:

1. liquid placement form volume (when adding liquids to protocol)
2. aspirate air gap volume 
3. aspirate mix volume
4. dispense mix volume
5. multi dispense disposal volume (this one is tricky, PD won't let you multi-dispense if your volume is too big for the pipette to break up... see screenshot attached)
6. transfer volume field



![image](https://user-images.githubusercontent.com/5788529/78073708-64ec6700-736f-11ea-9358-768a773e3111.png)




## risk assessment

Medium — touches text input masking for several different forms in PD