### PR TITLE
fix(protocol-designer): Unify pause step item spacing

### DIFF
--- a/protocol-designer/src/components/steplist/PauseStepItems.js
+++ b/protocol-designer/src/components/steplist/PauseStepItems.js
@@ -23,13 +23,13 @@ export function PauseStepItems(props: Props) {
             <span>Pause for Time</span>
           </li>
           <li className={styles.substep_content}>
-            <span>
+            <span className={styles.substep_time}>
               {hours} {i18n.t('application.units.hours')}
             </span>
-            <span>
+            <span className={styles.substep_time}>
               {minutes} {i18n.t('application.units.minutes')}
             </span>
-            <span>
+            <span className={styles.substep_time}>
               {seconds} {i18n.t('application.units.seconds')}
             </span>
           </li>

--- a/protocol-designer/src/components/steplist/StepItem.css
+++ b/protocol-designer/src/components/steplist/StepItem.css
@@ -58,6 +58,10 @@
   font-size: var(--fs-caption);
   text-transform: uppercase;
   justify-content: space-between;
+
+  &:last-child {
+    padding-bottom: 1.25rem;
+  }
 }
 
 .substep_content {
@@ -73,6 +77,10 @@
   &:last-child {
     padding-bottom: 1.25rem;
   }
+}
+
+.substep_time {
+  margin-right: 1rem;
 }
 
 .module_substep_value {


### PR DESCRIPTION
## overview

This PR closes #5387 by unifying the pause step item content spacing.
<img width="298" alt="Screen Shot 2020-04-10 at 10 28 13 AM" src="https://user-images.githubusercontent.com/3430313/78998397-83442680-7b16-11ea-9ff9-1e9bf024ce65.png">

## changelog

- fix(protocol-designer): Unify pause step item spacing

## review requests

Make all 3 variations of pause steps with and without messages to display
- [ ] No weird spacing!

## risk assessment

Low, CSS in PD only
