### PR TITLE
fix: adds missing space to Thermocycler command

### DIFF
--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -445,7 +445,7 @@ def thermocycler_set_block_temp(temperature,
 
         clean_seconds = total_seconds % 60
         clean_minutes = (total_seconds - clean_seconds) / 60
-        text += 'with a hold time of '
+        text += ' with a hold time of '
         if clean_minutes > 0:
             text += f'{clean_minutes} minutes and '
         text += f'{clean_seconds} seconds'


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Hello 👋
To Address issue #6258
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
Setting Block temperature of Thermocycler module currently outputs
>`Setting Thermocycler well block temperature to 60.0 °Cwith a hold time of 5.0 minutes and 0 seconds`

with the change adds a space before "with" changes output to
>`Setting Thermocycler well block temperature to 60.0 °C with a hold time of 5.0 minutes and 0 seconds`
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Let me know if i have missed or overlooked something i can change it
The error is reproducable with the following protocol
> [my_protocol.zip](https://github.com/Opentrons/opentrons/files/5015194/my_protocol.zip)

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low Risk
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Thanks Benedict! 🚀