### PR TITLE
fix(protocol-designer): Default to GEN1 model for TC

### DIFF
--- a/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.js
@@ -72,7 +72,11 @@ export function ModuleFields(props: Props) {
     const targetToClear = `modulesByType.${type}.model`
 
     onFieldChange(e)
-    onSetFieldValue(targetToClear, null)
+
+    // only clear model dropdown if not TC
+    if (targetToClear !== 'modulesByType.thermocyclerModuleType.model') {
+      onSetFieldValue(targetToClear, null)
+    }
     onSetFieldTouched(targetToClear, false)
   }
 

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.js
@@ -17,6 +17,7 @@ import {
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
+  THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
 import { i18n } from '../../../localization'
 import { SPAN7_8_10_11_SLOT } from '../../../constants'
@@ -95,7 +96,7 @@ const initialFormState: FormState = {
     },
     [THERMOCYCLER_MODULE_TYPE]: {
       onDeck: false,
-      model: null,
+      model: THERMOCYCLER_MODULE_V1, // Default to GEN1 for TC only
       slot: SPAN7_8_10_11_SLOT,
     },
   },


### PR DESCRIPTION
## overview

This PR closes #5389 by defaulting the model dropdown for TC only to GEN1.

## changelog

- fix(protocol-designer): Default to GEN1 model for TC

## review requests
http://sandbox.designer.opentrons.com/pd_autoselect-tc-gen1/
Make a protocol with all 3 modules. 
Check and uncheck each module (add remove then re-add to deck)
- [ ] Magnetic and Temperature modules model is always cleared to start (user needs to manually choose generation)
- [ ] Thermocycler module always defaults to GEN1 model

Export a protocol with a TC
- [ ] TC should show up in modules object
Export a protocol without a TC
- [ ] No TC in modules object

## risk assessment

Low, PD single form field.