### PR TITLE
chore(robot-server,update-server): push systemd units

### DIFF
--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -96,10 +96,12 @@ local-shell:
 .PHONY: push
 push: wheel
 	scp -i $(br_ssh_key) $(ssh_opts) $(wheel_file) root@$(host):/data/
+	scp -i $(br_ssh_key) $(ssh_opts) ./opentrons-robot-server.service root@$(host):/data/
 	ssh -i $(br_ssh_key) $(ssh_opts) root@$(host) \
-"function cleanup () { rm -f /data/robotserver*.whl && mount -o remount,ro / && systemctl start opentrons-robot-server; } ;\
+"function cleanup () { rm -f /data/robotserver*.whl && mount -o remount,ro / && systemctl daemon-reload && systemctl start opentrons-robot-server; } ;\
 systemctl stop opentrons-robot-server &&\
 mount -o remount,rw / &&\
+cp /data/opentrons-robot-server.service /etc/systemd/system/ &&\
 cd /usr/lib/python3.7/site-packages &&\
 unzip -o /data/robotserver*.whl && cleanup || cleanup"
 

--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -75,9 +75,11 @@ restart:
 .PHONY: push
 push: wheel
 	scp -i $(br_ssh_key) $(br_ssh_opts) $(wheel_file) root@$(host):/data/
+	scp -i $(br_ssh_key) $(br_ssh_opts) ./opentrons-update-server.service root@$(host):/data/
 	ssh -i $(br_ssh_key) $(br_ssh_opts) root@$(host) \
-"function cleanup () { rm -f /data/otupdate*.whl && mount -o remount,ro / && systemctl start opentrons-update-server; } ;\
+"function cleanup () { rm -f /data/otupdate*.whl && mount -o remount,ro / && systemctl daemon-reload && systemctl start opentrons-update-server; } ;\
 systemctl stop opentrons-update-server &&\
 mount -o remount,rw / &&\
+cp /data/opentrons-update-server.service /etc/systemd/system/ &&\
 cd /usr/lib/python3.7/site-packages &&\
 unzip -o /data/otupdate-*.whl && cleanup || cleanup"


### PR DESCRIPTION
Change the makefiles to also copy over systemd unitfiles for our
monorepo-based units, which prevents having to install new buildroot
builds when we change the unitfiles

## Testing
Do a `make push` on this branch and it should work.