### PR TITLE
feat(components): add Box primitive to components library

### DIFF
--- a/app/src/components/SystemInfoCard/U2EAdapterInfo.js
+++ b/app/src/components/SystemInfoCard/U2EAdapterInfo.js
@@ -1,12 +1,14 @@
 // @flow
 import * as React from 'react'
 import { useSelector } from 'react-redux'
-import { css } from 'styled-components'
 
 import {
+  Box,
   Text,
   FONT_SIZE_BODY_1,
   FONT_WEIGHT_SEMIBOLD,
+  SPACING_2,
+  SPACING_3,
 } from '@opentrons/components'
 
 import * as SystemInfo from '../../system-info'
@@ -25,30 +27,17 @@ export const U2EAdapterInfo = () => {
   })
 
   return (
-    <div
-      css={css`
-        font-size: ${FONT_SIZE_BODY_1};
-        padding: 1rem;
-      `}
-    >
+    <Box fontSize={FONT_SIZE_BODY_1} padding={SPACING_3}>
       <Text
         as="h3"
         fontSize={FONT_SIZE_BODY_1}
         fontWeight={FONT_WEIGHT_SEMIBOLD}
-        css={css`
-          margin-bottom: 0.5rem;
-        `}
+        marginBottom={SPACING_2}
       >
         {U2E_ADAPTER_INFORMATION}
       </Text>
-      {driverOutdated && (
-        <U2EDriverWarning
-          css={css`
-            margin-bottom: 1rem;
-          `}
-        />
-      )}
+      {driverOutdated && <U2EDriverWarning marginBottom={SPACING_3} />}
       <U2EDeviceDetails device={device} />
-    </div>
+    </Box>
   )
 }

--- a/app/src/components/SystemInfoCard/U2EDeviceDetails.js
+++ b/app/src/components/SystemInfoCard/U2EDeviceDetails.js
@@ -1,8 +1,16 @@
 // @flow
 import * as React from 'react'
-import { css } from 'styled-components'
+import styled from 'styled-components'
 
-import { Flex, Text, FONT_STYLE_ITALIC } from '@opentrons/components'
+import {
+  Box,
+  Flex,
+  Text,
+  FONT_STYLE_ITALIC,
+  SPACING_1,
+  SPACING_2,
+} from '@opentrons/components'
+
 import type { UsbDevice } from '../../system-info/types'
 
 // TODO(mc, 2020-04-28): i18n
@@ -15,17 +23,9 @@ export type U2EDeviceDetailsProps = {|
   device: UsbDevice | null,
 |}
 
-const MARGIN_TOP_0_5 = css`
-  margin-top: 0.5rem;
-`
-
-const MARGIN_BOTTOM_0_25 = css`
-  margin-bottom: 0.25rem;
-`
-
-const DETAIL_TEXT_STYLE = css`
+const DetailText = styled.span`
   min-width: 6rem;
