### PR TITLE
feat(robot-server): Robot server command namespaces

### DIFF
--- a/app/src/sessions/__fixtures__/index.js
+++ b/app/src/sessions/__fixtures__/index.js
@@ -36,12 +36,12 @@ export const mockSession: Types.Session = {
 }
 
 export const mockSessionCommand: Types.SessionCommandAttributes = {
-  command: 'jog',
+  command: 'calibration.jog',
   data: { someData: 32 },
 }
 
 export const mockSessionCommandAttributes: Types.SessionCommandAttributes = {
-  command: 'preparePipette',
+  command: 'calibration.preparePipette',
   status: 'accepted',
   data: {},
 }

--- a/app/src/sessions/calibration-check/constants.js
+++ b/app/src/sessions/calibration-check/constants.js
@@ -42,15 +42,18 @@ export const CHECK_STEP_BAD_ROBOT_CALIBRATION: 'badCalibrationData' =
 export const CHECK_STEP_NO_PIPETTES_ATTACHED: 'noPipettesAttached' =
   'noPipettesAttached'
 
-const LOAD_LABWARE: 'loadLabware' = 'loadLabware'
-const PREPARE_PIPETTE: 'preparePipette' = 'preparePipette'
-const JOG: 'jog' = 'jog'
-const PICK_UP_TIP: 'pickUpTip' = 'pickUpTip'
-const CONFIRM_TIP: 'confirmTip' = 'confirmTip'
-const INVALIDATE_TIP: 'invalidateTip' = 'invalidateTip'
-const COMPARE_POINT: 'comparePoint' = 'comparePoint'
-const GO_TO_NEXT_CHECK: 'goToNextCheck' = 'goToNextCheck'
-const EXIT: 'exitSession' = 'exitSession'
+const LOAD_LABWARE: 'calibration.loadLabware' = 'calibration.loadLabware'
+const PREPARE_PIPETTE: 'calibration.preparePipette' =
+  'calibration.preparePipette'
+const JOG: 'calibration.jog' = 'calibration.jog'
+const PICK_UP_TIP: 'calibration.pickUpTip' = 'calibration.pickUpTip'
+const CONFIRM_TIP: 'calibration.confirmTip' = 'calibration.confirmTip'
+const INVALIDATE_TIP: 'calibration.invalidateTip' = 'calibration.invalidateTip'
+const COMPARE_POINT: 'calibration.check.comparePoint' =
+  'calibration.check.comparePoint'
+const GO_TO_NEXT_CHECK: 'calibration.check.goToNextCheck' =
+  'calibration.check.goToNextCheck'
+const EXIT: 'calibration.exitSession' = 'calibration.exitSession'
 
 export const checkCommands = {
   LOAD_LABWARE,

--- a/app/src/sessions/epic/__tests__/createSessionCommandEpic.test.js
+++ b/app/src/sessions/epic/__tests__/createSessionCommandEpic.test.js
@@ -33,7 +33,7 @@ describe('createSessionCommandEpic', () => {
       data: {
         type: 'Command',
         attributes: {
-          command: 'jog',
+          command: 'calibration.jog',
           data: {
             someData: 32,
           },

--- a/robot-server/robot_server/robot/calibration/check/session.py
+++ b/robot-server/robot_server/robot/calibration/check/session.py
@@ -13,7 +13,8 @@ from robot_server.robot.calibration.check.models import ComparisonStatus
 from robot_server.robot.calibration.helper_classes import (
     CheckMove, DeckCalibrationError, PipetteRank, PipetteInfo, PipetteStatus
 )
-from robot_server.service.session.models import OffsetVector
+from robot_server.service.session.models import OffsetVector,\
+    CalibrationCommand, CalibrationCheckCommand
 from opentrons.hardware_control import ThreadManager
 from opentrons.protocol_api import labware
 
@@ -57,16 +58,16 @@ class CalibrationCheckState(str, Enum):
 
 
 class CalibrationCheckTrigger(str, Enum):
-    load_labware = "loadLabware"
-    prepare_pipette = "preparePipette"
-    jog = "jog"
-    pick_up_tip = "pickUpTip"
-    confirm_tip_attached = "confirmTip"
-    invalidate_tip = "invalidateTip"
-    compare_point = "comparePoint"
-    go_to_next_check = "goToNextCheck"
-    exit = "exitSession"
-    reject_calibration = "rejectCalibration"
+    load_labware = CalibrationCommand.load_labware.value
+    prepare_pipette = CalibrationCommand.prepare_pipette.value
+    jog = CalibrationCommand.jog.value
+    pick_up_tip = CalibrationCommand.pick_up_tip.value
+    confirm_tip_attached = CalibrationCommand.confirm_tip_attached.value
+    invalidate_tip = CalibrationCommand.invalidate_tip.value
+    compare_point = CalibrationCheckCommand.compare_point.value
+    go_to_next_check = CalibrationCheckCommand.go_to_next_check.value
+    exit = CalibrationCommand.exit.value
+    reject_calibration = CalibrationCheckCommand.reject_calibration.value
 
 
 CHECK_TRANSITIONS: typing.List[typing.Dict[str, typing.Any]] = [

--- a/robot-server/robot_server/robot/calibration/tip_length/state_machine.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/state_machine.py
@@ -1,5 +1,5 @@
 from typing import Dict
-from robot_server.service.session.models import CommandName
+from robot_server.service.session.models import CommonCommand
 from robot_server.robot.calibration.tip_length.util import (
     SimpleStateMachine,
     TipCalibrationError as Error
@@ -9,29 +9,29 @@ from robot_server.robot.calibration.tip_length.constants import (
 )
 
 
-TIP_LENGTH_TRANSITIONS: Dict[State, Dict[CommandName, State]] = {
+TIP_LENGTH_TRANSITIONS: Dict[State, Dict[CommonCommand, State]] = {
     State.sessionStarted: {
-        CommandName.load_labware: State.labwareLoaded
+        CommonCommand.load_labware: State.labwareLoaded
     },
     State.labwareLoaded: {
-        CommandName.move_to_reference_point: State.measuringNozzleOffset
+        CommonCommand.move_to_reference_point: State.measuringNozzleOffset
     },
     State.measuringNozzleOffset: {
-        CommandName.save_offset: State.preparingPipette,
-        CommandName.jog: State.measuringNozzleOffset
+        CommonCommand.save_offset: State.preparingPipette,
+        CommonCommand.jog: State.measuringNozzleOffset
     },
     State.preparingPipette: {
-        CommandName.jog: State.preparingPipette,
-        CommandName.pick_up_tip: State.preparingPipette,
-        CommandName.invalidate_tip: State.preparingPipette,
-        CommandName.move_to_reference_point: State.measuringTipOffset
+        CommonCommand.jog: State.preparingPipette,
+        CommonCommand.pick_up_tip: State.preparingPipette,
+        CommonCommand.invalidate_tip: State.preparingPipette,
+        CommonCommand.move_to_reference_point: State.measuringTipOffset
     },
     State.measuringTipOffset: {
-        CommandName.save_offset: State.calibrationComplete,
-        CommandName.jog: State.measuringTipOffset
+        CommonCommand.save_offset: State.calibrationComplete,
+        CommonCommand.jog: State.measuringTipOffset
     },
     State.WILDCARD: {
-        CommandName.exit: State.sessionExited
+        CommonCommand.exit: State.sessionExited
     }
 }
 
@@ -43,7 +43,7 @@ class TipCalibrationStateMachine():
             transitions=TIP_LENGTH_TRANSITIONS
         )
 
-    def get_next_state(self, from_state: State, command: CommandName):
+    def get_next_state(self, from_state: State, command: CommonCommand):
         next_state = self._state_machine.get_next_state(from_state, command)
         if next_state:
             return next_state

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -2,7 +2,7 @@ from typing import Dict, Awaitable, Callable, Any
 from opentrons.types import Mount, Point
 from opentrons.hardware_control import ThreadManager
 from robot_server.service.session.models import CalibrationCommand, \
-    TipLengthCalibrationCommand, CommandDefinition
+    TipLengthCalibrationCommand
 from robot_server.robot.calibration.tip_length.state_machine import (
     TipCalibrationStateMachine
 )
@@ -19,32 +19,6 @@ A collection of functions that allow a consumer to prepare and update
 calibration data associated with the combination of a pipette tip type and a
 unique (by serial number) physical pipette.
 """
-
-TIP_LENGTH_TRANSITIONS: Dict[State, Dict[CommandDefinition, State]] = {
-    State.sessionStarted: {
-        CalibrationCommand.load_labware: State.labwareLoaded
-    },
-    State.labwareLoaded: {
-        TipLengthCalibrationCommand.move_to_reference_point: State.measuringNozzleOffset  # noqa: E501
-    },
-    State.measuringNozzleOffset: {
-        CalibrationCommand.save_offset: State.preparingPipette,
-        CalibrationCommand.jog: State.measuringNozzleOffset
-    },
-    State.preparingPipette: {
-        CalibrationCommand.jog: State.preparingPipette,
-        CalibrationCommand.pick_up_tip: State.preparingPipette,
-        CalibrationCommand.invalidate_tip: State.preparingPipette,
-        TipLengthCalibrationCommand.move_to_reference_point: State.measuringTipOffset  # noqa: E501
-    },
-    State.measuringTipOffset: {
-        CalibrationCommand.save_offset: State.calibrationComplete,
-        CalibrationCommand.jog: State.measuringTipOffset
-    },
-    State.WILDCARD: {
-        CalibrationCommand.exit: State.sessionExited
-    }
-}
 
 # TODO: BC 2020-07-08: type all command logic here with actual Model type
 COMMAND_HANDLER = Callable[..., Awaitable]

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -1,7 +1,7 @@
 from typing import Dict, Awaitable, Callable, Any
 from opentrons.types import Mount, Point
 from opentrons.hardware_control import ThreadManager
-from robot_server.service.session.models import CommandName
+from robot_server.service.session.models import CommonCommand
 from robot_server.robot.calibration.tip_length.state_machine import (
     TipCalibrationStateMachine
 )
@@ -19,29 +19,29 @@ calibration data associated with the combination of a pipette tip type and a
 unique (by serial number) physical pipette.
 """
 
-TIP_LENGTH_TRANSITIONS: Dict[State, Dict[CommandName, State]] = {
+TIP_LENGTH_TRANSITIONS: Dict[State, Dict[CommonCommand, State]] = {
     State.sessionStarted: {
-        CommandName.load_labware: State.labwareLoaded
+        CommonCommand.load_labware: State.labwareLoaded
     },
     State.labwareLoaded: {
-        CommandName.move_to_reference_point: State.measuringNozzleOffset
+        CommonCommand.move_to_reference_point: State.measuringNozzleOffset
     },
     State.measuringNozzleOffset: {
-        CommandName.save_offset: State.preparingPipette,
-        CommandName.jog: State.measuringNozzleOffset
+        CommonCommand.save_offset: State.preparingPipette,
+        CommonCommand.jog: State.measuringNozzleOffset
     },
     State.preparingPipette: {
-        CommandName.jog: State.preparingPipette,
-        CommandName.pick_up_tip: State.preparingPipette,
-        CommandName.invalidate_tip: State.preparingPipette,
-        CommandName.move_to_reference_point: State.measuringTipOffset
+        CommonCommand.jog: State.preparingPipette,
+        CommonCommand.pick_up_tip: State.preparingPipette,
+        CommonCommand.invalidate_tip: State.preparingPipette,
+        CommonCommand.move_to_reference_point: State.measuringTipOffset
     },
     State.measuringTipOffset: {
-        CommandName.save_offset: State.calibrationComplete,
-        CommandName.jog: State.measuringTipOffset
+        CommonCommand.save_offset: State.calibrationComplete,
+        CommonCommand.jog: State.measuringTipOffset
     },
     State.WILDCARD: {
-        CommandName.exit: State.sessionExited
+        CommonCommand.exit: State.sessionExited
     }
 }
 
@@ -68,13 +68,13 @@ class TipCalibrationUserFlow():
                         'cannot run tip length calibration')
 
         self._command_map: COMMAND_MAP = {
-            CommandName.load_labware: self.load_labware,
-            CommandName.jog: self.jog,
-            CommandName.pick_up_tip: self.pick_up_tip,
-            CommandName.invalidate_tip: self.invalidate_tip,
-            CommandName.save_offset: self.save_offset,
-            CommandName.move_to_reference_point: self.move_to_reference_point,
-            CommandName.exit: self.exit_session,
+            CommonCommand.load_labware: self.load_labware,
+            CommonCommand.jog: self.jog,
+            CommonCommand.pick_up_tip: self.pick_up_tip,
+            CommonCommand.invalidate_tip: self.invalidate_tip,
+            CommonCommand.save_offset: self.save_offset,
+            CommonCommand.move_to_reference_point: self.move_to_reference_point,  # noqa: E501
+            CommonCommand.exit: self.exit_session,
         }
 
     def _set_current_state(self, to_state: State):

--- a/robot-server/robot_server/service/session/command_execution/__init__.py
+++ b/robot-server/robot_server/service/session/command_execution/__init__.py
@@ -1,5 +1,5 @@
 from .base_command_queue import CommandQueue  # noqa(W0611)
 from .base_executor import CommandExecutor  # noqa(W0611)
-from .command import Command, CompletedCommand, create_command # noqa(W0611)
+from .command import Command, CompletedCommand, create_command, CommandResult # noqa(W0611)
 from .callable_executor import CallableExecutor  # noqa(W0611)
 from .hardware_executor import HardwareExecutor, DefaultHardwareExecutor  # noqa(W0611)

--- a/robot-server/robot_server/service/session/command_execution/command.py
+++ b/robot-server/robot_server/service/session/command_execution/command.py
@@ -2,12 +2,12 @@ from datetime import datetime
 from dataclasses import dataclass, field
 
 from robot_server.service.session.models import IdentifierType, \
-    create_identifier, CommandName, CommandDataType, CommandStatus
+    create_identifier, CommonCommand, CommandDataType, CommandStatus
 
 
 @dataclass(frozen=True)
 class CommandContent:
-    name: CommandName
+    name: CommonCommand
     data: CommandDataType
 
 
@@ -37,7 +37,7 @@ class CompletedCommand:
     result: CommandResult
 
 
-def create_command(name: CommandName, data: CommandDataType) -> Command:
+def create_command(name: CommonCommand, data: CommandDataType) -> Command:
     """Create a command object"""
     return Command(
         content=CommandContent(

--- a/robot-server/robot_server/service/session/command_execution/command.py
+++ b/robot-server/robot_server/service/session/command_execution/command.py
@@ -2,12 +2,12 @@ from datetime import datetime
 from dataclasses import dataclass, field
 
 from robot_server.service.session.models import IdentifierType, \
-    create_identifier, CommonCommand, CommandDataType, CommandStatus
+    create_identifier, CommandDefinition, CommandDataType, CommandStatus
 
 
 @dataclass(frozen=True)
 class CommandContent:
-    name: CommonCommand
+    name: CommandDefinition
     data: CommandDataType
 
 
@@ -37,7 +37,7 @@ class CompletedCommand:
     result: CommandResult
 
 
-def create_command(name: CommonCommand, data: CommandDataType) -> Command:
+def create_command(name: CommandDefinition, data: CommandDataType) -> Command:
     """Create a command object"""
     return Command(
         content=CommandContent(

--- a/robot-server/robot_server/service/session/command_execution/hardware_executor.py
+++ b/robot-server/robot_server/service/session/command_execution/hardware_executor.py
@@ -1,11 +1,10 @@
 import typing
 from opentrons.hardware_control import ThreadManager
 
-from . import Command, CompletedCommand
+from . import Command, CompletedCommand, CommandResult
 from . base_executor import CommandExecutor
-from .command import CommandResult
 from ..errors import UnsupportedCommandException
-from ..models import CommandDataType, CommandName
+from ..models import CommandDataType, CommonCommand
 from robot_server.util import duration
 
 
@@ -25,14 +24,14 @@ async def toggle_lights(hardware: ThreadManager, *args):
 class HardwareExecutor(CommandExecutor):
     """A command executor that executes direct hardware commands"""
 
-    COMMAND_TO_FUNC: typing.Dict[CommandName, COMMAND_HANDLER] = {
-        CommandName.home_all_motors: home_all_motors,
-        CommandName.toggle_lights: toggle_lights
+    COMMAND_TO_FUNC: typing.Dict[CommonCommand, COMMAND_HANDLER] = {
+        CommonCommand.home_all_motors: home_all_motors,
+        CommonCommand.toggle_lights: toggle_lights
     }
 
     def __init__(self,
                  hardware: ThreadManager,
-                 command_filter: typing.Optional[typing.Set[CommandName]]):
+                 command_filter: typing.Optional[typing.Set[CommonCommand]]):
         """
         Constructor
 
@@ -59,7 +58,7 @@ class HardwareExecutor(CommandExecutor):
                                  completed_at=timed.end)
         )
 
-    def get_handler(self, command_name: CommandName) \
+    def get_handler(self, command_name: CommonCommand) \
             -> typing.Optional[COMMAND_HANDLER]:
         """Get the handler for the command type"""
         if self._command_filter is not None:
@@ -71,6 +70,6 @@ class HardwareExecutor(CommandExecutor):
 class DefaultHardwareExecutor(HardwareExecutor):
     """The default command executor"""
     def __init__(self, hardware: ThreadManager):
-        super().__init__(hardware, {CommandName.home_all_motors,
-                                    CommandName.home_pipette,
-                                    CommandName.toggle_lights})
+        super().__init__(hardware, {CommonCommand.home_all_motors,
+                                    CommonCommand.home_pipette,
+                                    CommonCommand.toggle_lights})

--- a/robot-server/robot_server/service/session/command_execution/hardware_executor.py
+++ b/robot-server/robot_server/service/session/command_execution/hardware_executor.py
@@ -4,7 +4,7 @@ from opentrons.hardware_control import ThreadManager
 from . import Command, CompletedCommand, CommandResult
 from . base_executor import CommandExecutor
 from ..errors import UnsupportedCommandException
-from ..models import CommandDataType, CommonCommand
+from ..models import CommandDataType, CommonCommand, CommandDefinition
 from robot_server.util import duration
 
 
@@ -24,7 +24,7 @@ async def toggle_lights(hardware: ThreadManager, *args):
 class HardwareExecutor(CommandExecutor):
     """A command executor that executes direct hardware commands"""
 
-    COMMAND_TO_FUNC: typing.Dict[CommonCommand, COMMAND_HANDLER] = {
+    COMMAND_TO_FUNC: typing.Dict[CommandDefinition, COMMAND_HANDLER] = {
         CommonCommand.home_all_motors: home_all_motors,
         CommonCommand.toggle_lights: toggle_lights
     }
@@ -58,7 +58,7 @@ class HardwareExecutor(CommandExecutor):
                                  completed_at=timed.end)
         )
 
-    def get_handler(self, command_name: CommonCommand) \
+    def get_handler(self, command_name: CommandDefinition) \
             -> typing.Optional[COMMAND_HANDLER]:
         """Get the handler for the command type"""
         if self._command_filter is not None:

--- a/robot-server/robot_server/service/session/command_execution/hardware_executor.py
+++ b/robot-server/robot_server/service/session/command_execution/hardware_executor.py
@@ -4,7 +4,7 @@ from opentrons.hardware_control import ThreadManager
 from . import Command, CompletedCommand, CommandResult
 from . base_executor import CommandExecutor
 from ..errors import UnsupportedCommandException
-from ..models import CommandDataType, CommonCommand, CommandDefinition
+from ..models import CommandDataType, RobotCommand, CommandDefinition
 from robot_server.util import duration
 
 
@@ -25,13 +25,13 @@ class HardwareExecutor(CommandExecutor):
     """A command executor that executes direct hardware commands"""
 
     COMMAND_TO_FUNC: typing.Dict[CommandDefinition, COMMAND_HANDLER] = {
-        CommonCommand.home_all_motors: home_all_motors,
-        CommonCommand.toggle_lights: toggle_lights
+        RobotCommand.home_all_motors: home_all_motors,
+        RobotCommand.toggle_lights: toggle_lights
     }
 
     def __init__(self,
                  hardware: ThreadManager,
-                 command_filter: typing.Optional[typing.Set[CommonCommand]]):
+                 command_filter: typing.Optional[typing.Set[RobotCommand]]):
         """
         Constructor
 
@@ -70,6 +70,6 @@ class HardwareExecutor(CommandExecutor):
 class DefaultHardwareExecutor(HardwareExecutor):
     """The default command executor"""
     def __init__(self, hardware: ThreadManager):
-        super().__init__(hardware, {CommonCommand.home_all_motors,
-                                    CommonCommand.home_pipette,
-                                    CommonCommand.toggle_lights})
+        super().__init__(hardware, {RobotCommand.home_all_motors,
+                                    RobotCommand.home_pipette,
+                                    RobotCommand.toggle_lights})

--- a/robot-server/robot_server/service/session/models.py
+++ b/robot-server/robot_server/service/session/models.py
@@ -72,7 +72,7 @@ class CommandDefinition(str, Enum):
         """
         This is primarily for allowing  definitions to define a
         namespace. The name space will be used to make the value of the
-        enum. It will be "{namespoce}.{value}"
+        enum. It will be "{namespace}.{value}"
         """
         return None
 

--- a/robot-server/robot_server/service/session/models.py
+++ b/robot-server/robot_server/service/session/models.py
@@ -50,7 +50,35 @@ class CommandStatus(str, Enum):
     failed = "failed"
 
 
-class CommandName(str, Enum):
+class CommandDefinition(str, Enum):
+    def __new__(cls, value, model=EmptyModel, namespace=None):
+        """Create a string enum with the expected model and optional
+        namespace"""
+        full_name = f"{namespace}.{value}" if namespace else value
+        obj = str.__new__(cls, full_name)
+        obj._value_ = full_name
+        obj._localname = value
+        obj._model = model
+        obj._namespace = namespace
+        return obj
+
+    @property
+    def model(self):
+        """Get the data model of the payload of the command"""
+        return self._model
+
+    @property
+    def namespace(self):
+        """Get the namespace"""
+        return self._namespace
+
+    @property
+    def localname(self):
+        """Get the name of the command without the namespace"""
+        return self._localname
+
+
+class CommonCommand(CommandDefinition):
     """The available session commands"""
     home_all_motors = "homeAllMotors"
     home_pipette = "homePipette"
@@ -75,22 +103,14 @@ class CommandName(str, Enum):
     # Tip Length Calibration Specific
     move_to_reference_point = "moveToReferencePoint"
 
-    def __new__(cls, value, model=EmptyModel):
-        """Create a string enum with the expected model"""
-        obj = str.__new__(cls, value)
-        obj._value_ = value
-        obj._model = model
-        return obj
-
-    @property
-    def model(self):
-        return self._model
-
 
 CommandDataType = typing.Union[
     JogPosition,
     EmptyModel
 ]
+
+
+CommandDefinitions = typing.Union[CommonCommand]
 
 
 class BasicSession(BaseModel):
@@ -114,8 +134,8 @@ class BasicSessionCommand(BaseModel):
     """A session command"""
     data: CommandDataType
     # For validation, command MUST appear after data
-    command: CommandName = Field(...,
-                                 description="The command description")
+    command: CommandDefinitions = Field(...,
+                                        description="The command description")
 
     @validator('command', always=True, allow_reuse=True)
     def check_data_type(cls, v, values):

--- a/robot-server/robot_server/service/session/models.py
+++ b/robot-server/robot_server/service/session/models.py
@@ -102,7 +102,7 @@ class CalibrationCommand(CommandDefinition):
     confirm_tip_attached = "confirmTip"
     invalidate_tip = "invalidateTip"
     save_offset = "saveOffset"
-    exit = "exit"
+    exit = "exitSession"
 
     @staticmethod
     def namespace():

--- a/robot-server/robot_server/service/session/models.py
+++ b/robot-server/robot_server/service/session/models.py
@@ -82,7 +82,7 @@ class CommandDefinition(str, Enum):
         return self._localname
 
 
-class CommonCommand(CommandDefinition):
+class RobotCommand(CommandDefinition):
     """Generic commands"""
     home_all_motors = "homeAllMotors"
     home_pipette = "homePipette"
@@ -136,8 +136,9 @@ CommandDataType = typing.Union[
 ]
 
 
-CommandDefinitions = typing.Union[
-    CommonCommand,
+# A Union of all CommandDefinition enumerations accepted
+CommandDefinitionType = typing.Union[
+    RobotCommand,
     CalibrationCommand,
     CalibrationCheckCommand,
     TipLengthCalibrationCommand
@@ -165,8 +166,9 @@ class BasicSessionCommand(BaseModel):
     """A session command"""
     data: CommandDataType
     # For validation, command MUST appear after data
-    command: CommandDefinitions = Field(...,
-                                        description="The command description")
+    command: CommandDefinitionType = Field(
+        ...,
+        description="The command description")
 
     @validator('command', always=True, allow_reuse=True)
     def check_data_type(cls, v, values):

--- a/robot-server/robot_server/service/session/models.py
+++ b/robot-server/robot_server/service/session/models.py
@@ -78,13 +78,27 @@ class CommandDefinition(str, Enum):
         return self._localname
 
 
+def cmd_def(name, model=EmptyModel, ns=None):
+    """
+    Convenience function for creating CommandDefinition tuple.
+
+    :param name: Name of command
+    :param model: Model of the command data payload
+    :param ns: namespace
+    :return: Tuple
+    """
+    return name, model, ns
+
+
 class CommonCommand(CommandDefinition):
     """The available session commands"""
     home_all_motors = "homeAllMotors"
     home_pipette = "homePipette"
     toggle_lights = "toggleLights"
 
-    # Shared Between Calibration Flows
+
+class CalibrationCommand(CommandDefinition):
+    """Shared Between Calibration Flows"""
     load_labware = "loadLabware"
     prepare_pipette = "preparePipette"
     jog = ("jog", JogPosition)
@@ -92,16 +106,21 @@ class CommonCommand(CommandDefinition):
     confirm_tip_attached = "confirmTip"
     invalidate_tip = "invalidateTip"
     save_offset = "saveOffset"
+    exit = "exit"
 
-    # Cal Check Specific
+
+class CalibrationCheckCommand(CommandDefinition):
+    """Cal Check Specific"""
     compare_point = "comparePoint"
     go_to_next_check = "goToNextCheck"
-    exit = "exit"
     # TODO: remove unused command name and trigger
     reject_calibration = "rejectCalibration"
 
-    # Tip Length Calibration Specific
-    move_to_reference_point = "moveToReferencePoint"
+
+class TipLengthCalibrationCommand(CommandDefinition):
+    """Tip Length Calibration Specific"""
+    move_to_reference_point = cmd_def("moveToReferencePoint",
+                                      ns=SessionType.tip_length_calibration)
 
 
 CommandDataType = typing.Union[
@@ -110,7 +129,12 @@ CommandDataType = typing.Union[
 ]
 
 
-CommandDefinitions = typing.Union[CommonCommand]
+CommandDefinitions = typing.Union[
+    CommonCommand,
+    CalibrationCommand,
+    CalibrationCheckCommand,
+    TipLengthCalibrationCommand
+]
 
 
 class BasicSession(BaseModel):

--- a/robot-server/tests/integration/sessions/test_default.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_default.tavern.yaml
@@ -72,7 +72,7 @@ stages:
         data:
           type: SessionCommand
           attributes:
-            command: homeAllMotors
+            command: robot.homeAllMotors
             data: {}
     response:
       status_code: 200
@@ -84,7 +84,7 @@ stages:
         data:
           type: SessionCommand
           attributes:
-            command: toggleLights
+            command: robot.toggleLights
             data: {}
     response:
       status_code: 200
@@ -96,7 +96,7 @@ stages:
         data:
           type: SessionCommand
           attributes:
-            command: loadLabware
+            command: calibration.loadLabware
             data: {}
     response:
       status_code: 400

--- a/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
@@ -44,7 +44,7 @@ stages:
         data:
           type: SessionCommand
           attributes:
-            command: loadLabware
+            command: calibration.loadLabware
             data: {}
     response:
       status_code: 200
@@ -55,7 +55,7 @@ stages:
           type: SessionCommand
           attributes:
             status: executed
-            command: loadLabware
+            command: calibration.loadLabware
             created_at: &dt
               !re_match "\\d+-\\d+-\\d+T"
             started_at: *dt

--- a/robot-server/tests/robot/calibration/tip_length/test_state_machine.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_state_machine.py
@@ -1,30 +1,30 @@
 import pytest
 from typing import List, Tuple
 
-from robot_server.service.session.models import CommandName
+from robot_server.service.session.models import CommonCommand
 from robot_server.robot.calibration.tip_length.state_machine import \
     TipCalibrationStateMachine
 
 valid_commands: List[Tuple[str, str, str]] = [
-  (CommandName.load_labware, 'sessionStarted', 'labwareLoaded'),
-  (CommandName.move_to_reference_point, 'labwareLoaded',
+  (CommonCommand.load_labware, 'sessionStarted', 'labwareLoaded'),
+  (CommonCommand.move_to_reference_point, 'labwareLoaded',
    'measuringNozzleOffset'),
-  (CommandName.jog, 'measuringNozzleOffset',
+  (CommonCommand.jog, 'measuringNozzleOffset',
    'measuringNozzleOffset'),
-  (CommandName.save_offset, 'measuringNozzleOffset', 'preparingPipette'),
-  (CommandName.jog, 'preparingPipette', 'preparingPipette'),
-  (CommandName.pick_up_tip, 'preparingPipette', 'preparingPipette'),
-  (CommandName.invalidate_tip, 'preparingPipette', 'preparingPipette'),
-  (CommandName.move_to_reference_point, 'preparingPipette',
+  (CommonCommand.save_offset, 'measuringNozzleOffset', 'preparingPipette'),
+  (CommonCommand.jog, 'preparingPipette', 'preparingPipette'),
+  (CommonCommand.pick_up_tip, 'preparingPipette', 'preparingPipette'),
+  (CommonCommand.invalidate_tip, 'preparingPipette', 'preparingPipette'),
+  (CommonCommand.move_to_reference_point, 'preparingPipette',
    'measuringTipOffset'),
-  (CommandName.jog, 'measuringTipOffset', 'measuringTipOffset'),
-  (CommandName.save_offset, 'measuringTipOffset', 'calibrationComplete'),
-  (CommandName.exit, 'calibrationComplete', 'sessionExited'),
-  (CommandName.exit, 'sessionStarted', 'sessionExited'),
-  (CommandName.exit, 'labwareLoaded', 'sessionExited'),
-  (CommandName.exit, 'measuringNozzleOffset', 'sessionExited'),
-  (CommandName.exit, 'preparingPipette', 'sessionExited'),
-  (CommandName.exit, 'measuringTipOffset', 'sessionExited'),
+  (CommonCommand.jog, 'measuringTipOffset', 'measuringTipOffset'),
+  (CommonCommand.save_offset, 'measuringTipOffset', 'calibrationComplete'),
+  (CommonCommand.exit, 'calibrationComplete', 'sessionExited'),
+  (CommonCommand.exit, 'sessionStarted', 'sessionExited'),
+  (CommonCommand.exit, 'labwareLoaded', 'sessionExited'),
+  (CommonCommand.exit, 'measuringNozzleOffset', 'sessionExited'),
+  (CommonCommand.exit, 'preparingPipette', 'sessionExited'),
+  (CommonCommand.exit, 'measuringTipOffset', 'sessionExited'),
 ]
 
 

--- a/robot-server/tests/robot/calibration/tip_length/test_state_machine.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_state_machine.py
@@ -1,30 +1,33 @@
 import pytest
 from typing import List, Tuple
 
-from robot_server.service.session.models import CommonCommand
+from robot_server.service.session.models import CalibrationCommand, \
+    TipLengthCalibrationCommand
 from robot_server.robot.calibration.tip_length.state_machine import \
     TipCalibrationStateMachine
 
 valid_commands: List[Tuple[str, str, str]] = [
-  (CommonCommand.load_labware, 'sessionStarted', 'labwareLoaded'),
-  (CommonCommand.move_to_reference_point, 'labwareLoaded',
+  (CalibrationCommand.load_labware, 'sessionStarted', 'labwareLoaded'),
+  (TipLengthCalibrationCommand.move_to_reference_point, 'labwareLoaded',
    'measuringNozzleOffset'),
-  (CommonCommand.jog, 'measuringNozzleOffset',
+  (CalibrationCommand.jog, 'measuringNozzleOffset',
    'measuringNozzleOffset'),
-  (CommonCommand.save_offset, 'measuringNozzleOffset', 'preparingPipette'),
-  (CommonCommand.jog, 'preparingPipette', 'preparingPipette'),
-  (CommonCommand.pick_up_tip, 'preparingPipette', 'preparingPipette'),
-  (CommonCommand.invalidate_tip, 'preparingPipette', 'preparingPipette'),
-  (CommonCommand.move_to_reference_point, 'preparingPipette',
+  (CalibrationCommand.save_offset, 'measuringNozzleOffset',
+   'preparingPipette'),
+  (CalibrationCommand.jog, 'preparingPipette', 'preparingPipette'),
+  (CalibrationCommand.pick_up_tip, 'preparingPipette', 'preparingPipette'),
+  (CalibrationCommand.invalidate_tip, 'preparingPipette', 'preparingPipette'),
+  (TipLengthCalibrationCommand.move_to_reference_point, 'preparingPipette',
    'measuringTipOffset'),
-  (CommonCommand.jog, 'measuringTipOffset', 'measuringTipOffset'),
-  (CommonCommand.save_offset, 'measuringTipOffset', 'calibrationComplete'),
-  (CommonCommand.exit, 'calibrationComplete', 'sessionExited'),
-  (CommonCommand.exit, 'sessionStarted', 'sessionExited'),
-  (CommonCommand.exit, 'labwareLoaded', 'sessionExited'),
-  (CommonCommand.exit, 'measuringNozzleOffset', 'sessionExited'),
-  (CommonCommand.exit, 'preparingPipette', 'sessionExited'),
-  (CommonCommand.exit, 'measuringTipOffset', 'sessionExited'),
+  (CalibrationCommand.jog, 'measuringTipOffset', 'measuringTipOffset'),
+  (CalibrationCommand.save_offset, 'measuringTipOffset',
+   'calibrationComplete'),
+  (CalibrationCommand.exit, 'calibrationComplete', 'sessionExited'),
+  (CalibrationCommand.exit, 'sessionStarted', 'sessionExited'),
+  (CalibrationCommand.exit, 'labwareLoaded', 'sessionExited'),
+  (CalibrationCommand.exit, 'measuringNozzleOffset', 'sessionExited'),
+  (CalibrationCommand.exit, 'preparingPipette', 'sessionExited'),
+  (CalibrationCommand.exit, 'measuringTipOffset', 'sessionExited'),
 ]
 
 

--- a/robot-server/tests/robot/calibration/tip_length/test_tip_length_calibration.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_tip_length_calibration.py
@@ -4,19 +4,19 @@ from typing import List, Tuple, Dict, Any
 from opentrons.types import Mount, Point
 from opentrons.hardware_control import pipette
 
-from robot_server.service.session.models import CommandName
+from robot_server.service.session.models import CommonCommand
 from robot_server.robot.calibration.tip_length.user_flow import \
     TipCalibrationUserFlow
 
 stub_jog_data = {'vector': Point(1, 1, 1)}
 
 valid_commands: List[Tuple[str, str, Dict[Any, Any]]] = [
-  (CommandName.move_to_reference_point, 'labwareLoaded', {}),
-  (CommandName.jog, 'measuringNozzleOffset', stub_jog_data),
-  (CommandName.pick_up_tip, 'preparingPipette', {}),
-  (CommandName.invalidate_tip, 'preparingPipette', {}),
-  (CommandName.save_offset, 'measuringTipOffset', {}),
-  (CommandName.exit, 'calibrationComplete', {}),
+  (CommonCommand.move_to_reference_point, 'labwareLoaded', {}),
+  (CommonCommand.jog, 'measuringNozzleOffset', stub_jog_data),
+  (CommonCommand.pick_up_tip, 'preparingPipette', {}),
+  (CommonCommand.invalidate_tip, 'preparingPipette', {}),
+  (CommonCommand.save_offset, 'measuringTipOffset', {}),
+  (CommonCommand.exit, 'calibrationComplete', {}),
 ]
 
 
@@ -43,9 +43,9 @@ def mock_user_flow(hardware):
 
 
 hw_commands: List[Tuple[str, str, Dict[Any, Any], str]] = [
-  (CommandName.jog, 'measuringNozzleOffset', stub_jog_data, 'move_rel'),
-  (CommandName.pick_up_tip, 'preparingPipette', {}, 'pick_up_tip'),
-  (CommandName.invalidate_tip, 'preparingPipette', {}, 'drop_tip'),
+  (CommonCommand.jog, 'measuringNozzleOffset', stub_jog_data, 'move_rel'),
+  (CommonCommand.pick_up_tip, 'preparingPipette', {}, 'pick_up_tip'),
+  (CommonCommand.invalidate_tip, 'preparingPipette', {}, 'drop_tip'),
 ]
 
 

--- a/robot-server/tests/robot/calibration/tip_length/test_tip_length_calibration.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_tip_length_calibration.py
@@ -4,19 +4,20 @@ from typing import List, Tuple, Dict, Any
 from opentrons.types import Mount, Point
 from opentrons.hardware_control import pipette
 
-from robot_server.service.session.models import CommonCommand
+from robot_server.service.session.models import TipLengthCalibrationCommand, \
+    CalibrationCommand
 from robot_server.robot.calibration.tip_length.user_flow import \
     TipCalibrationUserFlow
 
 stub_jog_data = {'vector': Point(1, 1, 1)}
 
 valid_commands: List[Tuple[str, str, Dict[Any, Any]]] = [
-  (CommonCommand.move_to_reference_point, 'labwareLoaded', {}),
-  (CommonCommand.jog, 'measuringNozzleOffset', stub_jog_data),
-  (CommonCommand.pick_up_tip, 'preparingPipette', {}),
-  (CommonCommand.invalidate_tip, 'preparingPipette', {}),
-  (CommonCommand.save_offset, 'measuringTipOffset', {}),
-  (CommonCommand.exit, 'calibrationComplete', {}),
+  (TipLengthCalibrationCommand.move_to_reference_point, 'labwareLoaded', {}),
+  (CalibrationCommand.jog, 'measuringNozzleOffset', stub_jog_data),
+  (CalibrationCommand.pick_up_tip, 'preparingPipette', {}),
+  (CalibrationCommand.invalidate_tip, 'preparingPipette', {}),
+  (CalibrationCommand.save_offset, 'measuringTipOffset', {}),
+  (CalibrationCommand.exit, 'calibrationComplete', {}),
 ]
 
 
@@ -43,9 +44,9 @@ def mock_user_flow(hardware):
 
 
 hw_commands: List[Tuple[str, str, Dict[Any, Any], str]] = [
-  (CommonCommand.jog, 'measuringNozzleOffset', stub_jog_data, 'move_rel'),
-  (CommonCommand.pick_up_tip, 'preparingPipette', {}, 'pick_up_tip'),
-  (CommonCommand.invalidate_tip, 'preparingPipette', {}, 'drop_tip'),
+  (CalibrationCommand.jog, 'measuringNozzleOffset', stub_jog_data, 'move_rel'),
+  (CalibrationCommand.pick_up_tip, 'preparingPipette', {}, 'pick_up_tip'),
+  (CalibrationCommand.invalidate_tip, 'preparingPipette', {}, 'drop_tip'),
 ]
 
 

--- a/robot-server/tests/service/session/session_types/test_check_session.py
+++ b/robot-server/tests/service/session/session_types/test_check_session.py
@@ -12,8 +12,8 @@ from robot_server.robot.calibration.check.util import StateMachineError
 
 from robot_server.service.session.command_execution import create_command
 from robot_server.service.session.configuration import SessionConfiguration
-from robot_server.service.session.models import (CommonCommand, EmptyModel,
-                                                 JogPosition)
+from robot_server.service.session.models import (EmptyModel, JogPosition,
+                                                 CalibrationCommand)
 from robot_server.service.session.session_types import CheckSession, \
     SessionMetaData, BaseSession
 
@@ -170,7 +170,7 @@ async def test_session_command_execute(check_session_instance,
                                        mock_cal_session):
     await check_session_instance.command_executor.execute(
         create_command(
-            CommonCommand.jog,
+            CalibrationCommand.jog,
             JogPosition(vector=(1, 2, 3)))
     )
 
@@ -184,7 +184,7 @@ async def test_session_command_execute_no_body(check_session_instance,
                                                mock_cal_session):
     await check_session_instance.command_executor.execute(
         create_command(
-            CommonCommand.load_labware,
+            CalibrationCommand.load_labware,
             EmptyModel())
     )
 
@@ -209,5 +209,6 @@ async def test_session_command_execute_raise(check_session_instance,
 
     with pytest.raises(SessionCommandException):
         await check_session_instance.command_executor.execute(
-            create_command(CommonCommand.jog, JogPosition(vector=(1, 2, 3)))
+            create_command(CalibrationCommand.jog,
+                           JogPosition(vector=(1, 2, 3)))
         )

--- a/robot-server/tests/service/session/session_types/test_check_session.py
+++ b/robot-server/tests/service/session/session_types/test_check_session.py
@@ -12,7 +12,7 @@ from robot_server.robot.calibration.check.util import StateMachineError
 
 from robot_server.service.session.command_execution import create_command
 from robot_server.service.session.configuration import SessionConfiguration
-from robot_server.service.session.models import (CommandName, EmptyModel,
+from robot_server.service.session.models import (CommonCommand, EmptyModel,
                                                  JogPosition)
 from robot_server.service.session.session_types import CheckSession, \
     SessionMetaData, BaseSession
@@ -170,7 +170,7 @@ async def test_session_command_execute(check_session_instance,
                                        mock_cal_session):
     await check_session_instance.command_executor.execute(
         create_command(
-            CommandName.jog,
+            CommonCommand.jog,
             JogPosition(vector=(1, 2, 3)))
     )
 
@@ -184,7 +184,7 @@ async def test_session_command_execute_no_body(check_session_instance,
                                                mock_cal_session):
     await check_session_instance.command_executor.execute(
         create_command(
-            CommandName.load_labware,
+            CommonCommand.load_labware,
             EmptyModel())
     )
 
@@ -209,5 +209,5 @@ async def test_session_command_execute_raise(check_session_instance,
 
     with pytest.raises(SessionCommandException):
         await check_session_instance.command_executor.execute(
-            create_command(CommandName.jog, JogPosition(vector=(1, 2, 3)))
+            create_command(CommonCommand.jog, JogPosition(vector=(1, 2, 3)))
         )

--- a/robot-server/tests/service/session/session_types/test_check_session.py
+++ b/robot-server/tests/service/session/session_types/test_check_session.py
@@ -175,7 +175,7 @@ async def test_session_command_execute(check_session_instance,
     )
 
     mock_cal_session.trigger_transition.assert_called_once_with(
-        trigger="jog",
+        trigger="calibration.jog",
         vector=(1.0, 2.0, 3.0)
     )
 
@@ -189,7 +189,7 @@ async def test_session_command_execute_no_body(check_session_instance,
     )
 
     mock_cal_session.trigger_transition.assert_called_once_with(
-        trigger="loadLabware"
+        trigger="calibration.loadLabware"
     )
 
 

--- a/robot-server/tests/service/session/test_models.py
+++ b/robot-server/tests/service/session/test_models.py
@@ -3,14 +3,14 @@ from robot_server.service.session import models
 
 
 def test_command_type_validation_jog():
-    c = models.BasicSessionCommand(**{'command': models.CommandName.jog,
+    c = models.BasicSessionCommand(**{'command': models.CommonCommand.jog,
                                       'data': {'vector': [1, 2, 3]}})
     assert c.data == models.JogPosition(vector=(1, 2, 3,))
 
 
 def test_command_type_validation_jog_fail():
     with pytest.raises(ValueError):
-        models.BasicSessionCommand(**{'command': models.CommandName.jog,
+        models.BasicSessionCommand(**{'command': models.CommonCommand.jog,
                                       'data': {}})
 
 
@@ -18,6 +18,6 @@ def test_command_type_empty():
     """Test that we create command correctly for
      commands that have no added data."""
     c = models.BasicSessionCommand(
-        **{'command': models.CommandName.prepare_pipette,
+        **{'command': models.CommonCommand.prepare_pipette,
            'data': {}})
     assert c.data == models.EmptyModel()

--- a/robot-server/tests/service/session/test_models.py
+++ b/robot-server/tests/service/session/test_models.py
@@ -3,14 +3,14 @@ from robot_server.service.session import models
 
 
 def test_command_type_validation_jog():
-    c = models.BasicSessionCommand(**{'command': models.CommonCommand.jog,
+    c = models.BasicSessionCommand(**{'command': models.CalibrationCommand.jog,
                                       'data': {'vector': [1, 2, 3]}})
     assert c.data == models.JogPosition(vector=(1, 2, 3,))
 
 
 def test_command_type_validation_jog_fail():
     with pytest.raises(ValueError):
-        models.BasicSessionCommand(**{'command': models.CommonCommand.jog,
+        models.BasicSessionCommand(**{'command': models.CalibrationCommand.jog,
                                       'data': {}})
 
 
@@ -18,6 +18,6 @@ def test_command_type_empty():
     """Test that we create command correctly for
      commands that have no added data."""
     c = models.BasicSessionCommand(
-        **{'command': models.CommonCommand.prepare_pipette,
+        **{'command': models.CalibrationCommand.prepare_pipette,
            'data': {}})
     assert c.data == models.EmptyModel()

--- a/robot-server/tests/service/session/test_router.py
+++ b/robot-server/tests/service/session/test_router.py
@@ -13,8 +13,8 @@ from robot_server.service.session.command_execution.command import \
     CommandResult, CompletedCommand, CommandContent, CommandMeta, CommandStatus
 from robot_server.service.session.errors import SessionCreationException, \
     UnsupportedCommandException, CommandExecutionException
-from robot_server.service.session.models import CommonCommand, EmptyModel, \
-    SessionType, JogPosition
+from robot_server.service.session.models import CalibrationCommand, \
+    EmptyModel, SessionType, JogPosition
 from robot_server.service.session.session_types import NullSession, \
     SessionMetaData
 
@@ -297,7 +297,7 @@ def test_execute_command(api_client,
     mock_command_executor.execute.assert_called_once_with(
         Command(
             content=CommandContent(
-                name=CommonCommand.jog,
+                name=CalibrationCommand.jog,
                 data=JogPosition(vector=(1, 2, 3,))
             ),
             meta=CommandMeta(identifier=command_id,
@@ -349,7 +349,7 @@ def test_execute_command_no_body(api_client,
     mock_command_executor.execute.assert_called_once_with(
         Command(
             content=CommandContent(
-                name=CommonCommand.load_labware,
+                name=CalibrationCommand.load_labware,
                 data=EmptyModel()),
             meta=CommandMeta(command_id, command_created_at)
         )

--- a/robot-server/tests/service/session/test_router.py
+++ b/robot-server/tests/service/session/test_router.py
@@ -13,7 +13,7 @@ from robot_server.service.session.command_execution.command import \
     CommandResult, CompletedCommand, CommandContent, CommandMeta, CommandStatus
 from robot_server.service.session.errors import SessionCreationException, \
     UnsupportedCommandException, CommandExecutionException
-from robot_server.service.session.models import CommandName, EmptyModel, \
+from robot_server.service.session.models import CommonCommand, EmptyModel, \
     SessionType, JogPosition
 from robot_server.service.session.session_types import NullSession, \
     SessionMetaData
@@ -297,7 +297,7 @@ def test_execute_command(api_client,
     mock_command_executor.execute.assert_called_once_with(
         Command(
             content=CommandContent(
-                name=CommandName.jog,
+                name=CommonCommand.jog,
                 data=JogPosition(vector=(1, 2, 3,))
             ),
             meta=CommandMeta(identifier=command_id,
@@ -349,7 +349,7 @@ def test_execute_command_no_body(api_client,
     mock_command_executor.execute.assert_called_once_with(
         Command(
             content=CommandContent(
-                name=CommandName.load_labware,
+                name=CommonCommand.load_labware,
                 data=EmptyModel()),
             meta=CommandMeta(command_id, command_created_at)
         )

--- a/robot-server/tests/service/session/test_router.py
+++ b/robot-server/tests/service/session/test_router.py
@@ -291,7 +291,7 @@ def test_execute_command(api_client,
                          patch_create_command):
     response = api_client.post(
         f"/sessions/{mock_session_meta.identifier}/commands/execute",
-        json=command("jog",
+        json=command("calibration.jog",
                      JogPosition(vector=(1, 2, 3,))))
 
     mock_command_executor.execute.assert_called_once_with(
@@ -308,7 +308,7 @@ def test_execute_command(api_client,
     assert response.json() == {
         'data': {
             'attributes': {
-                'command': 'jog',
+                'command': 'calibration.jog',
                 'data': {'vector': [1.0, 2.0, 3.0]},
                 'status': 'executed',
                 'created_at': '2000-01-01T00:00:00',
@@ -343,7 +343,7 @@ def test_execute_command_no_body(api_client,
     """Test that a command with empty body can be accepted"""
     response = api_client.post(
         f"/sessions/{mock_session_meta.identifier}/commands/execute",
-        json=command("loadLabware", None)
+        json=command("calibration.loadLabware", None)
     )
 
     mock_command_executor.execute.assert_called_once_with(
@@ -358,7 +358,7 @@ def test_execute_command_no_body(api_client,
     assert response.json() == {
         'data': {
             'attributes': {
-                'command': 'loadLabware',
+                'command': 'calibration.loadLabware',
                 'data': {},
                 'status': 'executed',
                 'created_at': '2000-01-01T00:00:00',


### PR DESCRIPTION
# Overview

The first release of sessions defined a set of commands for calibration check sessions. A command is defined as a name and a data payload schema. The command names are: 
```
"loadLabware"
"preparePipette"
"jog"
"pickUpTip"
"confirmTip"
"invalidateTip"
"saveOffset"
"exit"
```

As we begin work on tip length calibration, default, and protocol sessions we see that this naming was short sighted. 

This PR adds two features:
- namespaces command names.
- command defintions can be created in more than one enumeration. This eliminates the need for one monster CommandName enumeration.

After this PR. Command names will look like this:

```
"robot.homeAllMotors"
"robot.homePipette"
"robot.toggleLights"
"calibration.loadLabware"
"calibration.preparePipette"
"calibration.jog"
"calibration.pickUpTip"
"calibration.confirmTip"
"calibration.invalidateTip"
"calibration.saveOffset"
"calibration.exit"
"calibration.check.comparePoint"
"calibration.check.goToNextCheck"
"calibration.check.rejectCalibration"
"calibration.tipLength.moveToReferencePoint"'
```

Additionally, since the `calibration.X` and `calibration.check.X` commands are released to production, we have a backwards compatibility layer that accepts these commands without the namespace. 

# Changelog

- Make `CommandName` into `CommandDefinition` base enumeration. Add `namespace` static method which derived classes can use to define a namespace.
- Create separate enumerations for robot, calibration, calcheck, and tiplengthcal command definitions.
- Create pydantic validator in `BasicSessionCommand` to identify calcheck commands that have to be accepted without a namespace. 

# Review requests

- [ ] Agree with naming convention? 

Besides unit and integration tests, I ran calibration check flow unmodified against robot-server, proving that the backwards compatibility works.

# Risk assessment

Low. Only affects calibration check flow.


closes #6089