### PR TITLE
fix(protocol-designer): fix dnd bug

### DIFF
--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/DragPreview.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/DragPreview.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import { DragLayer } from 'react-dnd'
 import { LabwareOnDeck } from '../LabwareOnDeck'
-import { DND_TYPES } from './constants'
+import { DND_TYPES } from '../../../constants'
 import type { LabwareOnDeck as LabwareOnDeckType } from '../../../step-forms'
 import type { RobotWorkSpaceRenderProps } from '@opentrons/components'
 import styles from './DragPreview.css'

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/EditLabware.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/EditLabware.js
@@ -7,7 +7,7 @@ import { getLabwareDisplayName } from '@opentrons/shared-data'
 import { DragSource, DropTarget } from 'react-dnd'
 import { i18n } from '../../../localization'
 import { NameThisLabware } from './NameThisLabware'
-import { DND_TYPES } from './constants'
+import { DND_TYPES } from '../../../constants'
 import {
   openIngredientSelector,
   deleteContainer,

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.js
@@ -7,6 +7,7 @@ import { connect } from 'react-redux'
 import { DropTarget } from 'react-dnd'
 import noop from 'lodash/noop'
 import { i18n } from '../../../localization'
+import { DND_TYPES } from '../../../constants'
 import {
   getLabwareIsCompatible,
   getLabwareIsCustom,
@@ -18,7 +19,6 @@ import {
 } from '../../../labware-ingred/actions'
 import { selectors as labwareDefSelectors } from '../../../labware-defs'
 import { START_TERMINAL_ITEM_ID, type TerminalItemId } from '../../../steplist'
-import { DND_TYPES } from './constants'
 
 import type { DeckSlot, ThunkDispatch, BaseState } from '../../../types'
 import type { LabwareDefByDefURI } from '../../../labware-defs'

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.js
@@ -33,6 +33,7 @@ type DNDP = {|
   isOver: boolean,
   connectDropTarget: Node => Node,
   draggedItem: ?{ labwareOnDeck: LabwareOnDeck },
+  itemType: string,
 |}
 type OP = {|
   slot: {| ...DeckSlotDefinition, id: DeckSlot |}, // NOTE: Ian 2019-10-22 make slot `id` more restrictive when used in PD
@@ -58,9 +59,14 @@ export const SlotControlsComponent = (props: Props) => {
     connectDropTarget,
     moduleType,
     draggedItem,
+    itemType,
     customLabwareDefs,
   } = props
-  if (selectedTerminalItemId !== START_TERMINAL_ITEM_ID) return null
+  if (
+    selectedTerminalItemId !== START_TERMINAL_ITEM_ID ||
+    itemType !== DND_TYPES.LABWARE
+  )
+    return null
 
   const draggedDef = draggedItem?.labwareOnDeck?.def
   const isCustomLabware = draggedItem
@@ -158,6 +164,7 @@ const collectSlotTarget = (connect, monitor) => ({
   connectDropTarget: connect.dropTarget(),
   isOver: monitor.isOver(),
   draggedItem: monitor.getItem(),
+  itemType: monitor.getItemType(),
 })
 
 export const SlotControls = connect<{| ...OP, ...DP, ...SP |}, OP, _, DP, _, _>(

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/__tests__/SlotControls.test.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/__tests__/SlotControls.test.js
@@ -4,6 +4,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import fixture_96_plate from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
 import { MAGNETIC_MODULE_TYPE } from '@opentrons/shared-data'
+import { DND_TYPES } from '../../../../constants'
 import * as labwareModuleCompatibility from '../../../../utils/labwareModuleCompatibility'
 import { START_TERMINAL_ITEM_ID } from '../../../../steplist'
 import { SlotControlsComponent } from '../SlotControls'
@@ -42,6 +43,7 @@ describe('SlotControlsComponent', () => {
       draggedItem: {
         labwareOnDeck,
       },
+      itemType: DND_TYPES.LABWARE,
       customLabwareDefs: {},
     }
 

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/constants.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/constants.js
@@ -1,5 +1,0 @@
-// @flow
-// TODO: BC 2019-01-03 consolidate with DraggableStepItems DND_TYPES
-export const DND_TYPES: { LABWARE: 'LABWARE' } = {
-  LABWARE: 'LABWARE',
-}

--- a/protocol-designer/src/components/steplist/DraggableStepItems.js
+++ b/protocol-designer/src/components/steplist/DraggableStepItems.js
@@ -4,8 +4,9 @@ import { connect } from 'react-redux'
 import { DragSource, DropTarget, DragLayer } from 'react-dnd'
 import isEqual from 'lodash/isEqual'
 
-import { PDTitledList } from '../lists'
+import { DND_TYPES } from '../../constants'
 import { ConnectedStepItem } from '../../containers/ConnectedStepItem'
+import { PDTitledList } from '../lists'
 import {
   stepIconsByType,
   type StepIdType,
@@ -15,10 +16,6 @@ import { selectors as stepFormSelectors } from '../../step-forms'
 import type { BaseState } from '../../types'
 import { ContextMenu } from './ContextMenu'
 import styles from './StepItem.css'
-
-const DND_TYPES: { STEP_ITEM: 'STEP_ITEM' } = {
-  STEP_ITEM: 'STEP_ITEM',
-}
 
 type DragDropStepItemProps = {|
   ...$Exact<React.ElementProps<typeof ConnectedStepItem>>,

--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -158,3 +158,8 @@ export const MODULES_WITH_COLLISION_ISSUES = [
 export const PAUSE_UNTIL_RESUME: 'untilResume' = 'untilResume'
 export const PAUSE_UNTIL_TIME: 'untilTime' = 'untilTime'
 export const PAUSE_UNTIL_TEMP: 'untilTemperature' = 'untilTemperature'
+
+export const DND_TYPES = {
+  LABWARE: 'LABWARE',
+  STEP_ITEM: 'STEP_ITEM',
+}


### PR DESCRIPTION
## overview

Closes #5367 

I think this bug is: in any loaded protocol, reordering the steps caused a whitescreen because SlotControlsComponent receives the STEP_ITEM itemType and attempted to access a key that isn't there, because it's expecting a LABWARE itemType that has different keys. (For some reason a newly-created protocol works fine -- race condition?)

## changelog

- consolidate DND_TYPES as in old TODOs
- make slot overlay check if indeed there's a labware being dragged, (and not a STEP_ITEM or something else)

## review requests

I think 5367 was a latent bug that until recently wasn't able to surface due to some kind of race condition?? Not sure what could have made it surface.

- New protocol, reorder steps: should work as expected
- Loaded protocol, reorder steps: should work as expected
- Dragging labware: should work as expected

## risk assessment

just pd