### PR TITLE
fix(robot-server): /modules was not returning the right module specific data

### DIFF
--- a/robot-server/robot_server/service/models/modules.py
+++ b/robot-server/robot_server/service/models/modules.py
@@ -65,9 +65,13 @@ class ThermocyclerModuleLiveData(BaseModel):
               description="The total number of steps within the current cycle")
 
 
+# ThermocyclerModuleLiveData must be first. The ordering in a Union has to go
+# in order of specicifity.
 ModuleLiveData = typing.Union[
-    TemperatureModuleLiveData, MagneticModuleLiveData,
-    ThermocyclerModuleLiveData]
+    ThermocyclerModuleLiveData,
+    TemperatureModuleLiveData,
+    MagneticModuleLiveData,
+]
 
 
 class Module(BaseModel):


### PR DESCRIPTION
## overview

The live_data was not being returned properly. The unit tests were woefully incomplete. 

The root cause is that the live data is modeled as a Union of the three module live_data types. It is crucial that unions be sorted in order of specific-ness.  

## changelog

Changed union order and filled out the unit tests

## risk assessment

Low. It's a bug fix.
