### PR TITLE
feat(app): alert user if Windows U2E driver is out of date

### DIFF
--- a/app/src/components/Alerts/U2EDriverOutdatedAlert.js
+++ b/app/src/components/Alerts/U2EDriverOutdatedAlert.js
@@ -9,7 +9,6 @@ import {
   Link,
   useToggle,
 } from '@opentrons/components'
-import { useFeatureFlag } from '../../config'
 import { useTrackEvent } from '../../analytics'
 import {
   U2E_DRIVER_UPDATE_URL,
@@ -46,12 +45,6 @@ export function U2EDriverOutdatedAlert(props: AlertProps) {
   const trackEvent = useTrackEvent()
   const [rememberDismiss, toggleRememberDismiss] = useToggle()
   const { dismissAlert } = props
-
-  // TODO(mc, 2020-05-07): remove this feature flag
-  const enabled = useFeatureFlag('enableSystemInfo')
-  React.useLayoutEffect(() => {
-    if (!enabled) dismissAlert()
-  })
 
   return (
     <AlertModal

--- a/app/src/components/Alerts/U2EDriverOutdatedAlert.js
+++ b/app/src/components/Alerts/U2EDriverOutdatedAlert.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import { useHistory, Link as InternalLink } from 'react-router-dom'
+import { Link as InternalLink } from 'react-router-dom'
 import styled from 'styled-components'
 
 import {
@@ -41,7 +41,6 @@ const IgnoreCheckbox = styled(CheckboxField)`
 `
 
 export function U2EDriverOutdatedAlert(props: AlertProps) {
-  const history = useHistory()
   const trackEvent = useTrackEvent()
   const [rememberDismiss, toggleRememberDismiss] = useToggle()
   const { dismissAlert } = props
@@ -70,7 +69,6 @@ export function U2EDriverOutdatedAlert(props: AlertProps) {
           external: true,
           children: GET_UPDATE,
           onClick: () => {
-            history.push(ADAPTER_INFO_URL)
             dismissAlert(rememberDismiss)
             trackEvent({
               name: EVENT_U2E_DRIVER_LINK_CLICKED,

--- a/app/src/components/Alerts/__tests__/U2EDriverOutdatedAlert.test.js
+++ b/app/src/components/Alerts/__tests__/U2EDriverOutdatedAlert.test.js
@@ -10,9 +10,6 @@ import { U2EDriverOutdatedAlert } from '../U2EDriverOutdatedAlert'
 jest.mock('../../../analytics')
 
 jest.mock('react-router-dom', () => ({
-  // TODO(mc, 2020-05-11): code smell; figure out a better way to test usage
-  // of the useHistory hook
-  useHistory: () => ({ push: jest.fn() }),
   // TODO(mc, 2020-05-07): create a tested Link wrapper that's safe to mock
   Link: () => <></>,
 }))

--- a/app/src/config/constants.js
+++ b/app/src/config/constants.js
@@ -6,7 +6,6 @@ export const DEV_INTERNAL_FLAGS: Array<DevInternalFlag> = [
   'allPipetteConfig',
   'enableBundleUpload',
   'enableRobotCalCheck',
-  'enableSystemInfo',
 ]
 
 // action type constants

--- a/app/src/config/types.js
+++ b/app/src/config/types.js
@@ -11,7 +11,6 @@ export type DevInternalFlag =
   | 'allPipetteConfig'
   | 'enableBundleUpload'
   | 'enableRobotCalCheck'
-  | 'enableSystemInfo'
 
 export type FeatureFlags = $Shape<{|
   [DevInternalFlag]: boolean | void,

--- a/app/src/nav/__tests__/selectors.test.js
+++ b/app/src/nav/__tests__/selectors.test.js
@@ -7,7 +7,6 @@ import * as RobotSelectors from '../../robot/selectors'
 import * as BuildrootSelectors from '../../buildroot/selectors'
 import * as ShellSelectors from '../../shell'
 import * as SystemInfoSelectors from '../../system-info/selectors'
-import * as ConfigSelectors from '../../config/selectors'
 import * as Selectors from '../selectors'
 
 import { NOT_APPLICABLE, OUTDATED } from '../../system-info'
@@ -80,11 +79,6 @@ const mockGetCommands: JestMockFn<
   any
 > = (RobotSelectors.getCommands: any)
 
-const mockGetFeatureFlags: JestMockFn<
-  [State],
-  $Call<typeof ConfigSelectors.getFeatureFlags, State>
-> = ConfigSelectors.getFeatureFlags
-
 const EXPECTED_ROBOTS = {
   id: 'robots',
   path: '/robots',
@@ -139,9 +133,6 @@ describe('nav selectors', () => {
     mockGetSessionIsLoaded.mockReturnValue(false)
     mockGetCommands.mockReturnValue([])
     mockGetU2EWindowsDriverStatus.mockReturnValue(NOT_APPLICABLE)
-
-    // TODO(mc, 2020-05-08): remove enableSystemInfo feature flag
-    mockGetFeatureFlags.mockReturnValue({ enableSystemInfo: true })
   })
 
   afterEach(() => {

--- a/app/src/nav/selectors.js
+++ b/app/src/nav/selectors.js
@@ -147,8 +147,7 @@ export const getMoreLocation: State => NavLocation = createSelector(
     let notificationReason = null
     if (appUpdate) {
       notificationReason = APP_UPDATE_AVAILABLE
-      // TODO(mc, 2020-05-08): remove enableSystemInfo feature flag
-    } else if (driverStatus === OUTDATED && flags.enableSystemInfo) {
+    } else if (driverStatus === OUTDATED) {
       notificationReason = DRIVER_UPDATE_AVAILABLE
     }
 

--- a/app/src/pages/More/NetworkAndSystem.js
+++ b/app/src/pages/More/NetworkAndSystem.js
@@ -3,7 +3,6 @@
 import * as React from 'react'
 import { css } from 'styled-components'
 
-import { useFeatureFlag } from '../../config'
 import { Page } from '../../components/Page'
 import { NetworkSettingsCard } from '../../components/NetworkSettingsCard'
 import { SystemInfoCard } from '../../components/SystemInfoCard'
@@ -19,16 +18,11 @@ const CARD_GRID_STYLE = css`
   }
 `
 
-export const NetworkAndSystem = () => {
-  // TODO(mc, 2020-04-28): remove enableSystemInfo feature-flag
-  const showSystemInfo = useFeatureFlag('enableSystemInfo')
-
-  return (
-    <Page titleBarProps={{ title: NETWORK_AND_SYSTEM }}>
-      <div css={CARD_GRID_STYLE}>
-        <NetworkSettingsCard />
-        {showSystemInfo && <SystemInfoCard />}
-      </div>
-    </Page>
-  )
-}
+export const NetworkAndSystem = () => (
+  <Page titleBarProps={{ title: NETWORK_AND_SYSTEM }}>
+    <div css={CARD_GRID_STYLE}>
+      <NetworkSettingsCard />
+      <SystemInfoCard />
+    </div>
+  </Page>
+)

--- a/app/src/pages/More/__tests__/NetworkAndSystem.test.js
+++ b/app/src/pages/More/__tests__/NetworkAndSystem.test.js
@@ -7,11 +7,6 @@ import { NetworkSettingsCard } from '../../../components/NetworkSettingsCard'
 import { SystemInfoCard } from '../../../components/SystemInfoCard'
 import { NetworkAndSystem } from '../NetworkAndSystem'
 
-// TODO(mc, 2020-04-28): remove enableSystemInfo feature-flag
-jest.mock('../../../config/hooks', () => ({
-  useFeatureFlag: flag => flag === 'enableSystemInfo',
-}))
-
 describe('/more/network-and-system page component', () => {
   it('should render a Page with the correct title', () => {
     const wrapper = shallow(<NetworkAndSystem />)

--- a/app/src/system-info/constants.js
+++ b/app/src/system-info/constants.js
@@ -34,4 +34,4 @@ export const U2E_DRIVER_OUTDATED_MESSAGE =
 export const U2E_DRIVER_DESCRIPTION =
   'The OT-2 uses this adapter for its USB connection to the Opentrons App.'
 export const U2E_DRIVER_OUTDATED_CTA =
-  "If you are experiencing connectivity issues with your OT-2, please update your computer's driver."
+  "Please update your computer's driver to ensure a reliable connection to your OT-2."


### PR DESCRIPTION
## overview

This PR removes the `enableSystemInfo` feature flag to release the guarded U2E driver update notification functionality to users.

Closes #5493. See ticket for screenshots and GIF recordings made prior to the tweaks listed below:

## changelog

Besides removing the feature flag, this PR makes requested UX and product tweaks:

- Clicking "Get Update" in the warning modal will **not** redirect the user to the System Info car
- Modal and card warning CTA made slightly more forceful:

    > Please update your computer’s driver to ensure a reliable connection to your OT-2.

## review requests

There are various flows and facets in this user experience related to dismissing the alert vs. dismissing the alert permanently, the range of driver versions that can trigger this alert, and analytics collected. Care was taken to make sure those various little behaviors were captured in unit tests.

From a manual QA standpoint, we should focus on smoke tests that ensure:

- On Windows: the alert is triggered and warning information is shown in our worst case (no updates applied to the driver at all)
- On other OS's: dongle information is present in the UI if plugged in and no warnings nor alerts are shown

### Windows testing prereq: downgrade your driver

This procedure _should_ downgrade your Realtek driver to the Windows default version, which on my machine is `10.5.x.y`

1. Plug in U2E dongle / robot USB
2. Open Windows Device Manager
3. Find Realtek device under “Network Adapters”
4. Open device properties and select “Uninstall device”
5. Check the box that says “Remove driver software” during uninstallation
6. Unplug dongle once uninstall is complete

### Windows smoke test

1. Open Opentrons App (use the branch build from this PR)
2. Plug in your robot / dongle
3. Alert should trigger
4. Clicking "View Adapter Info" should close alert and take you to the System Information card
5. Card should display a warning and a "Get Update" button
6. Clicking "Get Update" should take you to the Realtek driver download page
7. Download and install the `10.38.x.y` update
8. Windows should trigger a device remove and re-add for the app, which should pick up the new version
9. Warning in System Info card (and notification dot on the More navbar button) should disappear and device info should list `10.38.x.y` as driver version

### Other OS smoke test

1. Open Opentrons App (use the branch build from this PR)
2. Plug in your robot / dongle
3. Navigate to "More" > "Network & System"
4. "System Information" card should display adapter information *without* warning nor driver version

## risk assessment

Low. We've been interacting with this code and behavior for a little while now, and the behavior seems good and reliable. The logic and UI is well-covered by unit tests. Finally, at the end of the day, this feature is purely informational; it does not change any connectivity behavior that the app has control over
