### PR TITLE
docs(api): corrects labware definition example's syntax to "location" 

### DIFF
--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -24,7 +24,7 @@ A third optional argument can be used to give the labware a nickname to be displ
 .. code-block:: python
 
     plate = protocol.load_labware('corning_96_wellplate_360ul_flat',
-                                  slot='2',
+                                  location='2',
                                   label='any-name-you-want')
 
 Labware is loaded into a protocol using :py:meth:`.ProtocolContext.load_labware`, which returns


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->


# Overview

The labware example used "slot" for loading a well plate, which returns an error because it should be "location"

# Changelog


List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.
- fixed syntax error ExceptionInProtocolError: TypeError...  unexpected keyword argument 'slot' 


# Review requests


Describe any requests for your reviewers here.
This is my first pull request, so please let me know if I can make things better in future requests!


# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
This does not effect other parts of the system. It is an isolated piece of labware example users can copy and paste. The well plate is not referenced otherwise.

