### PR TITLE
test(protocol-designer): add data-test attrs to ModuleTag and ModuleViz

### DIFF
--- a/protocol-designer/src/components/DeckSetup/ModuleTag.js
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.js
@@ -6,6 +6,7 @@ import { RobotCoordsForeignDiv } from '@opentrons/components'
 import {
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
+  type ModuleRealType,
 } from '@opentrons/shared-data'
 import { i18n } from '../../localization'
 import { timelineFrameBeforeActiveItem } from '../../top-selectors/timelineFrames'
@@ -91,9 +92,9 @@ const ModuleTagComponent = (props: Props) => {
   const moduleEntity = useSelector(stepFormSelectors.getModuleEntities)[
     props.id
   ]
-  const moduleState: ?* =
+  const moduleState: ?$PropertyType<ModuleTemporalProperties, 'moduleState'> =
     timelineFrame.robotState.modules[props.id]?.moduleState
-  const moduleType: ?* = moduleEntity?.type
+  const moduleType: ?ModuleRealType = moduleEntity?.type
 
   const hoveredLabwares = useSelector(uiSelectors.getHoveredStepLabware)
   const initialDeck = useSelector(stepFormSelectors.getInitialDeckSetup)
@@ -128,6 +129,7 @@ const ModuleTagComponent = (props: Props) => {
       height={TAG_HEIGHT}
       width={TAG_WIDTH}
       innerDivProps={{
+        'data-test': `ModuleTag_${moduleType}`,
         className: cx(styles.module_info_tag, {
           [styles.highlighted_border_right_none]:
             isHoveredModuleStep && props.orientation === 'left',

--- a/protocol-designer/src/components/DeckSetup/ModuleViz.js
+++ b/protocol-designer/src/components/DeckSetup/ModuleViz.js
@@ -27,7 +27,7 @@ export const ModuleViz = (props: Props) => {
   } = getModuleVizDims(props.orientation, moduleType)
 
   return (
-    <g>
+    <g data-test={`ModuleViz_${moduleType}`}>
       <rect
         x={props.x + xOffset}
         y={props.y + yOffset}


### PR DESCRIPTION
## overview

Part of @dozercodes's work on E2E tests in PD, this makes 2 new data-attr selectors

## changelog

- add `data-test` attrs w/ values `ModuleViz_{moduleType}` and `ModuleTag_{moduleType}` to ModuleViz & ModuleTag components respectively
- Flow type cleanup

## review requests

- [ ] Code review. This is lightly setting a precedent for how we'll name E2E selectors (at least for cases when no semantic selector makes sense)
- [ ] You can test by adding modules and doing `document.querySelectorAll(`[data-test*="ModuleTag_"]`)` or `document.querySelectorAll(`[data-test*="ModuleViz_"]`)` in the console

## risk assessment

just PD