### PR TITLE
fix(app): don't doublecount labware on modules

### DIFF
--- a/app/src/calibration/labware/__tests__/selectors.test.js
+++ b/app/src/calibration/labware/__tests__/selectors.test.js
@@ -274,5 +274,45 @@ describe('labware calibration selectors', () => {
         },
       ])
     })
+
+    it('does not aggregate labware across differing parents', () => {
+      getLabware.mockReturnValue([
+        ({
+          type: wellPlate96Def.parameters.loadName,
+          definition: wellPlate96Def,
+          slot: '2',
+        }: $Shape<ProtocolLabware>),
+        ({
+          type: wellPlate96Def.parameters.loadName,
+          definition: wellPlate96Def,
+          slot: '3',
+        }: $Shape<ProtocolLabware>),
+      ])
+
+      getModulesBySlot.mockImplementation(calledState => {
+        return {
+          '3': {
+            model: 'magneticModuleV1',
+            slot: '3',
+            _id: 1945365648,
+          },
+        }
+      })
+
+      expect(Selectors.getProtocolLabwareList(state, robotName)).toEqual([
+        {
+          displayName: wellPlate96Def.metadata.displayName,
+          parentDisplayName: null,
+          quantity: 1,
+          calibration: null,
+        },
+        {
+          displayName: wellPlate96Def.metadata.displayName,
+          parentDisplayName: 'Magnetic Module GEN1',
+          quantity: 1,
+          calibration: null,
+        },
+      ])
+    })
   })
 })

--- a/app/src/calibration/labware/selectors.js
+++ b/app/src/calibration/labware/selectors.js
@@ -70,16 +70,25 @@ export const getProtocolLabwareList: (
       const { definition: def, loadName, namespace, version, parent } = lw
       const displayName = def ? getLabwareDisplayName(def) : loadName
       const parentDisplayName = parent ? getModuleDisplayName(parent) : null
-      const matchesLabwareIdentity = target =>
+      const matchesLabwareIdentityForQuantity = target =>
+        target.loadName === loadName &&
+        target.namespace === namespace &&
+        target.version === version &&
+        target.parent === parent
+
+      const quantity = baseLabwareList.filter(matchesLabwareIdentityForQuantity)
+        .length
+
+      const matchesLabwareIdentityForCalibration = target =>
         target.loadName === loadName &&
         target.namespace === namespace &&
         target.version === version &&
         (parent === null || target.parent === parent)
 
-      const quantity = baseLabwareList.filter(matchesLabwareIdentity).length
-
       const calData = calibrations
-        .filter(({ attributes }) => matchesLabwareIdentity(attributes))
+        .filter(({ attributes }) =>
+          matchesLabwareIdentityForCalibration(attributes)
+        )
         .map(({ attributes }) => {
           const calVector = attributes.calibrationData.offset.value.map(n =>
             round(n, 1)


### PR DESCRIPTION
If you have a labware on a module, and another of that labware on the
deck, the app will display (x2) next to the entry for the labware on the
deck in the file info panel. This is becaues of too-loose matching on
parent in a new selector. Tighten up that matching so labware on modules
doesn't get doublecounted.


## Testing
- Load a protocol that has the same labware on the module and the deck
- Make sure the quantities in the file info page are correct