### PR TITLE
chore(protocol-designer): update PD version constant to 4.0.0

### DIFF
--- a/protocol-designer/webpack.config.js
+++ b/protocol-designer/webpack.config.js
@@ -16,7 +16,7 @@ const PROTOCOL_DESIGNER_ENV_VAR_PREFIX = 'OT_PD_'
 // Also remove all OT_PD_VERSION env vars, the version should always
 // be gleaned from the package.json
 
-const OT_PD_VERSION = '3.0.8'
+const OT_PD_VERSION = '4.0.0'
 const OT_PD_BUILD_DATE = new Date().toUTCString()
 
 const JS_ENTRY = path.join(__dirname, 'src/index.js')


### PR DESCRIPTION
## overview

Closes #5148

Just bumps the version

## changelog

## review requests

- Tests pass
- I can't think of anything that could be bad about this now :p Both #5371 and #5123 are dependent on this

## risk assessment

none, just PD