### PR TITLE
refactor(robot-server): add deck cal user flow to http server + integration tests

### DIFF
--- a/robot-server/robot_server/robot/calibration/deck/models.py
+++ b/robot-server/robot_server/robot/calibration/deck/models.py
@@ -1,0 +1,42 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+from ..helper_classes import AttachedPipette, RequiredLabware
+
+
+class DeckCalibrationSessionStatus(BaseModel):
+    """The current status of a deck calibration session."""
+    # TODO: make instrument not optional
+    instrument: Optional[AttachedPipette]
+    currentStep: str = Field(
+        ...,
+        description="Current step of deck calibration user flow")
+    labware: List[RequiredLabware]
+
+    class Config:
+        schema_extra = {
+            "example": [
+                {
+                    "instrument": {
+                        "model": "p300_single_v1.5",
+                        "name": "p300_single",
+                        "tip_length": 42,
+                        "mount": "right",
+                        "serial": "P3HS12123041",
+                    },
+                    "currentStep": "sessionStarted",
+                    "labware": [
+                        {
+                            "slot": "8",
+                            "loadName": "opentrons_96_tiprack_300ul",
+                            "namespace": "opentrons",
+                            "version": 1,
+                            "isTiprack": "true",
+                            "definition": {
+                                "ordering": "the ordering section..."
+                            }
+                        }
+                    ]
+                }
+            ]
+        }

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -15,6 +15,7 @@ from .constants import (
     TIP_RACK_SLOT,
     MOVE_TO_TIP_RACK_SAFETY_BUFFER)
 from .state_machine import DeckCalibrationStateMachine
+# TODO: uncomment the following to raise deck cal errors
 # from .util import (
 #     DeckCalibrationException as ErrorExc,
 #     DeckCalibrationError as Error)
@@ -90,15 +91,7 @@ class DeckCalibrationUserFlow:
 
     def get_required_labware(self) -> List[RequiredLabware]:
         lw = self._get_tip_rack_lw()
-        return [
-            RequiredLabware(
-                slot=lw._parent,
-                loadName=lw.load_name,
-                namespace=lw._definition['namespace'],
-                version=str(lw._definition['version']),
-                isTiprack=lw.is_tiprack,
-                definition=lw._definition)
-            ]
+        return [RequiredLabware.from_lw(lw)]
 
     def _set_current_state(self, to_state: State):
         self._current_state = to_state

--- a/robot-server/robot_server/robot/calibration/deck/util.py
+++ b/robot-server/robot_server/robot/calibration/deck/util.py
@@ -1,0 +1,25 @@
+from enum import Enum
+
+from http import HTTPStatus
+from robot_server.service.errors import RobotServerError
+from robot_server.service.json_api.errors import Error
+
+
+class DeckCalibrationError(Enum):
+    NO_PIPETTE = (
+        HTTPStatus.FORBIDDEN,
+        'No pipettes Attached',
+        'No pipettes present')
+
+
+class DeckCalibrationException(RobotServerError):
+    def __init__(self, whicherror: DeckCalibrationError, *fmt_args):
+        super().__init__(
+            whicherror.value[0],
+            Error(
+                id=str(whicherror),
+                status=str(whicherror.value[0]),
+                title=whicherror.value[1],
+                detail=whicherror.value[2].format(*fmt_args)
+            )
+        )

--- a/robot-server/robot_server/robot/calibration/deck/util.py
+++ b/robot-server/robot_server/robot/calibration/deck/util.py
@@ -8,8 +8,9 @@ from robot_server.service.json_api.errors import Error
 class DeckCalibrationError(Enum):
     NO_PIPETTE = (
         HTTPStatus.FORBIDDEN,
-        'No pipettes Attached',
-        'No pipettes present')
+        'No Pipettes Attached',
+        'At least one pipette must be attached to the OT-2 to '
+        'run deck calibration')
 
 
 class DeckCalibrationException(RobotServerError):

--- a/robot-server/robot_server/robot/calibration/helper_classes.py
+++ b/robot-server/robot_server/robot/calibration/helper_classes.py
@@ -4,7 +4,9 @@ from opentrons.types import Point, Mount
 from enum import Enum, auto
 from uuid import uuid4, UUID
 from dataclasses import dataclass
+from pydantic import BaseModel, Field
 from opentrons.hardware_control.types import CriticalPoint
+
 
 if typing.TYPE_CHECKING:
     from opentrons.protocol_api.labware import LabwareDefinition
