### PR TITLE
chore(build): dev wheel versions on edge builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ jobs:
             # want to add the build number in the test deploys - having a dev
             # tag means python infrastructure considers this a "dev version",
             # which is prerelease
-            BUILD_NUMBER=${TRAVIS_BUILD_NUMBER} make clean-py deploy-py pypi_username=${TEST_PYPI_USER} pypi_password=${TEST_PYPI_PASSWORD} twine_repository_url="https://test.pypi.org/legacy/"
+            QUIET=1 BUILD_NUMBER=${TRAVIS_BUILD_NUMBER} make clean-py deploy-py pypi_username=${TEST_PYPI_USER} pypi_password=${TEST_PYPI_PASSWORD} twine_repository_url="https://test.pypi.org/legacy/"
           on:
             repo: Opentrons/opentrons
             all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,8 @@ jobs:
             BUILD_NUMBER=${TRAVIS_BUILD_NUMBER} make clean deploy-py pypi_username=${TEST_PYPI_USER} pypi_password=${TEST_PYPI_PASSWORD} twine_repository_url="https://test.pypi.org/legacy/"
           on:
             repo: Opentrons/opentrons
-            branch: edge
+            all_branches: true
+            # branch: edge
 
     # test, build, and upload for JavaScript projects
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,8 +85,7 @@ jobs:
             QUIET=1 BUILD_NUMBER=${TRAVIS_BUILD_NUMBER} make clean-py deploy-py pypi_username=${TEST_PYPI_USER} pypi_password=${TEST_PYPI_PASSWORD} twine_repository_url="https://test.pypi.org/legacy/"
           on:
             repo: Opentrons/opentrons
-            all_branches: true
-            # branch: edge
+            branch: edge
 
     # test, build, and upload for JavaScript projects
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ jobs:
             # want to add the build number in the test deploys - having a dev
             # tag means python infrastructure considers this a "dev version",
             # which is prerelease
-            BUILD_NUMBER=${TRAVIS_BUILD_NUMBER} make clean deploy-py pypi_username=${TEST_PYPI_USER} pypi_password=${TEST_PYPI_PASSWORD} twine_repository_url="https://test.pypi.org/legacy/"
+            BUILD_NUMBER=${TRAVIS_BUILD_NUMBER} make clean-py deploy-py pypi_username=${TEST_PYPI_USER} pypi_password=${TEST_PYPI_PASSWORD} twine_repository_url="https://test.pypi.org/legacy/"
           on:
             repo: Opentrons/opentrons
             all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,12 @@ jobs:
         # push to test pypi on pr
         - provider: script
           skip_cleanup: true
-          script: make deploy-py pypi_username=${TEST_PYPI_USER} pypi_password=${TEST_PYPI_PASSWORD} twine_repository_url="https://test.pypi.org/legacy/"
+          script:
+            # we have to set the build number here and clean because we only
+            # want to add the build number in the test deploys - having a dev
+            # tag means python infrastructure considers this a "dev version",
+            # which is prerelease
+            BUILD_NUMBER=${TRAVIS_BUILD_NUMBER} make clean deploy-py pypi_username=${TEST_PYPI_USER} pypi_password=${TEST_PYPI_PASSWORD} twine_repository_url="https://test.pypi.org/legacy/"
           on:
             repo: Opentrons/opentrons
             branch: edge

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,12 @@ UPDATE_SERVER_DIR := update-server
 ROBOT_SERVER_DIR := robot-server
 APP_SHELL_DIR := app-shell
 
