### PR TITLE
fix(robot-server): fix multi channel move in tip length cal

### DIFF
--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -195,9 +195,7 @@ class TipCalibrationUserFlow:
                 self._hw_pipette.critical_point)
 
     async def _get_current_point(self):
-        cp = self._get_critical_point()
-        return await self._hardware.gantry_position(self._mount,
-                                                    critical_point=cp)
+        return await self._hardware.gantry_position(self._mount)
 
     async def jog(self, vector):
         await self._hardware.move_rel(mount=self._mount,
@@ -262,10 +260,8 @@ class TipCalibrationUserFlow:
             coeff = self._hw_pipette.config.return_tip_height
             to_pt = self._tip_origin_pt - Point(0, 0, tip_length * coeff)
 
-            cp = self._get_critical_point()
             await self._hardware.move_to(mount=self._mount,
-                                         abs_position=to_pt,
-                                         critical_point=cp)
+                                         abs_position=to_pt)
             await self._hardware.drop_tip(self._mount)
             self._tip_origin_pt = None
 

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -140,13 +140,17 @@ class TipCalibrationUserFlow:
         pass
 
     async def move_to_tip_rack(self):
-        point = self._deck[TIP_RACK_SLOT].wells()[0].top().point + \
-                MOVE_TO_TIP_RACK_SAFETY_BUFFER
+        # point safely above target tip well in tip rack
+        pt_above_well = self._deck[TIP_RACK_SLOT].wells()[0].top().point + \
+            MOVE_TO_TIP_RACK_SAFETY_BUFFER
         if self._tip_origin_pt is not None:
-            # use saved jogged to x and y values only if returning tip to rack
-            point = Point(self._tip_origin_pt.x, self._tip_origin_pt.y,
-                          point.z)
-        await self._move(Location(point, None))
+            # use jogged to x and y offsets only if returning tip to rack
+            await self._move(Location(Point(self._tip_origin_pt.x,
+                                            self._tip_origin_pt.y,
+                                            pt_above_well.z),
+                                      None))
+        else:
+            await self._move(Location(pt_above_well, None))
 
     async def move_to_reference_point(self):
         to_loc = self._get_reference_point()

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -142,8 +142,11 @@ class TipCalibrationUserFlow:
     async def move_to_tip_rack(self):
         point = self._deck[TIP_RACK_SLOT].wells()[0].top().point + \
                 MOVE_TO_TIP_RACK_SAFETY_BUFFER
-        to_loc = Location(point, None)
-        await self._move(to_loc)
+        if self._tip_origin_pt is not None:
+            # use saved jogged to x and y values only if returning tip to rack
+            point = Point(self._tip_origin_pt.x, self._tip_origin_pt.y,
+                          point.z)
+        await self._move(Location(point, None))
 
     async def move_to_reference_point(self):
         to_loc = self._get_reference_point()
@@ -209,7 +212,8 @@ class TipCalibrationUserFlow:
             self._hw_pipette.update_config_item('pick_up_current', 0.1)
 
         # grab position of active nozzle for ref when returning tip later
-        self._tip_origin_pt = await self._get_current_point()
+        self._tip_origin_pt = await self._hardware.gantry_position(
+            self._mount, critical_point=self._get_critical_point())
 
         tip_length = self._get_default_tip_length()
         await self._hardware.pick_up_tip(self._mount, tip_length)
@@ -259,9 +263,10 @@ class TipCalibrationUserFlow:
             tip_length = self._get_default_tip_length()
             coeff = self._hw_pipette.config.return_tip_height
             to_pt = self._tip_origin_pt - Point(0, 0, tip_length * coeff)
-
+            cp = self._get_critical_point()
             await self._hardware.move_to(mount=self._mount,
-                                         abs_position=to_pt)
+                                         abs_position=to_pt,
+                                         critical_point=cp)
             await self._hardware.drop_tip(self._mount)
             self._tip_origin_pt = None
 

--- a/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
@@ -203,6 +203,7 @@ async def test_invalidate_tip(mock_user_flow):
         call(
             mount=Mount.RIGHT,
             abs_position=Point(1, 1, 1 - z_offset),
+            critical_point=uf._hw_pipette.critical_point
         ),
     ]
     uf._hardware.move_to.assert_has_calls(move_calls)
@@ -221,6 +222,7 @@ async def test_exit(mock_user_flow):
         call(
             mount=Mount.RIGHT,
             abs_position=Point(1, 1, 1 - z_offset),
+            critical_point=uf._hw_pipette.critical_point
         ),
     ]
     uf._hardware.move_to.assert_has_calls(move_calls)

--- a/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
@@ -203,7 +203,6 @@ async def test_invalidate_tip(mock_user_flow):
         call(
             mount=Mount.RIGHT,
             abs_position=Point(1, 1, 1 - z_offset),
-            critical_point=uf._hw_pipette.critical_point
         ),
     ]
     uf._hardware.move_to.assert_has_calls(move_calls)
@@ -222,7 +221,6 @@ async def test_exit(mock_user_flow):
         call(
             mount=Mount.RIGHT,
             abs_position=Point(1, 1, 1 - z_offset),
-            critical_point=uf._hw_pipette.critical_point
         ),
     ]
     uf._hardware.move_to.assert_has_calls(move_calls)


### PR DESCRIPTION
# Overview

Fix bug identified by @Laura-Danielle while reviewing #6316. Multichannel pipettes were improperly factoring in the front nozzle critical point in some move to commands which led to separate and extraneous motion.

# Changelog

- no longer specifying critical point when getting `gantry_position` or when calling `move_to` for return tip.

# Review requests

 - [ ] run TLC with a multi-channel, should move smoothly to expected points

# Risk assessment

Low, This code is still behind a ff