-  margin-right: 0.25rem;
+  margin-right: ${SPACING_1};
 `
 
 const STATS: Array<{| label: string, property: $Keys<UsbDevice> |}> = [
@@ -39,20 +39,20 @@ export const U2EDeviceDetails = ({ device }: U2EDeviceDetailsProps) => (
   <div>
     <Text>{U2E_ADAPTER_DESCRIPTION}</Text>
     {device === null ? (
-      <Text fontStyle={FONT_STYLE_ITALIC} css={MARGIN_TOP_0_5}>
+      <Text fontStyle={FONT_STYLE_ITALIC} marginTop={SPACING_2}>
         {NO_ADAPTER_FOUND}
       </Text>
     ) : (
-      <ul css={MARGIN_TOP_0_5}>
+      <Box as="ul" marginTop={SPACING_2}>
         {STATS.filter(({ property }) => property in device).map(
           ({ label, property }) => (
-            <Flex as="li" key={property} css={MARGIN_BOTTOM_0_25}>
-              <span css={DETAIL_TEXT_STYLE}>{label}:</span>
-              <span css={DETAIL_TEXT_STYLE}>{device[property] ?? UNKNOWN}</span>
+            <Flex as="li" key={property} marginBottom={SPACING_1}>
+              <DetailText>{label}:</DetailText>
+              <DetailText>{device[property] ?? UNKNOWN}</DetailText>
             </Flex>
           )
         )}
-      </ul>
+      </Box>
     )}
   </div>
 )

--- a/components/src/primitives/Box.js
+++ b/components/src/primitives/Box.js
@@ -1,0 +1,23 @@
+// @flow
+import styled from 'styled-components'
+
+import * as StyleProps from './style-props'
+
+import type { StyledComponent } from 'styled-components'
+
+export type BoxProps = {|
+  ...StyleProps.ColorProps,
+  ...StyleProps.SpacingProps,
+  ...StyleProps.TypographyProps,
+|}
+
+/**
+ * Box primitive
+ *
+ * @component
+ */
+export const Box: StyledComponent<BoxProps, {||}, HTMLDivElement> = styled.div`
+  ${StyleProps.colorStyles}
+  ${StyleProps.spacingStyles}
+  ${StyleProps.typographyStyles}
+`

--- a/components/src/primitives/Box.md
+++ b/components/src/primitives/Box.md
@@ -1,0 +1,28 @@
+Simple Box primitive. Renders a `div` by default with various styling props for color, spacing, and typography
+
+```js
+import {
+  Icon,
+  C_DARK_GRAY,
+  C_WHITE,
+  SPACING_2,
+  SPACING_3,
+} from '@opentrons/components'
+;<Box
+  color={C_WHITE}
+  backgroundColor={C_DARK_GRAY}
+  paddingX={SPACING_3}
+  paddingY={SPACING_2}
+>
+  hello world
+</Box>
+```
+
+`<Box>` is a [StyledComponent](https://styled-components.com/docs/basics#getting-started), and accepts an `as` prop to render as any other DOM element or React component.
+
+```js
+<Box as="ul" paddingLeft={0}>
+  <li>hello</li>
+  <li>world</li>
+</Box>
+```

--- a/components/src/primitives/Flex.js
+++ b/components/src/primitives/Flex.js
@@ -1,5 +1,8 @@
 // @flow
 import styled from 'styled-components'
+
+import * as StyleProps from './style-props'
+
 import type { StyledComponent } from 'styled-components'
 
 export const ALIGN_NORMAL = 'normal'
@@ -34,7 +37,9 @@ export const WRAP_REVERSE = 'wrap-reverse'
 // style props are string type for flexibility, but try to use the constants
 // defined above for safety
 export type FlexProps = {|
-  color?: string,
+  ...StyleProps.ColorProps,
+  ...StyleProps.SpacingProps,
+  ...StyleProps.TypographyProps,
   alignItems?: string,
   justifyContent?: string,
   direction?: string,
@@ -52,7 +57,9 @@ export const Flex: StyledComponent<
   HTMLDivElement
 > = styled.div`
   display: flex;
-  ${({ color }) => (color ? `color: ${color};` : '')}
+  ${StyleProps.colorStyles}
+  ${StyleProps.spacingStyles}
+  ${StyleProps.typographyStyles}
   ${({ alignItems: ai }) => (ai ? `align-items: ${ai};` : '')}
   ${({ justifyContent: jc }) => (jc ? `justify-content: ${jc};` : '')}
   ${({ direction: d }) => (d ? `flex-direction: ${d};` : '')}

--- a/components/src/primitives/Link.js
+++ b/components/src/primitives/Link.js
@@ -1,31 +1,29 @@
 // @flow
 import * as React from 'react'
 import styled from 'styled-components'
+
+import * as StyleProps from './style-props'
+
 import type { StyledComponent } from 'styled-components'
 
 // props are string type for flexibility, but try to use constants for safety
 export type LinkProps = {|
+  ...StyleProps.ColorProps,
+  ...StyleProps.TypographyProps,
+  ...StyleProps.SpacingProps,
   href: string,
   external?: boolean,
-  color?: string,
-  fontSize?: string,
-  fontWeight?: number | string,
-  fontStyle?: string,
-  lineHeight?: number | string,
 |}
 
-// TODO(mc, 2020-05-11): move common style interpolations into common location
 const StyledLink: StyledComponent<
   LinkProps,
   {||},
   HTMLAnchorElement
 > = styled.a`
   text-decoration: none;
-  ${({ fontSize }) => (fontSize ? `font-size: ${fontSize};` : '')}
-  ${({ fontWeight }) => (fontWeight ? `font-weight: ${fontWeight};` : '')}
-  ${({ fontStyle }) => (fontStyle ? `font-style: ${fontStyle};` : '')}
-  ${({ lineHeight }) => (lineHeight ? `line-height: ${lineHeight};` : '')}
-  ${({ color }) => (color ? `color: ${color};` : '')}
+  ${StyleProps.colorStyles}
+  ${StyleProps.typographyStyles}
+  ${StyleProps.spacingStyles}
 `
 
 type StyledLinkProps = React.ElementProps<typeof StyledLink>

--- a/components/src/primitives/Text.js
+++ b/components/src/primitives/Text.js
@@ -1,15 +1,13 @@
 // @flow
 import styled from 'styled-components'
+import * as StyleProps from './style-props'
+
 import type { StyledComponent } from 'styled-components'
 
-// props are string type for flexibility, but try to use constants for safety
-// TODO(mc, 2020-05-11): move common style interpolations into common location
 export type TextProps = {|
-  color?: string,
-  fontSize?: string,
-  fontWeight?: number | string,
-  fontStyle?: string,
-  lineHeight?: number | string,
+  ...StyleProps.ColorProps,
+  ...StyleProps.TypographyProps,
+  ...StyleProps.SpacingProps,
 |}
 
 // TODO(mc, 2020-05-08): add variants (--font-body-2-dark, etc) as variant prop
