### PR TITLE
feat(protocol-designer): update export v4 protocol modal copy

### DIFF
--- a/protocol-designer/src/components/FileSidebar/FileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.js
@@ -145,10 +145,16 @@ function getWarningContent({
 
 // TODO (ka 2020-2-26): Update this knowledgebase link when available
 export const v4WarningContent = (
-  <p>
-    {i18n.t(`alert.hint.export_v4_protocol.body`)} <br />
-    <KnowledgeBaseLink to="protocolSteps">Learn more here.</KnowledgeBaseLink>
-  </p>
+  <div>
+    <p>{i18n.t(`alert.hint.export_v4_protocol.body1`)} </p>
+    <p>{i18n.t(`alert.hint.export_v4_protocol.body2`)}</p>
+    <p>{i18n.t(`alert.hint.export_v4_protocol.body3`)}</p>
+    <p>
+      <KnowledgeBaseLink to="betaReleases">
+        Learn more about Beta releases here
+      </KnowledgeBaseLink>
+    </p>
+  </div>
 )
 
 export function FileSidebar(props: Props) {

--- a/protocol-designer/src/components/KnowledgeBaseLink/index.js
+++ b/protocol-designer/src/components/KnowledgeBaseLink/index.js
@@ -11,7 +11,8 @@ export const links = {
   recommendedLabware:
     'https://support.opentrons.com/en/articles/3540964-what-labware-can-i-use-with-my-modules',
   pipetteGen1MultiModuleCollision:
-    'https://docs.google.com/document/d/1kE8qwlx6jVoPmWe0AwNmHVbnDNa4RHnoLCcDTt0SA1s/edit?usp=sharing', // TODO - update before launch with intercom article
+    'https://docs.google.com/document/d/1kE8qwlx6jVoPmWe0AwNmHVbnDNa4RHnoLCcDTt0SA1s/edit?usp=sharing', // TODO - update before launch with intercom article,
+  betaReleases: `https://support.opentrons.com/en/articles/3854833-opentrons-beta-software-releases`,
 }
 
 type Link = $Keys<typeof links>

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -35,7 +35,7 @@
       "body3": "Beta releases provide early access to new software versions and features. While we make a best effort to test each version, Beta features and software versions may include bugs or incomplete functionality."
     },
     "change_magnet_module_model": {
-      "title": "All existing engage heights will be cleared"      
+      "title": "All existing engage heights will be cleared"
     }
   },
   "timeline": {

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -30,10 +30,12 @@
     },
     "export_v4_protocol": {
       "title": "Robot requirements for running module inclusive JSON protocols",
-      "body": "This protocol utilizes modules and can only run on app and robot server version 3.17 or higher. Please ensure your OT-2 is updated to the correct version."
+      "body1": "This protocol includes Temperature and Magnetic modules.",
+      "body2": "Modules support is currently a Beta feature. To run this protocol, update your Opentrons App and OT-2 to software version 3.17.0 Beta.",
+      "body3": "Beta releases provide early access to new software versions and features. While we make a best effort to test each version, Beta features and software versions may include bugs or incomplete functionality."
     },
     "change_magnet_module_model": {
-      "title": "All existing engage heights will be cleared"
+      "title": "All existing engage heights will be cleared"      
     }
   },
   "timeline": {


### PR DESCRIPTION
## overview
This PR closes #5335 by updating the copy for the export v4 json protocol announcement modal. Note, the support link doesn't work yet.

## review requests
Make sure the modal matches what's on the ticket

## risk assessment
Low- just updating modal text