### PR TITLE
fix(api): correctly set magdeck offsets

### DIFF
--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -13,8 +13,8 @@ MAX_ENGAGE_HEIGHT = {  # mm from home position
     'magneticModuleV1': 45,
     'magneticModuleV2': 25}
 OFFSET_TO_LABWARE_BOTTOM = {
-    'magneticModuleV1': 10,
-    'magneticModuleV2': 5}
+    'magneticModuleV1': 5,
+    'magneticModuleV2': 2.5}
 
 FIRST_GEN2_REVISION = 20
 


### PR DESCRIPTION
In
https://github.com/Opentrons/opentrons/pull/5330/ (f1cfb967c18fd2f43ea962cddc86e10e95e1d9f3)
we added per-model offsets for the height from base command for
magdecks. Previously, this value had been set to 5. The PR incorrectly
uses 5mm true for gen2s, and doubles it for the incorrect units for
gen1. Instead, what we need to do is use 5 (bad) mm for gen1, and 2.5 mm
true for gen2.

## Testing
This one is a bit tough to test. The easiest way is to connect the magnetic module to your computer, command the offsets (`G0Z5` on a gen1, `G0Z2.5` on a gen2 with proper firmware) and use a straightedge of some kind to check that the magnets are _roughly_ level with the labware engage plane. Keep in mind that it may not (will not) be exact because of piece-to-piece variance.

It's less important to test this on a gen1, since this commit moves to the same number we used before the commit above, but a gen2 should be tested.