### PR TITLE
feat(protocol-designer): Implement custom tiprack UI behind flag

### DIFF
--- a/protocol-designer/src/components/modals/EditPipettesModal/index.js
+++ b/protocol-designer/src/components/modals/EditPipettesModal/index.js
@@ -29,6 +29,7 @@ type SP = {|
   _prevPipettes: { [pipetteId: string]: PipetteOnDeck },
   _orderedStepIds: Array<StepIdType>,
   thermocyclerEnabled: ?boolean,
+  customTipracksEnabled: ?boolean,
   moduleRestrictionsDisabled: ?boolean,
 |}
 
@@ -44,6 +45,7 @@ const mapSTP = (state: BaseState): SP => {
     _prevPipettes: stepFormSelectors.getInitialDeckSetup(state).pipettes, // TODO: Ian 2019-01-02 when multi-step editing is supported, don't use initial deck state. Instead, show the pipettes available for the selected step range
     _orderedStepIds: stepFormSelectors.getOrderedStepIds(state),
     thermocyclerEnabled: featureFlagSelectors.getEnableThermocycler(state),
+    customTipracksEnabled: featureFlagSelectors.getEnableCustomTipracks(state),
     moduleRestrictionsDisabled: featureFlagSelectors.getDisableModuleRestrictions(
       state
     ),

--- a/protocol-designer/src/components/modals/FilePipettesModal/FilePipettesModal.css
+++ b/protocol-designer/src/components/modals/FilePipettesModal/FilePipettesModal.css
@@ -71,8 +71,34 @@
   flex-grow: 1;
 }
 
