### PR TITLE
refactor(discovery-client): refactor poller to enable wire-up to Redux

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,7 +9,7 @@ shared-data/python/**
 **/venv/**
 
 # flow
-**/flow-typed/**
+flow-typed/npm/**
 
 # compiled
 app-shell/lib/**

--- a/discovery-client/src/__tests__/health-poller.test.js
+++ b/discovery-client/src/__tests__/health-poller.test.js
@@ -46,6 +46,9 @@ const HOST_3 = { ip: '127.0.0.3', port: 31950 }
 const flush = () => new Promise(resolve => setImmediate(resolve))
 
 describe('health poller', () => {
+  const onPollResult = jest.fn()
+  let poller
+
   beforeEach(() => {
     jest.useFakeTimers()
     fetch.mockResolvedValue(
@@ -55,6 +58,8 @@ describe('health poller', () => {
         text: () => Promise.resolve('AH'),
       }: any)
     )
+
+    poller = createHealthPoller({ onPollResult })
   })
 
   afterEach(() => {
@@ -64,12 +69,6 @@ describe('health poller', () => {
   })
 
   it('should call GET /health and GET /server/update/health', () => {
-    const poller = createHealthPoller({
-      list: [HOST_1, HOST_2, HOST_3],
-      interval: 1000,
-      onPollResult: () => {},
-    })
-
     const expectedFetches = [
       'http://127.0.0.1:31950/health',
       'http://127.0.0.1:31950/server/update/health',
@@ -85,7 +84,7 @@ describe('health poller', () => {
       'http://127.0.0.3:31950/server/update/health',
     ]
 
-    poller.start()
+    poller.start({ list: [HOST_1, HOST_2, HOST_3], interval: 1000 })
     jest.advanceTimersByTime(2000)
     expect(fetch).toHaveBeenCalledTimes(expectedFetches.length)
     expectedFetches.forEach((url, idx) => {
@@ -93,38 +92,15 @@ describe('health poller', () => {
     })
   })
 
-  it('should not poll until started', () => {
-    createHealthPoller({
-      list: [HOST_1, HOST_2, HOST_3],
-      interval: 1000,
-      onPollResult: () => {},
-    })
-
-    jest.advanceTimersByTime(2000)
-    expect(fetch).toHaveBeenCalledTimes(0)
-  })
-
   it('should be able to stop polling', () => {
-    const poller = createHealthPoller({
-      list: [HOST_1, HOST_2, HOST_3],
-      interval: 1000,
-      onPollResult: () => {},
-    })
-
-    poller.start()
+    poller.start({ list: [HOST_1, HOST_2, HOST_3], interval: 1000 })
     poller.stop()
     jest.advanceTimersByTime(2000)
     expect(fetch).toHaveBeenCalledTimes(0)
   })
 
   it('should be able to restart with a new list', () => {
-    const poller = createHealthPoller({
-      list: [HOST_1, HOST_2],
-      interval: 1000,
-      onPollResult: () => {},
-    })
-
-    poller.start()
+    poller.start({ list: [HOST_1, HOST_2], interval: 1000 })
     jest.advanceTimersByTime(1000)
     poller.start({ list: [HOST_1, HOST_3] })
     jest.advanceTimersByTime(1000)
@@ -149,17 +125,6 @@ describe('health poller', () => {
   })
 
   it('should be able to restart with a new list and new polling interval', () => {
-    const poller = createHealthPoller({
-      list: [HOST_1, HOST_2],
-      interval: 1000,
-      onPollResult: () => {},
-    })
-
-    poller.start()
-    jest.advanceTimersByTime(1000)
-    poller.start({ list: [HOST_1, HOST_3], interval: 2000 })
-    jest.advanceTimersByTime(2000)
-
     const expectedFetches = [
       // round 1: poll HOST_1 and HOST_2
       'http://127.0.0.1:31950/health',
@@ -173,20 +138,32 @@ describe('health poller', () => {
       'http://127.0.0.3:31950/server/update/health',
     ]
 
-    expect(fetch).toHaveBeenCalledTimes(expectedFetches.length)
-    expectedFetches.forEach((url, idx) => {
+    // round 1
+    poller.start({ list: [HOST_1, HOST_2], interval: 1000 })
+    jest.advanceTimersByTime(1000)
+    expect(fetch).toHaveBeenCalledTimes(4)
+    expectedFetches.slice(0, 4).forEach((url, idx) => {
+      expect(fetch).toHaveBeenNthCalledWith(idx + 1, url, EXPECTED_FETCH_OPTS)
+    })
+
+    // round 2
+    fetch.mockClear()
+    poller.start({ list: [HOST_1, HOST_3], interval: 4000 })
+    // advance timer by old interval, ensure no fetches went out
+    // 4000 should be high enough to avoid any requests going out from the
+    // poller spreading requests out over the interval
+    jest.advanceTimersByTime(1000)
+    expect(fetch).toHaveBeenCalledTimes(0)
+    // then advance timer enough to hit 4000 total time elapsed
+    jest.advanceTimersByTime(3000)
+    expect(fetch).toHaveBeenCalledTimes(4)
+    expectedFetches.slice(4, 8).forEach((url, idx) => {
       expect(fetch).toHaveBeenNthCalledWith(idx + 1, url, EXPECTED_FETCH_OPTS)
     })
   })
 
   it('should not lose queue order on restart with same list contents', () => {
-    const poller = createHealthPoller({
-      list: [HOST_1, HOST_2],
-      interval: 1000,
-      onPollResult: () => {},
-    })
-
-    poller.start()
+    poller.start({ list: [HOST_1, HOST_2], interval: 1000 })
     jest.advanceTimersByTime(500)
     poller.start({ list: [HOST_1, HOST_2] })
     jest.advanceTimersByTime(500)
@@ -207,8 +184,6 @@ describe('health poller', () => {
   })
 
   it('should map successful fetch responses to onPollResult', () => {
-    const onPollResult = jest.fn()
-
     stubFetchOnce('http://127.0.0.1:31950/health')(
       makeMockJsonResponse(Fixtures.mockHealthResponse)
     )
@@ -216,13 +191,8 @@ describe('health poller', () => {
       makeMockJsonResponse(Fixtures.mockServerHealthResponse)
     )
 
-    const poller = createHealthPoller({
-      list: [HOST_1],
-      interval: 1000,
-      onPollResult,
-    })
+    poller.start({ list: [HOST_1], interval: 1000 })
 
-    poller.start()
     jest.advanceTimersByTime(1000)
 
     return flush().then(() => {
@@ -238,8 +208,6 @@ describe('health poller', () => {
   })
 
   it('should map partially successful fetch responses to onPollResult', () => {
-    const onPollResult = jest.fn()
-
     stubFetchOnce('http://127.0.0.1:31950/health')(
       makeMockJsonResponse({ message: 'some error' }, false, 400)
     )
@@ -247,13 +215,7 @@ describe('health poller', () => {
       makeMockJsonResponse(Fixtures.mockServerHealthResponse)
     )
 
-    const poller = createHealthPoller({
-      list: [HOST_1],
-      interval: 1000,
-      onPollResult,
-    })
-
-    poller.start()
+    poller.start({ list: [HOST_1], interval: 1000 })
     jest.advanceTimersByTime(1000)
 
     return flush().then(() => {
@@ -269,8 +231,6 @@ describe('health poller', () => {
   })
 
   it('should map routable but failed responses to onPollResult', () => {
-    const onPollResult = jest.fn()
-
     stubFetchOnce('http://127.0.0.1:31950/health')({
       ok: false,
       status: 504,
@@ -282,13 +242,7 @@ describe('health poller', () => {
       text: () => Promise.resolve('Gateway timeout'),
     })
 
-    const poller = createHealthPoller({
-      list: [HOST_1],
-      interval: 1000,
-      onPollResult,
-    })
-
-    poller.start()
+    poller.start({ list: [HOST_1], interval: 1000 })
     jest.advanceTimersByTime(1000)
 
     return flush().then(() => {
@@ -304,20 +258,12 @@ describe('health poller', () => {
   })
 
   it('should map fetch errors to onPollResult', () => {
-    const onPollResult = jest.fn()
-
     stubFetchOnce('http://127.0.0.1:31950/health')(new Error('Failed to fetch'))
     stubFetchOnce('http://127.0.0.1:31950/server/update/health')(
       new Error('Failed to fetch')
     )
 
-    const poller = createHealthPoller({
-      list: [HOST_1],
-      interval: 1000,
-      onPollResult,
-    })
-
-    poller.start()
+    poller.start({ list: [HOST_1], interval: 1000 })
     jest.advanceTimersByTime(1000)
 
     return flush().then(() => {
@@ -333,12 +279,6 @@ describe('health poller', () => {
   })
 
   it('should spread its fetches out over the interval', () => {
-    const poller = createHealthPoller({
-      list: [HOST_1, HOST_2, HOST_3],
-      interval: 300,
-      onPollResult: () => {},
-    })
-
     const expectedFetches = [
       'http://127.0.0.1:31950/health',
       'http://127.0.0.1:31950/server/update/health',
@@ -350,7 +290,7 @@ describe('health poller', () => {
       'http://127.0.0.1:31950/server/update/health',
     ]
 
-    poller.start()
+    poller.start({ list: [HOST_1, HOST_2, HOST_3], interval: 300 })
     jest.advanceTimersByTime(100)
     expect(fetch).toHaveBeenCalledTimes(2)
     expectedFetches.slice(0, 2).forEach((url, idx) => {
@@ -383,16 +323,9 @@ describe('health poller', () => {
     // TODO(mc, 2020-07-13): Jest v25 fake timers do not mock Date.now,
     // so this test needs real timers. Move back to fake timers after upgrade
     jest.useRealTimers()
-
+    // these need to be created after real timers are back on for tests to pass
     const onPollResult = jest.fn()
-    const poller = createHealthPoller({
-      list: [HOST_1],
-      // NOTE(mc, 2020-07-13): see TODO above. This value chosen to work well
-      // with real time but runs the risk of being flakey because setTimeout
-      // is not exact in real life
-      interval: 50,
-      onPollResult,
-    })
+    const poller = createHealthPoller({ onPollResult })
 
     // the first two calls the fetch (/health and /server/update/health) will error
     // out _after_ the second two calls are made and completed
@@ -413,7 +346,13 @@ describe('health poller', () => {
       makeMockJsonResponse(Fixtures.mockServerHealthResponse)
     )
 
-    poller.start()
+    poller.start({
+      list: [HOST_1],
+      // NOTE(mc, 2020-07-13): see TODO above. This value chosen to work well
+      // with real time but runs the risk of being flakey because setTimeout
+      // is not exact in real life
+      interval: 50,
+    })
 
     return new Promise(resolve => setTimeout(resolve, 150)).then(() => {
       // ensure that the fact that the second poll returned means the eventual
@@ -431,13 +370,6 @@ describe('health poller', () => {
   })
 
   it('should ignore responses after stop()', () => {
-    const onPollResult = jest.fn()
-    const poller = createHealthPoller({
-      list: [HOST_1],
-      interval: 50,
-      onPollResult,
-    })
-
     const mockErrorImpl = () => {
       return new Promise((resolve, reject) => {
         setTimeout(() => reject(new Error('Oh no eventual error!')), 25)
@@ -446,7 +378,7 @@ describe('health poller', () => {
     fetch.mockImplementationOnce(mockErrorImpl)
     fetch.mockImplementationOnce(mockErrorImpl)
 
-    poller.start()
+    poller.start({ list: [HOST_1], interval: 50 })
     jest.advanceTimersByTime(50)
     poller.stop()
     jest.advanceTimersByTime(50)

--- a/discovery-client/src/__tests__/health-poller.test.js
+++ b/discovery-client/src/__tests__/health-poller.test.js
@@ -63,7 +63,7 @@ describe('health poller', () => {
     jest.resetAllMocks()
   })
 
-  it('should call GET /health and GET /server/health', () => {
+  it('should call GET /health and GET /server/update/health', () => {
     const poller = createHealthPoller({
       list: [HOST_1, HOST_2, HOST_3],
       interval: 1000,
@@ -72,17 +72,17 @@ describe('health poller', () => {
 
     const expectedFetches = [
       'http://127.0.0.1:31950/health',
-      'http://127.0.0.1:31950/server/health',
+      'http://127.0.0.1:31950/server/update/health',
       'http://127.0.0.2:31950/health',
-      'http://127.0.0.2:31950/server/health',
+      'http://127.0.0.2:31950/server/update/health',
       'http://127.0.0.3:31950/health',
-      'http://127.0.0.3:31950/server/health',
+      'http://127.0.0.3:31950/server/update/health',
       'http://127.0.0.1:31950/health',
-      'http://127.0.0.1:31950/server/health',
+      'http://127.0.0.1:31950/server/update/health',
       'http://127.0.0.2:31950/health',
-      'http://127.0.0.2:31950/server/health',
+      'http://127.0.0.2:31950/server/update/health',
       'http://127.0.0.3:31950/health',
-      'http://127.0.0.3:31950/server/health',
+      'http://127.0.0.3:31950/server/update/health',
     ]
 
     poller.start()
@@ -132,14 +132,14 @@ describe('health poller', () => {
     const expectedFetches = [
       // round 1: poll HOST_1 and HOST_2
       'http://127.0.0.1:31950/health',
-      'http://127.0.0.1:31950/server/health',
+      'http://127.0.0.1:31950/server/update/health',
       'http://127.0.0.2:31950/health',
-      'http://127.0.0.2:31950/server/health',
+      'http://127.0.0.2:31950/server/update/health',
       // round 2: HOST_1 still in list, HOST_2 removed, HOST_3 added
       'http://127.0.0.1:31950/health',
-      'http://127.0.0.1:31950/server/health',
+      'http://127.0.0.1:31950/server/update/health',
       'http://127.0.0.3:31950/health',
-      'http://127.0.0.3:31950/server/health',
+      'http://127.0.0.3:31950/server/update/health',
     ]
 
     expect(fetch).toHaveBeenCalledTimes(expectedFetches.length)
@@ -163,14 +163,14 @@ describe('health poller', () => {
     const expectedFetches = [
       // round 1: poll HOST_1 and HOST_2
       'http://127.0.0.1:31950/health',
-      'http://127.0.0.1:31950/server/health',
+      'http://127.0.0.1:31950/server/update/health',
       'http://127.0.0.2:31950/health',
-      'http://127.0.0.2:31950/server/health',
+      'http://127.0.0.2:31950/server/update/health',
       // round 2: HOST_1 still in list, HOST_2 removed, HOST_3 added
       'http://127.0.0.1:31950/health',
-      'http://127.0.0.1:31950/server/health',
+      'http://127.0.0.1:31950/server/update/health',
       'http://127.0.0.3:31950/health',
-      'http://127.0.0.3:31950/server/health',
+      'http://127.0.0.3:31950/server/update/health',
     ]
 
     expect(fetch).toHaveBeenCalledTimes(expectedFetches.length)
@@ -194,10 +194,10 @@ describe('health poller', () => {
     const expectedFetches = [
       // round 1: poll HOST_1
       'http://127.0.0.1:31950/health',
-      'http://127.0.0.1:31950/server/health',
+      'http://127.0.0.1:31950/server/update/health',
       // round 2: poll HOST_2 after list "refreshed"
       'http://127.0.0.2:31950/health',
-      'http://127.0.0.2:31950/server/health',
+      'http://127.0.0.2:31950/server/update/health',
     ]
 
     expect(fetch).toHaveBeenCalledTimes(expectedFetches.length)
@@ -212,7 +212,7 @@ describe('health poller', () => {
     stubFetchOnce('http://127.0.0.1:31950/health')(
       makeMockJsonResponse(Fixtures.mockHealthResponse)
     )
-    stubFetchOnce('http://127.0.0.1:31950/server/health')(
+    stubFetchOnce('http://127.0.0.1:31950/server/update/health')(
       makeMockJsonResponse(Fixtures.mockServerHealthResponse)
     )
 
@@ -243,7 +243,7 @@ describe('health poller', () => {
     stubFetchOnce('http://127.0.0.1:31950/health')(
       makeMockJsonResponse({ message: 'some error' }, false, 400)
     )
-    stubFetchOnce('http://127.0.0.1:31950/server/health')(
+    stubFetchOnce('http://127.0.0.1:31950/server/update/health')(
       makeMockJsonResponse(Fixtures.mockServerHealthResponse)
     )
 
@@ -276,7 +276,7 @@ describe('health poller', () => {
       status: 504,
       text: () => Promise.resolve('Gateway timeout'),
     })
-    stubFetchOnce('http://127.0.0.1:31950/server/health')({
+    stubFetchOnce('http://127.0.0.1:31950/server/update/health')({
       ok: false,
       status: 504,
       text: () => Promise.resolve('Gateway timeout'),
@@ -307,7 +307,7 @@ describe('health poller', () => {
     const onPollResult = jest.fn()
 
     stubFetchOnce('http://127.0.0.1:31950/health')(new Error('Failed to fetch'))
-    stubFetchOnce('http://127.0.0.1:31950/server/health')(
+    stubFetchOnce('http://127.0.0.1:31950/server/update/health')(
       new Error('Failed to fetch')
     )
 
@@ -341,13 +341,13 @@ describe('health poller', () => {
 
     const expectedFetches = [
       'http://127.0.0.1:31950/health',
-      'http://127.0.0.1:31950/server/health',
+      'http://127.0.0.1:31950/server/update/health',
       'http://127.0.0.2:31950/health',
-      'http://127.0.0.2:31950/server/health',
+      'http://127.0.0.2:31950/server/update/health',
       'http://127.0.0.3:31950/health',
-      'http://127.0.0.3:31950/server/health',
+      'http://127.0.0.3:31950/server/update/health',
       'http://127.0.0.1:31950/health',
-      'http://127.0.0.1:31950/server/health',
+      'http://127.0.0.1:31950/server/update/health',
     ]
 
     poller.start()
@@ -394,7 +394,7 @@ describe('health poller', () => {
       onPollResult,
     })
 
-    // the first two calls the fetch (/health and /server/health) will error
+    // the first two calls the fetch (/health and /server/update/health) will error
     // out _after_ the second two calls are made and completed
     const mockErrorImpl = () => {
       return new Promise((resolve, reject) => {
@@ -409,7 +409,7 @@ describe('health poller', () => {
     stubFetchOnce('http://127.0.0.1:31950/health')(
       makeMockJsonResponse(Fixtures.mockHealthResponse)
     )
-    stubFetchOnce('http://127.0.0.1:31950/server/health')(
+    stubFetchOnce('http://127.0.0.1:31950/server/update/health')(
       makeMockJsonResponse(Fixtures.mockServerHealthResponse)
     )
 

--- a/discovery-client/src/__tests__/health-poller.test.js
+++ b/discovery-client/src/__tests__/health-poller.test.js
@@ -1,0 +1,458 @@
+// @flow
+import nodeFetch from 'node-fetch'
+import { isError } from 'lodash'
+
+import * as Fixtures from '../__fixtures__/health'
+import { createHealthPoller } from '../health-poller'
+
+import type { Request, RequestInit, Response } from 'node-fetch'
+
+// TODO(mc, 2020-07-13): remove __mocks__/node-fetch
+jest.mock('node-fetch', () => ({ __esModule: true, default: jest.fn() }))
+
+const fetch: JestMockFn<
+  [string | Request, ?RequestInit],
+  $Call<typeof nodeFetch, any, any>
+> = nodeFetch
+
+const EXPECTED_FETCH_OPTS = { timeout: 10000 }
+
+const stubFetchOnce = (
+  stubUrl: string,
+  stubOptions: RequestInit = EXPECTED_FETCH_OPTS
+) => (response: $Shape<Response> | Error) => {
+  fetch.mockImplementationOnce((url, options) => {
+    expect(url).toBe(stubUrl)
+    expect(options).toEqual(stubOptions)
+
+    return isError(response)
+      ? Promise.reject(response)
+      : Promise.resolve(((response: any): Response))
+  })
+}
+
+const makeMockJsonResponse = (
+  body: any,
+  ok = true,
+  status = 200
+): $Shape<Response> => {
+  return { ok, status, text: () => Promise.resolve(JSON.stringify(body)) }
+}
+
+const HOST_1 = { ip: '127.0.0.1', port: 31950 }
+const HOST_2 = { ip: '127.0.0.2', port: 31950 }
+const HOST_3 = { ip: '127.0.0.3', port: 31950 }
+
+const flush = () => new Promise(resolve => setImmediate(resolve))
+
+describe('health poller', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    fetch.mockResolvedValue(
+      ({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('AH'),
+      }: any)
+    )
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.useRealTimers()
+    jest.resetAllMocks()
+  })
+
+  it('should call GET /health and GET /server/health', () => {
+    const poller = createHealthPoller({
+      list: [HOST_1, HOST_2, HOST_3],
+      interval: 1000,
+      onPollResult: () => {},
+    })
+
+    const expectedFetches = [
+      'http://127.0.0.1:31950/health',
+      'http://127.0.0.1:31950/server/health',
+      'http://127.0.0.2:31950/health',
+      'http://127.0.0.2:31950/server/health',
+      'http://127.0.0.3:31950/health',
+      'http://127.0.0.3:31950/server/health',
+      'http://127.0.0.1:31950/health',
+      'http://127.0.0.1:31950/server/health',
+      'http://127.0.0.2:31950/health',
+      'http://127.0.0.2:31950/server/health',
+      'http://127.0.0.3:31950/health',
+      'http://127.0.0.3:31950/server/health',
+    ]
+
+    poller.start()
+    jest.advanceTimersByTime(2000)
+    expect(fetch).toHaveBeenCalledTimes(expectedFetches.length)
+    expectedFetches.forEach((url, idx) => {
+      expect(fetch).toHaveBeenNthCalledWith(idx + 1, url, EXPECTED_FETCH_OPTS)
+    })
+  })
+
+  it('should not poll until started', () => {
+    createHealthPoller({
+      list: [HOST_1, HOST_2, HOST_3],
+      interval: 1000,
+      onPollResult: () => {},
+    })
+
+    jest.advanceTimersByTime(2000)
+    expect(fetch).toHaveBeenCalledTimes(0)
+  })
+
+  it('should be able to stop polling', () => {
+    const poller = createHealthPoller({
+      list: [HOST_1, HOST_2, HOST_3],
+      interval: 1000,
+      onPollResult: () => {},
+    })
+
+    poller.start()
+    poller.stop()
+    jest.advanceTimersByTime(2000)
+    expect(fetch).toHaveBeenCalledTimes(0)
+  })
+
+  it('should be able to restart with a new list', () => {
+    const poller = createHealthPoller({
+      list: [HOST_1, HOST_2],
+      interval: 1000,
+      onPollResult: () => {},
+    })
+
+    poller.start()
+    jest.advanceTimersByTime(1000)
+    poller.start({ list: [HOST_1, HOST_3] })
+    jest.advanceTimersByTime(1000)
+
+    const expectedFetches = [
+      // round 1: poll HOST_1 and HOST_2
+      'http://127.0.0.1:31950/health',
+      'http://127.0.0.1:31950/server/health',
+      'http://127.0.0.2:31950/health',
+      'http://127.0.0.2:31950/server/health',
+      // round 2: HOST_1 still in list, HOST_2 removed, HOST_3 added
+      'http://127.0.0.1:31950/health',
+      'http://127.0.0.1:31950/server/health',
+      'http://127.0.0.3:31950/health',
+      'http://127.0.0.3:31950/server/health',
+    ]
+
+    expect(fetch).toHaveBeenCalledTimes(expectedFetches.length)
+    expectedFetches.forEach((url, idx) => {
+      expect(fetch).toHaveBeenNthCalledWith(idx + 1, url, EXPECTED_FETCH_OPTS)
+    })
+  })
+
+  it('should be able to restart with a new list and new polling interval', () => {
+    const poller = createHealthPoller({
+      list: [HOST_1, HOST_2],
+      interval: 1000,
+      onPollResult: () => {},
+    })
+
+    poller.start()
+    jest.advanceTimersByTime(1000)
+    poller.start({ list: [HOST_1, HOST_3], interval: 2000 })
+    jest.advanceTimersByTime(2000)
+
+    const expectedFetches = [
+      // round 1: poll HOST_1 and HOST_2
+      'http://127.0.0.1:31950/health',
+      'http://127.0.0.1:31950/server/health',
+      'http://127.0.0.2:31950/health',
+      'http://127.0.0.2:31950/server/health',
+      // round 2: HOST_1 still in list, HOST_2 removed, HOST_3 added
+      'http://127.0.0.1:31950/health',
+      'http://127.0.0.1:31950/server/health',
+      'http://127.0.0.3:31950/health',
+      'http://127.0.0.3:31950/server/health',
+    ]
+
+    expect(fetch).toHaveBeenCalledTimes(expectedFetches.length)
+    expectedFetches.forEach((url, idx) => {
+      expect(fetch).toHaveBeenNthCalledWith(idx + 1, url, EXPECTED_FETCH_OPTS)
+    })
+  })
+
+  it('should not lose queue order on restart with same list contents', () => {
+    const poller = createHealthPoller({
+      list: [HOST_1, HOST_2],
+      interval: 1000,
+      onPollResult: () => {},
+    })
+
+    poller.start()
+    jest.advanceTimersByTime(500)
+    poller.start({ list: [HOST_1, HOST_2] })
+    jest.advanceTimersByTime(500)
+
+    const expectedFetches = [
+      // round 1: poll HOST_1
+      'http://127.0.0.1:31950/health',
+      'http://127.0.0.1:31950/server/health',
+      // round 2: poll HOST_2 after list "refreshed"
+      'http://127.0.0.2:31950/health',
+      'http://127.0.0.2:31950/server/health',
+    ]
+
+    expect(fetch).toHaveBeenCalledTimes(expectedFetches.length)
+    expectedFetches.forEach((url, idx) => {
+      expect(fetch).toHaveBeenNthCalledWith(idx + 1, url, EXPECTED_FETCH_OPTS)
+    })
+  })
+
+  it('should map successful fetch responses to onPollResult', () => {
+    const onPollResult = jest.fn()
+
+    stubFetchOnce('http://127.0.0.1:31950/health')(
+      makeMockJsonResponse(Fixtures.mockHealthResponse)
+    )
+    stubFetchOnce('http://127.0.0.1:31950/server/health')(
+      makeMockJsonResponse(Fixtures.mockServerHealthResponse)
+    )
+
+    const poller = createHealthPoller({
+      list: [HOST_1],
+      interval: 1000,
+      onPollResult,
+    })
+
+    poller.start()
+    jest.advanceTimersByTime(1000)
+
+    return flush().then(() => {
+      expect(onPollResult).toHaveBeenCalledWith({
+        ip: '127.0.0.1',
+        port: 31950,
+        health: Fixtures.mockHealthResponse,
+        serverHealth: Fixtures.mockServerHealthResponse,
+        healthError: null,
+        serverHealthError: null,
+      })
+    })
+  })
+
+  it('should map partially successful fetch responses to onPollResult', () => {
+    const onPollResult = jest.fn()
+
+    stubFetchOnce('http://127.0.0.1:31950/health')(
+      makeMockJsonResponse({ message: 'some error' }, false, 400)
+    )
+    stubFetchOnce('http://127.0.0.1:31950/server/health')(
+      makeMockJsonResponse(Fixtures.mockServerHealthResponse)
+    )
+
+    const poller = createHealthPoller({
+      list: [HOST_1],
+      interval: 1000,
+      onPollResult,
+    })
+
+    poller.start()
+    jest.advanceTimersByTime(1000)
+
+    return flush().then(() => {
+      expect(onPollResult).toHaveBeenCalledWith({
+        ip: '127.0.0.1',
+        port: 31950,
+        health: null,
+        serverHealth: Fixtures.mockServerHealthResponse,
+        healthError: { status: 400, body: { message: 'some error' } },
+        serverHealthError: null,
+      })
+    })
+  })
+
+  it('should map routable but failed responses to onPollResult', () => {
+    const onPollResult = jest.fn()
+
+    stubFetchOnce('http://127.0.0.1:31950/health')({
+      ok: false,
+      status: 504,
+      text: () => Promise.resolve('Gateway timeout'),
+    })
+    stubFetchOnce('http://127.0.0.1:31950/server/health')({
+      ok: false,
+      status: 504,
+      text: () => Promise.resolve('Gateway timeout'),
+    })
+
+    const poller = createHealthPoller({
+      list: [HOST_1],
+      interval: 1000,
+      onPollResult,
+    })
+
+    poller.start()
+    jest.advanceTimersByTime(1000)
+
+    return flush().then(() => {
+      expect(onPollResult).toHaveBeenCalledWith({
+        ip: '127.0.0.1',
+        port: 31950,
+        health: null,
+        serverHealth: null,
+        healthError: { status: 504, body: 'Gateway timeout' },
+        serverHealthError: { status: 504, body: 'Gateway timeout' },
+      })
+    })
+  })
+
+  it('should map fetch errors to onPollResult', () => {
+    const onPollResult = jest.fn()
+
+    stubFetchOnce('http://127.0.0.1:31950/health')(new Error('Failed to fetch'))
+    stubFetchOnce('http://127.0.0.1:31950/server/health')(
+      new Error('Failed to fetch')
+    )
+
+    const poller = createHealthPoller({
+      list: [HOST_1],
+      interval: 1000,
+      onPollResult,
+    })
+
+    poller.start()
+    jest.advanceTimersByTime(1000)
+
+    return flush().then(() => {
+      expect(onPollResult).toHaveBeenCalledWith({
+        ip: '127.0.0.1',
+        port: 31950,
+        health: null,
+        serverHealth: null,
+        healthError: { status: -1, body: 'Failed to fetch' },
+        serverHealthError: { status: -1, body: 'Failed to fetch' },
+      })
+    })
+  })
+
+  it('should spread its fetches out over the interval', () => {
+    const poller = createHealthPoller({
+      list: [HOST_1, HOST_2, HOST_3],
+      interval: 300,
+      onPollResult: () => {},
+    })
+
+    const expectedFetches = [
+      'http://127.0.0.1:31950/health',
+      'http://127.0.0.1:31950/server/health',
+      'http://127.0.0.2:31950/health',
+      'http://127.0.0.2:31950/server/health',
+      'http://127.0.0.3:31950/health',
+      'http://127.0.0.3:31950/server/health',
+      'http://127.0.0.1:31950/health',
+      'http://127.0.0.1:31950/server/health',
+    ]
+
+    poller.start()
+    jest.advanceTimersByTime(100)
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expectedFetches.slice(0, 2).forEach((url, idx) => {
+      expect(fetch).toHaveBeenNthCalledWith(idx + 1, url, EXPECTED_FETCH_OPTS)
+    })
+
+    fetch.mockClear()
+    jest.advanceTimersByTime(100)
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expectedFetches.slice(2, 4).forEach((url, idx) => {
+      expect(fetch).toHaveBeenNthCalledWith(idx + 1, url, EXPECTED_FETCH_OPTS)
+    })
+
+    fetch.mockClear()
+    jest.advanceTimersByTime(100)
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expectedFetches.slice(4, 6).forEach((url, idx) => {
+      expect(fetch).toHaveBeenNthCalledWith(idx + 1, url, EXPECTED_FETCH_OPTS)
+    })
+
+    fetch.mockClear()
+    jest.advanceTimersByTime(100)
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expectedFetches.slice(6, 8).forEach((url, idx) => {
+      expect(fetch).toHaveBeenNthCalledWith(idx + 1, url, EXPECTED_FETCH_OPTS)
+    })
+  })
+
+  it('should ignore late responses', () => {
+    // TODO(mc, 2020-07-13): Jest v25 fake timers do not mock Date.now,
+    // so this test needs real timers. Move back to fake timers after upgrade
+    jest.useRealTimers()
+
+    const onPollResult = jest.fn()
+    const poller = createHealthPoller({
+      list: [HOST_1],
+      // NOTE(mc, 2020-07-13): see TODO above. This value chosen to work well
+      // with real time but runs the risk of being flakey because setTimeout
+      // is not exact in real life
+      interval: 50,
+      onPollResult,
+    })
+
+    // the first two calls the fetch (/health and /server/health) will error
+    // out _after_ the second two calls are made and completed
+    const mockErrorImpl = () => {
+      return new Promise((resolve, reject) => {
+        setTimeout(() => reject(new Error('Oh no eventual error!')), 75)
+      })
+    }
+    fetch.mockImplementationOnce(mockErrorImpl)
+    fetch.mockImplementationOnce(mockErrorImpl)
+
+    // the second two calls with successfully resolve quickly before the first
+    // two calls return their eventual errors
+    stubFetchOnce('http://127.0.0.1:31950/health')(
+      makeMockJsonResponse(Fixtures.mockHealthResponse)
+    )
+    stubFetchOnce('http://127.0.0.1:31950/server/health')(
+      makeMockJsonResponse(Fixtures.mockServerHealthResponse)
+    )
+
+    poller.start()
+
+    return new Promise(resolve => setTimeout(resolve, 150)).then(() => {
+      // ensure that the fact that the second poll returned means the eventual
+      // errors for the first poll are thrown away
+      expect(onPollResult).toHaveBeenCalledTimes(1)
+      expect(onPollResult).toHaveBeenCalledWith({
+        ip: '127.0.0.1',
+        port: 31950,
+        health: Fixtures.mockHealthResponse,
+        serverHealth: Fixtures.mockServerHealthResponse,
+        healthError: null,
+        serverHealthError: null,
+      })
+    })
+  })
+
+  it('should ignore responses after stop()', () => {
+    const onPollResult = jest.fn()
+    const poller = createHealthPoller({
+      list: [HOST_1],
+      interval: 50,
+      onPollResult,
+    })
+
+    const mockErrorImpl = () => {
+      return new Promise((resolve, reject) => {
+        setTimeout(() => reject(new Error('Oh no eventual error!')), 25)
+      })
+    }
+    fetch.mockImplementationOnce(mockErrorImpl)
+    fetch.mockImplementationOnce(mockErrorImpl)
+
+    poller.start()
+    jest.advanceTimersByTime(50)
+    poller.stop()
+    jest.advanceTimersByTime(50)
+
+    return flush().then(() => {
+      expect(onPollResult).toHaveBeenCalledTimes(0)
+    })
+  })
+})

--- a/discovery-client/src/constants.js
+++ b/discovery-client/src/constants.js
@@ -4,3 +4,7 @@
 export const HEALTH_STATUS_UNREACHABLE: 'unreachable' = 'unreachable'
 export const HEALTH_STATUS_NOT_OK: 'notOk' = 'notOk'
 export const HEALTH_STATUS_OK: 'ok' = 'ok'
+
+// health endpoint paths
+export const ROBOT_SERVER_HEALTH_PATH = '/health'
+export const UPDATE_SERVER_HEALTH_PATH = '/server/update/health'

--- a/discovery-client/src/health-poller.js
+++ b/discovery-client/src/health-poller.js
@@ -1,0 +1,166 @@
+// @flow
+import fetch from 'node-fetch'
+import intersectionBy from 'lodash/intersectionBy'
+import unionBy from 'lodash/unionBy'
+import xorBy from 'lodash/xorBy'
+
+import type {
+  HealthPoller,
+  HealthPollerTarget,
+  HealthPollerConfig,
+  HealthPollerOptions,
+  HealthPollerResult,
+  HealthResponse,
+  ServerHealthResponse,
+  LogLevel,
+} from './types'
+
+const DEFAULT_REQUEST_OPTS = { timeout: 10000 }
+
+/**
+ * Create a HealthPoller to monitor the health of a set of IP addresses
+ */
+export function createHealthPoller(options: HealthPollerOptions): HealthPoller {
+  const { onPollResult, logger } = options
+  const log = (level: LogLevel, msg: string, meta: {} = {}) => {
+    typeof logger?.[level] === 'function' && logger[level](msg, meta)
+  }
+
+  let { interval } = options
+  let pollQueue: Array<HealthPollerTarget> = [...options.list]
+  let pollIntervalId: IntervalID | null = null
+  let lastCompletedPollTimeByIp: { [ip: string]: number | void, ... } = {}
+
+  const pollAndNotify = (ip, port) => {
+    log('silly', 'Polling health', { ip, port })
+
+    const pollTime = Date.now()
+
+    return pollHealth(ip, port)
+      .then(result => {
+        const lastPollTime = lastCompletedPollTimeByIp[ip] ?? 0
+
+        // only notify if the poll result is the freshest result available and
+        // polling is currently active
+        if (pollTime > lastPollTime && pollIntervalId !== null) {
+          log('silly', 'Poll completed', { ip, port, result })
+          onPollResult(result)
+          lastCompletedPollTimeByIp[ip] = pollTime
+        } else {
+          log('debug', 'Stale poll result ignored', { ip, port, result })
+        }
+      })
+      .catch((e: Error) => {
+        log('error', 'Unexpected poll error', { ip, port, message: e.message })
+      })
+  }
+
+  const start = (nextOpts: $Partial<HealthPollerConfig> = {}) => {
+    const { interval: nextInterval, list: nextList } = nextOpts
+    let needsNewInterval = pollIntervalId === null
+
+    if (nextInterval != null && nextInterval !== interval) {
+      interval = nextInterval
+      needsNewInterval = true
+    }
+
+    // if xor (symmetric difference) returns values, then elements exist in
+    // one list and not the other and need to be added to and/or removed from the queue
+    if (nextList && xorBy(pollQueue, nextList, 'ip').length > 0) {
+      // keeping the order of `pollQueue`, remove all elements that aren't
+      // in the new list via `intersection`, then add new elements via `union`
+      pollQueue = unionBy(
+        intersectionBy(pollQueue, nextList, 'ip'),
+        nextList,
+        'ip'
+      )
+      needsNewInterval = true
+    }
+
+    if (needsNewInterval && pollQueue.length > 0) {
+      const handlePoll = () => {
+        // since we're using a mutable array as a queue, guard against unsafe
+        // array access before we start shifting and pushing
+        if (pollQueue.length > 0) {
+          // take the head of the queue out and put it back in at the end
+          const head = pollQueue.shift()
+          pollQueue.push(head)
+          pollAndNotify(head.ip, head.port)
+        }
+      }
+
+      stop()
+      log('debug', 'starting new health poll interval')
+      pollIntervalId = setInterval(handlePoll, interval / pollQueue.length)
+    } else {
+      log('debug', 'poller (re)start called but no new interval needed')
+    }
+  }
+
+  const stop = () => {
+    log('debug', 'stopping health poller')
+    lastCompletedPollTimeByIp = {}
+    clearInterval(pollIntervalId)
+    pollIntervalId = null
+  }
+
+  return { start, stop }
+}
+
+type FetchAndParseResult<SuccessBody> =
+  | {| ok: true, status: number, body: SuccessBody |}
+  | {| ok: false, status: number, body: string | { ... } |}
+
+/**
+ * Fetch a URL and parse its response to JSON if possible. If the body can't
+ * be parsed, return the string body to preserve non-JSON NGINX responses
+ */
+function fetchAndParse<SuccessBody>(
+  url: string
+): Promise<FetchAndParseResult<SuccessBody>> {
+  return fetch(url, DEFAULT_REQUEST_OPTS)
+    .then(resp => {
+      const { ok, status } = resp
+
+      return resp
+        .text()
+        .catch((e: Error) => `Unable to read response body: ${e.message}`)
+        .then(text => {
+          try {
+            return JSON.parse(text)
+          } catch (e) {
+            return text
+          }
+        })
+        .then(body => ({ ok, status, body }: any))
+    })
+    .catch((error: Error) => {
+      return { ok: false, status: -1, body: error.message }
+    })
+}
+
+/**
+ * Poll both /heath and /server/health of an IP address and combine the
+ * responses into a single result object
+ */
+function pollHealth(ip: string, port: number): Promise<HealthPollerResult> {
+  const healthReq = fetchAndParse<HealthResponse>(`http://${ip}:${port}/health`)
+  const serverHealthReq = fetchAndParse<ServerHealthResponse>(
+    `http://${ip}:${port}/server/health`
+  )
+
+  return Promise.all([healthReq, serverHealthReq]).then(
+    ([healthResp, serverHealthResp]) => ({
+      ip,
+      port,
+      health: healthResp.ok ? healthResp.body : null,
+      serverHealth: serverHealthResp.ok ? serverHealthResp.body : null,
+      healthError: !healthResp.ok
+        ? { status: healthResp.status, body: healthResp.body }
+        : null,
+      serverHealthError: !serverHealthResp.ok
+        ? { status: serverHealthResp.status, body: serverHealthResp.body }
+        : null,
+    })
+  )
+}

