### PR TITLE
feat(robot-server): Mock up of access control models and router.

### DIFF
--- a/robot-server/robot_server/service/access/models.py
+++ b/robot-server/robot_server/service/access/models.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from enum import Enum
+import typing
+
+from pydantic import BaseModel, Field
+
+from robot_server.service.json_api import \
+    ResponseDataModel, ResponseModel, RequestDataModel, RequestModel
+
+TokenType = str
+
+
+class AccessTokenInfo(BaseModel):
+    token: TokenType =\
+        Field(..., description="An access token")
+    createdOn: typing.Optional[datetime] =\
+        Field(..., description="When this token was created")
+
+
+AccessTokenResponse = ResponseModel[
+    ResponseDataModel[AccessTokenInfo], dict
+]
+MultipleAccessTokenResponse = ResponseModel[
+    typing.List[ResponseDataModel[AccessTokenInfo]], dict
+]
+AccessTokenRequest = RequestModel[
+    RequestDataModel[AccessTokenInfo]
+]
+
+
+class ControlScope(str, Enum):
+    """The scope of robot control"""
+    robot = 'robot'

--- a/robot-server/robot_server/service/access/router.py
+++ b/robot-server/robot_server/service/access/router.py
@@ -1,0 +1,97 @@
+import secrets
+from datetime import datetime
+from starlette import status as status_codes
+from fastapi import APIRouter
+
+from robot_server.service.errors import RobotServerError
+from robot_server.service.access import models as access
+from robot_server.service.json_api import ErrorResponse, Error
+
+router = APIRouter()
+
+
+@router.get("/access/tokens",
+            description="Get all created access tokens",
+            response_model=access.MultipleAccessTokenResponse)
+async def get_access_tokens() -> access.MultipleAccessTokenResponse:
+    raise RobotServerError(status_code=status_codes.HTTP_501_NOT_IMPLEMENTED,
+                           error=Error(title="Not implemented"))
+
+
+@router.post("/access/tokens",
+             description="Create an access token",
+             response_model=access.AccessTokenResponse,
+             status_code=status_codes.HTTP_201_CREATED)
+async def create_access_token() -> access.AccessTokenResponse:
+    token = secrets.token_urlsafe(nbytes=8)
+    # TODO Store the token
+    return access.AccessTokenResponse(
+        data=access.ResponseDataModel.create(
+            attributes=access.AccessTokenInfo(
+                token=token,
+                createdOn=datetime.utcnow()),
+            resource_id=token,
+        ))
+
+
+@router.delete("/access/tokens/{access_token}",
+               description="Delete an access token",
+               response_model=access.AccessTokenResponse,
+               responses={
+                   status_codes.HTTP_404_NOT_FOUND: {"model": ErrorResponse},
+               })
+async def delete_access_token(access_token: access.TokenType) \
+        -> access.AccessTokenResponse:
+    raise RobotServerError(status_code=status_codes.HTTP_501_NOT_IMPLEMENTED,
+                           error=Error(title="Not implemented"))
+
+
+@router.get("/access/controls/{scope}",
+            description="Get access token in control of robot scope",
+            response_model=access.AccessTokenResponse,
+            responses={
+                status_codes.HTTP_404_NOT_FOUND: {"model": ErrorResponse},
+            })
+async def get_control(scope: access.ControlScope) \
+        -> access.AccessTokenResponse:
+    raise RobotServerError(status_code=status_codes.HTTP_501_NOT_IMPLEMENTED,
+                           error=Error(title="Not implemented"))
+
+
+@router.post("/access/controls/{scope}",
+             description="Try to take control of a robot scope.",
+             response_model=access.AccessTokenResponse,
+             responses={
+                status_codes.HTTP_409_CONFLICT: {"model": ErrorResponse},
+             })
+async def post_control(scope: access.ControlScope,
+                       access_token: access.AccessTokenRequest) \
+        -> access.AccessTokenResponse:
+    raise RobotServerError(status_code=status_codes.HTTP_501_NOT_IMPLEMENTED,
+                           error=Error(title="Not implemented"))
+
+
+@router.put("/access/controls/{scope}/{token}",
+            description="Forcibly take control of a robot scope.",
+            response_model=access.AccessTokenResponse,
+            responses={
+                status_codes.HTTP_404_NOT_FOUND: {"model": ErrorResponse},
+            })
+async def put_control(scope: access.ControlScope,
+                      token: access.TokenType) \
+        -> access.AccessTokenResponse:
+    raise RobotServerError(status_code=status_codes.HTTP_501_NOT_IMPLEMENTED,
+                           error=Error(title="Not implemented"))
+
+
+@router.delete("/access/controls/{scope}/{token}",
+               description="Release control of a robot scope.",
+               response_model=access.AccessTokenResponse,
+               responses={
+                   status_codes.HTTP_404_NOT_FOUND: {"model": ErrorResponse},
+               })
+async def release_control(scope: access.ControlScope,
+                          token: access.TokenType) \
+        -> access.AccessTokenResponse:
+    raise RobotServerError(status_code=status_codes.HTTP_501_NOT_IMPLEMENTED,
+                           error=Error(title="Not implemented"))

