### PR TITLE
refactor(protocol-designer): Use new complib tooltip component

### DIFF
--- a/components/src/buttons/Button.js
+++ b/components/src/buttons/Button.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import cx from 'classnames'
 import omit from 'lodash/omit'
 
-import type { HoverTooltipHandlers } from '../tooltips'
+// import type { HoverTooltipHandlers } from '../tooltips'
 import { Icon, type IconName } from '../icons'
 import styles from './buttons.css'
 
@@ -40,7 +40,13 @@ export type ButtonProps = {
   /** custom element or component to use instead of `<button>` */
   Component?: string | React.AbstractComponent<any>,
   /** handlers for HoverTooltipComponent */
-  hoverTooltipHandlers?: ?HoverTooltipHandlers,
+  hoverTooltipHandlers?: ?$Shape<{
+    ref: (Element | null) => mixed,
+    'aria-describedby': string,
+    onMouseEnter: () => mixed,
+    onMouseLeave: () => mixed,
+    ...
+  }>,
   /** html tabindex property */
   tabIndex?: number,
 }

--- a/components/src/buttons/Button.js
+++ b/components/src/buttons/Button.js
@@ -3,7 +3,6 @@ import * as React from 'react'
 import cx from 'classnames'
 import omit from 'lodash/omit'
 
-// import type { HoverTooltipHandlers } from '../tooltips'
 import { Icon, type IconName } from '../icons'
 import styles from './buttons.css'
 

--- a/components/src/tooltips/types.js
+++ b/components/src/tooltips/types.js
@@ -41,7 +41,7 @@ export type UseTooltipOptions = $Shape<{|
 |}>
 
 export type UseTooltipResultTargetProps = {|
-  ref: (HTMLElement | null) => mixed,
+  ref: (Element | null) => mixed,
   'aria-describedby': string,
 |}
 

--- a/protocol-designer/src/components/StepCreationButton.js
+++ b/protocol-designer/src/components/StepCreationButton.js
@@ -71,7 +71,7 @@ function StepCreationButtonComponent(props: Props) {
 
             const buttonProps = {
               disabled: disabled,
-              onClick: () => onClick,
+              onClick: onClick,
               stepType: stepType,
             }
             return <StepButtonItem {...buttonProps} key={stepType} />
@@ -82,7 +82,7 @@ function StepCreationButtonComponent(props: Props) {
 }
 
 type ItemProps = {
-  onClick: () => mixed,
+  onClick?: (SyntheticMouseEvent<>) => mixed,
   disabled: boolean,
   stepType: string,
 }
@@ -108,9 +108,7 @@ function StepButtonItem(props: ItemProps) {
       >
         {i18n.t(`application.stepType.${stepType}`, stepType)}
       </PrimaryButton>
-      <Tooltip key={stepType} {...tooltipProps}>
-        {tooltipMessage}
-      </Tooltip>
+      <Tooltip {...tooltipProps}>{tooltipMessage}</Tooltip>
     </>
   )
 }

--- a/protocol-designer/src/components/StepCreationButton.js
+++ b/protocol-designer/src/components/StepCreationButton.js
@@ -2,7 +2,14 @@
 import * as React from 'react'
 import { connect } from 'react-redux'
 import cx from 'classnames'
