### PR TITLE
refactor(app): limit preloaded shell remote to ipcRenderer

### DIFF
--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -14,7 +14,6 @@ module.exports = {
       to: './ui',
       filter: ['**/*'],
     },
-    'build/release-notes.md',
     'build/br-premigration-wheels',
     '!Makefile',
   ],

--- a/app-shell/src/discovery.js
+++ b/app-shell/src/discovery.js
@@ -107,12 +107,6 @@ export function registerDiscovery(dispatch: Dispatch): Action => mixed {
   }
 }
 
-export function getRobots(): Array<Service> {
-  if (!client) return []
-
-  return client.services
-}
-
 function filterServicesToPersist(services: Array<Service>) {
   const candidateOverrides = getOverrides('discovery.candidates')
   if (!candidateOverrides) return client.services

--- a/app-shell/src/exports.js
+++ b/app-shell/src/exports.js
@@ -1,4 +1,0 @@
-// @flow
-// remote exports entry-point for the preload script to remote-load
-export { getRobots } from './discovery'
-export { CURRENT_VERSION, CURRENT_RELEASE_NOTES } from './update'

--- a/app-shell/src/preload.js
+++ b/app-shell/src/preload.js
@@ -2,15 +2,6 @@
 // preload script for renderer process
 // defines subset of Electron API that renderer process is allowed to access
 // for security reasons
-import { ipcRenderer, remote } from 'electron'
+import { ipcRenderer } from 'electron'
 
-const { getRobots, CURRENT_VERSION, CURRENT_RELEASE_NOTES } = remote.require(
-  './exports'
-)
-
-global.APP_SHELL_REMOTE = {
-  ipcRenderer,
-  CURRENT_VERSION,
-  CURRENT_RELEASE_NOTES,
-  INITIAL_ROBOTS: getRobots(),
-}
+global.APP_SHELL_REMOTE = { ipcRenderer }

--- a/app-shell/src/update.js
+++ b/app-shell/src/update.js
@@ -1,7 +1,5 @@
 // @flow
 // app updater
-import path from 'path'
-import fs from 'fs'
 import { autoUpdater as updater } from 'electron-updater'
 
 import { UI_INITIALIZED } from '@opentrons/app/src/shell/actions'
@@ -15,11 +13,6 @@ updater.logger = createLogger('update')
 updater.autoDownload = false
 
 export const CURRENT_VERSION: string = updater.currentVersion.version
-export const CURRENT_RELEASE_NOTES: string = fs.readFileSync(
-  // NOTE: __dirname refers to output directory
-  path.join(__dirname, '../build/release-notes.md'),
-  'utf8'
-)
 
 export function registerUpdate(dispatch: Dispatch): Action => mixed {
   return function handleAction(action: Action) {

--- a/app-shell/webpack.config.js
+++ b/app-shell/webpack.config.js
@@ -5,7 +5,6 @@ const webpackMerge = require('webpack-merge')
 const { nodeBaseConfig } = require('@opentrons/webpack-config')
 
 const ENTRY_MAIN = path.join(__dirname, 'src/main.js')
-const ENTRY_EXPORTS = path.join(__dirname, 'src/exports.js')
 const ENTRY_PRELOAD = path.join(__dirname, 'src/preload.js')
 const OUTPUT_PATH = path.join(__dirname, 'lib')
 
@@ -15,7 +14,7 @@ module.exports = [
   // main process (runs in electron)
   webpackMerge(nodeBaseConfig, COMMON_CONFIG, {
     target: 'electron-main',
-    entry: { main: ENTRY_MAIN, exports: ENTRY_EXPORTS },
+    entry: { main: ENTRY_MAIN },
   }),
 
   // preload script (runs in the browser window)

--- a/app/src/discovery/__tests__/reducer.test.js
+++ b/app/src/discovery/__tests__/reducer.test.js
@@ -1,15 +1,6 @@
 // discovery reducer test
 import { discoveryReducer } from '../reducer'
 
-jest.mock('../../shell/remote', () => ({
-  remote: {
-    INITIAL_ROBOTS: [
-      { name: 'foo', ip: '192.168.1.1', port: 31950 },
-      { name: 'bar', ip: '192.168.1.2', port: 31950 },
-    ],
-  },
-}))
-
 describe('discoveryReducer', () => {
   afterEach(() => {
     jest.clearAllMocks()
@@ -17,15 +8,12 @@ describe('discoveryReducer', () => {
 
   const SPECS = [
     {
-      name: 'pulls initial robot list from shell and sets scanning to false',
+      name: 'empty dict for robotsByName and sets scanning to false',
       action: {},
       initialState: undefined,
       expectedState: {
         scanning: false,
-        robotsByName: {
-          foo: [{ name: 'foo', ip: '192.168.1.1', port: 31950 }],
-          bar: [{ name: 'bar', ip: '192.168.1.2', port: 31950 }],
-        },
+        robotsByName: {},
       },
     },
     {

--- a/app/src/discovery/reducer.js
+++ b/app/src/discovery/reducer.js
@@ -2,7 +2,6 @@
 // robot discovery state
 import groupBy from 'lodash/groupBy'
 import { UI_INITIALIZED } from '../shell'
-import { remote } from '../shell/remote'
 import * as actions from './actions'
 
 import type { Action } from '../types'
@@ -14,7 +13,7 @@ export const normalizeRobots = (robots: Array<Service> = []): RobotsMap => {
 
 export const INITIAL_STATE: DiscoveryState = {
   scanning: false,
-  robotsByName: normalizeRobots(remote.INITIAL_ROBOTS),
+  robotsByName: {},
 }
 
 export function discoveryReducer(

--- a/app/src/shell/__mocks__/remote.js
+++ b/app/src/shell/__mocks__/remote.js
@@ -7,10 +7,4 @@ class MockIpcRenderer extends EventEmitter {
   send = jest.fn()
 }
 
-export const remote = {
-  ipcRenderer: new MockIpcRenderer(),
-  CURRENT_VERSION: '0.0.0',
-  CURRENT_RELEASE_NOTES: 'Release notes for 0.0.0',
-  INITIAL_CONFIG: {},
-  INITIAL_ROBOTS: [],
-}
+export const remote = { ipcRenderer: new MockIpcRenderer() }

--- a/app/src/shell/index.js
+++ b/app/src/shell/index.js
@@ -1,13 +1,11 @@
 // @flow
 // desktop shell module
 
-import { remote } from './remote'
-
-const { CURRENT_VERSION, CURRENT_RELEASE_NOTES } = remote
+import pkg from '../../package.json'
 
 export * from './actions'
 export * from './update'
 export * from './robot-logs/actions'
 export * from './robot-logs/selectors'
 
-export { CURRENT_VERSION, CURRENT_RELEASE_NOTES }
+export const CURRENT_VERSION: string = pkg.version

--- a/app/src/shell/types.js
+++ b/app/src/shell/types.js
@@ -1,13 +1,9 @@
 // @flow
-import type { Service } from '@opentrons/discovery-client'
 import type { Error } from '../types'
 import type { RobotLogsState, RobotLogsAction } from './robot-logs/types'
 
 export type Remote = {|
   ipcRenderer: {| send: (string, ...args: Array<mixed>) => void |},
-  CURRENT_VERSION: string,
-  CURRENT_RELEASE_NOTES: string,
-  INITIAL_ROBOTS: Array<Service>,
 |}
 
 export type UpdateInfo = {


### PR DESCRIPTION
## overview

This PR removes everything from the app's preloaded remote module except for the IPC channel. Closes #5900 

## changelog

- refactor(app): limit preloaded shell remote to ipcRenderer

## review requests

- [ ] App should continue to function normally
    - Robot discovery list
    - App version info card on "More" page

## risk assessment

Low, mostly removals
