### PR TITLE
chore(*): Tweak issue and PR template formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,16 +20,16 @@ To ensure your issue can be addressed quickly, please fill out the sections belo
 Use this section to describe your bug at a high level. Please include any issues you can find that may be related.
 -->
 
-# Current behavior
-
-<!--
-Describe how the software currently behaves and how that differs from how you think the software should behave.
--->
-
 # Steps to reproduce
 
 <!--
 If this is a bug report and there are specific steps we can take to reproduce the bug, please list them here. This is a good place to put things like software version, hardware version, and operating system.
+-->
+
+# Current behavior
+
+<!--
+Describe how the software currently behaves and how that differs from how you think the software should behave.
 -->
 
 # Expected behavior

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: File a bug
-title: 'bug:'
+title: 'bug: '
 labels: 'bug'
 assignees: ''
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,33 +7,33 @@ assignees: ''
 ---
 
 <!--
-  Thanks for taking the time to file an issue! Please make sure you've read the "Opening Issues" section of our Contributing Guide:
+Thanks for taking the time to file an issue! Please make sure you've read the "Opening Issues" section of our Contributing Guide:
 
-  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-issues
+https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-issues
 
-  To ensure your issue can be addressed quickly, please fill out the sections below to the best of your ability!
+To ensure your issue can be addressed quickly, please fill out the sections below to the best of your ability!
 -->
 
 # Overview
 
 <!--
-  Use this section to describe your bug at a high level. Please include any issues you can find that may be related.
+Use this section to describe your bug at a high level. Please include any issues you can find that may be related.
 -->
 
 # Current behavior
 
 <!--
-  Describe how the software currently behaves and how that differs from how you think the software should behave.
+Describe how the software currently behaves and how that differs from how you think the software should behave.
 -->
 
 # Steps to reproduce
 
 <!--
-  If this is a bug report and there are specific steps we can take to reproduce the bug, please list them here. This is a good place to put things like software version, hardware version, and operating system.
+If this is a bug report and there are specific steps we can take to reproduce the bug, please list them here. This is a good place to put things like software version, hardware version, and operating system.
 -->
 
 # Expected behavior
 
 <!--
-  Describe how you think the software should behave.
+Describe how you think the software should behave.
 -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,35 +7,29 @@ assignees: ''
 ---
 
 <!--
-  Thanks for taking the time to file an issue! Please make sure you've read the
-  "Opening Issues" section of our Contributing Guide:
+  Thanks for taking the time to file an issue! Please make sure you've read the "Opening Issues" section of our Contributing Guide:
 
   https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-issues
 
-  To ensure your issue can be addressed quickly, please fill out the sections
-  below to the best of your ability!
+  To ensure your issue can be addressed quickly, please fill out the sections below to the best of your ability!
 -->
 
 # Overview
 
 <!--
-  Use this section to describe your bug at a high level. Please include any
-  issues you can find that may be related.
+  Use this section to describe your bug at a high level. Please include any issues you can find that may be related.
 -->
 
 # Current behavior
 
 <!--
-  Describe how the software currently behaves and how that differs from how you
-  think the software should behave.
+  Describe how the software currently behaves and how that differs from how you think the software should behave.
 -->
 
 # Steps to reproduce
 
 <!--
-  If this is a bug report and there are specific steps we can take to reproduce
-  the bug, please list them here. This is a good place to put things like
-  software version, hardware version, and operating system.
+  If this is a bug report and there are specific steps we can take to reproduce the bug, please list them here. This is a good place to put things like software version, hardware version, and operating system.
 -->
 
 # Expected behavior

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,33 +7,33 @@ assignees: ''
 ---
 
 <!--
-  Thanks for taking the time to file a feature request! Please make sure you've read the "Opening Issues" section of our Contributing Guide:
+Thanks for taking the time to file a feature request! Please make sure you've read the "Opening Issues" section of our Contributing Guide:
 
-  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-issues
+https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-issues
 
-  To ensure your issue can be addressed quickly, please fill out the sections below to the best of your ability!
+To ensure your issue can be addressed quickly, please fill out the sections below to the best of your ability!
 -->
 
 # Overview
 
 <!--
-  Use this section to describe your issue at a high level. Please include some context about why you want this feature. What would this feature allow you to accomplish? Are there any workarounds you use to partially achieve your goal? Are there any issues you could find that may be related?
+Use this section to describe your issue at a high level. Please include some context about why you want this feature. What would this feature allow you to accomplish? Are there any workarounds you use to partially achieve your goal? Are there any issues you could find that may be related?
 -->
 
 # Implementation details
 
 <!--
