### PR TITLE
chore(protocol-designer): bump to 5.0.0

### DIFF
--- a/protocol-designer/webpack.config.js
+++ b/protocol-designer/webpack.config.js
@@ -16,7 +16,7 @@ const PROTOCOL_DESIGNER_ENV_VAR_PREFIX = 'OT_PD_'
 // Also remove all OT_PD_VERSION env vars, the version should always
 // be gleaned from the package.json
 
-const OT_PD_VERSION = '4.0.5'
+const OT_PD_VERSION = '5.0.0'
 const OT_PD_BUILD_DATE = new Date().toUTCString()
 
 const JS_ENTRY = path.join(__dirname, 'src/index.js')


### PR DESCRIPTION
# Overview

Closes #6276

# Blocked

Do not merge until we're ready to QA

Though, this may be a prereq to #6183 since migrations need to look at the version number

# Changelog


# Review requests


# Risk assessment

