### PR TITLE
feat(robot-server,api): change useFastApi to useV1HttpApi

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -145,12 +145,9 @@ settings = [
                     ' affects GEN1 P10S, P10M, P50S, P50M, and P300S pipettes.'
     ),
     SettingDefinition(
-        _id='useFastApi',
-        title='Enable experimental HTTP API v2',
-        description='Tells the OT-2 to run a newer, highly experimental '
-                    'version of its HTTP API based on the FastAPI framework. '
-                    'This is an internal setting for Opentrons engineers; '
-                    'do not enable this setting or you will break your OT-2.',
+        _id='useV1HttpApi',
+        title='Revert to legacy HTTP API v1',
+        description='Tells the OT-2 to run the legacy v1 http api.',
         restart_required=True
     ),
 ]

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -293,7 +293,17 @@ def _migrate2to3(previous: SettingsMap) -> SettingsMap:
     return newmap
 
 
-_MIGRATIONS = [_migrate0to1, _migrate1to2, _migrate2to3]
+def _migrate3to4(previous: SettingsMap) -> SettingsMap:
+    """
+    Migration to version 4 of the feature flags file. Adds the
+    useV1HttpApi config element.
+    """
+    newmap = {k: v for k, v in previous.items()}
+    newmap['useV1HttpApi'] = None
+    return newmap
+
+
+_MIGRATIONS = [_migrate0to1, _migrate1to2, _migrate2to3, _migrate3to4]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below
 for how the migration functions are applied. Each migration function should
@@ -352,7 +362,7 @@ _SETTINGS_RESTART_REQUIRED = False
 # the same process, will require _all_ of them to be restarted.
 
 
-def restart_required() -> bool:
+def is_restart_required() -> bool:
     return _SETTINGS_RESTART_REQUIRED
 
 

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -26,4 +26,4 @@ def use_old_aspiration_functions():
 
 
 def use_fast_api() -> bool:
-    return advs.get_setting_with_env_overload('useFastApi')
+    return not advs.get_setting_with_env_overload('useV1HttpApi')

--- a/api/src/opentrons/server/endpoints/settings.py
+++ b/api/src/opentrons/server/endpoints/settings.py
@@ -28,7 +28,7 @@ def _get_adv_settings_response() -> Dict[
                List[Dict[str, Union[str, bool, None]]]]]:
     data = advs.get_all_adv_settings()
 
-    if advs.restart_required():
+    if advs.is_restart_required():
         links = {'restart': '/server/restart'}
     else:
         links = {}

--- a/api/tests/opentrons/config/test_advanced_settings.py
+++ b/api/tests/opentrons/config/test_advanced_settings.py
@@ -110,10 +110,10 @@ async def test_on_change_called(loop,
 
 
 async def test_restart_required(loop, restore_restart_required):
-    assert advanced_settings.restart_required() is False
-    _id = 'useFastApi'
+    assert advanced_settings.is_restart_required() is False
+    _id = 'useV1HttpApi'
     await advanced_settings.set_adv_setting(_id, True)
-    assert advanced_settings.restart_required() is True
+    assert advanced_settings.is_restart_required() is True
 
 
 def test_get_setting_use_env_overload(mock_read_settings_file,

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -1,7 +1,7 @@
 from opentrons.config.advanced_settings import _migrate, _ensure
 
 
-good_file_version = 3
+good_file_version = 4
 good_file_settings = {
     'shortFixedTrash': None,
     'calibrateToBottom': None,
@@ -11,7 +11,7 @@ good_file_settings = {
     'disableLogAggregation': None,
     'enableApi1BackCompat': None,
     'useProtocolApi2': None,
-    'useFastApi': None,
+    'useV1HttpApi': None,
 }
 
 
@@ -41,7 +41,7 @@ def test_migrates_versionless_new_config():
       'disableLogAggregation': None,
       'enableApi1BackCompat': None,
       'useProtocolApi2': None,
-      'useFastApi': None
+      'useV1HttpApi': None
     }
 
 
@@ -63,7 +63,7 @@ def test_migrates_versionless_old_config():
       'disableLogAggregation': None,
       'enableApi1BackCompat': None,
       'useProtocolApi2': None,
-      'useFastApi': None
+      'useV1HttpApi': None
     }
 
 
@@ -97,6 +97,7 @@ def test_migrates_v1_config():
         'disableLogAggregation': None,
         'useProtocolApi2': None,
         'enableApi1BackCompat': None,
+        'useV1HttpApi': None,
     }
 
 