@@ -104,3 +106,36 @@ class PipetteStatus:
     rank: str
     tiprack_id: typing.Optional[UUID]
     serial: str
+
+
+# TODO: BC: the mount field here is typed as a string
+# because of serialization problems, though they are actually
+# backed by enums. This shouldn't be the case, and we should
+# be able to handle the de/serialization of these fields from
+# the middle ware before they are returned to the client
+class AttachedPipette(BaseModel):
+    """Pipette (if any) attached to the mount"""
+    model: str =\
+        Field(None,
+              description="The model of the attached pipette. These are snake "
+                          "case as in the Protocol API. This includes the full"
+                          " version string")
+    name: str =\
+        Field(None, description="Short name of pipette model without"
+                                "generation version")
+    tipLength: float =\
+        Field(None, description="The default tip length for this pipette")
+    mount: str =\
+        Field(None, description="The mount this pipette attached to")
+    serial: str =\
+        Field(None, description="The serial number of the attached pipette")
+
+
+class RequiredLabware(BaseModel):
+    """A model describing all tipracks required, based on pipettes attached."""
+    slot: str
+    loadName: str
+    namespace: str
+    version: str
+    isTiprack: bool
+    definition: dict

--- a/robot-server/robot_server/robot/calibration/tip_length/models.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/models.py
@@ -1,38 +1,7 @@
 from typing import Dict, Optional, List, Any
 from pydantic import BaseModel, Field
 
-
-# TODO: BC: the mount field here is typed as a string
-# because of serialization problems, though they are actually
-# backed by enums. This shouldn't be the case, and we should
-# be able to handle the de/serialization of these fields from
-# the middle ware before they are returned to the client
-class AttachedPipette(BaseModel):
-    """Pipette (if any) attached to the mount"""
-    model: str =\
-        Field(None,
-              description="The model of the attached pipette. These are snake "
-                          "case as in the Protocol API. This includes the full"
-                          " version string")
-    name: str =\
-        Field(None, description="Short name of pipette model without"
-                                "generation version")
-    tipLength: float =\
-        Field(None, description="The default tip length for this pipette")
-    mount: str =\
-        Field(None, description="The mount this pipette attached to")
-    serial: str =\
-        Field(None, description="The serial number of the attached pipette")
-
-
-class RequiredLabware(BaseModel):
-    """A model describing all tipracks required, based on pipettes attached."""
-    slot: str
-    loadName: str
-    namespace: str
-    version: str
-    isTiprack: bool
-    definition: dict
+from ..helper_classes import AttachedPipette, RequiredLabware
 
 
 class SessionCreateParams(BaseModel):

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -30,7 +30,7 @@ from .constants import (
     MOVE_TO_REF_POINT_SAFETY_BUFFER,
     TRASH_REF_POINT_OFFSET
 )
-from .models import (
+from ..helper_classes import (
     RequiredLabware,
     AttachedPipette
 )

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -106,15 +106,8 @@ class TipCalibrationUserFlow:
         slots = self._deck.get_non_fixture_slots()
         lw_by_slot = {s: self._deck[s] for s in slots if self._deck[s]}
         return [
-            RequiredLabware(
-                slot=s,
-                loadName=lw.load_name,
-                namespace=lw._definition['namespace'],  # type: ignore
-                version=str(lw._definition['version']),  # type: ignore
-                isTiprack=lw.is_tiprack,  # type: ignore
-                definition=lw._definition,  # type: ignore
-            ) for s, lw in lw_by_slot.items()
-        ]
+            RequiredLabware.from_lw(lw, s)  # type: ignore
+            for s, lw in lw_by_slot.items()]
 
     async def handle_command(self,
                              name: Any,

--- a/robot-server/robot_server/service/session/manager.py
+++ b/robot-server/robot_server/service/session/manager.py
@@ -10,8 +10,9 @@ from robot_server.service.session.errors import SessionCreationException, \
 from robot_server.service.session.session_types.base_session import BaseSession
 from robot_server.service.session.configuration import SessionConfiguration
 from robot_server.service.session.models import IdentifierType, SessionType
-from robot_server.service.session.session_types import NullSession, \
-    CheckSession, SessionMetaData, TipLengthCalibration, DefaultSession
+from robot_server.service.session.session_types import (
+    NullSession, CheckSession, SessionMetaData, TipLengthCalibration,
+    DeckCalibrationSession, DefaultSession)
 from robot_server.service.session.session_types.protocol_session import \
     ProtocolSession
 
@@ -21,6 +22,7 @@ SessionTypeToClass: Dict[SessionType, Type[BaseSession]] = {
     SessionType.null: NullSession,
     SessionType.calibration_check: CheckSession,
     SessionType.tip_length_calibration: TipLengthCalibration,
+    SessionType.deck_calibration: DeckCalibrationSession,
     SessionType.default: DefaultSession,
     SessionType.protocol: ProtocolSession,
 }

--- a/robot-server/robot_server/service/session/models.py
+++ b/robot-server/robot_server/service/session/models.py
@@ -9,6 +9,8 @@ from robot_server.robot.calibration.check import (
     models as calibration_check_models)
 from robot_server.robot.calibration.tip_length import (
     models as tip_length_calibration_models)
+from robot_server.robot.calibration.deck import (
+    models as deck_calibration_models)
 
 from robot_server.service.json_api import \
     ResponseDataModel, ResponseModel, RequestDataModel, RequestModel
@@ -57,6 +59,7 @@ class SessionType(str, Enum):
         'tipLengthCalibration',
         tip_length_calibration_models.SessionCreateParams
     )
