### PR TITLE
chore(build): fix pypi test deploy again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ jobs:
             QUIET=1 BUILD_NUMBER=${TRAVIS_BUILD_NUMBER} make clean-py deploy-py pypi_username=${TEST_PYPI_USER} pypi_password=${TEST_PYPI_PASSWORD} twine_repository_url="https://test.pypi.org/legacy/"
           on:
             repo: Opentrons/opentrons
-            branch: edge
+            all_branches: true
 
     # test, build, and upload for JavaScript projects
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ jobs:
             QUIET=1 BUILD_NUMBER=${TRAVIS_BUILD_NUMBER} make clean-py deploy-py pypi_username=${TEST_PYPI_USER} pypi_password=${TEST_PYPI_PASSWORD} twine_repository_url="https://test.pypi.org/legacy/"
           on:
             repo: Opentrons/opentrons
-            all_branches: true
+            branch: edge
 
     # test, build, and upload for JavaScript projects
     - stage: test

--- a/shared-data/python/Makefile
+++ b/shared-data/python/Makefile
@@ -73,7 +73,7 @@ push: push-no-restart
 
 .PHONY: deploy
 deploy: wheel
-	$(call python_upload_package,$(twine_auth_args),$(twine_repository_url),../$(wheel_file))
+	$(call python_upload_package,$(twine_auth_args),$(twine_repository_url),$(wheel_file))
 
 .PHONY: test
 test:


### PR DESCRIPTION
Deploys were breaking after I moved the python makefile tasks in shared-data to a subdirectory

## When is this no longer a draft?
- When the build passes and the deploy goes ok and i revert the change that deploys on all branches