### PR TITLE
fix(api): do not allow v1 imports in v2 protocols

### DIFF
--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -67,16 +67,6 @@ metadata = {
 p = instruments.P10_Single(mount='right')
 """, APIVersion(1, 0)),
     ("""
-from opentrons import instruments
-
-metadata = {
-  'apiLevel': '2.0'
-  }
-
-p = instruments.P10_Single(mount='right')
-def run(ctx): pass
-""", APIVersion(2, 0)),
-    ("""
 from opentrons import types
 
 metadata = {
@@ -304,7 +294,13 @@ def test_extra_contents(
     '''
 from opentrons import robot
 metadata={"apiLevel": "2.0"}
-print("hi")''',
+def run(ctx): pass
+''',
+    '''
+metadata = {"apiLevel": "2.0"}
+
+print('hi')
+''',
     '''
 metadata = {"apiLevel": "2.0"}
 def run(ctx):
@@ -312,7 +308,7 @@ def run(ctx):
 
 def run(blahblah):
   pass
-    '''
+'''
 ])
 def test_bad_structure(bad_protocol):
     with pytest.raises(MalformedProtocolError):


### PR DESCRIPTION
If you import v1 protocols in your v2 protocol, it slows things down and
kinda messes them up since those modules are designed to do a lot of
work on import, and it's work that actively shouldn't be done unless
necessary.

If you then _use_ those modules, it can play absolute havoc with
assumptions inside the protocol session machinery.

This is just straight up not supported, and this pr adds an error that
will occur when you try and upload a protocol that does this.

Closes #5852

<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->

## risk assessment

<!--
  Carefully go over your pull request and look at the other parts of the
  codebase it may affect. Look for the possibility, even if you think it's
  small, that your change may affect some other part of the system - for
  instance, changing return tip behavior in protocol may also change the
  behavior of labware calibration.

  Identify the other parts of the system your codebase may affect, so that in
  addition to your own review and testing, other people who may not have
  the system internalized as much as you can focus their attention and testing
  there.
-->
