### PR TITLE
feat(protocol-designer): update intro announcement modal copy

### DIFF
--- a/protocol-designer/src/components/modals/AnnouncementModal/announcements.js
+++ b/protocol-designer/src/components/modals/AnnouncementModal/announcements.js
@@ -25,15 +25,22 @@ export const announcements: Array<Announcement> = [
     message: (
       <>
         <p>
-          Protocol Designer BETA now supports Temperature and Magnetic modules.
+          Protocol Designer now includes Beta support for Temperature and
+          Magnetic modules.
         </p>
-
         <p>
-          Note: Protocols with modules{' '}
-          <strong>may require an app and robot update to run</strong>. You will
-          need to have the OT-2 app and robot on the latest versions (
-          <strong>3.17 and higher</strong>).
+          To use Temperature and Magnetic modules in the Protocol Designer
+          protocols, update your Opentrons App and OT-2 to software version
+          3.17.0 Beta.
         </p>
+        <p>
+          Beta releases provide early access to new software versions and
+          features. While we make a best effort to test each version, Beta
+          features and software versions may include bugs or incomplete
+          functionality.
+        </p>
+        {/* TODO IMMEDIATELY (sa, 2020-04-01): Update with the link to support article when provided */}
+        <p>Learn more about Beta releases [here].</p>
       </>
     ),
   },

--- a/protocol-designer/src/components/modals/AnnouncementModal/announcements.js
+++ b/protocol-designer/src/components/modals/AnnouncementModal/announcements.js
@@ -40,7 +40,13 @@ export const announcements: Array<Announcement> = [
           functionality.
         </p>
         {/* TODO IMMEDIATELY (sa, 2020-04-01): Update with the link to support article when provided */}
-        <p>Learn more about Beta releases [here].</p>
+        <p>
+          Learn more about Beta releases{' '}
+          <a href="https://support.opentrons.com/en/articles/3854833-opentrons-beta-software-releases">
+            here
+          </a>
+          .
+        </p>
       </>
     ),
   },


### PR DESCRIPTION
## overview
This PR closes #5334 by updating the copy for the intro announcement modal. Note, the support link doesn't work yet.

## review requests
Make sure the modal matches what's on the ticket

## risk assessment
Low- just updating modal text