### PR TITLE
feat(components): add hooks-based tooltip component to library

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -21,6 +21,7 @@
     "react-router-dom": "^5.0.1"
   },
   "dependencies": {
+    "@popperjs/core": "2.1.1",
     "react-popper": "^1.0.0",
     "react-remove-scroll": "^1.0.8",
     "react-select": "^3.0.8",

--- a/components/src/instrument/InstrumentDiagram.md
+++ b/components/src/instrument/InstrumentDiagram.md
@@ -1,10 +1,11 @@
 Single channel GEN1:
 
-````js
+```js
 <InstrumentDiagram
   mount="left"
   pipetteSpecs={{ channels: 1, displayCategory: 'GEN1' }}
-/>```
+/>
+```
 
 Multi channel GEN1:
 
@@ -12,7 +13,8 @@ Multi channel GEN1:
 <InstrumentDiagram
   mount="right"
   pipetteSpecs={{ channels: 8, displayCategory: 'GEN1' }}
-/>```
+/>
+```
 
 Single channel GEN2:
 
@@ -20,7 +22,8 @@ Single channel GEN2:
 <InstrumentDiagram
   mount="left"
   pipetteSpecs={{ channels: 1, displayCategory: 'GEN2' }}
-/>```
+/>
+```
 
 Multi channel GEN2:
 
@@ -28,5 +31,5 @@ Multi channel GEN2:
 <InstrumentDiagram
   mount="right"
   pipetteSpecs={{ channels: 8, displayCategory: 'GEN2' }}
-/>```
-````
+/>
+```

--- a/components/src/styles/colors.js
+++ b/components/src/styles/colors.js
@@ -1,5 +1,7 @@
 // @flow
 
+export const C_DARK_GRAY = '#4a4a4a'
+
 // TDOD(isk: 3/2/20): Rename to be more generic (e.g. not FONT)
 export const C_FONT_DISABLED = '#9c9c9c'
-export const C_FONT_DARK = '#4a4a4a'
+export const C_FONT_LIGHT = 'white'

--- a/components/src/styles/colors.js
+++ b/components/src/styles/colors.js
@@ -1,7 +1,7 @@
 // @flow
 
 export const C_DARK_GRAY = '#4a4a4a'
+export const C_WHITE = '#ffffff'
 
 // TDOD(isk: 3/2/20): Rename to be more generic (e.g. not FONT)
 export const C_FONT_DISABLED = '#9c9c9c'
-export const C_FONT_LIGHT = 'white'

--- a/components/src/styles/typography.js
+++ b/components/src/styles/typography.js
@@ -2,7 +2,7 @@
 
 import { css } from 'styled-components'
 
-import { C_DARK_GRAY, C_FONT_LIGHT } from './colors'
+import { C_DARK_GRAY, C_WHITE } from './colors'
 import { FS_HEADER, FS_BODY_1 } from './font-size'
 import { FW_SEMIBOLD, FW_REGULAR } from './font-weight'
 
@@ -21,5 +21,5 @@ export const FONT_BODY_1_DARK = css`
 export const FONT_BODY_1_LIGHT = css`
   ${FS_BODY_1}
   ${FW_REGULAR}
-  color: ${C_FONT_LIGHT};
+  color: ${C_WHITE};
 `

--- a/components/src/styles/typography.js
+++ b/components/src/styles/typography.js
@@ -2,18 +2,24 @@
 
 import { css } from 'styled-components'
 
-import { C_FONT_DARK } from './colors'
+import { C_DARK_GRAY, C_FONT_LIGHT } from './colors'
 import { FS_HEADER, FS_BODY_1 } from './font-size'
 import { FW_SEMIBOLD, FW_REGULAR } from './font-weight'
 
 export const FONT_HEADER_DARK = css`
   ${FS_HEADER}
   ${FW_SEMIBOLD}
-  color: ${C_FONT_DARK};
+  color: ${C_DARK_GRAY};
 `
 
 export const FONT_BODY_1_DARK = css`
   ${FS_BODY_1}
   ${FW_REGULAR}
-  color: ${C_FONT_DARK};
+  color: ${C_DARK_GRAY};
+`
+
+export const FONT_BODY_1_LIGHT = css`
+  ${FS_BODY_1}
+  ${FW_REGULAR}
+  color: ${C_FONT_LIGHT};
 `

--- a/components/src/tooltips/DeprecatedTooltip.js
+++ b/components/src/tooltips/DeprecatedTooltip.js
@@ -1,0 +1,111 @@
+// @flow
+
+import * as React from 'react'
+import { Manager, Reference, Popper } from 'react-popper'
+import cx from 'classnames'
+import styles from './tooltips.css'
+
+const DISTANCE_FROM_REFERENCE = 8
+
+type PopperProps = React.ElementProps<typeof Popper>
+
+export type TooltipChildProps<ChildProps: {}> = {|
+  ...$Exact<ChildProps>,
+  ref: React.Ref<*>,
+|}
+
+export type DeprecatedTooltipProps<ChildProps: {}> = {|
+  /** show or hide the tooltip */
+  open?: boolean,
+  /** contents of the tooltip */
+  tooltipComponent?: React.Node,
+  /** optional portal to place the tooltipComponent inside */
+  portal?: React.ComponentType<*>,
+  /** <https://github.com/FezVrasta/react-popper#placement> */
+  placement?: $PropertyType<PopperProps, 'placement'>,
+  /** <https://github.com/FezVrasta/react-popper#positionfixed> */
+  positionFixed?: $PropertyType<PopperProps, 'positionFixed'>,
+  /** <https://github.com/FezVrasta/react-popper#modifiers> */
+  modifiers?: $PropertyType<PopperProps, 'modifiers'>,
+  /** render function for tooltip'd component */
+  children: (props?: TooltipChildProps<ChildProps>) => React.Node,
+  /** extra props to pass to the children render function */
+  childProps?: ChildProps,
+|}
+
+/**
+ *  Basic, fully controlled Tooltip component.
+ *
+ * `props.children` is a function that receives the following props object:
+ * ```js
+ * type TooltipChildProps = {|
+ *   ref: React.Ref<*>,
+ * |}
+ * ```
+ *
+ * `props.childProps` can be used to add extra fields to the child props object
+ *
+ * @deprecated Use `Tooltip` and `useTooltip` instead
+ */
+export function DeprecatedTooltip<ChildProps: {}>(
+  props: DeprecatedTooltipProps<ChildProps>
+) {
+  if (!props.tooltipComponent) return props.children()
+
+  return (
+    <Manager>
+      <Reference>
+        {// TODO(mc, 2020-02-21): this is pretty hard to type as is, ref
+        // should probably be a whole separate argument to children
+        // this may become a moot point if we switch tooltips to hooks
+        // $FlowFixMe(mc, 2020-02-21): Error from Flow 0.118 upgrade
+        ({ ref }) => props.children({ ...props.childProps, ref })}
+      </Reference>
+      {props.open && (
+        <Popper
+          placement={props.placement}
+          modifiers={{
+            offset: { offset: `0, ${DISTANCE_FROM_REFERENCE}` },
+            ...props.modifiers,
+          }}
+          positionFixed={props.positionFixed}
+        >
+          {({ ref, style, placement, arrowProps }) => {
+            // remove optional -start and -end modifiers for arrow style
+            // https://popper.js.org/popper-documentation.html#Popper.placements
+            const arrowPlacement = placement
+              ? placement.replace(/-(?:start|end)/, '')
+              : ''
+
+            let { style: arrowStyle } = arrowProps
+            if (arrowPlacement === 'left' || arrowPlacement === 'right') {
+              arrowStyle = { top: '0.6em' }
+            }
+            const tooltipContents = (
+              <div
+                ref={ref}
+                className={styles.tooltip_box}
+                style={style}
+                data-placement={placement}
+              >
+                {props.tooltipComponent}
+                <div
+                  className={cx(styles.arrow, styles[arrowPlacement])}
+                  ref={arrowProps.ref}
+                  style={arrowStyle}
+                />
+              </div>
+            )
+
+            if (props.portal) {
+              const PortalClass = props.portal
+              return <PortalClass>{tooltipContents}</PortalClass>
+            }
+
+            return tooltipContents
+          }}
+        </Popper>
+      )}
+    </Manager>
+  )
+}

--- a/components/src/tooltips/DeprecatedTooltip.md
+++ b/components/src/tooltips/DeprecatedTooltip.md
@@ -1,0 +1,49 @@
+Basic usage:
+
+```js
+<DeprecatedTooltip
+  open={true}
+  tooltipComponent={<div>Something Explanatory!</div>}
+>
+  {props => <span ref={props.ref}>Look at my tooltip!</span>}
+</DeprecatedTooltip>
+```
+
+Component is controlled by the `open` prop:
+
+```js
+<DeprecatedTooltip
+  open={false}
+  tooltipComponent={<div>Something Explanatory!</div>}
+>
+  {props => <span ref={props.ref}>My tooltip is closed!</span>}
+</DeprecatedTooltip>
+```
+
+Specify Placement:
+
+```js
+<DeprecatedTooltip
+  open={true}
+  placement="right"
+  tooltipComponent={<div>Something Explanatory, but over here this time!</div>}
+>
+  {props => <span ref={props.ref}>Look at my tooltip!</span>}
+</DeprecatedTooltip>
+```
+
+Specify Placement (with override):
+
+```js
+<DeprecatedTooltip
+  open={true}
+  placement="left"
+  tooltipComponent={
+    <div>
+      Something explanatory that cannot go left so it defaults to right!
+    </div>
+  }
+>
+  {props => <span ref={props.ref}>Look at my tooltip!</span>}
+</DeprecatedTooltip>
+```

--- a/components/src/tooltips/HoverTooltip.js
+++ b/components/src/tooltips/HoverTooltip.js
@@ -2,9 +2,12 @@
 
 import * as React from 'react'
 
-import { Tooltip } from './Tooltip'
+import { DeprecatedTooltip } from './DeprecatedTooltip'
 
-import type { TooltipChildProps, TooltipProps } from './Tooltip'
+import type {
+  TooltipChildProps,
+  DeprecatedTooltipProps,
+} from './DeprecatedTooltip'
 
 const OPEN_DELAY_MS = 300
 const CLOSE_DELAY_MS = 0
@@ -14,7 +17,7 @@ export type HoverTooltipHandlers = TooltipChildProps<{
   onMouseLeave: (SyntheticMouseEvent<*>) => void,
 }>
 
-export type HoverTooltipProps = TooltipProps<HoverTooltipHandlers>
+export type HoverTooltipProps = DeprecatedTooltipProps<HoverTooltipHandlers>
 
 type HoverTooltipState = {| isOpen: boolean |}
 
@@ -67,7 +70,7 @@ export class HoverTooltip extends React.Component<
 
   render() {
     return (
-      <Tooltip
+      <DeprecatedTooltip
         open={this.state.isOpen}
         childProps={{
           onMouseEnter: this.delayedOpen,

--- a/components/src/tooltips/Tooltip.js
+++ b/components/src/tooltips/Tooltip.js
@@ -23,17 +23,15 @@ export type TooltipProps = {|
   visible: boolean,
   /** Contents of the tooltip */
   children?: React.Node,
+  /**
+   * Tooltip element ID (provided by useTooltip). Will match
+   * targetProps.aria-describedby
+   */
+  id: string,
   /** Actual tooltip placement, if known (provided by useTooltip) */
   placement: Placement | null,
-  /**
-   * Tooltip element ID (provided by useTooltip). Should match
-   * aria-describedby on target element
-   */
-  tooltipId: string,
-  /** React function ref for tooltip element (provided by useTooltip) */
-  tooltipRef: (HTMLElement | null) => mixed,
   /** Inline styles to apply to the tooltip element (provided by useTooltip) */
-  tooltipStyle: $Shape<CSSStyleDeclaration>,
+  style: $Shape<CSSStyleDeclaration>,
   /** React function ref for tooltip's arrow element (provided by useTooltip) */
   arrowRef: (HTMLElement | null) => mixed,
   /** Inline styles to apply to arrow element (provided by useTooltip) */
@@ -44,31 +42,26 @@ export type TooltipProps = {|
  * Tooltip component that renders based on its `visible` prop. For use with the
  * `useTooltip` hook; see examples in `Tooltip.md`.
  */
-export function Tooltip(props: TooltipProps) {
-  const {
-    visible,
-    placement,
-    tooltipId,
-    tooltipRef,
-    tooltipStyle,
-    arrowRef,
-    arrowStyle,
-    children,
-  } = props
+export const Tooltip = React.forwardRef<TooltipProps, _>(
+  function TooltipComponent(props: TooltipProps, ref) {
+    const {
+      visible,
+      placement,
+      id,
+      style,
+      arrowRef,
+      arrowStyle,
+      children,
+    } = props
 
-  return visible ? (
-    <div
-      role="tooltip"
-      id={tooltipId}
-      style={tooltipStyle}
-      ref={tooltipRef}
-      css={TOOLTIP_CSS}
-    >
-      {children}
-      <Arrow {...{ arrowRef, arrowStyle, placement }} />
-    </div>
-  ) : null
-}
+    return visible ? (
+      <div role="tooltip" id={id} style={style} ref={ref} css={TOOLTIP_CSS}>
+        {children}
+        <Arrow {...{ arrowRef, arrowStyle, placement }} />
+      </div>
+    ) : null
+  }
+)
 
 // shift arrows off the element
 const ARROW_ANCHOR_OFFSET = `-${ARROW_SIZE_PX}px;`

--- a/components/src/tooltips/Tooltip.js
+++ b/components/src/tooltips/Tooltip.js
@@ -19,20 +19,30 @@ const TOOLTIP_CSS = css`
 `
 
 export type TooltipProps = {|
+  /** Whether or not the tooltip should be rendered */
   visible: boolean,
-  placement: Placement | '',
-  tooltipId: string,
-  tooltipRef: (HTMLElement | null) => mixed,
-  tooltipStyle: $Shape<CSSStyleDeclaration>,
-  arrowRef: (HTMLElement | null) => mixed,
-  arrowStyle: $Shape<CSSStyleDeclaration>,
+  /** Contents of the tooltip */
   children?: React.Node,
+  /** Actual tooltip placement, if known (provided by useTooltip) */
+  placement: Placement | null,
+  /**
+   * Tooltip element ID (provided by useTooltip). Should match
+   * aria-describedby on target element
+   */
+  tooltipId: string,
+  /** React function ref for tooltip element (provided by useTooltip) */
+  tooltipRef: (HTMLElement | null) => mixed,
+  /** Inline styles to apply to the tooltip element (provided by useTooltip) */
+  tooltipStyle: $Shape<CSSStyleDeclaration>,
+  /** React function ref for tooltip's arrow element (provided by useTooltip) */
+  arrowRef: (HTMLElement | null) => mixed,
+  /** Inline styles to apply to arrow element (provided by useTooltip) */
+  arrowStyle: $Shape<CSSStyleDeclaration>,
 |}
 
 /**
  * Tooltip component that renders based on its `visible` prop. For use with the
- * `useTooltip` hook; see examples below.
- * ```
+ * `useTooltip` hook; see examples in `Tooltip.md`.
  */
 export function Tooltip(props: TooltipProps) {
   const {
@@ -111,13 +121,13 @@ const ARROW_CSS_BY_PLACEMENT_BASE: { [string]: CSSRules | void } = {
 }
 
 export type ArrowProps = {|
-  placement: Placement | '',
+  placement: Placement | null,
   arrowRef: (HTMLElement | null) => mixed,
   arrowStyle: $Shape<CSSStyleDeclaration>,
 |}
 
 export function Arrow(props: ArrowProps) {
-  const { placement = '' } = props
+  const placement = props.placement ?? ''
   const placementBase = placement.split('-')[0]
   const arrowCss = ARROW_CSS_BY_PLACEMENT_BASE[placementBase]
 

--- a/components/src/tooltips/Tooltip.md
+++ b/components/src/tooltips/Tooltip.md
@@ -2,12 +2,10 @@ Basic usage with the `useTooltip` hook
 
 ```js
 import { useTooltip } from '@opentrons/components'
-const { targetRef, ...tooltipProps } = useTooltip()
+const [targetProps, tooltipProps] = useTooltip()
 
 ;<>
-  <span ref={targetRef} aria-describedby={tooltipProps.tooltipId}>
-    Target!
-  </span>
+  <span {...targetProps}>Target!</span>
   <Tooltip visible={true} {...tooltipProps}>
     Something Explanatory!
   </Tooltip>
@@ -26,12 +24,10 @@ import {
 } from '@opentrons/components'
 
 const [placement, setPlacement] = React.useState(TOOLTIP_RIGHT)
-const { targetRef, ...tooltipProps } = useTooltip({ placement })
+const [targetProps, tooltipProps] = useTooltip({ placement })
 
 ;<>
-  <span ref={targetRef} aria-describedby={tooltipProps.tooltipId}>
-    Target!
-  </span>
+  <span {...targetProps}>Target!</span>
   <Tooltip visible={true} {...tooltipProps}>
     Something Explanatory!
   </Tooltip>

--- a/components/src/tooltips/Tooltip.md
+++ b/components/src/tooltips/Tooltip.md
@@ -1,43 +1,52 @@
-Basic usage:
+Basic usage with the `useTooltip` hook
 
 ```js
-<Tooltip open={true} tooltipComponent={<div>Something Explanatory!</div>}>
-  {props => <span ref={props.ref}>Look at my tooltip!</span>}
-</Tooltip>
+import { useTooltip } from '@opentrons/components'
+const { targetRef, ...tooltipProps } = useTooltip()
+
+;<>
+  <span ref={targetRef} aria-describedby={tooltipProps.tooltipId}>
+    Target!
+  </span>
+  <Tooltip visible={true} {...tooltipProps}>
+    Something Explanatory!
+  </Tooltip>
+</>
 ```
 
-Component is controlled by the `open` prop:
+Getting a little fancier and overriding the position:
 
 ```js
-<Tooltip open={false} tooltipComponent={<div>Something Explanatory!</div>}>
-  {props => <span ref={props.ref}>My tooltip is closed!</span>}
-</Tooltip>
-```
+import { useTooltip } from '@opentrons/components'
+const [placement, setPlacement] = React.useState(null)
+const { targetRef, ...tooltipProps } = useTooltip({ placement })
 
-Specify Placement:
+const handleChange = e => setPlacement(e.target.value)
 
-```js
-<Tooltip
-  open={true}
-  placement="right"
-  tooltipComponent={<div>Something Explanatory, but over here this time!</div>}
->
-  {props => <span ref={props.ref}>Look at my tooltip!</span>}
-</Tooltip>
-```
-
-Specify Placement (with override):
-
-```js
-<Tooltip
-  open={true}
-  placement="left"
-  tooltipComponent={
-    <div>
-      Something explanatory that cannot go left so it defaults to right!
-    </div>
-  }
->
-  {props => <span ref={props.ref}>Look at my tooltip!</span>}
-</Tooltip>
+;<>
+  <span ref={targetRef} aria-describedby={tooltipProps.tooltipId}>
+    Target!
+  </span>
+  <Tooltip visible={true} {...tooltipProps}>
+    Something Explanatory!
+  </Tooltip>
+  <div style={{ float: 'left', marginRight: '8rem' }}>
+    <label style={{ display: 'block' }}>
+      <input type="radio" name="place" value="top" onChange={handleChange} />
+      top
+    </label>
+    <label style={{ display: 'block' }}>
+      <input type="radio" name="place" value="right" onChange={handleChange} />
+      right
+    </label>
+    <label style={{ display: 'block' }}>
+      <input type="radio" name="place" value="bottom" onChange={handleChange} />
+      bottom
+    </label>
+    <label style={{ display: 'block' }}>
+      <input type="radio" name="place" value="left" onChange={handleChange} />
+      left
+    </label>
+  </div>
+</>
 ```

--- a/components/src/tooltips/Tooltip.md
+++ b/components/src/tooltips/Tooltip.md
@@ -14,14 +14,19 @@ const { targetRef, ...tooltipProps } = useTooltip()
 </>
 ```
 
-Getting a little fancier and overriding the position:
+Getting a little fancier and overriding the placement:
 
 ```js
-import { useTooltip } from '@opentrons/components'
-const [placement, setPlacement] = React.useState(null)
-const { targetRef, ...tooltipProps } = useTooltip({ placement })
+import {
+  useTooltip,
+  TOOLTIP_TOP,
+  TOOLTIP_RIGHT,
+  TOOLTIP_BOTTOM,
+  TOOLTIP_LEFT,
+} from '@opentrons/components'
 
-const handleChange = e => setPlacement(e.target.value)
+const [placement, setPlacement] = React.useState(TOOLTIP_RIGHT)
+const { targetRef, ...tooltipProps } = useTooltip({ placement })
 
 ;<>
   <span ref={targetRef} aria-describedby={tooltipProps.tooltipId}>
@@ -31,22 +36,18 @@ const handleChange = e => setPlacement(e.target.value)
     Something Explanatory!
   </Tooltip>
   <div style={{ float: 'left', marginRight: '8rem' }}>
-    <label style={{ display: 'block' }}>
-      <input type="radio" name="place" value="top" onChange={handleChange} />
-      top
-    </label>
-    <label style={{ display: 'block' }}>
-      <input type="radio" name="place" value="right" onChange={handleChange} />
-      right
-    </label>
-    <label style={{ display: 'block' }}>
-      <input type="radio" name="place" value="bottom" onChange={handleChange} />
-      bottom
-    </label>
-    <label style={{ display: 'block' }}>
-      <input type="radio" name="place" value="left" onChange={handleChange} />
-      left
-    </label>
+    {[TOOLTIP_TOP, TOOLTIP_RIGHT, TOOLTIP_BOTTOM, TOOLTIP_LEFT].map(p => (
+      <label style={{ display: 'block' }}>
+        <input
+          type="radio"
+          name="place"
+          value={p}
+          onChange={() => setPlacement(p)}
+          checked={placement === p}
+        />
+        {p}
+      </label>
+    ))}
   </div>
 </>
 ```

--- a/components/src/tooltips/__tests__/Tooltip.test.js
+++ b/components/src/tooltips/__tests__/Tooltip.test.js
@@ -1,0 +1,92 @@
+// @flow
+import * as React from 'react'
+import { mount } from 'enzyme'
+
+import { TOOLTIP_TOP } from '../constants'
+import { Tooltip, Arrow } from '../Tooltip'
+
+const placement = TOOLTIP_TOP
+const tooltipId = 'tooltip-id'
+const tooltipRef = jest.fn()
+const tooltipStyle = { position: 'absolute', left: '2px' }
+const arrowRef = jest.fn()
+const arrowStyle = { position: 'absolute', left: '8px' }
+
+const TOOLTIP_SELECTOR = 'div[role="tooltip"]'
+
+const render = (visible = true, children = <></>) => {
+  return mount(
+    <Tooltip
+      {...{
+        visible,
+        placement,
+        tooltipId,
+        tooltipRef,
+        tooltipStyle,
+        arrowRef,
+        arrowStyle,
+      }}
+    >
+      {children}
+    </Tooltip>
+  )
+}
+
+describe('hook-based Tooltip', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders nothing when visible: false', () => {
+    const wrapper = render(false)
+
+    expect(wrapper.html()).toBe(null)
+  })
+
+  it('renders something with role="tooltip", id, and children when visible', () => {
+    const wrapper = render(true, 'hello world')
+    const tooltip = wrapper.find(TOOLTIP_SELECTOR)
+
+    expect(tooltip.prop('id')).toBe(tooltipId)
+    expect(tooltip.html()).toContain('hello world')
+  })
+
+  it('attaches the tooltip ref to the tooltip', () => {
+    const wrapper = render(true)
+    const tooltip = wrapper.find(TOOLTIP_SELECTOR)
+    const refResult = tooltipRef.mock.calls[0][0]
+
+    expect(refResult).toEqual(tooltip.getDOMNode())
+  })
+
+  it('attaches styles to the tooltip', () => {
+    const wrapper = render(true)
+    const tooltip = wrapper.find(TOOLTIP_SELECTOR)
+    const style = tooltip.getDOMNode().style
+    expect(style.getPropertyValue('position')).toEqual(tooltipStyle.position)
+    expect(style.getPropertyValue('left')).toEqual(tooltipStyle.left)
+  })
+
+  it('attaches an arrow ref to the arrow', () => {
+    const wrapper = render(true)
+    const arrow = wrapper.find(Arrow)
+    const refResult = arrowRef.mock.calls[0][0]
+
+    expect(refResult).toEqual(arrow.getDOMNode())
+  })
+
+  it('attaches styles to the arrow', () => {
+    const wrapper = render(true)
+    const arrow = wrapper.find(Arrow)
+    const style = arrow.getDOMNode().style
+    expect(style.getPropertyValue('position')).toEqual(arrowStyle.position)
+    expect(style.getPropertyValue('left')).toEqual(arrowStyle.left)
+  })
+
+  it('passes placement to the arrow', () => {
+    const wrapper = render(true)
+    const arrow = wrapper.find(Arrow)
+
+    expect(arrow.prop('placement')).toEqual(placement)
+  })
+})

--- a/components/src/tooltips/__tests__/Tooltip.test.js
+++ b/components/src/tooltips/__tests__/Tooltip.test.js
@@ -15,20 +15,24 @@ const arrowStyle = { position: 'absolute', left: '8px' }
 const TOOLTIP_SELECTOR = 'div[role="tooltip"]'
 
 const render = (visible = true, children = <></>) => {
+  // NOTE(mc): redundant fragement necessary for enzyme issue with forwardRef
+  // https://github.com/enzymejs/enzyme/issues/1852
   return mount(
-    <Tooltip
-      {...{
-        visible,
-        placement,
-        tooltipId,
-        tooltipRef,
-        tooltipStyle,
-        arrowRef,
-        arrowStyle,
-      }}
-    >
-      {children}
-    </Tooltip>
+    <>
+      <Tooltip
+        {...{
+          visible,
+          placement,
+          id: tooltipId,
+          ref: tooltipRef,
+          style: tooltipStyle,
+          arrowRef,
+          arrowStyle,
+        }}
+      >
+        {children}
+      </Tooltip>
+    </>
   )
 }
 
@@ -51,6 +55,7 @@ describe('hook-based Tooltip', () => {
     expect(tooltip.html()).toContain('hello world')
   })
 
+  // NOTE(mc): this test fails if redundant fragment in `render` is removed
   it('attaches the tooltip ref to the tooltip', () => {
     const wrapper = render(true)
     const tooltip = wrapper.find(TOOLTIP_SELECTOR)

--- a/components/src/tooltips/__tests__/usePopper.test.js
+++ b/components/src/tooltips/__tests__/usePopper.test.js
@@ -1,0 +1,179 @@
+// @flow
+import * as React from 'react'
+import { mount } from 'enzyme'
+import { usePopper } from '../usePopper'
+import * as Types from '../types'
+import * as Constants from '../constants'
+
+const onStateUpdate = jest.fn()
+
+describe('usePopper hook', () => {
+  let result: null | Types.UsePopperResult = null
+
+  const render = (options: Types.UsePopperOptions) => {
+    const TestUsePopper = (props: Types.UsePopperOptions) => {
+      result = usePopper(props)
+      return null
+    }
+
+    // render and then immediately re-render to run effects
+    const wrapper = mount(<TestUsePopper {...options} />)
+    wrapper.setProps({})
+
+    return wrapper
+  }
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('takes refs for target, tooltip, and arrow and returns a Popper instance', () => {
+    const target = document.createElement('div')
+    const tooltip = document.createElement('div')
+    const arrow = document.createElement('div')
+
+    // arrow node must be a child of the tooltip node
+    tooltip.appendChild(arrow)
+
+    render({ target, tooltip, arrow, onStateUpdate })
+
+    expect(result?.state.elements.reference).toBe(target)
+    expect(result?.state.elements.popper).toBe(tooltip)
+    expect(result?.state.elements.arrow).toBe(arrow)
+  })
+
+  // slightly non-sensical case, but important for safety
+  it('returns null if target is not rendered', () => {
+    const target = null
+    const tooltip = document.createElement('div')
+    const arrow = document.createElement('div')
+
+    // arrow node must be a child of the tooltip node
+    tooltip.appendChild(arrow)
+
+    render({ target, tooltip, arrow, onStateUpdate })
+
+    expect(result).toBe(null)
+  })
+
+  it('returns null if tooltip is not rendered', () => {
+    const target = document.createElement('div')
+    const tooltip = null
+    const arrow = null
+
+    render({ target, tooltip, arrow, onStateUpdate })
+
+    expect(result).toBe(null)
+  })
+
+  it('handles no arrow rendered', () => {
+    const target = document.createElement('div')
+    const tooltip = document.createElement('div')
+    const arrow = null
+
+    render({ target, tooltip, arrow, onStateUpdate })
+
+    expect(result?.state.elements.reference).toBe(target)
+    expect(result?.state.elements.popper).toBe(tooltip)
+    expect(result?.state.elements.arrow).toBe(undefined)
+  })
+
+  it("returns the same Popper instance render-to-render if nodes don't change", () => {
+    const target = document.createElement('div')
+    const tooltip = document.createElement('div')
+    const arrow = null
+
+    const wrapper = render({ target, tooltip, arrow, onStateUpdate })
+    const prevResult = result
+
+    // force re-render
+    wrapper.setProps({})
+
+    // NOTE(mc, 2020-03-20): expect(prevResult).toBe(result) prints a confusing
+    // assertion failure, see https://jestjs.io/docs/en/expect#tobevalue
+    expect(Object.is(prevResult, result)).toBe(true)
+  })
+
+  it('destroys previous Popper instance if nodes change', () => {
+    const target = document.createElement('div')
+    const tooltip = document.createElement('div')
+    const arrow = null
+
+    const wrapper = render({ target, tooltip, arrow, onStateUpdate })
+    const prevResult = result
+    const destroy = jest.spyOn(prevResult, 'destroy')
+
+    // force re-render with tooltip no longer rendered
+    // re-render again to propagate effects
+    wrapper.setProps({ tooltip: null })
+    wrapper.setProps({})
+
+    expect(result).toBe(null)
+    expect(destroy).toHaveBeenCalled()
+  })
+
+  it('can pass placement / strategy options into popper', () => {
+    const target = document.createElement('div')
+    const tooltip = document.createElement('div')
+    const arrow = null
+
+    render({
+      target,
+      tooltip,
+      arrow,
+      onStateUpdate,
+      placement: Constants.TOOLTIP_TOP,
+      strategy: Constants.TOOLTIP_FIXED,
+    })
+
+    expect(result?.state.options.placement).toEqual('top')
+    expect(result?.state.options.strategy).toEqual('fixed')
+  })
+
+  it("disables popper's default applyStyle modifier", () => {
+    const target = document.createElement('div')
+    const tooltip = document.createElement('div')
+    const arrow = null
+
+    render({ target, tooltip, arrow, onStateUpdate, placement: 'right' })
+
+    expect(result?.state.orderedModifiers).not.toContainEqual(
+      expect.objectContaining({
+        name: 'applyStyle',
+      })
+    )
+  })
+
+  it('adds a modifier that calls onUpdateState', () => {
+    const target = document.createElement('div')
+    const tooltip = document.createElement('div')
+    const arrow = null
+
+    render({ target, tooltip, arrow, onStateUpdate, placement: 'right' })
+
+    // test that state is set immediately
+    expect(onStateUpdate).toHaveBeenCalledWith(
+      'right',
+      expect.objectContaining({
+        popper: expect.objectContaining({ position: 'absolute' }),
+        arrow: expect.objectContaining({ position: 'absolute' }),
+      })
+    )
+  })
+
+  it('can set the offset modifier', () => {
+    const target = document.createElement('div')
+    const tooltip = document.createElement('div')
+    const arrow = null
+    const offset = 16
+
+    render({ target, tooltip, arrow, onStateUpdate, offset })
+
+    expect(result?.state.orderedModifiers).toContainEqual(
+      expect.objectContaining({
+        name: 'offset',
+        options: { offset: [0, 16] },
+      })
+    )
+  })
+})

--- a/components/src/tooltips/__tests__/useTooltip.test.js
+++ b/components/src/tooltips/__tests__/useTooltip.test.js
@@ -1,0 +1,122 @@
+// @flow
+import * as React from 'react'
+import { act } from 'react-dom/test-utils'
+import { mount } from 'enzyme'
+
+import { Tooltip, Arrow } from '../Tooltip'
+import * as UsePopper from '../usePopper'
+import { useTooltip } from '../useTooltip'
+import * as Types from '../types'
+
+// mocking out usePopper because it calls stuff async and that makes
+// react complain about wrapping stuff in `act`, which we can't
+jest.mock('../usePopper')
+
+const usePopper: JestMockFn<[Types.UsePopperOptions], Types.UsePopperResult> =
+  UsePopper.usePopper
+
+type TestUseTooltipProps = {|
+  ...Types.UseTooltipOptions,
+  visible: boolean,
+|}
+
+describe('useTooltip hook', () => {
+  const render = (options: TestUseTooltipProps) => {
+    const TestUseTooltip = (props: TestUseTooltipProps) => {
+      const { visible, ...hookOptions } = props
+      const { targetRef, ...tooltipProps } = useTooltip(hookOptions)
+
+      return (
+        <>
+          <div ref={targetRef} data-test="target">
+            Target!
+          </div>
+          <Tooltip visible={props.visible} {...tooltipProps}>
+            Tooltip!
+          </Tooltip>
+        </>
+      )
+    }
+
+    // render and then immediately re-render to run effects
+    const wrapper = mount(<TestUseTooltip {...options} />)
+    wrapper.setProps({})
+
+    return wrapper
+  }
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('can take placement, strategy, and offset options to pass to popper', () => {
+    render({
+      visible: true,
+      placement: 'top-start',
+      strategy: 'fixed',
+      offset: 42,
+    })
+
+    expect(usePopper).toHaveBeenCalledWith(
+      expect.objectContaining({
+        placement: 'top-start',
+        strategy: 'fixed',
+        offset: 42,
+      })
+    )
+  })
+
+  it('applies a default offset of 0.5rem if omitted', () => {
+    render({ visible: true })
+
+    expect(usePopper).toHaveBeenCalledWith(
+      expect.objectContaining({
+        offset: 8,
+      })
+    )
+  })
+
+  it('returns refs that pass elements to usePopper', () => {
+    const wrapper = render({ visible: true })
+    const target = wrapper.find('[data-test="target"]').getDOMNode()
+    const tooltip = wrapper.find(Tooltip).getDOMNode()
+    const arrow = wrapper.find(Arrow).getDOMNode()
+
+    expect(usePopper).toHaveBeenCalledWith(
+      expect.objectContaining({ target, tooltip, arrow })
+    )
+  })
+
+  it('updates tooltip placement and style state from Popper', () => {
+    const wrapper = render({ visible: true })
+    const handleStateUpdate = usePopper.mock.calls[0][0].onStateUpdate
+
+    act(() => {
+      handleStateUpdate('top-end', {
+        popper: { position: 'absolute', left: '42px' },
+        arrow: { position: 'absolute', left: '21px' },
+      })
+    })
+    wrapper.update()
+    const tooltip = wrapper.find(Tooltip)
+
+    expect(tooltip.prop('placement')).toEqual('top-end')
+    expect(tooltip.prop('tooltipStyle')).toEqual({
+      position: 'absolute',
+      left: '42px',
+    })
+    expect(tooltip.prop('arrowStyle')).toEqual({
+      position: 'absolute',
+      left: '21px',
+    })
+  })
+
+  it('generates a unique tooltipId', () => {
+    const tooltip1 = render({ visible: true }).find(Tooltip)
+    const tooltip2 = render({ visible: true }).find(Tooltip)
+
+    expect(tooltip1.prop('tooltipId')).toEqual(expect.any(String))
+    expect(tooltip2.prop('tooltipId')).toEqual(expect.any(String))
+    expect(tooltip1.prop('tooltipId')).not.toEqual(tooltip2.prop('tooltipId'))
+  })
+})

--- a/components/src/tooltips/__tests__/useTooltip.test.js
+++ b/components/src/tooltips/__tests__/useTooltip.test.js
@@ -24,11 +24,11 @@ describe('useTooltip hook', () => {
   const render = (options: TestUseTooltipProps) => {
     const TestUseTooltip = (props: TestUseTooltipProps) => {
       const { visible, ...hookOptions } = props
-      const { targetRef, ...tooltipProps } = useTooltip(hookOptions)
+      const [targetProps, tooltipProps] = useTooltip(hookOptions)
 
       return (
         <>
-          <div ref={targetRef} data-test="target">
+          <div {...targetProps} data-test="target">
             Target!
           </div>
           <Tooltip visible={props.visible} {...tooltipProps}>
@@ -101,7 +101,7 @@ describe('useTooltip hook', () => {
     const tooltip = wrapper.find(Tooltip)
 
     expect(tooltip.prop('placement')).toEqual('top-end')
-    expect(tooltip.prop('tooltipStyle')).toEqual({
+    expect(tooltip.prop('style')).toEqual({
       position: 'absolute',
       left: '42px',
     })
@@ -115,8 +115,8 @@ describe('useTooltip hook', () => {
     const tooltip1 = render({ visible: true }).find(Tooltip)
     const tooltip2 = render({ visible: true }).find(Tooltip)
 
-    expect(tooltip1.prop('tooltipId')).toEqual(expect.any(String))
-    expect(tooltip2.prop('tooltipId')).toEqual(expect.any(String))
-    expect(tooltip1.prop('tooltipId')).not.toEqual(tooltip2.prop('tooltipId'))
+    expect(tooltip1.prop('id')).toEqual(expect.any(String))
+    expect(tooltip2.prop('id')).toEqual(expect.any(String))
+    expect(tooltip1.prop('id')).not.toEqual(tooltip2.prop('id'))
   })
 })

--- a/components/src/tooltips/constants.js
+++ b/components/src/tooltips/constants.js
@@ -1,0 +1,30 @@
+// @flow
+
+// placement constants
+// NOTE: these aren't exported from Popper, but they are copied from:
+// @popperjs/core/src/enums.js
+export const TOOLTIP_AUTO: 'auto' = 'auto'
+export const TOOLTIP_AUTO_START: 'auto-start' = 'auto-start'
+export const TOOLTIP_AUTO_END: 'auto-end' = 'auto-end'
+
+export const TOOLTIP_TOP: 'top' = 'top'
+export const TOOLTIP_TOP_START: 'top-start' = 'top-start'
+export const TOOLTIP_TOP_END: 'top-end' = 'top-end'
+
+export const TOOLTIP_RIGHT: 'right' = 'right'
+export const TOOLTIP_RIGHT_START: 'right-start' = 'right-start'
+export const TOOLTIP_RIGHT_END: 'right-end' = 'right-end'
+
+export const TOOLTIP_BOTTOM: 'bottom' = 'bottom'
+export const TOOLTIP_BOTTOM_START: 'bottom-start' = 'bottom-start'
+export const TOOLTIP_BOTTOM_END: 'bottom-end' = 'bottom-end'
+
+export const TOOLTIP_LEFT: 'left' = 'left'
+export const TOOLTIP_LEFT_START: 'left-start' = 'left-start'
+export const TOOLTIP_LEFT_END: 'left-end' = 'left-end'
+
+// strategy constants
+// NOTE: these aren't exported from Popper, but they are copied from:
+// @popperjs/core/src/types.js
+export const TOOLTIP_ABSOLUTE: 'absolute' = 'absolute'
+export const TOOLTIP_FIXED: 'fixed' = 'fixed'

--- a/components/src/tooltips/index.js
+++ b/components/src/tooltips/index.js
@@ -1,5 +1,10 @@
 // @flow
 // tooltip components
 
-export * from './Tooltip'
+export * from './DeprecatedTooltip'
 export * from './HoverTooltip'
+export * from './Tooltip'
+export * from './useTooltip'
+export * from './usePopper'
+export * from './constants'
+export * from './types'

--- a/components/src/tooltips/styles.js
+++ b/components/src/tooltips/styles.js
@@ -1,0 +1,21 @@
+// @flow
+// common style constants
+
+export const INITIAL_TOOLTIP_STYLE = {
+  // copied from @popperjs/core/src/modifiers/applyStyles.js
+  position: 'absolute',
+  left: '0',
+  top: '0',
+  margin: '0',
+}
+
+export const INITIAL_ARROW_STYLE = {
+  // copied from @popperjs/core/src/modifiers/applyStyles.js
+  position: 'absolute',
+}
+
+export const TOOLTIP_OFFSET_PX = 8
+
+export const ARROW_OFFSET_PX = 2
+
+export const ARROW_SIZE_PX = TOOLTIP_OFFSET_PX - ARROW_OFFSET_PX

--- a/components/src/tooltips/types.js
+++ b/components/src/tooltips/types.js
@@ -40,7 +40,7 @@ export type UseTooltipOptions = $Shape<{|
 
 export type UseTooltipResult = {|
   targetRef: (HTMLElement | null) => mixed,
-  placement: Placement | '',
+  placement: Placement | null,
   tooltipId: string,
   tooltipRef: (HTMLElement | null) => mixed,
   tooltipStyle: $Shape<CSSStyleDeclaration>,

--- a/components/src/tooltips/types.js
+++ b/components/src/tooltips/types.js
@@ -1,0 +1,49 @@
+// @flow
+// TODO(mc, 2020-03-20): Popper build misconfigured, but can import types directly
+// https://github.com/popperjs/popper-core/issues/1031
+import type {
+  Instance as PopperInstance,
+  Options as PopperOptions,
+} from '@popperjs/core/lib/types'
+
+export type Placement = $PropertyType<PopperOptions, 'placement'>
+
+export type Strategy = $PropertyType<PopperOptions, 'strategy'>
+
+export type { PopperInstance, PopperOptions }
+
+export type HandleStateUpdate = (
+  placement: Placement,
+  styles: {|
+    popper?: $Shape<CSSStyleDeclaration>,
+    arrow?: $Shape<CSSStyleDeclaration>,
+  |}
+) => void
+
+export type UsePopperOptions = {|
+  target: Element | null,
+  tooltip: HTMLElement | null,
+  arrow: HTMLElement | null,
+  onStateUpdate: HandleStateUpdate,
+  placement?: Placement | null,
+  strategy?: Strategy | null,
+  offset?: number,
+|}
+
+export type UsePopperResult = PopperInstance | null
+
+export type UseTooltipOptions = $Shape<{|
+  placement?: Placement,
+  strategy?: Strategy,
+  offset?: number,
+|}>
+
+export type UseTooltipResult = {|
+  targetRef: (HTMLElement | null) => mixed,
+  placement: Placement | '',
+  tooltipId: string,
+  tooltipRef: (HTMLElement | null) => mixed,
+  tooltipStyle: $Shape<CSSStyleDeclaration>,
+  arrowRef: (HTMLElement | null) => mixed,
+  arrowStyle: $Shape<CSSStyleDeclaration>,
+|}

--- a/components/src/tooltips/types.js
+++ b/components/src/tooltips/types.js
@@ -38,12 +38,21 @@ export type UseTooltipOptions = $Shape<{|
   offset?: number,
 |}>
 
-export type UseTooltipResult = {|
-  targetRef: (HTMLElement | null) => mixed,
+export type UseTooltipResultTargetProps = {|
+  ref: (HTMLElement | null) => mixed,
+  'aria-describedby': string,
+|}
+
+export type UseTooltipResultTooltipProps = {|
+  id: string,
+  ref: (HTMLElement | null) => mixed,
   placement: Placement | null,
-  tooltipId: string,
-  tooltipRef: (HTMLElement | null) => mixed,
-  tooltipStyle: $Shape<CSSStyleDeclaration>,
+  style: $Shape<CSSStyleDeclaration>,
   arrowRef: (HTMLElement | null) => mixed,
   arrowStyle: $Shape<CSSStyleDeclaration>,
 |}
+
+export type UseTooltipResult = [
+  UseTooltipResultTargetProps,
+  UseTooltipResultTooltipProps
+]

--- a/components/src/tooltips/usePopper.js
+++ b/components/src/tooltips/usePopper.js
@@ -18,10 +18,7 @@ const makeUpdateStateModifier = (handleStateUpdate: HandleStateUpdate) => ({
   name: 'updateUsePopperState',
   enabled: true,
   phase: 'write',
-  fn: ({ state }) => {
-    console.log('applyStyles', state)
-    handleStateUpdate(state.placement, state.styles)
-  },
+  fn: ({ state }) => handleStateUpdate(state.placement, state.styles),
 })
 
 const makeOffsetModifier = (offset: number) => ({

--- a/components/src/tooltips/usePopper.js
+++ b/components/src/tooltips/usePopper.js
@@ -1,0 +1,85 @@
+// @flow
+import { useRef, useLayoutEffect } from 'react'
+import { createPopper } from '@popperjs/core'
+
+import type {
+  UsePopperOptions,
+  UsePopperResult,
+  PopperOptions,
+  HandleStateUpdate,
+} from './types'
+
+const DISABLED_APPLY_STYLES_MODIFIER = {
+  name: 'applyStyles',
+  enabled: false,
+}
+
+const makeUpdateStateModifier = (handleStateUpdate: HandleStateUpdate) => ({
+  name: 'updateUsePopperState',
+  enabled: true,
+  phase: 'write',
+  fn: ({ state }) => {
+    console.log('applyStyles', state)
+    handleStateUpdate(state.placement, state.styles)
+  },
+})
+
+const makeOffsetModifier = (offset: number) => ({
+  name: 'offset',
+  options: { offset: [0, offset] },
+})
+
+const makeArrowModifier = (arrow: Element) => ({
+  name: 'arrow',
+  options: { element: arrow },
+})
+
+export function usePopper(options: UsePopperOptions): UsePopperResult {
+  const {
+    target,
+    tooltip,
+    arrow,
+    placement,
+    strategy,
+    offset,
+    onStateUpdate,
+  } = options
+
+  const popperRef = useRef<UsePopperResult | null>(null)
+
+  // useLayoutEffect instead of useEffect to avoid positioning flash
+  useLayoutEffect(() => {
+    if (target && tooltip) {
+      const options: $Shape<PopperOptions> = {
+        modifiers: [
+          DISABLED_APPLY_STYLES_MODIFIER,
+          makeUpdateStateModifier(onStateUpdate),
+        ],
+      }
+
+      if (offset != null) {
+        options.modifiers.push(makeOffsetModifier(offset))
+      }
+
+      if (arrow) {
+        options.modifiers.push(makeArrowModifier(arrow))
+      }
+
+      if (placement != null) options.placement = placement
+      if (strategy != null) options.strategy = strategy
+
+      const popperInstance = createPopper(target, tooltip, options)
+
+      // immediately force a synchronous update to avoid positioning flash
+      popperInstance.forceUpdate()
+      popperRef.current = popperInstance
+
+      return () => {
+        popperInstance.destroy()
+        popperRef.current = null
+      }
+    }
+  }, [target, tooltip, arrow, placement, strategy, offset, onStateUpdate])
+
+  return popperRef.current
+}

--- a/components/src/tooltips/useTooltip.js
+++ b/components/src/tooltips/useTooltip.js
@@ -7,7 +7,7 @@ import * as Styles from './styles'
 import type { UseTooltipOptions, UseTooltipResult, Placement } from './types'
 
 type TooltipState = {|
-  placement: Placement | '',
+  placement: Placement | null,
   tooltipStyle: $Shape<CSSStyleDeclaration>,
   arrowStyle: $Shape<CSSStyleDeclaration>,
 |}
@@ -21,7 +21,7 @@ export function useTooltip(options: UseTooltipOptions = {}): UseTooltipResult {
   const [tooltip, tooltipRef] = useState<HTMLElement | null>(null)
   const [arrow, arrowRef] = useState<HTMLElement | null>(null)
   const [tooltipState, setTooltipState] = useState<TooltipState>({
-    placement: '',
+    placement: null,
     tooltipStyle: Styles.INITIAL_TOOLTIP_STYLE,
     arrowStyle: Styles.INITIAL_ARROW_STYLE,
   })

--- a/components/src/tooltips/useTooltip.js
+++ b/components/src/tooltips/useTooltip.js
@@ -44,11 +44,19 @@ export function useTooltip(options: UseTooltipOptions = {}): UseTooltipResult {
     onStateUpdate,
   })
 
-  return {
-    ...tooltipState,
-    tooltipId,
-    targetRef,
-    tooltipRef,
+  const targetProps = {
+    ref: targetRef,
+    'aria-describedby': tooltipId,
+  }
+
+  const tooltipProps = {
+    id: tooltipId,
+    ref: tooltipRef,
+    style: tooltipState.tooltipStyle,
+    arrowStyle: tooltipState.arrowStyle,
+    placement: tooltipState.placement,
     arrowRef,
   }
+
+  return [targetProps, tooltipProps]
 }

--- a/components/src/tooltips/useTooltip.js
+++ b/components/src/tooltips/useTooltip.js
@@ -1,0 +1,54 @@
+// @flow
+import { useState, useCallback, useRef } from 'react'
+import uniqueId from 'lodash/uniqueId'
+import { usePopper } from './usePopper'
+import * as Styles from './styles'
+
+import type { UseTooltipOptions, UseTooltipResult, Placement } from './types'
+
+type TooltipState = {|
+  placement: Placement | '',
+  tooltipStyle: $Shape<CSSStyleDeclaration>,
+  arrowStyle: $Shape<CSSStyleDeclaration>,
+|}
+
+const TOOLTIP_ID_PREFIX = 'Tooltip__'
+
+export function useTooltip(options: UseTooltipOptions = {}): UseTooltipResult {
+  const { placement, strategy, offset = Styles.TOOLTIP_OFFSET_PX } = options
+  const tooltipId = useRef(uniqueId(TOOLTIP_ID_PREFIX)).current
+  const [target, targetRef] = useState<Element | null>(null)
+  const [tooltip, tooltipRef] = useState<HTMLElement | null>(null)
+  const [arrow, arrowRef] = useState<HTMLElement | null>(null)
+  const [tooltipState, setTooltipState] = useState<TooltipState>({
+    placement: '',
+    tooltipStyle: Styles.INITIAL_TOOLTIP_STYLE,
+    arrowStyle: Styles.INITIAL_ARROW_STYLE,
+  })
+
+  const onStateUpdate = useCallback((placement, styles) => {
+    setTooltipState({
+      placement,
+      tooltipStyle: styles.popper ?? Styles.INITIAL_TOOLTIP_STYLE,
+      arrowStyle: styles.arrow ?? Styles.INITIAL_ARROW_STYLE,
+    })
+  }, [])
+
+  usePopper({
+    target,
+    tooltip,
+    arrow,
+    placement,
+    strategy,
+    offset,
+    onStateUpdate,
+  })
+
+  return {
+    ...tooltipState,
+    tooltipId,
+    targetRef,
+    tooltipRef,
+    arrowRef,
+  }
+}

--- a/labware-library/src/components/labware-ui/LoadName.js
+++ b/labware-library/src/components/labware-ui/LoadName.js
@@ -2,7 +2,7 @@
 // labware load name with copy button
 import * as React from 'react'
 
-import { IconButton, Tooltip } from '@opentrons/components'
+import { IconButton, DeprecatedTooltip } from '@opentrons/components'
 import { LabelText, LABEL_TOP } from '../ui'
 
 import { API_NAME, COPIED_TO_CLIPBOARD } from '../../localization'
@@ -58,7 +58,7 @@ export function LoadName(props: LoadNameProps) {
           readOnly
         />
       </label>
-      <Tooltip open={success} tooltipComponent={COPIED_TO_CLIPBOARD}>
+      <DeprecatedTooltip open={success} tooltipComponent={COPIED_TO_CLIPBOARD}>
         {tooltipProps => (
           <IconButton
             onClick={handleCopyButtonClick}
@@ -68,7 +68,7 @@ export function LoadName(props: LoadNameProps) {
             inverted
           />
         )}
-      </Tooltip>
+      </DeprecatedTooltip>
     </div>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2742,6 +2742,11 @@
   dependencies:
     "@types/node" ">= 8"
 
+"@popperjs/core@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.1.1.tgz#12c572ab88ef7345b43f21883fca26631c223085"
+  integrity sha512-sLqWxCzC5/QHLhziXSCAksBxHfOnQlhPRVgPK0egEw+ktWvG75T2k+aYWVjVh9+WKeT3tlG3ZNbZQvZLmfuOIw==
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"


### PR DESCRIPTION
## overview

This PR closes #5120 by adding a `useTooltip` hook + `<Tooltip>` component pair to the component library. At the moment, this component is standalone and not used anywhere except the styleguide examples.

Future PRs will be needed to:

- Add hover functionality via a `useHover` and `useHoverTooltip` hook (#5364)
- Rewrite the internals of `HoverTooltip` to use the hooks
- Gradually replace usage of `HoverTooltip` with either:
    - Direct hook usage
    - More considered CL components that can take a disabled reason for a tooltip rather than simply disabling themselves 

## changelog

- feat(components): add hooks-based tooltip component to library
    - Note: renamed existing `Tooltip` component to `DeprecatedTooltip`

## review requests

- [ ] Play around with tooltips in Component Library
- [ ] Checkout the code + tests
- [ ] Ensure "copied to clipboard" tooltip in LL still works
    - It still uses the old `react-popper` tooltip but that component was renamed

## risk assessment

Very low. New tooltip component is not being used yet