### PR TITLE
ci(travis): run cypress e2e tests on build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,14 +84,13 @@ jobs:
 
     # test, build, and upload for JavaScript projects
     - stage: test
-      name: 'JS unit & E2E tests; build Protocol Designer, Labware Library, Components Library'
+      name: 'JS unit; build Protocol Designer, Labware Library, Components Library'
       # node version pulled from .nvmrc
       language: node_js
       install:
         - make install-js
       script:
         - make test-js
-        - make test-e2e
         - make lint-js
         - make circular-dependencies-js
         - make lint-css
@@ -121,6 +120,15 @@ jobs:
           local-dir: components/dist
           bucket: opentrons-components
           upload-dir: $TRAVIS_BRANCH
+
+    # E2E tests for FE JavaScript projects
+    - stage: test
+      name: 'JS E2E tests'
+      language: node_js
+      install:
+        - make install-js
+      script:
+        - make test-e2e
 
     # typecheck JavaScript projects
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,13 +84,14 @@ jobs:
 
     # test, build, and upload for JavaScript projects
     - stage: test
-      name: 'JS unit tests; build Protocol Designer, Labware Library, Components Library'
+      name: 'JS unit & E2E tests; build Protocol Designer, Labware Library, Components Library'
       # node version pulled from .nvmrc
       language: node_js
       install:
         - make install-js
       script:
         - make test-js
+        - make test-e2e
         - make lint-js
         - make circular-dependencies-js
         - make lint-css

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ jobs:
 
     # test, build, and upload for JavaScript projects
     - stage: test
-      name: 'JS unit; build Protocol Designer, Labware Library, Components Library'
+      name: 'JS unit tests; build Protocol Designer, Labware Library, Components Library'
       # node version pulled from .nvmrc
       language: node_js
       install:

--- a/labware-library/Makefile
+++ b/labware-library/Makefile
@@ -35,5 +35,5 @@ serve: all
 .PHONY: test-e2e
 test-e2e:
 	concurrently --no-color --kill-others --success "last" --names "labware-library-server,labware-library-tests" \
-	"$(MAKE) dev CYPRESS=1" \
+	"$(MAKE) dev CYPRESS=1 GTM_ID=''" \
 	"wait-on http://localhost:8080/ && cypress run --browser chrome --headless --record false"

--- a/labware-library/Makefile
+++ b/labware-library/Makefile
@@ -34,6 +34,6 @@ serve: all
 # end to end tests
 .PHONY: test-e2e
 test-e2e:
-	concurrently --no-color --kill-others --success "first" --names "labware-library,labware-library-tests" \
-		"$(MAKE) dev" \
-		"cypress run --browser chrome"
+	concurrently --no-color --kill-others --success "last" --names "labware-library-server,labware-library-tests" \
+	"$(MAKE) dev CYPRESS=1" \
+	"wait-on http://localhost:8080/ && cypress run --browser chrome --headless --record false"

--- a/labware-library/Makefile
+++ b/labware-library/Makefile
@@ -34,6 +34,6 @@ serve: all
 # end to end tests
 .PHONY: test-e2e
 test-e2e:
-	concurrently --no-color --kill-others --success "last" --names "labware-library-server,labware-library-tests" \
+	concurrently --no-color --kill-others --success first --names "labware-library-server,labware-library-tests" \
 	"$(MAKE) dev CYPRESS=1 GTM_ID=''" \
 	"wait-on http://localhost:8080/ && cypress run --browser chrome --headless --record false"

--- a/labware-library/cypress.json
+++ b/labware-library/cypress.json
@@ -1,3 +1,4 @@
 {
-  "baseUrl": "http://localhost:8080"
+  "baseUrl": "http://localhost:8080",
+  "video": false
 }

--- a/labware-library/src/index.hbs
+++ b/labware-library/src/index.hbs
@@ -9,14 +9,16 @@
   <title>{{htmlWebpackPlugin.options.title}}</title>
   <link rel="icon" href="https://s3.amazonaws.com/opentrons-images/website/OTfavicon.ico">
   <!-- Google Tag Manager -->
