### PR TITLE
feat(api): add multiplication operator(s) to types.Point

### DIFF
--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -37,12 +37,12 @@ class Point(NamedTuple):
             return NotImplemented
         return Point(self.x - other.x, self.y - other.y, self.z - other.z)
 
-    def __mul__(self, other: Any) -> 'Point':
+    def __mul__(self, other: Union[int, float]) -> 'Point':
         if not (isinstance(other, float) or isinstance(other, int)):
             return NotImplemented
         return Point(self.x*other, self.y*other, self.z*other)
 
-    def __rmul__(self, other: Any) -> 'Point':
+    def __rmul__(self, other: Union[int, float]) -> 'Point':
         if not (isinstance(other, float) or isinstance(other, int)):
             return NotImplemented
         return Point(self.x*other, self.y*other, self.z*other)

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -37,6 +37,16 @@ class Point(NamedTuple):
             return NotImplemented
         return Point(self.x - other.x, self.y - other.y, self.z - other.z)
 
+    def __mul__(self, other: Any) -> 'Point':
+        if not (isinstance(other, float) or isinstance(other, int)):
+            return NotImplemented
+        return Point(self.x*other, self.y*other, self.z*other)
+
+    def __rmul__(self, other: Any) -> 'Point':
+        if not (isinstance(other, float) or isinstance(other, int)):
+            return NotImplemented
+        return Point(self.x*other, self.y*other, self.z*other)
+
     def __abs__(self) -> 'Point':
         return Point(abs(self.x), abs(self.y), abs(self.z))
 

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -38,12 +38,12 @@ class Point(NamedTuple):
         return Point(self.x - other.x, self.y - other.y, self.z - other.z)
 
     def __mul__(self, other: Union[int, float]) -> 'Point':
-        if not (isinstance(other, float) or isinstance(other, int)):
+        if not isinstance(other, (float, int)):
             return NotImplemented
         return Point(self.x*other, self.y*other, self.z*other)
 
     def __rmul__(self, other: Union[int, float]) -> 'Point':
-        if not (isinstance(other, float) or isinstance(other, int)):
+        if not isinstance(other, (float, int)):
             return NotImplemented
         return Point(self.x*other, self.y*other, self.z*other)
 

--- a/api/tests/opentrons/test_types.py
+++ b/api/tests/opentrons/test_types.py
@@ -1,6 +1,7 @@
 import pytest
 from opentrons.types import Point
 
+
 def test_point_mul():
     a = Point(1, 2, 3)
     b = 2


### PR DESCRIPTION


## overview

Adds multiplication operator(s) to types.Point wrt to floats or ints.

This allows scaling an offset by a fixed amount, making it easy to combine e.g. a direction vector and a distance.

Previously:
```types.Point(1,2,3) * 2 => (1, 2, 3, 1, 2, 3)```

Feel totally free to reject this e.g. if Points are not meant to be used for offset vectors. I couldn't find tests for this but feel free to point me (NPI) to them and I can add one.

## changelog

Added mul and rmul operators.

## risk assessment

Changes a fundamental type, but seems very unlikely this operator is invoked anywhere at present except accidentally?