### PR TITLE
refactor(app): ensure proper API cal data is associated to protocol labware

### DIFF
--- a/app/src/calibration/labware/__tests__/selectors.test.js
+++ b/app/src/calibration/labware/__tests__/selectors.test.js
@@ -133,6 +133,7 @@ describe('labware calibration selectors', () => {
 
     it('grabs calibration data for labware if present, rounding to 1 decimal', () => {
       getModulesBySlot.mockReturnValue({})
+
       const lwCalibration = Fixtures.mockLabwareCalibration1
       const { attributes } = lwCalibration
       const { calibrationData } = attributes
@@ -151,6 +152,7 @@ describe('labware calibration selectors', () => {
                     loadName: wellPlate96Def.parameters.loadName,
                     namespace: wellPlate96Def.namespace,
                     version: wellPlate96Def.version,
+                    parent: '',
                     calibrationData: {
                       ...calibrationData,
                       offset: {
@@ -191,6 +193,7 @@ describe('labware calibration selectors', () => {
         ...lwCalibration,
         attributes: {
           ...attributes,
+          parent: '',
           loadName: wellPlate96Def.parameters.loadName,
           namespace: wellPlate96Def.namespace,
           version: wellPlate96Def.version,
@@ -238,6 +241,77 @@ describe('labware calibration selectors', () => {
         {
           displayName: wellPlate96Def.metadata.displayName,
           parentDisplayName: 'Magnetic Module GEN1',
+          quantity: 1,
+          calibration: { x: 1.2, y: 4.6, z: 7.9 },
+        },
+        {
+          displayName: 'some_v1_labware',
+          parentDisplayName: null,
+          quantity: 1,
+          calibration: null,
+        },
+      ])
+    })
+
+    it('grabs calibration data for labware not on module if on-module cal data is present', () => {
+      const lwCalibration = Fixtures.mockLabwareCalibration1
+      const { attributes } = lwCalibration
+      const { calibrationData } = attributes
+
+      const calNotOnModule = {
+        ...lwCalibration,
+        attributes: {
+          ...attributes,
+          parent: '',
+          loadName: wellPlate96Def.parameters.loadName,
+          namespace: wellPlate96Def.namespace,
+          version: wellPlate96Def.version,
+          calibrationData: {
+            ...calibrationData,
+            offset: {
+              ...calibrationData.offset,
+              value: [1.23, 4.56, 7.89],
+            },
+          },
+        },
+      }
+
+      const calOnModule = {
+        ...lwCalibration,
+        attributes: {
+          ...attributes,
+          parent: 'magneticModuleV1',
+          loadName: wellPlate96Def.parameters.loadName,
+          namespace: wellPlate96Def.namespace,
+          version: wellPlate96Def.version,
+          calibrationData: {
+            ...calibrationData,
+            offset: {
+              ...calibrationData.offset,
+              value: [0, 0, 0],
+            },
+          },
+        },
+      }
+
+      getModulesBySlot.mockReturnValue({})
+
+      state = ({
+        calibration: {
+          robotName: {
+            calibrationStatus: null,
+            labwareCalibrations: {
+              meta: {},
+              data: [calOnModule, calNotOnModule],
+            },
+          },
+        },
+      }: $Shape<State>)
+
+      expect(Selectors.getProtocolLabwareList(state, robotName)).toEqual([
+        {
+          displayName: wellPlate96Def.metadata.displayName,
+          parentDisplayName: null,
           quantity: 1,
           calibration: { x: 1.2, y: 4.6, z: 7.9 },
         },


### PR DESCRIPTION
## overview

This PR follows up on an #6100 and #6246. A given labware used in a protocol should be associated to a given entry in the labware calibrations results if the labware's:

1. loadName matches the calibration data entry, and
2. namespace matches the calibration data entry, and
3. version matches the calibration data entry, and
4. parent module (or lack of parent) matches the data entry

The implementation I wrote in #6100 was buggy, and #6246 noted that it resulted in incorrect quantities being displayed in the table. However, it it turns out 6100 was buggy for both quantity linking _and_ calibration data linking. If a labware does not have a module parent, it could get linked (in UI) to module-based calibration data **if the module-based calibration entry was earlier in the response array**.

This PR adds a test and fix for this case.

## changelog

- refactor(app): ensure proper API cal data is associated to protocol labware

## review requests

- [ ] Tests look good
- [ ] Cal data gets linked in UI properly
- [ ] Quantity fixes from #6246 aren't messed up

## risk assessment

Low. Unit test coverage was already high for this logic, and bug+fix was TDD'd.