+    deck_calibration = 'deckCalibration'
     protocol = ('protocol', ProtocolCreateParams)
 
     @property
@@ -90,6 +93,7 @@ Read more here: https://pydantic-docs.helpmanual.io/usage/types/#unions
 SessionDetails = typing.Union[
     calibration_check_models.CalibrationSessionStatus,
     tip_length_calibration_models.TipCalibrationSessionStatus,
+    deck_calibration_models.DeckCalibrationSessionStatus,
     EmptyModel
 ]
 

--- a/robot-server/robot_server/service/session/session_types/__init__.py
+++ b/robot-server/robot_server/service/session/session_types/__init__.py
@@ -1,5 +1,6 @@
 from .null_session import NullSession  # noqa: W0611
 from .check_session import CheckSession  # noqa: W0611
 from .tip_length_calibration import TipLengthCalibration  # noqa: W0611
+from .deck_calibration_session import DeckCalibrationSession  # noqa: W0611
 from .base_session import BaseSession, SessionMetaData  # noqa: W0611
 from .default_session import DefaultSession  # noqa: W0611

--- a/robot-server/robot_server/service/session/session_types/deck_calibration_session.py
+++ b/robot-server/robot_server/service/session/session_types/deck_calibration_session.py
@@ -1,0 +1,67 @@
+from robot_server.robot.calibration.deck.user_flow import \
+    DeckCalibrationUserFlow
+from robot_server.robot.calibration.deck.models import \
+    DeckCalibrationSessionStatus
+from robot_server.robot.calibration.session import CalibrationException
+from robot_server.service.session.errors import (SessionCreationException,
+                                                 CommandExecutionException)
+from robot_server.service.session.command_execution import \
+    CallableExecutor, Command, CompletedCommand, CommandQueue, CommandExecutor
+
+from .base_session import BaseSession, SessionMetaData
+from ..configuration import SessionConfiguration
+from ..models import SessionType, SessionDetails
+from ..errors import UnsupportedFeature
+
+
+class DeckCalibrationCommandExecutor(CallableExecutor):
+
+    async def execute(self, command: Command) -> CompletedCommand:
+        try:
+            return await super().execute(command)
+        except (CalibrationException, AssertionError) as e:
+            raise CommandExecutionException(e)
+
+
+class DeckCalibrationSession(BaseSession):
+    def __init__(self,
+                 configuration: SessionConfiguration,
+                 instance_meta: SessionMetaData,
+                 deck_cal_user_flow: DeckCalibrationUserFlow):
+        super().__init__(configuration, instance_meta)
+        self._deck_cal_user_flow = deck_cal_user_flow
+        self._command_executor = DeckCalibrationCommandExecutor(
+            self._deck_cal_user_flow.handle_command
+        )
+
+    @classmethod
+    async def create(cls,
+                     configuration: SessionConfiguration,
+                     instance_meta: SessionMetaData) -> 'BaseSession':
+        try:
+            deck_cal_user_flow = DeckCalibrationUserFlow(
+                hardware=configuration.hardware)
+        except (AssertionError, CalibrationException) as e:
+            raise SessionCreationException(str(e))
+
+        return cls(configuration=configuration,
+                   instance_meta=instance_meta,
+                   deck_cal_user_flow=deck_cal_user_flow)
+
+    @property
+    def command_executor(self) -> CommandExecutor:
+        return self._command_executor
+
+    @property
+    def command_queue(self) -> CommandQueue:
+        raise UnsupportedFeature()
+
+    @property
+    def session_type(self) -> SessionType:
+        return SessionType.deck_calibration
+
+    def _get_response_details(self) -> SessionDetails:
+        return DeckCalibrationSessionStatus(
+            instrument=self._deck_cal_user_flow.get_pipette(),
+            currentStep=self._deck_cal_user_flow.current_state,
+            labware=self._deck_cal_user_flow.get_required_labware())

