### PR TITLE
fix(api): set parent for in-slot offsets to empty

### DIFF
--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -36,7 +36,9 @@ def _format_calibration_type(
 def _format_parent(
         data: 'CalibrationIndexDict')\
             -> local_types.ParentOptions:
-    options = local_types.ParentOptions(slot=data['slot'])
+    # Since the slot is not saved and the data in the index is actually
+    # the labware hash to aid lookup, we erase it here.
+    options = local_types.ParentOptions(slot='')
     if data['module']:
         options.module = data['module']['parent']
     return options

--- a/api/src/opentrons/calibration_storage/types.py
+++ b/api/src/opentrons/calibration_storage/types.py
@@ -47,6 +47,8 @@ class ParentOptions:
     a module, as well the original parent (slot).
     As of now, the slot is not saved in association
     with labware calibrations.
+
+    The slot value will be the empty string.
     """
     slot: str
     module: str = ''

--- a/robot-server/robot_server/service/labware/models.py
+++ b/robot-server/robot_server/service/labware/models.py
@@ -56,7 +56,8 @@ class LabwareCalibration(BaseModel):
     version: int = Field(..., description="The labware definition version")
     parent: str =\
         Field(...,
-              description="The slot or module associated with this labware.")
+              description="The module associated with this offset or an empty"
+                          " string if the offset is associated with a slot")
 
     class Config:
         schema_extra = {
@@ -64,18 +65,34 @@ class LabwareCalibration(BaseModel):
                 {
                     "calibrationData": {
                         "tipLength": {
-                                "value"
-                                "lastModified"
+                            "value": 10,
+                            "lastModified": "2020-07-10T12:50:47.156321"
                             },
                         "offset": {
-                                "value"
-                                "lastModified"
+                            "value": [1, -2, 10],
+                            "lastModified": "2020-07-10T12:40:17.05"
                         }
                     },
                     "version": "1",
-                    "parent": "3",
-                    "namespace": "opentrons"
-
+                    "parent": "",
+                    "namespace": "opentrons",
+                    "loadName": "opentrons_96_tiprack_300ul",
+                },
+                {
+                    "calibrationData": {
+                        "tipLength": {
+                            "value": 10,
+                            "lastModified": "2020-07-10T12:50:47.156321"
+                            },
+                        "offset": {
+                            "value": [1, -2, 10],
+                            "lastModified": "2020-07-10T12:40:17.05"
+                        }
+                    },
+                    "version": "1",
+                    "parent": "temperatureModuleV2",
+                    "namespace": "opentrons",
+                    "loadName": "corning_96_wellPlate_384ul",
                 }
             ]
         }

--- a/robot-server/robot_server/service/labware/router.py
+++ b/robot-server/robot_server/service/labware/router.py
@@ -113,7 +113,7 @@ async def get_all_labware_calibrations(
     all_calibrations = get_cal.get_all_calibrations()
 
     if not all_calibrations:
-        lw_models.MultipleCalibrationsResponse(data=all_calibrations)
+        return lw_models.MultipleCalibrationsResponse(data=all_calibrations)
 
     if namespace:
         all_calibrations = list(filter(

--- a/robot-server/tests/service/labware/test_labware_calibration_access.py
+++ b/robot-server/tests/service/labware/test_labware_calibration_access.py
@@ -32,7 +32,7 @@ def test_access_individual_labware(api_client, grab_id):
         'loadName': 'opentrons_96_tiprack_10ul',
         'namespace': 'opentrons',
         'version': 1,
-        'parent': calibration_id}
+        'parent': ''}
 
     resp = api_client.get(f'/labware/calibrations/{calibration_id}')
     assert resp.status_code == 200


### PR DESCRIPTION
We store calibration offsets by parent - including by slot. When an
offset is stored for a slot, the parent key (which is used to determine
the location of the calibration file) is saved as the labware hash.

However, this is not how it should be expressed when loaded - the parent
of a slot-relative offset is empty until and unless we start saving
different calibration offsets for the same labware in different slots.

Also, fill out the example fields for the labware calibration model in
the robot server and restore an early return in get labware calibrations
if there are no calibrations to return.
\
 This also is required to support #6100 