### PR TITLE
fix(app): show conn. alert if WS closes **or** robot becomes unhealthy

### DIFF
--- a/app/src/components/LostConnectionAlert/index.js
+++ b/app/src/components/LostConnectionAlert/index.js
@@ -26,7 +26,7 @@ export function LostConnectionAlert(): React.Node {
     const robot = getAllRobots(state).find(r => r.name === connectedName)
     const unexpectedDisconnect = state.robot.connection.unexpectedDisconnect
 
-    return Boolean(!robot?.ok || unexpectedDisconnect)
+    return Boolean((connectedName && !robot?.ok) || unexpectedDisconnect)
   })
 
   const disconnect = () => {

--- a/app/src/components/LostConnectionAlert/index.js
+++ b/app/src/components/LostConnectionAlert/index.js
@@ -26,7 +26,7 @@ export function LostConnectionAlert(): React.Node {
     const robot = getAllRobots(state).find(r => r.name === connectedName)
     const unexpectedDisconnect = state.robot.connection.unexpectedDisconnect
 
-    return Boolean(robot && !robot.ok && unexpectedDisconnect)
+    return Boolean(!robot?.ok || unexpectedDisconnect)
   })
 
   const disconnect = () => {


### PR DESCRIPTION
# Overview

#5626 introduced a bug caused by switching the logic for showing the LostConnectionAlert

- Before (good): Show alert if RPC WS goes down unexpectedly **or** robot stops responding on /health
- After (bad): Show alert if RPC WS goes down **and** robot stops responding on /health

This PR switches that **and** back to the proper **or**. Yay software. Bug noted in this thread: https://github.com/Opentrons/opentrons/issues/6159#issuecomment-665197896

# Changelog

- fix(app): show conn. alert if WS closes **or** robot becomes unhealthy

# Review requests

You can test this by creating a condition for the WS to go down but the robot to remain healthy

1. Connect a robot to both Wi-Fi and U2E
2. Click "connect" once the app shows the robot as wired
3. Pull the USB cable to sever the WebSocket connection

Bug on `edge`:
- WS will go down but robot will still be responding to /health on Wi-Fi
- Connection alert will never pop up

Fix on this branch:
- WS will go down but robot will still be responding to /health on Wi-Fi
- Connection alert **will** pop up

# Risk assessment

Bug fix
