### PR TITLE
fix(protocol-designer): Remove mm unit from engage height field

### DIFF
--- a/protocol-designer/src/components/StepEditForm/forms/MagnetForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MagnetForm.js
@@ -90,7 +90,6 @@ export const MagnetForm = (props: MagnetFormProps): React.Element<'div'> => {
             <TextField
               name="engageHeight"
               className={styles.small_field}
-              units={i18n.t('application.units.millimeter')}
               caption={engageHeightCaption}
               {...focusHandlers}
             />


### PR DESCRIPTION
## overview

This PR is also a bug ticket. During the demo yesterday we noticed the mm unit was still in the engage height field. This PR removes it to avoid confusing 'short' mm vs 'real' mm 

## changelog

- fix(protocol-designer): Remove mm unit from engage height field

## review requests

- [ ] no more mms referenced in magnetic form engage height 

## risk assessment

Low PD removal of a single unit.