### PR TITLE
feat(robot-server): create middleware to support api versioning

### DIFF
--- a/robot-server/robot_server/__init__.py
+++ b/robot-server/robot_server/__init__.py
@@ -1,3 +1,0 @@
-# This is the version of the API supported by the server. The
-# application version is in package.json.
-API_VERSION = "1.0.0"

--- a/robot-server/robot_server/__init__.py
+++ b/robot-server/robot_server/__init__.py
@@ -1,0 +1,3 @@
+# This is the version of the API supported by the server. The
+# application version is in package.json.
+API_VERSION = "1.0.0"

--- a/robot-server/robot_server/constants.py
+++ b/robot-server/robot_server/constants.py
@@ -1,0 +1,10 @@
+# This is the version of the API supported by the server. The
+# application version is in package.json.
+API_VERSION = 1
+
+# Header identifying maximum acceptable version in request and actual version
+# used to create response. Optional in requests. Mandatory in responses.
+API_VERSION_HEADER = 'Opentrons-Version'
+
+# Tag applied to legacy api endpoints
+V1_TAG = "v1"

--- a/robot-server/robot_server/service/errors.py
+++ b/robot-server/robot_server/service/errors.py
@@ -1,0 +1,77 @@
+from typing import List, Dict, Any
+
+from pydantic import ValidationError
+from starlette.exceptions import HTTPException
+
+from robot_server.service.models.json_api.errors import ErrorResponse, Error, \
+    ErrorSource
+
+
+class V1HandlerError(Exception):
+    """An exception raised in order to produce a V1BasicResponse response"""
+    def __init__(self, status_code, message):
+        self.status_code = status_code
+        self.message = message
+
+
+def transform_http_exception_to_json_api_errors(exception: HTTPException) \
+        -> ErrorResponse:
+    """
+    Object marshalling for http exceptions (these errors come back differently
+    than validation errors). e.g. invalid json in request body.
+    """
+    request_error = Error(
+        status=str(exception.status_code),
+        detail=exception.detail,
+        title='Bad Request'
+    )
+    return ErrorResponse(errors=[request_error])
+
+
+def transform_validation_error_to_json_api_errors(
+    status_code: int,
+    exception: ValidationError
+) -> ErrorResponse:
+    """
+    Object marshalling for validation errors.  format pydantic validation
+    errors to expected json:api response shape.
+    """
+    def transform_error(error):
+        return Error(
+            status=str(status_code),
+            detail=error.get('msg'),
+            source=ErrorSource(pointer='/' + '/'.join(
+                str(node) for node in error['loc'])),
+            title=error.get('type')
+        )
+
+    return ErrorResponse(
+        errors=[transform_error(error) for error in exception.errors()]
+    )
+
+
+def consolidate_fastapi_response(all_exceptions: List[Dict[str, Any]]) -> str:
+    """
+    Consolidate the default fastAPI response so it can be returned as a string.
+    Default schema of fastAPI exception response is:
+    {
+        'loc': ('body',
+                '<outer_scope1>',
+                '<outer_scope2>',
+                '<inner_param>'),
+        'msg': '<the_error_message>',
+        'type': '<expected_type>'
+    }
+    In order to create a meaningful V1-style response, we consolidate the
+    above response into a string of shape:
+    '<outer_scope1>.<outer_scope2>.<inner_param>: <the_error_message>'
+    """
+
+    # Pick just the error message while discarding v2 response items
+    def error_to_str(error: dict) -> str:
+        err_node = ".".join(str(loc) for loc in error['loc'] if loc != 'body')
+        res = ": ".join([err_node, error["msg"]])
+        return res
+
+    all_errs = ". ".join(error_to_str(exc) for exc in all_exceptions)
+    return all_errs

--- a/robot-server/robot_server/service/exceptions.py
+++ b/robot-server/robot_server/service/exceptions.py
@@ -1,6 +1,0 @@
-
-
-class V1HandlerError(Exception):
-    def __init__(self, status_code, message):
-        self.status_code = status_code
-        self.message = message

--- a/robot-server/robot_server/service/models/json_api/errors.py
+++ b/robot-server/robot_server/service/models/json_api/errors.py
@@ -59,35 +59,3 @@ class ErrorResponse(BaseModel):
     errors: List[Error] = \
         Field(...,
               description="a list containing one of more error objects.")
