### PR TITLE
fix(docs): Remove legacy intercom script

### DIFF
--- a/api/docs/templates/v1/layout.html
+++ b/api/docs/templates/v1/layout.html
@@ -25,40 +25,6 @@ endif %}
     app_id: 'ukpodv2l',
   }
 </script>
-<script>
-  ;(function() {
-    var w = window
-    var ic = w.Intercom
-    if (typeof ic === 'function') {
-      ic('reattach_activator')
-      ic('update', intercomSettings)
-    } else {
-      var d = document
-      var i = function() {
-        i.c(arguments)
-      }
-      i.q = []
-      i.c = function(args) {
-        i.q.push(args)
-      }
-      w.Intercom = i
-
-      function l() {
-        var s = d.createElement('script')
-        s.type = 'text/javascript'
-        s.async = true
-        s.src = 'https://widget.intercom.io/widget/ukpodv2l'
-        var x = d.getElementsByTagName('script')[0]
-        x.parentNode.insertBefore(s, x)
-      }
-      if (w.attachEvent) {
-        w.attachEvent('onload', l)
-      } else {
-        w.addEventListener('load', l, false)
-      }
-    }
-  })()
-</script>
 {% endblock %} {# Disable base theme's top+bottom related navs; we have our own
 in sidebar #} {%- block relbar1 %}{% endblock %} {%- block relbar2 %}{% endblock
 %} {# Nav should appear before content, not after #} {%- block content %}

--- a/api/docs/templates/v2/layout.html
+++ b/api/docs/templates/v2/layout.html
@@ -25,40 +25,6 @@ endif %}
     app_id: 'ukpodv2l',
   }
 </script>
-<script>
-  ;(function() {
-    var w = window
-    var ic = w.Intercom
-    if (typeof ic === 'function') {
-      ic('reattach_activator')
-      ic('update', intercomSettings)
-    } else {
-      var d = document
-      var i = function() {
-        i.c(arguments)
-      }
-      i.q = []
-      i.c = function(args) {
-        i.q.push(args)
-      }
-      w.Intercom = i
-
-      function l() {
-        var s = d.createElement('script')
-        s.type = 'text/javascript'
-        s.async = true
-        s.src = 'https://widget.intercom.io/widget/ukpodv2l'
-        var x = d.getElementsByTagName('script')[0]
-        x.parentNode.insertBefore(s, x)
-      }
-      if (w.attachEvent) {
-        w.attachEvent('onload', l)
-      } else {
-        w.addEventListener('load', l, false)
-      }
-    }
-  })()
-</script>
 {% endblock %} {# Disable base theme's top+bottom related navs; we have our own
 in sidebar #} {%- block relbar1 %}{% endblock %} {%- block relbar2 %}{% endblock
 %} {# Nav should appear before content, not after #} {%- block content %}


### PR DESCRIPTION
# Overview

This PR removes legacy intercom code in favor of GTM. This was conflicting with the new script and causing issues for support and sales.

# Changelog

fix(docs): Remove legacy intercom script

# Review requests

- [ ] docs still build
- [ ] intercom still loads despite script removal (GTM handles it)

# Risk assessment

Low. docs invisible script only

