### PR TITLE
fix(scripts): make python_build_utils 2.7 compatible again

### DIFF
--- a/scripts/python_build_utils.py
+++ b/scripts/python_build_utils.py
@@ -41,7 +41,7 @@ def get_version(project, extra_tag=''):
     pkg_json_path = package_entries[project].pkg_json
     builtin_ver = json.load(open(pkg_json_path))['version']
     if extra_tag:
-        version = builtin_ver + f'.dev{extra_tag}'
+        version = builtin_ver + '.dev{}'.format(extra_tag)
     else:
         version = builtin_ver
     return version


### PR DESCRIPTION
there's even a big warning at the top! That I just missed. This needs to
be able to run under python 2.7 for annoying buildroot reasons.
