### PR TITLE
docs(api): update mix description behavior

### DIFF
--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -348,8 +348,7 @@ The ``mix`` command takes up to three arguments: ``mix(repetitions, volume, loca
 
 .. note::
 
-    Mixes consist of aspirates and then immediate dispenses. In between these actions, the pipette moves up and out of the target well. This is normal, and is done to avoid incorrect aspirate and dispense actions.
-
+    In API Versions 2.4 and earlier, mixes consist of aspirates and then immediate dispenses. In between these actions, the pipette moves up and out of the target well. In API Version 2.5 and later, the pipette will not move between actions. 
 
 .. versionadded:: 2.0
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -348,7 +348,7 @@ The ``mix`` command takes up to three arguments: ``mix(repetitions, volume, loca
 
 .. note::
 
-    In API Versions 2.4 and earlier, mixes consist of aspirates and then immediate dispenses. In between these actions, the pipette moves up and out of the target well. In API Version 2.5 and later, the pipette will not move between actions. 
+    In API Versions 2.2 and earlier, mixes consist of aspirates and then immediate dispenses. In between these actions, the pipette moves up and out of the target well. In API Version 2.3 and later, the pipette will not move between actions. 
 
 .. versionadded:: 2.0
 


### PR DESCRIPTION
# Overview

We changed `mix()` to not move between actions in apiLevel 2.3 (#5128). This fixes the description in the docs to reflect actual behavior

# Review requests

Make sure it uses the correct idiom "API Version"?? rather than `apiLevel` ??