@@ -123,6 +124,7 @@ def test_migrates_v2_config():
         'disableLogAggregation': False,
         'useProtocolApi2': None,
         'enableApi1BackCompat': None,
+        'useV1HttpApi': None,
     }
 
 
@@ -148,6 +150,7 @@ def test_migrates_v3_config():
         'disableLogAggregation': False,
         'useProtocolApi2': None,
         'enableApi1BackCompat': False,
+        'useV1HttpApi': None
     }
 
 
@@ -165,5 +168,5 @@ def test_ensures_config():
              'useOldAspirationFunctions': None,
              'disableLogAggregation': True,
              'useProtocolApi2': None,
-             'useFastApi': None
+             'useV1HttpApi': None
          }

--- a/robot-server/robot_server/service/routers/settings.py
+++ b/robot-server/robot_server/service/routers/settings.py
@@ -57,7 +57,7 @@ def _create_settings_response() -> AdvancedSettingsResponse:
     """Create the feature flag settings response object"""
     data = advanced_settings.get_all_adv_settings()
 
-    if advanced_settings.restart_required():
+    if advanced_settings.is_restart_required():
         links = Links(restart='/server/restart')
     else:
         links = Links()

--- a/robot-server/tests/service/routers/test_settings.py
+++ b/robot-server/tests/service/routers/test_settings.py
@@ -383,8 +383,8 @@ def mock_get_all_adv_settings():
 
 
 @pytest.fixture
-def mock_restart_required():
-    with patch("robot_server.service.routers.settings.advanced_settings.restart_required") as p:   # noqa: E501
+def mock_is_restart_required():
+    with patch("robot_server.service.routers.settings.advanced_settings.is_restart_required") as p:   # noqa: E501
         yield p
 
 
@@ -417,9 +417,9 @@ def validate_response_body(body, restart):
                              [False, None],
                              [True, "/server/restart"]
                          ])
-def test_get(api_client, mock_get_all_adv_settings, mock_restart_required,
+def test_get(api_client, mock_get_all_adv_settings, mock_is_restart_required,
              restart_required, link):
-    mock_restart_required.return_value = restart_required
+    mock_is_restart_required.return_value = restart_required
     resp = api_client.get('/settings')
     body = resp.json()
     assert resp.status_code == 200
@@ -432,9 +432,9 @@ def test_get(api_client, mock_get_all_adv_settings, mock_restart_required,
                              [advanced_settings.SettingException("Fail", "e"),
                               500]
                          ])
-def test_set_err(api_client, mock_restart_required,
+def test_set_err(api_client, mock_is_restart_required,
                  mock_set_adv_setting, exc, expected_status):
-    mock_restart_required.return_value = False
+    mock_is_restart_required.return_value = False
 
     def raiser(i, v):
         raise exc
@@ -449,8 +449,8 @@ def test_set_err(api_client, mock_restart_required,
     assert body == {"message": str(exc)}
 
 
-def test_set(api_client, mock_set_adv_setting, mock_restart_required):
-    mock_restart_required.return_value = False
+def test_set(api_client, mock_set_adv_setting, mock_is_restart_required):
+    mock_is_restart_required.return_value = False
 
     test_id = 'disableHomeOnBoot'
 


### PR DESCRIPTION
## overview

Changes the default http handling from the aiohttp app in opentrons to the fastapi one in robot-server.

## changelog

- remove `useFastApi` in favor of `useV1HttpApi`

## review requests

- Is it right to just remove `useFastApi` feature flag? 

## risk assessment

Super duper high! This is a total re-implementation of the http api processing.

closes #5510 
