### PR TITLE
test(app): remove commented out tests

### DIFF
--- a/app/src/components/ModuleItem/__tests__/ModuleUpdate.test.js
+++ b/app/src/components/ModuleItem/__tests__/ModuleUpdate.test.js
@@ -65,4 +65,9 @@ describe('ModuleUpdate', () => {
       }
     )
   })
+
+  it.todo('is available and can control')
+  it.todo('is available and cannot control')
+  it.todo('is not available and can control')
+  it.todo('is not available and cannot control')
 })

--- a/app/src/components/ModuleItem/__tests__/ModuleUpdate.test.js
+++ b/app/src/components/ModuleItem/__tests__/ModuleUpdate.test.js
@@ -26,51 +26,6 @@ describe('ModuleUpdate', () => {
     jest.resetAllMocks()
   })
 
-  // TODO(mc, 2020-03-16): these shallow snapshots don't test anything
-  // remove commented out tests when actual tests have been written
-  // it('component renders', () => {
-  //   const treeAvailableCanControl = shallow(
-  //     <Provider store={store}>
-  //       <ModuleUpdate
-  //         controlDisabledReason={null}
-  //         moduleId="FAKEMODULE1234"
-  //         hasAvailableUpdate={true}
-  //       />
-  //     </Provider>,
-  //   )
-  //   const treeAvailableNoControl = shallow(
-  //     <Provider store={store}>
-  //       <ModuleUpdate
-  //         controlDisabledReason={"Can't touch this"}
-  //         moduleId="FAKEMODULE1234"
-  //         hasAvailableUpdate={true}
-  //       />
-  //     </Provider>
-  //   )
-  //   const treeNotAvailableCanControl = shallow(
-  //     <Provider store={store}>
-  //       <ModuleUpdate
-  //         controlDisabledReason={null}
-  //         moduleId="FAKEMODULE1234"
-  //         hasAvailableUpdate={false}
-  //       />
-  //     </Provider>
-  //   )
-  //   const treeNotAvailableNoControl = shallow(
-  //     <Provider store={store}>
-  //       <ModuleUpdate
-  //         controlDisabledReason={"Can't touch this"}
-  //         moduleId="FAKEMODULE1234"
-  //         hasAvailableUpdate={false}
-  //       />
-  //     </Provider>
-  //   )
-  //   expect(treeAvailableCanControl).toMatchSnapshot()
-  //   expect(treeNotAvailableCanControl).toMatchSnapshot()
-  //   expect(treeAvailableNoControl).toMatchSnapshot()
-  //   expect(treeNotAvailableNoControl).toMatchSnapshot()
-  // })
-
   it('displays a Warning for invalid files', () => {
     const SPECS = [
       {


### PR DESCRIPTION
# Overview

Deleting these commented out tests to remove the linter warning. I didn't actually write new tests to cover what these commented snapshots were supposed to be covering, but maybe we can create a ticket or something to do so. 

# Review requests
NA

# Risk assessment
Low
