### PR TITLE
feat(robot-server): Robot server protocol session mockup

### DIFF
--- a/robot-server/robot_server/service/dependencies.py
+++ b/robot-server/robot_server/service/dependencies.py
@@ -7,12 +7,11 @@ from opentrons.hardware_control import ThreadManager, ThreadedAsyncLock
 
 from robot_server.hardware_wrapper import HardwareWrapper
 from robot_server.service.session.manager import SessionManager
+from robot_server.service.protocol.manager import ProtocolManager
 from robot_server.service.legacy.rpc import RPCServer
 
 
 # The single instance of the RPCServer
-from .protocol.manager import ProtocolManager
-
 _rpc_server_instance = None
 
 # The single instance of the SessionManager
@@ -56,16 +55,20 @@ async def get_rpc_server() -> RPCServer:
     return _rpc_server_instance
 
 
-def get_session_manager(hardware: ThreadManager = Depends(get_hardware)) \
-        -> SessionManager:
-    """The single session manager instance"""
-    global _session_manager_inst
-    if not _session_manager_inst:
-        _session_manager_inst = SessionManager(hardware=hardware)
-    return _session_manager_inst
-
-
 @lru_cache(maxsize=1)
 def get_protocol_manager() -> ProtocolManager:
     """The single protocol manager instance"""
     return ProtocolManager()
+
+
+def get_session_manager(
+        hardware: ThreadManager = Depends(get_hardware),
+        protocol_manager: ProtocolManager = Depends(get_protocol_manager)) \
+        -> SessionManager:
+    """The single session manager instance"""
+    global _session_manager_inst
+    if not _session_manager_inst:
+        _session_manager_inst = SessionManager(
+            hardware=hardware,
+            protocol_manager=protocol_manager)
+    return _session_manager_inst

--- a/robot-server/robot_server/service/protocol/protocol.py
+++ b/robot-server/robot_server/service/protocol/protocol.py
@@ -76,3 +76,8 @@ class UploadedProtocol:
     @property
     def meta(self) -> UploadedProtocolMeta:
         return self._meta
+
+    def get_contents(self) -> str:
+        """Read the protocol file contents as a string"""
+        with self.meta.protocol_file.path.open("r") as f:
+            return f.read()

--- a/robot-server/robot_server/service/session/command_execution/command.py
+++ b/robot-server/robot_server/service/session/command_execution/command.py
@@ -2,12 +2,12 @@ from datetime import datetime
 from dataclasses import dataclass, field
 
 from robot_server.service.session.models import IdentifierType, \
-    create_identifier, CommandDefinition, CommandDataType, CommandStatus
+    create_identifier, CommandDefinitionType, CommandDataType, CommandStatus
 
 
 @dataclass(frozen=True)
 class CommandContent:
-    name: CommandDefinition
+    name: CommandDefinitionType
     data: CommandDataType
 
 
@@ -37,7 +37,8 @@ class CompletedCommand:
     result: CommandResult
 
 
-def create_command(name: CommandDefinition, data: CommandDataType) -> Command:
+def create_command(name: CommandDefinitionType,
+                   data: CommandDataType) -> Command:
     """Create a command object"""
     return Command(
         content=CommandContent(

--- a/robot-server/robot_server/service/session/configuration.py
+++ b/robot-server/robot_server/service/session/configuration.py
@@ -2,6 +2,7 @@ from typing import Callable
 
 from opentrons.hardware_control import ThreadManager
 
+from robot_server.service.protocol.manager import ProtocolManager
 from robot_server.service.session.models import IdentifierType
 
 
@@ -11,9 +12,11 @@ class SessionConfiguration:
 
     def __init__(self,
                  hardware: ThreadManager,
-                 is_active: Callable[[IdentifierType], bool]):
+                 is_active: Callable[[IdentifierType], bool],
+                 protocol_manager: ProtocolManager):
         self._hardware = hardware
         self._is_active = is_active
+        self._protocol_manager = protocol_manager
 
     @property
     def hardware(self) -> ThreadManager:
@@ -23,3 +26,8 @@ class SessionConfiguration:
     def is_active(self, identifier: IdentifierType) -> bool:
         """Is session identifier active"""
         return self._is_active(identifier)
+
+    @property
+    def protocol_manager(self) -> ProtocolManager:
+        """Access the protocol manager"""
+        return self._protocol_manager

--- a/robot-server/robot_server/service/session/errors.py
+++ b/robot-server/robot_server/service/session/errors.py
@@ -1,3 +1,8 @@
+# TODO: Amit 07/30/2020 - SessionException should derive from RobotServerError
+#   and provide an easy way to customize the HTTP status code along with
+#   other Error attributes
+
+
 class SessionException(Exception):
     """Base of all session exceptions"""
     pass

--- a/robot-server/robot_server/service/session/models.py
+++ b/robot-server/robot_server/service/session/models.py
@@ -33,6 +33,10 @@ class JogPosition(BaseModel):
     vector: OffsetVector
 
 
+class ProtocolCreateParams(BaseModel):
+    protocol_id: str
+
+
 class SessionType(str, Enum):
     """The available session types"""
     def __new__(cls, value, create_param_model=type(None)):
@@ -53,6 +57,7 @@ class SessionType(str, Enum):
         'tipLengthCalibration',
         tip_length_calibration_models.SessionCreateParams
     )
