### PR TITLE
chore: add mypy stuff to eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,7 @@
 api/**
 update-server/**
 robot-server/**
+shared-data/python/**
 **/node_modules/**
 **/coverage/**
 **/dist/**
@@ -18,3 +19,6 @@ discovery-client/lib/**
 **/package.json
 **/CHANGELOG.md
 lerna.json
+
+# mypy
+**/.mypy_cache/**


### PR DESCRIPTION
This means we won't be trying to format internal caching stuff from
mypy, among other things
