### PR TITLE
refactor(app): fix error caused by two refactors touching robot selectors

### DIFF
--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -479,7 +479,7 @@ export const getTipracksByMount: (
   getTipracks,
   getPipettesByMount,
   (tipracks, pipettesMap) => {
-    return PIPETTE_MOUNTS.reduce<TiprackByMountMap>(
+    return Constants.PIPETTE_MOUNTS.reduce<TiprackByMountMap>(
       (tiprackMap, mount) => {
         const byCalibrator = tipracks.find(tr => tr.calibratorMount === mount)
         const byTiprackList = tipracks.find(tr =>


### PR DESCRIPTION
## overview

Both #5322 and #5319 touched `app/src/robot/selectors.js` and merging both created a bug due to one of those PRs changing `import { ... PIPETTE_MOUNTS ... } from './constants'` to `import * as Constants from './constants'`

This PR corrects that merge bug to get tests passing and builds working

## changelog

- refactor(app): fix error caused by two refactors touching robot selectors

## review requests

Nothing specific since it's a one line fix. Make sure tests pass on your machine if you're feeling thorough

## risk assessment

Very low. Bug was caused by merge and caught by tests.
