### PR TITLE
fix(app-shell): clean up old robot update files

### DIFF
--- a/app-shell/src/buildroot/__tests__/release-files.test.js
+++ b/app-shell/src/buildroot/__tests__/release-files.test.js
@@ -1,0 +1,54 @@
+// @flow
+// TODO(mc, 2020-06-11): test all release-files functions
+import path from 'path'
+import { promises as fs } from 'fs'
+import fse from 'fs-extra'
+import tempy from 'tempy'
+
+import { cleanupReleaseFiles } from '../release-files'
+
+describe('buildroot release files utilities', () => {
+  const tempDirs: Array<string> = []
+  const makeEmptyDir = (): string => {
+    const dir: string = tempy.directory()
+    tempDirs.push(dir)
+    return dir
+  }
+
+  afterAll(() => {
+    return Promise.all(tempDirs.map(d => fse.remove(d)))
+  })
+
+  describe('cleanupReleaseFiles', () => {
+    it('should leave current version files alone', () => {
+      const dir = makeEmptyDir()
+      const releaseDir = path.join(dir, '4.0.0')
+
+      return fs
+        .mkdir(releaseDir)
+        .then(() => cleanupReleaseFiles(dir, '4.0.0'))
+        .then(() => fs.readdir(dir))
+        .then(files => {
+          expect(files).toEqual(['4.0.0'])
+        })
+    })
+
+    it('should delete other directories', () => {
+      const dir = makeEmptyDir()
+      const releaseDir = path.join(dir, '4.0.0')
+      const oldReleaseDir = path.join(dir, '3.9.0')
+      const olderReleaseDir = path.join(dir, '3.8.0')
+
+      return Promise.all([
+        fs.mkdir(releaseDir),
+        fs.mkdir(oldReleaseDir),
+        fs.mkdir(olderReleaseDir),
+      ])
+        .then(() => cleanupReleaseFiles(dir, '4.0.0'))
+        .then(() => fs.readdir(dir))
+        .then(files => {
+          expect(files).toEqual(['4.0.0'])
+        })
+    })
+  })
+})

--- a/app-shell/src/buildroot/index.js
+++ b/app-shell/src/buildroot/index.js
@@ -8,7 +8,11 @@ import { createLogger } from '../log'
 import { getConfig } from '../config'
 import { CURRENT_VERSION } from '../update'
 import { downloadManifest, getReleaseSet } from './release-manifest'
-import { getReleaseFiles, readUserFileInfo } from './release-files'
+import {
+  getReleaseFiles,
+  readUserFileInfo,
+  cleanupReleaseFiles,
+} from './release-files'
 import { startPremigration, uploadSystemFile } from './update'
 
 import type { Action, Dispatch } from '../types'
@@ -170,6 +174,10 @@ export function checkForBuildrootUpdate(dispatch: Dispatch): Promise<mixed> {
       .catch((error: Error) =>
         dispatch({ type: 'buildroot:DOWNLOAD_ERROR', payload: error.message })
       )
+      .then(() => cleanupReleaseFiles(DIRECTORY, CURRENT_VERSION))
+      .catch((error: Error) => {
+        log.warn('Unable to cleanup old release files', { error })
+      })
   })
 }
 

--- a/app-shell/src/buildroot/release-files.js
+++ b/app-shell/src/buildroot/release-files.js
@@ -1,11 +1,10 @@
 // @flow
 // functions for downloading and storing release files
-// TODO(mc, 2019-07-02): cleanup old downloads
 import assert from 'assert'
 import path from 'path'
 import { promisify } from 'util'
 import tempy from 'tempy'
-import { move, readdir } from 'fs-extra'
+import { move, readdir, remove } from 'fs-extra'
 import StreamZip from 'node-stream-zip'
 import getStream from 'get-stream'
 
@@ -124,4 +123,17 @@ export function readUserFileInfo(systemFile: string): Promise<UserFileInfo> {
 
     return result
   })
+}
+
+export function cleanupReleaseFiles(
+  downloadsDir: string,
+  currentRelease: string
+): void {
+  return readdir(downloadsDir)
+    .then(files => {
+      return files
+        .filter(f => f !== currentRelease)
+        .map(f => path.join(downloadsDir, f))
+    })
+    .then(removals => Promise.all(removals.map(f => remove(f))))
 }


### PR DESCRIPTION
## overview

This PR adds old robot update file cleanup to the app-shell's buildroot module. The cleanup is run after the current release is successfully download, and is allowed to fail (with a log message).

Closes #4667

## changelog

- fix(app-shell): clean up old robot update files

## review requests

Note: due to the build bug fixed by #5886, this test plan won't currently work on `edge` because there's no release available for `3.19.0-alpha.1`. To test, **manually set your `app-shell/package.json` version to 3.19.0-alpha.0** before running `make -C app dev`

1. Check the contents of your Robot OS downloads folder
    - On macOS: `ls ~/Library/Application\ Support/Opentrons/__ot_buildroot__`
2. Notice that there are probably a bunch of folders in there
3. Open the app and wait a few seconds
4. Check your Robot OS downloads folder again
    - [ ] Folder should only contain the Robot OS update for your app's current version

## risk assessment

Low. Tests for this are more integration tests than unit tests (they test with the actual filesystem), the cleanup runs _after_ the UI is notified about the available update, and the cleanup can fail without affecting the update process.
