### PR TITLE
feat(api): add warning when a wrong tiprack is used for the pipette in the protocol

### DIFF
--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -191,8 +191,8 @@ def _build_safe_height(from_loc: types.Location,
                     "This may be because the labware is incorrectly defined, "
                     "incorrectly calibrated, or physically too tall. This "
                     "could also be caused by the pipette and its tipracks "
-                    "being mismatched. Please check your labware definitions "
-                    "and calibrations.")
+                    "being mismatched. Please check your protocol, labware "
+                    "definitions and calibrations.")
         from_safety = 0.0  # (ignore since it’s in a max())
 
     return max_many(

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -189,8 +189,10 @@ def _build_safe_height(from_loc: types.Location,
                     f"only be raised to {constraints.instr_max_height} mm "
                     "above the deck. "
                     "This may be because the labware is incorrectly defined, "
-                    "incorrectly calibrated, or physically too tall. Please "
-                    "check your labware definitions and calibrations.")
+                    "incorrectly calibrated, or physically too tall. This "
+                    "could also be caused by the pipette and its tipracks "
+                    "being mismatched. Please check your labware definitions "
+                    "and calibrations.")
         from_safety = 0.0  # (ignore since it’s in a max())
 
     return max_many(

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -27,12 +27,12 @@ AdvancedLiquidHandling = Union[
     List[List[Well]]]
 
 
-VALID_PIP_TIPRACK_COMBO = {
-    '10ul': ['p10', 'p20'],
-    '20ul': ['p10', 'p20'],
-    '200ul': ['p50', 'p300'],
-    '300ul': ['p50', 'p300'],
-    '1000ul': ['p1000']
+VALID_PIP_TIPRACK_VOL = {
+    'p10': [10, 20],
+    'p20': [10, 20],
+    'p50': [200, 300],
+    'p300': [200, 300],
+    'p1000': [1000]
 }
 
 
@@ -134,10 +134,12 @@ class InstrumentContext(CommandPublisher):
         self._default_speed = speed
 
     def _validate_tiprack(self, tiprack: Labware):
+        # TODO AA 2020-06-24 - we should instead add the acceptable Opentrons
+        # tipracks to the pipette as a refactor
         if tiprack._definition['namespace'] == 'opentrons':
-            tiprack_id = tiprack.load_name.split('_')[-1]
-            valid_pips = VALID_PIP_TIPRACK_COMBO.get(tiprack_id)
-            if valid_pips and self.name.split('_')[0] not in valid_pips:
+            tiprack_vol = tiprack.wells()[0].max_volume
+            valid_vols = VALID_PIP_TIPRACK_VOL[self.name.split('_')[0]]
+            if tiprack_vol not in valid_vols:
                 self._log.warning(
                     f'The pipette {self.name} and its tiprack '
                     f'{tiprack.load_name} in slot {tiprack.parent} appear to '


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR does the following:
1. adding a new warning when the wrong **Opentrons** tipracks are using for a pipette (this warning does not work for custom tipracks)
2. updating the LabwareHeightError message to alert user that the mismatched pipette/tiprack combo could be the cause of the error


<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