-import { HoverTooltip, PrimaryButton } from '@opentrons/components'
+import {
+  Tooltip,
+  PrimaryButton,
+  useHoverTooltip,
+  TOOLTIP_RIGHT,
+  TOOLTIP_FIXED,
+} from '@opentrons/components'
+
 import {
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
@@ -33,77 +40,79 @@ type Props = {|
   ...DP,
 |}
 
-type State = { expanded?: boolean }
+function StepCreationButtonComponent(props: Props) {
+  const [expanded, setExpanded] = React.useState(false)
 
-class StepCreationButtonComponent extends React.Component<Props, State> {
-  state = { expanded: false }
+  // TODO: Ian 2019-01-17 move out to centralized step info file - see #2926
+  const supportedSteps = [
+    'moveLiquid',
+    'mix',
+    'pause',
+    'magnet',
+    'temperature',
+    'thermocycler',
+  ]
+  const { isStepTypeEnabled } = props
 
-  handleExpandClick = (e: SyntheticEvent<>) => {
-    this.setState({ expanded: !this.state.expanded })
-  }
+  return (
+    <div
+      className={styles.list_item_button}
+      onMouseLeave={() => setExpanded(false)}
+    >
+      <PrimaryButton onClick={() => setExpanded(true)}>
+        {i18n.t('button.add_step')}
+      </PrimaryButton>
 
-  handleMouseLeave = (e: SyntheticEvent<>) => {
-    this.setState({ expanded: false })
-  }
+      <div className={styles.buttons_popover}>
+        {expanded &&
+          supportedSteps.map(stepType => {
+            const disabled = !isStepTypeEnabled[stepType]
+            const onClick = !disabled ? props.makeAddStep(stepType) : () => null
 
-  render() {
-    // TODO: Ian 2019-01-17 move out to centralized step info file - see #2926
-    const supportedSteps = [
-      'moveLiquid',
-      'mix',
-      'pause',
-      'magnet',
-      'temperature',
-      'thermocycler',
-    ]
-    const { isStepTypeEnabled } = this.props
-
-    return (
-      <div
-        className={styles.list_item_button}
-        onMouseLeave={this.handleMouseLeave}
-      >
-        <PrimaryButton onClick={this.handleExpandClick}>
-          {i18n.t('button.add_step')}
-        </PrimaryButton>
-
-        <div className={styles.buttons_popover}>
-          {this.state.expanded &&
-            supportedSteps.map(stepType => {
-              const disabled = !isStepTypeEnabled[stepType]
-              const tooltipMessage = disabled
-                ? i18n.t(`tooltip.disabled_module_step`)
-                : i18n.t(`tooltip.step_description.${stepType}`)
-              const onClick = !disabled
-                ? this.props.makeAddStep(stepType)
-                : () => null
-              return (
-                <HoverTooltip
-                  key={stepType}
-                  placement="right"
-                  modifiers={{ preventOverflow: { enabled: false } }}
-                  positionFixed
-                  tooltipComponent={tooltipMessage}
-                >
-                  {hoverTooltipHandlers => (
-                    <PrimaryButton
-                      hoverTooltipHandlers={hoverTooltipHandlers}
-                      onClick={onClick}
-                      iconName={stepIconsByType[stepType]}
-                      className={cx({
-                        [styles.step_button_disabled]: disabled,
-                      })}
-                    >
-                      {i18n.t(`application.stepType.${stepType}`, stepType)}
-                    </PrimaryButton>
-                  )}
-                </HoverTooltip>
-              )
-            })}
-        </div>
+            const buttonProps = {
+              disabled: disabled,
+              onClick: () => onClick,
+              stepType: stepType,
+            }
+            return <StepButtonItem {...buttonProps} key={stepType} />
+          })}
       </div>
-    )
-  }
+    </div>
+  )
+}
+
+type ItemProps = {
+  onClick: () => mixed,
+  disabled: boolean,
+  stepType: string,
+}
+
+function StepButtonItem(props: ItemProps) {
+  const { onClick, disabled, stepType } = props
+  const [targetProps, tooltipProps] = useHoverTooltip({
+    placement: TOOLTIP_RIGHT,
+    strategy: TOOLTIP_FIXED,
+  })
+  const tooltipMessage = disabled
+    ? i18n.t(`tooltip.disabled_module_step`)
+    : i18n.t(`tooltip.step_description.${stepType}`)
+  return (
+    <>
+      <PrimaryButton
+        hoverTooltipHandlers={targetProps}
+        onClick={onClick}
+        iconName={stepIconsByType[stepType]}
+        className={cx({
+          [styles.step_button_disabled]: disabled,
+        })}
+      >
+        {i18n.t(`application.stepType.${stepType}`, stepType)}
+      </PrimaryButton>
+      <Tooltip key={stepType} {...tooltipProps}>
+        {tooltipMessage}
+      </Tooltip>
+    </>
+  )
 }
 
 const mapSTP = (state: BaseState): SP => {

--- a/protocol-designer/src/components/listButtons.css
+++ b/protocol-designer/src/components/listButtons.css
@@ -1,7 +1,7 @@
 @import '@opentrons/components';
 
 .list_item_button {
-  z-index: 5;
+  z-index: 11;
   position: relative;
   padding: 1rem 2rem 1.25rem 2rem;
 }


### PR DESCRIPTION
## overview

closes #5386 by refactoring the tooltips from the older deprecated tooltip with Mikes shiny new one! By doing so we fixed a lot of styling issued that arose.

## changelog

- refactor(protocol-designer): Use new complib tooltip component
- refactor(components): Update types in Buttons.js so that it works with refs/new tooltips properly

## review requests

- [ ] Tooltips for step creation buttons are all now centered on the proper button
- [ ] Nothing in App/PD broke with tooltips!

## risk assessment
Low? This is implementing the new tooltip in one spot in PD and should NOT affect older instances anywhere.
