### PR TITLE
refactor(api): add set_acceleration to SimulatingDriver

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/__init__.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/__init__.py
@@ -78,6 +78,6 @@ class SimulatingDriver:
 
     def set_dwelling_current(self, settings):
         pass
-    
+
     def set_acceleration(self, settings):
         pass

--- a/api/src/opentrons/drivers/smoothie_drivers/__init__.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/__init__.py
@@ -78,3 +78,6 @@ class SimulatingDriver:
 
     def set_dwelling_current(self, settings):
         pass
+    
+    def set_acceleration(self, settings):
+        pass


### PR DESCRIPTION
## overview
This adds the `set_acceleration` command to `SimulatingDriver` meaning that this command can be used in simulated protocols.

Hit this while developing something - does it seem reasonable to add?

## changelog

Adds `set_acceleration` that is simply `pass`, in line with other functions in this class.

## risk assessment

Very low