--- a/robot-server/tests/integration/sessions/test_deck_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_deck_calibration.tavern.yaml
@@ -1,0 +1,296 @@
+---
+test_name: Deck calibration session full flow
+strict:
+  - json:on
+marks:
+  - usefixtures:
+      - run_server
+stages:
+  - name: Create the session
+    request:
+      url: "{host:s}:{port:d}/sessions"
+      method: POST
+      json:
+        data:
+          type: Session
+          attributes:
+            sessionType: deckCalibration
+    response:
+      status_code: 201
+      save:
+        json:
+          session_id: data.id
+
+  - name: Get the session
+    request: &get_session
+      url: "{host:s}:{port:d}/sessions/{session_id}"
+      method: GET
+    response:
+      status_code: 200
+      json:
+        links: !anydict
+        data: &session_data
+          id: "{session_id}"
+          type: Session
+          attributes: &session_data_attributes
+            sessionType: deckCalibration
+            createdAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+.\\d+"
+            createParams: null
+            details: &session_data_attribute_details
+              currentStep: sessionStarted
+              instrument: !anydict
+              labware: !anylist
+
+  - name: Load labware
+    request: &post_command
+      url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"
+      method: POST
+      json:
+        data:
+          type: SessionCommand
+          attributes:
+            command: calibration.loadLabware
+            data: {}
+    response:
+      status_code: 200
+  - name: Check the effect of command
+    request: *get_session
+    response:
+      status_code: 200
+      json:
+        links: !anydict
+        data:
+          <<: *session_data
+          attributes:
+            <<: *session_data_attributes
+            details:
+              <<: *session_data_attribute_details
+              currentStep: labwareLoaded
+
+  - name: Move to tiprack
+    request:
+      <<: *post_command
+      json:
+        data:
+          type: SessionCommand
+          attributes:
+            command: calibration.deck.moveToTipRack
+            data: {}
+    response:
+      status_code: 200
+  - name: Check the effect of command
+    request: *get_session
+    response:
+      status_code: 200
+      json:
+        links: !anydict
+        data:
+          <<: *session_data
+          attributes:
+            <<: *session_data_attributes
+            details:
+              <<: *session_data_attribute_details
+              currentStep: preparingPipette
+
+  - name: Move to deck
+    request:
+      <<: *post_command
+      json:
+        data:
+          type: SessionCommand
+          attributes:
+            command: calibration.deck.moveToDeck
+            data: {}
+    response:
+      status_code: 200
+  - name: Check the effect of command
+    request: *get_session
+    response:
+      status_code: 200
+      json:
+        links: !anydict
+        data:
+          <<: *session_data
+          attributes:
+            <<: *session_data_attributes
+            details:
+              <<: *session_data_attribute_details
+              currentStep: joggingToDeck
+
+  - name: Jog pipette to deck
+    request:
+      <<: *post_command
+      json:
+        data:
+          type: SessionCommand
+          attributes:
+            command: calibration.jog
+            data:
+              vector: [0, 0, -10]
+    response:
+      status_code: 200
+  - name: Check the effect of command
+    request: *get_session
+    response:
+      status_code: 200
+      json:
+        links: !anydict
+        data:
+          <<: *session_data
+          attributes:
+            <<: *session_data_attributes
+            details:
+              <<: *session_data_attribute_details
+              currentStep: joggingToDeck
+
+  - name: Save deck height
+    request:
+      <<: *post_command
+      json:
+        data:
+          type: SessionCommand
+          attributes:
+            command: calibration.saveOffset
+            data: {}
+    response:
+      status_code: 200
+  - name: Check the effect of command
+    request: *get_session
+    response:
+      status_code: 200
+      json:
+        links: !anydict
+        data:
+          <<: *session_data
+          attributes:
+            <<: *session_data_attributes
+            details:
+              <<: *session_data_attribute_details
+              currentStep: joggingToDeck
+
+  - name: Move to point one
+    request:
+      url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"
+      method: POST
+      json:
+        data:
+          type: SessionCommand
+          attributes:
+            command: calibration.deck.moveToPointOne
+            data: {}
+    response:
+      status_code: 200
+  - name: Check the effect of command
+    request: *get_session
+    response:
+      status_code: 200
+      json:
+        links: !anydict
+        data:
+          <<: *session_data
+          attributes:
+            <<: *session_data_attributes
+            details:
+              <<: *session_data_attribute_details
+              currentStep: savingPointOne
+
+  - name: Move to point two
+    request:
+      url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"
+      method: POST
+      json:
+        data:
+          type: SessionCommand
+          attributes:
+            command: calibration.deck.moveToPointTwo
+            data: {}
+    response:
+      status_code: 200
+  - name: Check the effect of command
+    request: *get_session
+    response:
+      status_code: 200
+      json:
+        links: !anydict
+        data:
+          <<: *session_data
+          attributes:
+            <<: *session_data_attributes
+            details:
+              <<: *session_data_attribute_details
+              currentStep: savingPointTwo
+
+  - name: Move to point three
+    request:
+      url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"
+      method: POST
+      json:
+        data:
+          type: SessionCommand
+          attributes:
+            command: calibration.deck.moveToPointThree
+            data: {}
+    response:
+      status_code: 200
+  - name: Check the effect of command
+    request: *get_session
+    response:
+      status_code: 200
+      json:
+        links: !anydict
+        data:
+          <<: *session_data
+          attributes:
+            <<: *session_data_attributes
+            details:
+              <<: *session_data_attribute_details
+              currentStep: savingPointThree
+
+  - name: Exit Session
+    request:
+      url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"
+      method: POST
+      json:
+        data:
+          type: SessionCommand
+          attributes:
+            command: calibration.exitSession
+            data: {}
+    response:
+      status_code: 200
+  - name: Check the effect of command
+    request: *get_session
+    response:
+      status_code: 200
+      json:
+        links: !anydict
+        data:
+          <<: *session_data
+          attributes:
+            <<: *session_data_attributes
+            details:
+              <<: *session_data_attribute_details
+              currentStep: sessionExited
+
+  - name: Delete the session
+    request:
+      url: "{host:s}:{port:d}/sessions/{session_id}"
+      method: DELETE
+    response:
+      status_code: 200
+
+  - name: There are no session except default
+    request:
+        url: "{host:s}:{port:d}/sessions"
+        method: GET
+    response:
+      status_code: 200
+      json:
+        data:
+          - id: "default"
+            type: Session
+            attributes:
+              sessionType: default
+              createdAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
+              details: {}
+              createParams: null