+# This may be set as an environment variable (and is by CI tasks that upload
+# to test pypi) to add a .dev extension to the python package versions. If
+# empty, no .dev extension is appended, so this definition is here only as
+# documentation
+BUILD_NUMBER ?=
+
 # this may be set as an environment variable to select the version of
 # python to run if pyenv is not available. it should always be set to
 # point to a python3.6.

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,14 @@ usb_host=$(shell yarn run -s discovery find -i 169.254 fd00 -c "[fd00:0:cafe:fef
 .PHONY: setup
 setup: setup-js setup-py
 
+.PHONY: clean-py
+clean-py:
+	$(MAKE) -C $(API_DIR) clean
+	$(MAKE) -C $(UPDATE_SERVER_DIR) clean
+	$(MAKE) -C $(ROBOT_SERVER_DIR) clean
+	$(MAKE) -C $(SHARED_DATA_DIR) clean
+
+
 .PHONY: setup-py
 setup-py:
 	$(OT_PYTHON) -m pip install pipenv==2018.10.9
@@ -53,6 +61,7 @@ setup-py:
 	$(MAKE) -C $(UPDATE_SERVER_DIR) setup
 	$(MAKE) -C $(ROBOT_SERVER_DIR) setup
 	$(MAKE) -C $(SHARED_DATA_DIR) setup-py
+
 
 # front-end dependecies handled by yarn
 .PHONY: setup-js

--- a/api/Makefile
+++ b/api/Makefile
@@ -22,7 +22,7 @@ sphinx_build := $(pipenv_envvars) pipenv run sphinx-build
 # Find the version of the wheel from package.json using a helper script. We
 # use python here so we can use the same version normalization that will be
 # used to create the wheel.
-wheel_file = dist/$(call python_get_wheelname,api,opentrons)
+wheel_file = dist/$(call python_get_wheelname,api,opentrons,$(BUILD_NUMBER))
 
 # These variables are for simulating python protocols
 sim_log_level ?= info
@@ -150,7 +150,7 @@ simulate:
 
 .PHONY: deploy
 deploy: wheel
-	$(call python_upload_package,$(twine_auth_args),$(twine_repository_url),$(wheel_file))
+	$(call python_upload_package,$(twine_auth_args),$(twine_repository_url),$(wheel_file),$(BUILD_NUMBER))
 
 # User must currently specify host, e.g.: `make term host=169.254.202.176`
 .PHONY: term

--- a/api/Makefile
+++ b/api/Makefile
@@ -150,7 +150,7 @@ simulate:
 
 .PHONY: deploy
 deploy: wheel
-	$(call python_upload_package,$(twine_auth_args),$(twine_repository_url),$(wheel_file),$(BUILD_NUMBER))
+	$(call python_upload_package,$(twine_auth_args),$(twine_repository_url),$(wheel_file))
 
 # User must currently specify host, e.g.: `make term host=169.254.202.176`
 .PHONY: term

--- a/api/setup.py
+++ b/api/setup.py
@@ -4,9 +4,14 @@ import sys
 import codecs
 import os
 import os.path
+
 from setuptools import setup, find_packages
 
-import json
+HERE = os.path.abspath(os.path.dirname(__file__))
+sys.path.append(os.path.join(HERE, '..', 'scripts'))
+
+from python_build_utils import normalize_version
+
 
 # make stdout blocking since Travis sets it to nonblocking
 if os.name == 'posix':
@@ -14,14 +19,14 @@ if os.name == 'posix':
     flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL)
     fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags & ~os.O_NONBLOCK)
 
-HERE = os.path.abspath(os.path.dirname(__file__))
-
 
 def get_version():
-    with open(os.path.join(HERE, 'src', 'opentrons', 'package.json')) as pkg:
-        package_json = json.load(pkg)
-        return package_json.get('version')
-
+    buildno = os.getenv('BUILD_NUMBER')
+    if buildno:
+        normalize_opts = {'extra_tag': buildno}
+    else:
+        normalize_opts = {}
+    return normalize_version('api', **normalize_opts)
 
 VERSION = get_version()
 

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -18,7 +18,7 @@ SRC_PATH = robot_server
 # Find the version of the wheel from package.json using a helper script. We
 # use python here so we can use the same version normalization that will be
 # used to create the wheel.
-wheel_file = dist/$(call python_get_wheelname,robot-server,robotserver)
+wheel_file = dist/$(call python_get_wheelname,robot-server,robotserver,$(BUILD_NUMBER))
 
 
 # These variables can be overriden when make is invoked to customize the

--- a/robot-server/setup.py
+++ b/robot-server/setup.py
@@ -6,8 +6,6 @@ import os
 import os.path
 from setuptools import setup, find_packages
 
-import json
-
 # make stdout blocking since Travis sets it to nonblocking
 if os.name == 'posix':
     import fcntl
@@ -15,12 +13,18 @@ if os.name == 'posix':
     fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags & ~os.O_NONBLOCK)
 
 HERE = os.path.abspath(os.path.dirname(__file__))
+sys.path.append(os.path.join(HERE, '..', 'scripts'))
+
+from python_build_utils import normalize_version
 
 
 def get_version():
-    with open(os.path.join(HERE, 'robot_server', 'package.json')) as pkg:
-        package_json = json.load(pkg)
-        return package_json.get('version')
+    buildno = os.getenv('BUILD_NUMBER')
+    if buildno:
+        normalize_opts = {'extra_tag': buildno}
+    else:
+        normalize_opts = {}
+    return normalize_version('shared-data', **normalize_opts)
 
 
 VERSION = get_version()

--- a/scripts/python.mk
+++ b/scripts/python.mk
@@ -33,5 +33,5 @@ endef
 # parameter 3: the wheel file to upload
 # parameter 4 (optional): a prefix command, like changing directory
 define python_upload_package
-$(if $(findstring test,$(2)),-)$(if $(4),$(4) &&)$(python) -m twine upload --repository-url $(2) $(1) $(3)
+$(if $(4),$(4) &&)$(python) -m twine upload --repository-url $(2) $(1) $(3)
 endef

--- a/scripts/python.mk
+++ b/scripts/python.mk
@@ -12,17 +12,19 @@ pypi_test_upload_url := https://test.pypi.org/legacy/
 
 # get the python package version
 # (evaluates to that string)
-# paramter 1: name of the project (aka api, robot-server, etc)
+# parameter 1: name of the project (aka api, robot-server, etc)
+# parameter 2: an extra version tag string
 define python_package_version
-$(shell $(python) ../scripts/python_build_utils.py $(1) normalize_version)
+$(shell $(python) ../scripts/python_build_utils.py $(1) normalize_version $(if $(2),-e $(2)))
 endef
 
 
 # get the name of the wheel that setup.py will build
 # parameter 1: the name of the project (aka api, robot-server, etc)
 # parameter 2: the name of the python package (aka opentrons, robot_server, etc)
