### PR TITLE
fix(app): clear <input> value after robot update file select

### DIFF
--- a/app/src/components/RobotSettings/UploadRobotUpdate.js
+++ b/app/src/components/RobotSettings/UploadRobotUpdate.js
@@ -22,6 +22,8 @@ export function UploadRobotUpdate(props: UploadRobotUpdateProps) {
       // https://electronjs.org/docs/api/file-object
       dispatch(startBuildrootUpdate(robotName, (files[0]: any).path))
     }
+    // clear input value to allow same file to be selected again if necessary
+    event.target.value = ''
   }
 
   return (


### PR DESCRIPTION
## overview

In a small (code-wise) oversight, we forgot to clear the value of the `<input type="file">` that drives the "robot update from file" flow. Without that value reset (as is present on the protocol upload input), the upload button can become "stuck" if you attempt to select the same file

Fixes #5781 

## changelog

- fix(app): clear <input> value after robot update file select

## review requests

1. Try to upload an "update" file that you know will cause an error (e.g. a random, non-update zip file)
2. After the update fails, try to upload a new, working file
    - Bonus points: have the second file have the exact same absolute path as the first file

- [ ] Second file triggers the update flow

## risk assessment

Low; fixing a bug by mirroring implementation of the protocol file upload button which, once upon a time, had this exact same problem.

The component isn't covered by unit tests, which is a problem, though. See #5174 for tracking that lack of testing