### PR TITLE
fix(robot-server): type mismatch in SerialCommand args

### DIFF
--- a/robot-server/robot_server/service/legacy/models/modules.py
+++ b/robot-server/robot_server/service/legacy/models/modules.py
@@ -216,9 +216,7 @@ class SerialCommand(BaseModel):
     command_type: str = \
         Field(...,
               description="The name of the module function to call")
-    args: typing.Optional[typing.List[typing.Union[int,
-                                                   float,
-                                                   typing.List[dict]]]] = \
+    args: typing.Optional[typing.List[typing.Any]] = \
         Field(None,
               description="The ordered args list for the call")
 

--- a/robot-server/robot_server/service/legacy/models/modules.py
+++ b/robot-server/robot_server/service/legacy/models/modules.py
@@ -216,7 +216,9 @@ class SerialCommand(BaseModel):
     command_type: str = \
         Field(...,
               description="The name of the module function to call")
-    args: typing.Optional[typing.List[str]] = \
+    args: typing.Optional[typing.List[typing.Union[int,
+                                                   float,
+                                                   typing.List[dict]]]] = \
         Field(None,
               description="The ordered args list for the call")
 

--- a/robot-server/robot_server/service/legacy/routers/modules.py
+++ b/robot-server/robot_server/service/legacy/routers/modules.py
@@ -104,8 +104,9 @@ async def post_serial_command(
         except TypeError as e:
             raise V1HandlerError(
                 message=f'Server encountered a TypeError '
-                        f'while running {method} : {e}',
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+                        f'while running {method} : {e}. \n'
+                        f'Possibly type mismatch in args',
+                status_code=status.HTTP_400_BAD_REQUEST)
         else:
             return SerialCommandResponse(message='Success', returnValue=val)
     else:

--- a/robot-server/robot_server/service/legacy/routers/modules.py
+++ b/robot-server/robot_server/service/legacy/routers/modules.py
@@ -104,8 +104,8 @@ async def post_serial_command(
         except TypeError as e:
             raise V1HandlerError(
                 message=f'Server encountered a TypeError '
-                        f'while running {method} : {e}. \n'
-                        f'Possibly type mismatch in args',
+                        f'while running {method} : {e}. '
+                        f'Possibly a type mismatch in args',
                 status_code=status.HTTP_400_BAD_REQUEST)
         else:
             return SerialCommandResponse(message='Success', returnValue=val)

--- a/robot-server/robot_server/service/legacy/routers/modules.py
+++ b/robot-server/robot_server/service/legacy/routers/modules.py
@@ -1,6 +1,5 @@
 import typing
 import asyncio
-
 from starlette import status
 from fastapi import Path, APIRouter, Depends
 
@@ -12,7 +11,6 @@ from robot_server.service.legacy.models import V1BasicResponse
 from robot_server.service.errors import V1HandlerError
 from robot_server.service.legacy.models.modules import Module, ModuleSerial,\
     Modules, SerialCommandResponse, SerialCommand
-
 
 router = APIRouter()
 

--- a/robot-server/tests/service/legacy/models/test_modules.py
+++ b/robot-server/tests/service/legacy/models/test_modules.py
@@ -1,0 +1,33 @@
+import pytest
+from robot_server.service.legacy.models import modules
+
+
+def test_validate_command_invalid_arg_type():
+    with pytest.raises(ValueError,
+                       match="3 validation errors for SerialCommand\nargs ->"):
+        modules.SerialCommand(
+            command_type="set_temperature",
+            args=["thirty"]
+        )
+
+
+def test_validate_command_arg_type_conversion():
+    cmd = modules.SerialCommand(
+            command_type="set_temperature",
+            args=["30"]
+        )
+    assert type(cmd.args[0]) == int
+    assert cmd.args[0] == 30
+
+
+def test_validate_command_args_all_valid_types():
+    cmd = modules.SerialCommand(
+            command_type="a_valid_cmd_type",
+            args=[[{"temperature": 30, "hold_time_seconds": 20},
+                   {"temperature": 40, "hold_time_seconds": 35}],
+                  10,
+                  50.5]
+        )
+    assert type(cmd.args[0]) == list
+    assert type(cmd.args[1]) == int
+    assert type(cmd.args[2]) == float

--- a/robot-server/tests/service/legacy/models/test_modules.py
+++ b/robot-server/tests/service/legacy/models/test_modules.py
@@ -1,28 +1,18 @@
-import pytest
 from robot_server.service.legacy.models import modules
 
 
-def test_validate_command_invalid_arg_type():
-    with pytest.raises(ValueError,
-                       match="3 validation errors for SerialCommand\nargs ->"):
-        modules.SerialCommand(
-            command_type="set_temperature",
-            args=["thirty"]
-        )
-
-
-def test_validate_command_arg_type_conversion():
+def test_validate_command_no_type_conversion():
     cmd = modules.SerialCommand(
-            command_type="set_temperature",
+            command_type="a_valid_cmd",
             args=["30"]
         )
-    assert type(cmd.args[0]) == int
-    assert cmd.args[0] == 30
+    assert type(cmd.args[0]) == str
+    assert cmd.args[0] == "30"
 
 
-def test_validate_command_args_all_valid_types():
+def test_validate_command_args_multiple_types():
     cmd = modules.SerialCommand(
-            command_type="a_valid_cmd_type",
+            command_type="a_valid_cmd",
             args=[[{"temperature": 30, "hold_time_seconds": 20},
                    {"temperature": 40, "hold_time_seconds": 35}],
                   10,

--- a/robot-server/tests/service/legacy/routers/test_modules.py
+++ b/robot-server/tests/service/legacy/routers/test_modules.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import patch, PropertyMock
+from unittest.mock import patch, PropertyMock, MagicMock
 
 import pytest
 import asyncio
@@ -290,13 +290,14 @@ def test_execute_module_command_bad_command(api_client, hardware, magdeck):
 def test_execute_module_command_bad_args(api_client, hardware, thermocycler):
     hardware.attached_modules = [thermocycler]
 
-    Thermocycler.wait_for_temp.side_effect = TypeError("found a 'str'")
+    thermocycler.wait_for_temp = MagicMock(side_effect=
+                                           TypeError("found a 'str'"))
 
     resp = api_client.post('modules/dummySerialTC',
                            json={'command_type': 'set_temperature',
                                  'args': ['30']})
     body = resp.json()
-    assert resp.status_code == 500
+    assert resp.status_code == 400
     assert 'message' in body
     assert 'TypeError' in body['message']
 

--- a/robot-server/tests/service/legacy/routers/test_modules.py
+++ b/robot-server/tests/service/legacy/routers/test_modules.py
@@ -290,13 +290,7 @@ def test_execute_module_command_bad_command(api_client, hardware, magdeck):
 def test_execute_module_command_bad_args(api_client, hardware, thermocycler):
     hardware.attached_modules = [thermocycler]
 
-    async def mock_set_temperature(temperature, hold_secs, hold_mins,
-                                   ramp_rate, vol):
-        while temperature > Thermocycler.target:
-            pass
-        return
-
-    Thermocycler.set_temperature.side_effect = mock_set_temperature
+    Thermocycler.wait_for_temp.side_effect = TypeError("found a 'str'")
 
     resp = api_client.post('modules/dummySerialTC',
                            json={'command_type': 'set_temperature',

--- a/robot-server/tests/service/legacy/routers/test_modules.py
+++ b/robot-server/tests/service/legacy/routers/test_modules.py
@@ -7,7 +7,6 @@ from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.modules import MagDeck, Thermocycler, TempDeck
 from opentrons.hardware_control.modules import utils, UpdateError, \
     BundledFirmware
-from typing import List
 
 
 @pytest.fixture
@@ -290,8 +289,8 @@ def test_execute_module_command_bad_command(api_client, hardware, magdeck):
 def test_execute_module_command_bad_args(api_client, hardware, thermocycler):
     hardware.attached_modules = [thermocycler]
 
-    thermocycler.wait_for_temp = MagicMock(side_effect=
-                                           TypeError("found a 'str'"))
+    thermocycler.wait_for_temp = MagicMock(side_effect=TypeError(
+                                                       "found a 'str'"))
 
     resp = api_client.post('modules/dummySerialTC',
                            json={'command_type': 'set_temperature',

--- a/robot-server/tests/service/legacy/routers/test_modules.py
+++ b/robot-server/tests/service/legacy/routers/test_modules.py
@@ -290,13 +290,21 @@ def test_execute_module_command_bad_command(api_client, hardware, magdeck):
 def test_execute_module_command_bad_args(api_client, hardware, thermocycler):
     hardware.attached_modules = [thermocycler]
 
+    async def mock_set_temperature(temperature, hold_secs, hold_mins,
+                                   ramp_rate, vol):
+        while temperature > Thermocycler.target:
+            pass
+        return
+
+    Thermocycler.set_temperature.side_effect = mock_set_temperature
+
     resp = api_client.post('modules/dummySerialTC',
                            json={'command_type': 'set_temperature',
-                                 'args': ['hello']})
+                                 'args': ['30']})
     body = resp.json()
-    assert resp.status_code == 422
+    assert resp.status_code == 500
     assert 'message' in body
-    # assert body['message'] == "command.args.0: value is not a valid float. command.args.0: value is not a valid list"
+    assert 'TypeError' in body['message']
 
 
 def test_execute_module_command_valid_args(api_client, hardware, thermocycler):
@@ -306,33 +314,6 @@ def test_execute_module_command_valid_args(api_client, hardware, thermocycler):
                            json={'command_type': 'set_temperature',
                                  'args': [30]})
     assert resp.status_code == 200
-
-
-def test_execute_module_command_float_to_int_args(api_client,
-                                                  hardware,
-                                                  thermocycler):
-    hardware.attached_modules = [thermocycler]
-    the_args = []
-
-    def mock_cycle_temperatures(steps: List,
-                                repetitions: int,
-                                volume: float = None):
-        the_args = [steps, repetitions, volume]
-
-    Thermocycler.cycle_temperatures.side_effect = mock_cycle_temperatures
-
-    resp = api_client.post('modules/dummySerialTC',
-                           json={'command_type': 'cycle_temperatures',
-                                 'args': [
-                                    [{"temperature": 30,
-                                      "hold_time_seconds": 20},
-                                     {"temperature": 40,
-                                      "hold_time_seconds": 35}],
-                                    10]})
-    assert resp.status_code == 200
-    assert type(the_args[0]) == list
-    assert type(the_args[1]) == int
-    assert type(the_args[2]) == float
 
 
 def test_post_serial_update_no_bundled_fw(api_client, hardware, magdeck):


### PR DESCRIPTION
Closes #5882 

## overview

Updates modules' SerialCommand model (`/robot-server/service/legacy/models`) to accept any type of args. Previously the args were strictly str type which caused type errors while executing module commands since these commands have various arg types.

## changelog

- Changed the modules model to accept `typing.Any` args
- Updated `post_serial_command` (routers/modules) to catch any TypeErrors because of bad args and respond with a helpful message.
- Added tests for modules SerialCommand model
- Added tests for modules routers

## review requests

- Code & tests make sense
- If you have a module, send it a POST request and verify that the command is executed with good args while a helpful response is provided for bad args. (If you have a tempdeck or thermocycler, the pre temp card in the app should now work correctly)

## risk assessment

Low. It's a small change that updates a not too heavily used feature.
