### PR TITLE
fix(app): restart MDNS browser when network interfaces change

### DIFF
--- a/app-shell/src/system-info/index.js
+++ b/app-shell/src/system-info/index.js
@@ -16,6 +16,8 @@ import type { Action, Dispatch } from '../types'
 import type { UsbDeviceMonitor, Device } from './usb-devices'
 import type { NetworkInterfaceMonitor } from './network-interfaces'
 
+export { createNetworkInterfaceMonitor }
+
 const RE_REALTEK = /realtek/i
 const IFACE_POLL_INTERVAL_MS = 30000
 

--- a/app/src/discovery/__tests__/epic.test.js
+++ b/app/src/discovery/__tests__/epic.test.js
@@ -1,6 +1,7 @@
 import { TestScheduler } from 'rxjs/testing'
 
-import * as actions from '../actions'
+import * as Shell from '../../shell'
+import * as Actions from '../actions'
 import { discoveryEpic } from '../epic'
 
 describe('discovery actions', () => {
@@ -14,22 +15,33 @@ describe('discovery actions', () => {
 
   it('startDiscoveryEpic with default timeout', () => {
     testScheduler.run(({ hot, expectObservable }) => {
-      const action$ = hot('-a', { a: actions.startDiscovery() })
+      const action$ = hot('-a', { a: Actions.startDiscovery() })
       const output$ = discoveryEpic(action$)
 
       expectObservable(output$).toBe('- 30000ms a ', {
-        a: actions.finishDiscovery(),
+        a: Actions.finishDiscovery(),
       })
     })
   })
 
   it('startDiscoveryEpic with specified timeout', () => {
     testScheduler.run(({ hot, expectObservable }) => {
-      const action$ = hot('-a', { a: actions.startDiscovery(42) })
+      const action$ = hot('-a', { a: Actions.startDiscovery(42) })
       const output$ = discoveryEpic(action$)
 
       expectObservable(output$).toBe('- 42ms a ', {
-        a: actions.finishDiscovery(),
+        a: Actions.finishDiscovery(),
+      })
+    })
+  })
+
+  it('startDiscoveryEpic with shell:UI_INITIALIZED', () => {
+    testScheduler.run(({ hot, expectObservable }) => {
+      const action$ = hot('-a', { a: Shell.uiInitialized() })
+      const output$ = discoveryEpic(action$)
+
+      expectObservable(output$).toBe('- 30000ms a ', {
+        a: Actions.finishDiscovery(),
       })
     })
   })
@@ -45,7 +57,7 @@ describe('discovery actions', () => {
       const output$ = discoveryEpic(action$)
 
       expectObservable(output$).toBe('-a ', {
-        a: actions.startDiscovery(60000),
+        a: Actions.startDiscovery(60000),
       })
     })
   })

--- a/app/src/discovery/epic.js
+++ b/app/src/discovery/epic.js
@@ -3,9 +3,11 @@ import { of } from 'rxjs'
 import { filter, switchMap, delay } from 'rxjs/operators'
 import { ofType, combineEpics } from 'redux-observable'
 
+import { UI_INITIALIZED } from '../shell'
 import { DISCOVERY_START, startDiscovery, finishDiscovery } from './actions'
 
 import type { Epic } from '../types'
+import type { UiInitializedAction } from '../shell/types'
 import type { DiscoveryAction, StartDiscoveryAction } from './types'
 
 export const DISCOVERY_TIMEOUT_MS = 30000
@@ -13,11 +15,16 @@ export const RESTART_DISCOVERY_TIMEOUT_MS = 60000
 
 export const startDiscoveryEpic: Epic = action$ =>
   action$.pipe(
-    ofType(DISCOVERY_START),
-    switchMap<StartDiscoveryAction, _, DiscoveryAction>(startAction => {
-      const timeout = startAction.payload.timeout || DISCOVERY_TIMEOUT_MS
-      return of(finishDiscovery()).pipe(delay(timeout))
-    })
+    ofType(DISCOVERY_START, UI_INITIALIZED),
+    switchMap<StartDiscoveryAction | UiInitializedAction, _, DiscoveryAction>(
+      startAction => {
+        const timeout = startAction.payload
+          ? startAction.payload.timeout ?? DISCOVERY_TIMEOUT_MS
+          : DISCOVERY_TIMEOUT_MS
+
+        return of(finishDiscovery()).pipe(delay(timeout))
+      }
+    )
   )
 
 // TODO(mc, 2019-08-01): handle restart requests using robot-api actions


### PR DESCRIPTION
## overview

PR from pairing with @sanni-t. Fixes #5343; see ticket for details and acceptance criteria.

Also fixes an unreleased regression with the discovery spinner never stopping introduced by #5874 

## changelog

- fix(app): restart MDNS browser when network interfaces change

## review requests

Test plan:

1. Start the app with your USB-to-Ethernet robot **unplugged**
2. While the discovery spinner is going, plug the robot in
3. The robot should show up without you needing to click "try again"
    - Depending on how long your computer takes to get the network interface activated with a self-assigned IP address, the spinner may time out before the robot shows up
    - This is ok as long as the robot still (eventually) shows up

For the spinner regression:

- [ ] Discovery spinner ends after 30 seconds like it's supposed to

## risk assessment

Low. This PR repurposes the (already tested) network interface monitoring logic from the app's `system-info` module and adds unit tests to cover its logic