--- a/robot-server/tests/integration/sessions/test_deck_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_deck_calibration.tavern.yaml
@@ -92,6 +92,68 @@ stages:
               <<: *session_data_attribute_details
               currentStep: preparingPipette
 
+  - name: Pick up the tip
+    request:
+      <<: *post_command
+      json:
+        data:
+          type: SessionCommand
+          attributes:
+            command: calibration.pickUpTip
+            data: {}
+    response:
+      status_code: 200
+  - name: Check the effect of command
+    request: *get_session
+    response:
+      status_code: 200
+      json:
+        links: !anydict
+        data:
+          <<: *session_data
+          attributes:
+            <<: *session_data_attributes
+            details:
+              <<: *session_data_attribute_details
+              currentStep: inspectingTip  
+
+  - name: Invalidate the tip
+    request:
+      <<: *post_command
+      json:
+        data:
+          type: SessionCommand
+          attributes:
+            command: calibration.invalidateTip
+            data: {}
+    response:
+      status_code: 200
+  - name: Check the effect of command
+    request: *get_session
+    response:
+      status_code: 200
+      json:
+        links: !anydict
+        data:
+          <<: *session_data
+          attributes:
+            <<: *session_data_attributes
+            details:
+              <<: *session_data_attribute_details
+              currentStep: preparingPipette
+
+  - name: Pick up the tip
+    request:
+      <<: *post_command
+      json:
+        data:
+          type: SessionCommand
+          attributes:
+            command: calibration.pickUpTip
+            data: {}
+    response:
+      status_code: 200
+
   - name: Move to deck
     request:
       <<: *post_command


### PR DESCRIPTION


<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This hooks up the deck calibration user flow to the HTTP server.

closes #6251
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- add `DeckCalibrationSession` and new SessionType
- move `AttachedPipette` and `RequiredLabware` from `/robot-server/robot/calibration/tip_length/models.py` to top level `helper_classes.py` 
- add integration tests
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
