### PR TITLE
fix(api): moves type_extension in calibration storage to dev_types for type checking only

### DIFF
--- a/api/src/opentrons/calibration_storage/dev_types.py
+++ b/api/src/opentrons/calibration_storage/dev_types.py
@@ -1,0 +1,45 @@
+import typing
+from typing_extensions import TypedDict
+from datetime import datetime
+
+
+class TipLengthCalibration(TypedDict):
+    tipLength: float
+    lastModified: datetime
+
+
+class ModuleDict(TypedDict):
+    parent: str
+    fullParent: str
+
+
+class CalibrationIndexDict(TypedDict):
+    """
+    The dict that is returned from
+    the index.json file.
+    """
+    uri: str
+    slot: str
+    module: ModuleDict
+
+
+class OffsetDict(TypedDict):
+    offset: typing.List[float]
+    lastModified: datetime
+
+
+class TipLengthDict(TypedDict):
+    length: float
+    lastModified: datetime
+
+
+class CalibrationDict(TypedDict):
+    """
+    The dict that is returned from a labware
+    offset file.
+    """
+    default: OffsetDict
+    tipLength: TipLengthDict
+
+
+PipTipLengthCalibration = typing.Dict[str, TipLengthCalibration]

--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -13,10 +13,12 @@ from . import (
     file_operators as io, helpers)
 if typing.TYPE_CHECKING:
     from opentrons_shared_data.labware.dev_types import LabwareDefinition
+    from .dev_types import (
+        TipLengthCalibration, CalibrationIndexDict, CalibrationDict)
 
 
 def _format_calibration_type(
-        data: local_types.CalibrationDict) -> local_types.CalibrationTypes:
+        data: 'CalibrationDict') -> local_types.CalibrationTypes:
     offset = local_types.OffsetData(
         value=data['default']['offset'],
         last_modified=data['default']['lastModified']
@@ -32,7 +34,7 @@ def _format_calibration_type(
 
 
 def _format_parent(
-        data: local_types.CalibrationIndexDict)\
+        data: 'CalibrationIndexDict')\
             -> local_types.ParentOptions:
     options = local_types.ParentOptions(slot=data['slot'])
     if data['module']:
@@ -72,7 +74,7 @@ def get_all_calibrations() -> typing.List[local_types.CalibrationInformation]:
 
 def _get_tip_length_data(
         pip_id: str, labware_hash: str, labware_load_name: str
-) -> local_types.TipLengthCalibration:
+) -> 'TipLengthCalibration':
     try:
         pip_tip_length_path = config.get_tip_length_cal_path()/f'{pip_id}.json'
         tip_length_data =\
@@ -107,7 +109,7 @@ def get_labware_calibration(lookup_path: local_types.StrPath) -> Point:
 def load_tip_length_calibration(
         pip_id: str,
         definition: 'LabwareDefinition',
-        parent: str) -> local_types.TipLengthCalibration:
+        parent: str) -> 'TipLengthCalibration':
     """
     Function used to grab the current tip length associated
     with a particular tiprack.

--- a/api/src/opentrons/calibration_storage/modify.py
+++ b/api/src/opentrons/calibration_storage/modify.py
@@ -16,6 +16,7 @@ from . import (
     helpers)
 
 if typing.TYPE_CHECKING:
+    from .dev_types import (TipLengthCalibration, PipTipLengthCalibration)
     from opentrons_shared_data.labware.dev_types import LabwareDefinition
     from opentrons.types import Point
 
@@ -86,7 +87,7 @@ def save_labware_calibration(
 def create_tip_length_data(
         definition: 'LabwareDefinition',
         parent: str,
-        length: float) -> local_types.PipTipLengthCalibration:
+        length: float) -> 'PipTipLengthCalibration':
     """
     Function to correctly format tip length data.
 
@@ -102,7 +103,7 @@ def create_tip_length_data(
     #     'cannot save tip length for non-tiprack labware'
     labware_hash = helpers.hash_labware_def(definition)
 
-    tip_length_data: local_types.TipLengthCalibration = {
+    tip_length_data: 'TipLengthCalibration' = {
         'tipLength': length,
         'lastModified': datetime.datetime.utcnow()
     }
@@ -143,7 +144,7 @@ def _append_to_index_tip_length_file(pip_id: str, lw_hash: str):
 
 
 def save_tip_length_calibration(
-        pip_id: str, tip_length_cal: local_types.PipTipLengthCalibration):
+        pip_id: str, tip_length_cal: 'PipTipLengthCalibration'):
     """
     Function used to save tip length calibration to file.
 

--- a/api/src/opentrons/calibration_storage/types.py
+++ b/api/src/opentrons/calibration_storage/types.py
@@ -1,6 +1,5 @@
 import typing
 
-from typing_extensions import TypedDict
 from dataclasses import dataclass
 from datetime import datetime
 from os import PathLike
@@ -73,45 +72,3 @@ class CalibrationInformation:
     parent: ParentOptions
     labware_id: str
     uri: str
-
-
-class TipLengthCalibration(TypedDict):
-    tipLength: float
-    lastModified: datetime
-
-
-class ModuleDict(TypedDict):
-    parent: str
-    fullParent: str
-
-
-class CalibrationIndexDict(TypedDict):
-    """
-    The dict that is returned from
-    the index.json file.
-    """
-    uri: str
-    slot: str
-    module: ModuleDict
-
-
-class OffsetDict(TypedDict):
-    offset: typing.List[float]
-    lastModified: datetime
-
-
-class TipLengthDict(TypedDict):
-    length: float
-    lastModified: datetime
-
-
-class CalibrationDict(TypedDict):
-    """
-    The dict that is returned from a labware
-    offset file.
-    """
-    default: OffsetDict
-    tipLength: TipLengthDict
-
-
-PipTipLengthCalibration = typing.Dict[str, TipLengthCalibration]

--- a/api/src/opentrons/legacy_api/containers/__init__.py
+++ b/api/src/opentrons/legacy_api/containers/__init__.py
@@ -26,7 +26,7 @@ from opentrons.calibration_storage import (
     modify)
 
 if TYPE_CHECKING:
-    from opentrons.calibration_storage.types import TipLengthCalibration
+    from opentrons.calibration_storage.dev_types import TipLengthCalibration
 
 
 __all__ = [


### PR DESCRIPTION
# Overview
Robot server fails to start on robot because `typing_extensions` (not present on the robot) was imported at runtime. 

This PR moves `type_extensions` dependent types to `dev_types.py` and make sure they are only used during type checking.

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
