### PR TITLE
feat(components): add primitive btns and fix useHover on disabled buttons

### DIFF
--- a/app/src/components/CheckCalibration/styles.css
+++ b/app/src/components/CheckCalibration/styles.css
@@ -25,16 +25,12 @@
 }
 
 .intro_header {
-  @apply --modal-contents;
-
   font-weight: bold;
   margin-bottom: 1rem;
   font-size: var('--fs-body-2');
 }
 
 .intro_content {
-  @apply --modal-contents;
-
   margin-bottom: 1rem;
   font-size: var('--fs-body-2');
 }

--- a/app/src/components/RobotSettings/CheckCalibrationControl.js
+++ b/app/src/components/RobotSettings/CheckCalibrationControl.js
@@ -10,6 +10,7 @@ import {
   Flex,
   Box,
   Text,
+  SecondaryBtn,
   ALIGN_CENTER,
   SIZE_2,
   SPACING_1,
@@ -25,7 +26,7 @@ import {
 
 import { Portal } from '../portal'
 import { CheckCalibration } from '../CheckCalibration'
-import { TitledButton } from '../TitledButton'
+import { TitledControl } from '../TitledControl'
 
 import type { State } from '../../types'
 
@@ -76,25 +77,23 @@ export function CheckCalibrationControl({
   }, [requestStatus])
 
   // TODO(mc, 2020-06-17): extract alert presentational stuff
-  // TODO(lc, 2020-06-18): edit calCheckDisabled to check for a bad calibration status from the new endpoint
   return (
     <>
-      <TitledButton
+      <TitledControl
         borderBottom={BORDER_SOLID_LIGHT}
         title={CHECK_ROBOT_CAL}
         description={<Text>{CHECK_ROBOT_CAL_DESCRIPTION}</Text>}
-        buttonProps={{
-          children: buttonChildren,
-          disabled: buttonDisabled,
-          onClick: ensureSession,
-          // TODO(mc, 2020-06-18): we _still_ can't attach tooltips directly
-          // to disabled buttons because of pointer-events: none. fix this
-          hoverToolTipHandler: targetProps,
-        }}
+        control={
+          <SecondaryBtn
+            {...targetProps}
+            width="9rem"
+            onClick={ensureSession}
+            disabled={buttonDisabled}
+          >
+            {buttonChildren}
+          </SecondaryBtn>
+        }
       >
-        {disabledReason !== null && (
-          <Tooltip {...tooltipProps}>{disabledReason}</Tooltip>
-        )}
         {requestState && requestState.status === RobotApi.FAILURE && (
           <Flex
             alignItems={ALIGN_CENTER}
@@ -111,7 +110,10 @@ export function CheckCalibrationControl({
             </Box>
           </Flex>
         )}
-      </TitledButton>
+      </TitledControl>
+      {disabledReason !== null && (
+        <Tooltip {...tooltipProps}>{disabledReason}</Tooltip>
+      )}
       {showWizard && (
         <Portal>
           <CheckCalibration

--- a/app/src/components/RobotSettings/CheckCalibrationControl.js
+++ b/app/src/components/RobotSettings/CheckCalibrationControl.js
@@ -94,6 +94,9 @@ export function CheckCalibrationControl({
           </SecondaryBtn>
         }
       >
+        {disabledReason !== null && (
+          <Tooltip {...tooltipProps}>{disabledReason}</Tooltip>
+        )}
         {requestState && requestState.status === RobotApi.FAILURE && (
           <Flex
             alignItems={ALIGN_CENTER}
@@ -111,9 +114,6 @@ export function CheckCalibrationControl({
           </Flex>
         )}
       </TitledControl>
-      {disabledReason !== null && (
-        <Tooltip {...tooltipProps}>{disabledReason}</Tooltip>
-      )}
       {showWizard && (
         <Portal>
           <CheckCalibration

--- a/app/src/components/RobotSettings/ControlsCard.js
+++ b/app/src/components/RobotSettings/ControlsCard.js
@@ -9,6 +9,7 @@ import {
   Text,
   LabeledToggle,
   LabeledButton,
+  SecondaryBtn,
   BORDER_SOLID_LIGHT,
   SPACING_2,
 } from '@opentrons/components'
@@ -30,7 +31,7 @@ import { CONNECTABLE } from '../../discovery'
 import type { State, Dispatch } from '../../types'
 import type { ViewableRobot } from '../../discovery/types'
 
-import { TitledButton } from '../TitledButton'
+import { TitledControl } from '../TitledControl'
 import { CheckCalibrationControl } from './CheckCalibrationControl'
 import { DeckCalibrationWarning } from './DeckCalibrationWarning'
 
@@ -100,21 +101,26 @@ export function ControlsCard(props: Props): React.Node {
 
   return (
     <Card title={TITLE} disabled={notConnectable}>
-      <TitledButton
+      {/* TODO(mc, 2020-06-22): move to DeckCalibrationControl component */}
+      <TitledControl
         borderBottom={BORDER_SOLID_LIGHT}
         title="Calibrate deck"
         description={<Text>{CALIBRATE_DECK_DESCRIPTION}</Text>}
-        buttonProps={{
-          onClick: startCalibration,
-          disabled: buttonDisabled,
-          children: 'Calibrate',
-        }}
+        control={
+          <SecondaryBtn
+            width="9rem"
+            onClick={startCalibration}
+            disabled={buttonDisabled}
+          >
+            Calibrate
+          </SecondaryBtn>
+        }
       >
         <DeckCalibrationWarning
           deckCalibrationStatus={deckCalStatus}
           marginTop={SPACING_2}
         />
-      </TitledButton>
+      </TitledControl>
       <LabeledButton
         label="Home all axes"
         buttonProps={{

--- a/app/src/components/RobotSettings/__tests__/CheckCalibrationControl.test.js
+++ b/app/src/components/RobotSettings/__tests__/CheckCalibrationControl.test.js
@@ -10,7 +10,7 @@ import { mockRobot } from '../../../robot-api/__fixtures__'
 
 import { Icon, Tooltip } from '@opentrons/components'
 import { Portal } from '../../portal'
-import { TitledButton } from '../../TitledButton'
+import { TitledControl } from '../../TitledControl'
 import { CheckCalibration } from '../../CheckCalibration'
 import { CheckCalibrationControl } from '../CheckCalibrationControl'
 
@@ -46,16 +46,12 @@ describe('CheckCalibrationControl', () => {
     jest.resetAllMocks()
   })
 
-  it('should render a TitledButton', () => {
+  it('should render a TitledControl', () => {
     const wrapper = render({ disabledReason: null })
-    const titledButton = wrapper.find(TitledButton)
+    const titledButton = wrapper.find(TitledControl)
 
     expect(titledButton.prop('title')).toBe('Check robot calibration')
     expect(titledButton.html()).toMatch(/check the robot's calibration state/i)
-    expect(titledButton.prop('buttonProps')).toMatchObject({
-      children: 'Check',
-      disabled: false,
-    })
   })
 
   it('should be able to disable the button', () => {

--- a/app/src/components/RobotSettings/__tests__/ControlsCard.test.js
+++ b/app/src/components/RobotSettings/__tests__/ControlsCard.test.js
@@ -58,7 +58,7 @@ describe('ControlsCard', () => {
   let render
 
   const getDeckCalButton = wrapper =>
-    wrapper.find('TitledButton[title="Calibrate deck"]').find('button')
+    wrapper.find('TitledControl[title="Calibrate deck"]').find('button')
 
   const getCheckCalibrationControl = wrapper =>
     wrapper.find(CheckCalibrationControl)

--- a/app/src/components/TitledControl/__tests__/TitledControl.test.js
+++ b/app/src/components/TitledControl/__tests__/TitledControl.test.js
@@ -3,19 +3,18 @@
 import * as React from 'react'
 import { mount } from 'enzyme'
 
-import { TitledButton } from '..'
+import { TitledControl } from '..'
 
-describe('TitledButton', () => {
-  const handleClick = jest.fn()
+describe('TitledControl', () => {
   const render = () => {
     return mount(
-      <TitledButton
+      <TitledControl
         title="Great title"
         description={<span data-test="cool-description" />}
-        buttonProps={{ children: 'click me', onClick: handleClick }}
+        control={<button data-test="control" />}
       >
         <span data-test="child" />
-      </TitledButton>
+      </TitledControl>
     )
   }
 
@@ -35,11 +34,7 @@ describe('TitledButton', () => {
 
   it('should have a button', () => {
     const wrapper = render()
-    const button = wrapper.find('button')
-
-    expect(button.children().html()).toBe('click me')
-    button.simulate('click')
-    expect(handleClick).toHaveBeenCalled()
+    expect(wrapper.exists('[data-test="control"]')).toBe(true)
   })
 
   it('should render children', () => {

--- a/app/src/components/TitledControl/index.js
+++ b/app/src/components/TitledControl/index.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react'
 import {
-  OutlineButton,
   Box,
   Flex,
   Text,
@@ -15,23 +14,23 @@ import {
   FONT_WEIGHT_SEMIBOLD,
 } from '@opentrons/components'
 
-import type { StyleProps, ButtonProps } from '@opentrons/components'
+import type { StyleProps } from '@opentrons/components'
 
-export type TitledButtonProps = {|
+export type TitledControlProps = {|
   title: string,
   description: React.Node,
-  buttonProps: ButtonProps,
+  control?: React.Node,
   children?: React.Node,
   ...StyleProps,
 |}
 
-export function TitledButton({
+export function TitledControl({
   title,
   description,
-  buttonProps,
+  control,
   children,
   ...styleProps
-}: TitledButtonProps): React.Node {
+}: TitledControlProps): React.Node {
   return (
     <Box fontSize={FONT_SIZE_BODY_1} padding={SPACING_3} {...styleProps}>
       <Flex alignItems={ALIGN_START}>
@@ -45,9 +44,11 @@ export function TitledButton({
           </Text>
           {description}
         </Box>
-        <Box paddingTop={SPACING_1} flex={FLEX_NONE}>
-          <OutlineButton {...buttonProps} />
-        </Box>
+        {Boolean(control) && (
+          <Box paddingTop={SPACING_1} flex={FLEX_NONE}>
+            {control}
+          </Box>
+        )}
       </Flex>
       {children}
     </Box>

--- a/components/src/buttons/Button.js
+++ b/components/src/buttons/Button.js
@@ -6,9 +6,11 @@ import omit from 'lodash/omit'
 import { Icon, type IconName } from '../icons'
 import styles from './buttons.css'
 
-export const BUTTON_TYPE_SUBMIT: 'submit' = 'submit'
-export const BUTTON_TYPE_RESET: 'reset' = 'reset'
-export const BUTTON_TYPE_BUTTON: 'button' = 'button'
+import {
+  BUTTON_TYPE_SUBMIT,
+  BUTTON_TYPE_RESET,
+  BUTTON_TYPE_BUTTON,
+} from '../primitives'
 
 export type ButtonProps = {
   /** click handler */
@@ -44,10 +46,13 @@ export type ButtonProps = {
     'aria-describedby': string,
     onMouseEnter: () => mixed,
     onMouseLeave: () => mixed,
+    onPointerEnter: () => mixed,
+    onPointerLeave: () => mixed,
     ...
   }>,
   /** html tabindex property */
   tabIndex?: number,
+  ...
 }
 
 // props to strip if using a custom component

--- a/components/src/interaction-enhancers/__tests__/useHover.test.js
+++ b/components/src/interaction-enhancers/__tests__/useHover.test.js
@@ -36,7 +36,7 @@ describe('useHover hook', () => {
     const target = wrapper.find(TARGET_SELECTOR)
 
     act(() => {
-      target.simulate('mouseEnter')
+      target.simulate('pointerEnter')
     })
 
     expect(result[0]).toBe(true)
@@ -47,11 +47,11 @@ describe('useHover hook', () => {
     const target = wrapper.find(TARGET_SELECTOR)
 
     act(() => {
-      target.simulate('mouseEnter')
+      target.simulate('pointerEnter')
     })
 
     act(() => {
-      target.simulate('mouseLeave')
+      target.simulate('pointerLeave')
     })
 
     expect(result[0]).toBe(false)
@@ -64,7 +64,7 @@ describe('useHover hook', () => {
     const target = wrapper.find(TARGET_SELECTOR)
 
     act(() => {
-      target.simulate('mouseEnter')
+      target.simulate('pointerEnter')
     })
 
     expect(result[0]).toBe(false)
@@ -83,8 +83,8 @@ describe('useHover hook', () => {
     const target = wrapper.find(TARGET_SELECTOR)
 
     act(() => {
-      target.simulate('mouseEnter')
-      target.simulate('mouseLeave')
+      target.simulate('pointerEnter')
+      target.simulate('pointerLeave')
       jest.advanceTimersByTime(42)
     })
 
@@ -98,8 +98,8 @@ describe('useHover hook', () => {
     const target = wrapper.find(TARGET_SELECTOR)
 
     act(() => {
-      target.simulate('mouseEnter')
-      target.simulate('mouseLeave')
+      target.simulate('pointerEnter')
+      target.simulate('pointerLeave')
     })
 
     expect(result[0]).toBe(true)
@@ -118,9 +118,9 @@ describe('useHover hook', () => {
     const target = wrapper.find(TARGET_SELECTOR)
 
     act(() => {
-      target.simulate('mouseEnter')
-      target.simulate('mouseLeave')
-      target.simulate('mouseEnter')
+      target.simulate('pointerEnter')
+      target.simulate('pointerLeave')
+      target.simulate('pointerEnter')
       jest.advanceTimersByTime(42)
     })
 
@@ -138,7 +138,7 @@ describe('useHover hook', () => {
     const target = wrapper.find(TARGET_SELECTOR)
 
     act(() => {
-      target.simulate('mouseEnter')
+      target.simulate('pointerEnter')
       wrapper.unmount()
       jest.advanceTimersByTime(0)
     })

--- a/components/src/interaction-enhancers/useHover.js
+++ b/components/src/interaction-enhancers/useHover.js
@@ -7,8 +7,8 @@ export type UseHoverOptions = $Shape<{|
 |}>
 
 export type HoverHandlers = {|
-  onMouseEnter: () => mixed,
-  onMouseLeave: () => mixed,
+  onPointerEnter: () => mixed,
+  onPointerLeave: () => mixed,
 |}
 
 export type UseHoverResult = [boolean, HoverHandlers]
@@ -52,8 +52,8 @@ export function useHover(options: UseHoverOptions = {}): UseHoverResult {
 
   const handlers = useMemo(
     () => ({
-      onMouseEnter: () => handleHoverChange(true, enterDelay),
-      onMouseLeave: () => handleHoverChange(false, leaveDelay),
+      onPointerEnter: () => handleHoverChange(true, enterDelay),
+      onPointerLeave: () => handleHoverChange(false, leaveDelay),
     }),
     [handleHoverChange, enterDelay, leaveDelay]
   )

--- a/components/src/primitives/Btn.js
+++ b/components/src/primitives/Btn.js
@@ -1,0 +1,145 @@
+// @flow
+import styled, { css } from 'styled-components'
+
+import * as Styles from '../styles'
+import { styleProps, isntStyleProp } from './style-props'
+
+import type { PrimitiveComponent } from './types'
+
+export const BUTTON_TYPE_SUBMIT: 'submit' = 'submit'
+export const BUTTON_TYPE_RESET: 'reset' = 'reset'
+export const BUTTON_TYPE_BUTTON: 'button' = 'button'
+
+const BUTTON_BASE_STYLE = css`
+  appearance: none;
+  padding: 0;
+  border-width: 0;
+  border-style: solid;
+  background-color: transparent;
+  cursor: pointer;
+
+  &:disabled {
+    cursor: default;
+  }
+`
+
+const BUTTON_VARIANT_STYLE = css`
+  border-color: inherit;
+  border-radius: ${Styles.BORDER_RADIUS_DEFAULT};
+  font-size: ${Styles.FONT_SIZE_BODY_2};
+  font-weight: ${Styles.FONT_WEIGHT_SEMIBOLD};
+  line-height: 1.4;
+  padding-left: ${Styles.SPACING_4};
+  padding-right: ${Styles.SPACING_4};
+  padding-top: ${Styles.SPACING_2};
+  padding-bottom: ${Styles.SPACING_2};
+  text-transform: ${Styles.TEXT_TRANSFORM_UPPERCASE};
+`
+
+type BtnComponent = PrimitiveComponent<HTMLButtonElement>
+
+/**
+ * Button primitive
+ *
+ * @component
+ */
+export const Btn: BtnComponent = styled.button
+  .withConfig({
+    shouldForwardProp: isntStyleProp,
+  })
+  .attrs((props: { type?: string, ... }) => ({
+    type: props.type ?? BUTTON_TYPE_BUTTON,
+  }))`
+  ${BUTTON_BASE_STYLE}
+  ${styleProps}
+`
+
+/**
+ * Primary button variant
+ *
+ * @component
+ */
+// $FlowFixMe(mc, 2020-06-19): styled type definition expects PrimitiveComponent<typeof Btn>, but it doesn't work in usage
+export const PrimaryBtn: BtnComponent = styled(Btn)`
+  ${BUTTON_VARIANT_STYLE}
+  background-color: ${Styles.C_DARK_GRAY};
+  color: ${Styles.C_WHITE};
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.2);
+
+  &:hover,
+  &:focus {
+    background-color: ${Styles.C_BLACK};
+  }
+
+  &:active {
+    background-color: ${Styles.C_MED_DARK_GRAY};
+  }
+
+  &:disabled {
+    background-color: ${Styles.C_LIGHT_GRAY};
+    color: ${Styles.C_MED_GRAY};
+    box-shadow: none;
+  }
+`
+
+/**
+ * Secondary button variant
+ *
+ * @component
+ */
+// $FlowFixMe(mc, 2020-06-19): styled type definition expects PrimitiveComponent<typeof Btn>, but it doesn't work in usage
+export const SecondaryBtn: BtnComponent = styled(Btn)`
+  ${BUTTON_VARIANT_STYLE}
+  background-color: ${Styles.C_WHITE};
+  border-width: ${Styles.BORDER_WIDTH_THIN};
+  color: ${Styles.C_DARK_GRAY};
+
+  &:hover,
+  &:focus {
+    background-color: ${Styles.C_LIGHT_GRAY};
+  }
+
+  &:active {
+    background-color: ${Styles.C_MED_LIGHT_GRAY};
+  }
+
+  &:disabled {
+    background-color: ${Styles.C_WHITE};
+    color: ${Styles.C_MED_GRAY};
+  }
+`
+
+/**
+ * Light secondary button variant
+ *
+ * @component
+ */
+// $FlowFixMe(mc, 2020-06-19): styled type definition expects PrimitiveComponent<typeof Btn>, but it doesn't work in usage
+export const LightSecondaryBtn: BtnComponent = styled(SecondaryBtn)`
+  background-color: ${Styles.C_TRANSPARENT};
+  color: ${Styles.C_WHITE};
+
+  &:hover,
+  &:focus {
+    background-color: ${Styles.OVERLAY_WHITE_10};
+  }
+
+  &:active {
+    background-color: ${Styles.OVERLAY_WHITE_20};
+  }
+
+  &:disabled {
+    background-color: ${Styles.C_TRANSPARENT};
+    color: ${Styles.C_MED_GRAY};
+  }
+`
+
+/**
+ * Tertiary button variant
+ *
+ * @component
+ */
+// $FlowFixMe(mc, 2020-06-19): styled type definition expects PrimitiveComponent<typeof Btn>, but it doesn't work in usage
+export const TertiaryBtn: BtnComponent = styled(LightSecondaryBtn)`
+  border-width: 0;
+`

--- a/components/src/primitives/Btn.js
+++ b/components/src/primitives/Btn.js
@@ -91,7 +91,7 @@ export const PrimaryBtn: BtnComponent = styled(Btn)`
 export const SecondaryBtn: BtnComponent = styled(Btn)`
   ${BUTTON_VARIANT_STYLE}
   background-color: ${Styles.C_WHITE};
-  border-width: ${Styles.BORDER_WIDTH_THIN};
+  border-width: ${Styles.BORDER_WIDTH_DEFAULT};
   color: ${Styles.C_DARK_GRAY};
 
   &:hover,

--- a/components/src/primitives/Btn.md
+++ b/components/src/primitives/Btn.md
@@ -1,0 +1,51 @@
+Like our Button component, but smaller (in code)! Renders an unstyled `<button>` by default and accepts all primitive styling props.
+
+```js
+<>
+  <Btn onClick={() => console.log('hello world')}>click me</Btn>
+  <Btn marginLeft="1rem" disabled>
+    but not me
+  </Btn>
+</>
+```
+
+We have different styled variants of buttons available:
+
+```js
+import {
+  Box,
+  PrimaryBtn,
+  SecondaryBtn,
+  LightSecondaryBtn,
+  TertiaryBtn,
+  C_DARK_GRAY,
+  SPACING_2,
+  SPACING_3,
+} from '@opentrons/components'
+;<>
+  <Box paddingX={SPACING_3} paddingY={SPACING_2}>
+    <PrimaryBtn>primary</PrimaryBtn>
+    <PrimaryBtn marginLeft={SPACING_3} disabled>
+      not clickable
+    </PrimaryBtn>
+  </Box>
+  <Box paddingX={SPACING_3} padding={SPACING_2}>
+    <SecondaryBtn>secondary</SecondaryBtn>
+    <SecondaryBtn marginLeft={SPACING_3} disabled>
+      not clickable
+    </SecondaryBtn>
+  </Box>
+  <Box paddingX={SPACING_3} padding={SPACING_2} backgroundColor={C_DARK_GRAY}>
+    <LightSecondaryBtn>light secondary</LightSecondaryBtn>
+    <LightSecondaryBtn marginLeft={SPACING_3} disabled>
+      not clickable
+    </LightSecondaryBtn>
+  </Box>
+  <Box paddingX={SPACING_3} padding={SPACING_2} backgroundColor={C_DARK_GRAY}>
+    <TertiaryBtn>tertiary</TertiaryBtn>
+    <TertiaryBtn marginLeft={SPACING_3} disabled>
+      not clickable
+    </TertiaryBtn>
+  </Box>
+</>
+```

--- a/components/src/primitives/README.md
+++ b/components/src/primitives/README.md
@@ -83,6 +83,8 @@ Note: If you specify both of a shorthand prop and the explicit prop (e.g. `margi
 | `borderBottom` | `border-bottom` |
 | `borderLeft`   | `border-left`   |
 | `borderRadius` | `border-radius` |
+| `borderWidth`  | `border-width`  |
+| `borderColor`  | `border-color`  |
 
 ```js static
 import {

--- a/components/src/primitives/__tests__/Btn.test.js
+++ b/components/src/primitives/__tests__/Btn.test.js
@@ -12,7 +12,7 @@ import {
   BUTTON_TYPE_RESET,
 } from '..'
 
-describe('Link primitive component', () => {
+describe('Btn primitive component', () => {
   it('should be an <button> with css reset and type: button', () => {
     const wrapper = shallow(<Btn />)
 
@@ -44,7 +44,6 @@ describe('Link primitive component', () => {
 
   it('should allow type to be changed', () => {
     const wrapper = shallow(<Btn type={BUTTON_TYPE_SUBMIT} />)
-
     expect(wrapper.find('button').prop('type')).toBe('submit')
 
     wrapper.setProps({ type: BUTTON_TYPE_RESET })

--- a/components/src/primitives/__tests__/Btn.test.js
+++ b/components/src/primitives/__tests__/Btn.test.js
@@ -1,0 +1,237 @@
+// @flow
+import * as React from 'react'
+import { shallow } from 'enzyme'
+
+import {
+  Btn,
+  PrimaryBtn,
+  SecondaryBtn,
+  LightSecondaryBtn,
+  TertiaryBtn,
+  BUTTON_TYPE_SUBMIT,
+  BUTTON_TYPE_RESET,
+} from '..'
+
+describe('Link primitive component', () => {
+  it('should be an <button> with css reset and type: button', () => {
+    const wrapper = shallow(<Btn />)
+
+    expect(wrapper).toHaveStyleRule('appearance', 'none')
+    expect(wrapper).toHaveStyleRule('cursor', 'pointer')
+    expect(wrapper).toHaveStyleRule('padding', '0')
+    expect(wrapper).toHaveStyleRule('border-width', '0')
+    expect(wrapper).toHaveStyleRule('border-style', 'solid')
+    expect(wrapper).toHaveStyleRule('background-color', 'transparent')
+    expect(wrapper.find('button').prop('type')).toBe('button')
+  })
+
+  it('should be clickable', () => {
+    const handleClick = jest.fn()
+    const wrapper = shallow(<Btn onClick={handleClick} />)
+
+    wrapper.find('button').simulate('click')
+    expect(handleClick).toHaveBeenCalled()
+  })
+
+  it('should render children', () => {
+    const wrapper = shallow(
+      <Btn>
+        <span data-test="child" />
+      </Btn>
+    )
+    expect(wrapper.exists('[data-test="child"]')).toBe(true)
+  })
+
+  it('should allow type to be changed', () => {
+    const wrapper = shallow(<Btn type={BUTTON_TYPE_SUBMIT} />)
+
+    expect(wrapper.find('button').prop('type')).toBe('submit')
+
+    wrapper.setProps({ type: BUTTON_TYPE_RESET })
+    expect(wrapper.find('button').prop('type')).toBe('reset')
+  })
+
+  it('should set cursor to default when disabled', () => {
+    const wrapper = shallow(<Btn type={BUTTON_TYPE_SUBMIT} disabled />)
+
+    expect(wrapper).toHaveStyleRule('cursor', 'default', {
+      modifier: ':disabled',
+    })
+  })
+
+  describe('variants', () => {
+    it('should render a primary button variant', () => {
+      const wrapper = shallow(<PrimaryBtn />)
+
+      expect(wrapper).toHaveStyleRule('background-color', '#4a4a4a')
+      expect(wrapper).toHaveStyleRule('border-radius', '2px')
+      expect(wrapper).toHaveStyleRule('color', '#ffffff')
+      expect(wrapper).toHaveStyleRule('font-size', '0.875rem')
+      expect(wrapper).toHaveStyleRule('font-weight', '600')
+      expect(wrapper).toHaveStyleRule('line-height', '1.4')
+      expect(wrapper).toHaveStyleRule('padding-left', '2rem')
+      expect(wrapper).toHaveStyleRule('padding-right', '2rem')
+      expect(wrapper).toHaveStyleRule('padding-top', '0.5rem')
+      expect(wrapper).toHaveStyleRule('padding-bottom', '0.5rem')
+      expect(wrapper).toHaveStyleRule('text-transform', 'uppercase')
+
+      // focus
+      expect(wrapper).toHaveStyleRule('background-color', '#000000', {
+        modifier: ':focus',
+      })
+
+      // hover
+      expect(wrapper).toHaveStyleRule('background-color', '#000000', {
+        modifier: ':hover',
+      })
+
+      // active
+      expect(wrapper).toHaveStyleRule('background-color', '#6c6c6c', {
+        modifier: ':active',
+      })
+
+      // disabled
+      expect(wrapper).toHaveStyleRule('background-color', '#e6e6e6', {
+        modifier: ':disabled',
+      })
+      expect(wrapper).toHaveStyleRule('color', '#9b9b9b', {
+        modifier: ':disabled',
+      })
+    })
+
+    it('should render a secondary button variant', () => {
+      const wrapper = shallow(<SecondaryBtn />)
+
+      expect(wrapper).toHaveStyleRule('background-color', '#ffffff')
+      expect(wrapper).toHaveStyleRule('border-radius', '2px')
+      expect(wrapper).toHaveStyleRule('border-width', '1px')
+      expect(wrapper).toHaveStyleRule('color', '#4a4a4a')
+      expect(wrapper).toHaveStyleRule('font-size', '0.875rem')
+      expect(wrapper).toHaveStyleRule('font-weight', '600')
+      expect(wrapper).toHaveStyleRule('line-height', '1.4')
+      expect(wrapper).toHaveStyleRule('padding-left', '2rem')
+      expect(wrapper).toHaveStyleRule('padding-right', '2rem')
+      expect(wrapper).toHaveStyleRule('padding-top', '0.5rem')
+      expect(wrapper).toHaveStyleRule('padding-bottom', '0.5rem')
+      expect(wrapper).toHaveStyleRule('text-transform', 'uppercase')
+
+      // focus
+      expect(wrapper).toHaveStyleRule('background-color', '#e6e6e6', {
+        modifier: ':focus',
+      })
+
+      // hover
+      expect(wrapper).toHaveStyleRule('background-color', '#e6e6e6', {
+        modifier: ':hover',
+      })
+
+      // active
+      expect(wrapper).toHaveStyleRule('background-color', '#d2d2d2', {
+        modifier: ':active',
+      })
+
+      // disabled
+      expect(wrapper).toHaveStyleRule('background-color', '#ffffff', {
+        modifier: ':disabled',
+      })
+      expect(wrapper).toHaveStyleRule('color', '#9b9b9b', {
+        modifier: ':disabled',
+      })
+    })
+
+    it('should render a light secondary button variant', () => {
+      const wrapper = shallow(<LightSecondaryBtn />)
+
+      expect(wrapper).toHaveStyleRule('background-color', 'transparent')
+      expect(wrapper).toHaveStyleRule('border-radius', '2px')
+      expect(wrapper).toHaveStyleRule('border-width', '1px')
+      expect(wrapper).toHaveStyleRule('color', '#ffffff')
+      expect(wrapper).toHaveStyleRule('font-size', '0.875rem')
+      expect(wrapper).toHaveStyleRule('font-weight', '600')
+      expect(wrapper).toHaveStyleRule('line-height', '1.4')
+      expect(wrapper).toHaveStyleRule('padding-left', '2rem')
+      expect(wrapper).toHaveStyleRule('padding-right', '2rem')
+      expect(wrapper).toHaveStyleRule('padding-top', '0.5rem')
+      expect(wrapper).toHaveStyleRule('padding-bottom', '0.5rem')
+      expect(wrapper).toHaveStyleRule('text-transform', 'uppercase')
+
+      // focus
+      expect(wrapper).toHaveStyleRule(
+        'background-color',
+        'rgba(255,255,255,0.1)',
+        {
+          modifier: ':focus',
+        }
+      )
+
+      // hover
+      expect(wrapper).toHaveStyleRule(
+        'background-color',
+        'rgba(255,255,255,0.1)',
+        {
+          modifier: ':hover',
+        }
+      )
+
+      // disabled
+      expect(wrapper).toHaveStyleRule('background-color', 'transparent', {
+        modifier: ':disabled',
+      })
+      expect(wrapper).toHaveStyleRule('color', '#9b9b9b', {
+        modifier: ':disabled',
+      })
+    })
+
+    it('should render a tertiary button variant', () => {
+      const wrapper = shallow(<TertiaryBtn />)
+
+      expect(wrapper).toHaveStyleRule('background-color', 'transparent')
+      expect(wrapper).toHaveStyleRule('border-radius', '2px')
+      expect(wrapper).toHaveStyleRule('border-width', '0')
+      expect(wrapper).toHaveStyleRule('color', '#ffffff')
+      expect(wrapper).toHaveStyleRule('font-size', '0.875rem')
+      expect(wrapper).toHaveStyleRule('font-weight', '600')
+      expect(wrapper).toHaveStyleRule('line-height', '1.4')
+      expect(wrapper).toHaveStyleRule('padding-left', '2rem')
+      expect(wrapper).toHaveStyleRule('padding-right', '2rem')
+      expect(wrapper).toHaveStyleRule('padding-top', '0.5rem')
+      expect(wrapper).toHaveStyleRule('padding-bottom', '0.5rem')
+      expect(wrapper).toHaveStyleRule('text-transform', 'uppercase')
+
+      // focus
+      expect(wrapper).toHaveStyleRule(
+        'background-color',
+        'rgba(255,255,255,0.1)',
+        {
+          modifier: ':focus',
+        }
+      )
+
+      // hover
+      expect(wrapper).toHaveStyleRule(
+        'background-color',
+        'rgba(255,255,255,0.1)',
+        {
+          modifier: ':hover',
+        }
+      )
+
+      // active
+      expect(wrapper).toHaveStyleRule(
+        'background-color',
+        'rgba(255,255,255,0.2)',
+        {
+          modifier: ':active',
+        }
+      )
+
+      // disabled
+      expect(wrapper).toHaveStyleRule('background-color', 'transparent', {
+        modifier: ':disabled',
+      })
+      expect(wrapper).toHaveStyleRule('color', '#9b9b9b', {
+        modifier: ':disabled',
+      })
+    })
+  })
+})

--- a/components/src/primitives/index.js
+++ b/components/src/primitives/index.js
@@ -1,6 +1,7 @@
 // @flow
 export * from './style-props'
 export * from './Box'
+export * from './Btn'
 export * from './Flex'
 export * from './Link'
 export * from './Text'

--- a/components/src/primitives/style-props.js
+++ b/components/src/primitives/style-props.js
@@ -43,6 +43,8 @@ const BORDER_PROPS = [
   'borderBottom',
   'borderLeft',
   'borderRadius',
+  'borderWidth',
+  'borderColor',
 ]
 
 const FLEXBOX_PROPS = [

--- a/components/src/primitives/types.js
+++ b/components/src/primitives/types.js
@@ -42,6 +42,8 @@ export type BorderProps = {|
   borderBottom?: string,
   borderLeft?: string,
   borderRadius?: string | number,
+  borderWidth?: string | number,
+  borderColor?: string,
 |}
 
 export type FlexboxProps = {|

--- a/components/src/styles/borders.js
+++ b/components/src/styles/borders.js
@@ -4,6 +4,7 @@ import { C_LIGHT_GRAY } from './colors'
 
 export const BORDER_WIDTH_DEFAULT = '1px'
 
+export const BORDER_WIDTH_THIN = '1px'
 export const BORDER_RADIUS_DEFAULT = '2px'
 
 export const BORDER_STYLE_NONE = 'none'

--- a/components/src/styles/borders.js
+++ b/components/src/styles/borders.js
@@ -4,7 +4,6 @@ import { C_LIGHT_GRAY } from './colors'
 
 export const BORDER_WIDTH_DEFAULT = '1px'
 
-export const BORDER_WIDTH_THIN = '1px'
 export const BORDER_RADIUS_DEFAULT = '2px'
 
 export const BORDER_STYLE_NONE = 'none'

--- a/components/src/styles/colors.js
+++ b/components/src/styles/colors.js
@@ -3,16 +3,22 @@
 // color names
 export const C_BLACK = '#000000'
 export const C_DARK_GRAY = '#4a4a4a'
+export const C_MED_DARK_GRAY = '#6c6c6c'
 export const C_MED_GRAY = '#9b9b9b'
+export const C_MED_LIGHT_GRAY = '#d2d2d2'
 export const C_LIGHT_GRAY = '#e6e6e6'
 export const C_WHITE = '#ffffff'
-export const C_ORANGE = '#f5a623'
+export const C_TRANSPARENT = 'transparent'
 
 // colors by usage
 export const COLOR_DISABLED = '#9c9c9c'
 export const COLOR_WARNING = '#e28200'
 export const COLOR_WARNING_LIGHT = '#ffd58f'
 export const COLOR_ERROR = '#d12929'
+
+// overlays
+export const OVERLAY_WHITE_10 = 'rgba(255, 255, 255, 0.1)'
+export const OVERLAY_WHITE_20 = 'rgba(255, 255, 255, 0.2)'
 
 // opacities
 export const OPACITY_DISABLED = 0.3

--- a/components/src/tooltips/__tests__/useHoverTooltip.test.js
+++ b/components/src/tooltips/__tests__/useHoverTooltip.test.js
@@ -60,14 +60,14 @@ describe('useHoverTooltip', () => {
     expect(tooltip.props()).toMatchObject(otherTooltipProps)
   })
 
-  it('attaches onMouseEnter handler to target props with enter delay', () => {
+  it('attaches onPointerEnter handler to target props with enter delay', () => {
     jest.useFakeTimers()
 
     const wrapper = render()
     const target = wrapper.find('[data-test="target"]')
 
     act(() => {
-      target.invoke('onMouseEnter')()
+      target.invoke('onPointerEnter')()
     })
     wrapper.update()
 
@@ -84,16 +84,16 @@ describe('useHoverTooltip', () => {
     wrapper.unmount()
   })
 
-  it('attaches onMouseLeave handler to target props without leave delay', () => {
+  it('attaches onPointerLeave handler to target props without leave delay', () => {
     jest.useFakeTimers()
 
     const wrapper = render()
     const target = wrapper.find('[data-test="target"]')
 
     act(() => {
-      target.invoke('onMouseEnter')()
+      target.invoke('onPointerEnter')()
       jest.runTimersToTime(300)
-      target.invoke('onMouseLeave')()
+      target.invoke('onPointerLeave')()
     })
     wrapper.update()
 
@@ -110,7 +110,7 @@ describe('useHoverTooltip', () => {
     const target = wrapper.find('[data-test="target"]')
 
     act(() => {
-      target.invoke('onMouseEnter')()
+      target.invoke('onPointerEnter')()
       jest.runTimersToTime(300)
     })
     wrapper.update()
@@ -135,8 +135,8 @@ describe('useHoverTooltip', () => {
     const target = wrapper.find('[data-test="target"]')
 
     act(() => {
-      target.invoke('onMouseEnter')()
-      target.invoke('onMouseLeave')()
+      target.invoke('onPointerEnter')()
+      target.invoke('onPointerLeave')()
     })
     wrapper.update()
 


### PR DESCRIPTION
## overview

A _very_ common pattern that comes up when using our buttons is: "display a tooltip when this button is disabled". There are two problems that prevent us from doing this easily with out current button components:

- When disabled, our existing button CSS adds `pointer-events: none` to the button node, preventing enter and leave events
- When a `<button>` is disabled, React will not trigger `mouseleave` events (nor `mouseenter` events, starting at [React v16.13](https://github.com/facebook/react/blob/master/CHANGELOG.md#react-dom-1)), even if `pointer-events` aren't touched and **sometimes even if the handlers are attached to the button's parent**

This PR tackles both of these issues so that we can easily display tooltips on disabled buttons:

- Added new buttons in `primitives` that don't come with any of our existing button baggage:
    - `<Btn>` - `<button>` with CSS reset and default `type="button"`
    - `<PrimaryBtn>` - `<Btn>` styled to look like a "Primary Button" from the Zeplin components guide
    - `<SecondaryBtn>` - `<Btn>` styled to look like a "Secondary Button" from the Zeplin components guide
    - `<LightSecondaryBtn>` - `<Btn>` styled to look like a "Light Secondary Button" from the Zeplin components guide
    - `<TertiaryBtn>` - `<Btn>` styled to look like a "Tertiary Button" from the Zeplin components guide
- Switched the `useHover` hook from [MouseEvents](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) to [PointerEvents](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent)
    - [Browser support for the PointerEvent API](https://caniuse.com/#feat=mdn-api_pointerevent)

## changelog

- feat(components): add primitive btns and fix useHover on disabled buttons
- reafactor(app): Switch several `<OutlineButton>` components to `<SecondaryBtn>` components to demonstrate usage and tooltips

## review requests

- [ ] Buttons look good
    - <https://s3-us-west-2.amazonaws.com/opentrons-components/components_prmitive-btn/index.html#btn>
- [ ] Change from mouse events to pointer events make sense
    - **Other hover tooltips in our codebase didn't break**
    - It all looks to be working to me after clicking around PD in macOS Firefox v77
- [ ] Disabled "Check Calibration" control in the app's robot page displays a tooltip when disabled

Components where `useHoverTooltip` is used and smoke testing is needed

- `app/src/components/CheckCalibration/EndOfStepComparisons.js`
- `app/src/components/CheckCalibration/PipetteComparisons.js`
- `app/src/components/RobotSettings/CheckCalibrationControl.js`
- `protocol-designer/src/components/StepCreationButton.js`
- `protocol-designer/src/components/modals/EditModulesModal/index.js`
- `protocol-designer/src/components/modules/ModuleRow.js`
- `protocol-designer/src/components/StepEditForm/fields/ProfileItemRows.js`
- `protocol-designer/src/components/StepEditForm/fields/ChangeTipField/ChangeTip.js`
- `protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.js`
- `protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.js`
- `protocol-designer/src/components/steplist/AspirateDispenseHeader.js`
- `protocol-designer/src/components/steplist/MixHeader.js`
- `protocol-designer/src/components/steplist/ModuleStepItems.js`
- `protocol-designer/src/components/steplist/SubstepRow.js`

## risk assessment

Button are important and this changes the handlers used **for all existing usages of `useHoverTooltip`**, so this is medium risk. The following mitigation steps were taken:

- Heavily tested the new Btn components down to CSS via jest-styled-components
- Avoided touching existing `<Button>` components
- Only switched out two existing buttons in the app


