### PR TITLE
refactor(app): fix race condition introduced by async anayltics init

### DIFF
--- a/app/src/analytics/__tests__/epic.test.js
+++ b/app/src/analytics/__tests__/epic.test.js
@@ -126,7 +126,7 @@ describe('analytics epics', () => {
       })
     })
 
-    it('noops on no change in status', () => {
+    it('noops on no change in status or if config not yet initialized', () => {
       testScheduler.run(({ hot, expectObservable, flush }) => {
         const action$ = hot('----')
         const state$ = hot('-a-b', { a: on, b: on })
@@ -150,6 +150,16 @@ describe('analytics epics', () => {
       testScheduler.run(({ hot, expectObservable, flush }) => {
         const action$ = hot('----')
         const state$ = hot('-a-b', { a: { config: null }, b: { config: null } })
+        const output$ = analyticsEpic(action$, state$)
+
+        expectObservable(output$).toBe('----')
+        flush()
+        expect(setMixpanelTracking).toHaveBeenCalledTimes(0)
+      })
+
+      testScheduler.run(({ hot, expectObservable, flush }) => {
+        const action$ = hot('----')
+        const state$ = hot('-a-b', { a: { config: null }, b: on })
         const output$ = analyticsEpic(action$, state$)
 
         expectObservable(output$).toBe('----')

--- a/app/src/analytics/epic.js
+++ b/app/src/analytics/epic.js
@@ -52,8 +52,13 @@ const sendAnalyticsEventEpic: Epic = (action$, state$) => {
 const optIntoAnalyticsEpic: Epic = (_, state$) => {
   return state$.pipe(
     map<State, AnalyticsConfig | null>(getAnalyticsConfig),
+    // this epic is for runtime changes in opt-in (not initialization)
+    // ensure config exists so it doesn't conflict with initialzeAnalyticsEpic
+    filter<AnalyticsConfig | null, AnalyticsConfig>(
+      maybeConfig => maybeConfig !== null
+    ),
     pairwise(),
-    filter(([prev, next]) => next !== null && prev?.optedIn !== next?.optedIn),
+    filter(([prev, next]) => prev.optedIn !== next.optedIn),
     tap(([_, config]: [mixed, AnalyticsConfig]) => setMixpanelTracking(config)),
     ignoreElements()
   )


### PR DESCRIPTION
## overview

#5874 switched the app's MixPanel module from sync loading at launch to async loading when the app-shell sent over the config. This introduced a race condition where the app's previously existing logic to change the user's opt-in status in response to user initiated events would erroneously fire at config init, because it saw a change from `null` to "opted in or out".

This PR ensures the runtime opt-in change only fires after the config is fully loaded to avoid opt-in changes conflicting with (or rather, happening before) mixpanel is initialized.

Closes #5970

## changelog

- refactor(app): fix race condition introduced by async anayltics init
     - *Refactor* rather than "fix" because bug was never released

## review requests

- [ ] App launches without logging a big old mixpanel warning
    - You can test this with the branch build or with the dev task with `OT_APP_MIXPANEL_ID` set
    - Hit me up in slack if you need the mixpanel ID for testing

## risk assessment

Low. Bug easily caught by unit tests
