### PR TITLE
docs(api): explain trash has a well

### DIFF
--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -678,7 +678,11 @@ class ProtocolContext(CommandPublisher):
     @property  # type: ignore
     @requires_version(2, 0)
     def fixed_trash(self) -> Labware:
-        """ The trash fixed to slot 12 of the robot deck. """
+        """ The trash fixed to slot 12 of the robot deck.
+        
+        It has one well and should be accessed like labware in your protocol
+        e.g. ``protocol.fixed_trash['A1']``
+        """
         trash = self._deck_layout['12']
         if not trash:
             raise RuntimeError("Robot must have a trash container in 12")

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -679,8 +679,8 @@ class ProtocolContext(CommandPublisher):
     @requires_version(2, 0)
     def fixed_trash(self) -> Labware:
         """ The trash fixed to slot 12 of the robot deck.
-        
-        It has one well and should be accessed like labware in your protocol
+
+        It has one well and should be accessed like labware in your protocol.
         e.g. ``protocol.fixed_trash['A1']``
         """
         trash = self._deck_layout['12']


### PR DESCRIPTION

# Overview

Closes #5467 

Explains `fixed_trash` has a well and you should specify it to use as a pipetting destination

# Review requests

Does it make sense?

# Risk assessment

Low/none, it's a docstring