### PR TITLE
fix(api): make delay wait for existing pause before pausing itself

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -252,6 +252,7 @@ class API(HardwareAPILike):
     async def delay(self, duration_s: int):
         """ Delay execution by pausing and sleeping.
         """
+        await self._wait_for_is_running()
         self.pause()
         if not self.is_simulator:
             async def sleep_for_seconds(seconds: int):


### PR DESCRIPTION
If a delay appears after a pause in a protocol and there is no actual robot or module command to await the execution manager between them, the delay will capture the current pause and resume automatically when its timer has elapsed. This change makes the delay function await the execution manager to keep this edge case from occurring.

Closes #4801