### PR TITLE
feat(api): print API Version in simulate

### DIFF
--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -169,6 +169,7 @@ def get_protocol_api(
     elif not isinstance(version, APIVersion):
         raise TypeError('version must be either a string or an APIVersion')
     else:
+        print(f'Executing using API Version {checked_version}')
         checked_version = version
     if extra_labware is None\
        and IS_ROBOT\

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -169,8 +169,8 @@ def get_protocol_api(
     elif not isinstance(version, APIVersion):
         raise TypeError('version must be either a string or an APIVersion')
     else:
-        print(f'Executing using API Version {checked_version}')
         checked_version = version
+    print(f'Executing using API Version {checked_version}')
     if extra_labware is None\
        and IS_ROBOT\
        and JUPYTER_NOTEBOOK_LABWARE_DIR.is_dir():  # type: ignore


### PR DESCRIPTION

# Overview

Closes #6015 and #6074

prints 'Executing using API Version {checked_version}' to stdout from simulate module

# Review requests

- Would adding this statement to the runlog be a better way to do it than the stdout print?
- If going with the stdout print, is this the right place to add it? Or should I add it to `main()` ?
- simulate a few different `apiLevel` protocols including this purposefully malformed one
```python
from opentrons import robot
def run(protocol):
    pipette1 = protocol.load_instrument('p1000_single_gen2', 'left', tip_racks=nonexistant)
    pipette1.pick_up_tip()
```

# Risk assessment

Low. If the recently removed prints from importing `robot` didn't break anything, adding one back in that only prints when simulating probably shouldn't.
