### PR TITLE
feat(robot-server): return created_at in session response

### DIFF
--- a/robot-server/robot_server/service/session/models.py
+++ b/robot-server/robot_server/service/session/models.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from enum import Enum
 import typing
 from uuid import uuid4
@@ -92,6 +93,9 @@ class Session(BasicSession):
     details: SessionDetails =\
         Field(...,
               description="Detailed session specific status")
+    created_at: datetime = \
+        Field(...,
+              description="Date and time that this session was created")
 
 
 class BasicSessionCommand(BaseModel):

--- a/robot-server/robot_server/service/session/models.py
+++ b/robot-server/robot_server/service/session/models.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from enum import Enum
 import typing
 from uuid import uuid4
-from datetime import datetime
 
 from pydantic import BaseModel, Field, validator
 from robot_server.robot.calibration.check import models as calibration_models

--- a/robot-server/robot_server/service/session/router.py
+++ b/robot-server/robot_server/service/session/router.py
@@ -54,7 +54,7 @@ async def create_session_handler(
     """Create a session"""
     session_type = create_request.data.attributes.sessionType
     try:
-        new_session = await session_manager.add(session_type)
+        new_session = await session_manager.add(session_type=session_type)
     except SessionCreationException as e:
         log.exception("Failed to create session")
         raise RobotServerError(

--- a/robot-server/robot_server/service/session/session_types/base_session.py
+++ b/robot-server/robot_server/service/session/session_types/base_session.py
@@ -52,7 +52,8 @@ class BaseSession(ABC):
     def get_response_model(self) -> models.Session:
         """Get the response model"""
         return models.Session(sessionType=self.session_type,
-                              details=self._get_response_details())
+                              details=self._get_response_details(),
+                              created_at=self.meta.created_at)
 
     @abstractmethod
     def _get_response_details(self) -> models.SessionDetails:

--- a/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
@@ -33,7 +33,7 @@ stages:
           type: Session
           attributes: &session_data_attributes
             sessionType: calibrationCheck
-            created_at: !re_match "\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
+            created_at: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
             details: &session_data_attribute_details
               currentStep: sessionStarted
               instruments: !anydict
@@ -658,6 +658,7 @@ stages:
             type: Session
             attributes:
               sessionType: default
+              created_at: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
               details: {}
 ---
 test_name: Calibration check session errors

--- a/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
@@ -33,6 +33,7 @@ stages:
           type: Session
           attributes: &session_data_attributes
             sessionType: calibrationCheck
+            created_at: !re_match "\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
             details: &session_data_attribute_details
               currentStep: sessionStarted
               instruments: !anydict

--- a/robot-server/tests/integration/sessions/test_default.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_default.tavern.yaml
@@ -56,6 +56,7 @@ stages:
           type: Session
           attributes:
             sessionType: default
+            created_at: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
             details: {}
 ---
 test_name: Default Commands

--- a/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
@@ -33,6 +33,7 @@ stages:
           type: Session
           attributes:
             sessionType: tipLengthCalibration
+            created_at: !re_match "\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
             details: {}
 
   - name: Load labware

--- a/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
@@ -33,7 +33,7 @@ stages:
           type: Session
           attributes:
             sessionType: tipLengthCalibration
-            created_at: !re_match "\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
+            created_at: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+.\\d+"
             details: {}
 
   - name: Load labware
@@ -82,5 +82,6 @@ stages:
             type: Session
             attributes:
               sessionType: default
+              created_at: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
               details: {}
 

--- a/robot-server/tests/integration/test_session.tavern.yaml
+++ b/robot-server/tests/integration/test_session.tavern.yaml
@@ -88,16 +88,19 @@ stages:
           type: Session
           attributes:
             sessionType: "default"
+            created_at: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
             details: {}
         - id: "{session_id_1}"
           type: Session
           attributes:
             sessionType: "null"
+            created_at: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
             details: {}
         - id: "{session_id_2}"
           type: Session
           attributes:
             sessionType: "calibrationCheck"
+            created_at: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
             details: !anydict
 
   - name: Get just the calcheck sessions
@@ -112,6 +115,7 @@ stages:
           type: Session
           attributes:
             sessionType: "calibrationCheck"
+            created_at: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
             details: !anydict
 
   - name: Delete session 1
@@ -140,4 +144,5 @@ stages:
           type: Session
           attributes:
             sessionType: "default"
+            created_at: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
             details: {}

--- a/robot-server/tests/service/session/test_router.py
+++ b/robot-server/tests/service/session/test_router.py
@@ -23,8 +23,6 @@ from robot_server.service.session.session_types import NullSession, \
 @pytest.fixture
 def mock_session_meta():
     return SessionMetaData(identifier="some_id",
-                           name="session name",
-                           description="session description",
                            created_at=datetime(2000, 1, 1, 0, 0, 0))
 
 
@@ -35,6 +33,7 @@ def session_response(mock_session_meta):
             'details': {
             },
             'sessionType': 'null',
+            'created_at': mock_session_meta.created_at.isoformat(),
         },
         'type': 'Session',
         'id': mock_session_meta.identifier


### PR DESCRIPTION
# Overview

Add `created_at` timestamp to Session response.

We always had this as part of the internal mode, but didn't include it in the body of the HTTP response.

# Changelog

- Add `created_at` timestamp to Session response.
- tests

# Risk assessment

None