### PR TITLE
chore(shared-data): add python/ makefile

### DIFF
--- a/scripts/python.mk
+++ b/scripts/python.mk
@@ -14,8 +14,9 @@ pypi_test_upload_url := https://test.pypi.org/legacy/
 # (evaluates to that string)
 # parameter 1: name of the project (aka api, robot-server, etc)
 # parameter 2: an extra version tag string
+# parameter 3: override python_build_utils.py path (default: ../scripts/python_build_utils.py)
 define python_package_version
-$(shell $(python) ../scripts/python_build_utils.py $(1) normalize_version $(if $(2),-e $(2)))
+$(shell $(python) $(if $(3),$(3),../scripts/python_build_utils.py) $(1) normalize_version $(if $(2),-e $(2)))
 endef
 
 
@@ -23,15 +24,16 @@ endef
 # parameter 1: the name of the project (aka api, robot-server, etc)
 # parameter 2: the name of the python package (aka opentrons, robot_server, etc)
 # parameter 3: any extra version tags
+# parameter 4: override python_build_utils.py path (default: ../scripts/python_build_utils.py)
+
 define python_get_wheelname
-$(2)-$(call python_package_version,$(1),$(3))-py2.py3-none-any.whl
+$(2)-$(call python_package_version,$(1),$(3),$(4))-py2.py3-none-any.whl
 endef
 
 # upload a package to a repository
 # parameter 1: auth arguments for twine
 # parameter 2: repository url
 # parameter 3: the wheel file to upload
-# parameter 4 (optional): a prefix command, like changing directory
 define python_upload_package
-$(if $(4),$(4) &&)$(python) -m twine upload --repository-url $(2) $(1) $(3)
+$(python) -m twine upload --repository-url $(2) $(1) $(3)
 endef

--- a/shared-data/Makefile
+++ b/shared-data/Makefile
@@ -1,12 +1,4 @@
 # shared-data makefile
-include ../scripts/python.mk
-include ../scripts/push.mk
-
-# Host key location for buildroot robot
-br_ssh_key ?= $(default_ssh_key)
-# Other SSH args for buildroot robots
-ssh_opts ?= $(default_ssh_opts)
-
 
 # using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
 SHELL := bash
@@ -17,17 +9,11 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 # TODO(mc, 2018-10-25): use dist to match other projects
 BUILD_DIR := build
 
-wheel_file = $(BUILD_DIR)/$(call python_get_wheelname,shared-data,opentrons_shared_data,$(BUILD_NUMBER))
-
-py_sources = $(filter %.py,$(shell $(SHX) find python/opentrons_shared_data))
-
-twine_auth_args := --username $(pypi_username) --password $(pypi_password)
-twine_repository_url ?= $(pypi_test_upload_url)
 
 #######################################
 
 .PHONY: all
-all: clean dist
+all: clean dist dist-py
 
 .PHONY: setup-js
 setup-js:
@@ -35,8 +21,8 @@ setup-js:
 
 .PHONY: setup-py
 setup-py:
-	cd python && $(pipenv_envvars) pipenv sync $(pipenv_opts)
-	cd python && $(pipenv_envvars) pipenv run pip freeze
+	$(MAKE) -C python setup-py
+
 
 .PHONY: setup
 setup: setup-py setup-js
@@ -47,38 +33,41 @@ dist:
 	@shx mkdir -p $(BUILD_DIR)
 	node js/scripts/build.js $(BUILD_DIR)
 
+
+.PHONY: dist-py
+dist-py:
+	$(MAKE) -C python wheel
+
+
+.PHONY: clean-py
+clean-py:
+	$(MAKE) -C python clean
+
+
 .PHONY: clean
-clean:
+clean: clean-py
 	shx rm -rf $(BUILD_DIR)
 
 
-.PHONY: wheel
-wheel: $(wheel_file)
-
-$(BUILD_DIR)/opentrons_shared_data-%-py2.py3-none-any.whl: python/setup.py $(py_sources)
-	$(SHX) mkdir -p build
-	$(SHX) cd python && $(python) setup.py $(wheel_opts) bdist_wheel
-	$(SHX) mv python/dist/$(notdir $(wheel_file)) $(BUILD_DIR)/
-	$(SHX) rm -rf python/build python/dist *.egg_info
-	$(SHX) ls $(BUILD_DIR)
 
 .PHONY: lint-py
