### PR TITLE
fix(api, robot-server): remove the deprecated useV1HttpApi config setting 

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -146,12 +146,6 @@ settings = [
                     ' affects GEN1 P10S, P10M, P50S, P50M, and P300S pipettes.'
     ),
     SettingDefinition(
-        _id='useV1HttpApi',
-        title='Revert to legacy HTTP API v1',
-        description='Tells the OT-2 to run the legacy v1 http api.',
-        restart_required=True
-    ),
-    SettingDefinition(
         _id='enableDoorSafetySwitch',
         title='Enable robot door safety switch',
         description="Automatically pause protocols when robot door opens. "

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -25,10 +25,6 @@ def use_old_aspiration_functions():
     return advs.get_setting_with_env_overload('useOldAspirationFunctions')
 
 
-def use_fast_api() -> bool:
-    return not advs.get_setting_with_env_overload('useV1HttpApi')
-
-
 def enable_door_safety_switch():
     return advs.get_setting_with_env_overload('enableDoorSafetySwitch')
 

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -239,7 +239,6 @@ def test_ensures_config():
              'useOldAspirationFunctions': None,
              'disableLogAggregation': True,
              'useProtocolApi2': None,
-             'useV1HttpApi': None,
              'enableDoorSafetySwitch': None,
              'enableTipLengthCalibration': None
          }

--- a/robot-server/tests/integration/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/test_settings.tavern.yaml
@@ -48,12 +48,6 @@ stages:
           description: !re_search "Aspirate with the less accurate volumetric calibrations"
           restart_required: false
           value: !anything
-        - id: useV1HttpApi
-          old_id: Null
-          title: Revert to legacy HTTP API v1
-          description: !re_match "Tells the OT-2 to run the legacy v1.*"
-          restart_required: true
-          value: !anything
         - id: enableDoorSafetySwitch
           old_id: Null
           title: Enable robot door safety switch
@@ -83,7 +77,6 @@ marks:
       - useProtocolApi2
       - disableHomeOnBoot
       - useOldAspirationFunctions
-      - useV1HttpApi
       - enableDoorSafetySwitch
   - parametrize:
       key: value
@@ -121,7 +114,6 @@ marks:
       - useProtocolApi2
       - disableHomeOnBoot
       - useOldAspirationFunctions
-      - useV1HttpApi
       - enableDoorSafetySwitch
 stages:
   - name: Set each setting to acceptable values 


### PR DESCRIPTION
# Overview

Remove the deprecated `useV1HttpApi` config setting and `use_fast_api` feature flag.  This is a setting that is irrelevant at this point.


# Review requests

The use deprecated v1 http api switch should no longer appear in the run app

# Risk assessment

Low. This is a removal of unused code.

closes #6079 