### PR TITLE
fix(app): loosen config version assert after migration

### DIFF
--- a/app-shell/src/config/migrate.js
+++ b/app-shell/src/config/migrate.js
@@ -114,11 +114,11 @@ export function migrate(prevConfig: ConfigV0 | ConfigV1): Config {
     result = migrateVersion(result)
   }
 
-  if (result.version !== CONFIG_VERSION_LATEST) {
+  if (result.version < CONFIG_VERSION_LATEST) {
     throw new Error(
-      `Config migration failed; expected version ${CONFIG_VERSION_LATEST} but got ${result.version}`
+      `Config migration failed; expected at least version ${CONFIG_VERSION_LATEST} but got ${result.version}`
     )
   }
 
-  return result
+  return ((result: any): Config)
 }


### PR DESCRIPTION
# Overview

When we added config migration to the app, we added an assert to make sure that the config migrates properly. Unfortunately, this assert doesn't handle the migrated config being at a _higher_ level than the "latest", which can happen in the case of regular development or in the case of user downgrades.

# Changelog

- fix(app): loosen config version assert after migration

# Review requests

1. Update your app's config file to have a higher version than is latest (e.g. `2`)
    - This might have already happened to your config file if you were testing #5976 
2. Try to open the app

- [ ] App should open

# Risk assessment

Low