+    protocol = ('protocol', ProtocolCreateParams)
 
     @property
     def model(self):
@@ -72,7 +77,9 @@ https://pydantic-docs.helpmanual.io/usage/types/#literal-type
 """
 SessionCreateParamType = typing.Union[
     tip_length_calibration_models.SessionCreateParams,
-    None, EmptyModel
+    ProtocolCreateParams,
+    None,
+    EmptyModel
 ]
 
 """
@@ -130,7 +137,7 @@ class CommandDefinition(str, Enum):
 
 
 class RobotCommand(CommandDefinition):
-    """Generic commands"""
+    """Robot commands"""
     home_all_motors = "homeAllMotors"
     home_pipette = "homePipette"
     toggle_lights = "toggleLights"
@@ -138,6 +145,20 @@ class RobotCommand(CommandDefinition):
     @staticmethod
     def namespace():
         return "robot"
+
+
+class ProtocolCommand(CommandDefinition):
+    """Protocol commands"""
+    start_run = "startRun"
+    start_simulate = "startSimulate"
+    cancel = "cancel"
+    pause = "pause"
+    resume = "resume"
+    step = "step"
+
+    @staticmethod
+    def namespace():
+        return "protocol"
 
 
 class CalibrationCommand(CommandDefinition):
@@ -194,7 +215,8 @@ CommandDefinitionType = typing.Union[
     RobotCommand,
     CalibrationCommand,
     CalibrationCheckCommand,
-    TipLengthCalibrationCommand
+    TipLengthCalibrationCommand,
+    ProtocolCommand
 ]
 
 

--- a/robot-server/robot_server/service/session/models.py
+++ b/robot-server/robot_server/service/session/models.py
@@ -154,7 +154,6 @@ class ProtocolCommand(CommandDefinition):
     cancel = "cancel"
     pause = "pause"
     resume = "resume"
-    step = "step"
 
     @staticmethod
     def namespace():

--- a/robot-server/robot_server/service/session/models.py
+++ b/robot-server/robot_server/service/session/models.py
@@ -34,7 +34,7 @@ class JogPosition(BaseModel):
 
 
 class ProtocolCreateParams(BaseModel):
-    protocol_id: str
+    protocolId: str
 
 
 class SessionType(str, Enum):