-
-
-# Note(isk: 3/13/20): object marshalling for http exceptions
-# (these errors come back differently than validation errors).
-# e.g. invalid json in request body
-def transform_http_exception_to_json_api_errors(exception) -> ErrorResponse:
-    request_error = Error(
-        status=exception.status_code,
-        detail=exception.detail,
-        title='Bad Request'
-    )
-    return ErrorResponse(errors=[request_error])
-
-
-# Note(isk: 3/13/20): object marshalling for validation errors.
-# format pydantic validation errors to expected json:api response shape.
-def transform_validation_error_to_json_api_errors(
-    status_code,
-    exception
-) -> ErrorResponse:
-    def transform_error(error):
-        return Error(
-            status=status_code,
-            detail=error.get('msg'),
-            source=ErrorSource(pointer='/' + '/'.join(
-                str(node) for node in error['loc'])),
-            title=error.get('type')
-        )
-
-    return ErrorResponse(
-        errors=[transform_error(error) for error in exception.errors()]
-    )

--- a/robot-server/robot_server/service/routers/control.py
+++ b/robot-server/robot_server/service/routers/control.py
@@ -8,7 +8,7 @@ from opentrons.hardware_control.types import Axis, CriticalPoint
 from opentrons.types import Mount, Point
 
 from robot_server.service.dependencies import get_hardware, get_motion_lock
-from robot_server.service.exceptions import V1HandlerError
+from robot_server.service.errors import V1HandlerError
 from robot_server.service.models import V1BasicResponse
 from robot_server.service.models import control
 

--- a/robot-server/robot_server/service/routers/deck_calibration.py
+++ b/robot-server/robot_server/service/routers/deck_calibration.py
@@ -6,7 +6,7 @@ from opentrons.hardware_control import HardwareAPILike
 import opentrons.deck_calibration.endpoints as dc
 
 from robot_server.service.dependencies import get_hardware
-from robot_server.service.exceptions import V1HandlerError
+from robot_server.service.errors import V1HandlerError
 from robot_server.service.models import V1BasicResponse
 from robot_server.service.models.deck_calibration import DeckStart, \
     DeckStartResponse, DeckCalibrationDispatch, PipetteDeckCalibration

--- a/robot-server/robot_server/service/routers/modules.py
+++ b/robot-server/robot_server/service/routers/modules.py
@@ -9,7 +9,7 @@ from opentrons.hardware_control.modules import AbstractModule
 
 from robot_server.service.dependencies import get_hardware
 from robot_server.service.models import V1BasicResponse
-from robot_server.service.exceptions import V1HandlerError
+from robot_server.service.errors import V1HandlerError
 from robot_server.service.models.modules import Module, ModuleSerial,\
     Modules, SerialCommandResponse, SerialCommand
 

--- a/robot-server/robot_server/service/routers/motors.py
+++ b/robot-server/robot_server/service/routers/motors.py
@@ -6,7 +6,7 @@ from opentrons.hardware_control import HardwareAPILike
 from opentrons.hardware_control.types import Axis
 
 from robot_server.service.dependencies import get_hardware
-from robot_server.service.exceptions import V1HandlerError
+from robot_server.service.errors import V1HandlerError
 from robot_server.service.models import motors as model, V1BasicResponse
 
 

--- a/robot-server/robot_server/service/routers/networking.py
+++ b/robot-server/robot_server/service/routers/networking.py
@@ -7,7 +7,7 @@ from starlette.responses import JSONResponse
 from fastapi import APIRouter, HTTPException, File, Path, UploadFile
 from opentrons.system import nmcli, wifi
 
-from robot_server.service.exceptions import V1HandlerError
+from robot_server.service.errors import V1HandlerError
 from robot_server.service.models import V1BasicResponse
 from robot_server.service.models.networking import NetworkingStatus, \
     WifiNetworks, WifiNetwork, WifiConfiguration, WifiConfigurationResponse, \

--- a/robot-server/robot_server/service/routers/settings.py
+++ b/robot-server/robot_server/service/routers/settings.py
@@ -11,7 +11,7 @@ from opentrons.config import pipette_config, reset as reset_util, \
 
 from robot_server.service.dependencies import get_hardware
 from robot_server.service.models import V1BasicResponse
-from robot_server.service.exceptions import V1HandlerError
+from robot_server.service.errors import V1HandlerError
 from robot_server.service.models.settings import AdvancedSettingsResponse, \
     LogLevel, LogLevels, FactoryResetOptions, PipetteSettings, \
     PipetteSettingsUpdate, RobotConfigs, MultiPipetteSettings, \

--- a/robot-server/tests/service/models/json_api/test_errors.py
+++ b/robot-server/tests/service/models/json_api/test_errors.py
@@ -1,14 +1,8 @@
 from functools import reduce
 
 import pytest
