### PR TITLE
feat(robot-server): make fastapi return v1 style errors

### DIFF
--- a/robot-server/tests/service/routers/test_item.py
+++ b/robot-server/tests/service/routers/test_item.py
@@ -61,26 +61,7 @@ def test_create_item_with_attribute_validation_error(api_client):
     )
     assert response.status_code == HTTP_422_UNPROCESSABLE_ENTITY
     assert response.json() == {
-      'errors': [{
-          'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
-          'title': 'value_error.missing',
-          'detail': 'field required',
-          'source': {
-            'pointer': '/body/item_request/data/attributes/name',
-          }
-      }, {
-          'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
-          'title': 'value_error.missing',
-          'detail': 'field required',
-          'source': {
-            'pointer': '/body/item_request/data/attributes/quantity',
-          }
-      }, {
-          'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
-          'title': 'value_error.missing',
-          'detail': 'field required',
-          'source': {
-            'pointer': '/body/item_request/data/attributes/price',
-          }
-      }]
+      'message': "item_request.data.attributes.name: field required. "
+                 "item_request.data.attributes.quantity: field required. "
+                 "item_request.data.attributes.price: field required"
     }

--- a/robot-server/tests/service/test_main.py
+++ b/robot-server/tests/service/test_main.py
@@ -1,0 +1,36 @@
+from http import HTTPStatus
+
+
+def test_custom_http_exception_handler(api_client):
+
+    expected = {
+        'message': HTTPStatus.METHOD_NOT_ALLOWED.phrase
+    }
+    resp = api_client.post('/health')
+    text = resp.json()
+    assert resp.status_code == HTTPStatus.METHOD_NOT_ALLOWED
+    assert text == expected
+
+
+def test_custom_request_validation_exception_handler(api_client):
+
+    expected = {
+        "message": "operation.command: value is not a valid enumeration "
+                   "member; permitted: 'jog', 'move', 'save xy', 'attach tip',"
+                   " 'detach tip', 'save z', 'save transform', 'release'. "
+                   "operation.point: value is not a valid enumeration member;"
+                   " permitted: '1', '2', '3', 'safeZ', 'attachTip'"
+    }
+    resp = api_client.post('/calibration/deck',
+                           json={
+                               "token": "1fdec5cc-234a-11ea-b24d-f2189817b27e",
+                               "command": 123,  # Invalid command
+                               "tipLength": 0,
+                               "point": "true",  # Invalid point
+                               "axis": "x",
+                               "direction": 1,
+                               "step": 0}
+                           )
+    text = resp.json()
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert text == expected


### PR DESCRIPTION
Closes #5285

## overview
To keep compatibility with APIv1, this PR makes fastAPI exception handlers return errors in API v1 style (i.e. in {'message': 'error_string' } format)

Helper functions for API v2 error formatting are left untouched for future use.

## changelog
- Added reformatting of errors to `/service/main.py`
- Added new tests: `/tests/service/test-main.py`
- Updated test in `/service/routers/test_item.py`

## review requests

- Does the code look good?
- Check if you get expected responses to requests
- Does this need more tests? 

## risk assessment
Low- Impacts only error responses
