### PR TITLE
fix(robot-server): tavern test setup fix

### DIFF
--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -53,11 +53,21 @@ def run_server(server_temp_directory):
                                'OT_API_CONFIG_DIR': server_temp_directory},
                           stdout=subprocess.PIPE,
                           stderr=subprocess.PIPE) as proc:
-        # Wait for a bit to get started
+        # Wait for a bit to get started by polling /health
         # TODO (lc, 23-06-2020) We should investigate
         # using symlinks for the file copy to avoid
-        # having such a long sleep
-        time.sleep(15)
+        # having such a long delay
+        import requests
+        while True:
+            try:
+                s = requests.get("http://localhost:31950/health")
+                if s.status_code == 200:
+                    # Got a 200. Ready to run
+                    break
+            except IOError:
+                pass
+            time.sleep(0.5)
+
         yield proc
         proc.kill()
 

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -58,14 +58,14 @@ def run_server(server_temp_directory):
         # using symlinks for the file copy to avoid
         # having such a long delay
         import requests
+        from requests.exceptions import ConnectionError
         while True:
             try:
-                s = requests.get("http://localhost:31950/health")
-                if s.status_code == 200:
-                    # Got a 200. Ready to run
-                    break
-            except IOError:
+                requests.get("http://localhost:31950/health")
+            except ConnectionError:
                 pass
+            else:
+                break
             time.sleep(0.5)
 
         yield proc


### PR DESCRIPTION
# Overview

When setting up the background robot-server we need to wait for it to be ready before running through the integration tests.  We use a `time.sleep` of 15 seconds. We had to raise it from 2 seconds recently. 

This PR removes the `time.sleep` and polls `/health` every 500ms waiting for server to be ready.

# Risk assessment

None. Tests only