### PR TITLE
feat(api): use lru_cache on get_all_adv_settings

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import sys
+from functools import lru_cache
 from typing import Any, Dict, Mapping, Tuple, Union, \
     Optional, TYPE_CHECKING, NamedTuple
 
@@ -162,13 +163,13 @@ settings_by_old_id: Dict[str, SettingDefinition] = \
     {s.old_id: s for s in settings if s.old_id}
 
 
-# TODO: LRU cache?
 def get_adv_setting(setting: str) -> Optional[Setting]:
     setting = _clean_id(setting)
     s = get_all_adv_settings()
     return s.get(setting, None)
 
 
+@lru_cache(maxsize=1)
 def get_all_adv_settings() -> Dict[str, Setting]:
     """Get all the advanced setting values and definitions"""
     settings_file = CONFIG['feature_flags_file']
@@ -194,6 +195,8 @@ async def set_adv_setting(_id: str, value: Optional[bool]):
     _write_settings_file(setting_data.settings_map,
                          setting_data.version,
                          settings_file)
+    # Clear the lru cache
+    get_all_adv_settings.cache_clear()
 
 
 def _clean_id(_id: str) -> str:


### PR DESCRIPTION
## overview

Advanced settings are read way more often than written. Each call to get_adv_setting loads the json file to extract the setting. 

## changelog

- Wrapped `get_all_adv_settings` with `lru_cache` decorator. The cache is invalidated when `set_adv_setting` succeedes.
- Tests to prove it works.

## risk assessment

High risk. Advanced settings are important.