### PR TITLE
refactor(shared-data): add python bindings skeleton

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -2,3 +2,4 @@
 source "$BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH/api/Config.in"
 source "$BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH/update-server/Config.in"
 source "$BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH/robot-server/Config.in"
+source "$BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH/shared-data/python/Config.in"

--- a/Makefile
+++ b/Makefile
@@ -46,14 +46,14 @@ install-py:
 	$(MAKE) -C $(API_DIR) install
 	$(MAKE) -C $(UPDATE_SERVER_DIR) install
 	$(MAKE) -C $(ROBOT_SERVER_DIR) install
-	$(MAKE) -C $(SHARED_DATA_DIR) install-py
+	$(MAKE) -C $(SHARED_DATA_DIR) setup-py
 
 # front-end dependecies handled by yarn
 .PHONY: install-js
 install-js:
 	yarn
 	$(MAKE) -j 1 -C $(APP_SHELL_DIR) setup
-	$(MAKE) -j 1 -C $(SHARED_DATA_DIR) install-js
+	$(MAKE) -j 1 -C $(SHARED_DATA_DIR) setup-js
 	$(MAKE) -j 1 -C $(DISCOVERY_CLIENT_DIR) install
 
 # uninstall all project dependencies

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ install-py:
 install-js:
 	yarn
 	$(MAKE) -j 1 -C $(APP_SHELL_DIR) setup
-	$(MAKE) -j 1 -C $(SHARED_DATA_DIR)
-	$(MAKE) -j 1 -C $(DISCOVERY_CLIENT_DIR) install-js
+	$(MAKE) -j 1 -C $(SHARED_DATA_DIR) install-js
+	$(MAKE) -j 1 -C $(DISCOVERY_CLIENT_DIR) install
 
 # uninstall all project dependencies
 # TODO(mc, 2018-03-22): API uninstall via pipenv --rm in api/Makefile

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ install-py:
 	$(MAKE) -C $(API_DIR) install
 	$(MAKE) -C $(UPDATE_SERVER_DIR) install
 	$(MAKE) -C $(ROBOT_SERVER_DIR) install
+	$(MAKE) -C $(SHARED_DATA_DIR) install-py
 
 # front-end dependecies handled by yarn
 .PHONY: install-js
@@ -53,7 +54,7 @@ install-js:
 	yarn
 	$(MAKE) -j 1 -C $(APP_SHELL_DIR) setup
 	$(MAKE) -j 1 -C $(SHARED_DATA_DIR)
-	$(MAKE) -j 1 -C $(DISCOVERY_CLIENT_DIR)
+	$(MAKE) -j 1 -C $(DISCOVERY_CLIENT_DIR) install-js
 
 # uninstall all project dependencies
 # TODO(mc, 2018-03-22): API uninstall via pipenv --rm in api/Makefile
@@ -89,6 +90,8 @@ push: export host=$(usb_host)
 push:
 	$(if $(host),@echo "Pushing to $(host)",$(error host variable required))
 	$(MAKE) -C $(API_DIR) push-no-restart
+	sleep 1
+	$(MAKE) -C $(SHARED_DATA_DIR) push-no-restart
 	sleep 1
 	$(MAKE) -C $(UPDATE_SERVER_DIR) push
 	sleep 1
@@ -148,6 +151,7 @@ lint-py:
 	$(MAKE) -C $(API_DIR) lint
 	$(MAKE) -C $(UPDATE_SERVER_DIR) lint
 	$(MAKE) -C $(ROBOT_SERVER_DIR) lint
+	$(MAKE) -C $(SHARED_DATA_DIR) lint-py
 
 .PHONY: lint-js
 lint-js:

--- a/api/Makefile
+++ b/api/Makefile
@@ -42,8 +42,6 @@ pypi_password ?=
 
 # Host key location for buildroot robot
 br_ssh_key ?= $(default_ssh_key)
-# Pubkey location for buildroot robot to install with install-key
-br_ssh_pubkey ?= $(br_ssh_key).pub
 # Other SSH args for buildroot robots
 ssh_opts ?= $(default_ssh_opts)
 

--- a/api/Pipfile
+++ b/api/Pipfile
@@ -26,6 +26,7 @@ typing-extensions = "*"
 wheel = "==0.30.0"
 "e1839a8" = {editable = true, path = "."}
 graphviz = "*"
