### PR TITLE
refactor(api): load v1 singletons lazily

### DIFF
--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -1,22 +1,15 @@
+import importlib
+import json
 import os
 import sys
-import json
+
+version = sys.version_info[0:2]
+if version < (3, 7):
+    raise RuntimeError(
+        'opentrons requires Python 3.7 or above, this is {0}.{1}'.format(
+            version[0], version[1]))
+
 HERE = os.path.abspath(os.path.dirname(__file__))
-from opentrons import config  # noqa(E402)
-from opentrons.data_storage import database_migration  # noqa(E402)
-
-if os.environ.get('OT_UPDATE_SERVER') != 'true':
-    database_migration.check_version_and_perform_full_migration()
-
-
-from .legacy_api.api import (robot,   # noqa(E402)
-                             reset,
-                             instruments,
-                             containers,
-                             labware,
-                             modules)
-names_list = [
-    'containers', 'instruments', 'robot', 'reset', 'modules', 'labware']
 
 try:
     with open(os.path.join(HERE, 'package.json')) as pkg:
@@ -25,11 +18,34 @@ try:
 except (FileNotFoundError, OSError):
     __version__ = 'unknown'
 
-version = sys.version_info[0:2]
-if version < (3, 5):
-    raise RuntimeError(
-        'opentrons requires Python 3.5 or above, this is {0}.{1}'.format(
-            version[0], version[1]))
+from opentrons import config  # noqa(E402)
+
+LEGACY_MODULES = [
+    'robot', 'reset', 'instruments', 'containers', 'labware', 'modules']
+
+__all__ = ['version', 'HERE', 'LEGACY_MODULES', 'config']
 
 
-__all__ = ['__version__', 'HERE'] + names_list
+def __getattr__(attrname):
+    """
+    Lazily load the robot singleton and friends to make importing faster
+
+    The first time somebody does opentrons.robot (or any other v1 "module"
+    that is actually a singleton), this will fire because the attr doesn't
+    exist, and we'll import and initialize all the singletons. Subsequently
+    this function won't be invoked.
+    """
+    if attrname in LEGACY_MODULES:
+        legacy_api = importlib.import_module(
+            '.'.join([__name__,
+                      'legacy_api',
+                      'api']))
+        for mod in LEGACY_MODULES:
+            setattr(sys.modules[__name__], attrname,
+                    getattr(legacy_api, attrname))
+        return getattr(sys.modules[__name__], attrname)
+    raise AttributeError(attrname)
+
+
+def __dir__():
+    return sorted(__all__ + LEGACY_MODULES)

--- a/api/src/opentrons/legacy_api/__init__.py
+++ b/api/src/opentrons/legacy_api/__init__.py
@@ -1,0 +1,3 @@
+from opentrons.data_storage import database_migration
+
+database_migration.check_version_and_perform_full_migration()


### PR DESCRIPTION
One of the most important parts of supporting APIv1 is continuing to
support direct execution of protocols as scripts, protocols that look
like this:

from opentrons import robot
robot.connect()

That means that the robot singleton has to be either created in the
package init, or has to be available by normal import means through
opentrons.robot. We don't want the second because we want to sequester
apiv1 in its own little subdirectory, so we went with the first. The
problem with the first, though, is that you have to build the singleton
on any import of anything inside the opentrons package, and that's
really slow especially on a raspberry pi.

However, python 3.7 includes
[pep-562](https://www.python.org/dev/peps/pep-0562/), which allows for a
__getattr__ at module scope that behaves like its object cousin. Using
this, we can defer singleton initialization until the singleton is
actually accessed. That means that importing the top level opentrons
package becomes much faster if you don't need the robot singleton, which
is an all around improvement.

We could take this a step farther if we wanted, and only import
opentrons.robot from opentrons.api.session if somebody actually uploads
a v1 protocol. That would fully defer loading the singleton until
needed, but it would make the first v1 protocol upload after boot take
an extra 30 seconds or so.

`edge` on my macbook:
<img width="374" alt="Screen Shot 2020-04-10 at 1 35 03 PM" src="https://user-images.githubusercontent.com/3091648/79010515-1d649880-7b30-11ea-9301-16462aeac58a.png">

this branch on my macbook (ignore that it kinda says `edge`, I hadn't made the branch yet):
<img width="252" alt="Screen Shot 2020-04-10 at 1 35 27 PM" src="https://user-images.githubusercontent.com/3091648/79010533-2b1a1e00-7b30-11ea-8dd7-b98d4a824630.png">
 