### PR TITLE
fix(api): Enable audio on GPIO startup

### DIFF
--- a/api/src/opentrons/drivers/rpi_drivers/gpio.py
+++ b/api/src/opentrons/drivers/rpi_drivers/gpio.py
@@ -123,6 +123,7 @@ class GPIOCharDev:
 
     async def setup(self):
         MODULE_LOG.info("Setting up GPIOs")
+        self.set_audio_enable(True)
         # smoothieware programming pins, must be in a known state (HIGH)
         self.set_halt_pin(True)
         self.set_isp_pin(True)
@@ -174,6 +175,12 @@ class GPIOCharDev:
             self.set_high(gpio_group.halt)
         else:
             self.set_low(gpio_group.halt)
+
+    def set_audio_enable(self, on: bool = True):
+        if on:
+            self.set_high(gpio_group.audio_enable)
+        else:
+            self.set_low(gpio_group.audio_enable)
 
     def _read(self, input_pin: GPIOPin):
         try:


### PR DESCRIPTION
## overview
The GPIO pin that allows the Pi to output audio was automatically enabled prior to the upgrade to libgpiod https://github.com/Opentrons/opentrons/pull/5381 . This is relied upon by e.g. this test https://github.com/Opentrons/opentrons/blob/751d9a402fa5d1f936df43ed12fd7387be23237f/api/src/opentrons/tools/factory_test.py#L217, and allows users to make their robots make sounds.

This should restore that functionality by enabling this pin during GPIO setup.

Do close this if it was an active decision to deprecate audio (but that seems a shame given it is the only way the OT2 has to communicate autonomously)

## changelog
- adds function to control audio_enable_pin and calls out to it during setup

## review requests

@ahiuchingau seems to be the expert on this

## risk assessment

- setup function should already be covered by tests?
- this will restore speaker functionality so might cause a robot's speaker to emit noise if it has a hardware fault and has only been used/tested since the libgpiod update, but this is quite recent!
