### PR TITLE
test(protocol-designer): Add modules in PD E2E tests 

### DIFF
--- a/protocol-designer/cypress/integration/newProtocol.spec.js
+++ b/protocol-designer/cypress/integration/newProtocol.spec.js
@@ -432,6 +432,7 @@ describe('Desktop Navigation', () => {
       cy.contains('Liquid name is required').should('not.exist')
       // Fill out the rest of the form
       cy.get("input[name='description']").type('It is just water')
+      // force option used because checkbox is hidden
       cy.get("input[name='serialize']").check({ force: true })
       cy.get('button')
         .contains('save')

--- a/protocol-designer/cypress/integration/newProtocolWithModules.spec.js
+++ b/protocol-designer/cypress/integration/newProtocolWithModules.spec.js
@@ -1,0 +1,774 @@
+// Common Variables and Selectors
+const protocolTitle = 'Modules Test Protocol'
+const tipRack = 'Opentrons 96 Tip Rack 300 µL'
+const tipRackWithoutUnit = 'Opentrons 96 Tip Rack 300'
+const sidePanel = '[class*="SidePanel__panel_contents"]'
+const designPageModal = '#main-page-modal-portal-root'
+const rowLetters = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
+const defaultTextInput = 'input[type="text"]'
+const alertTitleContainer = '[class*="alerts__title"]'
+const editModuleModal = 'div[class*="EditModules__modal_contents"]'
+const moduleModelDropdown =
+  'div[class*="EditModules__option_model"] select[class*="forms__dropdown"]'
+// Slots
+const slotOne = 'foreignObject[x="0"][y="0"]'
+const slotThree = 'foreignObject[x="265"][y="0"]'
+const slotFive = 'foreignObject[x="132.5"][y="90.5"]'
+
+describe('Protocols with Modules', () => {
+  beforeEach(() => {
+    cy.viewport('macbook-15')
+  })
+  before(() => {
+    cy.visit('/')
+    cy.closeAnnouncementModal()
+  })
+
+  describe('build a new protocol with mag deck', () => {
+    it('sets up pipettes, tips, and modules', () => {
+      cy.get('button')
+        .contains('Create New')
+        .click()
+      // Give it a name
+      cy.get("input[placeholder='Untitled']").type(protocolTitle)
+      // Choose pipette types and tip racks
+      cy.contains('Left Pipette')
+        .next()
+        .contains('None')
+        .click()
+      cy.contains('Left Pipette')
+        .next()
+        .contains('P300')
+        .click()
+      cy.contains('Right Pipette')
+        .next()
+        .contains('None')
+        .click()
+      cy.get('div[id*="select-3-option-2-5"]').click()
+      cy.selectTipRacks(tipRack, tipRack)
+
+      // Add modules
+      cy.contains('Magnetic').should('exist')
+      cy.contains('Temperature').should('exist')
+      cy.get('input[name="modulesByType.magneticModuleType.onDeck"]').click({
+        force: true,
+      })
+      cy.get('select[name="modulesByType.magneticModuleType.model"]').select(
+        'GEN1'
+      )
+      cy.get('input[name="modulesByType.temperatureModuleType.onDeck"]').click({
+        force: true,
+      })
+      cy.get('select[name="modulesByType.temperatureModuleType.model"]').select(
+        'GEN2'
+      )
+      cy.get('button')
+        .contains('save')
+        .click()
+
+      // Verify modules were added
+      cy.contains('File Details').should('exist')
+      cy.contains('Modules').should('exist')
+      var modulesSection = 'div[class*="modules_card_content"]'
+      cy.get(modulesSection).within(() => {
+        cy.contains('Magnetic').should('exist')
+        cy.contains('GEN1').should('exist')
+        cy.contains('Slot 1').should('exist')
+
+        cy.contains('Temperature').should('exist')
+        cy.contains('GEN2').should('exist')
+        cy.contains('Slot 3').should('exist')
+      })
+
+      // Edit modules
+      cy.get(modulesSection)
+        .contains('Edit')
+        .click()
+      cy.get(editModuleModal).within(() => {
+        cy.contains('GEN1')
+        cy.get('select[disabled]')
+          .contains('Slot 1')
+          .should('exist')
+        cy.get(moduleModelDropdown).select('GEN2')
+        cy.get('button')
+          .contains('save')
+          .click()
+      })
+      cy.get(editModuleModal).should('not.exist')
+      cy.contains('existing engage heights will be cleared').should('exist')
+      cy.get('button')
+        .contains('Continue')
+        .click()
+      cy.get(modulesSection).contains('GEN2')
+      cy.get(modulesSection)
+        .contains('Edit')
+        .click()
+      cy.get(editModuleModal).within(() => {
+        cy.get(moduleModelDropdown).select('GEN1')
+        cy.get('button')
+          .contains('save')
+          .click()
+      })
+    })
+
+    it('adds two liquids', () => {
+      cy.get('button')
+        .contains('Continue to Liquids')
+        .click()
+      cy.addLiquid('Water', 'pure H2O', true)
+      cy.addLiquid('Reagent', 'tasty chemicals')
+    })
+
+    it('design protocol with mag and temp decks', () => {
+      // Avoid failing the test on uncaught exception
+      // Happens when writing a nickname for the labware
+      Cypress.on('uncaught:exception', (err, runnable) => {
+        console.log(err.name)
+        return false
+      })
+
+      cy.openDesignPage()
+      // close "setting up" modal
+      cy.contains('Setting up your protocol').should('exist')
+      cy.get('input[type="checkbox"]').click({ force: true })
+      cy.get('button')
+        .contains('ok')
+        .click()
+      // verify design tab contents
+      cy.get('[class*="list_selected"] h3')
+        .contains('STARTING DECK STATE')
+        .should('exist')
+      cy.get('[class*="list_selected"] h3')
+        .contains('FINAL DECK STATE')
+        .should('not.exist')
+      cy.get('h3')
+        .contains('FINAL DECK STATE')
+        .should('exist')
+      cy.get('button[class*="button_primary"]')
+        .contains('Add Step')
+        .should('exist')
+      cy.get('header')
+        .contains(protocolTitle)
+        .should('exist')
+      // verify deckmap contents
+      cy.get('[class*="DeckSetup"]').within(() => {
+        cy.contains('Magnetic').should('exist')
+        cy.contains('disengaged').should('exist')
+        cy.contains(tipRackWithoutUnit).should('exist')
+        cy.contains('Temperature').should('exist')
+        cy.contains('deactivated').should('exist')
+        cy.contains('No GEN1 8-Channel access').should('exist')
+      })
+
+      // Add tip rack to slot 5
+      cy.get(slotFive).click()
+      cy.get(designPageModal).within(() => {
+        cy.contains('Slot 5 Labware').should('exist')
+        cy.get('h3')
+          .contains('Tip Rack')
+          .click()
+        cy.contains(tipRack).click()
+      })
+      cy.get(slotFive).within(() => {
+        cy.contains(tipRackWithoutUnit)
+      })
+
+      // Add labware to Mag Deck
+      cy.get(slotOne).click()
+      cy.get(designPageModal).within(() => {
+        cy.contains('Slot 1, Magnetic module Labware').should('exist')
+        cy.contains('Show only recommended labware').should('exist')
+        cy.contains('Upload custom labware').should('exist')
+        cy.get('ul')
+          .should('have.length', 1)
+          .contains('Well Plate')
+          .should('exist')
+          .click()
+        cy.get('ul').within(() => {
+          cy.get('li')
+            .should('have.length', 1)
+            .contains('Nest 96 Well Plate', { matchCase: false })
+        })
+        cy.get('[class*="forms__checkbox_icon"]').click()
+        cy.get('ul > div')
+          .should('have.length', 1)
+          .contains('Well Plate')
+          .should('exist')
+        cy.get('ul').within(() => {
+          cy.get('li').should('have.length.greaterThan', 1)
+          cy.contains('Nest 96 Well Plate', { matchCase: false }).click()
+        })
+      })
+      cy.get('input[class*="LabwareOverlays__name_input"]').type(
+        'Mag Deck Well'
+      )
+
+      // Add labware to Temp Deck
+      cy.get(slotThree).click()
+      var aluminumWellBlock =
+        'Opentrons 96 Well Aluminum Block with Generic PCR Strip 200'
+      cy.get(designPageModal).within(() => {
+        cy.contains('Slot 3, Temperature module Labware').should('exist')
+        cy.contains('Show only recommended labware').should('exist')
+        cy.contains('Upload custom labware').should('exist')
+        cy.get('ul > div')
+          .should('have.length', 1)
+          .contains('Aluminum Block')
+          .should('exist')
+        cy.get('[class*="forms__checkbox_icon"]').click()
+        cy.get('ul > div').should('have.length', 3)
+        cy.contains('Well Plate').should('exist')
+        cy.contains('Reservoir').should('exist')
+        cy.contains('Aluminum Block')
+          .should('exist')
+          .click()
+        cy.get('ul').within(() => {
+          cy.contains(aluminumWellBlock, { matchCase: false }).click()
+        })
+      })
+      cy.contains(aluminumWellBlock, { matchCase: false })
+      cy.get('input[class*="LabwareOverlays__name_input"]').type(
+        'Temp Deck Block'
+      )
+
+      // Add first liquid
+      cy.get(slotOne)
+        .contains('Name & Liquids')
+        .click()
+      rowLetters.forEach(element => {
+        cy.get(`[data-wellname="${element}1"]`).click()
+      })
+      cy.get('[name="selectedLiquidId"]').select('Water')
+      cy.get('[name="volume"]').type('50')
+      cy.get('button')
+        .contains('save')
+        .click()
+      cy.get('button')
+        .contains('Deck')
+        .click()
+
+      // Add second liquid
+      cy.get(slotThree)
+        .contains('Name & Liquids')
+        .click()
+      rowLetters.forEach(element => {
+        cy.get(`[data-wellname="${element}1"]`).click()
+      })
+      cy.get('[name="selectedLiquidId"]').select('Reagent')
+      cy.get('[name="volume"]').type('50')
+      cy.get('button')
+        .contains('save')
+        .click()
+      cy.get('button')
+        .contains('Deck')
+        .click()
+
+      // Add Temperature Step w/out Pause
+      cy.addStep('temperature')
+      cy.get(sidePanel)
+        .contains('temperature')
+        .should('exist')
+      cy.get(designPageModal).within(() => {
+        cy.get('[class*="section_header"]')
+          .contains('temperature')
+          .should('exist')
+        cy.contains('Change to temperature').click()
+        cy.get(defaultTextInput).should('exist')
+        cy.contains('Deactivate').click()
+        cy.get(defaultTextInput).should('not.exist')
+        cy.contains('Change to temperature').click()
+        cy.get(defaultTextInput)
+          .focus()
+          .blur()
+        cy.get(alertTitleContainer)
+          .contains('error')
+          .should('exist')
+        cy.get('button[disabled]')
+          .contains('Save')
+          .should('exist')
+        cy.get(defaultTextInput).type('non-numerical')
+        cy.get('button[disabled]')
+          .contains('Save')
+          .should('exist')
+        cy.get(defaultTextInput)
+          .clear()
+          .type('100')
+          .blur()
+        cy.get(alertTitleContainer)
+          .contains('warning')
+          .should('exist')
+        cy.get('button[disabled]')
+          .contains('Save')
+          .should('exist')
+        cy.contains('Max is 95')
+        cy.get(defaultTextInput)
+          .clear()
+          .type('37')
+          .blur()
+        cy.get(alertTitleContainer).should('not.exist')
+        cy.get('button')
+          .contains('Save')
+          .click()
+        cy.get('button')
+          .contains('pause later')
+          .click()
+      })
+      cy.get(sidePanel).within(() => {
+        cy.contains('2.').should('not.exist')
+        cy.contains('Temperature module').should('exist')
+        cy.contains('Go To', { matchCase: false }).should('exist')
+      })
+
+      // Add Pause Step until Temp
+      cy.addStep('pause')
+      cy.get(sidePanel)
+        .contains('pause')
+        .should('exist')
+      cy.get(designPageModal).within(() => {
+        cy.get('input[value="untilTemperature"]').click({ force: true })
+        cy.contains('Module', { matchCase: false }).should('exist')
+        cy.contains('Temp', { matchCase: false }).should('exist')
+        cy.get(defaultTextInput)
+          .focus()
+          .blur()
+        cy.get(alertTitleContainer)
+          .contains('error')
+          .should('exist')
+        cy.get('button[disabled]')
+          .contains('Save')
+          .should('exist')
+        cy.get(defaultTextInput)
+          .type('37')
+          .blur()
+        cy.get(alertTitleContainer).should('not.exist')
+        cy.get('button[disabled]').should('not.exist')
+        cy.get('textarea').type('heating up')
+        cy.get('button')
+          .contains('Save')
+          .click()
+      })
+      cy.get(sidePanel).within(() => {
+        cy.contains('2.').should('exist')
+        cy.contains('Pause Until', { matchCase: false }).should('exist')
+        cy.contains('heating up').should('exist')
+      })
+
+      // Add First Transfer Step
+      cy.addStep('transfer')
+      cy.get(sidePanel)
+        .contains('transfer')
+        .should('exist')
+      cy.get(designPageModal).within(() => {
+        cy.get('[class*="StepEditForm__form_row"]')
+          .contains('pipette')
+          .next()
+          .within(() => {
+            cy.get('select').select('P300 8-Channel GEN1')
+          })
+        cy.get('[class*="StepEditForm__form_row"]')
+          .contains('volume')
+          .next()
+          .within(() => {
+            cy.get('input[type="text"]').type('50')
+          })
+        // Aspirate
+        cy.get(
+          '[class*="StepEditForm__section_column"]:first-child select'
+        ).select('TEMP Temp Deck Block')
+        cy.get('input[name="aspirate_wells"]').click()
+        cy.get('[data-wellname="A1"]').click()
+        cy.get('button')
+          .contains('save selection', { matchCase: false })
+          .click()
+        // Dispense
+        cy.get('[class*="StepEditForm__section_column"]:nth-child(2)').within(
+          () => {
+            cy.get('select').select('MAG Mag Deck Well')
+            cy.get('button[class*="StepEditForm__advanced_settings"]').click()
+          }
+        )
+        cy.get(
+          `[class*="StepEditForm__advanced_settings_panel"] 
+          [class*="StepEditForm__section_column"]:nth-child(2)`
+        )
+          .contains('mix', { matchCase: false })
+          .click({ force: true })
+        cy.get('input[name="dispense_wells"]').click()
+        cy.get('[data-wellname="A1"]').click()
+        cy.get('button')
+          .contains('save selection', { matchCase: false })
+          .click()
+        cy.get('button')
+          .contains('Save')
+          .click()
+      })
+      cy.get(sidePanel).within(() => {
+        cy.contains('3.').should('exist')
+        cy.contains('Aspirate', { matchCase: false }).should('exist')
+        cy.contains('Dispense', { matchCase: false }).should('exist')
+        cy.contains('Temp Deck Block', { matchCase: false }).should('exist')
+        cy.contains('Mag Deck Well', { matchCase: false }).should('exist')
+        cy.contains('A1:H1').should('exist')
+      })
+
+      // Add Engage Magnet Step
+      cy.addStep('magnet')
+      cy.get(sidePanel)
+        .contains('magnet')
+        .should('exist')
+      cy.get(designPageModal).within(() => {
+        cy.contains('Module', { matchCase: false }).should('exist')
+        cy.contains('Magnet', { matchCase: false }).should('exist')
+        cy.get(defaultTextInput)
+          .clear()
+          .blur()
+        cy.get(alertTitleContainer)
+          .contains('error')
+          .should('exist')
+        cy.get('button[disabled]')
+          .contains('Save')
+          .should('exist')
+        cy.get(defaultTextInput)
+          .type('16')
+          .blur()
+        cy.get(alertTitleContainer).should('not.exist')
+        cy.get('button[disabled]').should('not.exist')
+        cy.get('button')
+          .contains('Save')
+          .click()
+      })
+      cy.get(sidePanel).within(() => {
+        cy.contains('4.').should('exist')
+        cy.contains('Magnet', { matchCase: false }).should('exist')
+        cy.contains('Engage', { matchCase: false }).should('exist')
+      })
+
+      // Add Pause Step for Time
+      cy.addStep('pause')
+      cy.get(designPageModal).within(() => {
+        cy.get('input[value="untilTime"]').click({ force: true })
+        cy.contains('h').should('exist')
+        cy.contains('m').should('exist')
+        cy.contains('s').should('exist')
+        cy.get(
+          '[class*="StepEditForm__small_field"]:nth-child(2) input[type="text"]'
+        )
+          .type('2')
+          .blur()
+        cy.get('button[disabled]').should('not.exist')
+        cy.get('button')
+          .contains('Save')
+          .click()
+      })
+      cy.get(sidePanel).within(() => {
+        cy.contains('5.').should('exist')
+      })
+      cy.get('[data-test="ModuleTag_magneticModuleType"]')
+        .contains('engaged')
+        .should('exist')
+
+      // Add Second Transfer Step
+      cy.addStep('transfer')
+      cy.get(designPageModal).within(() => {
+        cy.get('[class*="StepEditForm__form_row"]')
+          .contains('pipette')
+          .next()
+          .within(() => {
+            cy.get('select').select('P300 8-Channel GEN1')
+          })
+        cy.get('[class*="StepEditForm__form_row"]')
+          .contains('volume')
+          .next()
+          .within(() => {
+            cy.get('input[type="text"]').type('100')
+          })
+        // Aspirate
+        cy.get(
+          '[class*="StepEditForm__section_column"]:first-child select'
+        ).select('MAG Mag Deck Well')
+        cy.get('input[name="aspirate_wells"]').click()
+        cy.get('[data-wellname="A1"]').click()
+        cy.get('button')
+          .contains('save selection', { matchCase: false })
+          .click()
+        // Dispense
+        cy.get('[class*="StepEditForm__section_column"]:nth-child(2)').within(
+          () => {
+            cy.get('select').select('TEMP Temp Deck Block')
+            cy.get('button[class*="StepEditForm__advanced_settings"]').click()
+          }
+        )
+        cy.get(
+          `[class*="StepEditForm__advanced_settings_panel"] 
+          [class*="StepEditForm__section_column"]:nth-child(2)`
+        )
+          .contains('mix', { matchCase: false })
+          .click({ force: true })
+        cy.get('input[name="dispense_wells"]').click()
+        cy.get('[data-wellname="A2"]').click()
+        cy.get('button')
+          .contains('save selection', { matchCase: false })
+          .click()
+        cy.get('button')
+          .contains('Save')
+          .click()
+      })
+
+      // Add Disengage Magnet Step
+      cy.addStep('magnet')
+      cy.get(designPageModal).within(() => {
+        cy.get('input[value="disengage"][checked]').should('exist')
+        cy.get('button[disabled]').should('not.exist')
+        cy.get('button')
+          .contains('Save')
+          .click()
+      })
+
+      // Add Temperature Step w/ Pause
+      cy.addStep('temperature')
+      cy.get(designPageModal).within(() => {
+        cy.contains('Change to temperature').click()
+        cy.get(defaultTextInput)
+          .clear()
+          .type('4')
+          .blur()
+        cy.get('button')
+          .contains('Save')
+          .click()
+        cy.get('button')
+          .contains('Pause protocol now')
+          .click()
+      })
+      cy.get(sidePanel).within(() => {
+        cy.contains('8.').should('exist')
+        cy.contains('9.').should('exist')
+      })
+    })
+
+    it('deletes and replaces modules', () => {
+      // Delete Magnetic Module
+      cy.openFilePage()
+      cy.get('h4')
+        .contains('Magnetic')
+        .parent()
+        .within(() => {
+          cy.get('button')
+            .contains('remove')
+            .click()
+          cy.contains('Slot 1').should('not.exist')
+          cy.contains('add').should('exist')
+        })
+      cy.openDesignPage()
+      cy.get('h3')
+        .contains('4. magnet', { matchCase: false })
+        .click()
+      cy.get(designPageModal).within(() => {
+        cy.get(alertTitleContainer)
+          .contains('error')
+          .should('exist')
+        cy.get('button[disabled]')
+          .contains('Save')
+          .should('exist')
+      })
+      cy.get('h3')
+        .contains('7. magnet', { matchCase: false })
+        .click()
+      cy.get(designPageModal).within(() => {
+        cy.get(alertTitleContainer)
+          .contains('error')
+          .should('exist')
+        cy.get('button[disabled]')
+          .contains('Save')
+          .should('exist')
+      })
+
+      // Replace Magnetic Module
+      cy.openFilePage()
+      cy.get('h4')
+        .contains('Magnetic')
+        .parent()
+        .within(() => {
+          cy.get('button')
+            .contains('add')
+            .click()
+        })
+      cy.get(editModuleModal).within(() => {
+        cy.get('select[disabled]')
+          .contains('Slot 1')
+          .should('exist')
+        cy.get(moduleModelDropdown).select('GEN2')
+        cy.get('select[disabled]').should('not.exist')
+        cy.get('button')
+          .contains('save')
+          .click()
+      })
+      cy.get('h4')
+        .contains('Magnetic')
+        .parent()
+        .within(() => {
+          cy.contains('Slot 1').should('exist')
+          cy.contains('remove').should('exist')
+          cy.contains('Edit').should('exist')
+        })
+
+      // Verify timeline errors resolved
+      cy.openDesignPage()
+      cy.get('h3')
+        .contains('4. magnet', { matchCase: false })
+        .click()
+      cy.get(designPageModal).within(() => {
+        cy.get(alertTitleContainer).should('not.exist')
+        cy.get('button[disabled]').should('not.exist')
+      })
+      cy.get('h3')
+        .contains('7. magnet', { matchCase: false })
+        .click()
+      cy.get(designPageModal).within(() => {
+        cy.get(alertTitleContainer).should('not.exist')
+        cy.get('button[disabled]').should('not.exist')
+      })
+
+      // Delete Temperature Module
+      cy.openFilePage()
+      cy.get('h4')
+        .contains('Temperature')
+        .parent()
+        .within(() => {
+          cy.get('button')
+            .contains('remove')
+            .click()
+          cy.contains('Slot 3').should('not.exist')
+          cy.contains('add').should('exist')
+        })
+      cy.openDesignPage()
+      cy.get('h3')
+        .contains('1. temperature', { matchCase: false })
+        .click()
+      cy.get(designPageModal).within(() => {
+        cy.get(alertTitleContainer)
+          .contains('error')
+          .should('exist')
+        cy.get('select option').should('be.empty')
+        cy.get('button[disabled]')
+          .contains('Save')
+          .should('exist')
+      })
+      cy.get('h3')
+        .contains('2. pause', { matchCase: false })
+        .click()
+      cy.get(designPageModal).within(() => {
+        cy.get(alertTitleContainer)
+          .contains('error')
+          .should('exist')
+        cy.get('input[value="untilTemperature"][checked]').should('exist')
+        cy.get('select option').should('be.empty')
+        cy.get(defaultTextInput + '[value="37"]').should('exist')
+        cy.get('button[disabled]')
+          .contains('Save')
+          .should('exist')
+      })
+      cy.get('h3')
+        .contains('8. temperature', { matchCase: false })
+        .click()
+      cy.get(designPageModal).within(() => {
+        cy.get(alertTitleContainer)
+          .contains('error')
+          .should('exist')
+        cy.get('button[disabled]')
+          .contains('Save')
+          .should('exist')
+      })
+      cy.get('h3')
+        .contains('9. pause', { matchCase: false })
+        .click()
+      cy.get(designPageModal).within(() => {
+        cy.get(alertTitleContainer)
+          .contains('error')
+          .should('exist')
+        cy.get('button[disabled]')
+          .contains('Save')
+          .should('exist')
+      })
+
+      // Replace Temperature Module
+      cy.openFilePage()
+      cy.get('h4')
+        .contains('Temperature')
+        .parent()
+        .within(() => {
+          cy.get('button')
+            .contains('add')
+            .click()
+        })
+      cy.get(editModuleModal).within(() => {
+        cy.get('select[disabled]')
+          .contains('Slot 3')
+          .should('exist')
+        cy.get(moduleModelDropdown).select('GEN2')
+        cy.get('select[disabled]').should('not.exist')
+        cy.get('button')
+          .contains('save')
+          .click()
+      })
+      cy.get('h4')
+        .contains('Temperature')
+        .parent()
+        .within(() => {
+          cy.contains('Slot 3').should('exist')
+          cy.contains('remove').should('exist')
+          cy.contains('Edit').should('exist')
+        })
+
+      // Resolve Timeline Errors
+      cy.openDesignPage()
+      cy.get('h3')
+        .contains('1. temperature', { matchCase: false })
+        .click()
+      cy.get(designPageModal).within(() => {
+        cy.get('select').select('TEMP Temp Deck Block')
+        cy.get(alertTitleContainer).should('not.exist')
+        cy.get('button[disabled]').should('not.exist')
+        cy.get(defaultTextInput + '[value="37"]').should('exist')
+        cy.get('button')
+          .contains('Save')
+          .click()
+      })
+      cy.get('h3')
+        .contains('2. pause', { matchCase: false })
+        .click()
+      cy.get(designPageModal).within(() => {
+        cy.get('select').select('TEMP Temp Deck Block')
+        cy.get(alertTitleContainer).should('not.exist')
+        cy.get('button[disabled]').should('not.exist')
+        cy.get(defaultTextInput + '[value="37"]').should('exist')
+        cy.get('button')
+          .contains('Save')
+          .click()
+      })
+      cy.get('h3')
+        .contains('8. temperature', { matchCase: false })
+        .click()
+      cy.get(designPageModal).within(() => {
+        cy.get('select').select('TEMP Temp Deck Block')
+        cy.get(alertTitleContainer).should('not.exist')
+        cy.get('button[disabled]').should('not.exist')
+        cy.get(defaultTextInput + '[value="4"]').should('exist')
+        cy.get('button')
+          .contains('Save')
+          .click()
+      })
+      cy.get('h3')
+        .contains('9. pause', { matchCase: false })
+        .click()
+      cy.get(designPageModal).within(() => {
+        cy.get('select').select('TEMP Temp Deck Block')
+        cy.get(alertTitleContainer).should('not.exist')
+        cy.get('button[disabled]').should('not.exist')
+        cy.get(defaultTextInput + '[value="4"]').should('exist')
+        cy.get('button')
+          .contains('Save')
+          .click()
+      })
+    })
+  })
+})

--- a/protocol-designer/cypress/integration/newProtocolWithModules.spec.js
+++ b/protocol-designer/cypress/integration/newProtocolWithModules.spec.js
@@ -50,12 +50,14 @@ describe('Protocols with Modules', () => {
       // Add modules
       cy.contains('Magnetic').should('exist')
       cy.contains('Temperature').should('exist')
+      // force option used because checkbox is hidden
       cy.get('input[name="modulesByType.magneticModuleType.onDeck"]').click({
         force: true,
       })
       cy.get('select[name="modulesByType.magneticModuleType.model"]').select(
         'GEN1'
       )
+      // force option used because checkbox is hidden
       cy.get('input[name="modulesByType.temperatureModuleType.onDeck"]').click({
         force: true,
       })
@@ -130,6 +132,7 @@ describe('Protocols with Modules', () => {
       cy.openDesignPage()
       // close "setting up" modal
       cy.contains('Setting up your protocol').should('exist')
+      // force option used because checkbox is hidden
       cy.get('input[type="checkbox"]').click({ force: true })
       cy.get('button')
         .contains('ok')
@@ -325,6 +328,7 @@ describe('Protocols with Modules', () => {
         .contains('pause')
         .should('exist')
       cy.get(designPageModal).within(() => {
+        // force option used because this radio input is hidden
         cy.get('input[value="untilTemperature"]').click({ force: true })
         cy.contains('Module', { matchCase: false }).should('exist')
         cy.contains('Temp', { matchCase: false }).should('exist')
@@ -392,7 +396,7 @@ describe('Protocols with Modules', () => {
           [class*="StepEditForm__section_column"]:nth-child(2)`
         )
           .contains('mix', { matchCase: false })
-          .click({ force: true })
+          .click({ force: true }) // force option used because checkbox is hidden
         cy.get('input[name="dispense_wells"]').click()
         cy.get('[data-wellname="A1"]').click()
         cy.get('button')
@@ -446,6 +450,7 @@ describe('Protocols with Modules', () => {
       // Add Pause Step for Time
       cy.addStep('pause')
       cy.get(designPageModal).within(() => {
+        // force option used because radio input is hidden
         cy.get('input[value="untilTime"]').click({ force: true })
         cy.contains('h').should('exist')
         cy.contains('m').should('exist')
@@ -503,7 +508,7 @@ describe('Protocols with Modules', () => {
           [class*="StepEditForm__section_column"]:nth-child(2)`
         )
           .contains('mix', { matchCase: false })
-          .click({ force: true })
+          .click({ force: true }) // force option used because checkbox is hidden
         cy.get('input[name="dispense_wells"]').click()
         cy.get('[data-wellname="A2"]').click()
         cy.get('button')

--- a/protocol-designer/cypress/integration/settings.spec.js
+++ b/protocol-designer/cypress/integration/settings.spec.js
@@ -3,6 +3,7 @@ describe('The Settings Page', () => {
 
   before(() => {
     cy.visit('/')
+    localStorage.setItem('root.featureFlags.flags', '{"PRERELEASE_MODE":true}')
   })
 
   it('displays the announcement modal and clicks "GOT IT!" to close it', () => {
@@ -125,6 +126,60 @@ describe('The Settings Page', () => {
       .and('match', /toggled_off/)
   })
 
+  it("contains a 'disable module placement restrictions' toggle in the experimental settings card", () => {
+    // It's toggled off by default
+    cy.contains('Disable module')
+      .next()
+      .should('have.attr', 'class')
+      .and('match', /toggled_off/)
+    // Click it
+    cy.contains('Disable module')
+      .next()
+      .click()
+    // We have to confirm this one
+    cy.contains('Switching on an experimental feature').should('exist')
+    cy.get('button')
+      .contains('Cancel')
+      .should('exist')
+    cy.get('button')
+      .contains('Continue')
+      .should('exist')
+    // Abort!
+    cy.get('button')
+      .contains('Cancel')
+      .click()
+    // Still toggled off
+    cy.contains('Disable module')
+      .next()
+      .should('have.attr', 'class')
+      .and('match', /toggled_off/)
+    // Click it again and confirm
+    cy.contains('Disable module')
+      .next()
+      .click()
+    cy.get('button')
+      .contains('Continue')
+      .click()
+    // Now it's toggled on
+    cy.contains('Disable module')
+      .next()
+      .should('have.attr', 'class')
+      .and('match', /toggled_on/)
+    // Click it again
+    cy.contains('Disable module')
+      .next()
+      .click()
+    // We have to confirm to turn it off
+    cy.get('button')
+      .contains('Continue')
+      .click()
+    // Now it's toggled off again
+    cy.contains('Disable module')
+      .next()
+      .should('have.attr', 'class')
+      .and('match', /toggled_off/)
+  })
+
   it('remembers when we enable things', () => {
     // Enable a button
     // We're not using the privacy button because that
@@ -137,7 +192,9 @@ describe('The Settings Page', () => {
       .contains('Continue')
       .click()
     // Leave the settings page
-    cy.get("button[class*='navbar__tab__']").contains('FILE')
+    cy.get("button[class*='navbar__tab__']")
+      .contains('FILE')
+      .click()
     // Go back to settings
     cy.get("button[class*='navbar__tab__']")
       .contains('Settings')

--- a/protocol-designer/cypress/integration/settings.spec.js
+++ b/protocol-designer/cypress/integration/settings.spec.js
@@ -10,9 +10,7 @@ describe('The Settings Page', () => {
   })
 
   it('contains a working settings button', () => {
-    cy.get("button[class*='navbar__tab__']")
-      .contains('Settings')
-      .click()
+    cy.openSettingsPage()
     cy.contains('App Settings')
   })
 
@@ -195,9 +193,7 @@ describe('The Settings Page', () => {
       .contains('FILE')
       .click()
     // Go back to settings
-    cy.get("button[class*='navbar__tab__']")
-      .contains('Settings')
-      .click()
+    cy.openSettingsPage()
     // The toggle is still on
     cy.contains(exptlSettingText)
       .next()
@@ -219,9 +215,7 @@ describe('The Settings Page', () => {
     // Leave the settings page
     cy.get("button[class*='navbar__tab__']").contains('FILE')
     // Go back to settings
-    cy.get("button[class*='navbar__tab__']")
-      .contains('Settings')
-      .click()
+    cy.openSettingsPage()
     // The toggle is still off
     cy.contains(exptlSettingText)
       .next()

--- a/protocol-designer/cypress/integration/settings.spec.js
+++ b/protocol-designer/cypress/integration/settings.spec.js
@@ -3,7 +3,6 @@ describe('The Settings Page', () => {
 
   before(() => {
     cy.visit('/')
-    localStorage.setItem('root.featureFlags.flags', '{"PRERELEASE_MODE":true}')
   })
 
   it('displays the announcement modal and clicks "GOT IT!" to close it', () => {

--- a/protocol-designer/cypress/support/commands.js
+++ b/protocol-designer/cypress/support/commands.js
@@ -33,3 +33,86 @@ Cypress.Commands.add('closeAnnouncementModal', () => {
     .contains('Got It!')
     .click()
 })
+
+//
+// File Page Actions
+//
+Cypress.Commands.add('openFilePage', () => {
+  cy.get('button')
+    .contains('FILE')
+    .click()
+})
+
+//
+// Pipette Page Actions
+//
+Cypress.Commands.add('choosePipettes', (left, right) => {
+  cy.contains('Left Pipette')
+    .next()
+    .contains('None')
+    .click()
+  cy.contains('Left Pipette')
+    .next()
+    .contains(left)
+    .click()
+  cy.contains('Right Pipette')
+    .next()
+    .contains('None')
+    .click()
+  cy.contains('Right Pipette')
+    .next()
+    .contains(right)
+    .click()
+})
+
+Cypress.Commands.add('selectTipRacks', (left, right) => {
+  cy.get("select[name*='left.tiprack']").select(left)
+  cy.get("select[name*='right.tiprack']").select(right)
+})
+
+//
+// Liquid Page Actions
+//
+Cypress.Commands.add(
+  'addLiquid',
+  (liquidName, liquidDesc, serializeLiquid = false) => {
+    cy.get('button')
+      .contains('New Liquid')
+      .click()
+    cy.get("input[name='name']").type(liquidName)
+    cy.get("input[name='description']").type(liquidDesc)
+    if (serializeLiquid) {
+      cy.get("input[name='serialize']").check({ force: true })
+    }
+    cy.get('button')
+      .contains('save')
+      .click()
+  }
+)
+
+//
+// Design Page Actions
+//
+Cypress.Commands.add('openDesignPage', () => {
+  cy.get("button[class*='navbar__tab__']")
+    .contains('DESIGN')
+    .parent()
+    .click()
+})
+Cypress.Commands.add('addStep', stepName => {
+  cy.get('button')
+    .contains('Add Step')
+    .click()
+  cy.get('button')
+    .contains(stepName, { matchCase: false })
+    .click()
+})
+
+//
+// Settings Page Actions
+//
+Cypress.Commands.add('openSettingsPage', () => {
+  cy.get('button')
+    .contains('Settings')
+    .click()
+})

--- a/protocol-designer/cypress/support/commands.js
+++ b/protocol-designer/cypress/support/commands.js
@@ -38,7 +38,7 @@ Cypress.Commands.add('closeAnnouncementModal', () => {
 // File Page Actions
 //
 Cypress.Commands.add('openFilePage', () => {
-  cy.get('button')
+  cy.get('button[class*="navbar__tab__"]')
     .contains('FILE')
     .click()
 })
@@ -46,6 +46,7 @@ Cypress.Commands.add('openFilePage', () => {
 //
 // Pipette Page Actions
 //
+// TODO(SA 2020/04/14): Update this command to use better pipette selectors
 Cypress.Commands.add('choosePipettes', (left, right) => {
   cy.contains('Left Pipette')
     .next()
@@ -82,6 +83,7 @@ Cypress.Commands.add(
     cy.get("input[name='name']").type(liquidName)
     cy.get("input[name='description']").type(liquidDesc)
     if (serializeLiquid) {
+      // force option used because checkbox is hidden
       cy.get("input[name='serialize']").check({ force: true })
     }
     cy.get('button')
@@ -94,7 +96,7 @@ Cypress.Commands.add(
 // Design Page Actions
 //
 Cypress.Commands.add('openDesignPage', () => {
-  cy.get("button[class*='navbar__tab__']")
+  cy.get('button[class*="navbar__tab__"]')
     .contains('DESIGN')
     .parent()
     .click()
@@ -112,7 +114,7 @@ Cypress.Commands.add('addStep', stepName => {
 // Settings Page Actions
 //
 Cypress.Commands.add('openSettingsPage', () => {
-  cy.get('button')
+  cy.get('button[class*="navbar__tab__"]')
     .contains('Settings')
     .click()
 })


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

This PR closes #5321 by adding E2E tests for Modules in PD. This PR leans heavily on @Kadee80's Modules in PD [testing script](https://coda.io/d/PD-Testing-Script-Happy-Path_dCWXIDxlcsE/PD-Modules-Testing-Script_suaLi?loginToken=eyJjc3JmVG9rZW4iOiJLSmNYUjlCMWs4RFZDNkRDIiwiZXhwaXJ5TXNlYyI6MTU4NTg2NTMxMzc4M30#_luQlu) for direction. The bulk of this PR is a long protocol test that creates a new protocol test with pipettes, modules, liquids, and various steps. Note, there are quite a few unsavory selector in these tests, and I will be a compiling a list of elements which will need better selectors that we can add over time. 

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

Added tests:

- Toggle on/off "Disable module placement restriction" experimental setting
- Create a protocol file with modules
- Add liquids
- Add labware to deck and modules
- Add Temperature step w/out auto generated pause
- Add Pause step (until temp)
- Add Transfer step with mix
- Add Engage Magnet step (engage)
- Add Another Transfer step
- Add Disengage Magnet step (disengage)
- Add Temperature step w/ auto generated pause
- Delete and Replace Modules

Tests that were de-prioritized and not included in this PR:

- Any checks of hover states
- Any movement of labware between slots

## review requests

<!--
  Describe any requests for your reviewers here.
-->

- [ ] Code review
- [ ] Test readability


## risk assessment

<!--
  Carefully go over your pull request and look at the other parts of the
  codebase it may affect. Look for the possibility, even if you think it's
  small, that your change may affect some other part of the system - for
  instance, changing return tip behavior in protocol may also change the
  behavior of labware calibration.

  Identify the other parts of the system your codebase may affect, so that in
  addition to your own review and testing, other people who may not have
  the system internalized as much as you can focus their attention and testing
  there.
-->
Low, just adding E2E tests