--- a/robot-server/robot_server/service/session/router.py
+++ b/robot-server/robot_server/service/session/router.py
@@ -59,6 +59,9 @@ async def create_session_handler(
         new_session = await session_manager.add(
             session_type=session_type,
             session_meta_data=SessionMetaData(create_params=create_params))
+    # TODO: Amit 07/30/2020 - SessionCreationException should be a
+    #  RobotServerError. Customized by raiser with status code and rest of
+    #  Error attributes. The job here would be to log and re-raise.
     except SessionCreationException as e:
         log.exception("Failed to create session")
         raise RobotServerError(
@@ -92,6 +95,9 @@ async def delete_session_handler(
 
     try:
         await session_manager.remove(session_obj.meta.identifier)
+    # TODO: Amit 07/30/2020 - SessionException should be a RobotServerError.
+    #  Customized by raiser with status code and rest of
+    #  Error attributes. The job here would be to log and re-raise.
     except SessionException as e:
         log.exception("Failed to remove a session session")
         raise RobotServerError(
@@ -183,6 +189,9 @@ async def session_command_execute_handler(
                                  command_request.data.attributes.data)
         command_result = await session_obj.command_executor.execute(command)
         log.debug(f"Command completed {command}")
+    # TODO: Amit 07/30/2020 - SessionCommandException should be a
+    #  RobotServerError. Customized by raiser with status code and rest of
+    #  Error attributes. The job here would be to log and re-raise.
     except CommandExecutionConflict as e:
         log.exception("Failed to execute command due to conflict")
         raise RobotServerError(

--- a/robot-server/robot_server/service/session/session_types/protocol_session.py
+++ b/robot-server/robot_server/service/session/session_types/protocol_session.py
@@ -37,7 +37,7 @@ class ProtocolSession(BaseSession):
         """Try to create the protocol session"""
         protocol = configuration.protocol_manager.get(
             cast(models.ProtocolCreateParams,
-                 instance_meta.create_params).protocol_id
+                 instance_meta.create_params).protocolId
         )
         return cls(configuration, instance_meta, protocol)
 

--- a/robot-server/robot_server/service/session/session_types/protocol_session.py
+++ b/robot-server/robot_server/service/session/session_types/protocol_session.py
@@ -1,15 +1,13 @@
 import logging
 from typing import cast
 
+from robot_server.service.session.errors import UnsupportedFeature
 from robot_server.service.session.session_types import BaseSession, \
     SessionMetaData
 from robot_server.service.session import models
 from robot_server.service.session.command_execution import CommandQueue,\
     CommandExecutor
 from robot_server.service.session.configuration import SessionConfiguration
-from robot_server.service.session.errors import UnsupportedFeature, \
-    SessionCreationException
-from robot_server.service.protocol.errors import ProtocolNotFoundException
 from robot_server.service.protocol.protocol import UploadedProtocol
 
 
@@ -31,26 +29,24 @@ class ProtocolSession(BaseSession):
         """
         super().__init__(configuration, instance_meta)
         self._uploaded_protocol = protocol
+        self._command_executor = CommandExecutor()
 
     @classmethod
     async def create(cls, configuration: SessionConfiguration,
                      instance_meta: SessionMetaData) -> 'BaseSession':
         """Try to create the protocol session"""
-        try:
-            protocol = configuration.protocol_manager.get(
-                cast(models.ProtocolCreateParams,
-                     instance_meta.create_params).protocol_id
-            )
-            return cls(configuration, instance_meta, protocol)
-        except ProtocolNotFoundException as e:
-            raise SessionCreationException(str(e))
+        protocol = configuration.protocol_manager.get(
+            cast(models.ProtocolCreateParams,
+                 instance_meta.create_params).protocol_id
+        )
+        return cls(configuration, instance_meta, protocol)
 
     def _get_response_details(self) -> models.SessionDetails:
         return models.EmptyModel()
 
     @property
     def command_executor(self) -> CommandExecutor:
-        raise UnsupportedFeature()
+        return self._command_executor
 
     @property
     def command_queue(self) -> CommandQueue:

--- a/robot-server/robot_server/service/session/session_types/protocol_session.py
+++ b/robot-server/robot_server/service/session/session_types/protocol_session.py
@@ -1,0 +1,61 @@
+import logging
+from typing import cast
+
+from robot_server.service.session.session_types import BaseSession, \
+    SessionMetaData
+from robot_server.service.session import models
+from robot_server.service.session.command_execution import CommandQueue,\
+    CommandExecutor
+from robot_server.service.session.configuration import SessionConfiguration
+from robot_server.service.session.errors import UnsupportedFeature, \
+    SessionCreationException
+from robot_server.service.protocol.errors import ProtocolNotFoundException
+from robot_server.service.protocol.protocol import UploadedProtocol
+
+
+log = logging.getLogger(__name__)
+
+
+class ProtocolSession(BaseSession):
+
+    def __init__(self,
+                 configuration: SessionConfiguration,
+                 instance_meta: SessionMetaData,
+                 protocol: UploadedProtocol):
+        """
+        Constructor
+
+        :param configuration:
+        :param instance_meta:
+        :param protocol:
+        """
+        super().__init__(configuration, instance_meta)
+        self._uploaded_protocol = protocol
+
+    @classmethod
+    async def create(cls, configuration: SessionConfiguration,
+                     instance_meta: SessionMetaData) -> 'BaseSession':
+        """Try to create the protocol session"""
+        try:
+            protocol = configuration.protocol_manager.get(
+                cast(models.ProtocolCreateParams,
+                     instance_meta.create_params).protocol_id
+            )
+            return cls(configuration, instance_meta, protocol)
+        except ProtocolNotFoundException as e:
+            raise SessionCreationException(str(e))
+
+    def _get_response_details(self) -> models.SessionDetails:
+        return models.EmptyModel()
+
+    @property
+    def command_executor(self) -> CommandExecutor:
+        raise UnsupportedFeature()
+
+    @property
+    def command_queue(self) -> CommandQueue:
+        raise UnsupportedFeature()
+
+    @property
+    def session_type(self) -> models.SessionType:
+        return models.SessionType.protocol

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -11,7 +11,7 @@ import pytest
 from starlette.testclient import TestClient
 from robot_server.service.app import app
 from robot_server.service.dependencies import get_hardware, verify_hardware
-from opentrons.hardware_control import API, HardwareAPILike
+from opentrons.hardware_control import API, HardwareAPILike, ThreadedAsyncLock
 from opentrons import config
 
 from opentrons.calibration_storage import delete
@@ -19,6 +19,8 @@ from opentrons.protocol_api import labware
 from opentrons.types import Point
 from opentrons.protocol_api.geometry import Deck
 
+from robot_server.service.protocol.manager import ProtocolManager
+from robot_server.service.session.manager import SessionManager
 
 test_router = routing.APIRouter()
 
@@ -132,3 +134,9 @@ def set_up_index_file_temporary_directory(server_temp_directory):
         definition = labware.get_labware_definition(name)
         lw = labware.Labware(definition, parent)
         labware.save_calibration(lw, Point(0, 0, 0))
+
+
+@pytest.fixture
+def session_manager(hardware) -> SessionManager:
+    return SessionManager(hardware,
+                          ProtocolManager())

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -11,7 +11,7 @@ import pytest
 from starlette.testclient import TestClient
 from robot_server.service.app import app
 from robot_server.service.dependencies import get_hardware, verify_hardware
-from opentrons.hardware_control import API, HardwareAPILike, ThreadedAsyncLock
+from opentrons.hardware_control import API, HardwareAPILike
 from opentrons import config
 
 from opentrons.calibration_storage import delete

--- a/robot-server/tests/integration/sessions/test_protocol.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_protocol.tavern.yaml
@@ -16,7 +16,7 @@ stages:
           attributes:
             sessionType: protocol
             createParams:
-              protocol_id: "my_protocol"
+              protocolId: "my_protocol"
     response:
       status_code: 404
 ---
@@ -27,7 +27,7 @@ marks:
   - usefixtures:
       - run_server
 stages:
-  - name: Upload a protocol with support file
+  - name: Upload a protocol to use with the session
     request:
       url: "{host:s}:{port:d}/protocols"
       method: POST
@@ -48,7 +48,7 @@ stages:
           attributes:
             sessionType: protocol
             createParams:
-              protocol_id: "{protocol_id}"
+              protocolId: "{protocol_id}"
     response:
       status_code: 201
       save:
@@ -61,7 +61,7 @@ stages:
           attributes:
             sessionType: protocol
             createParams:
-              protocol_id: "{protocol_id}"
+              protocolId: "{protocol_id}"
             createdAt: !anystr
             details: {}
         links: !anydict

--- a/robot-server/tests/integration/sessions/test_protocol.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_protocol.tavern.yaml
@@ -1,0 +1,104 @@
+---
+test_name: Protocol session unknown protocol
+strict:
+  - json:on
+marks:
+  - usefixtures:
+      - run_server
+stages:
+  - name: Create the session
+    request:
+      url: "{host:s}:{port:d}/sessions"
+      method: POST
+      json:
+        data:
+          type: Session
+          attributes:
+            sessionType: protocol
+            createParams:
+              protocol_id: "my_protocol"
+    response:
+      status_code: 404
+---
+test_name: Protocol session life cycle
+strict:
+  - json:on
+marks:
+  - usefixtures:
+      - run_server
+stages:
+  - name: Upload a protocol with support file
+    request:
+      url: "{host:s}:{port:d}/protocols"
+      method: POST
+      files:
+        protocol_file: "tests/integration/protocols/phony_proto.py"
+    response:
+      save:
+        json:
+          protocol_id: data.id
+      status_code: 201
+  - name: Create the session
+    request:
+      url: "{host:s}:{port:d}/sessions"
+      method: POST
+      json:
+        data:
+          type: Session
+          attributes:
+            sessionType: protocol
+            createParams:
+              protocol_id: "{protocol_id}"
+    response:
+      status_code: 201
+      save:
+        json:
+          session_id: data.id
+      json: &proto_session
+        data:
+          id: !anystr
+          type: Session
+          attributes:
+            sessionType: protocol
+            createParams:
+              protocol_id: "{protocol_id}"
+            createdAt: !anystr
+            details: {}
+        links: !anydict
+  - name: Get the session
+    request:
+      url: "{host:s}:{port:d}/sessions/{session_id}"
+      method: GET
+    response:
+      status_code: 200
+      json: *proto_session
+  - name: Try to simulate
+    request:
+      url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"
+      method: POST
+      json:
+        data:
+          type: SessionCommand
+          attributes:
+            command: protocol.startSimulate
+            data: {}
+    response:
+      # Fails due to command execution not implemented yet
+      status_code: 400
+  - name: Delete the session
+    request:
+      url: "{host:s}:{port:d}/sessions/{session_id}"
+      method: DELETE
+    response:
+      status_code: 200
+      json: *proto_session
+  - name: Get the session will fail
+    request:
+      url: "{host:s}:{port:d}/sessions/{session_id}"
+      method: GET
+    response:
+      status_code: 404
+  - name: Delete the protocol
+    request:
+      url: "{host:s}:{port:d}/protocols/{protocol_id}"
+      method: DELETE

--- a/robot-server/tests/service/session/session_types/test_check_session.py
+++ b/robot-server/tests/service/session/session_types/test_check_session.py
@@ -97,7 +97,8 @@ def check_session_instance(patch_build_session, hardware, loop) -> BaseSession:
     return loop.run_until_complete(
         CheckSession.create(
             configuration=SessionConfiguration(hardware=hardware,
-                                               is_active=lambda x: False),
+                                               is_active=lambda x: False,
+                                               protocol_manager=None),
             instance_meta=SessionMetaData()
         )
     )
@@ -150,7 +151,8 @@ async def test_create_session_error(hardware, patch_build_session,
     with pytest.raises(SessionCreationException):
         await CheckSession.create(
             configuration=SessionConfiguration(hardware=hardware,
-                                               is_active=lambda x: False),
+                                               is_active=lambda x: False,
+                                               protocol_manager=None),
             instance_meta=SessionMetaData()
         )
 

--- a/robot-server/tests/service/session/test_manager.py
+++ b/robot-server/tests/service/session/test_manager.py
@@ -5,8 +5,7 @@ import pytest
 
 from robot_server.service.session.errors import SessionCreationException, \
     SessionException
-from robot_server.service.session.manager import SessionManager, \
-    SessionMetaData, BaseSession
+from robot_server.service.session.manager import SessionMetaData, BaseSession
 from robot_server.service.session.models import create_identifier, SessionType
 from robot_server.service.session.session_types import DefaultSession
 
@@ -16,15 +15,10 @@ async def side_effect(*args, **kwargs):
 
 
 @pytest.fixture
-def manager(hardware):
-    return SessionManager(hardware)
-
-
-@pytest.fixture
-async def session(manager, loop) -> BaseSession:
+async def session(session_manager, loop) -> BaseSession:
     """An added session"""
-    return await manager.add(session_type=SessionType.null,
-                             session_meta_data=SessionMetaData())
+    return await session_manager.add(session_type=SessionType.null,
+                                     session_meta_data=SessionMetaData())
 
 
 @pytest.fixture
@@ -35,132 +29,140 @@ def mock_session_create():
         yield m
 
 
-async def test_add_calls_session_create(manager, mock_session_create, session):
+async def test_add_calls_session_create(session_manager,
+                                        mock_session_create,
+                                        session):
     mock_session_create.assert_called_once()
     assert mock_session_create.call_args[1]['configuration'] == \
-        manager._session_common
+           session_manager._session_common
     assert isinstance(mock_session_create.call_args[1]['instance_meta'],
                       SessionMetaData)
 
 
-async def test_add_no_class_doesnt_call_create(manager, mock_session_create):
+async def test_add_no_class_doesnt_call_create(session_manager,
+                                               mock_session_create):
     # Patch the type to class dict
     with patch("robot_server.service.session.manager.SessionTypeToClass",
                new={}):
         with pytest.raises(SessionCreationException):
-            await manager.add(SessionType.null, SessionMetaData())
+            await session_manager.add(SessionType.null, SessionMetaData())
         mock_session_create.assert_not_called()
 
 
-async def test_add_stores_session(manager, session):
-    assert manager._sessions[session.meta.identifier] == session
+async def test_add_stores_session(session_manager, session):
+    assert session_manager._sessions[session.meta.identifier] == session
 
 
-async def test_add_activates_session(manager, session):
+async def test_add_activates_session(session_manager, session):
     """Test that adding a session also makes that new session active"""
-    assert manager._active.active_id == session.meta.identifier
+    assert session_manager._active.active_id == session.meta.identifier
 
 
-async def test_remove_removes(manager, session):
-    assert await manager.remove(session.meta.identifier) is session
-    assert session.meta.identifier not in manager._sessions
+async def test_remove_removes(session_manager, session):
+    assert await session_manager.remove(session.meta.identifier) is session
+    assert session.meta.identifier not in session_manager._sessions
 
 
-async def test_remove_calls_cleanup(manager):
-    session = await manager.add(SessionType.null, SessionMetaData())
+async def test_remove_calls_cleanup(session_manager):
+    session = await session_manager.add(SessionType.null, SessionMetaData())
     session.clean_up = MagicMock(side_effect=side_effect)
-    await manager.remove(session.meta.identifier)
+    await session_manager.remove(session.meta.identifier)
     session.clean_up.assert_called_once()
 
 
-async def test_remove_active_session(manager, session):
-    manager._active.active_id = session.meta.identifier
-    await manager.remove(session.meta.identifier)
-    assert manager._active.active_id is manager._active.default_id
+async def test_remove_active_session(session_manager, session):
+    session_manager._active.active_id = session.meta.identifier
+    await session_manager.remove(session.meta.identifier)
+    assert session_manager._active.active_id is \
+           session_manager._active.default_id
 
 
-async def test_remove_inactive_session(manager, session):
-    active_session = await manager.add(SessionType.null, SessionMetaData())
-    await manager.remove(session.meta.identifier)
-    assert manager._active.active_id is active_session.meta.identifier
+async def test_remove_inactive_session(session_manager, session):
+    active_session = await session_manager.add(SessionType.null,
+                                               SessionMetaData())
+    await session_manager.remove(session.meta.identifier)
+    assert session_manager._active.active_id is active_session.meta.identifier
 
 
-async def test_remove_unknown_session(manager):
-    assert await manager.remove(create_identifier()) is None
+async def test_remove_unknown_session(session_manager):
+    assert await session_manager.remove(create_identifier()) is None
 
 
-def test_get_by_id_not_found(manager):
-    assert manager.get_by_id(create_identifier()) is None
+def test_get_by_id_not_found(session_manager):
+    assert session_manager.get_by_id(create_identifier()) is None
 
 
-async def test_get_by_type(manager):
+async def test_get_by_type(session_manager):
     sessions = await asyncio.gather(
-        *[manager.add(SessionType.null, SessionMetaData()) for _ in range(5)]
+        *[session_manager.add(SessionType.null, SessionMetaData()) for _ in range(5)]  # noqa: e501
     )
-    assert manager.get(SessionType.null) == tuple(sessions)
-    assert manager.get(SessionType.calibration_check) == tuple()
+    assert session_manager.get(SessionType.null) == tuple(sessions)
+    assert session_manager.get(SessionType.calibration_check) == tuple()
 
 
-async def test_get_active(manager, session):
-    manager._active.active_id = session.meta.identifier
-    assert manager.get_active() is session
+async def test_get_active(session_manager, session):
+    session_manager._active.active_id = session.meta.identifier
+    assert session_manager.get_active() is session
 
 
-def test_get_active_no_active_returns_default(manager):
-    manager._active.active_id = None
-    assert manager.get_active() is manager._sessions[DefaultSession.DEFAULT_ID]
+def test_get_active_no_active_returns_default(session_manager):
+    session_manager._active.active_id = None
+    assert session_manager.get_active() is \
+           session_manager._sessions[DefaultSession.DEFAULT_ID]
 
 
-async def test_is_active(manager, session):
-    manager._active.active_id = session.meta.identifier
-    assert manager.is_active(session.meta.identifier) is True
+async def test_is_active(session_manager, session):
+    session_manager._active.active_id = session.meta.identifier
+    assert session_manager.is_active(session.meta.identifier) is True
 
 
-def test_is_active_not_active(manager):
-    assert manager.is_active(create_identifier()) is False
+def test_is_active_not_active(session_manager):
+    assert session_manager.is_active(create_identifier()) is False
 
 
-async def test_activate(manager, session):
-    assert manager.activate(session.meta.identifier) is session
-    assert manager._active.active_id == session.meta.identifier
+async def test_activate(session_manager, session):
+    assert session_manager.activate(session.meta.identifier) is session
+    assert session_manager._active.active_id == session.meta.identifier
 
 
-def test_activate_unknown_session(manager):
-    assert manager.activate(create_identifier()) is None
-    assert manager._active.active_id is manager._active.default_id
+def test_activate_unknown_session(session_manager):
+    assert session_manager.activate(create_identifier()) is None
+    assert session_manager._active.active_id is \
+           session_manager._active.default_id
 
 
-async def test_deactivate(manager, session):
-    manager._active.active_id = session.meta.identifier
-    assert manager.deactivate(session.meta.identifier) is session
-    assert manager._active.active_id is manager._active.default_id
+async def test_deactivate(session_manager, session):
+    session_manager._active.active_id = session.meta.identifier
+    assert session_manager.deactivate(session.meta.identifier) is session
+    assert session_manager._active.active_id is \
+           session_manager._active.default_id
 
 
-async def test_deactivate_unknown_session(manager, session):
-    manager._active.active_id = session.meta.identifier
-    assert manager.deactivate(create_identifier()) is None
-    assert manager._active.active_id is session.meta.identifier
+async def test_deactivate_unknown_session(session_manager, session):
+    session_manager._active.active_id = session.meta.identifier
+    assert session_manager.deactivate(create_identifier()) is None
+    assert session_manager._active.active_id is session.meta.identifier
 
 
-def test_deactivate_non_active(manager):
-    manager._active.active_id = None
-    assert manager.deactivate(create_identifier()) is None
+def test_deactivate_non_active(session_manager):
+    session_manager._active.active_id = None
+    assert session_manager.deactivate(create_identifier()) is None
 
 
 class TestDefaultSession:
 
-    def test_always_present(self, manager):
-        assert manager.get_by_id(DefaultSession.DEFAULT_ID) is not None
+    def test_always_present(self, session_manager):
+        assert session_manager.get_by_id(DefaultSession.DEFAULT_ID) is not None
 
-    def test_default_is_active(self, manager):
+    def test_default_is_active(self, session_manager):
         """Test that default is active if no other session is active"""
-        assert manager.is_active(DefaultSession.DEFAULT_ID) is True
+        assert session_manager.is_active(DefaultSession.DEFAULT_ID) is True
 
-    async def test_add_fails(self, manager):
+    async def test_add_fails(self, session_manager):
         with pytest.raises(SessionCreationException):
-            await manager.add(session_type=SessionType.default,
-                              session_meta_data=SessionMetaData())
+            await session_manager.add(session_type=SessionType.default,
+                                      session_meta_data=SessionMetaData())
 
-    async def test_remove_fails(self, manager):
+    async def test_remove_fails(self, session_manager):
         with pytest.raises(SessionException):
-            await manager.remove(DefaultSession.DEFAULT_ID)
+            await session_manager.remove(DefaultSession.DEFAULT_ID)


### PR DESCRIPTION
# Overview

Create the core of a protocol session.

# Changelog

- Created ProtocolSession derived from BaseSession
- Added CreateParams for ProtocolSession type
- SessionManager can create and delete protocol session
- Defined enum of protocol command definitions.


# Review requests

**This PR needs to be rebased once the protocol api PR is merged #6182**

Review naming of commands.


# Risk assessment

Zero. These endpoints don't do anything yet.


closes #6072 