@@ -27,9 +25,7 @@ export const Text: StyledComponent<
 > = styled.p`
   margin-top: 0;
   margin-bottom: 0;
-  ${({ fontSize }) => (fontSize ? `font-size: ${fontSize};` : '')}
-  ${({ fontWeight }) => (fontWeight ? `font-weight: ${fontWeight};` : '')}
-  ${({ fontStyle }) => (fontStyle ? `font-style: ${fontStyle};` : '')}
-  ${({ lineHeight }) => (lineHeight ? `line-height: ${lineHeight};` : '')}
-  ${({ color }) => (color ? `color: ${color};` : '')}
+  ${StyleProps.colorStyles}
+  ${StyleProps.typographyStyles}
+  ${StyleProps.spacingStyles}
 `

--- a/components/src/primitives/__tests__/Box.test.js
+++ b/components/src/primitives/__tests__/Box.test.js
@@ -1,0 +1,59 @@
+// @flow
+import * as React from 'react'
+import { shallow } from 'enzyme'
+
+import {
+  C_WHITE,
+  SPACING_AUTO,
+  SPACING_1,
+  FONT_SIZE_BODY_1,
+} from '../../styles'
+import { Box } from '..'
+
+describe('Box primitive component', () => {
+  it('should be a simple div', () => {
+    const wrapper = shallow(<Box />)
+    expect(wrapper.exists('div')).toBe(true)
+  })
+
+  it('should accept an `as` prop', () => {
+    const wrapper = shallow(<Box as="nav" />)
+    expect(wrapper.exists('nav')).toBe(true)
+  })
+
+  it('should accept an `className` prop', () => {
+    const wrapper = shallow(<Box className="extra-class" />)
+    expect(wrapper.hasClass('extra-class')).toBe(true)
+  })
+
+  it('should render children', () => {
+    const wrapper = shallow(
+      <Box>
+        <span data-test="child" />
+      </Box>
+    )
+    expect(wrapper.exists('[data-test="child"]')).toBe(true)
+  })
+
+  it('should take a color prop', () => {
+    const wrapper = shallow(<Box color={C_WHITE} />)
+    expect(wrapper).toHaveStyleRule('color', '#ffffff')
+  })
+
+  it('should take a backgroundColor prop', () => {
+    const wrapper = shallow(<Box backgroundColor={C_WHITE} />)
+    expect(wrapper).toHaveStyleRule('background-color', '#ffffff')
+  })
+
+  it('should take spacing props', () => {
+    const wrapper = shallow(<Box marginX={SPACING_AUTO} padding={SPACING_1} />)
+    expect(wrapper).toHaveStyleRule('margin-left', 'auto')
+    expect(wrapper).toHaveStyleRule('margin-right', 'auto')
+    expect(wrapper).toHaveStyleRule('padding', SPACING_1)
+  })
+
+  it('should take typography props', () => {
+    const wrapper = shallow(<Box fontSize={FONT_SIZE_BODY_1} />)
+    expect(wrapper).toHaveStyleRule('font-size', FONT_SIZE_BODY_1)
+  })
+})

--- a/components/src/primitives/__tests__/Flex.test.js
+++ b/components/src/primitives/__tests__/Flex.test.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import { shallow } from 'enzyme'
 
-import { C_WHITE } from '../../styles'
+import { C_WHITE, FONT_SIZE_BODY_1 } from '../../styles'
 import {
   Flex,
   ALIGN_NORMAL,
@@ -145,5 +145,16 @@ describe('Flex primitive component', () => {
 
     wrapper.setProps({ wrap: WRAP_REVERSE })
     expect(wrapper).toHaveStyleRule('flex-wrap', 'wrap-reverse')
+  })
+
+  it('should take spacing props', () => {
+    const wrapper = shallow(<Flex marginBottom={0} paddingLeft={0} />)
+    expect(wrapper).toHaveStyleRule('margin-bottom', '0')
+    expect(wrapper).toHaveStyleRule('padding-left', '0')
+  })
+
+  it('should take typography props', () => {
+    const wrapper = shallow(<Flex fontSize={FONT_SIZE_BODY_1} />)
+    expect(wrapper).toHaveStyleRule('font-size', FONT_SIZE_BODY_1)
   })
 })

--- a/components/src/primitives/__tests__/Link.test.js
+++ b/components/src/primitives/__tests__/Link.test.js
@@ -5,18 +5,13 @@ import { mount } from 'enzyme'
 import {
   C_WHITE,
   FONT_SIZE_DEFAULT,
-  FONT_SIZE_HEADER,
-  FONT_SIZE_BODY_2,
-  FONT_SIZE_BODY_1,
-  FONT_SIZE_CAPTION,
-  FONT_WEIGHT_REGULAR,
   FONT_WEIGHT_SEMIBOLD,
-  LINE_HEIGHT_SOLID,
   LINE_HEIGHT_TITLE,
-  LINE_HEIGHT_COPY,
-  FONT_STYLE_NORMAL,
   FONT_STYLE_ITALIC,
+  SPACING_AUTO,
+  SPACING_1,
 } from '../../styles'
