### PR TITLE
fix: Commands log: misleading "rate" for aspirate/dispense

### DIFF
--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -12,6 +12,7 @@ from opentrons.legacy_api.containers import (Well as OldWell,
                                              location_to_list)
 from opentrons.protocol_api.labware import Well, Labware
 from opentrons.protocol_api.module_geometry import ModuleGeometry
+from opentrons.protocol_api.util import FlowRates
 from opentrons.types import Location
 from opentrons.drivers import utils
 
@@ -120,8 +121,9 @@ def home(mount):
 
 def aspirate(instrument, volume, location, rate):
     location_text = stringify_location(location)
-    text = 'Aspirating {volume} uL from {location} at {rate} speed'.format(
-        volume=float(volume), location=location_text, rate=rate
+    flow_rate = rate * FlowRates(instrument).aspirate
+    text = 'Aspirating {volume} uL from {location} at {flow_rate} uL/sec'.format(
+        volume=float(volume), location=location_text, flow_rate=flow_rate
     )
     return make_command(
         name=command_types.ASPIRATE,
@@ -137,8 +139,9 @@ def aspirate(instrument, volume, location, rate):
 
 def dispense(instrument, volume, location, rate):
     location_text = stringify_location(location)
-    text = 'Dispensing {volume} uL into {location} at {rate} speed'.format(
-        volume=float(volume), location=location_text, rate=rate)
+    flow_rate = rate * FlowRates(instrument).dispense
+    text = 'Dispensing {volume} uL into {location} at {flow_rate} uL/sec'.format(
+        volume=float(volume), location=location_text, flow_rate=flow_rate)
 
     return make_command(
         name=command_types.DISPENSE,

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -122,9 +122,9 @@ def home(mount):
 def aspirate(instrument, volume, location, rate):
     location_text = stringify_location(location)
     flow_rate = rate * FlowRates(instrument).aspirate
-    text = 'Aspirating {volume} uL from {location} at {flow_rate} uL/sec'.format(
-        volume=float(volume), location=location_text, flow_rate=flow_rate
-    )
+    text = 'Aspirating {volume} uL from {location} at {flow} uL/sec'.format(
+            volume=float(volume), location=location_text, flow=flow_rate)
+
     return make_command(
         name=command_types.ASPIRATE,
         payload={
@@ -140,8 +140,8 @@ def aspirate(instrument, volume, location, rate):
 def dispense(instrument, volume, location, rate):
     location_text = stringify_location(location)
     flow_rate = rate * FlowRates(instrument).dispense
-    text = 'Dispensing {volume} uL into {location} at {flow_rate} uL/sec'.format(
-        volume=float(volume), location=location_text, flow_rate=flow_rate)
+    text = 'Dispensing {volume} uL into {location} at {flow} uL/sec'.format(
+            volume=float(volume), location=location_text, flow=flow_rate)
 
     return make_command(
         name=command_types.DISPENSE,

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -121,9 +121,21 @@ def home(mount):
 
 def aspirate(instrument, volume, location, rate):
     location_text = stringify_location(location)
-    flow_rate = rate * FlowRates(instrument).aspirate
-    text = 'Aspirating {volume} uL from {location} at {flow} uL/sec'.format(
-            volume=float(volume), location=location_text, flow=flow_rate)
+    try:
+        flow_rate = rate * FlowRates(instrument).aspirate
+        text = 'Aspirating {volume} uL from {location} at {flow} uL/sec'.format(
+                volume=float(volume), location=location_text, flow=flow_rate)
+    except:
+        flow_mms = instrument.speeds['aspirate']
+        print('my flow_mms:{}'.format(flow_mms))
+        flow_ulsec = flow_mms * instrument._ul_per_mm(instrument.max_volume,
+                                                      'aspirate')
+        print('my flow_ulsec:{}'.format(flow_ulsec))
+        flow_rate = rate * flow_ulsec
+        flow_rate = round(flow_rate, 1)
+        print('my flow_rate:{}'.format(flow_rate))
+        text = 'Aspirating {volume} uL from {location} at {flow} uL/sec'.format(
+                volume=float(volume), location=location_text, flow=flow_rate)
 
     return make_command(
         name=command_types.ASPIRATE,
@@ -139,9 +151,21 @@ def aspirate(instrument, volume, location, rate):
 
 def dispense(instrument, volume, location, rate):
     location_text = stringify_location(location)
-    flow_rate = rate * FlowRates(instrument).dispense
-    text = 'Dispensing {volume} uL into {location} at {flow} uL/sec'.format(
-            volume=float(volume), location=location_text, flow=flow_rate)
+    try:
+        flow_rate = rate * FlowRates(instrument).dispense
+        text = 'Dispensing {volume} uL into {location} at {flow} uL/sec'.format(
+                volume=float(volume), location=location_text, flow=flow_rate)
+    except:
+        flow_mms = instrument.speeds['dispense']
+        print('my flow_mms:{}'.format(flow_mms))
+        flow_ulsec = flow_mms * instrument._ul_per_mm(instrument.max_volume,
+                                                      'dispense')
+        print('my flow_ulsec:{}'.format(flow_ulsec))
+        flow_rate = rate * flow_ulsec
+        flow_rate = round(flow_rate, 1)
+        print('my flow_rate:{}'.format(flow_rate))
+        text = 'Dispensing {volume} uL from {location} at {flow} uL/sec'.format(
+                volume=float(volume), location=location_text, flow=flow_rate)
 
     return make_command(
         name=command_types.DISPENSE,

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -127,13 +127,10 @@ def aspirate(instrument, volume, location, rate):
                 volume=float(volume), location=location_text, flow=flow_rate)
     except:
         flow_mms = instrument.speeds['aspirate']
-        print('my flow_mms:{}'.format(flow_mms))
         flow_ulsec = flow_mms * instrument._ul_per_mm(instrument.max_volume,
                                                       'aspirate')
-        print('my flow_ulsec:{}'.format(flow_ulsec))
         flow_rate = rate * flow_ulsec
         flow_rate = round(flow_rate, 1)
-        print('my flow_rate:{}'.format(flow_rate))
         text = 'Aspirating {volume} uL from {location} at {flow} uL/sec'.format(
                 volume=float(volume), location=location_text, flow=flow_rate)
 
@@ -157,13 +154,10 @@ def dispense(instrument, volume, location, rate):
                 volume=float(volume), location=location_text, flow=flow_rate)
     except:
         flow_mms = instrument.speeds['dispense']
-        print('my flow_mms:{}'.format(flow_mms))
         flow_ulsec = flow_mms * instrument._ul_per_mm(instrument.max_volume,
                                                       'dispense')
-        print('my flow_ulsec:{}'.format(flow_ulsec))
         flow_rate = rate * flow_ulsec
         flow_rate = round(flow_rate, 1)
-        print('my flow_rate:{}'.format(flow_rate))
         text = 'Dispensing {volume} uL from {location} at {flow} uL/sec'.format(
                 volume=float(volume), location=location_text, flow=flow_rate)
 

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -158,7 +158,7 @@ def dispense(instrument, volume, location, rate):
                                                       'dispense')
         flow_rate = rate * flow_ulsec
         flow_rate = round(flow_rate, 1)
-        text = 'Dispensing {volume} uL from {location} at {flow} uL/sec'.format(
+        text = 'Dispensing {volume} uL into {location} at {flow} uL/sec'.format(
                 volume=float(volume), location=location_text, flow=flow_rate)
 
     return make_command(

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -121,17 +121,18 @@ def home(mount):
 
 def aspirate(instrument, volume, location, rate):
     location_text = stringify_location(location)
+    template = 'Aspirating {volume} uL from {location} at {flow} uL/sec'
     try:
         flow_rate = rate * FlowRates(instrument).aspirate
-        text = 'Aspirating {volume} uL from {location} at {flow} uL/sec'.format(
+        text = template.format(
                 volume=float(volume), location=location_text, flow=flow_rate)
-    except:
+    except AttributeError:
         flow_mms = instrument.speeds['aspirate']
         flow_ulsec = flow_mms * instrument._ul_per_mm(instrument.max_volume,
                                                       'aspirate')
         flow_rate = rate * flow_ulsec
         flow_rate = round(flow_rate, 1)
-        text = 'Aspirating {volume} uL from {location} at {flow} uL/sec'.format(
+        text = template.format(
                 volume=float(volume), location=location_text, flow=flow_rate)
 
     return make_command(
@@ -148,17 +149,18 @@ def aspirate(instrument, volume, location, rate):
 
 def dispense(instrument, volume, location, rate):
     location_text = stringify_location(location)
+    template = 'Dispensing {volume} uL into {location} at {flow} uL/sec'
     try:
         flow_rate = rate * FlowRates(instrument).dispense
-        text = 'Dispensing {volume} uL into {location} at {flow} uL/sec'.format(
+        text = template.format(
                 volume=float(volume), location=location_text, flow=flow_rate)
-    except:
+    except AttributeError:
         flow_mms = instrument.speeds['dispense']
         flow_ulsec = flow_mms * instrument._ul_per_mm(instrument.max_volume,
                                                       'dispense')
         flow_rate = rate * flow_ulsec
         flow_rate = round(flow_rate, 1)
-        text = 'Dispensing {volume} uL into {location} at {flow} uL/sec'.format(
+        text = template.format(
                 volume=float(volume), location=location_text, flow=flow_rate)
 
     return make_command(

--- a/api/tests/opentrons/labware/test_pipette_unittest.py
+++ b/api/tests/opentrons/labware/test_pipette_unittest.py
@@ -65,7 +65,7 @@ def test_aspirate_zero_volume(local_test_pipette, robot):
     assert robot.commands() == []
     p200.tip_attached = True
     p200.aspirate(0)
-    assert robot.commands() == ['Aspirating 0.0 uL from ? at 1.0 speed']  # noqa
+    assert robot.commands() == ['Aspirating 0.0 uL from ? at 92.5 uL/sec']  # noqa
 
 
 @pytest.mark.api1_only

--- a/api/tests/opentrons/test_execute.py
+++ b/api/tests/opentrons/test_execute.py
@@ -76,7 +76,7 @@ def test_execute_function_json_v3_apiv2(get_json_protocol_fixture,
         'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 1',
         'Aspirating 5.0 uL from A1 of Source Plate on 2 at 3.0 uL/sec',
         'Delaying for 0 minutes and 42 seconds',
-        'Dispensing 4.5 uL into B1 of Dest Plate on 3 at 1.0 speed',
+        'Dispensing 4.5 uL into B1 of Dest Plate on 3 at 2.5 uL/sec',
         'Touching tip',
         'Blowing out at B1 of Dest Plate on 3',
         'Dropping tip into A1 of Trash on 12'
@@ -102,7 +102,7 @@ def test_execute_function_json_v4_apiv2(get_json_protocol_fixture,
         'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 1',
         'Aspirating 5.0 uL from A1 of Source Plate on 2 at 3.0 uL/sec',
         'Delaying for 0 minutes and 42 seconds',
-        'Dispensing 4.5 uL into B1 of Dest Plate on 3 at 1.0 speed',
+        'Dispensing 4.5 uL into B1 of Dest Plate on 3 at 2.5 uL/sec',
         'Touching tip',
         'Blowing out at B1 of Dest Plate on 3',
         'Dropping tip into A1 of Trash on 12'
@@ -128,17 +128,17 @@ def test_execute_function_bundle_apiv2(get_bundle_fixture,
         'Transferring 1.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip from A1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 1.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
-        'Dispensing 1.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
+        'Dispensing 1.0 uL into A4 of FAKE example labware on 1 at 10.0 uL/sec',
         'Dropping tip into A1 of Opentrons Fixed Trash on 12',
         'Transferring 2.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 2.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
-        'Dispensing 2.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
+        'Dispensing 2.0 uL into A4 of FAKE example labware on 1 at 10.0 uL/sec',
         'Dropping tip into A1 of Opentrons Fixed Trash on 12',
         'Transferring 3.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip from C1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 3.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
-        'Dispensing 3.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
+        'Dispensing 3.0 uL into A4 of FAKE example labware on 1 at 10.0 uL/sec',
         'Dropping tip into A1 of Opentrons Fixed Trash on 12'
         ]
 
@@ -160,9 +160,9 @@ def test_execute_function_v1(protocol, protocol_file,
             if item['$'] == 'before'] == [
         'Picking up tip from well A1 in "5"',
         'Aspirating 10.0 uL from well A1 in "8" at 150.0 uL/sec',
-        'Dispensing 10.0 uL into well H12 in "8" at 1.0 speed',
+        'Dispensing 10.0 uL into well H12 in "8" at 300.0 uL/sec',
         'Aspirating 10.0 uL from well A1 in "11" at 150.0 uL/sec',
-        'Dispensing 10.0 uL into well H12 in "11" at 1.0 speed',
+        'Dispensing 10.0 uL into well H12 in "11" at 300.0 uL/sec',
         'Dropping tip into well A1 in "12"'
     ]
 

--- a/api/tests/opentrons/test_execute.py
+++ b/api/tests/opentrons/test_execute.py
@@ -51,8 +51,8 @@ def test_execute_function_apiv2(protocol,
     assert [item['payload']['text'] for item in entries
             if item['$'] == 'before'] == [
         'Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1',
-        'Aspirating 10.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 1.0 speed',  # noqa(E501),
-        'Dispensing 10.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 1.0 speed',  # noqa(E501),
+        'Aspirating 10.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 150.0 uL/sec',  # noqa(E501),
+        'Dispensing 10.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 300.0 uL/sec',  # noqa(E501),
         'Dropping tip into H12 of Opentrons 96 Tip Rack 300 µL on 1'
         ]
 
@@ -74,7 +74,7 @@ def test_execute_function_json_v3_apiv2(get_json_protocol_fixture,
     assert [item['payload']['text'] for item in entries
             if item['$'] == 'before'] == [
         'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 1',
-        'Aspirating 5.0 uL from A1 of Source Plate on 2 at 1.0 speed',
+        'Aspirating 5.0 uL from A1 of Source Plate on 2 at 3.0 uL/sec',
         'Delaying for 0 minutes and 42 seconds',
         'Dispensing 4.5 uL into B1 of Dest Plate on 3 at 1.0 speed',
         'Touching tip',
@@ -100,7 +100,7 @@ def test_execute_function_json_v4_apiv2(get_json_protocol_fixture,
     assert [item['payload']['text'] for item in entries
             if item['$'] == 'before'] == [
         'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 1',
-        'Aspirating 5.0 uL from A1 of Source Plate on 2 at 1.0 speed',
+        'Aspirating 5.0 uL from A1 of Source Plate on 2 at 3.0 uL/sec',
         'Delaying for 0 minutes and 42 seconds',
         'Dispensing 4.5 uL into B1 of Dest Plate on 3 at 1.0 speed',
         'Touching tip',
@@ -127,17 +127,17 @@ def test_execute_function_bundle_apiv2(get_bundle_fixture,
             for item in entries if item['$'] == 'before'] == [
         'Transferring 1.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip from A1 of Opentrons 96 Tip Rack 10 µL on 3',
-        'Aspirating 1.0 uL from A1 of FAKE example labware on 1 at 1.0 speed',
+        'Aspirating 1.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
         'Dispensing 1.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
         'Dropping tip into A1 of Opentrons Fixed Trash on 12',
         'Transferring 2.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 3',
-        'Aspirating 2.0 uL from A1 of FAKE example labware on 1 at 1.0 speed',
+        'Aspirating 2.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
         'Dispensing 2.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
         'Dropping tip into A1 of Opentrons Fixed Trash on 12',
         'Transferring 3.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip from C1 of Opentrons 96 Tip Rack 10 µL on 3',
-        'Aspirating 3.0 uL from A1 of FAKE example labware on 1 at 1.0 speed',
+        'Aspirating 3.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
         'Dispensing 3.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
         'Dropping tip into A1 of Opentrons Fixed Trash on 12'
         ]
@@ -159,9 +159,9 @@ def test_execute_function_v1(protocol, protocol_file,
     assert [item['payload']['text'] for item in entries
             if item['$'] == 'before'] == [
         'Picking up tip from well A1 in "5"',
-        'Aspirating 10.0 uL from well A1 in "8" at 1.0 speed',
+        'Aspirating 10.0 uL from well A1 in "8" at 150.0 uL/sec',
         'Dispensing 10.0 uL into well H12 in "8" at 1.0 speed',
-        'Aspirating 10.0 uL from well A1 in "11" at 1.0 speed',
+        'Aspirating 10.0 uL from well A1 in "11" at 150.0 uL/sec',
         'Dispensing 10.0 uL into well H12 in "11" at 1.0 speed',
         'Dropping tip into well A1 in "12"'
     ]

--- a/api/tests/opentrons/test_execute.py
+++ b/api/tests/opentrons/test_execute.py
@@ -127,13 +127,16 @@ def test_execute_function_bundle_apiv2(get_bundle_fixture,
             for item in entries if item['$'] == 'before'] == [
         'Transferring 1.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip from A1 of Opentrons 96 Tip Rack 10 µL on 3',
-        'Aspirating 1.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
-        'Dispensing 1.0 uL into A4 of FAKE example labware on 1 at 10.0 uL/sec',
+        "Aspirating 1.0 uL from A1 of FAKE example labware on 1 at" \
+        " 5.0 uL/sec",
+        "Dispensing 1.0 uL into A4 of FAKE example labware on 1 at" \
+        " 10.0 uL/sec",
         'Dropping tip into A1 of Opentrons Fixed Trash on 12',
         'Transferring 2.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 2.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
-        'Dispensing 2.0 uL into A4 of FAKE example labware on 1 at 10.0 uL/sec',
+        "Dispensing 2.0 uL into A4 of FAKE example labware on 1 at" \
+        " 10.0 uL/sec",
         'Dropping tip into A1 of Opentrons Fixed Trash on 12',
         'Transferring 3.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip from C1 of Opentrons 96 Tip Rack 10 µL on 3',

--- a/api/tests/opentrons/test_execute.py
+++ b/api/tests/opentrons/test_execute.py
@@ -141,7 +141,8 @@ def test_execute_function_bundle_apiv2(get_bundle_fixture,
         'Transferring 3.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip from C1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 3.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
-        'Dispensing 3.0 uL into A4 of FAKE example labware on 1 at 10.0 uL/sec',
+        "Dispensing 3.0 uL into A4 of FAKE example labware on 1 at" \
+        " 10.0 uL/sec",
         'Dropping tip into A1 of Opentrons Fixed Trash on 12'
         ]
 

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -52,17 +52,20 @@ def test_simulate_function_bundle_apiv2(get_bundle_fixture):
         'Transferring 1.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip from A1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 1.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
-        'Dispensing 1.0 uL into A4 of FAKE example labware on 1 at 10.0 uL/sec',
+        "Dispensing 1.0 uL into A4 of FAKE example labware on 1 at" \
+        " 10.0 uL/sec",
         'Dropping tip into A1 of Opentrons Fixed Trash on 12',
         'Transferring 2.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 2.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
-        'Dispensing 2.0 uL into A4 of FAKE example labware on 1 at 10.0 uL/sec',
+        "Dispensing 2.0 uL into A4 of FAKE example labware on 1 at" \
+        " 10.0 uL/sec",
         'Dropping tip into A1 of Opentrons Fixed Trash on 12',
         'Transferring 3.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip from C1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 3.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
-        'Dispensing 3.0 uL into A4 of FAKE example labware on 1 at 10.0 uL/sec',
+        "Dispensing 3.0 uL into A4 of FAKE example labware on 1 at" \
+        " 10.0 uL/sec",
         'Dropping tip into A1 of Opentrons Fixed Trash on 12'
         ]
 

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -22,7 +22,7 @@ def test_simulate_function_apiv2(protocol,
     assert [item['payload']['text'] for item in runlog] == [
         'Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1',
         'Aspirating 10.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 150.0 uL/sec',  # noqa(E501),
-        'Dispensing 10.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 1.0 speed',  # noqa(E501),
+        'Dispensing 10.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 300.0 uL/sec',  # noqa(E501),
         'Dropping tip into H12 of Opentrons 96 Tip Rack 300 µL on 1'
         ]
 
@@ -36,7 +36,7 @@ def test_simulate_function_json_apiv2(get_json_protocol_fixture):
         'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 1',
         'Aspirating 5.0 uL from A1 of Source Plate on 2 at 3.0 uL/sec',
         'Delaying for 0 minutes and 42 seconds',
-        'Dispensing 4.5 uL into B1 of Dest Plate on 3 at 1.0 speed',
+        'Dispensing 4.5 uL into B1 of Dest Plate on 3 at 2.5 uL/sec',
         'Touching tip',
         'Blowing out at B1 of Dest Plate on 3',
         'Dropping tip into A1 of Trash on 12'
@@ -52,17 +52,17 @@ def test_simulate_function_bundle_apiv2(get_bundle_fixture):
         'Transferring 1.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip from A1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 1.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
-        'Dispensing 1.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
+        'Dispensing 1.0 uL into A4 of FAKE example labware on 1 at 10.0 uL/sec',
         'Dropping tip into A1 of Opentrons Fixed Trash on 12',
         'Transferring 2.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 2.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
-        'Dispensing 2.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
+        'Dispensing 2.0 uL into A4 of FAKE example labware on 1 at 10.0 uL/sec',
         'Dropping tip into A1 of Opentrons Fixed Trash on 12',
         'Transferring 3.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip from C1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 3.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
-        'Dispensing 3.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
+        'Dispensing 3.0 uL into A4 of FAKE example labware on 1 at 10.0 uL/sec',
         'Dropping tip into A1 of Opentrons Fixed Trash on 12'
         ]
 
@@ -74,9 +74,9 @@ def test_simulate_function_v1(protocol, protocol_file):
     assert [item['payload']['text'] for item in runlog] == [
         'Picking up tip from well A1 in "5"',
         'Aspirating 10.0 uL from well A1 in "8" at 150.0 uL/sec',
-        'Dispensing 10.0 uL into well H12 in "8" at 1.0 speed',
+        'Dispensing 10.0 uL into well H12 in "8" at 300.0 uL/sec',
         'Aspirating 10.0 uL from well A1 in "11" at 150.0 uL/sec',
-        'Dispensing 10.0 uL into well H12 in "11" at 1.0 speed',
+        'Dispensing 10.0 uL into well H12 in "11" at 300.0 uL/sec',
         'Dropping tip into well A1 in "12"'
     ]
 

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -21,7 +21,7 @@ def test_simulate_function_apiv2(protocol,
     assert isinstance(bundle, protocols.types.BundleContents)
     assert [item['payload']['text'] for item in runlog] == [
         'Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1',
-        'Aspirating 10.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 1.0 speed',  # noqa(E501),
+        'Aspirating 10.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 150.0 uL/sec',  # noqa(E501),
         'Dispensing 10.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 1.0 speed',  # noqa(E501),
         'Dropping tip into H12 of Opentrons 96 Tip Rack 300 µL on 1'
         ]
@@ -34,7 +34,7 @@ def test_simulate_function_json_apiv2(get_json_protocol_fixture):
     assert bundle is None
     assert [item['payload']['text'] for item in runlog] == [
         'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 1',
-        'Aspirating 5.0 uL from A1 of Source Plate on 2 at 1.0 speed',
+        'Aspirating 5.0 uL from A1 of Source Plate on 2 at 3.0 uL/sec',
         'Delaying for 0 minutes and 42 seconds',
         'Dispensing 4.5 uL into B1 of Dest Plate on 3 at 1.0 speed',
         'Touching tip',
@@ -51,17 +51,17 @@ def test_simulate_function_bundle_apiv2(get_bundle_fixture):
     assert [item['payload']['text'] for item in runlog] == [
         'Transferring 1.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip from A1 of Opentrons 96 Tip Rack 10 µL on 3',
-        'Aspirating 1.0 uL from A1 of FAKE example labware on 1 at 1.0 speed',
+        'Aspirating 1.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
         'Dispensing 1.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
         'Dropping tip into A1 of Opentrons Fixed Trash on 12',
         'Transferring 2.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 3',
-        'Aspirating 2.0 uL from A1 of FAKE example labware on 1 at 1.0 speed',
+        'Aspirating 2.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
         'Dispensing 2.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
         'Dropping tip into A1 of Opentrons Fixed Trash on 12',
         'Transferring 3.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
         'Picking up tip from C1 of Opentrons 96 Tip Rack 10 µL on 3',
-        'Aspirating 3.0 uL from A1 of FAKE example labware on 1 at 1.0 speed',
+        'Aspirating 3.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
         'Dispensing 3.0 uL into A4 of FAKE example labware on 1 at 1.0 speed',
         'Dropping tip into A1 of Opentrons Fixed Trash on 12'
         ]
@@ -73,9 +73,9 @@ def test_simulate_function_v1(protocol, protocol_file):
     assert bundle is None
     assert [item['payload']['text'] for item in runlog] == [
         'Picking up tip from well A1 in "5"',
-        'Aspirating 10.0 uL from well A1 in "8" at 1.0 speed',
+        'Aspirating 10.0 uL from well A1 in "8" at 150.0 uL/sec',
         'Dispensing 10.0 uL into well H12 in "8" at 1.0 speed',
-        'Aspirating 10.0 uL from well A1 in "11" at 1.0 speed',
+        'Aspirating 10.0 uL from well A1 in "11" at 150.0 uL/sec',
         'Dispensing 10.0 uL into well H12 in "11" at 1.0 speed',
         'Dropping tip into well A1 in "12"'
     ]


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
Hello 👋
This pull request addresses the open issue #2772 
to display the flow rate in uL/sec instead of the rate multiplier e.g. "1.0"

With the aim to display the output as suggested in the expected behaviour of the issue

> 'Aspirating {volume} uL from {location} at {flow_rate} uL/sec'

an example output from the python protocol
[my_protocol.py.zip](https://github.com/Opentrons/opentrons/files/4960766/my_protocol.py.zip)
> Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1
Aspirating 100.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 300 uL/sec
Dispensing 100.0 uL into B2 of Corning 96 Well Plate 360 µL Flat on 2 at 375.0 uL/sec
Dropping tip into A1 of Opentrons Fixed Trash on 12


# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
- Imported FlowRates to commands.py to act as a getter for objects dispense and aspirate speeds
- Displayed rate multiplied by dispense or aspirate speed rather that just rate

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low risk 
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
# Comments
If there is any questions, suggestions or misunderstanding of the code on my half let me know as I'd like to continue working on this project in the future 🚀
Benedict