### PR TITLE
docs(api): Clarify that protocol.comment's message is computed in simulation

### DIFF
--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -621,6 +621,10 @@ class ProtocolContext(CommandPublisher):
         """
         Add a user-readable comment string that will be echoed to the Opentrons
         app.
+        
+        The value of the message is computed during protocol simulation,
+        so cannot be used to communicate real-time information from the robot's
+        actual run.
         """
         pass
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -621,7 +621,7 @@ class ProtocolContext(CommandPublisher):
         """
         Add a user-readable comment string that will be echoed to the Opentrons
         app.
-        
+
         The value of the message is computed during protocol simulation,
         so cannot be used to communicate real-time information from the robot's
         actual run.


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

Clarify that `protocol.comment` does not allow real time communication which one might otherwise guess it did. (I realise use cases where simulation might be different from reality are rare).