-from pytest import raises
-from pydantic import ValidationError
-from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
 
-from robot_server.service.models.json_api.errors import ErrorResponse, \
-    transform_validation_error_to_json_api_errors
-
-from tests.service.helpers import ItemRequest
+from robot_server.service.models.json_api.errors import ErrorResponse
 
 
 def errors_wrapper(d):
@@ -50,36 +44,3 @@ def test_empty_error_response_valid():
     error_response = {'errors': []}
     validated = ErrorResponse(**error_response)
     assert validated.dict(exclude_unset=True) == error_response
-
-
-def test_transform_validation_error_to_json_api_errors():
-    with raises(ValidationError) as e:
-        ItemRequest(**{
-            'data': {
-                'type': 'invalid'
-            }
-        })
-    assert transform_validation_error_to_json_api_errors(
-        HTTP_422_UNPROCESSABLE_ENTITY,
-        e.value
-    ).dict(exclude_unset=True) == {
-        'errors': [
-            {
-                'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
-                'detail': "value is not a valid enumeration member; permitted:"
-                          " 'item'",
-                'source': {
-                    'pointer': '/data/type'
-                },
-                'title': 'type_error.enum'
-            },
-            {
-                'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
-                'detail': 'field required',
-                'source': {
-                    'pointer': '/data/attributes'
-                },
-                'title': 'value_error.missing'
-            },
-        ]
-    }

--- a/robot-server/tests/service/test_app.py
+++ b/robot-server/tests/service/test_app.py
@@ -1,4 +1,5 @@
 from http import HTTPStatus
+from robot_server.service.app import RESPONSE_HEADERS
 
 
 def test_custom_http_exception_handler(api_client):
@@ -34,3 +35,10 @@ def test_custom_request_validation_exception_handler(api_client):
     text = resp.json()
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
     assert text == expected
+
+
+def test_response_headers(api_client):
+    resp = api_client.get('/openapi')
+    for k, v in RESPONSE_HEADERS.items():
+        assert k.lower() in resp.headers
+        assert resp.headers[k.lower()] == v.lower()

--- a/robot-server/tests/service/test_errors.py
+++ b/robot-server/tests/service/test_errors.py
@@ -1,0 +1,57 @@
+import pytest
+
+from pydantic import ValidationError
+from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
+from starlette.exceptions import HTTPException
+
+from robot_server.service import errors
+from tests.service.helpers import ItemRequest
+
+
+def test_transform_validation_error_to_json_api_errors():
+    with pytest.raises(ValidationError) as e:
+        ItemRequest(**{
+            'data': {
+                'type': 'invalid'
+            }
+        })
+    assert errors.transform_validation_error_to_json_api_errors(
+        HTTP_422_UNPROCESSABLE_ENTITY,
+        e.value
+    ).dict(exclude_unset=True) == {
+        'errors': [
+            {
+                'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
+                'detail': "value is not a valid enumeration member; permitted:"
+                          " 'item'",
+                'source': {
+                    'pointer': '/data/type'
+                },
+                'title': 'type_error.enum'
+            },
+            {
+                'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
+                'detail': 'field required',
+                'source': {
+                    'pointer': '/data/attributes'
+                },
+                'title': 'value_error.missing'
+            },
+        ]
+    }
+
+
+def test_transform_http_exception_to_json_api_errors():
+    exc = HTTPException(status_code=404, detail="i failed")
+    err = errors.transform_http_exception_to_json_api_errors(
+        exc
+    ).dict(
+        exclude_unset=True
+    )
+    assert err == {
+        'errors': [{
+            'status': str(exc.status_code),
+            'detail': exc.detail,
+            'title': 'Bad Request',
+        }]
+    }


### PR DESCRIPTION
## overview

Add API version header to responses.

## changelog

Define an api version. This is an integer starting at 1.

Middleware that examines the `opentrons-version` header in request.  The api version used to respond to the request is chosen in this manner: 
- if the request version is an integer and <= server api version, we use that version
- otherwise we use the server version.

The chosen version is attached to the request.state object for consumption by handlers.
Finally, the response will contain `opentrons-version` that holds the version used to handle the request.

Rename `exceptions.py` to `errors.py` and put error related helpers in there.
 
## review requests

- [x] Version string is ok
- [x] Header name is ok
- [x] Location of api version constant is ok
- [x] This closes #4633. (The ticket discusses validating request version headers. Is that something we want to do now?)

## risk assessment

None


closes #4633 