### PR TITLE
chore(api): fix lots of Sphinx warnings

### DIFF
--- a/api/docs/v1/complex_commands.rst
+++ b/api/docs/v1/complex_commands.rst
@@ -736,20 +736,20 @@ will have the steps
 
 .. note::
 
-The following scenarios may _not_ work as you expect them to.
+    The following scenarios may _not_ work as you expect them to.
 
-.. code-block:: python
+    .. code-block:: python
 
-    multi_pipette.transfer(50, plate_96.wells('A1'), plate_96.wells())
+        multi_pipette.transfer(50, plate_96.wells('A1'), plate_96.wells())
 
-The multi-channel would visit **every** well in the plate and dispense liquid
-outside of the plate boundaries so be careful!
+    The multi-channel would visit **every** well in the plate and dispense liquid
+    outside of the plate boundaries so be careful!
 
-.. code-block:: python
+    .. code-block:: python
 
-    multi_pipette.transfer(50, plate_96.wells('A1'), plate_96.rows('A'))
+        multi_pipette.transfer(50, plate_96.wells('A1'), plate_96.rows('A'))
 
-In this scenario, the multi-channel would only visit the first column of the plate.
+    In this scenario, the multi-channel would only visit the first column of the plate.
 
 
 Transfer in a 384 Well Plate

--- a/api/docs/v1/complex_commands.rst
+++ b/api/docs/v1/complex_commands.rst
@@ -736,7 +736,7 @@ will have the steps
 
 .. note::
 
-    The following scenarios may _not_ work as you expect them to.
+    The following scenarios may **not** work as you expect them to.
 
     .. code-block:: python
 

--- a/api/docs/v1/hardware_control.rst
+++ b/api/docs/v1/hardware_control.rst
@@ -29,7 +29,7 @@ The robot module can be thought of as the parent for all aspects of the Opentron
 
 
 User-Specified Pause
-==========
+====================
 
 This will pause your protocol at a specific step. You can resume by pressing 'resume' in your OT App.
 

--- a/api/docs/v1/modules.rst
+++ b/api/docs/v1/modules.rst
@@ -66,9 +66,9 @@ Both modules have the ability to check what state they are currently in. To do t
 For the temperature module this will return a string stating whether it's `heating`, `cooling`, `holding at target` or `idle`.
 For the magnetic module this will return a string stating whether it's `engaged` or `disengaged`.
 
-**********
+******************
 Temperature Module
-**********
+******************
 
 Our temperature module acts as both a cooling and heating device. The range
 of temperatures this module can reach goes from 4 to 95 degrees celsius with a resolution of 1 degree celcius.
@@ -92,7 +92,7 @@ To set the temperature module to a given temperature in degrees celsius do the f
 This will set your Temperature module to 4 degrees celsius.
 
 Wait Until Setpoint Reached
-==========================
+===========================
 This function will pause your protocol until your target temperature is reached.
 
 .. code-block:: python
@@ -169,9 +169,9 @@ clicking on the `Pipettes & Modules` tab. Your temperature module will automatic
 deactivate if another protocol is uploaded to the app. Your temperature module will
 not deactivate automatically upon protocol end, cancel or re-setting a protocol.
 
-**********
+***************
 Magnetic Module
-**********
+***************
 
 The magnetic module has two actions:
 

--- a/api/docs/v1/modules.rst
+++ b/api/docs/v1/modules.rst
@@ -139,6 +139,7 @@ We can read the target temperature of the module by the following:
     plate = labware.load('96-flat', slot, share=True)
 
     temperature = module.target
+
 This will return a float of the temperature that the module is trying to reach.
 
 Deactivate

--- a/api/docs/v1/pipettes.rst
+++ b/api/docs/v1/pipettes.rst
@@ -20,8 +20,6 @@ Pipette Model(s)
 ===================
 Currently in our API there are 10 pipette models to correspond with the offered pipette models on our website.
 
-.. note::
-
 They are as follows:
 
 - ``P10_Single`` (1 - 10 ul)

--- a/api/docs/v1/pipettes.rst
+++ b/api/docs/v1/pipettes.rst
@@ -81,7 +81,7 @@ The speeds at which the pipette will aspirate and dispense can be set through ``
 
 
 Minimum and Maximum Volume