+  {{#if htmlWebpackPlugin.options.gtmId}}
   <script>(function (w, d, s, l, i) {
-    w[l] = w[l] || []; w[l].push({
-      'gtm.start':
-        new Date().getTime(), event: 'gtm.js'
-    }); var f = d.getElementsByTagName(s)[0],
-      j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
-        'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
+      w[l] = w[l] || []; w[l].push({
+        'gtm.start':
+          new Date().getTime(), event: 'gtm.js'
+      }); var f = d.getElementsByTagName(s)[0],
+        j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
+          'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
     })(window, document, 'script', 'dataLayer', '{{htmlWebpackPlugin.options.gtmId}}');</script>
+  {{/if}}
   <!-- End Google Tag Manager -->
 </head>
 

--- a/labware-library/webpack.config.js
+++ b/labware-library/webpack.config.js
@@ -18,7 +18,7 @@ const LABWARE_LIBRARY_ENV_VAR_PREFIX = 'OT_LL'
 
 const passThruEnvVars = Object.keys(process.env)
   .filter(v => v.startsWith(LABWARE_LIBRARY_ENV_VAR_PREFIX))
-  .concat(['NODE_ENV'])
+  .concat(['NODE_ENV', 'CYPRESS'])
 
 const envVarsWithDefaults = {
   OT_LL_VERSION: pkg.version,

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "stylelint-processor-styled-components": "1.10.0",
     "terser-webpack-plugin": "^2.3.5",
     "url-loader": "^2.1.0",
-    "wait-on": "^3.3.0",
+    "wait-on": "^4.0.2",
     "webpack": "^4.41.6",
     "webpack-bundle-analyzer": "^3.6.0",
     "webpack-cli": "^3.3.11",

--- a/protocol-designer/Makefile
+++ b/protocol-designer/Makefile
@@ -45,6 +45,6 @@ serve: all
 # end to end tests
 .PHONY: test-e2e
 test-e2e:
-	concurrently --no-color --kill-others --success "first" --names "protocol-designer,protocol-designer-tests" \
-		"$(MAKE) dev" \
-		"cypress run --browser chrome"
+	concurrently --no-color --kill-others --success "last" --names "protocol-designer-server,protocol-designer-tests" \
+	"$(MAKE) dev CYPRESS=1" \
+	"wait-on http://localhost:8080/ && cypress run --browser chrome --headless --record false"

--- a/protocol-designer/Makefile
+++ b/protocol-designer/Makefile
@@ -45,6 +45,6 @@ serve: all
 # end to end tests
 .PHONY: test-e2e
 test-e2e:
-	concurrently --no-color --kill-others --success "last" --names "protocol-designer-server,protocol-designer-tests" \
+	concurrently --no-color --kill-others --success first --names "protocol-designer-server,protocol-designer-tests" \
 	"$(MAKE) dev CYPRESS=1" \
 	"wait-on http://localhost:8080/ && cypress run --browser chrome --headless --record false"

--- a/protocol-designer/cypress.json
+++ b/protocol-designer/cypress.json
@@ -1,3 +1,4 @@
 {
-  "baseUrl": "http://localhost:8080"
+  "baseUrl": "http://localhost:8080",
+  "video": false
 }

--- a/protocol-designer/src/components/FileSidebar/FileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.js
@@ -43,7 +43,7 @@ const saveFile = (downloadData: $PropertyType<Props, 'downloadData'>) => {
   const blob = new Blob([JSON.stringify(downloadData.fileData)], {
     type: 'application/json',
   })
-  if (global.Cypress) {
+  if (process.env.CYPRESS === '1') {
     // HACK(IL, 2020-04-02): can't figure out a better way to do this yet
     // https://docs.cypress.io/faq/questions/using-cypress-faq.html#Can-my-tests-interact-with-Redux-Vuex-data-store
     global.__lastSavedFile__ = downloadData.fileData

--- a/protocol-designer/webpack.config.js
+++ b/protocol-designer/webpack.config.js
@@ -25,7 +25,7 @@ const ERROR_HTML = path.join(__dirname, 'src/error.html')
 
 const passThruEnvVars = Object.keys(process.env)
   .filter(v => v.startsWith(PROTOCOL_DESIGNER_ENV_VAR_PREFIX))
-  .concat(['NODE_ENV'])
+  .concat(['NODE_ENV', 'CYPRESS'])
 
 const envVarsWithDefaults = {
   OT_PD_VERSION,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1424,37 +1424,45 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@hapi/address@2.x.x":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.1.tgz#61395b5ed94c4cb19c2dc4c85969cff3d40d583f"
-  integrity sha512-DYuHzu978pP1XW1GD3HGvLnAFjbQTIgc2+V153FGkbS2pgo9haigCdwBnUDrbhaOkgiJlbZvoEqDrcxSLHpiWA==
-
-"@hapi/bourne@1.x.x":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-1.3.2.tgz#0a7095adea067243ce3283e1b56b8a8f453b242a"
-  integrity sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==
-
-"@hapi/hoek@8.x.x":
-  version "8.2.2"
-  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.2.2.tgz#6eaa2e1ec3b50dfb8dccbe705dc289094652bc2d"
-  integrity sha512-18P3VwngjNEcmvPj1mmiHLPyUPjhPAxIyJKDj4PRIY0F5ac3P0Vd0hkASPyWXHK0rfY3P9N2FoxV8ZuYaRBZ1g==
-
-"@hapi/joi@^15.0.3":
-  version "15.1.1"
-  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-15.1.1.tgz#c675b8a71296f02833f8d6d243b34c57b8ce19d7"
-  integrity sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==
+"@hapi/address@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-4.0.1.tgz#267301ddf7bc453718377a6fb3832a2f04a721dd"
+  integrity sha512-0oEP5UiyV4f3d6cBL8F3Z5S7iWSX39Knnl0lY8i+6gfmmIBj44JCBNtcMgwyS+5v7j3VYavNay0NFHDS+UGQcw==
   dependencies:
-    "@hapi/address" "2.x.x"
-    "@hapi/bourne" "1.x.x"
-    "@hapi/hoek" "8.x.x"
-    "@hapi/topo" "3.x.x"
+    "@hapi/hoek" "^9.0.0"
 
-"@hapi/topo@3.x.x":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.3.tgz#c7a02e0d936596d29f184e6d7fdc07e8b5efce11"
-  integrity sha512-JmS9/vQK6dcUYn7wc2YZTqzIKubAQcJKu2KCKAru6es482U5RT5fP1EXCPtlXpiK7PR0On/kpQKI4fRKkzpZBQ==
+"@hapi/formula@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/formula/-/formula-2.0.0.tgz#edade0619ed58c8e4f164f233cda70211e787128"
+  integrity sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A==
+
+"@hapi/hoek@^9.0.0":
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.0.4.tgz#e80ad4e8e8d2adc6c77d985f698447e8628b6010"
+  integrity sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw==
+
+"@hapi/joi@^17.1.1":
+  version "17.1.1"
+  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-17.1.1.tgz#9cc8d7e2c2213d1e46708c6260184b447c661350"
+  integrity sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==
   dependencies:
-    "@hapi/hoek" "8.x.x"
+    "@hapi/address" "^4.0.1"
+    "@hapi/formula" "^2.0.0"
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/pinpoint" "^2.0.0"
+    "@hapi/topo" "^5.0.0"
+
+"@hapi/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/pinpoint/-/pinpoint-2.0.0.tgz#805b40d4dbec04fc116a73089494e00f073de8df"
+  integrity sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw==
+
+"@hapi/topo@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.0.0.tgz#c19af8577fa393a06e9c77b60995af959be721e7"
+  integrity sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
 
 "@hot-loader/react-dom@16.8.6":
   version "16.8.6"
@@ -3467,6 +3475,16 @@ ajv@^6.10.2, ajv@^6.2.1:
   integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
   dependencies:
     fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.5.5:
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.0.tgz#06d60b96d87b8454a5adaba86e7854da629db4b7"
+  integrity sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
@@ -7992,6 +8010,11 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
 
+fast-deep-equal@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
+  integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
+
 fast-diff@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.2.tgz#4b62c42b8e03de3f848460b639079920695d0154"
@@ -9158,6 +9181,14 @@ har-validator@~5.1.0:
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.0.tgz#44657f5688a22cfd4b72486e81b3a3fb11742c29"
   dependencies:
     ajv "^5.3.0"
+    har-schema "^2.0.0"
+
+har-validator@~5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
+  integrity sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
+  dependencies:
+    ajv "^6.5.5"
     har-schema "^2.0.0"
 
 harmony-reflect@^1.4.6:
@@ -12303,6 +12334,11 @@ minimist@1.1.x:
 minimist@1.2.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
 minimist@~0.0.1:
   version "0.0.10"
@@ -16161,7 +16197,7 @@ request-promise-core@1.1.3:
   dependencies:
     lodash "^4.17.15"
 
-request-promise-native@^1.0.7:
+request-promise-native@^1.0.7, request-promise-native@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.8.tgz#a455b960b826e44e2bf8999af64dff2bfe58cb36"
   integrity sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==
@@ -16221,6 +16257,32 @@ request@^2.45.0:
     tough-cookie "~2.3.3"
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
+
+request@^2.88.2:
+  version "2.88.2"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
+  integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.3"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.5.0"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -16501,10 +16563,6 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rx@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
-
 rxjs@^6.3.3, rxjs@^6.5.3:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.4.tgz#e0777fe0d184cec7872df147f303572d414e211c"
@@ -16530,6 +16588,13 @@ rxjs@^6.5.2:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.3.tgz#510e26317f4db91a7eb1de77d9dd9ba0a4899a3a"
   integrity sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.5.5:
+  version "6.5.5"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
+  integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
   dependencies:
     tslib "^1.9.0"
 
@@ -18275,7 +18340,7 @@ toposort@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
 
-tough-cookie@^2.3.3:
+tough-cookie@^2.3.3, tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
   integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
@@ -19132,16 +19197,17 @@ w3c-xmlserializer@^1.1.2:
     webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
 
-wait-on@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-3.3.0.tgz#9940981d047a72a9544a97b8b5fca45b2170a082"
-  integrity sha512-97dEuUapx4+Y12aknWZn7D25kkjMk16PbWoYzpSdA8bYpVfS6hpl2a2pOWZ3c+Tyt3/i4/pglyZctG3J4V1hWQ==
+wait-on@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-4.0.2.tgz#6ee9b5751b4e0329630abbb5fdba787802b32914"
+  integrity sha512-Qpmgm3Hw/sXm7xK68FBsYy5r+Uid94/QymwnEjn9GTpfiWTUVYm0bccivVwY/BXGYO2r+5Cd8S/DzrRZqHK/9w==
   dependencies:
-    "@hapi/joi" "^15.0.3"
-    core-js "^2.6.5"
-    minimist "^1.2.0"
-    request "^2.88.0"
-    rx "^4.1.0"
+    "@hapi/joi" "^17.1.1"
+    lodash "^4.17.15"
+    minimist "^1.2.5"
+    request "^2.88.2"
+    request-promise-native "^1.0.8"
+    rxjs "^6.5.5"
 
 walkdir@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
## overview

Run cypress tests in Travis! Build will fail if any e2e tests fail. Closes #5318 

This is dependent on #5424 - after it is merged, I'll rebase this PR and change `if (global.Cypress)` in that PR to `if (process.env.CYPRESS === '1')`.

## changelog

## review requests

Sanity check!
- One weird thing I encountered was that labware library tests failed in Travis because GTM_ID env var was set, which somehow caused an error to be thrown about Intercom being undefined. So I set `GTM_ID=''` and also just to be safe I cut out the GTM tag from the Handlebars HTML template if GTM_ID is falsey.
- I'm using `wait-until` to make sure that the dev server is running before trying to start Cypress
- Cypress by default saves videos. I don't think they're useful to us, so I turned them off. We can always enable them and upload them to S3 if we decide that's good, but otherwise it just slows down the build.
- I didn't add any Make commands for running Cypress while you're writing tests. I kind of don't want to, I'd rather do `cd protocol-designer; yarn cypress open (whatever args)` rather than going thru Make.

## risk assessment

Significant risk to our workflow, but easy to roll back. If this causes builds to fail intermittently, or go too slowly, we'll have to change it back. Worst case scenario is removing `make test-e2e` from Travis yml to stop running the tests until we fix whatever problem we might have.