### PR TITLE
fix(api): Document deck slot deletion

### DIFF
--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -672,6 +672,12 @@ class ProtocolContext(CommandPublisher):
         :py:attr:`loaded_modules` to see a dict of modules. For advanced
         control you can delete an item of labware from the deck with
         e.g. ``del protocol.deck['1']`` to free a slot for new labware.
+        (Note that for each slot only the last labware used in a command will 
+        be available for calibration in the OpenTrons UI, and that the 
+        tallest labware on the deck will be calculated using only currently
+        loaded labware, meaning that the labware loaded should always 
+        reflect the labware physically on the deck (or be higher than the
+        labware on the deck).
         """
         return self._deck_layout
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -673,7 +673,7 @@ class ProtocolContext(CommandPublisher):
         control you can delete an item of labware from the deck with
         e.g. ``del protocol.deck['1']`` to free a slot for new labware.
         (Note that for each slot only the last labware used in a command will
-        be available for calibration in the OpenTrons UI, and that the 
+        be available for calibration in the OpenTrons UI, and that the
         tallest labware on the deck will be calculated using only currently
         loaded labware, meaning that the labware loaded should always 
         reflect the labware physically on the deck (or be higher than the

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -675,7 +675,7 @@ class ProtocolContext(CommandPublisher):
         (Note that for each slot only the last labware used in a command will
         be available for calibration in the OpenTrons UI, and that the
         tallest labware on the deck will be calculated using only currently
-        loaded labware, meaning that the labware loaded should always 
+        loaded labware, meaning that the labware loaded should always
         reflect the labware physically on the deck (or be higher than the
         labware on the deck).
         """

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -669,7 +669,9 @@ class ProtocolContext(CommandPublisher):
         is useful for determining if a slot in the deck is free. Rather than
         filtering the objects in the deck map yourself, you can also use
         :py:attr:`loaded_labwares` to see a dict of labwares and
-        :py:attr:`loaded_modules` to see a dict of modules.
+        :py:attr:`loaded_modules` to see a dict of modules. For advanced
+        control you can delete an item of labware from the deck with
+        e.g. ``del protocol.deck['1']`` to free a slot for new labware.
         """
         return self._deck_layout
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -672,7 +672,7 @@ class ProtocolContext(CommandPublisher):
         :py:attr:`loaded_modules` to see a dict of modules. For advanced
         control you can delete an item of labware from the deck with
         e.g. ``del protocol.deck['1']`` to free a slot for new labware.
-        (Note that for each slot only the last labware used in a command will 
+        (Note that for each slot only the last labware used in a command will
         be available for calibration in the OpenTrons UI, and that the 
         tallest labware on the deck will be calculated using only currently
         loaded labware, meaning that the labware loaded should always 


### PR DESCRIPTION
# Overview

Document how to delete labware from a slot to load new labware mid-protocol. A somewhat popular request: #6214.


# Risk assessment

No functional change to code base but this is advanced usage which may not play hugely well with calibration flows, etc. Still think that documenting it in the API section, which only advanced users likely get to anyway, is useful.