### PR TITLE
ci(travis): remove unnecessary libudev build dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,8 +87,6 @@ jobs:
       name: 'JS unit tests; build Protocol Designer, Labware Library, Components Library'
       # node version pulled from .nvmrc
       language: node_js
-      before_install:
-        - sudo apt-get install -y --no-install-recommends libudev-dev
       install:
         - make install-js
       script:
@@ -127,8 +125,6 @@ jobs:
     - stage: test
       name: 'JS E2E tests'
       language: node_js
-      before_install:
-        - sudo apt-get install -y --no-install-recommends libudev-dev
       install:
         - make install-js
       script:
@@ -138,8 +134,6 @@ jobs:
     - stage: test
       name: 'JS type checks'
       language: node_js
-      before_install:
-        - sudo apt-get install -y --no-install-recommends libudev-dev
       install:
         - make install-js
       script:
@@ -149,8 +143,6 @@ jobs:
       <<: *app_stage_build
       name: 'Build/deploy Opentrons App for POSIX (unsigned dev builds)'
       os: linux
-      before_install:
-        - sudo apt-get install -y --no-install-recommends libudev-dev
       script: make -C app-shell dist-posix
       # skip app builds entirely if tag is present but does not match ^v
       if: tag IS blank
@@ -159,8 +151,6 @@ jobs:
       <<: *app_stage_build
       name: 'Build/deploy Opentrons App for Linux'
       os: linux
-      before_install:
-        - sudo apt-get install -y --no-install-recommends libudev-dev
       script: make -C app-shell dist-linux
       if: tag =~ ^v
 


### PR DESCRIPTION
## overview

#5482 added `libudev` to the TravisCI build dependencies for JS projects. Turns out the reason we need this dependency to get CI to pass was because the prebuilt binary download step (where  binaries for `usb-detection` on the given OS were downloaded) wasn't set up correctly.

#5545 fixed the broken prebuild step, so the `libudev` dependency is no longer needed. This PR removes it from the Travis config.

## changelog

- ci(travis): remove unnecessary libudev build dependency

## review requests

- [ ] CI is green

## risk assessment

Low if CI is green. `libudev` is not used by the Travis config because prebuilt binaries for `usb-detection` are downloaded. If the dependency was needed to build usb-detection, this PR would fail CI