### PR TITLE
fix(robot-server): preserve newlines in text logs

### DIFF
--- a/robot-server/robot_server/service/legacy/routers/logs.py
+++ b/robot-server/robot_server/service/legacy/routers/logs.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Response
 
 from opentrons.system import log_control
 from robot_server.service.legacy.models.logs import LogIdentifier, LogFormat
@@ -14,14 +14,16 @@ async def get_logs(
         log_control.DEFAULT_RECORDS, title="Number of records to retrieve",
         gt=0, le=log_control.MAX_RECORDS
     ),
-) -> str:
+) -> Response:
     identifier = 'opentrons-api-serial'
     if log_identifier == LogIdentifier.api:
         identifier = 'opentrons-api'
 
-    modes = {LogFormat.json: "json", LogFormat.text: "short"}
-    format_type = modes[format]
+    modes = {LogFormat.json: ("json", "application/json"),
+             LogFormat.text: ("short", "text/plain")}
+    format_type, media_type = modes[format]
     output = await log_control.get_records_dumb(
         identifier, records, format_type
     )
-    return output.decode("utf-8")
+    return Response(
+        content=output.decode('utf-8'), media_type=media_type)

--- a/robot-server/tests/service/legacy/routers/test_logs.py
+++ b/robot-server/tests/service/legacy/routers/test_logs.py
@@ -126,7 +126,6 @@ def test_get_api_log_with_params(
     else:
         expected = logs
 
-
     async def mock_get_records_dumb(identifier, records, format_type):
         return res_bytes
 

--- a/robot-server/tests/service/legacy/routers/test_logs.py
+++ b/robot-server/tests/service/legacy/routers/test_logs.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from unittest.mock import patch
 
@@ -15,7 +17,7 @@ def test_get_serial_log_with_defaults(api_client):
     with patch("opentrons.system.log_control.get_records_dumb") as m:
         m.side_effect = mock_get_records_dumb
         response = api_client.get("/logs/serial.log")
-        body = response.json()
+        body = response.text
         assert response.status_code == 200
         assert body == expected
         m.assert_called_once_with(
@@ -37,7 +39,10 @@ def test_get_serial_log_with_params(
 ):
     logs = '{"serial": "serial logs"}'
     res_bytes = logs.encode('utf-8')
-    expected = res_bytes.decode('utf-8')
+    if format_param == 'json':
+        expected = json.loads(res_bytes)
+    else:
+        expected = logs
 
     async def mock_get_records_dumb(identifier, records, mode):
         return res_bytes
@@ -47,9 +52,13 @@ def test_get_serial_log_with_params(
         response = api_client.get(
             f"/logs/serial.log?format={format_param}&records={records_param}"
         )
-        body = response.json()
-        assert response.status_code == 200
+        if format_param == 'json':
+            body = response.json()
+        else:
+            body = response.text
         assert body == expected
+        assert response.status_code == 200
+
         m.assert_called_once_with(
             "opentrons-api-serial", records_param, mode_param
         )
@@ -92,7 +101,7 @@ def test_get_api_log_with_defaults(api_client):
     with patch("opentrons.system.log_control.get_records_dumb") as m:
         m.side_effect = mock_get_records_dumb
         response = api_client.get("/logs/api.log")
-        body = response.json()
+        body = response.text
         assert response.status_code == 200
         assert body == expected
         m.assert_called_once_with("opentrons-api", DEFAULT_RECORDS, "short")
@@ -112,7 +121,11 @@ def test_get_api_log_with_params(
 ):
     logs = '{"api": "application programing interface logs"}'
     res_bytes = logs.encode('utf-8')
-    expected = res_bytes.decode('utf-8')
+    if format_param == 'json':
+        expected = json.loads(res_bytes)
+    else:
+        expected = logs
+
 
     async def mock_get_records_dumb(identifier, records, format_type):
         return res_bytes
@@ -122,7 +135,10 @@ def test_get_api_log_with_params(
         response = api_client.get(
             f"/logs/api.log?format={format_param}&records={records_param}"
         )
-        body = response.json()
+        if format_param == 'json':
+            body = response.json()
+        else:
+            body = response.text
         assert response.status_code == 200
         assert body == expected
         m.assert_called_once_with("opentrons-api", records_param, mode_param)


### PR DESCRIPTION
The fastapi automatic encoder for responses was doing a bit too much
when we returned a raw string in the logs response. By using the
Response class directly, we can specify the encoding as text/plain if
we're returning text logs instead of letting fastapi infer it.

Closes #5846

## Testing
Install it and get logs - there should be newlines
