### PR TITLE
fix(components): Update SlotMap prop names

### DIFF
--- a/components/src/__tests__/__snapshots__/slotmap.test.js.snap
+++ b/components/src/__tests__/__snapshots__/slotmap.test.js.snap
@@ -1,11 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SlotMap renders correctly with collision warning 1`] = `
-.c0 {
-  width: 20px;
-  height: 20px;
-}
-
 .c0.spin {
   -webkit-animation: GLFYz 0.8s steps(8) infinite;
   animation: GLFYz 0.8s steps(8) infinite;
@@ -74,8 +69,10 @@ exports[`SlotMap renders correctly with collision warning 1`] = `
       aria-hidden="true"
       className="sc-AxmLO c0 collision_icon"
       fill="currentColor"
+      height={20}
       version="1.1"
       viewBox="0 0 24 24"
+      width={20}
       x={6.5}
       xmlns="http://www.w3.org/2000/svg"
       y={1.5}
@@ -241,11 +238,6 @@ exports[`SlotMap renders correctly with error 1`] = `
 `;
 
 exports[`SlotMap renders correctly with error and collision warning 1`] = `
-.c0 {
-  width: 20px;
-  height: 20px;
-}
-
 .c0.spin {
   -webkit-animation: GLFYz 0.8s steps(8) infinite;
   animation: GLFYz 0.8s steps(8) infinite;
@@ -314,8 +306,10 @@ exports[`SlotMap renders correctly with error and collision warning 1`] = `
       aria-hidden="true"
       className="sc-AxmLO c0 collision_icon"
       fill="currentColor"
+      height={20}
       version="1.1"
       viewBox="0 0 24 24"
+      width={20}
       x={6.5}
       xmlns="http://www.w3.org/2000/svg"
       y={1.5}

--- a/components/src/slotmap/SlotMap.js
+++ b/components/src/slotmap/SlotMap.js
@@ -55,8 +55,8 @@ export function SlotMap(props: SlotMapProps): React.Node {
                 <Icon
                   className={styles.collision_icon}
                   name="information"
-                  width={iconSize}
-                  height={iconSize}
+                  svgWidth={iconSize}
+                  svgHeight={iconSize}
                   x={slotWidth / 2 - iconSize / 2}
                   y={slotHeight / 2 - iconSize / 2}
                 />


### PR DESCRIPTION
# Overview

This PR serves as its own ticket, found a styling bug during QA. When we switched our Icon component to use the Svg primitive, the collision warning icon got left behind.

width => svgWidth
height => svgHeight

# Changelog

- fix(comp-lib): Update SlotMap prop names

# Review requests

Take a look in both complib and PD and make sure the slotmap collision icon isnt goofy.

# Risk assessment

low, single component in PD/complib