### PR TITLE
feat(protocol-designer): Remove multi gen2 feature flag

### DIFF
--- a/protocol-designer/src/components/modals/FilePipettesModal/__tests__/PipetteFields.test.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/__tests__/PipetteFields.test.js
@@ -6,23 +6,17 @@ import { mount } from 'enzyme'
 import { PipetteSelect, DropdownField } from '@opentrons/components'
 import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_300_ul.json'
 import fixture_tiprack_1000_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_1000_ul.json'
-import { getEnableMultiGEN2Pipettes } from '../../../../feature-flags/selectors'
 import { getOnlyLatestDefs } from '../../../../labware-defs/utils'
 import { PipetteFields } from '../PipetteFields'
 import { TiprackDiagram } from '../TiprackDiagram'
 import { PipetteDiagram } from '../PipetteDiagram'
 
 import type { LabwareDefByDefURI } from '../../../../labware-defs'
-import type { BaseState } from '../../../../types'
 
 jest.mock('../../../../feature-flags/selectors')
 jest.mock('../../../../labware-defs/utils.js')
 jest.mock('../TiprackDiagram')
 
-const getEnableMultiGEN2PipettesMock: JestMockFn<
-  [BaseState],
-  ?boolean
-> = getEnableMultiGEN2Pipettes
 const getOnlyLatestDefsMock: JestMockFn<
   [],
   LabwareDefByDefURI
@@ -69,7 +63,6 @@ describe('PipetteFields', () => {
       touched: null,
     }
 
-    getEnableMultiGEN2PipettesMock.mockReturnValue(true)
     getOnlyLatestDefsMock.mockReturnValue({
       tiprack_300: fixture_tiprack_300_ul,
       tiprack_1000: fixture_tiprack_1000_ul,

--- a/protocol-designer/src/feature-flags/reducers.js
+++ b/protocol-designer/src/feature-flags/reducers.js
@@ -21,8 +21,6 @@ const initialFlags: Flags = {
   PRERELEASE_MODE: process.env.OT_PD_PRERELEASE_MODE === '1' || false,
   OT_PD_DISABLE_MODULE_RESTRICTIONS:
     process.env.OT_PD_DISABLE_MODULE_RESTRICTIONS === '1' || false,
-  OT_PD_ENABLE_MULTI_GEN2_PIPETTES:
-    process.env.OT_PD_ENABLE_MULTI_GEN2_PIPETTES === '1' || false,
   OT_PD_ENABLE_THERMOCYCLER:
     process.env.OT_PD_ENABLE_THERMOCYCLER === '1' || false,
 }

--- a/protocol-designer/src/feature-flags/selectors.js
+++ b/protocol-designer/src/feature-flags/selectors.js
@@ -18,8 +18,3 @@ export const getEnableThermocycler: Selector<?boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ENABLE_THERMOCYCLER
 )
-
-export const getEnableMultiGEN2Pipettes: Selector<?boolean> = createSelector(
-  getFeatureFlagData,
-  flags => flags.OT_PD_ENABLE_MULTI_GEN2_PIPETTES
-)

--- a/protocol-designer/src/feature-flags/types.js
+++ b/protocol-designer/src/feature-flags/types.js
@@ -8,18 +8,17 @@ export const DEPRECATED_FLAGS = [
   'OT_PD_SHOW_UPLOAD_CUSTOM_LABWARE_BUTTON',
   'OT_PD_ENABLE_GEN2_PIPETTES',
   'OT_PD_ENABLE_MODULES',
+  'OT_PD_ENABLE_MULTI_GEN2_PIPETTES',
 ]
 
 // union of feature flag string constant IDs
 export type FlagTypes =
   | 'PRERELEASE_MODE'
   | 'OT_PD_DISABLE_MODULE_RESTRICTIONS'
-  | 'OT_PD_ENABLE_MULTI_GEN2_PIPETTES'
   | 'OT_PD_ENABLE_THERMOCYCLER'
 
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: Array<FlagTypes> = [
-  'OT_PD_ENABLE_MULTI_GEN2_PIPETTES',
   'OT_PD_DISABLE_MODULE_RESTRICTIONS',
 ]
 

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -3,10 +3,6 @@
     "title": "Use prerelease mode",
     "description": "Show in-progress features for testing & internal use"
   },
-  "OT_PD_ENABLE_MODULES": {
-    "title": "Enable modules in PD",
-    "description": "!"
-  },
   "OT_PD_DISABLE_MODULE_RESTRICTIONS": {
     "title": "Disable module placement restrictions",
     "description_1": "Turn off all restrictions on module placement and related pipette crash guidance.",
@@ -15,9 +11,5 @@
   "OT_PD_ENABLE_THERMOCYCLER": {
     "title": "Enable thermocycler module",
     "description": "Allow adding thermocycler modules and steps to protocols."
-  },
-  "OT_PD_ENABLE_MULTI_GEN2_PIPETTES": {
-    "title": "Enable multi GEN2 pipettes in PD",
-    "description": "Allow multi GEN2 pipettes to be specified from Pipette Selection"
   }
 }


### PR DESCRIPTION
## overview

This PR closes #5336  by removing the visible FF toggle from experimental settings for GEN2 multi channel pipette usage. (The work to enable gen2 by default was already in place)

## changelog

- feat(protocol-designer): Remove multi gen2 feature flag

## review requests

- [ ] Gen2 multi channel pipette FF no longer in settings
- [ ] Gen2 multi channel pipettes available by default in new file modal and edit pipettes modal

## risk assessment

Low PD multi GEN2 only
