### PR TITLE
refactor(api): add info to debug warning on how IS_ROBOT is determined

### DIFF
--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -41,7 +41,9 @@ class Controller:
                 'This is intended to run on a robot, and while it can connect '
                 'to a smoothie via a usb/serial adapter unexpected things '
                 'using gpios (such as smoothie reset or light management) '
-                'will fail')
+                'will fail. If you are seeing this message and you are '
+                'running on a robot, you need to set the RUNNING_ON_PI '
+                'environmental variable to 1.')
 
         self.config = config or opentrons.config.robot_configs.load()
 


### PR DESCRIPTION
If you run a robot without RUNNING_ON_PI in the environment you get this warning message (and substantially reduced functionality), but it is not clear how to resolve it. This provides that information. In my case it was because I was invoking one Python script from another with subprocess.

<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->

## risk assessment

<!--
  Carefully go over your pull request and look at the other parts of the
  codebase it may affect. Look for the possibility, even if you think it's
  small, that your change may affect some other part of the system - for
  instance, changing return tip behavior in protocol may also change the
  behavior of labware calibration.

  Identify the other parts of the system your codebase may affect, so that in
  addition to your own review and testing, other people who may not have
  the system internalized as much as you can focus their attention and testing
  there.
-->
