### PR TITLE
docs(api): correct .move() example

### DIFF
--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -298,13 +298,10 @@ a reference to the associated :py:class:`.Well` (or :py:class:`.Labware`, or
 slot name, depending on context).
 
 To adjust the position within a well, you can use :py:meth:`.Location.move`.
+Pass it a :py:class:`opentrons.types.Point` representing a 3-dimensional offset.
+It will return a new location, representing the original location with that offset applied.
 
-:py:meth:`.Location.move` takes a single argument, ``point``,
-which should be a :py:class:`opentrons.types.Point`. This is a named tuple
-with elements ``x``, ``y``, and ``z``, representing a 3 dimensional offset.
-
-:py:meth:`.Location.move` returns a new location with that offset applied.
-You can use that location anywhere you could use a well.  For example:
+For example:
 
 .. code-block:: python
 
@@ -315,12 +312,14 @@ You can use that location anywhere you could use a well.  For example:
    def run(protocol):
         plate = protocol.load_labware(
            'corning_24_wellplate_3.4ml_flat', slot='1')
+        
+        # Get the center of well A1.
+        center_location = plate['A1'].center()
+        
+        # Get a location 1 mm right, 1 mm back, and 1 mm up from the center of well A1.
+        adjusted_location = center_location.move(types.Point(x=1, y=1, z=1))
 
-        # Get a location 1 mm right, 1 mm back, and 1 mm up
-        # from the center of well A1.
-        adjusted_location = plate['A1'].center().move(types.Point(x=1, y=1, z=1))
-
-        # Move to that location.
+        # Move to 1 mm right, 1 mm back, and 1 mm up from the center of well A1.
         pipette.move_to(adjusted_location)
 
 .. versionadded:: 2.0

--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -312,10 +312,10 @@ For example:
    def run(protocol):
         plate = protocol.load_labware(
            'corning_24_wellplate_3.4ml_flat', slot='1')
-        
+
         # Get the center of well A1.
         center_location = plate['A1'].center()
-        
+
         # Get a location 1 mm right, 1 mm back, and 1 mm up from the center of well A1.
         adjusted_location = center_location.move(types.Point(x=1, y=1, z=1))
 

--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -297,13 +297,14 @@ representing the combination of a point in space (another named tuple) and
 a reference to the associated :py:class:`.Well` (or :py:class:`.Labware`, or
 slot name, depending on context).
 
-To further change positions, you can use :py:meth:`.Location.move`, which
-lets you move the Location. This function takes a single argument, ``point``,
-which should be a :py:class:`opentrons.types.Point`. This is a named tuple
-with elements ``x``, ``y``, and ``z``, representing a 3 dimensional point.
+To adjust the position within a well, you can use :py:meth:`.Location.move`.
 
-To move a location, you create a :py:class:`.types.Point` representing a
-3d offset and give it to :py:meth:`.Location.move`:
+:py:meth:`.Location.move` takes a single argument, ``point``,
+which should be a :py:class:`opentrons.types.Point`. This is a named tuple
+with elements ``x``, ``y``, and ``z``, representing a 3 dimensional offset.
+
+:py:meth:`.Location.move` returns a new location with that offset applied.
+You can use that location anywhere you could use a well.  For example:
 
 .. code-block:: python
 

--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -314,8 +314,12 @@ To move a location, you create a :py:class:`.types.Point` representing a
    def run(protocol):
         plate = protocol.load_labware(
            'corning_24_wellplate_3.4ml_flat', slot='1')
-        plate['A1'].center().move(
-           types.Point(x=1, y=1, z=1)) # 1mm up, to the right, and towards the
-                                       # back of the robot
+
+        # Get a location 1 mm right, 1 mm back, and 1 mm up
+        # from the center of well A1.
+        adjusted_location = plate['A1'].center().move(types.Point(x=1, y=1, z=1))
+
+        # Move to that location.
+        pipette.move_to(adjusted_location)
 
 .. versionadded:: 2.0


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Fixes #5806.

# Changelog

* In a code sample, use the result of .move() as an adjusted location to which the pipette can be moved, instead of implying .move() does the actual moving.

# Review requests

None in particular.

# Risk assessment

Low.
