### PR TITLE
fix(protocol-designer): default to non-i18n step-gen errors if no i18n copy

### DIFF
--- a/protocol-designer/src/components/alerts/TimelineAlerts.js
+++ b/protocol-designer/src/components/alerts/TimelineAlerts.js
@@ -9,9 +9,10 @@ import { actions as dismissActions } from '../../dismiss'
 import * as timelineWarningSelectors from '../../top-selectors/timelineWarnings'
 import { getSelectedStepId } from '../../ui/steps'
 import { selectors as fileDataSelectors } from '../../file-data'
+import { Alerts, type Props } from './Alerts'
+import type { CommandCreatorError } from '../../step-generation/types'
 import type { BaseState } from '../../types'
 import type { StepIdType } from '../../form-types'
-import { Alerts, type Props } from './Alerts'
 
 type SP = {|
   errors: $PropertyType<Props, 'errors'>,
@@ -30,10 +31,12 @@ type SP = {|
 
 function mapStateToProps(state: BaseState): SP {
   const timeline = fileDataSelectors.getRobotStateTimeline(state)
-  const errors = (timeline.errors || []).map(error => ({
-    title: i18n.t(`alert.timeline.error.${error.type}.title`),
-    description: <ErrorContents level="timeline" errorType={error.type} />,
-  }))
+  const errors = (timeline.errors || []: Array<CommandCreatorError>).map(
+    error => ({
+      title: i18n.t(`alert.timeline.error.${error.type}.title`, error.message),
+      description: <ErrorContents level="timeline" errorType={error.type} />,
+    })
+  )
   const warnings = timelineWarningSelectors
     .getTimelineWarningsForSelectedStep(state)
     .map(warning => ({


### PR DESCRIPTION
## overview

Serves as its own ticket. @Kadee80 noticed that the PIPETTE_VOLUME_EXCEEDED error (which has no i18n entry, intended to default to the `step-generation` error copy) doesn't display the copy correctly:

![image](https://user-images.githubusercontent.com/11590381/78277762-034d0980-74e3-11ea-8871-60130b221a0b.png)


## changelog

- use step-generation timeline error copy if no i18n entry exists

## review requests

- [ ] Generate a PIPETTE_VOLUME_EXCEEDED error (eg, make an "advanced settings" Mix in a Transfer that exceeds the pipette volume. Don't forget a number in the "Times" field). The copy should match the below (from `pipetteVolumeExceeded` fn):

- `Attempted to ${actionName} volume greater than pipette max volume (${volume} > ${maxVolume})`
- Or, if using disposal volume: `Attemped to ${actionName} volume + disposal volume greater than pipette max volume (${volume} + ${disposalVolume} > ${maxVolume})`

## risk assessment

low

just PD