### PR TITLE
fix(protocol-designer e2e): Add custom command to close the 3.17 announcement modal in E2E tests

### DIFF
--- a/protocol-designer/cypress/integration/home.spec.js
+++ b/protocol-designer/cypress/integration/home.spec.js
@@ -1,6 +1,7 @@
 describe('The Home Page', () => {
   beforeEach(() => {
     cy.visit('/')
+    cy.closeAnnouncementModal()
   })
 
   it('successfully loads', () => {

--- a/protocol-designer/cypress/integration/newProtocol.spec.js
+++ b/protocol-designer/cypress/integration/newProtocol.spec.js
@@ -6,9 +6,7 @@ describe('Desktop Navigation', () => {
 
   describe('the setup form', () => {
     it('displays the announcement modal and clicks "GOT IT!" to close it', () => {
-      cy.get('button')
-        .contains('Got It!')
-        .click()
+      cy.closeAnnouncementModal()
     })
 
     it('clicks the "CREATE NEW" button', () => {

--- a/protocol-designer/cypress/integration/settings.spec.js
+++ b/protocol-designer/cypress/integration/settings.spec.js
@@ -4,9 +4,7 @@ describe('The Settings Page', () => {
   })
 
   it('displays the announcement modal and clicks "GOT IT!" to close it', () => {
-    cy.get('button')
-      .contains('Got It!')
-      .click()
+    cy.closeAnnouncementModal()
   })
 
   it('contains a working settings button', () => {

--- a/protocol-designer/cypress/integration/sidebar.spec.js
+++ b/protocol-designer/cypress/integration/sidebar.spec.js
@@ -1,7 +1,8 @@
 describe('Desktop Navigation', () => {
-  before(() => {
+  beforeEach(() => {
     cy.visit('/')
     cy.viewport('macbook-15')
+    cy.closeAnnouncementModal()
   })
 
   it('contains a working file button', () => {

--- a/protocol-designer/cypress/support/commands.js
+++ b/protocol-designer/cypress/support/commands.js
@@ -24,3 +24,12 @@ import 'cypress-file-upload'
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+//
+// General Custom Commands
+//
+Cypress.Commands.add('closeAnnouncementModal', () => {
+  cy.get('button')
+    .contains('Got It!')
+    .click()
+})


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

Adds a custom cypress command that can be used throughout all the PD cypress tests to close the announcement modal. This was already being done on some tests but needed to be done for all the tests. 

## review requests

<!--
  Describe any requests for your reviewers here.
-->

This is the first custom command, so any thoughts you have using this feature would be greatly appreciated. 

## risk assessment

<!--
  Carefully go over your pull request and look at the other parts of the
  codebase it may affect. Look for the possibility, even if you think it's
  small, that your change may affect some other part of the system - for
  instance, changing return tip behavior in protocol may also change the
  behavior of labware calibration.

  Identify the other parts of the system your codebase may affect, so that in
  addition to your own review and testing, other people who may not have
  the system internalized as much as you can focus their attention and testing
  there.
-->

None, this only affects the E2E tests. 
