### PR TITLE
refactor(app): add type annotation missing due to merge timing

### DIFF
--- a/app/src/components/NetworkSettingsCard/DisableDiscoveryCache.js
+++ b/app/src/components/NetworkSettingsCard/DisableDiscoveryCache.js
@@ -5,7 +5,7 @@ import { LabeledToggle } from '@opentrons/components'
 import type { State, Dispatch } from '../../types'
 import { getConfig, updateConfig } from '../../config'
 
-export const DisableDiscoveryCache = () => {
+export const DisableDiscoveryCache = (): React.Node => {
   const cacheDisabled = useSelector((state: State) => {
     const config = getConfig(state)
     return config.discovery.disableCache


### PR DESCRIPTION
## overview

We had some bad merge timing with #5759 and #5800 that broke the JS typecheck job in `edge`. Sorry everyone!

## changelog

- refactor(app): add type annotation missing due to merge timing

## review requests

A quick 👍 I guess?

## risk assessment

Nonexistent
