### PR TITLE
refactor(api): clarify warning on GPIO connection problem

### DIFF
--- a/api/src/opentrons/drivers/rpi_drivers/__init__.py
+++ b/api/src/opentrons/drivers/rpi_drivers/__init__.py
@@ -19,10 +19,12 @@ def build_gpio_chardev(chip_name: str) -> 'GPIODriverLike':
         MODULE_LOG.warning(
             'Failed to initialize character device, will not '
             'be able to control gpios (lights, button, smoothie'
-            'kill, smoothie reset). If you need to control gpios, '
-            'first stop the robot server with systemctl stop '
-            'opentrons-robot-server. Until you restart the server '
-            'with systemctl start opentrons-robot-server, you will '
-            'be unable to control the robot using the Opentrons app.')
+            'kill, smoothie reset). Only one connection can be'
+            ' made to the gpios at a time. '
+            'If you need to control gpios, first stop the robot '
+            'server with systemctl stop opentrons-robot-server. '
+            'Until you restart the server with systemctl start '
+            'opentrons-robot-server, you will be unable to '
+            'control the robot using the Opentrons app.')
         from .gpio_simulator import SimulatingGPIOCharDev
         return SimulatingGPIOCharDev(chip_name)


### PR DESCRIPTION
The message displayed when we fail to connect to GPIOs in Jupyter/Python script because another process is already using them doesn't explain that the reason stopping the server works is that it frees up the GPIOs for connecting. This may (or may not) be behind for example #6164.

This adds that to the message.
