### PR TITLE
ci: use Python 3.7 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
     - stage: test
       name: 'Python API unit tests, build API docs'
       language: python
-      python: 3.6
+      python: 3.7
       before_install:
         - sudo apt-get install -y --no-install-recommends texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended libsystemd-dev latexmk texlive-lang-greek
       install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,8 @@
 image: Visual Studio 2015
 
 environment:
-  # ensure Python 3.6 is first in path
-  PATH: 'C:\Python36;C:\Python36\Scripts;%PATH%'
+  # ensure Python 3.7 is first in path
+  PATH: 'C:\Python37;C:\Python37\Scripts;%PATH%'
   # GNU make
   MAKE: C:\MinGW\bin\mingw32-make.exe
 


### PR DESCRIPTION
## overview

Our CI configs weren't updated with our dev/prod environment upgrade to Python 3.7. This PR updates the Travis and AppVeyor configs to use Python 3.7 instead of 3.6

## changelog

- ci: use Python 3.7 in CI

## review requests

- [ ] CI is green

## risk assessment

Low if CI is green. Even with Python 3.6 in the CI configs, pipenv was still grabbing Python 3.7 to create its vitrual environments, so this change doesn't really do much except communicate developer intent a little more clearly