+"c445fee" = {editable = true, path = "./../shared-data/python"}
 
 [packages]
 aiohttp = "==3.4.4"

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0159d23270003bf0932bcfe9695406af4fbe2f76ed7b1afd42e6d70170af59e6"
+            "sha256": "38ccda70c311078256283f9350d25365f111207b512afa6cab0dd462481739bd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -200,10 +200,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
-                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "version": "==1.14.0"
+            "version": "==1.15.0"
         },
         "systemd-python": {
             "hashes": [
@@ -329,6 +329,10 @@
                 "sha256:3c4c520fdb9db59ef139915a5db79f8b51bc2a7257ea0389f30c846883430a4b"
             ],
             "version": "==3.1.5"
+        },
+        "c445fee": {
+            "editable": true,
+            "path": "./../shared-data/python"
         },
         "certifi": {
             "hashes": [
@@ -714,11 +718,11 @@
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b",
-                "sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"
+                "sha256:b6a814b8ed6247bd81ff47f038511b57fe1ce7f4cc25b9106f1a4b106f1d9322",
+                "sha256:c87dfd8465d865655a8213859f1b4749b43448b5fae465cb981e16d52a811424"
             ],
             "index": "pypi",
-            "version": "==2.8.1"
+            "version": "==2.9.0"
         },
         "pytz": {
             "hashes": [
@@ -766,10 +770,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
-                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "version": "==1.14.0"
+            "version": "==1.15.0"
         },
         "snowballstemmer": {
             "hashes": [

--- a/api/setup.py
+++ b/api/setup.py
@@ -5,7 +5,6 @@ import codecs
 import os
 import os.path
 from setuptools import setup, find_packages
-from setuptools.command import build_py, sdist
 
 import json
 
@@ -16,68 +15,6 @@ if os.name == 'posix':
     fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags & ~os.O_NONBLOCK)
 
 HERE = os.path.abspath(os.path.dirname(__file__))
-
-# Where we get our files from
-SHARED_DATA_PATH = os.path.join('..', 'shared-data')
-# The subdirectories of SHARED_DATA_PATH to scan for files
-SHARED_DATA_SUBDIRS = ['deck',
-                       'labware',
-                       'module',
-                       'pipette',
-                       'protocol']
-# Where, relative to the package root, we put the files we copy
-DEST_BASE_PATH = 'shared_data'
-
-
-def get_shared_data_files():
-    to_include = []
-    for subdir in SHARED_DATA_SUBDIRS:
-        top = os.path.join(SHARED_DATA_PATH, subdir)
-        for dirpath, dirnames, filenames in os.walk(top):
-            from_source = os.path.relpath(dirpath, SHARED_DATA_PATH)
-            to_include.extend([os.path.join(from_source, fname)
-                               for fname in filenames])
-    return to_include
-
-
-class SDistWithSharedData(sdist.sdist):
-    description = sdist.sdist.description\
-        + " Also, include opentrons data files."
-
-    def make_release_tree(self, base_dir, files):
-        self.announce("adding opentrons data files to base dir {}"
-                      .format(base_dir))
-        for data_file in get_shared_data_files():
-            sdist_dest = os.path.join(base_dir, DEST_BASE_PATH)
-            self.mkpath(os.path.join(sdist_dest, 'opentrons',
-                                     os.path.dirname(data_file)))
-            self.copy_file(os.path.join(SHARED_DATA_PATH, data_file),
-                           os.path.join(sdist_dest, data_file))
-        super().make_release_tree(base_dir, files)
-
-
-class BuildWithSharedData(build_py.build_py):
-    description = build_py.build_py.description\
-        + " Also, include opentrons data files"
-
-    def _get_data_files(self):
-        """
-        Override of build_py.get_data_files that includes out of tree configs.
-        These are currently hardcoded to include selected folders in
-         ../shared-data/, which will move to opentrons/config/shared-data
-        """
-        files = super()._get_data_files()
-        # We don’t really want to duplicate logic used in the original
-        # implementation, but we can back out what it did with commonpath -
-        # should be something ending in opentrons
-        build_base = os.path.commonpath([f[2] for f in files])
-        # We want a list of paths to only files relative to ../shared-data
-        to_include = get_shared_data_files()
-        destination = os.path.join(build_base, DEST_BASE_PATH)
-        # And finally, tell the system about our files
-        files.append(('opentrons', SHARED_DATA_PATH,
-                      destination, to_include))
-        return files
 
 
 def get_version():
@@ -147,10 +84,6 @@ if __name__ == "__main__":
         install_requires=INSTALL_REQUIRES,
         include_package_data=True,
         package_dir={'': 'src'},
-        cmdclass={
-            'build_py': BuildWithSharedData,
-            'sdist': SDistWithSharedData
-        },
         entry_points={
             'console_scripts': [
                 'opentrons_simulate = opentrons.simulate:main',

--- a/external.mk
+++ b/external.mk
@@ -2,3 +2,4 @@
 include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/api/buildroot.mk
 include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/update-server/buildroot.mk
 include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/robot-server/buildroot.mk
+include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/shared-data/python/buildroot.mk

--- a/robot-server/Pipfile
+++ b/robot-server/Pipfile
@@ -16,6 +16,7 @@ atomicwrites = {version = "*",sys_platform = "== 'win32'"}
 pylama = "*"
 requests = "*"
 tavern = "==1.0.0"
+"289f143" = {editable = true, path = "./../shared-data/python"}
 
 [packages]
 uvicorn = "==0.11.3"

--- a/robot-server/Pipfile.lock
+++ b/robot-server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "54a2a3d009fc7776b54d905cd50833bf668967c0684bbe05fce486178bada499"
+            "sha256": "50e282ccef7ef1953135837a92c1aa29b64ae5371feea9bc998477edd626e605"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -67,10 +67,10 @@
         },
         "click": {
             "hashes": [
-                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
-                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
+                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
+                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
             ],
-            "version": "==7.1.1"
+            "version": "==7.1.2"
         },
         "fastapi": {
             "hashes": [
@@ -114,52 +114,55 @@
         },
         "multidict": {
             "hashes": [
-                "sha256:317f96bc0950d249e96d8d29ab556d01dd38888fbe68324f46fd834b430169f1",
-                "sha256:42f56542166040b4474c0c608ed051732033cd821126493cf25b6c276df7dd35",
-                "sha256:4b7df040fb5fe826d689204f9b544af469593fb3ff3a069a6ad3409f742f5928",
-                "sha256:544fae9261232a97102e27a926019100a9db75bec7b37feedd74b3aa82f29969",
-                "sha256:620b37c3fea181dab09267cd5a84b0f23fa043beb8bc50d8474dd9694de1fa6e",
-                "sha256:6e6fef114741c4d7ca46da8449038ec8b1e880bbe68674c01ceeb1ac8a648e78",
-                "sha256:7774e9f6c9af3f12f296131453f7b81dabb7ebdb948483362f5afcaac8a826f1",
-                "sha256:85cb26c38c96f76b7ff38b86c9d560dea10cf3459bb5f4caf72fc1bb932c7136",
-                "sha256:a326f4240123a2ac66bb163eeba99578e9d63a8654a59f4688a79198f9aa10f8",
-                "sha256:ae402f43604e3b2bc41e8ea8b8526c7fa7139ed76b0d64fc48e28125925275b2",
-                "sha256:aee283c49601fa4c13adc64c09c978838a7e812f85377ae130a24d7198c0331e",
-                "sha256:b51249fdd2923739cd3efc95a3d6c363b67bbf779208e9f37fd5e68540d1a4d4",
-                "sha256:bb519becc46275c594410c6c28a8a0adc66fe24fef154a9addea54c1adb006f5",
-                "sha256:c2c37185fb0af79d5c117b8d2764f4321eeb12ba8c141a95d0aa8c2c1d0a11dd",
-                "sha256:dc561313279f9d05a3d0ffa89cd15ae477528ea37aa9795c4654588a3287a9ab",
-                "sha256:e439c9a10a95cb32abd708bb8be83b2134fa93790a4fb0535ca36db3dda94d20",
-                "sha256:fc3b4adc2ee8474cb3cd2a155305d5f8eda0a9c91320f83e55748e1fcb68f8e3"
+                "sha256:1ece5a3369835c20ed57adadc663400b5525904e53bae59ec854a5d36b39b21a",
+                "sha256:275ca32383bc5d1894b6975bb4ca6a7ff16ab76fa622967625baeebcf8079000",
+                "sha256:3750f2205b800aac4bb03b5ae48025a64e474d2c6cc79547988ba1d4122a09e2",
+                "sha256:4538273208e7294b2659b1602490f4ed3ab1c8cf9dbdd817e0e9db8e64be2507",
+                "sha256:5141c13374e6b25fe6bf092052ab55c0c03d21bd66c94a0e3ae371d3e4d865a5",
+                "sha256:51a4d210404ac61d32dada00a50ea7ba412e6ea945bbe992e4d7a595276d2ec7",
+                "sha256:5cf311a0f5ef80fe73e4f4c0f0998ec08f954a6ec72b746f3c179e37de1d210d",
+                "sha256:6513728873f4326999429a8b00fc7ceddb2509b01d5fd3f3be7881a257b8d463",
+                "sha256:7388d2ef3c55a8ba80da62ecfafa06a1c097c18032a501ffd4cabbc52d7f2b19",
+                "sha256:9456e90649005ad40558f4cf51dbb842e32807df75146c6d940b6f5abb4a78f3",
+                "sha256:c026fe9a05130e44157b98fea3ab12969e5b60691a276150db9eda71710cd10b",
+                "sha256:d14842362ed4cf63751648e7672f7174c9818459d169231d03c56e84daf90b7c",
+                "sha256:e0d072ae0f2a179c375f67e3da300b47e1a83293c554450b29c900e50afaae87",
+                "sha256:f07acae137b71af3bb548bd8da720956a3bc9f9a0b87733e0899226a2317aeb7",
+                "sha256:fbb77a75e529021e7c4a8d4e823d88ef4d23674a202be4f5addffc72cbb91430",
+                "sha256:fcfbb44c59af3f8ea984de67ec7c306f618a3ec771c2843804069917a8f2e255",
+                "sha256:feed85993dbdb1dbc29102f50bca65bdc68f2c0c8d352468c25b54874f23c39d"
             ],
-            "version": "==4.7.5"
+            "version": "==4.7.6"
         },
         "pydantic": {
             "hashes": [
-                "sha256:012c422859bac2e03ab3151ea6624fecf0e249486be7eb8c6ee69c91740c6752",
-                "sha256:07911aab70f3bc52bb845ce1748569c5e70478ac977e106a150dd9d0465ebf04",
-                "sha256:47b8db7024ba3d46c3d4768535e1cf87b6c8cf92ccd81e76f4e1cb8ee47688b3",
-                "sha256:50e4e948892a6815649ad5a9a9379ad1e5f090f17842ac206535dfaed75c6f2f",
-                "sha256:51f11c8bbf794a68086540da099aae4a9107447c7a9d63151edbb7d50110cf21",
-                "sha256:6100d7862371115c40be55cc4b8d766a74b1d0dbaf99dbfe72bb4bac0faf89ed",
-                "sha256:61d22d36808087d3184ed6ac0d91dd71c533b66addb02e4a9930e1e30833202f",
-                "sha256:72184c1421103cca128300120f8f1185fb42a9ea73a1c9845b1c53db8c026a7d",
-                "sha256:831a0265a9e3933b3d0f04d1a81bba543bafbe4119c183ff2771871db70524ab",
-                "sha256:8848b4eb458469739126e4c1a202d723dd092e087f8dbe3104371335f87ba5df",
-                "sha256:bbbed364376f4a0aebb9ea452ff7968b306499a9e74f4db69b28ff2cd4043a11",
-                "sha256:e27559cedbd7f59d2375bfd6eea29a330ea1a5b0589c34d6b4e0d7bec6027bbf",
-                "sha256:f17ec336e64d4583311249fb179528e9a2c27c8a2eaf590ec6ec2c6dece7cb3f",
-                "sha256:f863456d3d4bf817f2e5248553dee3974c5dc796f48e6ddb599383570f4215ac"
+                "sha256:0a1cdf24e567d42dc762d3fed399bd211a13db2e8462af9dfa93b34c41648efb",
+                "sha256:2007eb062ed0e57875ce8ead12760a6e44bf5836e6a1a7ea81d71eeecf3ede0f",
+                "sha256:20a15a303ce1e4d831b4e79c17a4a29cb6740b12524f5bba3ea363bff65732bc",
+                "sha256:2a6904e9f18dea58f76f16b95cba6a2f20b72d787abd84ecd67ebc526e61dce6",
+                "sha256:3714a4056f5bdbecf3a41e0706ec9b228c9513eee2ad884dc2c568c4dfa540e9",
+                "sha256:473101121b1bd454c8effc9fe66d54812fdc128184d9015c5aaa0d4e58a6d338",
+                "sha256:68dece67bff2b3a5cc188258e46b49f676a722304f1c6148ae08e9291e284d98",
+                "sha256:70f27d2f0268f490fe3de0a9b6fca7b7492b8fd6623f9fecd25b221ebee385e3",
+                "sha256:8433dbb87246c0f562af75d00fa80155b74e4f6924b0db6a2078a3cd2f11c6c4",
+                "sha256:8be325fc9da897029ee48d1b5e40df817d97fe969f3ac3fd2434ba7e198c55d5",
+                "sha256:93b9f265329d9827f39f0fca68f5d72cc8321881cdc519a1304fa73b9f8a75bd",
+                "sha256:9be755919258d5d168aeffbe913ed6e8bd562e018df7724b68cabdee3371e331",
+                "sha256:ab863853cb502480b118187d670f753be65ec144e1654924bec33d63bc8b3ce2",
+                "sha256:b96ce81c4b5ca62ab81181212edfd057beaa41411cd9700fbcb48a6ba6564b4e",
+                "sha256:da8099fca5ee339d5572cfa8af12cf0856ae993406f0b1eb9bb38c8a660e7416",
+                "sha256:e2c753d355126ddd1eefeb167fa61c7037ecd30b98e7ebecdc0d1da463b4ea09",
+                "sha256:f0018613c7a0d19df3240c2a913849786f21b6539b9f23d85ce4067489dfacfa"
             ],
-            "version": "==1.4"
+            "version": "==1.5.1"
         },
         "python-dotenv": {
             "hashes": [
-                "sha256:81822227f771e0cab235a2939f0f265954ac4763cafd806d845801c863bf372f",
-                "sha256:92b3123fb2d58a284f76cc92bfe4ee6c502c32ded73e8b051c4f6afc8b6751ed"
+                "sha256:25c0ff1a3e12f4bde8d592cc254ab075cfe734fc5dd989036716fd17ee7e5ec7",
+                "sha256:3b9909bc96b0edc6b01586e1eed05e71174ef4e04c71da5786370cebea53ad74"
             ],
             "index": "pypi",
-            "version": "==0.12.0"
+            "version": "==0.13.0"
         },
         "python-multipart": {
             "hashes": [
@@ -170,10 +173,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
-                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "version": "==1.14.0"
+            "version": "==1.15.0"
         },
         "starlette": {
             "hashes": [
@@ -256,6 +259,10 @@
         }
     },
     "develop": {
+        "289f143": {
+            "editable": true,
+            "path": "./../shared-data/python"
+        },
         "aiohttp": {
             "hashes": [
                 "sha256:0419705a36b43c0ac6f15469f9c2a08cad5c939d78bd12a5c23ea167c8253b2b",
@@ -300,12 +307,12 @@
         },
         "atomicwrites": {
             "hashes": [
-                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
-                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
+                "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197",
+                "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"
             ],
             "index": "pypi",
             "markers": "sys_platform == 'win32'",
-            "version": "==1.3.0"
+            "version": "==1.4.0"
         },
         "attrs": {
             "hashes": [
@@ -391,10 +398,10 @@
         },
         "jmespath": {
             "hashes": [
-                "sha256:695cb76fa78a10663425d5b73ddc5714eb711157e52704d69be03b1a02ba4fec",
-                "sha256:cca55c8d153173e21baa59983015ad0daf603f9cb799904ff057bfb8ff8dc2d9"
+                "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
+                "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
             ],
-            "version": "==0.9.5"
+            "version": "==0.10.0"
         },
         "jsonschema": {
             "hashes": [
@@ -412,32 +419,32 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
-                "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"
+                "sha256:558bb897a2232f5e4f8e2399089e35aecb746e1f9191b6584a151647e89267be",
+                "sha256:7818f596b1e87be009031c7653d01acc46ed422e6656b394b0f765ce66ed4982"
             ],
-            "version": "==8.2.0"
+            "version": "==8.3.0"
         },
         "multidict": {
             "hashes": [
-                "sha256:317f96bc0950d249e96d8d29ab556d01dd38888fbe68324f46fd834b430169f1",
-                "sha256:42f56542166040b4474c0c608ed051732033cd821126493cf25b6c276df7dd35",
-                "sha256:4b7df040fb5fe826d689204f9b544af469593fb3ff3a069a6ad3409f742f5928",
-                "sha256:544fae9261232a97102e27a926019100a9db75bec7b37feedd74b3aa82f29969",
-                "sha256:620b37c3fea181dab09267cd5a84b0f23fa043beb8bc50d8474dd9694de1fa6e",
-                "sha256:6e6fef114741c4d7ca46da8449038ec8b1e880bbe68674c01ceeb1ac8a648e78",
-                "sha256:7774e9f6c9af3f12f296131453f7b81dabb7ebdb948483362f5afcaac8a826f1",
-                "sha256:85cb26c38c96f76b7ff38b86c9d560dea10cf3459bb5f4caf72fc1bb932c7136",
-                "sha256:a326f4240123a2ac66bb163eeba99578e9d63a8654a59f4688a79198f9aa10f8",
-                "sha256:ae402f43604e3b2bc41e8ea8b8526c7fa7139ed76b0d64fc48e28125925275b2",
-                "sha256:aee283c49601fa4c13adc64c09c978838a7e812f85377ae130a24d7198c0331e",
-                "sha256:b51249fdd2923739cd3efc95a3d6c363b67bbf779208e9f37fd5e68540d1a4d4",
-                "sha256:bb519becc46275c594410c6c28a8a0adc66fe24fef154a9addea54c1adb006f5",
-                "sha256:c2c37185fb0af79d5c117b8d2764f4321eeb12ba8c141a95d0aa8c2c1d0a11dd",
-                "sha256:dc561313279f9d05a3d0ffa89cd15ae477528ea37aa9795c4654588a3287a9ab",
-                "sha256:e439c9a10a95cb32abd708bb8be83b2134fa93790a4fb0535ca36db3dda94d20",
-                "sha256:fc3b4adc2ee8474cb3cd2a155305d5f8eda0a9c91320f83e55748e1fcb68f8e3"
+                "sha256:1ece5a3369835c20ed57adadc663400b5525904e53bae59ec854a5d36b39b21a",
+                "sha256:275ca32383bc5d1894b6975bb4ca6a7ff16ab76fa622967625baeebcf8079000",
+                "sha256:3750f2205b800aac4bb03b5ae48025a64e474d2c6cc79547988ba1d4122a09e2",
+                "sha256:4538273208e7294b2659b1602490f4ed3ab1c8cf9dbdd817e0e9db8e64be2507",
+                "sha256:5141c13374e6b25fe6bf092052ab55c0c03d21bd66c94a0e3ae371d3e4d865a5",
+                "sha256:51a4d210404ac61d32dada00a50ea7ba412e6ea945bbe992e4d7a595276d2ec7",
+                "sha256:5cf311a0f5ef80fe73e4f4c0f0998ec08f954a6ec72b746f3c179e37de1d210d",
+                "sha256:6513728873f4326999429a8b00fc7ceddb2509b01d5fd3f3be7881a257b8d463",
+                "sha256:7388d2ef3c55a8ba80da62ecfafa06a1c097c18032a501ffd4cabbc52d7f2b19",
+                "sha256:9456e90649005ad40558f4cf51dbb842e32807df75146c6d940b6f5abb4a78f3",
+                "sha256:c026fe9a05130e44157b98fea3ab12969e5b60691a276150db9eda71710cd10b",
+                "sha256:d14842362ed4cf63751648e7672f7174c9818459d169231d03c56e84daf90b7c",
+                "sha256:e0d072ae0f2a179c375f67e3da300b47e1a83293c554450b29c900e50afaae87",
+                "sha256:f07acae137b71af3bb548bd8da720956a3bc9f9a0b87733e0899226a2317aeb7",
+                "sha256:fbb77a75e529021e7c4a8d4e823d88ef4d23674a202be4f5addffc72cbb91430",
+                "sha256:fcfbb44c59af3f8ea984de67ec7c306f618a3ec771c2843804069917a8f2e255",
+                "sha256:feed85993dbdb1dbc29102f50bca65bdc68f2c0c8d352468c25b54874f23c39d"
             ],
-            "version": "==4.7.5"
+            "version": "==4.7.6"
         },
         "mypy": {
             "hashes": [
@@ -468,36 +475,36 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:1598a6de323508cfeed6b7cd6c4efb43324f4692e20d1f76e1feec7f59013448",
-                "sha256:1b0ece94018ae21163d1f651b527156e1f03943b986188dd81bc7e066eae9d1c",
-                "sha256:2e40be731ad618cb4974d5ba60d373cdf4f1b8dcbf1dcf4d9dff5e212baf69c5",
-                "sha256:4ba59db1fcc27ea31368af524dcf874d9277f21fd2e1f7f1e2e0c75ee61419ed",
-                "sha256:59ca9c6592da581a03d42cc4e270732552243dc45e87248aa8d636d53812f6a5",
-                "sha256:5e0feb76849ca3e83dd396254e47c7dba65b3fa9ed3df67c2556293ae3e16de3",
-                "sha256:6d205249a0293e62bbb3898c4c2e1ff8a22f98375a34775a259a0523111a8f6c",
-                "sha256:6fcc5a3990e269f86d388f165a089259893851437b904f422d301cdce4ff25c8",
-                "sha256:82847f2765835c8e5308f136bc34018d09b49037ec23ecc42b246424c767056b",
-                "sha256:87902e5c03355335fc5992a74ba0247a70d937f326d852fc613b7f53516c0963",
-                "sha256:9ab21d1cb156a620d3999dd92f7d1c86824c622873841d6b080ca5495fa10fef",
-                "sha256:a1baa1dc8ecd88fb2d2a651671a84b9938461e8a8eed13e2f0a812a94084d1fa",
-                "sha256:a244f7af80dacf21054386539699ce29bcc64796ed9850c99a34b41305630286",
-                "sha256:a35af656a7ba1d3decdd4fae5322b87277de8ac98b7d9da657d9e212ece76a61",
-                "sha256:b1fe1a6f3a6f355f6c29789b5927f8bd4f134a4bd9a781099a7c4f66af8850f5",
-                "sha256:b5ad0adb51b2dee7d0ee75a69e9871e2ddfb061c73ea8bc439376298141f77f5",
-                "sha256:ba3c7a2814ec8a176bb71f91478293d633c08582119e713a0c5351c0f77698da",
-                "sha256:cd77d58fb2acf57c1d1ee2835567cd70e6f1835e32090538f17f8a3a99e5e34b",
-                "sha256:cdb3a70285e8220875e4d2bc394e49b4988bdb1298ffa4e0bd81b2f613be397c",
-                "sha256:deb529c40c3f1e38d53d5ae6cd077c21f1d49e13afc7936f7f868455e16b64a0",
-                "sha256:e7894793e6e8540dbeac77c87b489e331947813511108ae097f1715c018b8f3d"
+                "sha256:00d7b54c025601e28f468953d065b9b121ddca7fff30bed7be082d3656dd798d",
+                "sha256:02ec9582808c4e48be4e93cd629c855e644882faf704bc2bd6bbf58c08a2a897",
+                "sha256:0e6f72f7bb08f2f350ed4408bb7acdc0daba637e73bce9f5ea2b207039f3af88",
+                "sha256:1be2e96314a66f5f1ce7764274327fd4fb9da58584eaff00b5a5221edefee7d6",
+                "sha256:2466fbcf23711ebc5daa61d28ced319a6159b260a18839993d871096d66b93f7",
+                "sha256:2b573fcf6f9863ce746e4ad00ac18a948978bb3781cffa4305134d31801f3e26",
+                "sha256:3f0dae97e1126f529ebb66f3c63514a0f72a177b90d56e4bce8a0b5def34627a",
+                "sha256:50fb72bcbc2cf11e066579cb53c4ca8ac0227abb512b6cbc1faa02d1595a2a5d",
+                "sha256:57aea170fb23b1fd54fa537359d90d383d9bf5937ee54ae8045a723caa5e0961",
+                "sha256:709c2999b6bd36cdaf85cf888d8512da7433529f14a3689d6e37ab5242e7add5",
+                "sha256:7d59f21e43bbfd9a10953a7e26b35b6849d888fc5a331fa84a2d9c37bd9fe2a2",
+                "sha256:904b513ab8fbcbdb062bed1ce2f794ab20208a1b01ce9bd90776c6c7e7257032",
+                "sha256:96dd36f5cdde152fd6977d1bbc0f0561bccffecfde63cd397c8e6033eb66baba",
+                "sha256:9933b81fecbe935e6a7dc89cbd2b99fea1bf362f2790daf9422a7bb1dc3c3085",
+                "sha256:bbcc85aaf4cd84ba057decaead058f43191cc0e30d6bc5d44fe336dc3d3f4509",
+                "sha256:dccd380d8e025c867ddcb2f84b439722cf1f23f3a319381eac45fd077dee7170",
+                "sha256:e22cd0f72fc931d6abc69dc7764484ee20c6a60b0d0fee9ce0426029b1c1bdae",
+                "sha256:ed722aefb0ebffd10b32e67f48e8ac4c5c4cf5d3a785024fdf0e9eb17529cd9d",
+                "sha256:efb7ac5572c9a57159cf92c508aad9f856f1cb8e8302d7fdb99061dbe52d712c",
+                "sha256:efdba339fffb0e80fcc19524e4fdbda2e2b5772ea46720c44eaac28096d60720",
+                "sha256:f22273dd6a403ed870207b853a856ff6327d5cbce7a835dfa0645b3fc00273ec"
             ],
-            "version": "==1.18.2"
+            "version": "==1.18.4"
         },
         "packaging": {
             "hashes": [
-                "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3",
-                "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"
+                "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
+                "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
             ],
-            "version": "==20.3"
+            "version": "==20.4"
         },
         "paho-mqtt": {
             "hashes": [
@@ -528,10 +535,10 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
-                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+                "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
+                "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
             ],
-            "version": "==2.5.0"
+            "version": "==2.6.0"
         },
         "pydocstyle": {
             "hashes": [
@@ -591,11 +598,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
-                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
+                "sha256:95c710d0a72d91c13fae35dce195633c929c3792f54125919847fdcdf7caa0d3",
+                "sha256:eb2b5e935f6a019317e455b6da83dd8650ac9ffd2ee73a7b657a30873d67a698"
             ],
             "index": "pypi",
-            "version": "==5.4.1"
+            "version": "==5.4.2"
         },
         "pytest-aiohttp": {
             "hashes": [
@@ -607,18 +614,18 @@
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b",
-                "sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"
+                "sha256:b6a814b8ed6247bd81ff47f038511b57fe1ce7f4cc25b9106f1a4b106f1d9322",
+                "sha256:c87dfd8465d865655a8213859f1b4749b43448b5fae465cb981e16d52a811424"
             ],
             "index": "pypi",
-            "version": "==2.8.1"
+            "version": "==2.9.0"
         },
         "python-box": {
             "hashes": [
-                "sha256:5168fcd5572ec1e97754a636a9a93abef5d7f300cd5f1906927feb19839e7068",
-                "sha256:b47cac911e9d8f2ba6551fdb29d3e70a394b67691758baa114d4fcd9c0f1b1f8"
+                "sha256:37dcaee62446cef67ffad7baef0f1b5f541587e2064f1152ec3bc0ead64092a2",
+                "sha256:e54aaaf5deb2dc4c0427e0ecf60415697b559c98ab21f8a6e3ae1be443445f78"
             ],
-            "version": "==4.2.2"
+            "version": "==4.2.3"
         },
         "python-dateutil": {
             "hashes": [
@@ -685,10 +692,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
-                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "version": "==1.14.0"
+            "version": "==1.15.0"
         },
         "snowballstemmer": {
             "hashes": [
@@ -713,10 +720,10 @@
         },
         "toml": {
             "hashes": [
-                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
-                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+                "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f",
+                "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"
             ],
-            "version": "==0.10.0"
+            "version": "==0.10.1"
         },
         "typed-ast": {
             "hashes": [

--- a/robot-server/robot_server/service/rpc/rpc.py
+++ b/robot-server/robot_server/service/rpc/rpc.py
@@ -280,9 +280,9 @@ class RPCServer(object):
             trace = traceback.format_exc()
             try:
                 line_msg = ' [line ' + [
-                    l.split(',')[0].strip()
-                    for l in trace.split('line')
-                    if '<module>' in l][0] + ']'
+                    line.split(',')[0].strip()
+                    for line in trace.split('line')
+                    if '<module>' in line][0] + ']'
             except Exception:
                 line_msg = ''
             finally:

--- a/scripts/python_build_utils.py
+++ b/scripts/python_build_utils.py
@@ -30,7 +30,10 @@ package_entries = {
         'update_server'),
     'robot-server': PackageEntry(
         os.path.join(HERE, '..', 'robot-server', 'robot_server', 'package.json'),
-        'robot_server')
+        'robot_server'),
+    'shared-data': PackageEntry(
+        os.path.join(HERE, '..', 'shared-data', 'package.json'),
+        'shared_data'),
 }
 
 

--- a/shared-data/Makefile
+++ b/shared-data/Makefile
@@ -28,18 +28,17 @@ twine_auth_args := --username $(pypi_username) --password $(pypi_password)
 .PHONY: all
 all: clean dist
 
-.PHONY: install-js
-install-js:
-	yarn
+.PHONY: setup-js
+setup:
 	$(MAKE) dist
 
-.PHONY: install-py
-install-py:
+.PHONY: setup-py
+setup-py:
 	cd python && $(pipenv_envvars) pipenv sync $(pipenv_opts)
 	cd python && $(pipenv_envvars) pipenv run pip freeze
 
-.PHONY: install
-install: install-py install-js
+.PHONY: setup
+setup: setup-py setup-js
 
 
 .PHONY: dist

--- a/shared-data/Makefile
+++ b/shared-data/Makefile
@@ -29,7 +29,7 @@ twine_auth_args := --username $(pypi_username) --password $(pypi_password)
 all: clean dist
 
 .PHONY: setup-js
-setup:
+setup-js:
 	$(MAKE) dist
 
 .PHONY: setup-py

--- a/shared-data/Makefile
+++ b/shared-data/Makefile
@@ -1,4 +1,12 @@
-# opentrons app makefile
+# shared-data makefile
+include ../scripts/python.mk
+include ../scripts/push.mk
+
+# Host key location for buildroot robot
+br_ssh_key ?= $(default_ssh_key)
+# Other SSH args for buildroot robots
+ssh_opts ?= $(default_ssh_opts)
+
 
 # using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
 SHELL := bash
@@ -9,15 +17,30 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 # TODO(mc, 2018-10-25): use dist to match other projects
 BUILD_DIR := build
 
+wheel_file = $(BUILD_DIR)/$(call python_get_wheelname,shared-data,opentrons_shared_data)
+
+py_sources = $(filter %.py,$(shell $(SHX) find python/opentrons_shared_data))
+
+twine_auth_args := --username $(pypi_username) --password $(pypi_password)
+
 #######################################
 
 .PHONY: all
 all: clean dist
 
-.PHONY: install
-install:
+.PHONY: install-js
+install-js:
 	yarn
 	$(MAKE) dist
+
+.PHONY: install-py
+install-py:
+	$(pipenv_envvars) pipenv sync $(pipenv_opts)
+	$(pipenv_envvars) pipenv run pip freeze
+
+.PHONY: install
+install: install-py install-js
+
 
 .PHONY: dist
 dist:
@@ -27,3 +50,37 @@ dist:
 .PHONY: clean
 clean:
 	shx rm -rf $(BUILD_DIR)
+
+
+.PHONY: wheel
+wheel: $(wheel_file)
+
+$(BUILD_DIR)/opentrons_shared_data-%-py2.py3-none-any.whl: python/setup.py $(py_sources)
+	$(SHX) cd python && $(python) setup.py $(wheel_opts) bdist_wheel
+	$(SHX) mv python/dist/$(notdir $(wheel_file)) $(BUILD_DIR)/
+	$(SHX) rm -rf python/build python/dist *.egg_info
+	$(SHX) ls $(BUILD_DIR)
+
+.PHONY: lint-py
+lint-py: $(py_sources)
+	$(SHX) cd python && $(python) -m mypy opentrons_shared_data
+	$(SHX) cd python && $(python) -m pylama opentrons_shared_data
+
+.PHONY: push-no-restart
+push-no-restart: $(wheel_file)
+	$(call push-python-package,$(host),$(br_ssh_key),$(ssh_opts),$(wheel_file))
+
+.PHONY: push
+push: push-no-restart
+	$(call restart-service,$(host),$(br_ssh_key),$(ssh_opts),opentrons-robot-server)
+
+.PHONY: deploy-staging
+deploy-staging: wheel
+	-$(python) -m twine upload --repository-url "https://test.pypi.org/legacy/"\
+                             $(twine_auth_args)\
+                             $(wheel_file)
+
+.PHONY: deploy
+deploy: wheel
+	$(python) -m twine upload $(twine_auth_args)\
+                            $(wheel_file)

--- a/shared-data/Makefile
+++ b/shared-data/Makefile
@@ -35,8 +35,8 @@ install-js:
 
 .PHONY: install-py
 install-py:
-	$(pipenv_envvars) pipenv sync $(pipenv_opts)
-	$(pipenv_envvars) pipenv run pip freeze
+	cd python && $(pipenv_envvars) pipenv sync $(pipenv_opts)
+	cd python && $(pipenv_envvars) pipenv run pip freeze
 
 .PHONY: install
 install: install-py install-js

--- a/shared-data/python/Config.in
+++ b/shared-data/python/Config.in
@@ -1,0 +1,8 @@
+config BR2_PACKAGE_PYTHON_OPENTRONS_SHARED_DATA
+  bool "python-opentrons-shared-data"
+  depends on BR2_PACKAGE_PYTHON3
+  select BR2_PACKAGE_PYTHON_JSONSCHEMA # runtime
+  help
+    Opentrons data sources. Used on an OT2 robot.
+
+    https://opentrons.com

--- a/shared-data/python/Pipfile
+++ b/shared-data/python/Pipfile
@@ -1,0 +1,18 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[requires]
+python_version = "3.7"
+
+[dev-packages]
+typing-extensions = "*"
+mypy = "==0.770"
+pylama = "*"
+twine = "==2.0.0"
+wheel = "==0.30.0"
+"e1839a8" = {editable = true, path = "."}
+
+[packages]
+jsonschema = "==3.0.2"

--- a/shared-data/python/Pipfile.lock
+++ b/shared-data/python/Pipfile.lock
@@ -1,0 +1,323 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "5f8c3c54f4371f66f2c16eb26d1c57d2bb7479ae5a722327e180085a168b4883"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "version": "==19.3.0"
+        },
+        "jsonschema": {
+            "hashes": [
+                "sha256:5f9c0a719ca2ce14c5de2fd350a64fd2d13e8539db29836a86adc990bb1a068f",
+                "sha256:8d4a2b7b6c2237e0199c8ea1a6d3e05bf118e289ae2b9d7ba444182a2959560d"
+            ],
+            "index": "pypi",
+            "version": "==3.0.2"
+        },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:28669905fe725965daa16184933676547c5bb40a5153055a8dee2a4bd7933ad3"
+            ],
+            "version": "==0.16.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+            ],
+            "version": "==1.15.0"
+        }
+    },
+    "develop": {
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "version": "==19.3.0"
+        },
+        "bleach": {
+            "hashes": [
+                "sha256:2bce3d8fab545a6528c8fa5d9f9ae8ebc85a56da365c7f85180bfe96a35ef22f",
+                "sha256:3c4c520fdb9db59ef139915a5db79f8b51bc2a7257ea0389f30c846883430a4b"
+            ],
+            "version": "==3.1.5"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
+                "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
+            ],
+            "version": "==2020.4.5.1"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "docutils": {
+            "hashes": [
+                "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af",
+                "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"
+            ],
+            "version": "==0.16"
+        },
+        "e1839a8": {
+            "editable": true,
+            "path": "."
+        },
+        "idna": {
+            "hashes": [
+                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
+                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
+            ],
+            "version": "==2.9"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
+                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==1.6.0"
+        },
+        "jsonschema": {
+            "hashes": [
+                "sha256:5f9c0a719ca2ce14c5de2fd350a64fd2d13e8539db29836a86adc990bb1a068f",
+                "sha256:8d4a2b7b6c2237e0199c8ea1a6d3e05bf118e289ae2b9d7ba444182a2959560d"
+            ],
+            "index": "pypi",
+            "version": "==3.0.2"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "mypy": {
+            "hashes": [
+                "sha256:15b948e1302682e3682f11f50208b726a246ab4e6c1b39f9264a8796bb416aa2",
+                "sha256:219a3116ecd015f8dca7b5d2c366c973509dfb9a8fc97ef044a36e3da66144a1",
+                "sha256:3b1fc683fb204c6b4403a1ef23f0b1fac8e4477091585e0c8c54cbdf7d7bb164",
+                "sha256:3beff56b453b6ef94ecb2996bea101a08f1f8a9771d3cbf4988a61e4d9973761",
+                "sha256:7687f6455ec3ed7649d1ae574136835a4272b65b3ddcf01ab8704ac65616c5ce",
+                "sha256:7ec45a70d40ede1ec7ad7f95b3c94c9cf4c186a32f6bacb1795b60abd2f9ef27",
+                "sha256:86c857510a9b7c3104cf4cde1568f4921762c8f9842e987bc03ed4f160925754",
+                "sha256:8a627507ef9b307b46a1fea9513d5c98680ba09591253082b4c48697ba05a4ae",
+                "sha256:8dfb69fbf9f3aeed18afffb15e319ca7f8da9642336348ddd6cab2713ddcf8f9",
+                "sha256:a34b577cdf6313bf24755f7a0e3f3c326d5c1f4fe7422d1d06498eb25ad0c600",
+                "sha256:a8ffcd53cb5dfc131850851cc09f1c44689c2812d0beb954d8138d4f5fc17f65",
+                "sha256:b90928f2d9eb2f33162405f32dde9f6dcead63a0971ca8a1b50eb4ca3e35ceb8",
+                "sha256:c56ffe22faa2e51054c5f7a3bc70a370939c2ed4de308c690e7949230c995913",
+                "sha256:f91c7ae919bbc3f96cd5e5b2e786b2b108343d1d7972ea130f7de27fdd547cf3"
+            ],
+            "index": "pypi",
+            "version": "==0.770"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
+            ],
+            "version": "==0.4.3"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
+                "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
+            ],
+            "version": "==20.4"
+        },
+        "pkginfo": {
+            "hashes": [
+                "sha256:7424f2c8511c186cd5424bbf31045b77435b37a8d604990b79d4e70d741148bb",
+                "sha256:a6d9e40ca61ad3ebd0b72fbadd4fba16e4c0e4df0428c041e01e06eb6ee71f32"
+            ],
+            "version": "==1.5.0.1"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
+                "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
+            ],
+            "version": "==2.6.0"
+        },
+        "pydocstyle": {
+            "hashes": [
+                "sha256:da7831660b7355307b32778c4a0dbfb137d89254ef31a2b2978f50fc0b4d7586",
+                "sha256:f4f5d210610c2d153fae39093d44224c17429e2ad7da12a8b419aba5c2f614b5"
+            ],
+            "version": "==5.0.2"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
+                "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
+            ],
+            "version": "==2.2.0"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44",
+                "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"
+            ],
+            "version": "==2.6.1"
+        },
+        "pylama": {
+            "hashes": [
+                "sha256:9bae53ef9c1a431371d6a8dca406816a60d547147b60a4934721898f553b7d8f",
+                "sha256:fd61c11872d6256b019ef1235be37b77c922ef37ac9797df6bd489996dddeb15"
+            ],
+            "index": "pypi",
+            "version": "==7.7.1"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "version": "==2.4.7"
+        },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:28669905fe725965daa16184933676547c5bb40a5153055a8dee2a4bd7933ad3"
+            ],
+            "version": "==0.16.0"
+        },
+        "readme-renderer": {
+            "hashes": [
+                "sha256:cbe9db71defedd2428a1589cdc545f9bd98e59297449f69d721ef8f1cfced68d",
+                "sha256:cc4957a803106e820d05d14f71033092537a22daa4f406dfbdd61177e0936376"
+            ],
+            "version": "==26.0"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
+                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
+            ],
+            "version": "==2.23.0"
+        },
+        "requests-toolbelt": {
+            "hashes": [
+                "sha256:380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f",
+                "sha256:968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0"
+            ],
+            "version": "==0.9.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+            ],
+            "version": "==1.15.0"
+        },
+        "snowballstemmer": {
+            "hashes": [
+                "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0",
+                "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"
+            ],
+            "version": "==2.0.0"
+        },
+        "tqdm": {
+            "hashes": [
+                "sha256:4733c4a10d0f2a4d098d801464bdaf5240c7dadd2a7fde4ee93b0a0efd9fb25e",
+                "sha256:acdafb20f51637ca3954150d0405ff1a7edde0ff19e38fb99a80a66210d2a28f"
+            ],
+            "version": "==4.46.0"
+        },
+        "twine": {
+            "hashes": [
+                "sha256:5319dd3e02ac73fcddcd94f035b9631589ab5d23e1f4699d57365199d85261e1",
+                "sha256:9fe7091715c7576df166df8ef6654e61bada39571783f2fd415bdcba867c6993"
+            ],
+            "index": "pypi",
+            "version": "==2.0.0"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
+                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
+                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
+                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652",
+                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
+                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
+                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
+                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
+                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
+                "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c",
+                "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3",
+                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
+                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
+                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
+                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
+                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
+                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
+                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
+                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
+                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
+                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
+            ],
+            "version": "==1.4.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5",
+                "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae",
+                "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"
+            ],
+            "index": "pypi",
+            "version": "==3.7.4.2"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
+                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
+            ],
+            "version": "==1.25.9"
+        },
+        "webencodings": {
+            "hashes": [
+                "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
+                "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
+            ],
+            "version": "==0.5.1"
+        },
+        "wheel": {
+            "hashes": [
+                "sha256:9515fe0a94e823fd90b08d22de45d7bde57c90edce705b22f5e1ecf7e1b653c8",
+                "sha256:e721e53864f084f956f40f96124a74da0631ac13fbbd1ba99e8e2b5e9cafdf64"
+            ],
+            "index": "pypi",
+            "version": "==0.30.0"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
+                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
+            ],
+            "version": "==3.1.0"
+        }
+    }
+}

