### PR TITLE
refactor(protocol-designer): Update announcement and export modal text

### DIFF
--- a/protocol-designer/src/components/FileSidebar/FileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.js
@@ -152,14 +152,17 @@ function getWarningContent({
 // TODO (ka 2020-2-26): Update this knowledgebase link when available
 export const v4WarningContent = (
   <div>
-    <p>{i18n.t(`alert.hint.export_v4_protocol.body1`)} </p>
-    <p>{i18n.t(`alert.hint.export_v4_protocol.body2`)}</p>
-    <p>{i18n.t(`alert.hint.export_v4_protocol.body3`)}</p>
+    <p>
+      {i18n.t(`alert.hint.export_v4_protocol.body1`)}{' '}
+      <strong>{i18n.t(`alert.hint.export_v4_protocol.body2`)}</strong>
+      {i18n.t(`alert.hint.export_v4_protocol.body3`)}
+    </p>
+    {/* 
     <p>
       <KnowledgeBaseLink to="betaReleases">
         Learn more about Beta releases here
       </KnowledgeBaseLink>
-    </p>
+    </p> */}
   </div>
 )
 

--- a/protocol-designer/src/components/modals/AnnouncementModal/announcements.js
+++ b/protocol-designer/src/components/modals/AnnouncementModal/announcements.js
@@ -25,7 +25,7 @@ export const announcements: Array<Announcement> = [
     message: (
       <>
         <p>
-          Protocol Designer now includes Beta support for Temperature and
+          Protocol Designer Beta now includes support for Temperature and
           Magnetic modules.
         </p>
         <p>

--- a/protocol-designer/src/components/modals/AnnouncementModal/announcements.js
+++ b/protocol-designer/src/components/modals/AnnouncementModal/announcements.js
@@ -29,22 +29,10 @@ export const announcements: Array<Announcement> = [
           Magnetic modules.
         </p>
         <p>
-          To use Temperature and Magnetic modules in the Protocol Designer
-          protocols, update your Opentrons App and OT-2 to software version
-          3.17.0 Beta.
-        </p>
-        <p>
-          Beta releases provide early access to new software versions and
-          features. While we make a best effort to test each version, Beta
-          features and software versions may include bugs or incomplete
-          functionality.
-        </p>
-        <p>
-          Learn more about Beta releases{' '}
-          <a href="https://support.opentrons.com/en/articles/3854833-opentrons-beta-software-releases">
-            here
-          </a>
-          .
+          Note: Protocols with modules{' '}
+          <strong>may require an app and robot update to run</strong>. You will
+          need to have the OT-2 app and robot on the latest versions (
+          <strong>3.17 or higher</strong>).
         </p>
       </>
     ),

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -30,9 +30,9 @@
     },
     "export_v4_protocol": {
       "title": "Robot requirements for running module inclusive JSON protocols",
-      "body1": "This protocol includes Temperature and Magnetic modules.",
-      "body2": "Modules support is currently a Beta feature. To run this protocol, update your Opentrons App and OT-2 to software version 3.17.0 Beta.",
-      "body3": "Beta releases provide early access to new software versions and features. While we make a best effort to test each version, Beta features and software versions may include bugs or incomplete functionality."
+      "body1": "This protocol utilizes modules and can only run on app and robot server version",
+      "body2": "3.17 or higher",
+      "body3": ". Please ensure your OT-2 is updated to the correct version."
     },
     "change_magnet_module_model": {
       "title": "All existing engage heights will be cleared"


### PR DESCRIPTION
## overview

This PR serves as its own ticket, it removes references to beta in the announcement and V4 export text.

<img width="650" alt="Screen Shot 2020-04-23 at 4 38 56 PM" src="https://user-images.githubusercontent.com/3430313/80147153-0c307880-8581-11ea-8ecd-9a25f0dd65ef.png">


<img width="645" alt="Screen Shot 2020-04-23 at 12 58 22 PM" src="https://user-images.githubusercontent.com/3430313/80137770-c7e9ac00-8571-11ea-9c1a-86faaf137ac2.png">

## changelog

- refactor(protocol-designer): Update announcement and export modal text

## review requests

http://sandbox.designer.opentrons.com/pd_update-announements-remove-beta-wording/

- Open up this branch in an incognito window so you can see the modules announcement modal
- [ ] Text is accurate and does not reference 3.17.0 Beta

- Make a protocol with a module and export it to view V4 export modal
- [ ] Text is accurate and does not reference 3.17.0 Beta

## risk assessment

Low just text in PD