### PR TITLE
fix(app-shell): upgrade Electron, avoid hoisting dependencies, and fix devtools

### DIFF
--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -50,8 +50,10 @@ electron := electron . \
 all: package
 
 .PHONY: setup
+# must be wrapped in yarn run otherwise `prebuild-install` will fail silently
+# due to how `electron-rebuild` calls `prebuild-install`
 setup:
-	electron-rebuild
+	yarn electron-rebuild
 
 .PHONY: clean
 clean:

--- a/app-shell/__mocks__/usb-detection.js
+++ b/app-shell/__mocks__/usb-detection.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const EventEmitter = require('events')
+const detector = new EventEmitter()
+
+detector.startMonitoring = jest.fn()
+detector.stopMonitoring = jest.fn()
+detector.find = jest.fn()
+
+afterEach(() => {
+  detector.removeAllListeners()
+})
+
+module.exports = detector

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -6,7 +6,7 @@ const DEV_MODE = process.env.NODE_ENV !== 'production'
 
 module.exports = {
   appId: 'com.opentrons.app',
-  electronVersion: '6.0.7',
+  electronVersion: '6.1.10',
   files: [
     '**/*',
     {

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -19,9 +19,7 @@ module.exports = {
     '!Makefile',
   ],
   /* eslint-disable no-template-curly-in-string */
-  artifactName: DEV_MODE
-    ? '${productName}-v${version}-${os}-${dev}.${ext}'
-    : '${productName}-v${version}-${os}-${env.BUILD_ID}.${ext}',
+  artifactName: '${productName}-v${version}-${os}-${env.BUILD_ID}.${ext}',
   /* eslint-enable no-template-curly-in-string */
   asar: true,
   mac: {

--- a/app-shell/package.json
+++ b/app-shell/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opentrons/app-shell",
+  "private": true,
   "productName": "Opentrons",
   "version": "3.17.1-alpha.2",
   "description": "Opentrons desktop application",
@@ -20,10 +21,17 @@
     "url": "https://github.com/Opentrons/opentrons/issues"
   },
   "homepage": "https://github.com/Opentrons/opentrons",
-  "dependencies": {
+  "workspaces": {
+    "nohoist": [
+      "**"
+    ]
+  },
+  "devDependencies": {
     "@opentrons/app": "3.17.1-alpha.2",
     "@opentrons/discovery-client": "3.17.1-alpha.2",
-    "@opentrons/shared-data": "3.17.1-alpha.2",
+    "@opentrons/shared-data": "3.17.1-alpha.2"
+  },
+  "dependencies": {
     "@thi.ng/paths": "^1.6.5",
     "ajv": "^6.10.2",
     "dateformat": "^3.0.3",

--- a/app-shell/package.json
+++ b/app-shell/package.json
@@ -37,7 +37,7 @@
     "dateformat": "^3.0.3",
     "electron-context-menu": "^0.15.1",
     "electron-debug": "^3.0.1",
-    "electron-devtools-installer": "^2.2.4",
+    "electron-devtools-installer": "^3.0.0",
     "electron-dl": "^1.14.0",
     "electron-store": "^4.0.0",
     "electron-updater": "^4.1.2",

--- a/app-shell/src/main.js
+++ b/app-shell/src/main.js
@@ -34,7 +34,12 @@ let rendererLogger
 // https://github.com/electron/electron/issues/19468#issuecomment-623529556
 app.prependOnceListener('ready', startUp)
 if (config.devtools) app.once('ready', installDevtools)
-app.once('window-all-closed', () => app.quit())
+app.once('window-all-closed', () => {
+  log.debug('all windows closed, quitting the app', {
+    appListeners: app.eventNames(),
+  })
+  app.quit()
+})
 
 function startUp() {
   log.info('Starting App')

--- a/app-shell/src/main.js
+++ b/app-shell/src/main.js
@@ -34,10 +34,9 @@ let rendererLogger
 // https://github.com/electron/electron/issues/19468#issuecomment-623529556
 app.prependOnceListener('ready', startUp)
 if (config.devtools) app.once('ready', installDevtools)
+
 app.once('window-all-closed', () => {
-  log.debug('all windows closed, quitting the app', {
-    appListeners: app.eventNames(),
-  })
+  log.debug('all windows closed, quitting the app')
   app.quit()
 })
 
@@ -58,8 +57,10 @@ function startUp() {
 
   // wire modules to UI dispatches
   const dispatch = action => {
-    log.silly('Sending action via IPC to renderer', { action })
-    mainWindow.webContents.send('dispatch', action)
+    if (mainWindow) {
+      log.silly('Sending action via IPC to renderer', { action })
+      mainWindow.webContents.send('dispatch', action)
+    }
   }
 
   const actionHandlers = [

--- a/app-shell/src/system-info/__tests__/usb-devices.test.js
+++ b/app-shell/src/system-info/__tests__/usb-devices.test.js
@@ -7,14 +7,7 @@ import * as Fixtures from '@opentrons/app/src/system-info/__fixtures__'
 import { createUsbDeviceMonitor, getWindowsDriverVersion } from '../usb-devices'
 
 jest.mock('execa')
-jest.mock('usb-detection', () => {
-  const EventEmitter = require('events')
-  const detector = new EventEmitter()
-  detector.startMonitoring = jest.fn()
-  detector.stopMonitoring = jest.fn()
-  detector.find = jest.fn()
-  return detector
-})
+jest.mock('usb-detection')
 
 const usbDetectionFind: JestMockFn<[], any> = (usbDetection.find: any)
 

--- a/app-shell/src/system-info/index.js
+++ b/app-shell/src/system-info/index.js
@@ -3,7 +3,7 @@
 import { app } from 'electron'
 import { UI_INITIALIZED } from '@opentrons/app/src/shell/actions'
 import * as SystemInfo from '@opentrons/app/src/system-info'
-import { createLogger } from '../logger'
+import { createLogger } from '../log'
 import { isWindows } from '../os'
 import { createUsbDeviceMonitor, getWindowsDriverVersion } from './usb-devices'
 

--- a/app-shell/src/system-info/index.js
+++ b/app-shell/src/system-info/index.js
@@ -3,6 +3,7 @@
 import { app } from 'electron'
 import { UI_INITIALIZED } from '@opentrons/app/src/shell/actions'
 import * as SystemInfo from '@opentrons/app/src/system-info'
+import { createLogger } from '../logger'
 import { isWindows } from '../os'
 import { createUsbDeviceMonitor, getWindowsDriverVersion } from './usb-devices'
 
@@ -11,6 +12,8 @@ import type { Action, Dispatch } from '../types'
 import type { UsbDeviceMonitor, Device } from './usb-devices'
 
 const RE_REALTEK = /realtek/i
+
+const log = createLogger('system-info')
 
 const addDriverVersion = (device: Device): Promise<UsbDevice> => {
   if (isWindows() && RE_REALTEK.test(device.manufacturer)) {
@@ -35,7 +38,10 @@ export function registerSystemInfo(dispatch: Dispatch) {
   }
 
   app.once('will-quit', () => {
-    if (monitor) monitor.stop()
+    if (monitor) {
+      log.debug('stopping usb monitoring')
+      monitor.stop()
+    }
   })
 
   return function handleSystemAction(action: Action) {

--- a/app-shell/src/system-info/usb-devices.js
+++ b/app-shell/src/system-info/usb-devices.js
@@ -19,7 +19,7 @@ export type UsbDeviceMonitor = {|
   stop: () => void,
 |}
 
-const logger = createLogger('usb-devices')
+const log = createLogger('usb-devices')
 
 export function createUsbDeviceMonitor(
   options: UsbDeviceMonitorOptions = {}
@@ -46,6 +46,7 @@ export function createUsbDeviceMonitor(
       }
 
       usbDetection.stopMonitoring()
+      log.debug('usb detection monitoring stopped')
     },
   }
 }
@@ -74,7 +75,7 @@ export function getWindowsDriverVersion(
     )
     .then(result => result.stdout.trim())
     .catch(error => {
-      logger.warn('unable to read Windows USB driver version', {
+      log.warn('unable to read Windows USB driver version', {
         device,
         error,
       })

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ init:
 platform: x64
 
 cache:
-  # - "%LOCALAPPDATA%\\Yarn"
+  - "%LOCALAPPDATA%\\Yarn"
 
 install:
   # read node version from the first line of .nvmrc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ init:
 platform: x64
 
 cache:
-  - "%LOCALAPPDATA%\\Yarn"
+  # - "%LOCALAPPDATA%\\Yarn"
 
 install:
   # read node version from the first line of .nvmrc

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "cypress": "^4.0.2",
     "cypress-file-upload": "3.5.3",
     "cz-conventional-changelog": "2.1.0",
-    "electron": "^6.0.7",
+    "electron": "6.1.10",
     "electron-builder": "^21.2.0",
     "electron-notarize": "^0.1.1",
     "electron-publisher-s3": "^20.17.2",

--- a/scripts/setup-global-mocks.js
+++ b/scripts/setup-global-mocks.js
@@ -4,7 +4,6 @@
 jest.mock('electron')
 jest.mock('electron-updater')
 jest.mock('electron-store')
-jest.mock('usb-detection', () => {})
 
 jest.mock('../components/src/deck/getDeckDefinitions')
 jest.mock('../app/src/getLabware')

--- a/shared-data/package.json
+++ b/shared-data/package.json
@@ -10,6 +10,7 @@
   "license": "Apache-2.0",
   "main": "js/index.js",
   "dependencies": {
-    "uuid": "3.3.2"
+    "ajv": "^6.10.2",
+    "lodash": "^4.17.4"
   }
 }

--- a/webpack-config/lib/node-base-config.js
+++ b/webpack-config/lib/node-base-config.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const path = require('path')
 const webpackMerge = require('webpack-merge')
 const nodeExternals = require('webpack-node-externals')
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
@@ -11,10 +10,6 @@ const { ENABLE_ANALYZER } = require('./env')
 const MERGE_STRATEGY = {
   entry: 'replace',
   plugins: 'replace',
-}
-
-const EXTERNALS_CONFIG = {
-  whitelist: /^@opentrons\/.*/,
 }
 
 module.exports = webpackMerge.strategy(MERGE_STRATEGY)(baseConfig, {
@@ -35,15 +30,14 @@ module.exports = webpackMerge.strategy(MERGE_STRATEGY)(baseConfig, {
   // do not attempt to polyfill nor mock built-in Node libraries and globals
   node: false,
 
+  // exclude package.json dependencies from the bundle
   externals: [
-    // exclude package.json dependencies from the bundle
-    nodeExternals(EXTERNALS_CONFIG),
-    // also exclude workspace hoisted packages from the bundle
-    nodeExternals(
-      Object.assign(
-        { modulesDir: path.join(__dirname, '../../node_modules') },
-        EXTERNALS_CONFIG
-      )
-    ),
+    nodeExternals({
+      whitelist: /^@opentrons\/.*/,
+      modulesFromFile: {
+        include: ['dependencies'],
+        exclude: ['devDependencies'],
+      },
+    }),
   ],
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,10 +11,6 @@
   resolved "https://registry.yarnpkg.com/7zip-bin/-/7zip-bin-5.0.3.tgz#bc5b5532ecafd923a61f2fb097e3b108c0106a3f"
   integrity sha512-GLyWIFBbGvpKPGo55JyRZAo4lVbnBiD52cKlw/0Vt+wnmKvWJkpZvsjVoaIolyBXDeAQKSicRtqFNPem9w0WYA==
 
-"7zip@0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/7zip/-/7zip-0.0.6.tgz#9cafb171af82329490353b4816f03347aa150a30"
-
 "@babel/code-frame@7.5.5", "@babel/code-frame@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
@@ -5928,10 +5924,6 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cross-unzip@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/cross-unzip/-/cross-unzip-0.0.2.tgz#5183bc47a09559befcf98cc4657964999359372f"
-
 crypt@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
@@ -6982,14 +6974,14 @@ electron-debug@^3.0.1:
     electron-is-dev "^1.1.0"
     electron-localshortcut "^3.1.0"
 
-electron-devtools-installer@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.2.4.tgz#261a50337e37121d338b966f07922eb4939a8763"
+electron-devtools-installer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-3.0.0.tgz#b5c439708746ed36f7b0220e18657567bca275d8"
+  integrity sha512-zll3w/8PvnPiGmL5tBtgSSoSjWnUljsOjJYsYYU12PKLljzWyfD6S75LKTZFn21VYxVbae2OwmjM5uFStLp6nQ==
   dependencies:
-    "7zip" "0.0.6"
-    cross-unzip "0.0.2"
-    rimraf "^2.5.2"
-    semver "^5.3.0"
+    rimraf "^3.0.2"
+    semver "^7.2.1"
+    unzip-crx "^0.2.0"
 
 electron-dl@^1.14.0, electron-dl@^1.2.0:
   version "1.14.0"
@@ -11275,6 +11267,16 @@ jsx-ast-utils@^2.1.0:
   dependencies:
     array-includes "^3.0.3"
     object.assign "^4.1.0"
+
+jszip@^3.1.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.4.0.tgz#1a69421fa5f0bb9bc222a46bca88182fba075350"
+  integrity sha512-gZAOYuPl4EhPTXT0GjhI3o+ZAz3su6EhLrKUoAivcKqyqC7laS5JEv4XWZND9BgcDcF83vI85yGbDmDR6UhrIg==
+  dependencies:
+    lie "~3.3.0"
+    pako "~1.0.2"
+    readable-stream "~2.3.6"
+    set-immediate-shim "~1.0.1"
 
 jszip@^3.2.2:
   version "3.2.2"
@@ -16620,7 +16622,7 @@ right-pad@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz#8ca08c2cbb5b55e74dafa96bf7fd1a27d568c8d0"
 
-rimraf@2, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -16924,6 +16926,11 @@ semver@^7.1.1, semver@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
   integrity sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==
+
+semver@^7.2.1:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
 semver@~5.3.0:
   version "5.3.0"
@@ -19005,6 +19012,15 @@ unused-filename@^1.0.0:
     modify-filename "^1.1.0"
     path-exists "^3.0.0"
 
+unzip-crx@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/unzip-crx/-/unzip-crx-0.2.0.tgz#4c0baa8bdac756256754beca7843c13d7b858c18"
+  integrity sha1-TAuqi9rHViVnVL7KeEPBPXuFjBg=
+  dependencies:
+    jszip "^3.1.0"
+    mkdirp "^0.5.1"
+    yaku "^0.16.6"
+
 unzipper@^0.10.8:
   version "0.10.9"
   resolved "https://registry.yarnpkg.com/unzipper/-/unzipper-0.10.9.tgz#b3c9e93f1c3d6a2dc7e6c609580190126a0057e3"
@@ -19919,6 +19935,11 @@ xtend@~2.1.1:
 "y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
+
+yaku@^0.16.6:
+  version "0.16.7"
+  resolved "https://registry.yarnpkg.com/yaku/-/yaku-0.16.7.tgz#1d195c78aa9b5bf8479c895b9504fd4f0847984e"
+  integrity sha1-HRlceKqbW/hHnIlblQT9TwhHmE4=
 
 yallist@^2.1.2:
   version "2.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7122,10 +7122,10 @@ electron-updater@^4.1.2:
     pako "^1.0.10"
     semver "^6.2.0"
 
-electron@^6.0.7:
-  version "6.0.7"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-6.0.7.tgz#cf3f02502aa58d1517f3befd9c2da2a95cd2eb46"
-  integrity sha512-W0TFnJrBdYBUhzRnEqZt/CfYFmG9RwSnhhXBbOumn/qLQYr9e7kXb6z4y0XQQLhXKkDhuXp+dNqfzhtId5ZiQw==
+electron@6.1.10:
+  version "6.1.10"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-6.1.10.tgz#b2a875f5c8f3c3e7954dfa11c05083e49d2fb8c2"
+  integrity sha512-mOrV4jm0O6HSktLbUYPNAQdOAses1p8XGSad/lR5koBcI0fvBbUWV2EMnZipGwMADFXneTW6LaOpuiuL/67gzQ==
   dependencies:
     "@types/node" "^10.12.18"
     electron-download "^4.1.0"


### PR DESCRIPTION
## overview

The library that we use to build our production Electron app (`electron-builder`) has had a history of selecting incorrect dependencies from the `yarn` workspace for inclusion in the production bundle. This has caused issues in the past (see #3920) and will continue to cause issues if not fixed (see #5537).

A quick audit of the app-shell's spec'd dependencies vs what's actually in the bundle was [fairly alarming](https://github.com/Opentrons/opentrons/issues/5537#issuecomment-622464608).

This PR disables hoisting for `app-shell` dependencies, so that all app-shell production dependencies end up installed in `app-shell/node_modules`. This appears to be enough to get `electron-builder` selecting the correct dependencies.

On top of the hoisting issue, the app's devtools were running into + causing problems on Windows:

- Devtools would fail to install on Windows from the production app with `config.devtools` set
- If devtools _were_ successfully installed on Windows (e.g. from a dev build), the app could fail to launch in Windows if the OS's dark mode was enabled due to a very weird bug in Electron (electron/electron#19468)

Closes #5537 and closes #5541 

## changelog

- fix(deps): upgrade Electron to latest in the v6 line to resolve phantom process issues on Windows
- build(yarn): avoid hoisting app-shell dependencies and fix various problems this exposed:
    - `shared-data/package.json` did not have any dependencies listed
    - `electron-builder.config.js` set the asset name incorrectly if `NODE_ENV != production`
    - `usb-detection` mock needed to be moved since it was no longer being hoisted to the top level
    - Moved internal Opentrons dependencies of app-shell into the `package.json::devDependencies` section because webpack was bundling them into the JS files and we don't want them in `node_modules` in the production build
    - Tweaked externals configuration of webpack config for Node.js projects (discovery-client, app-shell)
- fix(app-shell): Bump electron-devtools-installer and fix problems this exposed
    - Worked around an Electron bug where the built-in devtools API would lock-up during setup and prevent the app from launching

## review requests

This is a fairly large change in terms of functionality because there were a lot of incorrect dependencies. Stuff we should be keeping an eye on:

- U2E driver version on windows (dependency `execa`)
- Buildroot migrations, auto updates, and updates from file (dependencies `fs-extra`, `node-fetch`, and `get-stream`)
- Custom labware (dependency `fs-extra`)
- Devtools installation on non-Windows OS's
- Keep an eye out for phantom processes!

## risk assessment

Medium

- The production app has been bundling incorrect dependencies, and now it is bundling the spec'd dependencies (😄)
- Fixed a [failure to launch bug](https://github.com/electron/electron/issues/19468#issuecomment-623529556) in Windows if a user had ever installed devtools (😄)
- Using the spec'd dependencies may expose unknown bugs like with #3920 (😨)
