### PR TITLE
fix(app): use troubleshooting link when calcheck fails at tip pickup

### DIFF
--- a/app/src/components/CheckCalibration/BadCalibration.js
+++ b/app/src/components/CheckCalibration/BadCalibration.js
@@ -10,13 +10,13 @@ const TO_TROUBLESHOOT = 'To troubleshoot this issue:'
 const TIP_RACK_CENTERED = 'Confirm your tip rack is centered in its slot'
 const USE_OPENTRONS_TIPS = 'Confirm you are using Opentrons brand tips'
 const PERFORM_CALIBRATION =
-  'If you continue to see this error, please perform a deck calibration and then try again. View'
+  'If you continue to see this error, view'
 const THIS_ARTICLE = 'this article'
-const LEARN_MORE = 'to learn more'
+const LEARN_MORE = 'to troubleshoot'
 const BAD_ROBOT_CALIBRATION_CHECK_BUTTON_TEXT = 'Drop tip in trash and exit'
 
 const DECK_CAL_ARTICLE_URL =
-  'https://support.opentrons.com/en/articles/2687620-get-started-calibrate-the-deck'
+  'https://support.opentrons.com/en/articles/4028788-checking-your-ot-2-s-calibration'
 type BadCalibrationProps = {|
   deleteSession: () => mixed,
 |}

--- a/app/src/components/CheckCalibration/BadCalibration.js
+++ b/app/src/components/CheckCalibration/BadCalibration.js
@@ -9,8 +9,7 @@ const SUMMARY =
 const TO_TROUBLESHOOT = 'To troubleshoot this issue:'
 const TIP_RACK_CENTERED = 'Confirm your tip rack is centered in its slot'
 const USE_OPENTRONS_TIPS = 'Confirm you are using Opentrons brand tips'
-const PERFORM_CALIBRATION =
-  'If you continue to see this error, view'
+const PERFORM_CALIBRATION = 'If you continue to see this error, view'
 const THIS_ARTICLE = 'this article'
 const LEARN_MORE = 'to troubleshoot'
 const BAD_ROBOT_CALIBRATION_CHECK_BUTTON_TEXT = 'Drop tip in trash and exit'


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

In calibration check, if the tip pickup location seems very wrong, the user gets an "unable to check robot calibration" screen. This screen says to redo deck calibration.

This matches the *design,* but I think this it's technically wrong? The problem could also be with pipette calibration. Therefore, the app should link to broader troubleshooting steps.

## changelog

* Changed that link from [Get started: Calibrate the deck](https://support.opentrons.com/en/articles/2687620-get-started-calibrate-the-deck) to [Checking your OT-2's calibration](https://support.opentrons.com/en/articles/4028788-checking-your-ot-2-s-calibration), which should be where the other pages link when they detect an ambiguous calibration error.
* Changed copy to match ("troubleshoot" instead of "learn more").
* Avoided renaming any variables, to keep the diff as simple as possible.

## review requests

Make sure my understanding of the underlying calibration problem is correct.

## risk assessment

Low. Copy edits only.