--- a/shared-data/python/buildroot.mk
+++ b/shared-data/python/buildroot.mk
@@ -1,0 +1,33 @@
+################################################################################
+#
+# python-opentrons-shared-data
+#
+################################################################################
+
+# Get a key from package.json (like version)
+define get_pkg_json_key
+	$(shell python -c "import json; print(json.load(open('$(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/shared-data/package.json'))[\"$(1)\"])")
+endef
+
+PYTHON_OPENTRONS_SHARED_DATA_VERSION = $(call get_pkg_json_key,version)
+PYTHON_OPENTRONS_SHARED_DATA_LICENSE = $(call get_pkg_json_key,license)
+PYTHON_OPENTRONS_SHARED_DATA_LICENSE_FILES = $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/LICENSE
+PYTHON_OPENTRONS_SHARED_DATA_SETUP_TYPE = setuptools
+PYTHON_OPENTRONS_SHARED_DATA_SITE_METHOD = local
+PYTHON_OPENTRONS_SHARED_DATA_SITE = $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)
+PYTHON_OPENTRONS_SHARED_DATA_SUBDIR = shared-data/python
+
+define OTSD_DUMP_BR_VERSION
+	$(shell python $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py shared-data dump_br_version)
+endef
+
+define PYTHON_OPENTRONS_SHARED_DATA_INSTALL_VERSION
+	echo '$(call OTSD_DUMP_BR_VERSION)' > $(BINARIES_DIR)/opentrons-shared-data-version.json
+endef
+
+ot_sd_name := python-opentrons-shared-data
+
+# Calling inner-python-package directly instead of using python-package macro
+# because our directory layout doesn’t conform to buildroot’s expectation of
+# having the directory name be the package name
+$(eval $(call inner-python-package,$(ot_sd_name),$(call UPPERCASE,$(ot_sd_name)),$(call UPPERCASE,$(ot_sd_name)),target))

