### PR TITLE
fix(app): correctly namespace calibration check command

### DIFF
--- a/app/src/sessions/__fixtures__/index.js
+++ b/app/src/sessions/__fixtures__/index.js
@@ -41,7 +41,7 @@ export const mockSessionCommand: Types.SessionCommandAttributes = {
 }
 
 export const mockSessionCommandAttributes: Types.SessionCommandAttributes = {
-  command: 'calibration.preparePipette',
+  command: 'calibration.check.preparePipette',
   status: 'accepted',
   data: {},
 }

--- a/app/src/sessions/calibration-check/constants.js
+++ b/app/src/sessions/calibration-check/constants.js
@@ -43,12 +43,12 @@ export const CHECK_STEP_NO_PIPETTES_ATTACHED: 'noPipettesAttached' =
   'noPipettesAttached'
 
 const LOAD_LABWARE: 'calibration.loadLabware' = 'calibration.loadLabware'
-const PREPARE_PIPETTE: 'calibration.preparePipette' =
-  'calibration.preparePipette'
 const JOG: 'calibration.jog' = 'calibration.jog'
 const PICK_UP_TIP: 'calibration.pickUpTip' = 'calibration.pickUpTip'
 const CONFIRM_TIP: 'calibration.confirmTip' = 'calibration.confirmTip'
 const INVALIDATE_TIP: 'calibration.invalidateTip' = 'calibration.invalidateTip'
+const PREPARE_PIPETTE: 'calibration.check.preparePipette' =
+  'calibration.check.preparePipette'
 const COMPARE_POINT: 'calibration.check.comparePoint' =
   'calibration.check.comparePoint'
 const GO_TO_NEXT_CHECK: 'calibration.check.goToNextCheck' =


### PR DESCRIPTION
# Overview

Fix unreleased command change of 'calibration.preparePipette' ->
'calibration.check.preparePipette' on client side.

In https://github.com/Opentrons/opentrons/pull/6105, I refactored the location of a specific check calibration command on the robot-server side, but forgot to reflect the change in the client. This repairs calibration check, which was broken by the error. 

# Review requests

Confirm Calibration Check works as expected

# Risk assessment

Fixing bug to unreleased code, should be minimal risk