--- a/robot-server/robot_server/service/app.py
+++ b/robot-server/robot_server/service/app.py
@@ -1,7 +1,7 @@
 import logging
 
 from opentrons import __version__
-from fastapi import FastAPI
+from fastapi import FastAPI, APIRouter
 from fastapi.exceptions import RequestValidationError
 from starlette.responses import Response, JSONResponse
 from starlette.requests import Request
@@ -16,7 +16,9 @@ from .errors import V1HandlerError, \
     consolidate_fastapi_response, RobotServerError, ErrorResponse
 from .dependencies import get_rpc_server
 from robot_server import constants
-from robot_server.service.legacy.routers import legacy_routes, routes
+from robot_server.service.legacy.routers import legacy_routes
+from robot_server.service.access.router import router as access_router
+from robot_server.service.session.router import router as session_router
 
 
 log = logging.getLogger(__name__)
@@ -42,6 +44,12 @@ app.include_router(router=legacy_routes,
                    })
 
 # New v2 routes
+routes = APIRouter()
+routes.include_router(router=session_router,
+                      tags=["Session Management"])
+routes.include_router(router=access_router,
+                      tags=["Access Control"])
+
 app.include_router(router=routes,
                    responses={
                        HTTP_422_UNPROCESSABLE_ENTITY: {

--- a/robot-server/robot_server/service/json_api/__init__.py
+++ b/robot-server/robot_server/service/json_api/__init__.py
@@ -1,0 +1,4 @@
+from .request import RequestModel, RequestDataModel  # noqa(W0611)
+from .response import ResponseModel, ResponseDataModel  # noqa(W0611)
+from .errors import Error, ErrorSource, ErrorResponse  # noqa(W0611)
+from .resource_links import ResourceLink, ResourceLinks  # noqa(W0611)

--- a/robot-server/robot_server/service/legacy/models/__init__.py
+++ b/robot-server/robot_server/service/legacy/models/__init__.py
@@ -4,7 +4,3 @@ from pydantic import BaseModel, Field
 class V1BasicResponse(BaseModel):
     """A response with a human readable message"""
     message: str = Field(..., description="A human-readable message")
-
-
-class EmptyModel(BaseModel):
-    pass

--- a/robot-server/robot_server/service/legacy/routers/__init__.py
+++ b/robot-server/robot_server/service/legacy/routers/__init__.py
@@ -2,7 +2,6 @@ from fastapi import APIRouter
 
 from . import health, networking, control, settings, deck_calibration, \
     modules, pipettes, motors, camera, logs, rpc
-from ...session import router
 
 legacy_routes = APIRouter()
 
@@ -19,7 +18,3 @@ legacy_routes.include_router(router=motors.router, tags=["Motors"])
 legacy_routes.include_router(router=camera.router, tags=["Camera"])
 legacy_routes.include_router(router=logs.router, tags=["Logs"])
 legacy_routes.include_router(router=rpc.router, tags=["RPC"])
-
-routes = APIRouter()
-routes.include_router(router=router.router,
-                      tags=["Session Management"])

--- a/robot-server/robot_server/service/session/models.py
+++ b/robot-server/robot_server/service/session/models.py
@@ -5,15 +5,15 @@ from pydantic import BaseModel, Field, validator
 from opentrons.calibration.check import models as calibration_models
 from opentrons.calibration.check.session import CalibrationCheckTrigger
 
-
-from robot_server.service.legacy.models import EmptyModel
-from robot_server.service.json_api.response import ResponseDataModel,\
-    ResponseModel
-from robot_server.service.json_api.request import RequestDataModel,\
-    RequestModel
+from robot_server.service.json_api import \
+    ResponseDataModel, ResponseModel, RequestDataModel, RequestModel
 
 
 SessionDetails = typing.Union[calibration_models.CalibrationSessionStatus]
+
+
+class EmptyModel(BaseModel):
+    pass
 
 
 class SessionCommands(str, Enum):

--- a/robot-server/robot_server/service/session/router.py
+++ b/robot-server/robot_server/service/session/router.py
@@ -9,15 +9,12 @@ from opentrons.calibration.session import CalibrationSession, \
 from opentrons.calibration.util import StateMachineError
 from opentrons.calibration.check import models
 
-
 from robot_server.service.dependencies import get_session_manager, get_hardware
 from robot_server.service.errors import RobotServerError
-from robot_server.service.json_api.errors import Error
-from robot_server.service.json_api.resource_links import ResourceLink
+from robot_server.service.json_api import Error, ResourceLink,\
+    ResponseDataModel
 from robot_server.service.session.session_status import create_session_details
 from robot_server.service.session import models as route_models
-from robot_server.service.session.models import SessionCreateRequest
-from robot_server.service.json_api.response import ResponseDataModel
 
 router = APIRouter()
 
@@ -50,7 +47,7 @@ def get_session(manager: SessionManager,
              status_code=http_status_codes.HTTP_201_CREATED,
              )
 async def create_session_handler(
-        create_request: SessionCreateRequest,
+        create_request: route_models.SessionCreateRequest,
         session_manager: SessionManager = Depends(get_session_manager),
         hardware=Depends(get_hardware)) \
         -> route_models.SessionResponse:
@@ -117,7 +114,6 @@ async def delete_session_handler(
     return route_models.SessionResponse(
         data=ResponseDataModel.create(
             attributes=route_models.Session(
-                sessionId=session_id,
                 # TODO support other session types
                 sessionType=models.SessionType.calibration_check,
                 details=create_session_details(session_obj)),
@@ -165,7 +161,6 @@ async def get_sessions_handler(
 
     sessions = (
         route_models.Session(
-            sessionId=session_id,
             # TODO use a proper session id rather than the type
             sessionType=models.SessionType(session_id),
             details=create_session_details(session_obj))


### PR DESCRIPTION
## overview

Mock up of API to interact with access tokens and take control of a robot.

See : https://coda.io/d/Session-State-Management_dZ8yJSRoO6_/Access-Control_suRGF#_lu_TE for more details


These are the new API
```
# Token stuff #
# Get all the tokens present in the system
GET /access/tokens
# Create a token. This could potentially be renamed login if we want to support authentication
POST /access/tokens
# Delete a token
DELETE /access/tokens/{token}

# Control #
# Get info about who is in control of some scope of the robot 
GET /access/controls/{scope}
# Try to give a token control of some scope of the robot 
POST /access/controls/{scope}
# Forcibly take control of some scope of the robot 
PUT /access/controls/{scope}/{token}
# Release control of robot scope
DELETE /access/controls/{scope}/{token}
```

Example of usage for taking control of robot:
```
request:
POST /access/tokens
response:
{
    'data': {
       'attributes': {
           'token': 'abc_123'
        }
    }
}

request
POST /access/controls/robot
{
    'data': {
       'attributes': {
           'token': 'abc_123'
        }
    }
}
```

## risk assessment

Zero. 

closes #5746 