### PR TITLE
fix(app): interpolate session type into session exit event name

### DIFF
--- a/app/src/analytics/__tests__/sessions-events.test.js
+++ b/app/src/analytics/__tests__/sessions-events.test.js
@@ -33,7 +33,7 @@ describe('events with calibration check session data', () => {
     )
 
     return expect(makeEvent(deleteSession, MOCK_STATE)).resolves.toEqual({
-      name: 'sessionExit',
+      name: 'calibrationCheckSessionExit',
       properties: sessionsFixtures.mockCalibrationCheckSessionAnalyticsProps,
     })
   })

--- a/app/src/analytics/make-event.js
+++ b/app/src/analytics/make-event.js
@@ -285,7 +285,7 @@ export function makeEvent(
       )
       if (analyticsProps) {
         return Promise.resolve({
-          name: 'sessionExit',
+          name: `${analyticsProps.sessionType}SessionExit`,
           properties: analyticsProps,
         })
       } else {


### PR DESCRIPTION
## overview

To aid usability/inspectability of the analytics platform, the analytics event named 'sessionExit' (which was never released, only recently merged into edge by #5780), has been altered to interpolate the session type into the event name as well (e.g. calibrationCheckSessionExit).

Note: the object still includes a property `sessionType: 'calibrationCheck'`, that can be seen as redundant, though it still acts as a record of the actual session type in code, without string parsing.

## risk assessment

none