-  List any implementation steps, specs, or links to docs here.
+List any implementation steps, specs, or links to docs here.
 -->
 
 # Design
 
 <!--
- Attach design images here or link to applicable Zeplin files.
+Attach design images here or link to applicable Zeplin files.
 -->
 
 # Acceptance criteria
 
 <!--
- A checklist of requirements and/or testing steps that must be complete before this feature is considered complete. This can also be used as a testing plan for associated PRs.
+A checklist of requirements and/or testing steps that must be complete before this feature is considered complete. This can also be used as a testing plan for associated PRs.
 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,13 +7,11 @@ assignees: ''
 ---
 
 <!--
-  Thanks for taking the time to file a feature request! Please make sure you've read the
-  "Opening Issues" section of our Contributing Guide:
+  Thanks for taking the time to file a feature request! Please make sure you've read the "Opening Issues" section of our Contributing Guide:
 
   https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-issues
 
-  To ensure your issue can be addressed quickly, please fill out the sections
-  below to the best of your ability!
+  To ensure your issue can be addressed quickly, please fill out the sections below to the best of your ability!
 -->
 
 # Overview

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,21 @@
 <!--
-  Thanks for taking the time to open a pull request! Please make sure you've
-  read the "Opening Pull Requests" section of our Contributing Guide:
+  Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:
 
   https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests
 
-  To ensure your code is reviewed quickly and thoroughly, please fill out the
-  sections below to the best of your ability!
+  To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
 -->
 
 ## overview
 
 <!--
-  Use this section to describe your pull-request at a high level. If the PR
-  addresses any open issues, please tag the issues here.
+  Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
 -->
 
 ## changelog
 
 <!--
-  List out the changes to the code in this PR. Please try your best to
-  categorize your changes and describe what has changed and why.
+  List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.
 
   Example changelog:
   - Fixed app crash when trying to calibrate an illegal pipette
@@ -38,14 +34,7 @@
 ## risk assessment
 
 <!--
-  Carefully go over your pull request and look at the other parts of the
-  codebase it may affect. Look for the possibility, even if you think it's
-  small, that your change may affect some other part of the system - for
-  instance, changing return tip behavior in protocol may also change the
-  behavior of labware calibration.
+  Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.
 
-  Identify the other parts of the system your codebase may affect, so that in
-  addition to your own review and testing, other people who may not have
-  the system internalized as much as you can focus their attention and testing
-  there.
+  Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,13 +6,13 @@
   To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
 -->
 
-## overview
+# Overview
 
 <!--
   Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
 -->
 
-## changelog
+# Changelog
 
 <!--
   List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.
@@ -25,13 +25,13 @@
   IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
 -->
 
-## review requests
+# Review requests
 
 <!--
   Describe any requests for your reviewers here.
 -->
 
-## risk assessment
+# Risk assessment
 
 <!--
   Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,40 +1,40 @@
 <!--
-  Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:
+Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:
 
-  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests
+https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests
 
-  To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
+To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
 -->
 
 # Overview
 
 <!--
-  Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
+Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
 -->
 
 # Changelog
 
 <!--
-  List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.
+List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.
 
-  Example changelog:
-  - Fixed app crash when trying to calibrate an illegal pipette
-  - Added state to API to track pipette usage
-  - Updated API docs to mention only two pipettes are supported
+Example changelog:
+- Fixed app crash when trying to calibrate an illegal pipette
+- Added state to API to track pipette usage
+- Updated API docs to mention only two pipettes are supported
 
-  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
+IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
 -->
 
 # Review requests
 
 <!--
-  Describe any requests for your reviewers here.
+Describe any requests for your reviewers here.
 -->
 
 # Risk assessment
 
 <!--
-  Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.
+Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.
 
-  Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
+Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
 -->


### PR DESCRIPTION
## overview

Nitpicky formatting tweaks to our bug report, feature request, and pull request templates.

## changelog

1. **Soft-wrap lines.** The templates use `<!-- comments -->` in each section to explain what to fill in. Formerly, lines in these comments were hard-wrapped. Because the GitHub editor uses a variable-width font, and because the browser window can be resized, this looked weird.
1. **Remove indentation,** for the same reasons as above. The former indentation was inconsistent, anyway.
1. **Rearrange bug report sections.** Now, it follows the logical order: "summarize the problem; show me what you did; show me what happened when you did that; tell me what you expected to happen instead." Formerly, the steps to reproduce were between the current behavior and the expected behavior, which felt a little weird.
1. **Use `Sentence case` h1s instead of `lowercase` h2s in the pull request template,** for consistency with the other templates.
1. **Add a missing space to the bug report template title.**

## review requests

None in particular.

## risk assessment

Low.