--- a/discovery-client/src/health-poller.js
+++ b/discovery-client/src/health-poller.js
@@ -4,6 +4,11 @@ import intersectionBy from 'lodash/intersectionBy'
 import unionBy from 'lodash/unionBy'
 import xorBy from 'lodash/xorBy'
 
+import {
+  ROBOT_SERVER_HEALTH_PATH,
+  UPDATE_SERVER_HEALTH_PATH,
+} from './constants'
+
 import type {
   HealthPoller,
   HealthPollerTarget,
@@ -140,13 +145,15 @@ function fetchAndParse<SuccessBody>(
 }
 
 /**
- * Poll both /heath and /server/health of an IP address and combine the
+ * Poll both /heath and /server/update/health of an IP address and combine the
  * responses into a single result object
  */
 function pollHealth(ip: string, port: number): Promise<HealthPollerResult> {
-  const healthReq = fetchAndParse<HealthResponse>(`http://${ip}:${port}/health`)
+  const healthReq = fetchAndParse<HealthResponse>(
+    `http://${ip}:${port}${ROBOT_SERVER_HEALTH_PATH}`
+  )
   const serverHealthReq = fetchAndParse<ServerHealthResponse>(
-    `http://${ip}:${port}/server/health`
+    `http://${ip}:${port}${UPDATE_SERVER_HEALTH_PATH}`
   )
 
   return Promise.all([healthReq, serverHealthReq]).then(

--- a/discovery-client/src/service.js
+++ b/discovery-client/src/service.js
@@ -109,7 +109,7 @@ export function fromResponse(
 
   if (!name) return null
 
-  // in case of name mismatch, prefer /server/health name and flag not ok
+  // in case of name mismatch, prefer /server/update/health name and flag not ok
   if (apiName != null && serverName != null && apiName !== serverName) {
     apiOk = false
   }

--- a/discovery-client/src/store/__tests__/hostsByIpReducer.test.js
+++ b/discovery-client/src/store/__tests__/hostsByIpReducer.test.js
@@ -7,8 +7,8 @@ import {
   mockHealthFetchErrorResponse,
 } from '../../__fixtures__/health'
 
+import * as Constants from '../../constants'
 import * as Actions from '../actions'
-import * as Constants from '../constants'
 import { reducer, hostsByIpReducer } from '../reducer'
 
 describe('hostsByIp reducer', () => {

--- a/discovery-client/src/store/index.js
+++ b/discovery-client/src/store/index.js
@@ -7,7 +7,6 @@ import type { Store } from 'redux'
 import type { State, Action } from './types'
 
 export * from './actions'
-export * from './constants'
 
 export function createStore(): Store<State, Action> {
   return createReduxStore(reducer)

--- a/discovery-client/src/store/reducer.js
+++ b/discovery-client/src/store/reducer.js
@@ -3,12 +3,13 @@ import { combineReducers } from 'redux'
 import isEqual from 'lodash/isEqual'
 import omit from 'lodash/omit'
 
-import * as Actions from './actions'
 import {
   HEALTH_STATUS_OK,
   HEALTH_STATUS_NOT_OK,
   HEALTH_STATUS_UNREACHABLE,
-} from './constants'
+} from '../constants'
+
+import * as Actions from './actions'
 
 import type { Reducer } from 'redux'
 

--- a/discovery-client/src/store/types.js
+++ b/discovery-client/src/store/types.js
@@ -8,18 +8,18 @@ import type {
 } from '../types'
 
 import typeof {
+  HEALTH_STATUS_UNREACHABLE,
+  HEALTH_STATUS_NOT_OK,
+  HEALTH_STATUS_OK,
+} from '../constants'
+
+import typeof {
   SERVICE_FOUND,
   HEALTH_POLLED,
   ADD_IP_ADDRESS,
   REMOVE_IP_ADDRESS,
   REMOVE_ROBOT,
 } from './actions'
-
-import typeof {
-  HEALTH_STATUS_UNREACHABLE,
-  HEALTH_STATUS_NOT_OK,
-  HEALTH_STATUS_OK,
-} from './constants'
 
 /**
  * Health state of a given robot
@@ -29,7 +29,7 @@ export type RobotState = $ReadOnly<{|
   name: string,
   /** latest /health response data from the robot */
   health: HealthResponse | null,
-  /** latest /server/health response data from the robot */
+  /** latest /server/update/health response data from the robot */
   serverHealth: ServerHealthResponse | null,
 |}>
 
@@ -56,11 +56,11 @@ export type HostState = $ReadOnly<{|
   seen: boolean,
   /** How the last GET /health responded (null if no response yet) */
   healthStatus: HealthStatus | null,
-  /** How the last GET /server/health responded (null if no response yet) */
+  /** How the last GET /server/update/health responded (null if no response yet) */
   serverHealthStatus: HealthStatus | null,
   /** Error status and response from /health if last request was not 200 */
   healthError: HealthErrorResponse | null,
-  /** Error status and response from /server/health if last request was not 200 */
+  /** Error status and response from /server/update/health if last request was not 200 */
   serverHealthError: HealthErrorResponse | null,
   /** Robot that this IP points to, if known */
   robotName: string | null,

--- a/discovery-client/src/store/types.js
+++ b/discovery-client/src/store/types.js
@@ -44,14 +44,18 @@ export type HealthStatus =
   | HEALTH_STATUS_NOT_OK
   | HEALTH_STATUS_OK
 
-/**
- * State for a given IP address, which should point to a robot
- */
-export type HostState = $ReadOnly<{|
+export type Address = $ReadOnly<{|
   /** IP address */
   ip: string,
   /** Port */
   port: number,
+|}>
+
+/**
+ * State for a given IP address, which should point to a robot
+ */
+export type HostState = $ReadOnly<{|
+  ...Address,
   /** Whether this IP has been seen via mDNS or HTTP while the client has been running */
   seen: boolean,
   /** How the last GET /health responded (null if no response yet) */

--- a/discovery-client/src/types.js
+++ b/discovery-client/src/types.js
@@ -138,11 +138,13 @@ export type HealthPollerOptions = $ReadOnly<{|
 export type HealthPoller = $ReadOnly<{|
   /**
    * (Re)start the poller, optionally passing in new configuration values.
-   * Any unspecified config values will be preserved from the last time
-   * they were set. `start` must be called with an interval and list at least
-   * once to actually poll anything.
+   * Any unspecified config will be preserved from the last time `start` was
+   * called. `start` must be called with an interval and list at least once.
    */
   start: (startOpts?: HealthPollerConfig) => void,
-  /** Stop the poller (will not cancel any in-flight HTTP requests) */
+  /**
+   * Stop the poller. In-flight HTTP requests may not be cancelled, but
+   * `onPollResult` will no longer be called.
+   */
   stop: () => void,
 |}>

--- a/discovery-client/src/types.js
+++ b/discovery-client/src/types.js
@@ -52,13 +52,13 @@ export type Service = {
   local: ?boolean,
   // GET /health response.ok === true
   ok: ?boolean,
-  // GET /server/health response.ok === true
+  // GET /server/update/health response.ok === true
   serverOk: ?boolean,
   // is advertising on MDNS
   advertising: ?boolean,
   // last good /health response
   health: ?HealthResponse,
-  // last good /server/health response
+  // last good /server/update/health response
   serverHealth: ?ServerHealthResponse,
   ...
 }
@@ -89,11 +89,11 @@ export type HealthPollerResult = $ReadOnly<{|
   port: number,
   /** GET /health data if server responded with 2xx */
   health: HealthResponse | null,
-  /** GET /server/health data if server responded with 2xx */
+  /** GET /server/update/health data if server responded with 2xx */
   serverHealth: ServerHealthResponse | null,
   /** GET /health status code and body if response was non-2xx */
   healthError: HealthErrorResponse | null,
-  /** GET /server/health status code and body if response was non-2xx */
+  /** GET /server/update/health status code and body if response was non-2xx */
   serverHealthError: HealthErrorResponse | null,
 |}>
 

--- a/discovery-client/src/types.js
+++ b/discovery-client/src/types.js
@@ -103,26 +103,28 @@ export type HealthPollerResult = $ReadOnly<{|
  * for its own state
  */
 export type HealthPollerTarget = $ReadOnly<{
+  /** IP address used to contruct health URLs */
   ip: string,
+  /** Port address used to construct health URLs */
   port: number,
   ...
 }>
 
 /**
- * Base configuration options of a HealthPoller
+ * HealthPoller runtime configuration that can be changed by multiple calls
+ * to start; previous config state will be preserved if left unspecified
  */
 export type HealthPollerConfig = $ReadOnly<{|
   /** List of addresses to poll */
-  list: $ReadOnlyArray<HealthPollerTarget>,
+  list?: $ReadOnlyArray<HealthPollerTarget>,
   /** Call the health endpoints for a given IP once every `interval` ms */
-  interval: number,
+  interval?: number,
 |}>
 
 /**
  * Options used to construct a health poller
  */
 export type HealthPollerOptions = $ReadOnly<{|
-  ...HealthPollerConfig,
   /** Function to call whenever the requests for an IP settle */
   onPollResult: (pollResult: HealthPollerResult) => mixed,
   /** Optional logger */
@@ -134,8 +136,13 @@ export type HealthPollerOptions = $ReadOnly<{|
  * addresses
  */
 export type HealthPoller = $ReadOnly<{|
-  /** (Re)start the poller, optionally passing in a new configuration */
-  start: (startOpts?: $Partial<HealthPollerConfig>) => void,
+  /**
+   * (Re)start the poller, optionally passing in new configuration values.
+   * Any unspecified config values will be preserved from the last time
+   * they were set. `start` must be called with an interval and list at least
+   * once to actually poll anything.
+   */
+  start: (startOpts?: HealthPollerConfig) => void,
   /** Stop the poller (will not cancel any in-flight HTTP requests) */
   stop: () => void,
 |}>

--- a/discovery-client/src/types.js
+++ b/discovery-client/src/types.js
@@ -20,6 +20,7 @@ export type Capability =
 
 export type CapabilityMap = {
   [capabilityName: Capability]: ?string,
+  ...,
 }
 
 export type ServerHealthResponse = {
@@ -40,6 +41,7 @@ export type HealthErrorResponse = {|
 export type Candidate = {
   ip: string,
   port: number,
+  ...
 }
 
 export type Service = {
@@ -58,6 +60,7 @@ export type Service = {
   health: ?HealthResponse,
   // last good /server/health response
   serverHealth: ?ServerHealthResponse,
+  ...
 }
 
 export type ServiceUpdate = $Shape<Service>
@@ -92,4 +95,47 @@ export type HealthPollerResult = $ReadOnly<{|
   healthError: HealthErrorResponse | null,
   /** GET /server/health status code and body if response was non-2xx */
   serverHealthError: HealthErrorResponse | null,
+|}>
+
+/**
+ * Object describing something than can be polled for health. Inexact to avoid
+ * coupling what the HealthPoller expects with what the DiscoveryClient needs
+ * for its own state
+ */
+export type HealthPollerTarget = $ReadOnly<{
+  ip: string,
+  port: number,
+  ...
+}>
+
+/**
+ * Base configuration options of a HealthPoller
+ */
+export type HealthPollerConfig = $ReadOnly<{|
+  /** List of addresses to poll */
+  list: $ReadOnlyArray<HealthPollerTarget>,
+  /** Call the health endpoints for a given IP once every `interval` ms */
+  interval: number,
+|}>
+
+/**
+ * Options used to construct a health poller
+ */
+export type HealthPollerOptions = $ReadOnly<{|
+  ...HealthPollerConfig,
+  /** Function to call whenever the requests for an IP settle */
+  onPollResult: (pollResult: HealthPollerResult) => mixed,
+  /** Optional logger */
+  logger?: Logger,
+|}>
+
+/**
+ * A HealthPoller manages polling the HTTP health endpoints of a set of IP
+ * addresses
+ */
+export type HealthPoller = $ReadOnly<{|
+  /** (Re)start the poller, optionally passing in a new configuration */
+  start: (startOpts?: $Partial<HealthPollerConfig>) => void,
+  /** Stop the poller (will not cancel any in-flight HTTP requests) */
+  stop: () => void,
 |}>

--- a/flow-typed/global.js
+++ b/flow-typed/global.js
@@ -1,0 +1,6 @@
+// @flow
+// global utility types
+
+// takes an object type Obj and returns an object type where all
+// keys are marked as possibly `void`
+export type $Partial<Obj: { ... }> = $Shape<$ObjMap<Obj, <V>(V) => V | void>>

--- a/flow-typed/global.js
+++ b/flow-typed/global.js
@@ -1,6 +1,0 @@
-// @flow
-// global utility types
-
-// takes an object type Obj and returns an object type where all
-// keys are marked as possibly `void`
-export type $Partial<Obj: { ... }> = $Shape<$ObjMap<Obj, <V>(V) => V | void>>

--- a/flow-typed/npm/lodash_v4.x.x.js
+++ b/flow-typed/npm/lodash_v4.x.x.js
@@ -455,25 +455,25 @@ declare module "lodash" {
     unzip<T>(array?: ?Array<T>): Array<T>;
     unzipWith<T>(array: ?Array<T>, iteratee?: ?Iteratee<T>): Array<T>;
     without<T>(array?: ?$ReadOnlyArray<T>, ...values?: Array<mixed>): Array<T>;
-    xor<T>(...array: Array<Array<T>>): Array<T>;
+    xor<T>(...arrays: Array<$ReadOnlyArray<T>>): Array<T>;
     //Workaround until (...parameter: T, parameter2: U) works
-    xorBy<T>(a1?: ?Array<T>, iteratee?: ?ValueOnlyIteratee<T>): Array<T>;
+    xorBy<T>(a1?: ?$ReadOnlyArray<T>, iteratee?: ?ValueOnlyIteratee<T>): Array<T>;
     xorBy<T>(
-      a1: Array<T>,
-      a2: Array<T>,
+      a1: $ReadOnlyArray<T>,
+      a2: $ReadOnlyArray<T>,
       iteratee?: ValueOnlyIteratee<T>
     ): Array<T>;
     xorBy<T>(
-      a1: Array<T>,
-      a2: Array<T>,
-      a3: Array<T>,
+      a1: $ReadOnlyArray<T>,
+      a2: $ReadOnlyArray<T>,
+      a3: $ReadOnlyArray<T>,
       iteratee?: ValueOnlyIteratee<T>
     ): Array<T>;
     xorBy<T>(
-      a1: Array<T>,
-      a2: Array<T>,
-      a3: Array<T>,
-      a4: Array<T>,
+      a1: $ReadOnlyArray<T>,
+      a2: $ReadOnlyArray<T>,
+      a3: $ReadOnlyArray<T>,
+      a4: $ReadOnlyArray<T>,
       iteratee?: ValueOnlyIteratee<T>
     ): Array<T>;
     //Workaround until (...parameter: T, parameter2: U) works


### PR DESCRIPTION
# Overview

This PR is part of #5981 and continues the work of #6106 by rewriting the existing health poller with two main goals:

- Hook in nicely with the new Redux state + actions
- Avoid surfacing polls that have become stale due to later polls returning
    - This is to avoid race conditions that cause robots to appear to flip back and forth between healthy and unhealthy

**This new health poller is not hooked up to anything.** You can compare it to the old health poller to get a sense of the logic that has changed (and also what has not changed).

- New poller (not hooked up): `discovery-client/src/health-poller.js`
- Old poller (still hooked up): `discovery-client/src/poller.js`

~Currently blocked by #6106 and will require rebase~

# Changelog

- refactor(discovery-client): refactor poller to enable wire-up to Redux

# Review requests

Code + test only review for now since it's not hooked up to anything. Might also be helpful in reviewing #6106 while it's still open.

# Risk assessment

N/A - This code is not connected to anything