### PR TITLE
refactor(robot-server): default session commands to camel case

### DIFF
--- a/robot-server/robot_server/service/session/models.py
+++ b/robot-server/robot_server/service/session/models.py
@@ -47,9 +47,9 @@ class CommandStatus(str, Enum):
 
 class CommandName(str, Enum):
     """The available session commands"""
-    home_all_motors = "home_all_motors"
-    home_pipette = "home_pipette"
-    toggle_lights = "toggle_lights"
+    home_all_motors = "homeAllMotors"
+    home_pipette = "homePipette"
+    toggle_lights = "toggleLights"
     load_labware = CalibrationCheckTrigger.load_labware.value
     prepare_pipette = CalibrationCheckTrigger.prepare_pipette.value
     jog = (CalibrationCheckTrigger.jog.value,

--- a/robot-server/tests/integration/sessions/test_default.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_default.tavern.yaml
@@ -64,7 +64,7 @@ marks:
   - usefixtures:
       - run_server
 stages:
-  - name: Send a home_all_motors command
+  - name: Send a homeAllMotors command
     request:
       url: "{host:s}:{port:d}/sessions/default/commands/execute"
       method: POST
@@ -72,11 +72,11 @@ stages:
         data:
           type: SessionCommand
           attributes:
-            command: home_all_motors
+            command: homeAllMotors
             data: {}
     response:
       status_code: 200
-  - name: Send a toggle_lights command
+  - name: Send a toggleLights command
     request:
       url: "{host:s}:{port:d}/sessions/default/commands/execute"
       method: POST
@@ -84,7 +84,7 @@ stages:
         data:
           type: SessionCommand
           attributes:
-            command: toggle_lights
+            command: toggleLights
             data: {}
     response:
       status_code: 200


### PR DESCRIPTION
# Overview

We should use camel instead of snake case for command names. 

# Risk assessment

None