### PR TITLE
fix(api): Fix failing test from edge due to kwarg check

### DIFF
--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -110,7 +110,9 @@ async def test_location_cache(loop, monkeypatch, get_labware_def, hardware):
     # To avoid modifying the hardware fixture, we should change the
     # gantry calibration inside this test.
     ctx._hw_manager.hardware.update_config(
-        gantry_calibration=identity_deck_transform())
+        gantry_calibration=[
+            [1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]])
     right = ctx.load_instrument('p10_single', Mount.RIGHT)
     lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 1)
     ctx.home()

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -13,7 +13,6 @@ from opentrons.hardware_control.types import Axis
 from opentrons.config.pipette_config import config_models
 from opentrons.protocol_api import transfers as tf
 from opentrons.protocols.types import APIVersion
-from opentrons.util.linal import identity_deck_transform
 
 import pytest
 

--- a/robot-server/tests/integration/test_deck_calibration.tavern.yaml
+++ b/robot-server/tests/integration/test_deck_calibration.tavern.yaml
@@ -212,7 +212,7 @@ stages:
       status_code: 200
       json:
         deckCalibration:
-          status: IDENTITY
+          status: OK
           data:
             - &matrix_row
               - !anyfloat


### PR DESCRIPTION
Test was failing in edge due to kwargs if statement being unable to compare a numpy array.
