### PR TITLE
fix: fix makefile refactor for push tasks

### DIFF
--- a/scripts/push.mk
+++ b/scripts/push.mk
@@ -41,5 +41,5 @@ endef
 # argument 4 is the unit file path
 define push-systemd-unit
 	scp -i $(2) $(3) "$(4)" root@$(1):/data/
-	ssh -i $(2) $(3) root@$(1) "mv /data/$(notdir $(4)) /etc/systemd/system/ && systemctl daemon-reload"
+	ssh -i $(2) $(3) root@$(1) "mount -o remount,rw / && mv /data/$(notdir $(4)) /etc/systemd/system/ && systemctl daemon-reload && mount -o remount,ro / || mount -o remount,ro /"
 endef

--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -14,7 +14,7 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 port ?= 34000
 tests ?= tests
 test_opts ?=
-wheel_file = $(python_get_wheelname,update-server,otupdate)
+wheel_file = $(call python_get_wheelname,update-server,otupdate)
 # Host key location for buildroot robot
 br_ssh_key ?= $(default_ssh_key)
 # Other SSH args for buildroot robots
@@ -69,6 +69,6 @@ restart:
 
 .PHONY: push
 push: wheel
-	$(call push-python-package,$(host),$(br_ssh_key),$(br_ssh_opts),$(wheel_file))
-	$(call push-systemd-unit,$(host),$(br_ssh_key),$(br_ssh_opts),$(./opentrons-update-server.service))
+	$(call push-python-package,$(host),$(br_ssh_key),$(br_ssh_opts),dist/$(wheel_file))
+	$(call push-systemd-unit,$(host),$(br_ssh_key),$(br_ssh_opts),./opentrons-update-server.service)
 	$(call restart-service,$(host),$(br_ssh_key),$(br_ssh_opts),opentrons-update-server)


### PR DESCRIPTION
This didn't quite work for a couple reasons:
- needed to fix some things specifically in the update-server package
- push-systemd-unit needs to remount the filesystem

Testing:
- `make push` from top level
- `make push` in each of `api`, `robot-server`, `update-server`

All should complete with no failures
