### PR TITLE
feat(api,robot-server): Robot server rpc http ff

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -216,8 +216,10 @@ class Session(RobotBusy):
         cls, name, contents, hardware, loop, broker, motion_lock, extra_labware
     ):
         if enable_http_protocol_sessions():
-            raise RuntimeError("Cannot run protocol due to HTTP Protocol "
-                               "Session feature being enabled.")
+            raise RuntimeError(
+                "Please disable the 'Enable Experimental HTTP Protocol "
+                "Sessions' advanced setting for this robot if you'd like to "
+                "upload protocols from the Opentrons App")
 
         protocol = parse(contents, filename=name,
                          extra_labware={helpers.uri_from_definition(defn): defn

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -8,6 +8,7 @@ from typing import List, Dict, Any, Optional, Set, TYPE_CHECKING
 from uuid import uuid4
 
 from opentrons.api.util import RobotBusy, robot_is_busy
+from opentrons.config.feature_flags import enable_http_protocol_sessions
 from opentrons.drivers.smoothie_drivers.driver_3_0 import SmoothieAlarm
 from opentrons.drivers.rpi_drivers.gpio_simulator import SimulatingGPIOCharDev
 from opentrons import robot
@@ -214,6 +215,10 @@ class Session(RobotBusy):
     def build_and_prep(
         cls, name, contents, hardware, loop, broker, motion_lock, extra_labware
     ):
+        if enable_http_protocol_sessions():
+            raise RuntimeError("Cannot run protocol due to HTTP Protocol "
+                               "Session feature being enabled.")
+
         protocol = parse(contents, filename=name,
                          extra_labware={helpers.uri_from_definition(defn): defn
                                         for defn in extra_labware})

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -159,6 +159,13 @@ settings = [
         description='Do not activate this unless you are a developer. '
                     'Enables the in-progress robot calibration flows '
                     'for tip length, deck, and instrument calibration.'
+    ),
+    SettingDefinition(
+        _id='enableHttpProtocolSessions',
+        title='Enable Experimental HTTP Protocol Sessions',
+        description='Do not activate this unless you are a developer. '
+                    'Activating this will disable protocol running from the '
+                    'Opentrons application.'
     )
 ]
 
@@ -335,8 +342,18 @@ def _migrate5to6(previous: SettingsMap) -> SettingsMap:
     return newmap
 
 
+def _migrate6to7(previous: SettingsMap) -> SettingsMap:
+    """
+    Migration to version 7 of the feature flags file. Adds the
+    enableHttpProtocolSessions config element.
+    """
+    newmap = {k: v for k, v in previous.items()}
+    newmap['enableHttpProtocolSessions'] = None
+    return newmap
+
+
 _MIGRATIONS = [_migrate0to1, _migrate1to2, _migrate2to3, _migrate3to4,
-               _migrate4to5, _migrate5to6]
+               _migrate4to5, _migrate5to6, _migrate6to7]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below
 for how the migration functions are applied. Each migration function should

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -165,7 +165,8 @@ settings = [
         title='Enable Experimental HTTP Protocol Sessions',
         description='Do not activate this unless you are a developer. '
                     'Activating this will disable protocol running from the '
-                    'Opentrons application.'
+                    'Opentrons application.',
+        restart_required=True,
     )
 ]
 

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -31,3 +31,7 @@ def enable_door_safety_switch():
 
 def enable_calibration_overhaul():
     return advs.get_setting_with_env_overload('enableTipLengthCalibration')
+
+
+def enable_http_protocol_sessions():
+    return advs.get_setting_with_env_overload('enableHttpProtocolSessions')

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 import itertools
 import copy
 import pytest
@@ -477,3 +478,14 @@ def run(ctx):
 
             for future in as_completed(tasks):
                 future.result()
