### PR TITLE
refactor(api): lower the log level for warnings that an instrument is not attached to one mount

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -1084,7 +1084,12 @@ class SmoothieDriver_3_0_0:
                 raise SmoothieError(ret_code)
         else:
             if is_alarm or is_error:
-                # these two errors happen when we're recovering from a hard
+               # info-level logging for errors of form: "no L instrument found"
+               if 'instrument found' in ret_code.lower():
+                  log.info(f"smoothie: {ret_code}")
+                  raise SmoothieError(ret_code)
+
+                # the two errors below happen when we're recovering from a hard
                 # halt. in that case, some try/finallys above us may send
                 # further commands. smoothie responds to those commands with
                 # errors like these. if we raise exceptions here, they


### PR DESCRIPTION
## overview

It is reasonable to use the pipette with only one pipette attached but this results in many error level warnings, e.g.:
```
alarm/error outside hard halt: error:no R instrument found
alarm/error outside hard halt: error:no R instrument found
alarm/error outside hard halt: error:no R instrument found
alarm/error outside hard halt: error:no R instrument found
```

This swallows those warnings by moving their log-level to info. It still raises the SmoothieError exception.

## changelog

detects this type of Smoothie error by string matching and uses a different log level.

## risk assessment

- If there is a genuine problem with the pipette's connection this makes it less apparent from the Python output, but most people won't be looking at the Python output anyway and this would be surfaced by the app regardless.