### PR TITLE
fix(robot-server): Robot server createParams bug

### DIFF
--- a/robot-server/robot_server/service/session/models.py
+++ b/robot-server/robot_server/service/session/models.py
@@ -39,7 +39,7 @@ class ProtocolCreateParams(BaseModel):
 
 class SessionType(str, Enum):
     """The available session types"""
-    def __new__(cls, value, create_param_model=type(None)):
+    def __new__(cls, value, create_param_model=None):
         """Create a session type enum with the optional create param model
 
         IMPORTANT: Model definition must appear in SessionCreateParamType
@@ -231,7 +231,15 @@ class BasicSession(BaseModel):
     def check_data_type(cls, v, values):
         """Validate that the session type and create params model match"""
         create_params = values.get('createParams')
-        if not isinstance(create_params, v.model):
+        if v.model is None:
+            # If model is None then we will accept either None or an
+            # EmptyModel (ie "{}")
+            is_valid_type = create_params is None or\
+                            isinstance(create_params, EmptyModel)
+        else:
+            is_valid_type = isinstance(create_params, v.model)
+
+        if not is_valid_type:
             raise ValueError(f"Invalid create param for session type {v}. "
                              f"Expecting {v.model}")
         return v

--- a/robot-server/tests/service/session/test_models.py
+++ b/robot-server/tests/service/session/test_models.py
@@ -21,3 +21,39 @@ def test_command_type_empty():
         **{'command': models.CalibrationCommand.load_labware,
            'data': {}})
     assert c.data == models.EmptyModel()
+
+
+@pytest.mark.parametrize(argnames="create_params",
+                         argvalues=[
+                            {'createParams': None},
+                            {'createParams': {}},
+                            {}
+                         ])
+def test_basic_session_type_validation_no_create_params(create_params):
+    """Test that when create params have no mandatory members we accept null,
+    and {}"""
+    body = {
+        "sessionType": "null",
+    }
+    body.update(create_params)
+
+    session = models.BasicSession(**body)
+    assert session.createParams == create_params.get('createParams')
+
+
+@pytest.mark.parametrize(argnames="create_params",
+                         argvalues=[
+                            {'createParams': None},
+                            {'createParams': {}},
+                            {}
+                         ])
+def test_basic_session_type_validation_with_create_params(create_params):
+    """Test that when create params have mandatory members we reject invalid
+    createParams"""
+    body = {
+        "sessionType": "protocol",
+    }
+    body.update(create_params)
+
+    with pytest.raises(ValueError):
+        models.BasicSession(**body)


### PR DESCRIPTION
If createParams isn't used we should be able to accept either a null or empty object or no createParams key at all.