### PR TITLE
feat(protocol-designer): hide tooltip when slot dropdown enabled

### DIFF
--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -290,7 +290,9 @@ export const EditModulesModal = (props: EditModulesProps) => {
                       <>
                         <HoverTooltip
                           placement="top"
-                          tooltipComponent={slotOptionTooltip}
+                          tooltipComponent={
+                            !enableSlotSelection ? slotOptionTooltip : null
+                          }
                         >
                           {hoverTooltipHandlers => (
                             <div


### PR DESCRIPTION
## overview

Closes #5385

## changelog


## review requests

- Disabling the "Slot" dropdown in EditModuleModal should show the tooltip
- Enabling it (either by selecting GEN2 or by turning on Disable Module Restrictions setting) should hide the tooltip
- Modal form still works the same

## risk assessment

low, only PD