### PR TITLE
feat(app): collect pipette and module load analytics from protocol runs

### DIFF
--- a/app/src/analytics/selectors.js
+++ b/app/src/analytics/selectors.js
@@ -27,6 +27,7 @@ import {
 
 import { getRobotSettings } from '../robot-settings'
 import { getAttachedPipettes } from '../pipettes'
+import { getPipettes, getModules } from '../robot/selectors'
 
 import { hash } from './hash'
 
@@ -51,7 +52,19 @@ const _getUnhashedProtocolAnalyticsData: ProtocolDataSelector = createSelector(
   getProtocolSource,
   getProtocolAuthor,
   getProtocolContents,
-  (type, app, apiVersion, name, source, author, contents) => ({
+  getPipettes,
+  getModules,
+  (
+    type,
+    app,
+    apiVersion,
+    name,
+    source,
+    author,
+    contents,
+    pipettes,
+    modules
+  ) => ({
     protocolType: type || '',
     protocolAppName: app.name || '',
     protocolAppVersion: app.version || '',
@@ -60,6 +73,8 @@ const _getUnhashedProtocolAnalyticsData: ProtocolDataSelector = createSelector(
     protocolSource: source || '',
     protocolAuthor: author || '',
     protocolText: contents || '',
+    pipettes: pipettes.map(p => p.requestedAs ?? p.name).join(','),
+    modules: modules.map(m => m.model).join(','),
   })
 )
 

--- a/app/src/analytics/types.js
+++ b/app/src/analytics/types.js
@@ -13,6 +13,8 @@ export type ProtocolAnalyticsData = {|
   protocolName: string,
   protocolAuthor: string,
   protocolText: string,
+  pipettes: string,
+  modules: string,
 |}
 
 export type RobotAnalyticsData = {|


### PR DESCRIPTION
## overview

This PR attaches pipette and module names to the existing protocol analytics event data

Closes #5540

## changelog

- feat(app): collect pipette and module load analytics from protocol runs

## review requests

- [ ] Code and tests look good

## risk assessment

Low. Small, unit-tested addition to existing data collection selector
