### PR TITLE
refactor(protocol-designer): Update tooltip component in substep headers

### DIFF
--- a/protocol-designer/src/components/steplist/AspirateDispenseHeader.js
+++ b/protocol-designer/src/components/steplist/AspirateDispenseHeader.js
@@ -1,11 +1,15 @@
 // @flow
 import * as React from 'react'
 import cx from 'classnames'
-import { Icon, HoverTooltip } from '@opentrons/components'
+import {
+  Icon,
+  Tooltip,
+  useHoverTooltip,
+  TOOLTIP_FIXED,
+} from '@opentrons/components'
 import { PDListItem } from '../lists'
 import styles from './StepItem.css'
 import { LabwareTooltipContents } from './LabwareTooltipContents'
-import { Portal } from './TooltipPortal'
 
 type AspirateDispenseHeaderProps = {
   sourceLabwareNickname: ?string,
@@ -22,13 +26,37 @@ export function AspirateDispenseHeader(props: AspirateDispenseHeaderProps) {
     destLabwareDefDisplayName,
   } = props
 
+  const [sourceTargetProps, sourceTooltipProps] = useHoverTooltip({
+    placement: 'bottom-start',
+    strategy: TOOLTIP_FIXED,
+  })
+
+  const [destTargetProps, destTooltipProps] = useHoverTooltip({
+    placement: 'bottom',
+    strategy: TOOLTIP_FIXED,
+  })
+
   return (
-    <React.Fragment>
+    <>
       <li className={styles.aspirate_dispense}>
         <span>ASPIRATE</span>
         <span className={styles.spacer} />
         <span>DISPENSE</span>
       </li>
+
+      <Tooltip {...sourceTooltipProps}>
+        <LabwareTooltipContents
+          labwareNickname={sourceLabwareNickname}
+          labwareDefDisplayName={sourceLabwareDefDisplayName}
+        />
+      </Tooltip>
+
+      <Tooltip {...destTooltipProps}>
+        <LabwareTooltipContents
+          labwareNickname={destLabwareNickname}
+          labwareDefDisplayName={destLabwareDefDisplayName}
+        />
+      </Tooltip>
 
       <PDListItem
         className={cx(
@@ -36,45 +64,17 @@ export function AspirateDispenseHeader(props: AspirateDispenseHeaderProps) {
           styles.emphasized_cell
         )}
       >
-        <HoverTooltip
-          portal={Portal}
-          tooltipComponent={
-            <LabwareTooltipContents
-              labwareNickname={sourceLabwareNickname}
-              labwareDefDisplayName={sourceLabwareDefDisplayName}
-            />
-          }
-        >
-          {hoverTooltipHandlers => (
-            <span
-              {...hoverTooltipHandlers}
-              className={styles.labware_display_name}
-            >
-              {sourceLabwareNickname}
-            </span>
-          )}
-        </HoverTooltip>
+        <span {...sourceTargetProps} className={styles.labware_display_name}>
+          {sourceLabwareNickname}
+        </span>
+
         {/* This is always a "transfer icon" (arrow pointing right) for any step: */}
         <Icon className={styles.step_subitem_spacer} name="ot-transfer" />
-        <HoverTooltip
-          portal={Portal}
-          tooltipComponent={
-            <LabwareTooltipContents
-              labwareNickname={destLabwareNickname}
-              labwareDefDisplayName={destLabwareDefDisplayName}
-            />
-          }
-        >
-          {hoverTooltipHandlers => (
-            <span
-              {...hoverTooltipHandlers}
-              className={styles.labware_display_name}
-            >
-              {destLabwareNickname}
-            </span>
-          )}
-        </HoverTooltip>
+
+        <span {...destTargetProps} className={styles.labware_display_name}>
+          {destLabwareNickname}
+        </span>
       </PDListItem>
-    </React.Fragment>
+    </>
   )
 }

--- a/protocol-designer/src/components/steplist/MixHeader.js
+++ b/protocol-designer/src/components/steplist/MixHeader.js
@@ -1,11 +1,10 @@
 // @flow
 import * as React from 'react'
 import cx from 'classnames'
-import { HoverTooltip } from '@opentrons/components'
+import { Tooltip, useHoverTooltip, TOOLTIP_FIXED } from '@opentrons/components'
 import { PDListItem } from '../lists'
 import styles from './StepItem.css'
 import { LabwareTooltipContents } from './LabwareTooltipContents'
-import { Portal } from './TooltipPortal'
 
 type Props = {
   volume: ?string,
@@ -16,27 +15,29 @@ type Props = {
 
 export function MixHeader(props: Props) {
   const { volume, times, labwareNickname, labwareDefDisplayName } = props
+  const [targetProps, tooltipProps] = useHoverTooltip({
+    placement: 'bottom-start',
+    strategy: TOOLTIP_FIXED,
+  })
   return (
-    <PDListItem className={styles.step_subitem}>
-      <HoverTooltip
-        portal={Portal}
-        tooltipComponent={
-          <LabwareTooltipContents
-            {...{ labwareNickname, labwareDefDisplayName }}
-          />
-        }
-      >
-        {hoverTooltipHandlers => (
-          <span
-            {...hoverTooltipHandlers}
-            className={cx(styles.emphasized_cell, styles.labware_display_name)}
-          >
-            {labwareNickname}
-          </span>
-        )}
-      </HoverTooltip>
-      <span>{volume} uL</span>
-      <span>{times}x</span>
-    </PDListItem>
+    <>
+      <Tooltip {...tooltipProps}>
+        <LabwareTooltipContents
+          {...{ labwareNickname, labwareDefDisplayName }}
+        />
+      </Tooltip>
+
+      <PDListItem className={styles.step_subitem}>
+        <span
+          {...targetProps}
+          className={cx(styles.emphasized_cell, styles.labware_display_name)}
+        >
+          {labwareNickname}
+        </span>
+
+        <span>{volume} uL</span>
+        <span>{times}x</span>
+      </PDListItem>
+    </>
   )
 }

--- a/protocol-designer/src/components/steplist/ModuleStepItems.js
+++ b/protocol-designer/src/components/steplist/ModuleStepItems.js
@@ -1,10 +1,9 @@
 // @flow
 import * as React from 'react'
 import cx from 'classnames'
-import { HoverTooltip } from '@opentrons/components'
+import { Tooltip, useHoverTooltip, TOOLTIP_FIXED } from '@opentrons/components'
 import { i18n } from '../../localization'
 import { PDListItem } from '../lists'
-import { Portal } from './TooltipPortal'
 import { LabwareTooltipContents } from './LabwareTooltipContents'
 import styles from './StepItem.css'
 import type { ModuleRealType } from '@opentrons/shared-data'
@@ -18,39 +17,40 @@ type Props = {|
   message?: ?string,
 |}
 
-export const ModuleStepItems = (props: Props) => (
-  <>
-    <li className={styles.substep_header}>
-      <span>{i18n.t(`modules.module_long_names.${props.moduleType}`)}</span>
-      <span>{props.action}</span>
-    </li>
-    <PDListItem
-      className={cx(styles.step_subitem_column_header, styles.substep_content)}
-    >
-      <HoverTooltip
-        portal={Portal}
-        tooltipComponent={
-          <LabwareTooltipContents
-            labwareNickname={props.labwareNickname}
-            labwareDefDisplayName={props.labwareDisplayName}
-          />
-        }
-      >
-        {hoverTooltipHandlers => (
-          <span
-            {...hoverTooltipHandlers}
-            className={styles.labware_display_name}
-          >
-            {props.labwareNickname}
-          </span>
+export const ModuleStepItems = (props: Props) => {
+  const [targetProps, tooltipProps] = useHoverTooltip({
+    placement: 'bottom-start',
+    strategy: TOOLTIP_FIXED,
+  })
+  return (
+    <>
+      <li className={styles.substep_header}>
+        <span>{i18n.t(`modules.module_long_names.${props.moduleType}`)}</span>
+        <span>{props.action}</span>
+      </li>
+      <Tooltip {...tooltipProps}>
+        <LabwareTooltipContents
+          labwareNickname={props.labwareNickname}
+          labwareDefDisplayName={props.labwareDisplayName}
+        />
+      </Tooltip>
+      <PDListItem
+        className={cx(
+          styles.step_subitem_column_header,
+          styles.substep_content
         )}
-      </HoverTooltip>
-      <span className={styles.module_substep_value}>{props.actionText}</span>
-    </PDListItem>
-    {props.message && (
-      <PDListItem className={cx(styles.substep_content, 'step-item-message')}>
-        &quot;{props.message}&quot;
+      >
+        <span {...targetProps} className={styles.labware_display_name}>
+          {props.labwareNickname}
+        </span>
+
+        <span className={styles.module_substep_value}>{props.actionText}</span>
       </PDListItem>
-    )}
-  </>
-)
+      {props.message && (
+        <PDListItem className={cx(styles.substep_content, 'step-item-message')}>
+          &quot;{props.message}&quot;
+        </PDListItem>
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
## overview

This PR addresses #5411 by replacing the old HoverTooltips with the shine new tooltip for labware names in the `AspirateDispenseHeader` `MixHeader` and `ModuleStepItems`. The next PR will handle the `IngredPill` and `SubstepRow` refactor. 

## changelog

- refactor(protocol-designer): Update tooltip component in substep headers

## review requests

Make a protocol with a Transfer, Mix, and  MagnetStep (make sure there's a labware on the magnetic module)
- [ ] Tooltip renders with labware info for transfer source labware
- [ ] Tooltip renders with labware info for transfer destination labware
- [ ] Tooltip renders with labware info for mix source labware
- [ ] Tooltip renders with labware info for magnetic step labware

PS - this rips out the Portal part of the old tooltip, placement is _slightly_ different than on edge for the destination labware tooltips, but this is because we are using popper.js built in placement arguments instead of getting crazy with custom styles and a Portal.

## risk assessment

Low, just PD tooltips.
