### PR TITLE
fix(robot-server): fix typo in change pipette position

### DIFF
--- a/robot-server/robot_server/service/legacy/routers/control.py
+++ b/robot-server/robot_server/service/legacy/routers/control.py
@@ -42,7 +42,7 @@ async def get_robot_positions() -> control.RobotPositionsResponse:
     robot_positions = control.RobotPositions(
         change_pipette=control.ChangePipette(target=control.MotionTarget.mount,
                                              left=[300, 40, 30],
-                                             right=[95, 30, 30]),
+                                             right=[95, 40, 30]),
         attach_tip=control.AttachTip(target=control.MotionTarget.pipette,
                                      point=[200, 90, 150])
     )


### PR DESCRIPTION
The right-pipette change position was offset 10mm in y, I think because
of a typo when porting it. This commit changes the value to match the
old HTTP API implementation.
