### PR TITLE
chore(js): improve jest watch performance by excluding node_modules

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -35,4 +35,5 @@ module.exports = {
   testPathIgnorePatterns: ['cypress/', '/node_modules/'],
   coverageReporters: ['lcov', 'text-summary'],
   snapshotSerializers: ['enzyme-to-json/serializer'],
+  watchPathIgnorePatterns: ['/node_modules/'],
 }


### PR DESCRIPTION
# Overview

Jest in watch mode consumes a lot of file watcher resources. It's watching many `node_modules` files it doesn't need to watch. On Linux, even after adding inotify resources, `yarn jest --watch` (or even `yarn jest --watch protocol-designer/src`) takes a few minutes to start and sometimes times out a few times unless I kill flow or something and try again.

Related issue: https://github.com/facebook/jest/issues/3254

# Changelog

Update Jest config to exclude any `/node_modules/` paths from the file watch

# Review requests

- Jest tests still pass, same number of tests run (config not excluding any tests)
- Jest watch startup time might be significantly faster (at least on Linux it is!)

# Risk assessment

low to medium, messing with jest config