### PR TITLE
chore(api,robot-server,shared-data,scripts): better win pyenv support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.py[cod]
 *$py.class
 *.pytest_cache
+**/.python-version
 
 # C extensions
 *.so

--- a/api/Makefile
+++ b/api/Makefile
@@ -16,7 +16,7 @@ SHX := npx shx
 firmware = $(wildcard smoothie/*.hex)
 
 # python and pipenv config
-sphinx_build := $(pipenv) pipenv sphinx-build
+sphinx_build := $(pipenv) run sphinx-build
 
 
 # Find the version of the wheel from package.json using a helper script. We

--- a/api/Makefile
+++ b/api/Makefile
@@ -16,7 +16,7 @@ SHX := npx shx
 firmware = $(wildcard smoothie/*.hex)
 
 # python and pipenv config
-sphinx_build := $(pipenv_envvars) pipenv run sphinx-build
+sphinx_build := $(pipenv) pipenv sphinx-build
 
 
 # Find the version of the wheel from package.json using a helper script. We
@@ -68,8 +68,8 @@ all: clean wheel
 
 .PHONY: setup
 setup:
-	$(pipenv_envvars) pipenv sync $(pipenv_opts)
-	$(pipenv_envvars) pipenv run pip freeze
+	$(pipenv) sync $(pipenv_opts)
+	$(pipenv) run pip freeze
 
 .PHONY: clean
 clean: docs-clean
@@ -77,7 +77,7 @@ clean: docs-clean
 
 .PHONY: teardown
 teardown:
-	$(pipenv_envvars)	pipenv --rm
+	$(pipenv) --rm
 
 dist/opentrons-%-py2.py3-none-any.whl: setup.py $(ot_sources)
 	$(clean_cmd)
@@ -131,7 +131,7 @@ dev:
 
 .PHONY: local-shell
 local-shell:
-	$(pipenv_envvars) pipenv shell
+	$(pipenv) shell
 
 .PHONY: push-no-restart
 push-no-restart: wheel

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -49,8 +49,8 @@ all: clean wheel
 
 .PHONY: setup
 setup:
-	$(pipenv_envvars) pipenv sync $(pipenv_opts)
-	$(pipenv_envvars) pipenv run pip freeze
+	$(pipenv) sync $(pipenv_opts)
+	$(pipenv) run pip freeze
 
 .PHONY: clean
 clean:
@@ -58,7 +58,7 @@ clean:
 
 .PHONY: teardown
 teardown:
-	$(pipenv_envvars)	pipenv --rm
+	$(pipenv) --rm
 
 dist/robotserver-%-py2.py3-none-any.whl: setup.py $(ot_sources)
 	$(clean_cmd)
@@ -84,7 +84,7 @@ dev:
 
 .PHONY: local-shell
 local-shell:
-	$(pipenv_envvars) pipenv shell
+	$(pipenv) shell
 
 .PHONY: push
 push: wheel

--- a/scripts/python.mk
+++ b/scripts/python.mk
@@ -1,7 +1,8 @@
 pipenv_envvars := $(and $(CI),PIPENV_IGNORE_VIRTUALENVS=1)
-python := $(pipenv_envvars) pipenv run python
-pip := $(pipenv_envvars) pipenv run pip
-pytest := $(pipenv_envvars) pipenv run py.test
+pipenv := $(pipenv_envvars) python -m pipenv
+python := $(pipenv) run python
+pip := $(pipenv) run pip
+pytest := $(pipenv) run py.test
 
 pipenv_opts := --dev
 pipenv_opts += $(and $(CI),--keep-outdated --clear)

--- a/shared-data/python/Makefile
+++ b/shared-data/python/Makefile
@@ -38,8 +38,8 @@ twine_repository_url ?= $(pypi_test_upload_url)
 
 .PHONY: setup-py
 setup-py:
-	$(pipenv_envvars) pipenv sync $(pipenv_opts)
-	$(pipenv_envvars) pipenv run pip freeze
+	$(pipenv) sync $(pipenv_opts)
+	$(pipenv) run pip freeze
 
 
 .PHONY: clean


### PR DESCRIPTION
There’s this nice pyenv-win package that is a fork of pyenv that works on
windows, but it doesn’t set up shims for everything installed to your python
scripts so things like pipenv don’t work - they look at the wrong place for the
python binary.

Invoking scripts like pipenv via python -m pipenv works fine, though. So this PR
does that. Shouldn’t affect other platforms.

## Testing
`make setup-py`