### PR TITLE
build(scripts): allow test pypi uploads to fail again

### DIFF
--- a/scripts/python.mk
+++ b/scripts/python.mk
@@ -29,6 +29,7 @@ endef
 # parameter 1: auth arguments for twine
 # parameter 2: repository url
 # parameter 3: the wheel file to upload
+# parameter 4 (optional): a prefix command, like changing directory
 define python_upload_package
-$(python) -m twine upload --repository-url $(2) $(1) $(3)
+$(if $(findstring test,$(2)),-)$(if $(4),$(4) &&)$(python) -m twine upload --repository-url $(2) $(1) $(3)
 endef

--- a/shared-data/Makefile
+++ b/shared-data/Makefile
@@ -76,7 +76,7 @@ push: push-no-restart
 
 .PHONY: deploy
 deploy-py: wheel
-	$(SHX) cd python && $(call python_upload_package,$(twine_auth_args),$(twine_repository_url),../$(wheel_file))
+	$(call python_upload_package,$(twine_auth_args),$(twine_repository_url),../$(wheel_file),$(SHX) cd python)
 
 .PHONY: test
 test-py:


### PR DESCRIPTION
The shared-data pr had a small makefile refactor to coalesce the deploy
and deploy-staging python makefile tasks, but what that forgot is that
uploads to test pypi must be allowed to fail, since every edge build
in the same version will upload a wheel with the same name, which pypi
doesn't allow.

This adds that functionality back to the python_upload_package makefile
function

It also adds a bit of complexity to allow callers to specify a prefix
command since the shared-data task needs to execute in a subdirectory.

<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->

## risk assessment

<!--
  Carefully go over your pull request and look at the other parts of the
  codebase it may affect. Look for the possibility, even if you think it's
  small, that your change may affect some other part of the system - for
  instance, changing return tip behavior in protocol may also change the
  behavior of labware calibration.

  Identify the other parts of the system your codebase may affect, so that in
  addition to your own review and testing, other people who may not have
  the system internalized as much as you can focus their attention and testing
  there.
-->
