### PR TITLE
feat(robot-server): return correct error format based on endpoint

### DIFF
--- a/robot-server/robot_server/service/routers/__init__.py
+++ b/robot-server/robot_server/service/routers/__init__.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter
+
+from . import health, networking, control, settings, deck_calibration, \
+    modules, pipettes, motors, camera, logs, rpc
+
+routes = APIRouter()
+
+
+routes.include_router(router=health.router, tags=["Health"])
+routes.include_router(router=networking.router, tags=["Networking"])
+routes.include_router(router=control.router, tags=["Control"])
+routes.include_router(router=settings.router, tags=["Settings"])
+routes.include_router(router=deck_calibration.router,
+                      tags=["Deck Calibration"])
+routes.include_router(router=modules.router, tags=["Modules"])
+routes.include_router(router=pipettes.router, tags=["Pipettes"])
+routes.include_router(router=motors.router, tags=["Motors"])
+routes.include_router(router=camera.router, tags=["Camera"])
+routes.include_router(router=logs.router, tags=["Logs"])
+routes.include_router(router=rpc.router, tags=["RPC"])

--- a/robot-server/tests/service/routers/test_item.py
+++ b/robot-server/tests/service/routers/test_item.py
@@ -61,7 +61,26 @@ def test_create_item_with_attribute_validation_error(api_client):
     )
     assert response.status_code == HTTP_422_UNPROCESSABLE_ENTITY
     assert response.json() == {
-      'message': "item_request.data.attributes.name: field required. "
-                 "item_request.data.attributes.quantity: field required. "
-                 "item_request.data.attributes.price: field required"
+        'errors': [{
+            'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
+            'title': 'value_error.missing',
+            'detail': 'field required',
+            'source': {
+                'pointer': '/body/item_request/data/attributes/name',
+            }
+        }, {
+            'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
+            'title': 'value_error.missing',
+            'detail': 'field required',
+            'source': {
+                'pointer': '/body/item_request/data/attributes/quantity',
+            }
+        }, {
+            'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
+            'title': 'value_error.missing',
+            'detail': 'field required',
+            'source': {
+                'pointer': '/body/item_request/data/attributes/price',
+            }
+        }]
     }


### PR DESCRIPTION
## overview

Fastapi exception handling middleware is applied to the entire application. We want legacy v1 endpoints to return errors with the format `{"message": "error string"}` while future v2 endpoints return a more complete JSON API inspired schema.

This means the middleware handling http and validation errors needs to know how to format the response.

The approach is to use an Openapi tag (`v1`) for legacy API. This has the benefit of labeling these endpoints as legacy in docs. 

## changelog

- Put all v1 routers into a single router.
- Add those routes with a `v1` tag.
- Add function to find whether tag exists on request endpoint. 

## review requests

Is this a reasonable approach to distinguishing v1 endpoints?  Is it too hacky?

Alternatives could be:
- a custom router that attaches a field to the `state` variable of a request.
- pick apart the `endpoint` function for it's packaging info and make the determination there.

## risk assessment

None. No effect on production code.

closes #5401 