-lint-py: $(py_sources)
-	$(SHX) cd python && $(python) -m mypy opentrons_shared_data
-	$(SHX) cd python && $(python) -m pylama opentrons_shared_data
+lint-py:
+	$(MAKE) -C python lint
 
 .PHONY: push-no-restart
-push-no-restart: $(wheel_file)
-	$(call push-python-package,$(host),$(br_ssh_key),$(ssh_opts),$(wheel_file))
+push-no-restart:
+	$(MAKE) -C python push-no-restart
+
 
 .PHONY: push
-push: push-no-restart
-	$(call restart-service,$(host),$(br_ssh_key),$(ssh_opts),opentrons-robot-server)
+push:
+	$(MAKE) -C python push
 
-.PHONY: deploy
-deploy-py: wheel
-	$(call python_upload_package,$(twine_auth_args),$(twine_repository_url),../$(wheel_file),$(SHX) cd python)
+.PHONY: deploy-py
+deploy-py:
+	$(MAKE) -C python deploy
 
-.PHONY: test
+
+.PHONY: test-py
 test-py:
-	$(SHX) cd python && $(python) -m pytest tests
+	$(MAKE) -C python test

--- a/shared-data/python/Makefile
+++ b/shared-data/python/Makefile
@@ -1,0 +1,80 @@
+# shared-data/python makefile
+
+include ../../scripts/python.mk
+include ../../scripts/push.mk
+
+# Host key location for buildroot robot
+br_ssh_key ?= $(default_ssh_key)
+# Other SSH args for buildroot robots
+ssh_opts ?= $(default_ssh_opts)
+
+# using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
+SHELL := bash
+
+# add node_modules/.bin to PATH
+PATH := $(shell cd ../.. && yarn bin):$(PATH)
+
+# This may be set as an environment variable (and is by CI tasks that upload
+# to test pypi) to add a .dev extension to the python package versions. If
+# empty, no .dev extension is appended, so this definition is here only as
+# documentation
+BUILD_NUMBER ?=
+
+# this may be set as an environment variable to select the version of
+# python to run if pyenv is not available. it should always be set to
+# point to a python3.6.
+OT_PYTHON ?= python
+
+BUILD_DIR := dist
+
+
+wheel_file = $(BUILD_DIR)/$(call python_get_wheelname,shared-data,opentrons_shared_data,$(BUILD_NUMBER),../../scripts/python_build_utils.py)
+
+py_sources = $(filter %.py,$(shell $(SHX) find opentrons_shared_data))
+json_sources = $(filter %.json,$(shell $(SHX) find ..))
+
+twine_auth_args := --username $(pypi_username) --password $(pypi_password)
+twine_repository_url ?= $(pypi_test_upload_url)
+
+.PHONY: setup-py
+setup-py:
+	$(pipenv_envvars) pipenv sync $(pipenv_opts)
+	$(pipenv_envvars) pipenv run pip freeze
+
+
+.PHONY: clean
+clean:
+	shx rm -rf $(BUILD_DIR)
+
+
+.PHONY: wheel
+wheel: $(wheel_file)
+
+
+$(BUILD_DIR)/opentrons_shared_data-%-py2.py3-none-any.whl: setup.py $(py_sources)
+	$(SHX) mkdir -p build
+	$(python) setup.py $(wheel_opts) bdist_wheel
+	$(SHX) rm -rf build *.egg_info
+	$(SHX) ls $(BUILD_DIR)
+
+
+.PHONY: lint
+lint: $(py_sources)
+	$(python) -m mypy opentrons_shared_data
+	$(python) -m pylama opentrons_shared_data
+
+.PHONY: push-no-restart
+push-no-restart: $(wheel_file)
+	$(call push-python-package,$(host),$(br_ssh_key),$(ssh_opts),$(wheel_file))
+
+.PHONY: push
+push: push-no-restart
+	$(call restart-service,$(host),$(br_ssh_key),$(ssh_opts),opentrons-robot-server)
+
+.PHONY: deploy
+deploy: wheel
+	$(call python_upload_package,$(twine_auth_args),$(twine_repository_url),../$(wheel_file)
+
+.PHONY: test
+test:
+	$(python) -m pytest tests


### PR DESCRIPTION
and put python stuff in there. that prevents an issue where the
wheelname variable would run at makefile rule build time and create
spurious venvs and pipenv files in shared-data/

## testing
can you run setup-py, dist-py, test-py, lint-py in shared-data? how about setup-py, test-py, and lint-py from the top level?

if you run setup-js, make sure you no longer get a special opentrons-(hash) venv in ~/.local/share/virtualenvs and spurious Pipfiles in shared-data