### PR TITLE
feat(api): support air gap command in V3+V4 executors

### DIFF
--- a/api/src/opentrons/protocol_api/execute_v3.py
+++ b/api/src/opentrons/protocol_api/execute_v3.py
@@ -153,7 +153,6 @@ def _dispense(instruments: Dict[str, InstrumentContext],
     pipette.dispense(volume, location)
 
 
-# TODO IMMEDIATELY: copy-pasted
 def _air_gap(instruments: Dict[str, InstrumentContext],
              loaded_labware: Dict[str, labware.Labware],
              params: 'StandardLiquidHandlingParams') -> None:
@@ -162,8 +161,14 @@ def _air_gap(instruments: Dict[str, InstrumentContext],
     offset_from_bottom = params['offsetFromBottomMm']
     volume = params['volume']
     _set_flow_rate(pipette, params)
-    # TODO IMMEDIATELY: must subtract well z dim (height)
-    offset_from_top = offset_from_bottom
+    well = _get_well(loaded_labware, params)
+    offset_from_top = offset_from_bottom - well._depth
+
+    # NOTE(IL, 2020-06-25): air_gap API fn is stateful, uses location
+    # cache. The JSON atomic command should be stateless. We'll
+    # explicitly move_to the specified well to ensure the location
+    # cache is set to that well.
+    pipette.move_to(well.top().move(Point(0, 0, offset_from_top)))
     pipette.air_gap(volume, offset_from_top)
 
 

--- a/api/src/opentrons/protocol_api/execute_v3.py
+++ b/api/src/opentrons/protocol_api/execute_v3.py
@@ -168,7 +168,7 @@ def _air_gap(instruments: Dict[str, InstrumentContext],
     # cache. The JSON atomic command should be stateless. We'll
     # explicitly move_to the specified well to ensure the location
     # cache is set to that well.
-    pipette.move_to(well.top().move(Point(0, 0, offset_from_top)))
+    pipette.move_to(well.top(offset_from_top))
     pipette.air_gap(volume, offset_from_top)
 
 

--- a/api/src/opentrons/protocol_api/execute_v3.py
+++ b/api/src/opentrons/protocol_api/execute_v3.py
@@ -153,6 +153,20 @@ def _dispense(instruments: Dict[str, InstrumentContext],
     pipette.dispense(volume, location)
 
 
+# TODO IMMEDIATELY: copy-pasted
+def _air_gap(instruments: Dict[str, InstrumentContext],
+             loaded_labware: Dict[str, labware.Labware],
+             params: 'StandardLiquidHandlingParams') -> None:
+    pipette_id = params['pipette']
+    pipette = instruments[pipette_id]
+    offset_from_bottom = params['offsetFromBottomMm']
+    volume = params['volume']
+    _set_flow_rate(pipette, params)
+    # TODO IMMEDIATELY: must subtract well z dim (height)
+    offset_from_top = offset_from_bottom
+    pipette.air_gap(volume, offset_from_top)
+
+
 def _touch_tip(instruments: Dict[str, InstrumentContext],
                loaded_labware: Dict[str, labware.Labware],
                params: 'TouchTipParams') -> None:

--- a/api/src/opentrons/protocol_api/json_dispatchers.py
+++ b/api/src/opentrons/protocol_api/json_dispatchers.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 from opentrons.protocol_api.execute_v3 import _blowout, _pick_up_tip, \
-    _drop_tip, _aspirate, _dispense, _touch_tip
+    _drop_tip, _aspirate, _dispense, _touch_tip, _air_gap
 from opentrons.protocol_api.execute_v4 import _engage_magnet, \
     _disengage_magnet, _temperature_module_set_temp, \
     _temperature_module_deactivate, \
@@ -29,10 +29,6 @@ if TYPE_CHECKING:
     )
 
 
-def not_implemented(*args, **kwargs) -> None:
-    raise NotImplementedError('Not implemented')
-
-
 pipette_command_map: 'JsonV4PipetteDispatch' = {
     JsonPipetteCommand.blowout.value: _blowout,
     JsonPipetteCommand.pickUpTip.value: _pick_up_tip,
@@ -40,7 +36,7 @@ pipette_command_map: 'JsonV4PipetteDispatch' = {
     JsonPipetteCommand.aspirate.value: _aspirate,
     JsonPipetteCommand.dispense.value: _dispense,
     JsonPipetteCommand.touchTip.value: _touch_tip,
-    JsonPipetteCommand.airGap.value: not_implemented,
+    JsonPipetteCommand.airGap.value: _air_gap,
 }
 
 magnetic_module_command_map: 'JsonV4MagneticModuleDispatch' = {

--- a/api/tests/opentrons/protocol_api/test_execute_v3.py
+++ b/api/tests/opentrons/protocol_api/test_execute_v3.py
@@ -8,7 +8,7 @@ from opentrons.protocol_api.geometry import Deck
 from opentrons.protocol_api import ProtocolContext, InstrumentContext, \
     execute, labware, MAX_SUPPORTED_VERSION
 from opentrons.protocol_api.execute_v3 import _aspirate, _dispense, _delay, \
-    _drop_tip, _blowout, dispatch_json, _pick_up_tip, _touch_tip, \
+    _drop_tip, _blowout, dispatch_json, _pick_up_tip, _touch_tip, _air_gap, \
     _move_to_slot, load_labware_from_json_defs, _get_well, _set_flow_rate, \
     _get_location_with_offset, load_pipettes_from_json
 
@@ -167,6 +167,29 @@ def test_drop_tip():
 
     assert pipette_mock.mock_calls == [
         mock.call.drop_tip(well)
+    ]
+
+
+def test_air_gap():
+    m = mock.MagicMock()
+    m.pipette_mock = mock.create_autospec(InstrumentContext)
+    m.mock_get_location_with_offset = mock.MagicMock(
+        return_value=mock.sentinel.location)
+    m.mock_set_flow_rate = mock.MagicMock()
+
+    params = {'pipette': 'somePipetteId', 'volume': 42,
+              'labware': 'someLabwareId', 'well': 'someWell',
+              'offsetFromBottomMm': 12}
+    instruments = {'somePipetteId': m.pipette_mock}
+
+    with mock.patch(
+            'opentrons.protocol_api.execute_v3._set_flow_rate',
+            new=m.mock_set_flow_rate):
+        _air_gap(instruments, mock.sentinel.loaded_labware, params)
+
+    assert m.mock_calls == [
+        mock.call.mock_set_flow_rate(m.pipette_mock, params),
+        mock.call.pipette_mock.air_gap(42, 12)
     ]
 
 


### PR DESCRIPTION
 # Overview

We finally will implement air gap! This PR should make the executors for both V3 and V4 protocols support the `"airGap"` command in the schema (command is the same in both schemas)

# Changelog
- Support `airGap` JSON command

# Review requests

- [ ] Careful code review plz
- [ ] Test on robot: air gap to the current well
- [ ] Test on robot: air gap to a new well

This is tricky to test correctly, because the API's `InstrumentContext.air_gap` fn is stateful. However, the JSON command should be stateless.

Like asp/disp/etc, API `air_gap` uses a remembered flow rate that must be reset (but this we already solved for asp/disp/etc). New problem for air gap is that `air_gap` uses the previous location and does not have an argument that allows specifying a well/location. However, the JSON command has a `well` parameter. Additional surface for error is that `air_gap` takes a height from top, while the JSON command specifies an `offsetFromBottomMm`, so I might have messed up that geometric transform. This should be captured in the tests, but I'm not familiar enough with the `Location` class stuff to think I got it right my first try!

TL;DR -- when testing on robot, make sure the air gap doesn't do a little dance up/down in Z (due to the `move_to`), and make sure the air gap's `offsetFromBottomMm` translates to that specified position from the well bottom.

Here is a test V4 protocol to run on the robot: [airGapTest.json.zip](https://github.com/Opentrons/opentrons/files/4832856/airGapTest.json.zip)

It should:
- Pick up tip from B1
- Aspirate 5uL from source plate in slot 2, well A1. (This is at 2mm from bottom.)
- Air gap at different well of source plate, well A2. The air gap should happen 30mm from the well bottom, which should be 5 mm above the well top (well depth is 25). 
- Dispense 4.5uL in well B1 of the other destination plate
- Drop the tip

If you need help editing the protocol to match a labware that you have (this is an 8-well plate, probably uncommon), LMK and I can rewrite the protocol for you.

# Risk assessment

This shouldn't affect any existing features, but if we get it wrong it's a pain to bugfix and re-release later.

See above for risky business