+
+
+async def test_http_protocol_sessions_enabled(session_manager, protocol):
+    """Test that we cannot create a session if enableHttpProtocolSessions is
+    enabled."""
+    with patch.object(session, "enable_http_protocol_sessions") as m:
+        m.return_value = True
+        with pytest.raises(RuntimeError,
+                           match="Cannot run protocol due to HTTP Protocol "
+                                 "Session feature being enabled"):
+            session_manager.create(name='<blank>', contents=protocol.text)

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -485,7 +485,9 @@ async def test_http_protocol_sessions_enabled(session_manager, protocol):
     enabled."""
     with patch.object(session, "enable_http_protocol_sessions") as m:
         m.return_value = True
-        with pytest.raises(RuntimeError,
-                           match="Cannot run protocol due to HTTP Protocol "
-                                 "Session feature being enabled"):
+        with pytest.raises(
+                RuntimeError,
+                match="Please disable the 'Enable Experimental HTTP Protocol "
+                      "Sessions' advanced setting for this robot if you'd "
+                      "like to upload protocols from the Opentrons App"):
             session_manager.create(name='<blank>', contents=protocol.text)

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -1,7 +1,7 @@
 from opentrons.config.advanced_settings import _migrate, _ensure
 
 
-good_file_version = 6
+good_file_version = 7
 good_file_settings = {
     'shortFixedTrash': None,
     'calibrateToBottom': None,
@@ -14,6 +14,7 @@ good_file_settings = {
     'useV1HttpApi': None,
     'enableDoorSafetySwitch': None,
     'enableTipLengthCalibration': None,
+    'enableHttpProtocolSessions': None,
 }
 
 
@@ -45,7 +46,8 @@ def test_migrates_versionless_new_config():
       'useProtocolApi2': None,
       'useV1HttpApi': None,
       'enableDoorSafetySwitch': None,
-      'enableTipLengthCalibration': None
+      'enableTipLengthCalibration': None,
+      'enableHttpProtocolSessions': None,
     }
 
 
@@ -69,7 +71,8 @@ def test_migrates_versionless_old_config():
       'useProtocolApi2': None,
       'useV1HttpApi': None,
       'enableDoorSafetySwitch': None,
-      'enableTipLengthCalibration': None
+      'enableTipLengthCalibration': None,
+      'enableHttpProtocolSessions': None,
     }
 
 
@@ -105,7 +108,8 @@ def test_migrates_v1_config():
         'enableApi1BackCompat': None,
         'useV1HttpApi': None,
         'enableDoorSafetySwitch': None,
-        'enableTipLengthCalibration': None
+        'enableTipLengthCalibration': None,
+        'enableHttpProtocolSessions': None,
     }
 
 
@@ -134,7 +138,8 @@ def test_migrates_v2_config():
         'enableApi1BackCompat': None,
         'useV1HttpApi': None,
         'enableDoorSafetySwitch': None,
-        'enableTipLengthCalibration': None
+        'enableTipLengthCalibration': None,
+        'enableHttpProtocolSessions': None,
     }
 
 
@@ -162,7 +167,8 @@ def test_migrates_v3_config():
         'enableApi1BackCompat': False,
         'useV1HttpApi': None,
         'enableDoorSafetySwitch': None,
-        'enableTipLengthCalibration': None
+        'enableTipLengthCalibration': None,
+        'enableHttpProtocolSessions': None,
     }
 
 
@@ -191,7 +197,8 @@ def test_migrates_v4_config():
         'enableApi1BackCompat': False,
         'useV1HttpApi': False,
         'enableDoorSafetySwitch': None,
-        'enableTipLengthCalibration': None
+        'enableTipLengthCalibration': None,
+        'enableHttpProtocolSessions': None,
     }
 
 
@@ -221,7 +228,8 @@ def test_migrates_v5_config():
         'enableApi1BackCompat': False,
         'useV1HttpApi': False,
         'enableDoorSafetySwitch': True,
-        'enableTipLengthCalibration': None
+        'enableTipLengthCalibration': None,
+        'enableHttpProtocolSessions': None,
     }
 
 
@@ -240,5 +248,6 @@ def test_ensures_config():
              'disableLogAggregation': True,
              'useProtocolApi2': None,
              'enableDoorSafetySwitch': None,
-             'enableTipLengthCalibration': None
+             'enableTipLengthCalibration': None,
+             'enableHttpProtocolSessions': None,
          }

--- a/robot-server/robot_server/service/session/session_types/protocol_session.py
+++ b/robot-server/robot_server/service/session/session_types/protocol_session.py
@@ -1,7 +1,10 @@
 import logging
 from typing import cast
 
-from robot_server.service.session.errors import UnsupportedFeature
+from opentrons.config.feature_flags import enable_http_protocol_sessions
+
+from robot_server.service.session.errors import UnsupportedFeature, \
+    SessionCreationException
 from robot_server.service.session.session_types import BaseSession, \
     SessionMetaData
 from robot_server.service.session import models
@@ -35,6 +38,10 @@ class ProtocolSession(BaseSession):
     async def create(cls, configuration: SessionConfiguration,
                      instance_meta: SessionMetaData) -> 'BaseSession':
         """Try to create the protocol session"""
+        if not enable_http_protocol_sessions():
+            raise SessionCreationException(
+                "HTTP Protocol Session feature is disabled")
+
         protocol = configuration.protocol_manager.get(
             cast(models.ProtocolCreateParams,
                  instance_meta.create_params).protocolId

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -6,6 +6,7 @@ import os
 import shutil
 from unittest.mock import MagicMock
 
+import requests
 from fastapi import routing
 import pytest
 from starlette.testclient import TestClient
@@ -140,3 +141,18 @@ def set_up_index_file_temporary_directory(server_temp_directory):
 def session_manager(hardware) -> SessionManager:
     return SessionManager(hardware,
                           ProtocolManager())
+
+
+@pytest.fixture
+def set_enable_http_protocol_sessions():
+    """For integration tests that need to set then clear the
+    enableHttpProtocolSessions feature flag"""
+    url = "http://localhost:31950/settings"
+    data = {
+        "id": "enableHttpProtocolSessions",
+        "value": True
+    }
+    requests.post(url, json=data)
+    yield None
+    data['value'] = None
+    requests.post(url, json=data)

--- a/robot-server/tests/integration/sessions/test_protocol.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_protocol.tavern.yaml
@@ -5,6 +5,7 @@ strict:
 marks:
   - usefixtures:
       - run_server
+      - set_enable_http_protocol_sessions
 stages:
   - name: Create the session
     request:
@@ -20,12 +21,54 @@ stages:
     response:
       status_code: 404
 ---
+test_name: Protocol Session Cannot be created due to feature flag
+strict:
+  - json:on
+marks:
+  - usefixtures:
+      - run_server
+stages:
+  - name: Upload a protocol to use with the session
+    request:
+      url: "{host:s}:{port:d}/protocols"
+      method: POST
+      files:
+        protocol_file: "tests/integration/protocols/phony_proto.py"
+    response:
+      save:
+        json:
+          protocol_id: data.id
+      status_code: 201
+  - name: Can't create session due to feature flag
+    request:
+      url: "{host:s}:{port:d}/sessions"
+      method: POST
+      json:
+        data:
+          type: Session
+          attributes:
+            sessionType: protocol
+            createParams:
+              protocolId: "{protocol_id}"
+    response:
+      status_code: 400
+      json:
+        errors:
+        - status: "400"
+          title: Creation Failed
+          detail: "Failed to create session of type 'protocol': HTTP Protocol Session feature is disabled."
+  - name: Delete the protocol
+    request:
+      url: "{host:s}:{port:d}/protocols/{protocol_id}"
+      method: DELETE
+---
 test_name: Protocol session life cycle
 strict:
   - json:on
 marks:
   - usefixtures:
       - run_server
+      - set_enable_http_protocol_sessions
 stages:
   - name: Upload a protocol to use with the session
     request:

--- a/robot-server/tests/integration/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/test_settings.tavern.yaml
@@ -63,8 +63,8 @@ stages:
         - id: enableHttpProtocolSessions
           old_id: Null
           title: Enable Experimental HTTP Protocol Sessions
-          description: !re_search "Activating this will disable protocol running from the Opentrons applicatio"
-          restart_required: false
+          description: !re_search "Activating this will disable protocol running from the Opentrons application"
+          restart_required: true
           value: !anything
         links: !anydict
 

--- a/robot-server/tests/integration/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/test_settings.tavern.yaml
@@ -60,7 +60,13 @@ stages:
           description: !re_search "Enables the in-progress robot calibration flows"
           restart_required: false
           value: !anything
-        links: !anydict 
+        - id: enableHttpProtocolSessions
+          old_id: Null
+          title: Enable Experimental HTTP Protocol Sessions
+          description: !re_search "Activating this will disable protocol running from the Opentrons applicatio"
+          restart_required: false
+          value: !anything
+        links: !anydict
 
 ---
 # All Possible Settings with bool values
@@ -70,7 +76,7 @@ marks:
       - run_server
   - parametrize:
       key: id
-      vals: 
+      vals:
       - shortFixedTrash
       - calibrateToBottom
       - deckCalibrationDots
@@ -78,6 +84,8 @@ marks:
       - disableHomeOnBoot
       - useOldAspirationFunctions
       - enableDoorSafetySwitch
+      - enableTipLengthCalibration
+      - enableHttpProtocolSessions
   - parametrize:
       key: value
       vals:
@@ -107,7 +115,7 @@ marks:
       - run_server
   - parametrize:
       key: id
-      vals: 
+      vals:
       - shortFixedTrash
       - calibrateToBottom
       - deckCalibrationDots
@@ -115,6 +123,8 @@ marks:
       - disableHomeOnBoot
       - useOldAspirationFunctions
       - enableDoorSafetySwitch
+      - enableTipLengthCalibration
+      - enableHttpProtocolSessions
 stages:
   - name: Set each setting to acceptable values 
     request:


### PR DESCRIPTION
Adds a feature flag (`enableHttpProtocolSessions`) that enables the creation of new HTTP protocol sessions, but disables creating RPC protocol sessions via SessionManager.

This is for a future beta release of experimental HTTP protocol sessions. 

# review requests

Please review the naming and the wording of the feature flag description. 

# testing

Tested with local robot-server and run-app
- connect to robot
- load a protocol
- return to main page and enable `enableHttpProtocolSessions`
- load a protocol and see this error:

![image](https://user-images.githubusercontent.com/6352830/89677019-a4493800-d8ba-11ea-863a-f614f2a5fb10.png)


# risk

low. 

closes #6305  