### PR TITLE
refactor(app): show spinners during tlc requests

### DIFF
--- a/app/src/components/CalibrateTipLength/MeasureNozzle.js
+++ b/app/src/components/CalibrateTipLength/MeasureNozzle.js
@@ -86,9 +86,13 @@ export function MeasureNozzle(props: CalibrateTipLengthChildProps): React.Node {
   )
 
   const jog = (axis: JogAxis, dir: JogDirection, step: JogStep) => {
-    sendSessionCommand(Sessions.tipCalCommands.JOG, {
-      vector: formatJogVector(axis, dir, step),
-    })
+    sendSessionCommand(
+      Sessions.tipCalCommands.JOG,
+      {
+        vector: formatJogVector(axis, dir, step),
+      },
+      false
+    )
   }
 
   const proceed = () => {

--- a/app/src/components/CalibrateTipLength/MeasureTip.js
+++ b/app/src/components/CalibrateTipLength/MeasureTip.js
@@ -85,9 +85,13 @@ export function MeasureTip(props: CalibrateTipLengthChildProps): React.Node {
   )
 
   const jog = (axis: JogAxis, dir: JogDirection, step: JogStep) => {
-    sendSessionCommand(Sessions.tipCalCommands.JOG, {
-      vector: formatJogVector(axis, dir, step),
-    })
+    sendSessionCommand(
+      Sessions.tipCalCommands.JOG,
+      {
+        vector: formatJogVector(axis, dir, step),
+      },
+      false
+    )
   }
 
   const proceed = () => {

--- a/app/src/components/CalibrateTipLength/__tests__/MeasureNozzle.test.js
+++ b/app/src/components/CalibrateTipLength/__tests__/MeasureNozzle.test.js
@@ -58,7 +58,8 @@ describe('MeasureNozzle', () => {
 
       expect(mockSendCommand).toHaveBeenCalledWith(
         Sessions.tipCalCommands.JOG,
-        { vector: jogParamsByDirection[direction] }
+        { vector: jogParamsByDirection[direction] },
+        false
       )
     })
 

--- a/app/src/components/CalibrateTipLength/__tests__/MeasureTip.test.js
+++ b/app/src/components/CalibrateTipLength/__tests__/MeasureTip.test.js
@@ -58,7 +58,8 @@ describe('MeasureTip', () => {
 
       expect(mockSendCommand).toHaveBeenCalledWith(
         Sessions.tipCalCommands.JOG,
-        { vector: jogParamsByDirection[direction] }
+        { vector: jogParamsByDirection[direction] },
+        false
       )
     })
 

--- a/app/src/components/CalibrateTipLength/index.js
+++ b/app/src/components/CalibrateTipLength/index.js
@@ -1,7 +1,7 @@
 // @flow
 // Tip Length Calibration Orchestration Component
 import * as React from 'react'
-import { useSelector } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
 import last from 'lodash/last'
 
 import {
@@ -61,6 +61,7 @@ export function CalibrateTipLength(
 ): React.Node {
   const { session, robotName, hasBlock, closeWizard } = props
   const [dispatchRequest, requestIds] = useDispatchApiRequest()
+  const dispatch = useDispatch()
 
   const requestStatus = useSelector<State, RequestState | null>(state =>
     getRequestById(state, last(requestIds))
@@ -68,15 +69,20 @@ export function CalibrateTipLength(
 
   function sendCommand(
     command: SessionCommandString,
-    data: SessionCommandData = {}
+    data: SessionCommandData = {},
+    trackRequest: boolean = true
   ) {
-    session?.id &&
-      dispatchRequest(
-        Sessions.createSessionCommand(robotName, session.id, {
-          command,
-          data,
-        })
-      )
+    if (session === null) return
+    const sessionCommand = Sessions.createSessionCommand(
+      robotName,
+      session.id,
+      { command, data }
+    )
+    if (trackRequest) {
+      dispatchRequest(sessionCommand)
+    } else {
+      dispatch(sessionCommand)
+    }
   }
 
   function deleteSession() {

--- a/app/src/components/CalibrateTipLength/types.js
+++ b/app/src/components/CalibrateTipLength/types.js
@@ -21,7 +21,8 @@ export type CalibrateTipLengthChildProps = {|
   labware: Array<TipLengthCalibrationLabware>,
   sendSessionCommand: (
     command: SessionCommandString,
-    data?: SessionCommandData
+    data?: SessionCommandData,
+    trackRequest?: boolean
   ) => void,
   hasBlock: boolean,
   deleteSession: () => void,


### PR DESCRIPTION
Pop a spinner modal while API requests are in flight for tip length calibration