+.mount_diagram {
+  display: flex;
+  justify-content: space-around;
+  flex: 1 1 4rem;
+  margin-right: 0.5rem;
+
+  & img {
+    margin-top: 1rem;
+    max-height: 5.25rem;
+  }
+
+  & .left_pipette {
+    padding-right: 0.5rem;
+  }
+
+  & .right_pipette {
+    padding-left: 0.5rem;
+  }
+}
+
 .mount_column:first-child {
   margin-right: 0.5rem;
+}
+
+.upload_custom_btn {
+  display: block;
+  width: 50%;
+  margin: 1.25rem auto;
 }
 
 .protocol_modules_group {

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteDiagram.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteDiagram.js
@@ -2,20 +2,39 @@
 
 import { getPipetteNameSpecs } from '@opentrons/shared-data'
 import * as React from 'react'
+import cx from 'classnames'
 import styles from './FilePipettesModal.css'
 import { InstrumentDiagram } from '@opentrons/components'
 
 type Props = {
   leftPipette: ?string,
   rightPipette: ?string,
+  customTipracksEnabled?: ?boolean,
 }
 export function PipetteDiagram(props: Props) {
+  const { leftPipette, rightPipette, customTipracksEnabled } = props
+
+  // TODO (ka 2020-4-16): This is temporaray until FF is removed.
+  // Gross but neccessary for removing the wrapper div when FF is off.
+  return (
+    <>
+      {customTipracksEnabled ? (
+        <div className={cx({ [styles.mount_diagram]: customTipracksEnabled })}>
+          <PipetteGroup leftPipette={leftPipette} rightPipette={rightPipette} />
+        </div>
+      ) : (
+        <PipetteGroup leftPipette={leftPipette} rightPipette={rightPipette} />
+      )}
+    </>
+  )
+}
+
+function PipetteGroup(props: Props) {
   const { leftPipette, rightPipette } = props
   const leftSpecs = leftPipette && getPipetteNameSpecs(leftPipette)
   const rightSpecs = rightPipette && getPipetteNameSpecs(rightPipette)
-
   return (
-    <React.Fragment>
+    <>
       {leftPipette && leftSpecs ? (
         <InstrumentDiagram
           pipetteSpecs={leftSpecs}
@@ -24,7 +43,7 @@ export function PipetteDiagram(props: Props) {
         />
       ) : (
         <div className={styles.left_pipette} />
-      )}
+      )}{' '}
       {rightPipette && rightSpecs ? (
         <InstrumentDiagram
           pipetteSpecs={rightSpecs}
@@ -34,6 +53,6 @@ export function PipetteDiagram(props: Props) {
       ) : (
         <div className={styles.right_pipette} />
       )}
-    </React.Fragment>
+    </>
   )
 }

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.js
@@ -4,6 +4,7 @@ import {
   DropdownField,
   FormGroup,
   PipetteSelect,
+  OutlineButton,
   type Mount,
 } from '@opentrons/components'
 import { getLabwareDefURI, getLabwareDisplayName } from '@opentrons/shared-data'
@@ -49,6 +50,7 @@ export type Props = {|
   onSetFieldValue: (field: string, value: string | null) => void,
   onSetFieldTouched: (field: string, touched: boolean) => void,
   onBlur: (event: SyntheticFocusEvent<HTMLSelectElement>) => mixed,
+  customTipracksEnabled: ?boolean,
 |}
 
 // TODO(mc, 2019-10-14): delete this typedef when gen2 ff is removed
@@ -63,6 +65,7 @@ export function PipetteFields(props: Props) {
     onBlur,
     errors,
     touched,
+    customTipracksEnabled,
   } = props
 
   const tiprackOptions = useMemo(() => {
@@ -151,6 +154,13 @@ export function PipetteFields(props: Props) {
             />
           </FormGroup>
         </div>
+        {customTipracksEnabled && (
+          <PipetteDiagram
+            leftPipette={values.left.pipetteName}
+            rightPipette={values.right.pipetteName}
+            customTipracksEnabled={customTipracksEnabled}
+          />
+        )}
         <div className={styles.mount_column}>
           <FormGroup
             key="rightPipetteModel"
@@ -193,15 +203,27 @@ export function PipetteFields(props: Props) {
           </FormGroup>
         </div>
       </div>
+      {!customTipracksEnabled ? (
+        <div className={styles.diagrams}>
+          <TiprackDiagram definitionURI={values.left.tiprackDefURI} />
 
-      <div className={styles.diagrams}>
-        <TiprackDiagram definitionURI={values.left.tiprackDefURI} />
-        <PipetteDiagram
-          leftPipette={values.left.pipetteName}
-          rightPipette={values.right.pipetteName}
-        />
-        <TiprackDiagram definitionURI={values.right.tiprackDefURI} />
-      </div>
+          <PipetteDiagram
+            leftPipette={values.left.pipetteName}
+            rightPipette={values.right.pipetteName}
+            customTipracksEnabled={customTipracksEnabled}
+          />
+          <TiprackDiagram definitionURI={values.right.tiprackDefURI} />
+        </div>
+      ) : (
+        <div>
+          <OutlineButton
+            className={styles.upload_custom_btn}
+            onClick={() => console.log('TODO: Open Upload Modal')}
+          >
+            upload custom tip rack
+          </OutlineButton>
+        </div>
+      )}
     </React.Fragment>
   )
 }

--- a/protocol-designer/src/components/modals/FilePipettesModal/__tests__/PipetteFields.test.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/__tests__/PipetteFields.test.js
@@ -61,6 +61,7 @@ describe('PipetteFields', () => {
       },
       errors: null,
       touched: null,
+      customTipracksEnabled: false,
     }
 
     getOnlyLatestDefsMock.mockReturnValue({
@@ -167,6 +168,7 @@ describe('PipetteFields', () => {
     expect(pipetteDiagram.props()).toEqual({
       leftPipette: leftPipette.pipetteName,
       rightPipette: rightPipette.pipetteName,
+      customTipracksEnabled: false,
     })
   })
 })

--- a/protocol-designer/src/components/modals/FilePipettesModal/__tests__/index.test.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/__tests__/index.test.js
@@ -59,6 +59,7 @@ describe('FilePipettesModal', () => {
       onSave: jest.fn(),
       thermocyclerEnabled: true,
       moduleRestrictionsDisabled: false,
+      customTipracksEnabled: false,
     }
   })
 

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.js
@@ -72,6 +72,7 @@ export type Props = {|
     modules: Array<ModuleCreationArgs>,
   |}) => mixed,
   thermocyclerEnabled: ?boolean,
+  customTipracksEnabled: ?boolean,
   moduleRestrictionsDisabled: ?boolean,
 |}
 

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.js
@@ -343,6 +343,9 @@ export class FilePipettesModal extends React.Component<Props, State> {
                           errors={errors.pipettesByMount ?? null}
                           touched={touched.pipettesByMount ?? null}
                           onSetFieldTouched={setFieldTouched}
+                          customTipracksEnabled={
+                            this.props.customTipracksEnabled
+                          }
                         />
 
                         {this.props.showModulesFields && (

--- a/protocol-designer/src/components/modals/NewFileModal/index.js
+++ b/protocol-designer/src/components/modals/NewFileModal/index.js
@@ -30,6 +30,7 @@ type SP = {|
   hideModal: $PropertyType<Props, 'hideModal'>,
   _hasUnsavedChanges: ?boolean,
   thermocyclerEnabled: ?boolean,
+  customTipracksEnabled: ?boolean,
   moduleRestrictionsDisabled: ?boolean,
 |}
 
@@ -49,6 +50,7 @@ function mapStateToProps(state: BaseState): SP {
     hideModal: !selectors.getNewProtocolModal(state),
     _hasUnsavedChanges: loadFileSelectors.getHasUnsavedChanges(state),
     thermocyclerEnabled: featureFlagSelectors.getEnableThermocycler(state),
+    customTipracksEnabled: featureFlagSelectors.getEnableCustomTipracks(state),
     moduleRestrictionsDisabled: featureFlagSelectors.getDisableModuleRestrictions(
       state
     ),
@@ -114,6 +116,7 @@ function mergeProps(stateProps: SP, dispatchProps: DP, ownProps: OP): Props {
   return {
     ...ownProps,
     thermocyclerEnabled: stateProps.thermocyclerEnabled,
+    customTipracksEnabled: stateProps.customTipracksEnabled,
     moduleRestrictionsDisabled: stateProps.moduleRestrictionsDisabled,
     showModulesFields: true,
     hideModal: stateProps.hideModal,

--- a/protocol-designer/src/feature-flags/reducers.js
+++ b/protocol-designer/src/feature-flags/reducers.js
@@ -23,6 +23,8 @@ const initialFlags: Flags = {
     process.env.OT_PD_DISABLE_MODULE_RESTRICTIONS === '1' || false,
   OT_PD_ENABLE_THERMOCYCLER:
     process.env.OT_PD_ENABLE_THERMOCYCLER === '1' || false,
+  OT_PD_ENABLE_CUSTOM_TIPRACKS:
+    process.env.OT_PD_ENABLE_CUSTOM_TIPRACKS === '1' || false,
 }
 
 const flags = handleActions<Flags, any>(

--- a/protocol-designer/src/feature-flags/selectors.js
+++ b/protocol-designer/src/feature-flags/selectors.js
@@ -18,3 +18,8 @@ export const getEnableThermocycler: Selector<?boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ENABLE_THERMOCYCLER
 )
+
+export const getEnableCustomTipracks: Selector<?boolean> = createSelector(
+  getFeatureFlagData,
+  flags => flags.OT_PD_ENABLE_CUSTOM_TIPRACKS
+)

--- a/protocol-designer/src/feature-flags/types.js
+++ b/protocol-designer/src/feature-flags/types.js
@@ -16,6 +16,7 @@ export type FlagTypes =
   | 'PRERELEASE_MODE'
   | 'OT_PD_DISABLE_MODULE_RESTRICTIONS'
   | 'OT_PD_ENABLE_THERMOCYCLER'
+  | 'OT_PD_ENABLE_CUSTOM_TIPRACKS'
 
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: Array<FlagTypes> = [

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -11,5 +11,9 @@
   "OT_PD_ENABLE_THERMOCYCLER": {
     "title": "Enable thermocycler module",
     "description": "Allow adding thermocycler modules and steps to protocols."
+  },
+  "OT_PD_ENABLE_CUSTOM_TIPRACKS": {
+    "title": "Enable Custom Tipracks",
+    "description": "Allow custom tiprack uploads in new file modal and edit pipettes modal."
   }
 }


### PR DESCRIPTION
## overview

This PR closes #5332 by adding a custom tiprack FF and conditionally rendering the new UI when the FF is turned on.

## changelog

- feat(protocol-designer): Implement custom tiprack UI behind flag

## review requests

This was a little whacky cause the layouts were very conditional, there is a little bit of component work that will be torn down once the Flag is removed and this is a full feature, but it was necessary to conditionally render both old and new layouts properly.

- [ ] New FF shows up under prerelease mode flag card
- [ ] If enable custom tipracks FF is OFF, new file modal UI is the same as before
- [ ] If enable custom tipracks FF is ON, new file modal UI matches design https://app.zeplin.io/project/5c87a3f55f998e3943ad5d38/screen/5e286a16e6bff79499ac17f0
- [ ] Same is true for edit pipettes modal


## risk assessment

Low. PD only behind a FF.