### PR TITLE
test(labware-library): add load-save e2e test for labware creator

### DIFF
--- a/labware-library/cypress/fixtures/TestLabwareProtocol.py
+++ b/labware-library/cypress/fixtures/TestLabwareProtocol.py
@@ -1,0 +1,119 @@
+import json
+from opentrons import protocol_api, types
+
+CALIBRATION_CROSS_COORDS = {
+    '1': {
+        'x': 12.13,
+        'y': 9.0,
+        'z': 0.0
+    },
+    '3': {
+        'x': 380.87,
+        'y': 9.0,
+        'z': 0.0
+    },
+    '7': {
+        'x': 12.13,
+        'y': 258.0,
+        'z': 0.0
+    }
+}
+CALIBRATION_CROSS_SLOTS = ['1', '3', '7']
+TEST_LABWARE_SLOT = '3'
+
+RATE = 0.25  # % of default speeds
+SLOWER_RATE = 0.1
+
+PIPETTE_MOUNT = 'right'
+PIPETTE_NAME = 'p10_single'
+
+TIPRACK_SLOT = '5'
+TIPRACK_LOADNAME = 'opentrons_96_tiprack_20ul'
+
+LABWARE_DEF_JSON = """{"ordering":[["A1","B1","C1"],["A2","B2","C2"],["A3","B3","C3"],["A4","B4","C4"],["A5","B5","C5"]],"brand":{"brand":"TestPro","brandId":["001"]},"metadata":{"displayName":"TestPro 15 Well Plate 5 µL","displayCategory":"wellPlate","displayVolumeUnits":"µL","tags":[]},"dimensions":{"xDimension":127,"yDimension":85,"zDimension":5},"wells":{"A1":{"depth":5,"totalLiquidVolume":5,"shape":"circular","diameter":5,"x":10,"y":75,"z":0},"B1":{"depth":5,"totalLiquidVolume":5,"shape":"circular","diameter":5,"x":10,"y":50,"z":0},"C1":{"depth":5,"totalLiquidVolume":5,"shape":"circular","diameter":5,"x":10,"y":25,"z":0},"A2":{"depth":5,"totalLiquidVolume":5,"shape":"circular","diameter":5,"x":35,"y":75,"z":0},"B2":{"depth":5,"totalLiquidVolume":5,"shape":"circular","diameter":5,"x":35,"y":50,"z":0},"C2":{"depth":5,"totalLiquidVolume":5,"shape":"circular","diameter":5,"x":35,"y":25,"z":0},"A3":{"depth":5,"totalLiquidVolume":5,"shape":"circular","diameter":5,"x":60,"y":75,"z":0},"B3":{"depth":5,"totalLiquidVolume":5,"shape":"circular","diameter":5,"x":60,"y":50,"z":0},"C3":{"depth":5,"totalLiquidVolume":5,"shape":"circular","diameter":5,"x":60,"y":25,"z":0},"A4":{"depth":5,"totalLiquidVolume":5,"shape":"circular","diameter":5,"x":85,"y":75,"z":0},"B4":{"depth":5,"totalLiquidVolume":5,"shape":"circular","diameter":5,"x":85,"y":50,"z":0},"C4":{"depth":5,"totalLiquidVolume":5,"shape":"circular","diameter":5,"x":85,"y":25,"z":0},"A5":{"depth":5,"totalLiquidVolume":5,"shape":"circular","diameter":5,"x":110,"y":75,"z":0},"B5":{"depth":5,"totalLiquidVolume":5,"shape":"circular","diameter":5,"x":110,"y":50,"z":0},"C5":{"depth":5,"totalLiquidVolume":5,"shape":"circular","diameter":5,"x":110,"y":25,"z":0}},"groups":[{"metadata":{"displayName":"TestPro 15 Well Plate 5 µL","displayCategory":"wellPlate","wellBottomShape":"flat"},"brand":{"brand":"TestPro","brandId":["001"]},"wells":["A1","B1","C1","A2","B2","C2","A3","B3","C3","A4","B4","C4","A5","B5","C5"]}],"parameters":{"format":"irregular","quirks":[],"isTiprack":false,"isMagneticModuleCompatible":false,"loadName":"testpro_15_wellplate_5ul"},"namespace":"custom_beta","version":1,"schemaVersion":2,"cornerOffsetFromSlot":{"x":0,"y":0,"z":0}}"""
+LABWARE_DEF = json.loads(LABWARE_DEF_JSON)
+LABWARE_LABEL = LABWARE_DEF.get('metadata', {}).get(
+    'displayName', 'test labware')
+
+metadata = {'apiLevel': '2.0'}
+
+
+def uniq(l):
+    res = []
+    for i in l:
+        if i not in res:
+            res.append(i)
+    return res
+
+def run(protocol: protocol_api.ProtocolContext):
+    tiprack = protocol.load_labware(TIPRACK_LOADNAME, TIPRACK_SLOT)
+    pipette = protocol.load_instrument(
+        PIPETTE_NAME, PIPETTE_MOUNT, tip_racks=[tiprack])
+
+    test_labware = protocol.load_labware_from_definition(
+        LABWARE_DEF,
+        TEST_LABWARE_SLOT,
+        LABWARE_LABEL,
+    )
+
+    num_cols = len(LABWARE_DEF.get('ordering', [[]]))
+    num_rows = len(LABWARE_DEF.get('ordering', [[]])[0])
+    well_locs = uniq([
+        'A1',
+        '{}{}'.format(chr(ord('A') + num_rows - 1), str(num_cols))])
+
+    pipette.pick_up_tip()
+
+    def set_speeds(rate):
+        protocol.max_speeds.update({
+            'X': (600 * rate),
+            'Y': (400 * rate),
+            'Z': (125 * rate),
+            'A': (125 * rate),
+        })
+
+        speed_max = max(protocol.max_speeds.values())
+
+        for instr in protocol.loaded_instruments.values():
+            instr.default_speed = speed_max
+
+    set_speeds(RATE)
+
+    for slot in CALIBRATION_CROSS_SLOTS:
+        coordinate = CALIBRATION_CROSS_COORDS[slot]
+        location = types.Location(point=types.Point(**coordinate),
+                                  labware=None)
+        pipette.move_to(location)
+        protocol.pause(
+            f"Confirm {PIPETTE_MOUNT} pipette is at slot {slot} calibration cross")
+
+    pipette.home()
+    protocol.pause(f"Place your labware in Slot {TEST_LABWARE_SLOT}")
+
+    for well_loc in well_locs:
+        well = test_labware.well(well_loc)
+        all_4_edges = [
+            [well._from_center_cartesian(x=-1, y=0, z=1), 'left'],
+            [well._from_center_cartesian(x=1, y=0, z=1), 'right'],
+            [well._from_center_cartesian(x=0, y=-1, z=1), 'front'],
+            [well._from_center_cartesian(x=0, y=1, z=1), 'back']
+        ]
+
+        set_speeds(RATE)
+        pipette.move_to(well.top())
+        protocol.pause("Moved to the top of the well")
+
+        for edge_pos, edge_name in all_4_edges:
+            set_speeds(SLOWER_RATE)
+            edge_location = types.Location(point=edge_pos, labware=None)
+            pipette.move_to(edge_location)
+            protocol.pause(f'Moved to {edge_name} edge')
+
+        set_speeds(RATE)
+        pipette.move_to(well.bottom())
+        protocol.pause("Moved to the bottom of the well")
+
+        pipette.blow_out(well)
+
+    set_speeds(1.0)
+    pipette.return_tip()