--- a/shared-data/python/opentrons_shared_data/__init__.py
+++ b/shared-data/python/opentrons_shared_data/__init__.py
@@ -1,0 +1,22 @@
+"""
+opentrons_shared_data: a python package wrapping json config definitions
+for the opentrons stack
+
+This package should never be installed on its own, only as a dependency of
+the main opentrons package
+"""
+
+import os
+import json
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+try:
+    with open(os.path.join(HERE, 'package.json')) as pkg:
+        package_json = json.load(pkg)
+        __version__ = package_json.get('version')
+except (FileNotFoundError, OSError):
+    __version__ = 'unknown'
+
+
+__all__ = ['__version__']

--- a/shared-data/python/setup.cfg
+++ b/shared-data/python/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = ../../LICENSE

--- a/shared-data/python/setup.py
+++ b/shared-data/python/setup.py
@@ -1,0 +1,134 @@
+import os
+import json
+
+from setuptools.command import build_py, sdist
+from setuptools import setup
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+DATA_ROOT = '..'
+DATA_SUBDIRS = ['deck',
+                'labware',
+                'module',
+                'pipette',
+                'protocol']
+DEST_BASE_PATH = 'data'
+
+def get_shared_data_files():
+    to_include = []
+    for subdir in DATA_SUBDIRS:
+        top = os.path.join(DATA_ROOT, subdir)
+        for dirpath, dirnames, filenames in os.walk(top):
+            from_source = os.path.relpath(dirpath, DATA_ROOT)
+            to_include.extend([os.path.join(from_source, fname)
+                               for fname in filenames])
+    return to_include
+
+
+class SDistWithData(sdist.sdist):
+    description = sdist.sdist.description\
+        + " Also, include data files."
+
+    def make_release_tree(self, base_dir, files):
+        self.announce("adding data files to base dir {}"
+                      .format(base_dir))
+        for data_file in get_shared_data_files():
+            sdist_dest = os.path.join(base_dir, DEST_BASE_PATH)
+            self.mkpath(os.path.join(sdist_dest, 'opentrons_shared_data',
+                                     os.path.dirname(data_file)))
+            self.copy_file(os.path.join(DATA_ROOT, data_file),
+                           os.path.join(sdist_dest, data_file))
+        # also grab our package.json
+        self.copy_file(os.path.join(HERE, '..', 'package.json'),
+                       os.path.join(base_dir, 'package.json'))
+        super().make_release_tree(base_dir, files)
+
+
+class BuildWithData(build_py.build_py):
+    description = build_py.build_py.description\
+        + " Also, include opentrons data files"
+
+    def _get_data_files(self):
+        """
+        Override of build_py.get_data_files that includes out of tree configs.
+        These are currently hardcoded to include selected folders in
+         ../shared-data/, which will move to opentrons/config/shared-data
+        """
+        files = super()._get_data_files()
+        # We don’t really want to duplicate logic used in the original
+        # implementation, but we can back out what it did with commonpath -
+        # should be something ending in opentrons_shared_data
+        build_base = os.path.commonpath([f[2] for f in files])
+        # We want a list of paths to only files relative to ../shared-data
+        to_include = get_shared_data_files()
+        destination = os.path.join(build_base, DEST_BASE_PATH)
+        # And finally, tell the system about our files, including package.json
+        files.extend([('opentrons_shared_data', DATA_ROOT,
+                       destination, to_include),
+                      ('opentrons_shared_data', '..',
+                       build_base, ['package.json'])])
+        return files
+
+
+def get_version():
+    with open(os.path.join(HERE, '..', 'package.json')) as pkg:
+        package_json = json.load(pkg)
+        return package_json['version']
+
+VERSION = get_version()
+
+DISTNAME = 'opentrons_shared_data'
+LICENSE = 'Apache 2.0'
+AUTHOR = "Opentrons"
+EMAIL = "engineering@opentrons.com"
+URL = "https://github.com/Opentrons/opentrons"
+DOWNLOAD_URL = ''
+CLASSIFIERS = [
+    'Development Status :: 5 - Production/Stable',
+    'Environment :: Console',
+    'Operating System :: OS Independent',
+    'Intended Audience :: Science/Research',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.7',
+    'Topic :: Scientific/Engineering',
+]
+KEYWORDS = ["robots", "protocols", "synbio", "pcr", "automation", "lab"]
+DESCRIPTION = (
+    "A bundle of data and python binding that supports the Opentrons API. "
+    "Does not need to be installed manually; only a dependency of the "
+    "opentrons package")
+PACKAGES = ['opentrons_shared_data']
+INSTALL_REQUIRES = [
+    'jsonschema>=3.0.2,<4',
+]
+
+
+if __name__ == "__main__":
+    setup(
+        python_requires='>=3.7',
+        name=DISTNAME,
+        description=DESCRIPTION,
+        license=LICENSE,
+        version=VERSION,
+        author=AUTHOR,
+        author_email=EMAIL,
+        maintainer=AUTHOR,
+        maintainer_email=EMAIL,
+        keywords=KEYWORDS,
+        packages=PACKAGES,
+        zip_safe=False,
+        classifiers=CLASSIFIERS,
+        install_requires=INSTALL_REQUIRES,
+        include_package_data=True,
+        cmdclass={
+            'build_py': BuildWithData,
+            'sdist': SDistWithData
+        },
+        project_urls={
+            'opentrons.com': "https://www.opentrons.com",
+            'Source Code On Github':
+            "https://github.com/Opentrons/opentrons/tree/edge/shared-data",
+            'Documentation': "https://docs.opentrons.com"
+        }
+    )


### PR DESCRIPTION
This adds the skeleton of python bindings for shared-data actually
resident in shared-data, like the js bindings. This is the prequel to
moving direct shared data handling to these bindings and adding a lot of
type definitions.

This package will be eventually published to pypi and installed as a dependency when users install the wheel.

You'll have to re-run make install-py.

https://github.com/Opentrons/buildroot/pull/88 will put this in buildroot builds

## Review requests
Does this uh seem like a good idea? Does it seem like the right structure? Does the dev workflow work?

## Risk assessment

None, no changes to actual code