### PR TITLE
fix(robot-server): make sure fastapi validation errors are properly documented

### DIFF
--- a/robot-server/robot_server/service/app.py
+++ b/robot-server/robot_server/service/app.py
@@ -42,7 +42,12 @@ app.include_router(router=legacy_routes,
                    })
 
 # New v2 routes
-app.include_router(router=routes)
+app.include_router(router=routes,
+                   responses={
+                       HTTP_422_UNPROCESSABLE_ENTITY: {
+                           "model": ErrorResponse
+                       }
+                   })
 
 
 @app.on_event("startup")


### PR DESCRIPTION
## overview

We're not using the default pydantic/fastapi validation error responses. We have our own error format.

## changelog

Add directive to openapi spec generator about the type of the pydantic/fastapi validation errors. 

## risk assessment

None. Only impacts openapi spec and docs.