-==================
+==========================
 
 The minimum and maximum volume of the pipette may be set using
 ``min_volume`` and ``max_volume``. The values are in microliters and have

--- a/api/docs/v1/writing.rst
+++ b/api/docs/v1/writing.rst
@@ -83,7 +83,7 @@ Jupyter Installation
 
 You must make sure that you install the `opentrons` package for whichever kernel and virtual environment the notebook is using. A generally good way to do this is
 
-.. code-block:: python
+.. code-block::
 
    import sys
    !{sys.executable} -m pip install opentrons

--- a/api/docs/v2/new_complex_commands.rst
+++ b/api/docs/v2/new_complex_commands.rst
@@ -144,7 +144,7 @@ When you are using a multi-channel pipette, you can transfer the entire column (
 
         Multichannel pipettes can only access a limited number of rows in a plate during `transfer`, `distribute` and `consolidate`: the first row (wells A1 - A12) of a 96-well plate, and (since API Version 2.2) the first two rows (wells A1 - B24) for a 384-well plate. Wells specified outside of the limit will be ignored. 
 
-Transfer commands will automatically create entire series of :py:meth:`.InstrumentContext.aspirate`, :py:meth:`.InstrumentContext.dispense`, and other :py:meth:`.InstrumentContext` commands.
+Transfer commands will automatically create entire series of :py:meth:`.InstrumentContext.aspirate`, :py:meth:`.InstrumentContext.dispense`, and other :py:obj:`.InstrumentContext` commands.
 
 
 Large Volumes

--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -45,9 +45,9 @@ The OT-2 has a set of labware well-supported by Opentrons defined internally. Th
 Custom Labware
 ^^^^^^^^^^^^^^
 
-If you have a piece of labware that is not in the Labware Library, you can create your own definition using the `Opentrons Labware Creator <https://labware.opentrons.com/create/>`_. Before using the Labware Creator, you should read the introduction article `here <https://support.opentrons.com/en/articles/3136504-creating-custom-labware-definitions>`_.
+If you have a piece of labware that is not in the Labware Library, you can create your own definition using the `Opentrons Labware Creator <https://labware.opentrons.com/create/>`_. Before using the Labware Creator, you should read the introduction article `here <https://support.opentrons.com/en/articles/3136504-creating-custom-labware-definitions>`__.
 
-Once you have created your labware and saved it as a ``.json`` file, you can add it to the Opentrons App by clicking "More" and then "Labware". Once you have added your labware to the Opentrons App, it will be available to all Python Protocol API version 2 protocols uploaded to your robot through that Opentrons App. If other people will be using this custom labware definition, they must also add it to their Opentrons App. You can find a support article about this custom labware process `here <https://support.opentrons.com/en/articles/3136506-using-labware-in-your-protocols>`_.
+Once you have created your labware and saved it as a ``.json`` file, you can add it to the Opentrons App by clicking "More" and then "Labware". Once you have added your labware to the Opentrons App, it will be available to all Python Protocol API version 2 protocols uploaded to your robot through that Opentrons App. If other people will be using this custom labware definition, they must also add it to their Opentrons App. You can find a support article about this custom labware process `here <https://support.opentrons.com/en/articles/3136506-using-labware-in-your-protocols>`__.
 
 
 .. _new-well-access:

--- a/api/docs/v2/new_pipette.rst
+++ b/api/docs/v2/new_pipette.rst
@@ -39,6 +39,7 @@ Pipettes are specified in a protocol using the method :py:meth:`.ProtocolContext
 
 
 .. _new-pipette-models:
+
 Pipette Models
 ==============
 

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -233,6 +233,7 @@ def execute(protocol_file: TextIO,
                               non-recursive contents of specified directories
                               are presented by the protocol context in
                               :py:attr:`.ProtocolContext.bundled_data`.
+
     The format of the runlog entries is as follows:
 
     .. code-block:: python

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -66,17 +66,19 @@ class Pipette(CommandPublisher):
 
     All model-specific instrument constructors are inheritors of this class.
     With any of those instances you can can:
-        * Handle liquids with :meth:`aspirate`, :meth:`dispense`,
-          :meth:`mix`, and :meth:`blow_out`
-        * Handle tips with :meth:`pick_up_tip`, :meth:`drop_tip`,
-          and :meth:`return_tip`
-        * Calibrate this pipette's plunger positions
-        * Calibrate the position of each :any:`Container` on deck
+    
+    * Handle liquids with :meth:`aspirate`, :meth:`dispense`,
+      :meth:`mix`, and :meth:`blow_out`
+    * Handle tips with :meth:`pick_up_tip`, :meth:`drop_tip`,
+      and :meth:`return_tip`
+    * Calibrate this pipette's plunger positions
+    * Calibrate the position of each :any:`Container` on deck
 
     Here are the typical steps of using the Pipette:
-        * Instantiate a pipette with a maximum volume (uL)
-        and a mount (`left` or `right`)
-        * Design your protocol through the pipette's liquid-handling commands
+    
+    * Instantiate a pipette with a maximum volume (uL)
+      and a mount (`left` or `right`)
+    * Design your protocol through the pipette's liquid-handling commands
 
     Methods in this class include assertions where needed to ensure that any
     action that requires a tip must be preceeded by `pick_up_tip`. For example:
@@ -1838,6 +1840,7 @@ class Pipette(CommandPublisher):
         Set the speed (uL/second) the :any:`Pipette` plunger will move
         during :meth:`aspirate` and :meth:`dispense`. The speed is set using
         nominal max volumes for any given pipette model.
+        
         Parameters
         ----------
         aspirate: int

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -1377,12 +1377,12 @@ class Pipette(CommandPublisher):
             a linear gradient between the two volumes in the tuple.
 
         source : Placeable or list
-            Single :any:`Placeable` or list of :any:`Placeable`s, from where
-            liquid will be :any:`aspirate`ed from.
+            Single :any:`Placeable` or list of :any:`Placeable`\\ s, from where
+            liquid will be :any:`aspirate`\\ d from.
 
         dest : Placeable or list
-            Single :any:`Placeable` or list of :any:`Placeable`s, where
-            liquid will be :any:`dispense`ed to.
+            Single :any:`Placeable` or list of :any:`Placeable`\\ s, where
+            liquid will be :any:`dispense`\\ ed to.
 
         new_tip : str
             The number of clean tips this transfer command will use. If

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -424,7 +424,7 @@ class Pipette(CommandPublisher):
 
         Examples
         --------
-        ..
+
         >>> from opentrons import instruments, labware, robot # doctest: +SKIP
         >>> robot.reset() # doctest: +SKIP
         >>> plate = labware.load('96-flat', '2') # doctest: +SKIP
@@ -526,7 +526,7 @@ class Pipette(CommandPublisher):
 
         Examples
         --------
-        ..
+
         >>> from opentrons import instruments, labware, robot # doctest: +SKIP
         >>> robot.reset() # doctest: +SKIP
         >>> plate = labware.load('96-flat', '3') # doctest: +SKIP
@@ -688,7 +688,7 @@ class Pipette(CommandPublisher):
 
         Examples
         --------
-        ..
+
         >>> from opentrons import instruments, labware, robot # doctest: +SKIP
         >>> robot.reset() # doctest: +SKIP
         >>> plate = labware.load('96-flat', '4') # doctest: +SKIP
@@ -748,7 +748,7 @@ class Pipette(CommandPublisher):
 
         Examples
         --------
-        ..
+
         >>> from opentrons import instruments, robot # doctest: +SKIP
         >>> robot.reset() # doctest: +SKIP
         >>> p300 = instruments.P300_Single(mount='left') # doctest: +SKIP
@@ -812,7 +812,7 @@ class Pipette(CommandPublisher):
 
         Examples
         --------
-        ..
+
         >>> from opentrons import instruments, labware, robot # doctest: +SKIP
         >>> robot.reset() # doctest: +SKIP
         >>> plate = labware.load('96-flat', '8') # doctest: +SKIP
@@ -895,7 +895,7 @@ class Pipette(CommandPublisher):
 
         Examples
         --------
-        ..
+
         >>> from opentrons import instruments, robot # doctest: +SKIP
         >>> robot.reset() # doctest: +SKIP
         >>> p300 = instruments.P300_Single(mount='left') # doctest: +SKIP
@@ -941,7 +941,7 @@ class Pipette(CommandPublisher):
 
         Examples
         --------
-        ..
+
         >>> from opentrons import instruments, labware, robot # doctest: +SKIP
         >>> robot.reset() # doctest: +SKIP
         >>> tiprack = labware.load('GEB-tiprack-300', '2') # doctest: +SKIP
@@ -996,7 +996,7 @@ class Pipette(CommandPublisher):
 
         Examples
         --------
-        ..
+
         >>> from opentrons import instruments, labware, robot # doctest: +SKIP
         >>> robot.reset() # doctest: +SKIP
         >>> tiprack = labware.load('GEB-tiprack-300', '2') # doctest: +SKIP
@@ -1106,7 +1106,7 @@ class Pipette(CommandPublisher):
 
         Examples
         --------
-        ..
+
         >>> from opentrons import instruments, labware, robot # doctest: +SKIP
         >>> robot.reset() # doctest: +SKIP
         >>> tiprack = labware.load('opentrons_96_tiprack_300ul', 'C2') # doctest: +SKIP  # noqa E501
@@ -1282,7 +1282,7 @@ class Pipette(CommandPublisher):
 
         Examples
         --------
-        ..
+
         >>> from opentrons import instruments, robot # doctest: +SKIP
         >>> robot.reset() # doctest: +SKIP
         >>> p300 = instruments.P300_Single(mount='right') # doctest: +SKIP
@@ -1310,7 +1310,7 @@ class Pipette(CommandPublisher):
 
         Examples
         --------
-        ..
+
         >>> from opentrons import instruments, labware, robot # doctest: +SKIP
         >>> robot.reset() # doctest: +SKIP
         >>> plate = labware.load('96-flat', '3') # doctest: +SKIP
@@ -1342,7 +1342,7 @@ class Pipette(CommandPublisher):
 
         Examples
         --------
-        ..
+
         >>> from opentrons import instruments, labware, robot # doctest: +SKIP
         >>> robot.reset() # doctest: +SKIP
         >>> plate = labware.load('96-flat', 'A3') # doctest: +SKIP

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -66,7 +66,7 @@ class Pipette(CommandPublisher):
 
     All model-specific instrument constructors are inheritors of this class.
     With any of those instances you can can:
-    
+
     * Handle liquids with :meth:`aspirate`, :meth:`dispense`,
       :meth:`mix`, and :meth:`blow_out`
     * Handle tips with :meth:`pick_up_tip`, :meth:`drop_tip`,
@@ -75,7 +75,7 @@ class Pipette(CommandPublisher):
     * Calibrate the position of each :any:`Container` on deck
 
     Here are the typical steps of using the Pipette:
-    
+
     * Instantiate a pipette with a maximum volume (uL)
       and a mount (`left` or `right`)
     * Design your protocol through the pipette's liquid-handling commands
@@ -1840,7 +1840,7 @@ class Pipette(CommandPublisher):
         Set the speed (uL/second) the :any:`Pipette` plunger will move
         during :meth:`aspirate` and :meth:`dispense`. The speed is set using
         nominal max volumes for any given pipette model.
-        
+
         Parameters
         ----------
         aspirate: int

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -1442,7 +1442,7 @@ class Pipette(CommandPublisher):
 
         Examples
         --------
-        ...
+
         >>> from opentrons import instruments, labware, robot # doctest: +SKIP
         >>> robot.reset() # doctest: +SKIP
         >>> plate = labware.load('96-flat', '5') # doctest: +SKIP

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -165,7 +165,7 @@ class InstrumentContext(CommandPublisher):
         :type volume: int or float
         :param location: Where to aspirate from. If `location` is a
                          :py:class:`.Well`, the robot will aspirate from
-                         :py:attr:`well_bottom_clearance```.aspirate`` mm
+                         :py:obj:`well_bottom_clearance```.aspirate`` mm
                          above the bottom of the well. If `location` is a
                          :py:class:`.Location` (i.e. the result of
                          :py:meth:`.Well.top` or :py:meth:`.Well.bottom`), the
@@ -266,7 +266,7 @@ class InstrumentContext(CommandPublisher):
 
         :param location: Where to dispense into. If `location` is a
                          :py:class:`.Well`, the robot will dispense into
-                         :py:attr:`well_bottom_clearance```.dispense`` mm
+                         :py:obj:`well_bottom_clearance```.dispense`` mm
                          above the bottom of the well. If `location` is a
                          :py:class:`.Location` (i.e. the result of
                          :py:meth:`.Well.top` or :py:meth:`.Well.bottom`), the

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -84,17 +84,17 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):  # noqa(E302)
 
         :param name: The name of the labware object.
         :param str label: An optional special name to give the labware. If
-                          specified, this is the name the labware will appear
-                          as in the run log and the calibration view in the
-                          Opentrons app.
-        .. versionadded:: 2.1
+            specified, this is the name the labware will appear as in the run
+            log and the calibration view in the Opentrons app.
         :param str namespace: The namespace the labware definition belongs to.
             If unspecified, will search 'opentrons' then 'custom_beta'
-        .. versionadded:: 2.1
         :param int version: The version of the labware definition. If
             unspecified, will use version 1.
-        .. versionadded:: 2.1
+
         :returns: The initialized and loaded labware object.
+
+        .. versionadded:: 2.1
+            The *label,* *namespace,* and *version* parameters.
         """
         if self.api_version < APIVersion(2, 1) and\
                 (label or namespace or version):
@@ -333,10 +333,12 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
 
         :param height_from_base: The height to raise the magnets to, in mm from
                                  the base of the labware
-        .. versionadded:: 2.1
         :param height: The height to raise the magnets to, in mm from home.
         :param offset: An offset relative to the default height for the labware
                        in mm
+
+        .. versionadded:: 2.1
+            The *height_from_base* parameter.
         """
         if height is not None:
             dist = height

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -489,6 +489,7 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
         :param block_max_volume: The maximum volume of any individual well
                                  of the loaded labware. If not supplied,
                                  the thermocycler will default to 25µL/well.
+
         .. note:
 
             If ``hold_time_minutes`` and ``hold_time_seconds`` are not

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -123,7 +123,7 @@ def get_protocol_api(
         hardware_simulator: HardwareToManage = None)\
         -> protocol_api.ProtocolContext:
     """
-    Build and return a :py:class:`ProtocolContext`connected to
+    Build and return a :py:class:`ProtocolContext` connected to
     Virtual Smoothie.
 
     This can be used to run protocols from interactive Python sessions


### PR DESCRIPTION
# Overview
`make docs` barfs hundreds of Sphinx warnings to the console, making the API docs difficult to work on. They're mostly silly syntax problems. This PR fixes many of them.

# Changelog
Fixed lots of silly syntax problems. See the commit messages; edits are grouped into commits based on which warning they resolve. (GitHub unfortunately lists the commits [in the wrong order](https://docs.github.com/en/github/committing-changes-to-your-project/why-are-my-commits-in-the-wrong-order) on this page, but they're independent, so it shouldn't matter.)

[Here is a diff of the `make docs` stderr](https://gist.github.com/SyntaxColoring/7a0c8b338516b245647b0c45dfe0ad44). I think I accidentally introduced a few new warnings, which I'll address in a follow-up PR.

This does result in some changes to the generated HTML. Unfortunately, I couldn't find a readable way to diff that, but we can manually check the [generated web pages](http://sandbox.docs.opentrons.com/max-docs-fix-warnings). It should all be unobjectionable formatting changes, though.

# Review requests


* Is `chore(api)` the right prefix for this commit message?

# Risk assessment
Low.

It's possible that I accidentally messed up formatting somewhere. But, on balance, things should be better. And when this work is complete, it'll be easier to detect formatting problems in the future.

# Further steps


* [ ] PR to fix the rest of these warnings.
* [ ] PR to make Sphinx warnings CI errors.



┆Issue is synchronized with this [Wrike Task](https://www.wrike.com/open.htm?id=535451529) by [Unito](https://www.unito.io/learn-more)
