### PR TITLE
refactor(api): raise GPIO warning, and add detail

### DIFF
--- a/api/src/opentrons/drivers/rpi_drivers/__init__.py
+++ b/api/src/opentrons/drivers/rpi_drivers/__init__.py
@@ -16,7 +16,10 @@ def build_gpio_chardev(chip_name: str) -> 'GPIODriverLike':
         from .gpio import GPIOCharDev
         return GPIOCharDev(chip_name)
     except (ImportError, OSError):
-        MODULE_LOG.info(
-            'Failed to initialize character device, cannot control gpios')
+        MODULE_LOG.warning(
+            'Failed to initialize character device, will not '
+            'be able to control gpios (lights, button, smoothie kill'
+            ', smoothie reset')
         from .gpio_simulator import SimulatingGPIOCharDev
         return SimulatingGPIOCharDev(chip_name)
+    

--- a/api/src/opentrons/drivers/rpi_drivers/__init__.py
+++ b/api/src/opentrons/drivers/rpi_drivers/__init__.py
@@ -23,6 +23,6 @@ def build_gpio_chardev(chip_name: str) -> 'GPIODriverLike':
             'stop the robot server with systemctl stop '
             'opentrons-robot-server. Until you restart the server '
             'with systemctl start opentrons-robot-server, you will '
-            'be unable to control the robot using the Opentrons app')
+            'be unable to control the robot using the Opentrons app.')
         from .gpio_simulator import SimulatingGPIOCharDev
         return SimulatingGPIOCharDev(chip_name)

--- a/api/src/opentrons/drivers/rpi_drivers/__init__.py
+++ b/api/src/opentrons/drivers/rpi_drivers/__init__.py
@@ -20,7 +20,7 @@ def build_gpio_chardev(chip_name: str) -> 'GPIODriverLike':
             'Failed to initialize character device, will not '
             'be able to control gpios (lights, button, smoothie'
             'kill, smoothie reset). If you need to control gpios, '
-            'stop the robot server with systemctl stop '
+            'first stop the robot server with systemctl stop '
             'opentrons-robot-server. Until you restart the server '
             'with systemctl start opentrons-robot-server, you will '
             'be unable to control the robot using the Opentrons app.')

--- a/api/src/opentrons/drivers/rpi_drivers/__init__.py
+++ b/api/src/opentrons/drivers/rpi_drivers/__init__.py
@@ -22,4 +22,3 @@ def build_gpio_chardev(chip_name: str) -> 'GPIODriverLike':
             ', smoothie reset')
         from .gpio_simulator import SimulatingGPIOCharDev
         return SimulatingGPIOCharDev(chip_name)
-    

--- a/api/src/opentrons/drivers/rpi_drivers/__init__.py
+++ b/api/src/opentrons/drivers/rpi_drivers/__init__.py
@@ -18,7 +18,11 @@ def build_gpio_chardev(chip_name: str) -> 'GPIODriverLike':
     except (ImportError, OSError):
         MODULE_LOG.warning(
             'Failed to initialize character device, will not '
-            'be able to control gpios (lights, button, smoothie kill'
-            ', smoothie reset')
+            'be able to control gpios (lights, button, smoothie'
+            'kill, smoothie reset). If you need to control gpios, '
+            'stop the robot server with systemctl stop '
+            'opentrons-robot-server. Until you restart the server '
+            'with systemctl start opentrons-robot-server, you will '
+            'be unable to control the robot using the Opentrons app')
         from .gpio_simulator import SimulatingGPIOCharDev
         return SimulatingGPIOCharDev(chip_name)


### PR DESCRIPTION
This raises the level of the warning about the failure to initialise a GPIO device from `info` to `warning`, making it more likely that it will be displayed (e.g. in Jupyter). Without this change, there is no indication given to the user of e.g. a Jupyter notebook of why their commands to control lights are doing nothing. It also adds some detail about what functionality is likely to be affected.

Ideally each function that requires GPIO would raise a warning (or even exception?) if the GPIO device is not available and this is not a simulation.