### PR TITLE
refactor(protocol-designer): Use new tooltip component in WellOrder and TipPosition 

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import { connect } from 'react-redux'
-import { HoverTooltip, FormGroup } from '@opentrons/components'
+import { FormGroup, Tooltip, useHoverTooltip } from '@opentrons/components'
 import cx from 'classnames'
 import { i18n } from '../../../../localization'
 import { selectors as stepFormSelectors } from '../../../../step-forms'
@@ -23,50 +23,48 @@ type SP = {| iconClassNames: Array<string> |}
 
 type Props = { ...OP, ...SP }
 
-type WellOrderInputState = { isModalOpen: boolean }
+function WellOrderInput(props: Props) {
+  const [isModalOpen, setModalOpen] = React.useState(false)
 
-class WellOrderInput extends React.Component<Props, WellOrderInputState> {
-  state: WellOrderInputState = { isModalOpen: false }
-
-  handleOpen = () => {
-    this.setState({ isModalOpen: true })
+  const handleOpen = () => {
+    setModalOpen(true)
   }
-  handleClose = () => {
-    this.setState({ isModalOpen: false })
+  const handleClose = () => {
+    setModalOpen(false)
   }
 
-  render() {
-    const className = cx(this.props.className, {
-      [styles.small_field]: !this.props.label,
-      [stepEditStyles.no_label]: !this.props.label,
-    })
-    return (
-      <HoverTooltip
-        tooltipComponent={i18n.t('form.step_edit_form.field.well_order.label')}
-      >
-        {hoverTooltipHandlers => (
-          <div {...hoverTooltipHandlers}>
-            <FormGroup label={this.props.label} className={className}>
-              <WellOrderModal
-                prefix={this.props.prefix}
-                closeModal={this.handleClose}
-                isOpen={this.state.isModalOpen}
-              />
-              <img
-                onClick={this.handleOpen}
-                src={ZIG_ZAG_IMAGE}
-                className={cx(
-                  styles.well_order_icon,
-                  { [styles.icon_with_label]: this.props.label },
-                  ...this.props.iconClassNames
-                )}
-              />
-            </FormGroup>
-          </div>
-        )}
-      </HoverTooltip>
-    )
-  }
+  const [targetProps, tooltipProps] = useHoverTooltip()
+
+  const className = cx(props.className, {
+    [styles.small_field]: !props.label,
+    [stepEditStyles.no_label]: !props.label,
+  })
+
+  return (
+    <>
+      <Tooltip {...tooltipProps}>
+        {i18n.t('form.step_edit_form.field.well_order.label')}
+      </Tooltip>
+      <div {...targetProps}>
+        <FormGroup label={props.label} className={className}>
+          <WellOrderModal
+            prefix={props.prefix}
+            closeModal={handleClose}
+            isOpen={isModalOpen}
+          />
+          <img
+            onClick={handleOpen}
+            src={ZIG_ZAG_IMAGE}
+            className={cx(
+              styles.well_order_icon,
+              { [styles.icon_with_label]: props.label },
+              ...props.iconClassNames
+            )}
+          />
+        </FormGroup>
+      </div>
+    </>
+  )
 }
 
 const mapSTP = (state: BaseState, ownProps: OP): SP => {


### PR DESCRIPTION
## overview

This PR is the first of many that addresses #5411. This PR refactors `WellOrderField` and `TipPositionField`

## changelog
- refactor(protocol-designer): Convert class based components to functional ones with hooks
- refactor(protocol-designer): Use new tooltip component in WellOrder and TipPosition 

## review requests

- Double check the WellOrder, TipPosition, and TipPosition (after you check off touch tip) fields in TRANSFER step advanced settings for both aspirate and dispense.
- Double check the WellOrder, TipPosition, and TipPosition (after you check off touch tip) fields in MIX step advanced settings for both aspirate and dispense.

- [ ] Tooltips render on hover
- [ ] TipPosition modal opens on clicking field
## risk assessment

Low, just a couple tooltip refactors. Just make sure they all work!