### PR TITLE
fix(protocol-designer): allow adding labware

### DIFF
--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.js
@@ -64,7 +64,7 @@ export const SlotControlsComponent = (props: Props) => {
   } = props
   if (
     selectedTerminalItemId !== START_TERMINAL_ITEM_ID ||
-    itemType !== DND_TYPES.LABWARE
+    (itemType !== DND_TYPES.LABWARE && itemType !== null)
   )
     return null
 


### PR DESCRIPTION
## overview

That was dumb. Introduced bug in #5370 where you couldn't add labware to slots. This is b/c `itemType` is `null` when nothing is actively being dragged. Instead of rendering the slot controls, SlotControlsComponent returned null when nothing was being dragged

## changelog

## review requests

:upside_down_face: 

## risk assessment

low, PD only