### PR TITLE
feat(protocol-designer): allow GEN1 multi pipette access N/S of GEN2 modules

### DIFF
--- a/protocol-designer/src/step-generation/__tests__/modulePipetteCollision.test.js
+++ b/protocol-designer/src/step-generation/__tests__/modulePipetteCollision.test.js
@@ -2,6 +2,7 @@
 import {
   MAGNETIC_MODULE_TYPE,
   MAGNETIC_MODULE_V1,
+  MAGNETIC_MODULE_V2,
 } from '@opentrons/shared-data'
 import { modulePipetteCollision } from '../utils/modulePipetteCollision'
 import { getInitialRobotStateStandard, makeContext } from '../__fixtures__'
@@ -43,6 +44,7 @@ describe('modulePipetteCollision', () => {
   it('should return true if using a GEN1 multi pipette "north" of a GEN1 magnetic module', () => {
     expect(modulePipetteCollision(collisionArgs)).toBe(true)
   })
+
   it('should return false under the same conditions, if OT_PD_DISABLE_MODULE_RESTRICTIONS flag is enabled', () => {
     mock_getFeatureFlag.mockReturnValue(true)
     expect(modulePipetteCollision(collisionArgs)).toBe(false)
@@ -50,6 +52,7 @@ describe('modulePipetteCollision', () => {
       'OT_PD_DISABLE_MODULE_RESTRICTIONS'
     )
   })
+
   it('should return false with no labware', () => {
     expect(
       modulePipetteCollision({
@@ -58,11 +61,24 @@ describe('modulePipetteCollision', () => {
       })
     ).toBe(false)
   })
+
   it('should return false with no pipette', () => {
     expect(
       modulePipetteCollision({
         ...collisionArgs,
         pipette: null,
+      })
+    ).toBe(false)
+  })
+
+  it('should return false when module is GEN2', () => {
+    invariantContext.moduleEntities['magDeckId'].model = MAGNETIC_MODULE_V2
+    expect(
+      modulePipetteCollision({
+        pipette: 'p10MultiId',
+        labware: 'destPlateId',
+        invariantContext,
+        prevRobotState: robotState,
       })
     ).toBe(false)
   })

--- a/protocol-designer/src/step-generation/__tests__/modulePipetteCollision.test.js
+++ b/protocol-designer/src/step-generation/__tests__/modulePipetteCollision.test.js
@@ -1,0 +1,69 @@
+// @flow
+import {
+  MAGNETIC_MODULE_TYPE,
+  MAGNETIC_MODULE_V1,
+} from '@opentrons/shared-data'
+import { modulePipetteCollision } from '../utils/modulePipetteCollision'
+import { getInitialRobotStateStandard, makeContext } from '../__fixtures__'
+import { _getFeatureFlag } from '../utils/_getFeatureFlag'
+jest.mock('../utils/_getFeatureFlag')
+
+const mock_getFeatureFlag: JestMockFn<[string], boolean> = _getFeatureFlag
+
+let invariantContext
+let robotState
+let collisionArgs
+beforeEach(() => {
+  jest.clearAllMocks()
+  mock_getFeatureFlag.mockReturnValue(false)
+
+  invariantContext = makeContext()
+  invariantContext.moduleEntities['magDeckId'] = {
+    id: 'magDeckId',
+    type: MAGNETIC_MODULE_TYPE,
+    model: MAGNETIC_MODULE_V1,
+  }
+  robotState = getInitialRobotStateStandard(invariantContext)
+  robotState.labware['destPlateId'].slot = '4'
+  robotState.labware['tiprack1Id'].slot = '10'
+  robotState.modules['magDeckId'] = {
+    slot: '1',
+    moduleState: { type: MAGNETIC_MODULE_TYPE, engaged: false },
+  }
+
+  collisionArgs = {
+    pipette: 'p10MultiId',
+    labware: 'destPlateId',
+    invariantContext,
+    prevRobotState: robotState,
+  }
+})
+
+describe('modulePipetteCollision', () => {
+  it('should return true if using a GEN1 multi pipette "north" of a GEN1 magnetic module', () => {
+    expect(modulePipetteCollision(collisionArgs)).toBe(true)
+  })
+  it('should return false under the same conditions, if OT_PD_DISABLE_MODULE_RESTRICTIONS flag is enabled', () => {
+    mock_getFeatureFlag.mockReturnValue(true)
+    expect(modulePipetteCollision(collisionArgs)).toBe(false)
+    expect(mock_getFeatureFlag).toHaveBeenCalledWith(
+      'OT_PD_DISABLE_MODULE_RESTRICTIONS'
+    )
+  })
+  it('should return false with no labware', () => {
+    expect(
+      modulePipetteCollision({
+        ...collisionArgs,
+        labware: null,
+      })
+    ).toBe(false)
+  })
+  it('should return false with no pipette', () => {
+    expect(
+      modulePipetteCollision({
+        ...collisionArgs,
+        pipette: null,
+      })
+    ).toBe(false)
+  })
+})

--- a/protocol-designer/src/step-generation/utils/_getFeatureFlag.js
+++ b/protocol-designer/src/step-generation/utils/_getFeatureFlag.js
@@ -1,0 +1,27 @@
+// @flow
+
+// HACK Ian 2019-11-12: this is a temporary solution to pass PD runtime feature flags
+// down into step-generation, which is meant to be relatively independent of PD.
+// WARNING: Unless you're careful to bust any caches (eg of selectors that use step-generation),
+// there could be delayed-sync issues when toggling a flag with this solution, because
+// we're directly accessing localStorage without an ability to monitor for changes.
+// A long-term solution might be to either restart PD upon setting flags that are used here,
+// or pass flags as "config options" into step-generation via a factory that stands in front of all step-generation imports,
+// or just avoid this complexity for non-experimental features.
+export const _getFeatureFlag = (flagName: string): boolean => {
+  if (!global.localStorage) {
+    let value = false
+    try {
+      value = process.env[flagName] === 'true'
+    } catch (e) {
+      console.error(
+        `appear to be in node environment, but cannot access ${flagName} in process.env. ${e}`
+      )
+    }
+    return value
+  }
+  const allFlags = JSON.parse(
+    global.localStorage.getItem('root.featureFlags.flags') || '{}'
+  )
+  return (allFlags && allFlags[flagName]) || false
+}

--- a/protocol-designer/src/step-generation/utils/modulePipetteCollision.js
+++ b/protocol-designer/src/step-generation/utils/modulePipetteCollision.js
@@ -1,9 +1,8 @@
 // @flow
 import {
-  MAGNETIC_MODULE_TYPE,
-  TEMPERATURE_MODULE_TYPE,
-} from '@opentrons/shared-data'
-import { GEN_ONE_MULTI_PIPETTES } from '../../constants'
+  GEN_ONE_MULTI_PIPETTES,
+  MODULES_WITH_COLLISION_ISSUES,
+} from '../../constants'
 import { _getFeatureFlag } from './_getFeatureFlag'
 import type { PipetteEntity } from '../../step-forms/types'
 import type { DeckSlot } from '../../types'
@@ -34,17 +33,16 @@ export const modulePipetteCollision = (args: {|
   // Does not care about GEN1/GEN2 module, just GEN1 multi-ch pipette
   const labwareInDangerZone = Object.keys(invariantContext.moduleEntities).some(
     moduleId => {
-      const moduleSlot: ?DeckSlot = prevRobotState.modules[moduleId]?.slot
-      const moduleType: ?string =
-        invariantContext.moduleEntities[moduleId]?.type
-      const hasNorthSouthProblem = [
-        MAGNETIC_MODULE_TYPE,
-        TEMPERATURE_MODULE_TYPE,
-      ].includes(moduleType)
-      const labwareInNorthSlot =
-        (moduleSlot === '1' && labwareSlot === '4') ||
-        (moduleSlot === '3' && labwareSlot === '6')
-      return hasNorthSouthProblem && labwareInNorthSlot
+      const moduleModel = invariantContext.moduleEntities[moduleId].model
+      if (MODULES_WITH_COLLISION_ISSUES.includes(moduleModel)) {
+        const moduleSlot: ?DeckSlot = prevRobotState.modules[moduleId]?.slot
+        const labwareInNorthSlot =
+          (moduleSlot === '1' && labwareSlot === '4') ||
+          (moduleSlot === '3' && labwareSlot === '6')
+        return labwareInNorthSlot
+      } else {
+        return false
+      }
     }
   )
 

--- a/protocol-designer/src/step-generation/utils/modulePipetteCollision.js
+++ b/protocol-designer/src/step-generation/utils/modulePipetteCollision.js
@@ -4,34 +4,10 @@ import {
   TEMPERATURE_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import { GEN_ONE_MULTI_PIPETTES } from '../../constants'
+import { _getFeatureFlag } from './_getFeatureFlag'
+import type { PipetteEntity } from '../../step-forms/types'
+import type { DeckSlot } from '../../types'
 import type { InvariantContext, RobotState } from '../types'
-
-// HACK Ian 2019-11-12: this is a temporary solution to pass PD runtime feature flags
-// down into step-generation, which is meant to be relatively independent of PD.
-// WARNING: Unless you're careful to bust any caches (eg of selectors that use step-generation),
-// there could be delayed-sync issues when toggling a flag with this solution, because
-// we're directly accessing localStorage without an ability to.
-// A long-term solution might be to either restart PD upon setting flags that are used here,
-// or pass flags as "config options" into step-generation via a factory that stands in front of all step-generation imports,
-// or just avoid this complexity for non-experimental features.
-const _getFeatureFlag = (flagName: string): boolean => {
-  if (!global.localStorage) {
-    let value = false
-    try {
-      value = process.env[flagName] === 'true'
-    } catch (e) {
-      console.error(
-        `appear to be in node environment, but cannot access ${flagName} in process.env. ${e}`
-      )
-    }
-    return value
-  }
-  const allFlags = JSON.parse(
-    global.localStorage.getItem('root.featureFlags.flags') || '{}'
-  )
-  return (allFlags && allFlags[flagName]) || false
-}
-
 export const modulePipetteCollision = (args: {|
   pipette: ?string,
   labware: ?string,
@@ -43,17 +19,24 @@ export const modulePipetteCollision = (args: {|
     return false
   }
   const { pipette, labware, invariantContext, prevRobotState } = args
-  const pipetteEntity: ?* = pipette && invariantContext.pipetteEntities[pipette]
-  const labwareSlot: ?* = labware && prevRobotState.labware[labware]?.slot
-  if (!pipette || !labware || !pipetteEntity || !labwareSlot) return false
+  const pipetteEntity: ?PipetteEntity = pipette
+    ? invariantContext.pipetteEntities[pipette]
+    : null
+  const labwareSlot: ?DeckSlot = labware
+    ? prevRobotState.labware[labware]?.slot
+    : null
+  if (!pipette || !labware || !pipetteEntity || !labwareSlot) {
+    return false
+  }
 
   // NOTE: does not handle thermocycler-adjacent slots.
   // Only handles labware is NORTH of mag/temp in slot 1 or 3
   // Does not care about GEN1/GEN2 module, just GEN1 multi-ch pipette
   const labwareInDangerZone = Object.keys(invariantContext.moduleEntities).some(
     moduleId => {
-      const moduleSlot: ?* = prevRobotState.modules[moduleId]?.slot
-      const moduleType: ?* = invariantContext.moduleEntities[moduleId]?.type
+      const moduleSlot: ?DeckSlot = prevRobotState.modules[moduleId]?.slot
+      const moduleType: ?string =
+        invariantContext.moduleEntities[moduleId]?.type
       const hasNorthSouthProblem = [
         MAGNETIC_MODULE_TYPE,
         TEMPERATURE_MODULE_TYPE,


### PR DESCRIPTION
## overview

Closes #5331

## changelog

## review requests

- [ ] GEN1 multi access attempt (eg asp/disp/blowout/pickuptip) still generates timeline error
- [ ] GEN2 multi access attempt works, no longer generates timeline error
- [ ] Mixed case GEN1 mag / GEN2 temp and so on work as expected
- [ ] test review

## risk assessment

just pd