+
 import { Link } from '..'
 
 describe('Link primitive component', () => {
@@ -63,45 +58,31 @@ describe('Link primitive component', () => {
 
   it('should take a fontSize prop', () => {
     const wrapper = mount(<Link href="#" fontSize={FONT_SIZE_DEFAULT} />)
-    expect(wrapper).toHaveStyleRule('font-size', '1rem')
-
-    wrapper.setProps({ fontSize: FONT_SIZE_HEADER })
-    expect(wrapper).toHaveStyleRule('font-size', '1.125rem')
-
-    wrapper.setProps({ fontSize: FONT_SIZE_BODY_2 })
-    expect(wrapper).toHaveStyleRule('font-size', '0.875rem')
-
-    wrapper.setProps({ fontSize: FONT_SIZE_BODY_1 })
-    expect(wrapper).toHaveStyleRule('font-size', '0.75rem')
-
-    wrapper.setProps({ fontSize: FONT_SIZE_CAPTION })
-    expect(wrapper).toHaveStyleRule('font-size', '0.625rem')
+    expect(wrapper).toHaveStyleRule('font-size', FONT_SIZE_DEFAULT)
   })
 
   it('should take a fontWeight prop', () => {
-    const wrapper = mount(<Link href="#" fontWeight={FONT_WEIGHT_REGULAR} />)
-    expect(wrapper).toHaveStyleRule('font-weight', '400')
-
-    wrapper.setProps({ fontWeight: FONT_WEIGHT_SEMIBOLD })
-    expect(wrapper).toHaveStyleRule('font-weight', '600')
+    const wrapper = mount(<Link href="#" fontWeight={FONT_WEIGHT_SEMIBOLD} />)
+    expect(wrapper).toHaveStyleRule('font-weight', `${FONT_WEIGHT_SEMIBOLD}`)
   })
 
   it('should take a lineHeight prop', () => {
-    const wrapper = mount(<Link href="#" lineHeight={LINE_HEIGHT_SOLID} />)
-    expect(wrapper).toHaveStyleRule('line-height', '1')
-
-    wrapper.setProps({ lineHeight: LINE_HEIGHT_TITLE })
-    expect(wrapper).toHaveStyleRule('line-height', '1.25')
-
-    wrapper.setProps({ lineHeight: LINE_HEIGHT_COPY })
-    expect(wrapper).toHaveStyleRule('line-height', '1.5')
+    const wrapper = mount(<Link href="#" lineHeight={LINE_HEIGHT_TITLE} />)
+    expect(wrapper).toHaveStyleRule('line-height', `${LINE_HEIGHT_TITLE}`)
   })
 
   it('should take a fontStyle prop', () => {
-    const wrapper = mount(<Link href="#" fontStyle={FONT_STYLE_NORMAL} />)
-    expect(wrapper).toHaveStyleRule('font-style', 'normal')
+    const wrapper = mount(<Link href="#" fontStyle={FONT_STYLE_ITALIC} />)
+    expect(wrapper).toHaveStyleRule('font-style', FONT_STYLE_ITALIC)
+  })
 
-    wrapper.setProps({ fontStyle: FONT_STYLE_ITALIC })
-    expect(wrapper).toHaveStyleRule('font-style', 'italic')
+  it('should take spacing props', () => {
+    const wrapper = mount(
+      <Link href="#" marginX={SPACING_AUTO} paddingY={SPACING_1} />
+    )
+    expect(wrapper).toHaveStyleRule('margin-left', 'auto')
+    expect(wrapper).toHaveStyleRule('margin-right', 'auto')
+    expect(wrapper).toHaveStyleRule('padding-top', SPACING_1)
+    expect(wrapper).toHaveStyleRule('padding-bottom', SPACING_1)
   })
 })

--- a/components/src/primitives/__tests__/Text.test.js
+++ b/components/src/primitives/__tests__/Text.test.js
@@ -5,18 +5,11 @@ import { shallow } from 'enzyme'
 import {
   C_WHITE,
   FONT_SIZE_DEFAULT,
-  FONT_SIZE_HEADER,
-  FONT_SIZE_BODY_2,
-  FONT_SIZE_BODY_1,
-  FONT_SIZE_CAPTION,
   FONT_WEIGHT_REGULAR,
-  FONT_WEIGHT_SEMIBOLD,
   LINE_HEIGHT_SOLID,
-  LINE_HEIGHT_TITLE,
-  LINE_HEIGHT_COPY,
   FONT_STYLE_NORMAL,
-  FONT_STYLE_ITALIC,
 } from '../../styles'
+
 import { Text } from '..'
 
 describe('Text primitive component', () => {
@@ -63,45 +56,27 @@ describe('Text primitive component', () => {
 
   it('should take a fontSize prop', () => {
     const wrapper = shallow(<Text fontSize={FONT_SIZE_DEFAULT} />)
-    expect(wrapper).toHaveStyleRule('font-size', '1rem')
-
-    wrapper.setProps({ fontSize: FONT_SIZE_HEADER })
-    expect(wrapper).toHaveStyleRule('font-size', '1.125rem')
-
-    wrapper.setProps({ fontSize: FONT_SIZE_BODY_2 })
-    expect(wrapper).toHaveStyleRule('font-size', '0.875rem')
-
-    wrapper.setProps({ fontSize: FONT_SIZE_BODY_1 })
-    expect(wrapper).toHaveStyleRule('font-size', '0.75rem')
-
-    wrapper.setProps({ fontSize: FONT_SIZE_CAPTION })
-    expect(wrapper).toHaveStyleRule('font-size', '0.625rem')
+    expect(wrapper).toHaveStyleRule('font-size', FONT_SIZE_DEFAULT)
   })
 
   it('should take a fontWeight prop', () => {
     const wrapper = shallow(<Text fontWeight={FONT_WEIGHT_REGULAR} />)
-    expect(wrapper).toHaveStyleRule('font-weight', '400')
-
-    wrapper.setProps({ fontWeight: FONT_WEIGHT_SEMIBOLD })
-    expect(wrapper).toHaveStyleRule('font-weight', '600')
+    expect(wrapper).toHaveStyleRule('font-weight', `${FONT_WEIGHT_REGULAR}`)
   })
 
   it('should take a lineHeight prop', () => {
     const wrapper = shallow(<Text lineHeight={LINE_HEIGHT_SOLID} />)
-    expect(wrapper).toHaveStyleRule('line-height', '1')
-
-    wrapper.setProps({ lineHeight: LINE_HEIGHT_TITLE })
-    expect(wrapper).toHaveStyleRule('line-height', '1.25')
-
-    wrapper.setProps({ lineHeight: LINE_HEIGHT_COPY })
-    expect(wrapper).toHaveStyleRule('line-height', '1.5')
+    expect(wrapper).toHaveStyleRule('line-height', `${LINE_HEIGHT_SOLID}`)
   })
 
   it('should take a fontStyle prop', () => {
     const wrapper = shallow(<Text fontStyle={FONT_STYLE_NORMAL} />)
-    expect(wrapper).toHaveStyleRule('font-style', 'normal')
+    expect(wrapper).toHaveStyleRule('font-style', FONT_STYLE_NORMAL)
+  })
 
-    wrapper.setProps({ fontStyle: FONT_STYLE_ITALIC })
-    expect(wrapper).toHaveStyleRule('font-style', 'italic')
+  it('should take spacing props', () => {
+    const wrapper = shallow(<Text marginRight="100%" paddingBottom={0} />)
+    expect(wrapper).toHaveStyleRule('margin-right', '100%')
+    expect(wrapper).toHaveStyleRule('padding-bottom', '0')
   })
 })

--- a/components/src/primitives/__tests__/style-props.test.js
+++ b/components/src/primitives/__tests__/style-props.test.js
@@ -1,0 +1,185 @@
+// @flow
+import * as React from 'react'
+import { shallow } from 'enzyme'
+import styled from 'styled-components'
+
+import * as Styles from '../../styles'
+import * as StyleProps from '../style-props'
+
+describe('style props', () => {
+  describe('color styles', () => {
+    const TestColor = styled.div`
+      ${StyleProps.colorStyles}
+    `
+
+    it('should be able to set color', () => {
+      const wrapper = shallow(<TestColor color={Styles.C_WHITE} />)
+      expect(wrapper).toHaveStyleRule('color', Styles.C_WHITE)
+    })
+
+    it('should be able to set background-color', () => {
+      const wrapper = shallow(<TestColor backgroundColor={Styles.C_WHITE} />)
+      expect(wrapper).toHaveStyleRule('background-color', Styles.C_WHITE)
+    })
+  })
+
+  describe('typography styles', () => {
+    const TestTypography = styled.div`
+      ${StyleProps.typographyStyles}
+    `
+
+    it('should be able to set font-size', () => {
+      const wrapper = shallow(
+        <TestTypography fontSize={Styles.FONT_SIZE_DEFAULT} />
+      )
+      expect(wrapper).toHaveStyleRule('font-size', '1rem')
+
+      wrapper.setProps({ fontSize: Styles.FONT_SIZE_HEADER })
+      expect(wrapper).toHaveStyleRule('font-size', '1.125rem')
+
+      wrapper.setProps({ fontSize: Styles.FONT_SIZE_BODY_2 })
+      expect(wrapper).toHaveStyleRule('font-size', '0.875rem')
+
+      wrapper.setProps({ fontSize: Styles.FONT_SIZE_BODY_1 })
+      expect(wrapper).toHaveStyleRule('font-size', '0.75rem')
+
+      wrapper.setProps({ fontSize: Styles.FONT_SIZE_CAPTION })
+      expect(wrapper).toHaveStyleRule('font-size', '0.625rem')
+    })
+
+    it('should be able to set font-weight', () => {
+      const wrapper = shallow(
+        <TestTypography fontWeight={Styles.FONT_WEIGHT_REGULAR} />
+      )
+      expect(wrapper).toHaveStyleRule('font-weight', '400')
+
+      wrapper.setProps({ fontWeight: Styles.FONT_WEIGHT_SEMIBOLD })
+      expect(wrapper).toHaveStyleRule('font-weight', '600')
+    })
+
+    it('should be able to set line-height', () => {
+      const wrapper = shallow(
+        <TestTypography lineHeight={Styles.LINE_HEIGHT_SOLID} />
+      )
+      expect(wrapper).toHaveStyleRule('line-height', '1')
+
+      wrapper.setProps({ lineHeight: Styles.LINE_HEIGHT_TITLE })
+      expect(wrapper).toHaveStyleRule('line-height', '1.25')
+
+      wrapper.setProps({ lineHeight: Styles.LINE_HEIGHT_COPY })
+      expect(wrapper).toHaveStyleRule('line-height', '1.5')
+    })
+
+    it('should be able to set font-style', () => {
+      const wrapper = shallow(
+        <TestTypography fontStyle={Styles.FONT_STYLE_NORMAL} />
+      )
+      expect(wrapper).toHaveStyleRule('font-style', 'normal')
+
+      wrapper.setProps({ fontStyle: Styles.FONT_STYLE_ITALIC })
+      expect(wrapper).toHaveStyleRule('font-style', 'italic')
+    })
+
+    it('should be able to set text-align', () => {
+      const wrapper = shallow(
+        <TestTypography textAlign={Styles.TEXT_ALIGN_LEFT} />
+      )
+      expect(wrapper).toHaveStyleRule('text-align', 'left')
+
+      wrapper.setProps({ textAlign: Styles.TEXT_ALIGN_CENTER })
+      expect(wrapper).toHaveStyleRule('text-align', 'center')
+
+      wrapper.setProps({ textAlign: Styles.TEXT_ALIGN_RIGHT })
+      expect(wrapper).toHaveStyleRule('text-align', 'right')
+
+      wrapper.setProps({ textAlign: Styles.TEXT_ALIGN_JUSTIFY })
+      expect(wrapper).toHaveStyleRule('text-align', 'justify')
+    })
+
+    it('should be able to set text-transform', () => {
+      const wrapper = shallow(
+        <TestTypography textTransform={Styles.TEXT_TRANSFORM_NONE} />
+      )
+      expect(wrapper).toHaveStyleRule('text-transform', 'none')
+
+      wrapper.setProps({ textTransform: Styles.TEXT_TRANSFORM_CAPITALIZE })
+      expect(wrapper).toHaveStyleRule('text-transform', 'capitalize')
+
+      wrapper.setProps({ textTransform: Styles.TEXT_TRANSFORM_UPPERCASE })
+      expect(wrapper).toHaveStyleRule('text-transform', 'uppercase')
+
+      wrapper.setProps({ textTransform: Styles.TEXT_TRANSFORM_LOWERCASE })
+      expect(wrapper).toHaveStyleRule('text-transform', 'lowercase')
+    })
+  })
+
+  describe('spacing styles', () => {
+    const TestSpacing = styled.div`
+      ${StyleProps.spacingStyles}
+    `
+
+    it('should be able to set margin', () => {
+      const wrapper = shallow(<TestSpacing margin={Styles.SPACING_1} />)
+      expect(wrapper).toHaveStyleRule('margin', '0.25rem')
+    })
+
+    it('should be able to set margin-right', () => {
+      const wrapper = shallow(<TestSpacing marginRight={Styles.SPACING_2} />)
+      expect(wrapper).toHaveStyleRule('margin-right', '0.5rem')
+    })
+
+    it('should be able to set margin-bottom', () => {
+      const wrapper = shallow(<TestSpacing marginBottom={Styles.SPACING_3} />)
+      expect(wrapper).toHaveStyleRule('margin-bottom', '1rem')
+    })
+
+    it('should be able to set margin-left', () => {
+      const wrapper = shallow(<TestSpacing marginLeft={Styles.SPACING_4} />)
+      expect(wrapper).toHaveStyleRule('margin-left', '2rem')
+    })
+
+    it('should be able to set margin-left and margin-right simultaneously', () => {
+      const wrapper = shallow(<TestSpacing marginX={Styles.SPACING_AUTO} />)
+      expect(wrapper).toHaveStyleRule('margin-left', 'auto')
+      expect(wrapper).toHaveStyleRule('margin-right', 'auto')
+    })
+
+    it('should be able to set margin-top and margin-bottom simultaneously', () => {
+      const wrapper = shallow(<TestSpacing marginY={Styles.SPACING_5} />)
+      expect(wrapper).toHaveStyleRule('margin-top', '4rem')
+      expect(wrapper).toHaveStyleRule('margin-bottom', '4rem')
+    })
+
+    it('should be able to set padding', () => {
+      const wrapper = shallow(<TestSpacing padding={Styles.SPACING_6} />)
+      expect(wrapper).toHaveStyleRule('padding', '8rem')
+    })
+
+    it('should be able to set padding-right', () => {
+      const wrapper = shallow(<TestSpacing paddingRight={Styles.SPACING_7} />)
+      expect(wrapper).toHaveStyleRule('padding-right', '16rem')
+    })
+
+    it('should be able to set padding-bottom', () => {
+      const wrapper = shallow(<TestSpacing paddingBottom={Styles.SPACING_8} />)
+      expect(wrapper).toHaveStyleRule('padding-bottom', '32rem')
+    })
+
+    it('should be able to set padding-left', () => {
+      const wrapper = shallow(<TestSpacing paddingLeft={0} />)
+      expect(wrapper).toHaveStyleRule('padding-left', '0')
+    })
+
+    it('should be able to set padding-left and padding-right simultaneously', () => {
+      const wrapper = shallow(<TestSpacing paddingX="25%" />)
+      expect(wrapper).toHaveStyleRule('padding-left', '25%')
+      expect(wrapper).toHaveStyleRule('padding-right', '25%')
+    })
+
+    it('should be able to set padding-top and padding-bottom simultaneously', () => {
+      const wrapper = shallow(<TestSpacing paddingY={Styles.SPACING_1} />)
+      expect(wrapper).toHaveStyleRule('padding-top', '0.25rem')
+      expect(wrapper).toHaveStyleRule('padding-bottom', '0.25rem')
+    })
+  })
+})

--- a/components/src/primitives/index.js
+++ b/components/src/primitives/index.js
@@ -1,4 +1,6 @@
 // @flow
+export * from './style-props'
+export * from './Box'
 export * from './Flex'
 export * from './Link'
 export * from './Text'

--- a/components/src/primitives/style-props.js
+++ b/components/src/primitives/style-props.js
@@ -1,0 +1,93 @@
+// @flow
+// common styling props you can apply to any styled-component
+// props are string type for flexibility, but try to use constants for safety
+
+export type ColorProps = {|
+  color?: string,
+  backgroundColor?: string,
+|}
+
+export type TypographyProps = {|
+  fontSize?: string | number,
+  fontWeight?: string | number,
+  fontStyle?: string,
+  lineHeight?: string | number,
+  textAlign?: string,
+  textTransform?: string,
+|}
+
+export type SpacingProps = {|
+  margin?: string | number,
+  marginX?: string | number,
+  marginY?: string | number,
+  marginTop?: string | number,
+  marginRight?: string | number,
+  marginBottom?: string | number,
+  marginLeft?: string | number,
+  padding?: string | number,
+  paddingX?: string | number,
+  paddingY?: string | number,
+  paddingTop?: string | number,
+  paddingRight?: string | number,
+  paddingBottom?: string | number,
+  paddingLeft?: string | number,
+|}
+
+type ColorPropsBase = { ...ColorProps, ... }
+
+type TypographyPropsBase = { ...TypographyProps, ... }
+
+type SpacingPropsBase = { ...SpacingProps, ... }
+
+export const colorStyles = ({ color, backgroundColor }: ColorPropsBase) => `
+  ${color != null ? `color: ${color};` : ''}
+  ${backgroundColor != null ? `background-color: ${backgroundColor};` : ''}
+`
+
+export const typographyStyles = ({
+  fontSize,
+  fontWeight,
+  fontStyle,
+  lineHeight,
+  textAlign,
+  textTransform,
+}: TypographyPropsBase) => `
+  ${fontSize != null ? `font-size: ${fontSize};` : ''}
+  ${fontWeight != null ? `font-weight: ${fontWeight};` : ''}
+  ${fontStyle != null ? `font-style: ${fontStyle};` : ''}
+  ${lineHeight != null ? `line-height: ${lineHeight};` : ''}
+  ${textAlign != null ? `text-align: ${textAlign};` : ''}
+  ${textTransform != null ? `text-transform: ${textTransform};` : ''}
+`
+
+export const spacingStyles = ({
+  margin,
+  marginX: mx,
+  marginY: my,
+  marginTop,
+  marginRight,
+  marginBottom,
+  marginLeft,
+  padding,
+  paddingX: px,
+  paddingY: py,
+  paddingTop,
+  paddingRight,
+  paddingBottom,
+  paddingLeft,
+}: SpacingPropsBase) => `
+  ${margin != null ? `margin: ${margin};` : ''}
+  ${mx != null ? `margin-right: ${mx}; margin-left: ${mx};` : ''}
+  ${my != null ? `margin-top: ${my}; margin-bottom: ${my};` : ''}
+  ${marginTop != null ? `margin-top: ${marginTop};` : ''}
+  ${marginRight != null ? `margin-right: ${marginRight};` : ''}
+  ${marginBottom != null ? `margin-bottom: ${marginBottom};` : ''}
+  ${marginLeft != null ? `margin-left: ${marginLeft};` : ''}
+  ${padding != null ? `padding: ${padding};` : ''}
+  ${px != null ? `padding-right: ${px}; padding-left: ${px};` : ''}
+  ${py != null ? `padding-top: ${py}; padding-bottom: ${py};` : ''}
+  ${paddingTop != null ? `padding-top: ${paddingTop};` : ''}
+  ${paddingRight != null ? `padding-right: ${paddingRight};` : ''}
+  ${paddingBottom != null ? `padding-bottom: ${paddingBottom};` : ''}
+  ${paddingLeft != null ? `padding-left: ${paddingLeft};` : ''}
+`

--- a/components/src/structure/Card.js
+++ b/components/src/structure/Card.js
@@ -62,6 +62,6 @@ const Title = styled.h3`
   ${styles.FONT_HEADER_DARK}
   font-weight: ${styles.FONT_WEIGHT_REGULAR};
   margin: 0;
-  padding: ${styles.S_1} ${styles.S_1} 0;
+  padding: ${styles.SPACING_3} ${styles.SPACING_3} 0;
   text-transform: capitalize;
 `

--- a/components/src/styles/spacing.js
+++ b/components/src/styles/spacing.js
@@ -1,6 +1,11 @@
 // @flow
 
-// TODO(isk: 3/2/20): Make these more generic and use calc() to compose spacing
-export const S_0875 = '0.875rem'
-export const S_1 = '1rem'
-export const S_1125 = '1.125rem'
+export const SPACING_AUTO = 'auto'
+export const SPACING_1 = '0.25rem'
+export const SPACING_2 = '0.5rem'
+export const SPACING_3 = '1rem'
+export const SPACING_4 = '2rem'
+export const SPACING_5 = '4rem'
+export const SPACING_6 = '8rem'
+export const SPACING_7 = '16rem'
+export const SPACING_8 = '32rem'

--- a/components/src/styles/typography.js
+++ b/components/src/styles/typography.js
@@ -29,6 +29,18 @@ export const FONT_WEIGHT_BOLD = 800
 export const FONT_STYLE_NORMAL = 'normal'
 export const FONT_STYLE_ITALIC = 'italic'
 
+// text align
+export const TEXT_ALIGN_LEFT = 'left'
+export const TEXT_ALIGN_CENTER = 'center'
+export const TEXT_ALIGN_RIGHT = 'right'
+export const TEXT_ALIGN_JUSTIFY = 'justify'
+
+// text transform
+export const TEXT_TRANSFORM_NONE = 'none'
+export const TEXT_TRANSFORM_CAPITALIZE = 'capitalize'
+export const TEXT_TRANSFORM_UPPERCASE = 'uppercase'
+export const TEXT_TRANSFORM_LOWERCASE = 'lowercase'
+
 // font property sets
 export const FONT_HEADER_DARK = css`
   font-size: ${FONT_SIZE_HEADER};


### PR DESCRIPTION
## overview

Palate cleanser PR for myself after the U2E project is officially dev complete. This PR follows up on #5637 by:

- Adding a `<Box>` primitive to the library
    - Just a `<div>` with styling props to reduce CSS repetition
- Adding spacing props to the primitive components
    - They allow you to set `margin` and `padding`
    - They inlcude very handy `marginX`, `marginY`, `paddingX`, and `paddingY` props to set left/right or top/bottom simultaneously
    - Also added a simple set of [power-of-two space scale](https://styled-system.com/guides/why-powers-of-two/) constants - the props don't require using the constants, though; they'll take whatever string or number you give them
    - They also make it very easy to ensure that only parent components deal with margins, which makes child components easier to deal with
        - [styled-system has a good take on this](https://styled-system.com/guides/spacing)

These components and props are, like #5637, pretty heavily inspired by theme-ui, styled-system, and rebass.

## changelog

- feat(components): add Box primitive to components library
    - Took the opportunity to address some TODO comments and consolidate some style prop logic into shareable chunks in `components/src/primitives/style-props.js`

## review requests

How does this look / feel? I replaced some inline styled-component styling logic with the new Box primitive and spacing props to demonstrate.

A really nice benefit of these primitives and styling props is that the more we can lean on them, the less reliant we are on any one particular styling solution. These primitives / props could be implemented in vanilla CSS, CSS Modules, styled-components, emotion, or whatever other thing without changing their APIs

## risk assessment

Low. Mostly internal components DX work, and logic is unit-tested all the way down to the CSS