--- a/labware-library/cypress/integration/labware-creator/fileImport.spec.js
+++ b/labware-library/cypress/integration/labware-creator/fileImport.spec.js
@@ -1,3 +1,8 @@
+import jszip from 'jszip'
+
+const importedLabwareFile = 'TestLabwareDefinition.json'
+const pythonFileFixture = 'TestLabwareProtocol.py'
+
 context('File Import', () => {
   before(() => {
     cy.visit('/create')
@@ -6,14 +11,12 @@ context('File Import', () => {
   })
 
   it('drags in a file', () => {
-    const fileName = 'TestLabwareDefinition.json'
-
-    cy.fixture(fileName, 'utf8').then(fileJson => {
+    cy.fixture(importedLabwareFile, 'utf8').then(fileJson => {
       const fileContent = JSON.stringify(fileJson)
       cy.get('[class*="_file_drop__"]').upload(
         {
           fileContent,
-          fileName,
+          fileName: importedLabwareFile,
           mimeType: 'application/json',
           encoding: 'utf8',
         },
@@ -101,7 +104,7 @@ context('File Import', () => {
 
     // Test pipette
     cy.contains('Select...').click({ force: true })
-    cy.contains('P10 Single').click({ force: true })
+    cy.contains('P10 Single GEN1').click({ force: true })
 
     // All fields present
     cy.get('button[class*="_export_button_"]').click({ force: true })
@@ -109,7 +112,29 @@ context('File Import', () => {
       'Please resolve all invalid fields in order to export the labware definition'
     ).should('not.exist')
 
-    // Wait for the file to finish downloading. We can't control this.
-    cy.wait(1500) // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.window()
+      .its('__lastSavedBlobZip__')
+      .should('be.a', 'blob') // wait until we get the blob
+      .then(blob => jszip.loadAsync(blob)) // load blob into ZipObject
+      .then(zipObject => {
+        const jsonFiles = zipObject.file(/.*\.json$/)
+        expect(jsonFiles).to.have.lengthOf(1)
+        cy.wrap(jsonFiles[0])
+          .invoke('async', 'string')
+          .then(jsonFile => {
+            cy.fixture(importedLabwareFile).then(expected => {
+              // TODO(IL, 2020/04/13): use deep equal util from PD cypress tests
+              expect(JSON.parse(jsonFile)).to.deep.equal(expected)
+            })
+          })
+
+        const pythonFiles = zipObject.file(/.*\.py$/)
+        expect(pythonFiles).to.have.lengthOf(1)
+        cy.wrap(pythonFiles[0].async('string')).then(contents => {
+          cy.fixture(pythonFileFixture).then(expected => {
+            expect(contents).to.equal(expected)
+          })
+        })
+      })
   })
 })

--- a/labware-library/cypress/integration/labware-creator/fileImport.spec.js
+++ b/labware-library/cypress/integration/labware-creator/fileImport.spec.js
@@ -1,4 +1,5 @@
 import jszip from 'jszip'
+import { expectDeepEqual } from '@opentrons/shared-data/js/cypressUtils'
 
 const importedLabwareFile = 'TestLabwareDefinition.json'
 const pythonFileFixture = 'TestLabwareProtocol.py'
@@ -124,7 +125,7 @@ context('File Import', () => {
           .then(jsonFile => {
             cy.fixture(importedLabwareFile).then(expected => {
               // TODO(IL, 2020/04/13): use deep equal util from PD cypress tests
-              expect(JSON.parse(jsonFile)).to.deep.equal(expected)
+              expectDeepEqual(assert, JSON.parse(jsonFile), expected)
             })
           })
 

--- a/labware-library/cypress/plugins/index.js
+++ b/labware-library/cypress/plugins/index.js
@@ -7,6 +7,7 @@
 // You can read more here:
 // https://on.cypress.io/plugins-guide
 // ***********************************************************
+const webpackPreprocessor = require('@cypress/webpack-preprocessor')
 
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
@@ -14,4 +15,8 @@
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
+  on(
+    'file:preprocessor',
+    webpackPreprocessor({ webpackOptions: require('../../webpack.config') })
+  )
 }

--- a/labware-library/src/labware-creator/index.js
+++ b/labware-library/src/labware-creator/index.js
@@ -492,9 +492,15 @@ export const LabwareCreator = () => {
             `test_${displayName}.py`,
             labwareTestProtocol({ pipetteName, definition: def })
           )
-          zip
-            .generateAsync({ type: 'blob' })
-            .then(blob => saveAs(blob, `${displayName}.zip`))
+          zip.generateAsync({ type: 'blob' }).then(blob => {
+            if (global.Cypress) {
+              // HACK(IL, 2020-04-02): can't figure out a better way to do this yet
+              // https://docs.cypress.io/faq/questions/using-cypress-faq.html#Can-my-tests-interact-with-Redux-Vuex-data-store
+              global.__lastSavedBlobZip__ = blob
+            } else {
+              saveAs(blob, `${displayName}.zip`)
+            }
+          })
 
           reportEvent({
             name: 'labwareCreatorFileExport',

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@babel/preset-env": "^7.8.4",
     "@babel/preset-flow": "^7.8.3",
     "@babel/preset-react": "^7.8.3",
+    "@cypress/webpack-preprocessor": "^5.1.2",
     "ajv": "^6.10.2",
     "aws-sdk": "^2.493.0",
     "babel-eslint": "^11.0.0-beta.2",

--- a/protocol-designer/cypress/integration/migrations.spec.js
+++ b/protocol-designer/cypress/integration/migrations.spec.js
@@ -1,6 +1,6 @@
 import 'cypress-file-upload'
 import cloneDeep from 'lodash/cloneDeep'
-import { expectDeepEqual } from '../utils'
+import { expectDeepEqual } from '@opentrons/shared-data/js/cypressUtils'
 
 describe('Protocol fixtures migrate and match snapshots', () => {
   beforeEach(() => {
@@ -137,7 +137,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
               f.designerApplication.version = 'x.x.x'
             })
 
-            expectDeepEqual(savedFile, expected)
+            expectDeepEqual(assert, savedFile, expected)
           })
         })
       })

--- a/protocol-designer/cypress/plugins/index.js
+++ b/protocol-designer/cypress/plugins/index.js
@@ -7,6 +7,7 @@
 // You can read more here:
 // https://on.cypress.io/plugins-guide
 // ***********************************************************
+const webpackPreprocessor = require('@cypress/webpack-preprocessor')
 
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
@@ -14,4 +15,8 @@
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
+  on(
+    'file:preprocessor',
+    webpackPreprocessor({ webpackOptions: require('../../webpack.config') })
+  )
 }

--- a/shared-data/js/cypressUtils.js
+++ b/shared-data/js/cypressUtils.js
@@ -1,3 +1,4 @@
+// @flow
 import isEqual from 'lodash/isEqual'
 import isObject from 'lodash/isObject'
 import transform from 'lodash/transform'
@@ -18,7 +19,7 @@ const difference = (object, base) => {
 
 // deepEqual won't always return a diff, Cypress doesn't fully support object diffs :(
 // also Cypress doesn't seem to support logging to the console? So throwing the diff as an error instead
-export const expectDeepEqual = (a, b) => {
+export const expectDeepEqual = (assert: any, a: any, b: any): void => {
   try {
     assert.deepEqual(a, b)
   } catch (e) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,6 +1222,14 @@
     date-fns "^1.27.2"
     figures "^1.7.0"
 
+"@cypress/webpack-preprocessor@^5.1.2":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@cypress/webpack-preprocessor/-/webpack-preprocessor-5.1.2.tgz#9395924915ffa6a4ecc02c159007eef68d7d6532"
+  integrity sha512-Id8OQ9sRlSHhh8xXYI10jN54Mr5MHCbkD3+mu0BTMGrVFGNcWfcMc5+aOhDPlgHJ7rHp1mmaEJtpx853Fpg7lg==
+  dependencies:
+    bluebird "3.7.1"
+    debug "4.1.1"
+
 "@cypress/xvfb@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@cypress/xvfb/-/xvfb-1.2.4.tgz#2daf42e8275b39f4aa53c14214e557bd14e7748a"
@@ -4154,6 +4162,11 @@ bluebird-lst@^1.0.9:
   integrity sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==
   dependencies:
     bluebird "^3.5.5"
+
+bluebird@3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.1.tgz#df70e302b471d7473489acf26a93d63b53f874de"
+  integrity sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==
 
 bluebird@3.7.2:
   version "3.7.2"


### PR DESCRIPTION
## overview

Closes #5103 and adds e2e load-save testing to Labware Creator, ensuring that LC transforms a labware definition into fields and then into a zip in exactly the same way

## changelog

- add e2e test for labware creator - confirm loading a labware definition fixture, selecting a pipette, and saving the zip gives you a zip with a matching labware definition and a python test protocol that matches a fixture

## review requests

- [ ] You can still download a file from LC in dev/sandbox
- [ ] Affected E2E tests should pass in timely manner
- [ ] Test code looks good

## risk assessment

low, just LL. Again like for the PD E2E file load-save tests, the riskiest thing is that if somehow `window.Cypress` exists in production, downloaded files would be disabled. When we make E2E tests run in CI and edit the Makefiles, we can replace this with an env var.