### PR TITLE
fix(api): convert extra seconds to minutes in delay command

### DIFF
--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -513,6 +513,10 @@ def thermocycler_close():
 
 
 def delay(seconds, minutes, msg=None):
+    m, s = divmod(seconds, 60)
+    minutes = minutes + m
+    seconds = s
+
     text = f"Delaying for {minutes} minutes and {seconds} seconds"
     if msg:
         text = f"{text}. {msg}"

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from . import types as command_types
 from opentrons.broker import Broker
 
@@ -513,9 +514,8 @@ def thermocycler_close():
 
 
 def delay(seconds, minutes, msg=None):
-    m, s = divmod(seconds, 60)
-    minutes = minutes + m
-    seconds = s
+    td = timedelta(minutes=minutes, seconds=seconds)
+    minutes, seconds = divmod(td.seconds, 60)
 
     text = f"Delaying for {minutes} minutes and {seconds} seconds"
     if msg:

--- a/api/tests/opentrons/commands/test_commands.py
+++ b/api/tests/opentrons/commands/test_commands.py
@@ -1,31 +1,31 @@
+import pytest
 from opentrons import commands
 
 
-def test_delay():
-    command = commands.delay(10, 0)
-    assert command['name'] == 'command.DELAY'
-    assert command['payload']['seconds'] == 10
-    assert command['payload']['minutes'] == 0
-    assert command['payload']['text'] == "Delaying for 0 minutes"\
-        " and 10 seconds"
+@pytest.mark.parametrize(
+    argnames="seconds,"
+             "minutes,"
+             "expected_seconds,"
+             "expected_minutes,"
+             "expected_text",
+    argvalues=[
+        [10, 0, 10, 0, "Delaying for 0 minutes and 10 seconds"],
+        [10, 9, 10, 9, "Delaying for 9 minutes and 10 seconds"],
+        [100, 0, 40, 1, "Delaying for 1 minutes and 40 seconds"],
+        [105, 5.25, 0, 7, "Delaying for 7 minutes and 0 seconds"],
+    ]
+)
+def test_delay(seconds,
+               minutes,
+               expected_seconds,
+               expected_minutes,
+               expected_text
+               ):
+    command = commands.delay(seconds, minutes)
+    name = command['name']
+    payload = command['payload']
 
-    command = commands.delay(10, 9)
-    assert command['name'] == 'command.DELAY'
-    assert command['payload']['seconds'] == 10
-    assert command['payload']['minutes'] == 9
-    assert command['payload']['text'] == "Delaying for 9 minutes"\
-        " and 10 seconds"
-
-    command = commands.delay(100, 0)
-    assert command['name'] == 'command.DELAY'
-    assert command['payload']['seconds'] == 40
-    assert command['payload']['minutes'] == 1
-    assert command['payload']['text'] == "Delaying for 1 minutes"\
-        " and 40 seconds"
-
-    command = commands.delay(105, 5.25)
-    assert command['name'] == 'command.DELAY'
-    assert command['payload']['seconds'] == 0
-    assert command['payload']['minutes'] == 7
-    assert command['payload']['text'] == "Delaying for 7 minutes"\
-        " and 0 seconds"
+    assert name == 'command.DELAY'
+    assert payload['seconds'] == expected_seconds
+    assert payload['minutes'] == expected_minutes
+    assert payload['text'] == expected_text

--- a/api/tests/opentrons/commands/test_commands.py
+++ b/api/tests/opentrons/commands/test_commands.py
@@ -1,0 +1,31 @@
+from opentrons import commands
+
+
+def test_delay():
+    command = commands.delay(10, 0)
+    assert command['name'] == 'command.DELAY'
+    assert command['payload']['seconds'] == 10
+    assert command['payload']['minutes'] == 0
+    assert command['payload']['text'] == "Delaying for 0 minutes"\
+        " and 10 seconds"
+
+    command = commands.delay(10, 9)
+    assert command['name'] == 'command.DELAY'
+    assert command['payload']['seconds'] == 10
+    assert command['payload']['minutes'] == 9
+    assert command['payload']['text'] == "Delaying for 9 minutes"\
+        " and 10 seconds"
+
+    command = commands.delay(100, 0)
+    assert command['name'] == 'command.DELAY'
+    assert command['payload']['seconds'] == 40
+    assert command['payload']['minutes'] == 1
+    assert command['payload']['text'] == "Delaying for 1 minutes"\
+        " and 40 seconds"
+
+    command = commands.delay(105, 5.25)
+    assert command['name'] == 'command.DELAY'
+    assert command['payload']['seconds'] == 0
+    assert command['payload']['minutes'] == 7
+    assert command['payload']['text'] == "Delaying for 7 minutes"\
+        " and 0 seconds"


### PR DESCRIPTION

[too_many_seconds.json.zip](https://github.com/Opentrons/opentrons/files/4704262/too_many_seconds.json.zip)
## overview 

This PR closes #5414. JSON protocols export delay duration in seconds (even with large durations), so when the commands get published to the run log, the formatting is funny. 

This PR normalizes delay duration to the format we'd expect (seconds > 60 carry over to minutes)

## changelog

  - Add unit test coverage for delay command
  - Normalize delay duration

## review requests
Make sure the tests look okay

Run a JSON protocol with seconds > 60 and make sure the run log converts the time correctly. For example, a delay duration of 0 minutes and 100 seconds should be converted to 1 minute and 40 seconds.

I attached a sample protocol to use to this PR

## risk assessment

Low, just normalizing time units