### PR TITLE
refactor(discovery-client): add robot and address initialization to state

### DIFF
--- a/discovery-client/src/store/__tests__/actions.test.js
+++ b/discovery-client/src/store/__tests__/actions.test.js
@@ -3,8 +3,50 @@
 import * as Actions from '../actions'
 
 describe('discovery client action creators', () => {
+  it('should create a client:INITIALIZE_STATE action with robots in the payload', () => {
+    const action = Actions.initializeState({
+      initialRobots: [
+        {
+          name: 'opentrons-dev',
+          health: null,
+          serverHealth: null,
+          addresses: [],
+        },
+      ],
+    })
+
+    expect(action).toEqual({
+      type: 'client:INITIALIZE_STATE',
+      payload: {
+        initialRobots: [
+          {
+            name: 'opentrons-dev',
+            health: null,
+            serverHealth: null,
+            addresses: [],
+          },
+        ],
+      },
+    })
+  })
+
+  it('should create a client:INITIALIZE_STATE action with manualAddresses in the payload', () => {
+    const action = Actions.initializeState({
+      manualAddresses: [{ ip: '127.0.0.1', port: 31950 }],
+    })
+
+    expect(action).toEqual({
+      type: 'client:INITIALIZE_STATE',
+      payload: { manualAddresses: [{ ip: '127.0.0.1', port: 31950 }] },
+    })
+  })
+
   it('should create an mdns:SERVICE_FOUND action', () => {
-    const action = Actions.serviceFound('opentrons-dev', '127.0.0.1', 31950)
+    const action = Actions.serviceFound({
+      name: 'opentrons-dev',
+      ip: '127.0.0.1',
+      port: 31950,
+    })
 
     expect(action).toEqual({
       type: 'mdns:SERVICE_FOUND',
@@ -78,24 +120,6 @@ describe('discovery client action creators', () => {
         healthError,
         serverHealthError,
       },
-    })
-  })
-
-  it('should allow the user to manually add an IP address to the client', () => {
-    const action = Actions.addIpAddress('localhost', 31950)
-
-    expect(action).toEqual({
-      type: 'client:ADD_IP_ADDRESS',
-      payload: { ip: 'localhost', port: 31950 },
-    })
-  })
-
-  it('should allow the user to manually remove an IP address from the client', () => {
-    const action = Actions.removeIpAddress('localhost')
-
-    expect(action).toEqual({
-      type: 'client:REMOVE_IP_ADDRESS',
-      payload: { ip: 'localhost' },
     })
   })
 

--- a/discovery-client/src/store/__tests__/hostsByIpReducer.test.js
+++ b/discovery-client/src/store/__tests__/hostsByIpReducer.test.js
@@ -12,13 +12,137 @@ import * as Actions from '../actions'
 import { reducer, hostsByIpReducer } from '../reducer'
 
 describe('hostsByIp reducer', () => {
-  it('should return an empty initial state', () => {
+  it('should return an empty initial state under hostsByIp in the root reducer', () => {
     const state = reducer(undefined, ({}: any))
     expect(state.hostsByIp).toEqual({})
   })
 
+  it('should not overwrite state if a "client:INITIALIZE_STATE" action has no robots', () => {
+    const initialState = {
+      '127.0.0.1': {
+        ip: '127.0.0.1',
+        port: 31950,
+        seen: false,
+        healthStatus: null,
+        serverHealthStatus: null,
+        healthError: null,
+        serverHealthError: null,
+        robotName: 'opentrons-dev',
+      },
+    }
+    const action = Actions.initializeState({})
+    const state = hostsByIpReducer(initialState, action)
+
+    expect(state).toBe(initialState)
+  })
+
+  it('should overwrite state with robots from "client:INITIALIZE_STATE"', () => {
+    const initialState = {
+      '127.0.0.1': {
+        ip: '127.0.0.1',
+        port: 31950,
+        seen: false,
+        healthStatus: null,
+        serverHealthStatus: null,
+        healthError: null,
+        serverHealthError: null,
+        robotName: 'opentrons-dev',
+      },
+    }
+
+    const action = Actions.initializeState({
+      initialRobots: [
+        {
+          name: 'opentrons-1',
+          health: mockHealthResponse,
+          serverHealth: mockServerHealthResponse,
+          addresses: [
+            {
+              ip: '127.0.0.2',
+              port: 31950,
+              seen: false,
+              healthStatus: null,
+              serverHealthStatus: null,
+              healthError: null,
+              serverHealthError: null,
+            },
+          ],
+        },
+        {
+          name: 'opentrons-2',
+          health: null,
+          serverHealth: mockServerHealthResponse,
+          addresses: [
+            {
+              ip: '127.0.0.3',
+              port: 31950,
+              seen: true,
+              healthStatus: Constants.HEALTH_STATUS_NOT_OK,
+              serverHealthStatus: Constants.HEALTH_STATUS_NOT_OK,
+              healthError: mockHealthErrorJsonResponse,
+              serverHealthError: mockHealthErrorJsonResponse,
+            },
+            {
+              ip: '127.0.0.4',
+              port: 31950,
+              seen: false,
+              healthStatus: Constants.HEALTH_STATUS_UNREACHABLE,
+              serverHealthStatus: Constants.HEALTH_STATUS_UNREACHABLE,
+              healthError: mockHealthFetchErrorResponse,
+              serverHealthError: mockHealthFetchErrorResponse,
+            },
+          ],
+        },
+        {
+          name: 'opentrons-3',
+          health: mockHealthResponse,
+          serverHealth: null,
+          addresses: [],
+        },
+      ],
+    })
+    const state = hostsByIpReducer(initialState, action)
+
+    expect(state).toEqual({
+      '127.0.0.2': {
+        ip: '127.0.0.2',
+        port: 31950,
+        seen: false,
+        healthStatus: null,
+        serverHealthStatus: null,
+        healthError: null,
+        serverHealthError: null,
+        robotName: 'opentrons-1',
+      },
+      '127.0.0.3': {
+        ip: '127.0.0.3',
+        port: 31950,
+        seen: false,
+        healthStatus: null,
+        serverHealthStatus: null,
+        healthError: null,
+        serverHealthError: null,
+        robotName: 'opentrons-2',
+      },
+      '127.0.0.4': {
+        ip: '127.0.0.4',
+        port: 31950,
+        seen: false,
+        healthStatus: null,
+        serverHealthStatus: null,
+        healthError: null,
+        serverHealthError: null,
+        robotName: 'opentrons-2',
+      },
+    })
+  })
+
   it('should handle an "mdns:SERVICE_FOUND" action for a new ip', () => {
-    const action = Actions.serviceFound('opentrons-dev', '127.0.0.1', 31950)
+    const action = Actions.serviceFound({
+      name: 'opentrons-dev',
+      ip: '127.0.0.1',
+      port: 31950,
+    })
     const initialState = {}
 
     expect(hostsByIpReducer(initialState, action)).toEqual({
@@ -36,7 +160,11 @@ describe('hostsByIp reducer', () => {
   })
 
   it('should handle an "mdns:SERVICE_FOUND" action for an existing, un-polled ip', () => {
-    const action = Actions.serviceFound('opentrons-dev', '127.0.0.1', 31950)
+    const action = Actions.serviceFound({
+      name: 'opentrons-dev',
+      ip: '127.0.0.1',
+      port: 31950,
+    })
     const initialState = {
       '127.0.0.1': {
         ip: '127.0.0.1',
@@ -66,7 +194,11 @@ describe('hostsByIp reducer', () => {
   })
 
   it('should handle an "mdns:SERVICE_FOUND" action for an existing, polled ip', () => {
-    const action = Actions.serviceFound('opentrons-dev', '127.0.0.1', 31950)
+    const action = Actions.serviceFound({
+      name: 'opentrons-dev',
+      ip: '127.0.0.1',
+      port: 31950,
+    })
     const initialState = {
       '127.0.0.1': {
         ip: '127.0.0.1',
@@ -86,7 +218,11 @@ describe('hostsByIp reducer', () => {
   })
 
   it('should handle an "mdns:SERVICE_FOUND" action for an existing ip with an old robot name', () => {
-    const action = Actions.serviceFound('opentrons-dev', '127.0.0.1', 31950)
+    const action = Actions.serviceFound({
+      name: 'opentrons-dev',
+      ip: '127.0.0.1',
+      port: 31950,
+    })
     const initialState = {
       '127.0.0.1': {
         ip: '127.0.0.1',
@@ -373,101 +509,6 @@ describe('hostsByIp reducer', () => {
         robotName: 'opentrons-other',
       },
     })
-  })
-
-  it('should handle "client:ADD_IP_ADDRESS" for new address', () => {
-    const action = Actions.addIpAddress('127.0.0.1', 31950)
-    const initialState = {}
-    const nextState = hostsByIpReducer(initialState, action)
-
-    expect(nextState).toEqual({
-      '127.0.0.1': {
-        ip: '127.0.0.1',
-        port: 31950,
-        seen: false,
-        healthStatus: null,
-        serverHealthStatus: null,
-        healthError: null,
-        serverHealthError: null,
-        robotName: null,
-      },
-    })
-  })
-
-  it('should noop "client:ADD_IP_ADDRESS" for existing address', () => {
-    const action = Actions.addIpAddress('127.0.0.1', 31950)
-    const initialState = {
-      '127.0.0.1': {
-        ip: '127.0.0.1',
-        port: 31950,
-        seen: true,
-        healthStatus: Constants.HEALTH_STATUS_OK,
-        serverHealthStatus: Constants.HEALTH_STATUS_OK,
-        healthError: null,
-        serverHealthError: null,
-        robotName: 'opentrons-dev',
-      },
-    }
-    const nextState = hostsByIpReducer(initialState, action)
-
-    expect(nextState).toBe(initialState)
-  })
-
-  it('should handle "client:REMOVE_IP_ADDRESS" for unseen address', () => {
-    const action = Actions.removeIpAddress('127.0.0.1')
-    const initialState = {
-      '127.0.0.1': {
-        ip: '127.0.0.1',
-        port: 31950,
-        seen: false,
-        healthStatus: null,
-        serverHealthStatus: null,
-        healthError: null,
-        serverHealthError: null,
-        robotName: null,
-      },
-    }
-    const nextState = hostsByIpReducer(initialState, action)
-
-    expect(nextState).toEqual({})
-  })
-
-  it('should noop "client:REMOVE_IP_ADDRESS" for seen address', () => {
-    const action = Actions.removeIpAddress('127.0.0.1')
-    const initialState = {
-      '127.0.0.1': {
-        ip: '127.0.0.1',
-        port: 31950,
-        seen: true,
-        healthStatus: Constants.HEALTH_STATUS_OK,
-        serverHealthStatus: Constants.HEALTH_STATUS_OK,
-        healthError: null,
-        serverHealthError: null,
-        robotName: 'opentrons-dev',
-      },
-    }
-    const nextState = hostsByIpReducer(initialState, action)
-
-    expect(nextState).toBe(initialState)
-  })
-
-  it('should noop "client:REMOVE_IP_ADDRESS" for non-existent address', () => {
-    const action = Actions.removeIpAddress('127.0.0.1')
-    const initialState = {
-      '127.0.0.2': {
-        ip: '127.0.0.2',
-        port: 31950,
-        seen: true,
-        healthStatus: Constants.HEALTH_STATUS_OK,
-        serverHealthStatus: Constants.HEALTH_STATUS_OK,
-        healthError: null,
-        serverHealthError: null,
-        robotName: 'opentrons-dev',
-      },
-    }
-    const nextState = hostsByIpReducer(initialState, action)
-
-    expect(nextState).toBe(initialState)
   })
 
   it('should handle "client:REMOVE_ROBOT"', () => {

--- a/discovery-client/src/store/__tests__/manualAddressesReducer.test.js
+++ b/discovery-client/src/store/__tests__/manualAddressesReducer.test.js
@@ -1,0 +1,35 @@
+// @flow
+import * as Actions from '../actions'
+import { reducer, manualAddressesReducer } from '../reducer'
+
+describe('manual addresses reducer', () => {
+  it('should return an empty initial array under manualAddresses in the root reducer', () => {
+    const state = reducer(undefined, ({}: any))
+    expect(state.manualAddresses).toEqual([])
+  })
+
+  it('should not overwrite state if a "client:INITIALIZE_STATE" action has no manualAddresses', () => {
+    const initialState = [{ ip: '127.0.0.1', port: 31950 }]
+    const action = Actions.initializeState({})
+    const state = manualAddressesReducer(initialState, action)
+
+    expect(state).toBe(initialState)
+  })
+
+  it('should overwrite state with addresses from "client:INITIALIZE_STATE"', () => {
+    const initialState = [{ ip: '127.0.0.1', port: 31950 }]
+
+    const action = Actions.initializeState({
+      manualAddresses: [
+        { ip: '127.0.0.2', port: 31950 },
+        { ip: '127.0.0.3', port: 31950 },
+      ],
+    })
+    const state = manualAddressesReducer(initialState, action)
+
+    expect(state).toEqual([
+      { ip: '127.0.0.2', port: 31950 },
+      { ip: '127.0.0.3', port: 31950 },
+    ])
+  })
+})

--- a/discovery-client/src/store/__tests__/selectors.test.js
+++ b/discovery-client/src/store/__tests__/selectors.test.js
@@ -1,0 +1,280 @@
+// @flow
+import {
+  mockHealthResponse,
+  mockServerHealthResponse,
+  mockHealthErrorJsonResponse,
+  mockHealthFetchErrorResponse,
+} from '../../__fixtures__/health'
+
+import {
+  HEALTH_STATUS_OK,
+  HEALTH_STATUS_NOT_OK,
+  HEALTH_STATUS_UNREACHABLE,
+} from '../../constants'
+
+import * as Selectors from '../selectors'
+
+import type { State, HostState } from '../types'
+
+const STATE: State = {
+  robotsByName: {
+    'opentrons-1': {
+      name: 'opentrons-1',
+      health: mockHealthResponse,
+      serverHealth: mockServerHealthResponse,
+    },
+    'opentrons-2': {
+      name: 'opentrons-2',
+      health: null,
+      serverHealth: mockServerHealthResponse,
+    },
+    'opentrons-3': {
+      name: 'opentrons-3',
+      health: mockHealthResponse,
+      serverHealth: null,
+    },
+  },
+  hostsByIp: {
+    '127.0.0.2': {
+      ip: '127.0.0.2',
+      port: 31950,
+      seen: false,
+      healthStatus: null,
+      serverHealthStatus: null,
+      healthError: null,
+      serverHealthError: null,
+      robotName: 'opentrons-1',
+    },
+    '127.0.0.3': {
+      ip: '127.0.0.3',
+      port: 31950,
+      seen: true,
+      healthStatus: HEALTH_STATUS_NOT_OK,
+      serverHealthStatus: HEALTH_STATUS_NOT_OK,
+      healthError: mockHealthErrorJsonResponse,
+      serverHealthError: mockHealthErrorJsonResponse,
+      robotName: 'opentrons-2',
+    },
+    '127.0.0.4': {
+      ip: '127.0.0.4',
+      port: 31950,
+      seen: false,
+      healthStatus: HEALTH_STATUS_UNREACHABLE,
+      serverHealthStatus: HEALTH_STATUS_UNREACHABLE,
+      healthError: mockHealthFetchErrorResponse,
+      serverHealthError: mockHealthFetchErrorResponse,
+      robotName: 'opentrons-2',
+    },
+  },
+  manualAddresses: [
+    { ip: '127.0.0.4', port: 31950 },
+    { ip: '127.0.0.5', port: 31950 },
+    { ip: '127.0.0.6', port: 31950 },
+  ],
+}
+
+describe('discovery client state selectors', () => {
+  it('should be able to get a list of robot states', () => {
+    expect(Selectors.getRobotStates(STATE)).toEqual([
+      {
+        name: 'opentrons-1',
+        health: mockHealthResponse,
+        serverHealth: mockServerHealthResponse,
+      },
+      {
+        name: 'opentrons-2',
+        health: null,
+        serverHealth: mockServerHealthResponse,
+      },
+      {
+        name: 'opentrons-3',
+        health: mockHealthResponse,
+        serverHealth: null,
+      },
+    ])
+  })
+
+  it('should be able to get a list of host states', () => {
+    expect(Selectors.getHostStates(STATE)).toEqual([
+      {
+        ip: '127.0.0.2',
+        port: 31950,
+        seen: false,
+        healthStatus: null,
+        serverHealthStatus: null,
+        healthError: null,
+        serverHealthError: null,
+        robotName: 'opentrons-1',
+      },
+      {
+        ip: '127.0.0.3',
+        port: 31950,
+        seen: true,
+        healthStatus: HEALTH_STATUS_NOT_OK,
+        serverHealthStatus: HEALTH_STATUS_NOT_OK,
+        healthError: mockHealthErrorJsonResponse,
+        serverHealthError: mockHealthErrorJsonResponse,
+        robotName: 'opentrons-2',
+      },
+      {
+        ip: '127.0.0.4',
+        port: 31950,
+        seen: false,
+        healthStatus: HEALTH_STATUS_UNREACHABLE,
+        serverHealthStatus: HEALTH_STATUS_UNREACHABLE,
+        healthError: mockHealthFetchErrorResponse,
+        serverHealthError: mockHealthFetchErrorResponse,
+        robotName: 'opentrons-2',
+      },
+    ])
+  })
+
+  it('should be able to return a list of composite robots', () => {
+    expect(Selectors.getRobots(STATE)).toEqual([
+      {
+        name: 'opentrons-1',
+        health: mockHealthResponse,
+        serverHealth: mockServerHealthResponse,
+        addresses: [
+          {
+            ip: '127.0.0.2',
+            port: 31950,
+            seen: false,
+            healthStatus: null,
+            serverHealthStatus: null,
+            healthError: null,
+            serverHealthError: null,
+          },
+        ],
+      },
+      {
+        name: 'opentrons-2',
+        health: null,
+        serverHealth: mockServerHealthResponse,
+        addresses: [
+          {
+            ip: '127.0.0.3',
+            port: 31950,
+            seen: true,
+            healthStatus: HEALTH_STATUS_NOT_OK,
+            serverHealthStatus: HEALTH_STATUS_NOT_OK,
+            healthError: mockHealthErrorJsonResponse,
+            serverHealthError: mockHealthErrorJsonResponse,
+          },
+          {
+            ip: '127.0.0.4',
+            port: 31950,
+            seen: false,
+            healthStatus: HEALTH_STATUS_UNREACHABLE,
+            serverHealthStatus: HEALTH_STATUS_UNREACHABLE,
+            healthError: mockHealthFetchErrorResponse,
+            serverHealthError: mockHealthFetchErrorResponse,
+          },
+        ],
+      },
+      {
+        name: 'opentrons-3',
+        health: mockHealthResponse,
+        serverHealth: null,
+        addresses: [],
+      },
+    ])
+  })
+
+  it('should be able to get a list addresses to poll', () => {
+    expect(Selectors.getAddresses(STATE)).toEqual([
+      { ip: '127.0.0.2', port: 31950 },
+      { ip: '127.0.0.3', port: 31950 },
+      { ip: '127.0.0.4', port: 31950 },
+      { ip: '127.0.0.5', port: 31950 },
+      { ip: '127.0.0.6', port: 31950 },
+    ])
+  })
+
+  describe('IP address sorting', () => {
+    const sort = arr => arr.sort(Selectors.compareHostsByConnectability)
+
+    it('should sort addresses with "ok" /health endpoints the highest', () => {
+      const ok: $Shape<HostState> = {
+        ip: '127.0.0.1',
+        healthStatus: HEALTH_STATUS_OK,
+      }
+
+      const notOk: $Shape<HostState> = {
+        ip: '127.0.0.2',
+        healthStatus: HEALTH_STATUS_NOT_OK,
+      }
+
+      const unreachable: $Shape<HostState> = {
+        ip: '127.0.0.3',
+        healthStatus: HEALTH_STATUS_UNREACHABLE,
+      }
+
+      const unknown: $Shape<HostState> = {
+        ip: '127.0.0.4',
+        healthStatus: null,
+      }
+
+      const result = sort([unknown, unreachable, notOk, ok])
+      expect(result).toEqual([ok, notOk, unreachable, unknown])
+    })
+
+    it('should fall back to /server/update/health status if /health is the same the highest', () => {
+      const ok: $Shape<HostState> = {
+        ip: '127.0.0.1',
+        healthStatus: HEALTH_STATUS_NOT_OK,
+        serverHealthStatus: HEALTH_STATUS_OK,
+      }
+
+      const notOk: $Shape<HostState> = {
+        ip: '127.0.0.2',
+        healthStatus: HEALTH_STATUS_NOT_OK,
+        serverHealthStatus: HEALTH_STATUS_NOT_OK,
+      }
+
+      const unreachable: $Shape<HostState> = {
+        ip: '127.0.0.3',
+        healthStatus: HEALTH_STATUS_NOT_OK,
+        serverHealthStatus: HEALTH_STATUS_UNREACHABLE,
+      }
+
+      const unknown: $Shape<HostState> = {
+        ip: '127.0.0.4',
+        healthStatus: HEALTH_STATUS_NOT_OK,
+        serverHealthStatus: null,
+      }
+
+      const result = sort([unknown, unreachable, notOk, ok])
+      expect(result).toEqual([ok, notOk, unreachable, unknown])
+    })
+
+    it('prefer more local "ip" addresses', () => {
+      const home: $Shape<HostState> = {
+        ip: '127.0.0.1',
+        healthStatus: HEALTH_STATUS_OK,
+        serverHealthStatus: HEALTH_STATUS_OK,
+      }
+
+      const localhost: $Shape<HostState> = {
+        ip: 'localhost',
+        healthStatus: HEALTH_STATUS_OK,
+        serverHealthStatus: HEALTH_STATUS_OK,
+      }
+
+      const linkLocal: $Shape<HostState> = {
+        ip: '169.254.24.42',
+        healthStatus: HEALTH_STATUS_OK,
+        serverHealthStatus: HEALTH_STATUS_OK,
+      }
+
+      const regular: $Shape<HostState> = {
+        ip: '192.168.1.100',
+        healthStatus: HEALTH_STATUS_OK,
+        serverHealthStatus: HEALTH_STATUS_OK,
+      }
+
+      const result = sort([regular, linkLocal, localhost, home])
+      expect(result).toEqual([home, localhost, linkLocal, regular])
+    })
+  })
+})

--- a/discovery-client/src/store/actions.js
+++ b/discovery-client/src/store/actions.js
@@ -1,23 +1,35 @@
 // @flow
 
-import type { HealthPollerResult } from '../types'
+import type { MdnsBrowserService, HealthPollerResult } from '../types'
 
 import * as Types from './types'
 
 export const SERVICE_FOUND: 'mdns:SERVICE_FOUND' = 'mdns:SERVICE_FOUND'
+
 export const HEALTH_POLLED: 'http:HEALTH_POLLED' = 'http:HEALTH_POLLED'
+
+export const INITIALIZE_STATE: 'client:INITIALIZE_STATE' =
+  'client:INITIALIZE_STATE'
+
 export const ADD_IP_ADDRESS: 'client:ADD_IP_ADDRESS' = 'client:ADD_IP_ADDRESS'
+
 export const REMOVE_IP_ADDRESS: 'client:REMOVE_IP_ADDRESS' =
   'client:REMOVE_IP_ADDRESS'
+
 export const REMOVE_ROBOT: 'client:REMOVE_ROBOT' = 'client:REMOVE_ROBOT'
 
+export const initializeState = (
+  payload: $PropertyType<Types.InitializeStateAction, 'payload'>
+): Types.InitializeStateAction => ({
+  type: INITIALIZE_STATE,
+  payload,
+})
+
 export const serviceFound = (
-  name: string,
-  ip: string,
-  port: number
+  payload: MdnsBrowserService
 ): Types.ServiceFoundAction => ({
   type: SERVICE_FOUND,
-  payload: { name, ip, port },
+  payload,
 })
 
 export const healthPolled = (
@@ -25,19 +37,6 @@ export const healthPolled = (
 ): Types.HealthPolledAction => ({
   type: HEALTH_POLLED,
   payload,
-})
-
-export const addIpAddress = (
-  ip: string,
-  port: number
-): Types.AddIpAddressAction => ({
-  type: ADD_IP_ADDRESS,
-  payload: { ip, port },
-})
-
-export const removeIpAddress = (ip: string): Types.RemoveIpAddressAction => ({
-  type: REMOVE_IP_ADDRESS,
-  payload: { ip },
 })
 
 export const removeRobot = (name: string): Types.RemoveRobotAction => ({

--- a/discovery-client/src/store/index.js
+++ b/discovery-client/src/store/index.js
@@ -4,10 +4,11 @@ import { createStore as createReduxStore } from 'redux'
 import { reducer } from './reducer'
 
 import type { Store } from 'redux'
-import type { State, Action } from './types'
+import type { State, Action, Dispatch } from './types'
 
 export * from './actions'
+export * from './selectors'
 
-export function createStore(): Store<State, Action> {
+export function createStore(): Store<State, Action, Dispatch> {
   return createReduxStore(reducer)
 }

--- a/discovery-client/src/store/reducer.js
+++ b/discovery-client/src/store/reducer.js
@@ -1,6 +1,7 @@
 // @flow
 import { combineReducers } from 'redux'
 import isEqual from 'lodash/isEqual'
+import keyBy from 'lodash/keyBy'
 import omit from 'lodash/omit'
 
 import {
@@ -20,22 +21,24 @@ import type {
   HostState,
   RobotsByNameMap,
   HostsByIpMap,
+  Address,
 } from './types'
 
-const INITIAL_STATE = {
+const INITIAL_STATE: State = {
   robotsByName: {},
   hostsByIp: {},
+  manualAddresses: [],
 }
 
-const makeInitialHostState = (ip, port) => ({
+const makeHostState = (ip, port, robotName) => ({
   ip,
   port,
+  robotName,
   seen: false,
   healthStatus: null,
   serverHealthStatus: null,
   healthError: null,
   serverHealthError: null,
-  robotName: null,
 })
 
 const getHealthStatus = (responseData, error) => {
@@ -49,6 +52,16 @@ export const robotsByNameReducer = (
   action: Action
 ): RobotsByNameMap => {
   switch (action.type) {
+    case Actions.INITIALIZE_STATE: {
+      const { initialRobots } = action.payload
+      if (!initialRobots) return state
+
+      const states = initialRobots.map(
+        ({ addresses, ...robotState }) => robotState
+      )
+      return keyBy(states, 'name')
+    }
+
     case Actions.REMOVE_ROBOT: {
       const { name } = action.payload
       return name in state ? omit(state, name) : state
@@ -92,15 +105,15 @@ export const hostsByIpReducer = (
   action: Action
 ): HostsByIpMap => {
   switch (action.type) {
-    case Actions.ADD_IP_ADDRESS: {
-      const { ip, port } = action.payload
-      return ip in state ? state : { [ip]: makeInitialHostState(ip, port) }
-    }
+    case Actions.INITIALIZE_STATE: {
+      const { initialRobots } = action.payload
+      if (!initialRobots) return state
 
-    case Actions.REMOVE_IP_ADDRESS: {
-      const { ip } = action.payload
-      const host: HostState | void = state[ip]
-      return host && host.seen === false ? omit(state, ip) : state
+      const states = initialRobots.flatMap<HostState>(({ name, addresses }) => {
+        return addresses.map(({ ip, port }) => makeHostState(ip, port, name))
+      })
+
+      return keyBy(states, 'ip')
     }
 
     case Actions.REMOVE_ROBOT: {
@@ -200,7 +213,21 @@ export const hostsByIpReducer = (
   return state
 }
 
+export const manualAddressesReducer = (
+  state: $ReadOnlyArray<Address> = INITIAL_STATE.manualAddresses,
+  action: Action
+): $ReadOnlyArray<Address> => {
+  switch (action.type) {
+    case Actions.INITIALIZE_STATE: {
+      return action.payload.manualAddresses ?? state
+    }
+  }
+
+  return state
+}
+
 export const reducer: Reducer<State, Action> = combineReducers({
   robotsByName: robotsByNameReducer,
   hostsByIp: hostsByIpReducer,
+  manualAddresses: manualAddressesReducer,
 })

--- a/discovery-client/src/store/selectors.js
+++ b/discovery-client/src/store/selectors.js
@@ -1,0 +1,81 @@
+// @flow
+import { createSelector } from 'reselect'
+import unionBy from 'lodash/unionBy'
+import {
+  HEALTH_STATUS_OK,
+  HEALTH_STATUS_NOT_OK,
+  HEALTH_STATUS_UNREACHABLE,
+} from '../constants'
+
+import type { DiscoveryClientRobot } from '../types'
+import type { State, RobotState, HostState, Address } from './types'
+
+export const getRobotStates: State => $ReadOnlyArray<RobotState> = createSelector(
+  state => state.robotsByName,
+  robotsMap => Object.keys(robotsMap).map((name: string) => robotsMap[name])
+)
+
+export const getHostStates: State => $ReadOnlyArray<HostState> = createSelector(
+  state => state.hostsByIp,
+  hostsMap => Object.keys(hostsMap).map((ip: string) => hostsMap[ip])
+)
+
+export const getAddresses: State => $ReadOnlyArray<Address> = createSelector(
+  state => state.manualAddresses,
+  getHostStates,
+  (manualAddresses, hosts) => {
+    const trackedAddresses = hosts.map(({ ip, port }) => ({ ip, port }))
+    return unionBy(trackedAddresses, manualAddresses, 'ip')
+  }
+)
+
+export const getRobots: State => $ReadOnlyArray<DiscoveryClientRobot> = createSelector(
+  getRobotStates,
+  getHostStates,
+  (robots, hosts) => {
+    return robots.map(robot => ({
+      ...robot,
+      addresses: hosts
+        .filter(({ robotName }) => robotName === robot.name)
+        .sort(compareHostsByConnectability)
+        .map(({ robotName, ...host }) => host),
+    }))
+  }
+)
+
+// accending priority order, where no match is lowest priority
+const HEALTH_PRIORITY = [
+  HEALTH_STATUS_UNREACHABLE,
+  HEALTH_STATUS_NOT_OK,
+  HEALTH_STATUS_OK,
+]
+
+// accending priority order, where no match is lowest priority
+const IP_PRIORITY_MATCH = [
+  /^169\.254\.\d+\.\d+$/,
+  /^localhost$/,
+  /^127\.0\.0\.1$/,
+]
+
+export const compareHostsByConnectability = (
+  a: HostState,
+  b: HostState
+): number => {
+  const healthSort =
+    HEALTH_PRIORITY.indexOf(b.healthStatus) -
+    HEALTH_PRIORITY.indexOf(a.healthStatus)
+
+  if (healthSort !== 0) return healthSort
+
+  const serverHealthSort =
+    HEALTH_PRIORITY.indexOf(b.serverHealthStatus) -
+    HEALTH_PRIORITY.indexOf(a.serverHealthStatus)
+
+  if (serverHealthSort !== 0) return serverHealthSort
+
+  const aIpPriority = IP_PRIORITY_MATCH.findIndex(re => re.test(a.ip))
+  const bIpPriority = IP_PRIORITY_MATCH.findIndex(re => re.test(b.ip))
+  const ipSort = bIpPriority - aIpPriority
+
+  return ipSort
+}

--- a/discovery-client/src/store/types.js
+++ b/discovery-client/src/store/types.js
@@ -5,6 +5,8 @@ import type {
   ServerHealthResponse,
   HealthErrorResponse,
   HealthPollerResult,
+  MdnsBrowserService,
+  DiscoveryClientRobot,
 } from '../types'
 
 import typeof {
@@ -14,10 +16,9 @@ import typeof {
 } from '../constants'
 
 import typeof {
+  INITIALIZE_STATE,
   SERVICE_FOUND,
   HEALTH_POLLED,
-  ADD_IP_ADDRESS,
-  REMOVE_IP_ADDRESS,
   REMOVE_ROBOT,
 } from './actions'
 
@@ -66,8 +67,8 @@ export type HostState = $ReadOnly<{|
   healthError: HealthErrorResponse | null,
   /** Error status and response from /server/update/health if last request was not 200 */
   serverHealthError: HealthErrorResponse | null,
-  /** Robot that this IP points to, if known */
-  robotName: string | null,
+  /** Robot that this IP points to */
+  robotName: string,
 |}>
 
 export type RobotsByNameMap = $ReadOnly<{
@@ -83,51 +84,49 @@ export type HostsByIpMap = $ReadOnly<{
 export type State = $ReadOnly<{|
   robotsByName: RobotsByNameMap,
   hostsByIp: HostsByIpMap,
+  manualAddresses: $ReadOnlyArray<Address>,
+|}>
+
+/**
+ * Action type to (re)initialize the discovered robots and manualAddress
+ * tracking state
+ */
+export type InitializeStateAction = $ReadOnly<{|
+  type: INITIALIZE_STATE,
+  payload: $ReadOnly<{|
+    initialRobots?: $ReadOnlyArray<DiscoveryClientRobot>,
+    manualAddresses?: $ReadOnlyArray<Address>,
+  |}>,
 |}>
 
 /**
  * Action type for when an mDNS service advertisement is received
  */
-export type ServiceFoundAction = {|
+export type ServiceFoundAction = $ReadOnly<{|
   type: SERVICE_FOUND,
-  payload: {| name: string, ip: string, port: number |},
-|}
+  payload: MdnsBrowserService,
+|}>
 
 /**
  * Action type for when an HTTP health poll completes
  */
-export type HealthPolledAction = {|
+export type HealthPolledAction = $ReadOnly<{|
   type: HEALTH_POLLED,
   payload: HealthPollerResult,
-|}
-
-/**
- * Add an IP address to the state for tracking
- */
-export type AddIpAddressAction = {|
-  type: ADD_IP_ADDRESS,
-  payload: {| ip: string, port: number |},
-|}
-
-/**
- * Remove an IP address to the state if that IP address has not been seen
- */
-export type RemoveIpAddressAction = {|
-  type: REMOVE_IP_ADDRESS,
-  payload: {| ip: string |},
-|}
+|}>
 
 /**
  * Remove an robot from the state if that IP address has not been seen
  */
-export type RemoveRobotAction = {|
+export type RemoveRobotAction = $ReadOnly<{|
   type: REMOVE_ROBOT,
-  payload: {| name: string |},
-|}
+  payload: $ReadOnly<{| name: string |}>,
+|}>
 
 export type Action =
+  | InitializeStateAction
   | ServiceFoundAction
   | HealthPolledAction
-  | AddIpAddressAction
-  | RemoveIpAddressAction
   | RemoveRobotAction
+
+export type Dispatch = (action: Action) => Action

--- a/discovery-client/src/types.js
+++ b/discovery-client/src/types.js
@@ -1,5 +1,7 @@
 // @flow
 
+import type { RobotState, HostState } from './store/types'
+
 // TODO(mc, 2018-10-03): figure out what to do with duplicate type in app
 export type HealthResponse = {
   name: string,
@@ -141,10 +143,32 @@ export type HealthPoller = $ReadOnly<{|
    * Any unspecified config will be preserved from the last time `start` was
    * called. `start` must be called with an interval and list at least once.
    */
-  start: (startOpts?: HealthPollerConfig) => void,
+  start: (config?: HealthPollerConfig) => void,
   /**
    * Stop the poller. In-flight HTTP requests may not be cancelled, but
    * `onPollResult` will no longer be called.
    */
   stop: () => void,
+|}>
+
+/**
+ * Relavent data from an mDNS advertisement
+ */
+export type MdnsBrowserService = $ReadOnly<{|
+  /** The service's name from the advertisement */
+  name: string,
+  /** The IP address that the service is using */
+  ip: string,
+  /** The port the service is using */
+  port: number,
+|}>
+
+/**
+ * Robot object that the DiscoveryClient returns that combines latest known
+ * health data from the robot along with possible IP addressess
+ */
+export type DiscoveryClientRobot = $ReadOnly<{|
+  ...RobotState,
+  /** IP addresses and health state, ranked by connectability (descending) */
+  addresses: $ReadOnlyArray<$Rest<HostState, {| robotName: mixed |}>>,
 |}>


### PR DESCRIPTION
# Overview

This PR adds an action, a reducer, and some selectors to the Discovery Client Redux state to enable:

- (Re)initializing the state with a list of robots
    - Used by the app's initialization of the Discovery Client with robots from its discovery cache
    - Also used by the app on discovery cache clear / disable
- (Re)initializing a list of IP addresses to manually track
    - Used by the app's "Manually Add / Remove IP Address" flow
    - Replaces the `ADD_IP_ADDRESS` and `REMOVE_IP_ADDRESS` actions from #6106 because they didn't work out well in practice given how the Discovery Client is actually hooked up to the app
- Getting the full list of robots from the Discovery Client
- Getting the full list of IP addresses to hand to the Health Poller

~Blocked by #6121, will require rebase~

# Changelog

- **Reducers + State**
    - Added `state.manualAddresses` array to hold an array of addresses to poll regardless of mDNS results
- **Actions**
    - Added `client:INITIALIZE_STATE` action with payload including:
        - Optional `initialRobots` field to overwrite `state.robotsByName` and `state.hostsByIp`, if present
        - Optional `manualAddresses` field to overwrite `state.manualAddresses`, if present
    - Removed `ADD_IP_ADDRESS` and `REMOVE_IP_ADDRESS` in favor of `INITIALIZE_STATE` with `payload.manualAddresses` present
    - Tweaked creator signature for `mdns:SERVICE_FOUND` to match `http:HEALTH_POLLED`
- **Selectors**
    - Added `getRobots` selector that synthesizes `robotsByName` and `hostsByIp` into a single list of unique robots with ranked IP addresses
    - Added `getAddresses` selector that combines `hostByIp` and `manualAddresses` into a list of addressses for the poller to hit

# Review requests

Code + test review! We're two additional PRs away from having an actual, testable thing that uses all this new logic

# Risk assessment

N/A