+# parameter 3: any extra version tags
 define python_get_wheelname
-$(2)-$(call python_package_version,$(1))-py2.py3-none-any.whl
+$(2)-$(call python_package_version,$(1),$(3))-py2.py3-none-any.whl
 endef
 
 # upload a package to a repository

--- a/scripts/python.mk
+++ b/scripts/python.mk
@@ -5,7 +5,7 @@ pytest := $(pipenv_envvars) pipenv run py.test
 
 pipenv_opts := --dev
 pipenv_opts += $(and $(CI),--keep-outdated --clear)
-wheel_opts := $(if $(or $(CI),$(V),$(VERBOSE)),,-q)
+wheel_opts := $(if $(and $(or $(CI),$(V),$(VERBOSE)),$(not $(QUIET))),,-q)
 
 pypi_upload_url := https://upload.pypi.org/legacy/
 pypi_test_upload_url := https://test.pypi.org/legacy/

--- a/shared-data/Makefile
+++ b/shared-data/Makefile
@@ -56,6 +56,7 @@ clean:
 wheel: $(wheel_file)
 
 $(BUILD_DIR)/opentrons_shared_data-%-py2.py3-none-any.whl: python/setup.py $(py_sources)
+	$(SHX) mkdir -p build
 	$(SHX) cd python && $(python) setup.py $(wheel_opts) bdist_wheel
 	$(SHX) mv python/dist/$(notdir $(wheel_file)) $(BUILD_DIR)/
 	$(SHX) rm -rf python/build python/dist *.egg_info

--- a/shared-data/Makefile
+++ b/shared-data/Makefile
@@ -17,7 +17,7 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 # TODO(mc, 2018-10-25): use dist to match other projects
 BUILD_DIR := build
 
-wheel_file = $(BUILD_DIR)/$(call python_get_wheelname,shared-data,opentrons_shared_data)
+wheel_file = $(BUILD_DIR)/$(call python_get_wheelname,shared-data,opentrons_shared_data,$(BUILD_NUMBER))
 
 py_sources = $(filter %.py,$(shell $(SHX) find python/opentrons_shared_data))
 

--- a/shared-data/python/setup.py
+++ b/shared-data/python/setup.py
@@ -9,6 +9,12 @@ sys.path.append(os.path.join(HERE, '..', '..', 'scripts'))
 
 from python_build_utils import normalize_version
 
+# make stdout blocking since Travis sets it to nonblocking
+if os.name == 'posix':
+    import fcntl
+    flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL)
+    fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags & ~os.O_NONBLOCK)
+
 DATA_ROOT = '..'
 DATA_SUBDIRS = ['deck',
                 'labware',

--- a/shared-data/python/setup.py
+++ b/shared-data/python/setup.py
@@ -1,10 +1,13 @@
 import os
-import json
+import sys
 
 from setuptools.command import build_py, sdist
 from setuptools import setup, find_packages
 
 HERE = os.path.abspath(os.path.dirname(__file__))
+sys.path.append(os.path.join(HERE, '..', '..', 'scripts'))
+
+from python_build_utils import normalize_version
 
 DATA_ROOT = '..'
 DATA_SUBDIRS = ['deck',
@@ -71,9 +74,13 @@ class BuildWithData(build_py.build_py):
 
 
 def get_version():
-    with open(os.path.join(HERE, '..', 'package.json')) as pkg:
-        package_json = json.load(pkg)
-        return package_json['version']
+    buildno = os.getenv('BUILD_NUMBER')
+    if buildno:
+        normalize_opts = {'extra_tag': buildno}
+    else:
+        normalize_opts = {}
+    return normalize_version('shared-data', **normalize_opts)
+
 
 VERSION = get_version()
 


### PR DESCRIPTION
These get uploaded to test pypi (where they are by and large never
downloaded, but it allows us to dry-run uploads to production pypi).
Test pypi doesn't allow you to reuse filenames, just like real pypi, and
each edge build in the same version will have the same wheel filename.
In the past, we overcame this by allowing the test pypi upload to fail,
but then... that doesn't really test anything.

Luckily, PEP440[1] which defines python versioning conventions, allows a
.devN tag to be at the end of versions, with the intent being that the N
is a build number. So this pr adds the capability to specify a
BUILD_NUMBER= environment variable - which travis edge builds now do -
which will get added to
    - the wheel filenames
    - the actual versions encoded in the wheel metadata
    - the required version for opentrons_shared_data in opentrons

and thus allow us to upload to pypi on every edge build.

[1]: https://www.python.org/dev/peps/pep-0440/

## Testing
- Do a `make clean wheel`  in the python projects and make sure there's no .dev tag
- Do `BUILD_NUMBER=4 make clean wheel` in python projects and make sure there is a .dev tag
- Check on the build for the temp commit and make sure it uploaded something to test.pypi (https://test.pypi.org/project/opentrons/ and https://test.pypi.org/project/opentrons-shared-data/)

## When will this be not a draft
- When the upload succeeds and I can revert the temp commit