### PR TITLE
feat(robot-server): Robot server protocol session model

### DIFF
--- a/robot-server/robot_server/service/session/session_types/protocol/execution/command_executor.py
+++ b/robot-server/robot_server/service/session/session_types/protocol/execution/command_executor.py
@@ -178,11 +178,15 @@ class ProtocolCommandExecutor(CommandExecutor, WorkerListener):
             event_name = cmd.get('name')
             event = None
             if dollar_val == 'before':
+                # text may be a format string using the payload vals as kwargs
+                text = deep_get(cmd, ('payload', 'text',), "")
+                if text:
+                    text = text.format(**cmd.get('payload', {}))
                 event = models.ProtocolSessionEvent(
                     source=models.EventSource.protocol_event,
                     event=f'{event_name}.start',
                     commandId=self._id_maker.create_id(),
-                    params={'text': deep_get(cmd, ('payload', 'text',))},
+                    params={'text': text},
                     timestamp=utc_now(),
                 )
             elif dollar_val == 'after':

--- a/robot-server/robot_server/service/session/session_types/protocol/execution/command_executor.py
+++ b/robot-server/robot_server/service/session/session_types/protocol/execution/command_executor.py
@@ -76,7 +76,7 @@ class ProtocolCommandExecutor(CommandExecutor, WorkerListener):
             ProtocolCommand.resume: self._worker.handle_resume,
             ProtocolCommand.pause: self._worker.handle_pause,
         }
-        self._commands: typing.List[models.ProtocolSessionEvent] = []
+        self._events: typing.List[models.ProtocolSessionEvent] = []
 
     @staticmethod
     def create_worker(configuration: SessionConfiguration,
@@ -116,7 +116,7 @@ class ProtocolCommandExecutor(CommandExecutor, WorkerListener):
         with duration() as timed:
             await handler()
 
-        self._commands.append(
+        self._events.append(
             models.ProtocolSessionEvent(
                 source=models.EventSource.session_command,
                 event=command.content.name,
@@ -133,8 +133,8 @@ class ProtocolCommandExecutor(CommandExecutor, WorkerListener):
                                  completed_at=timed.end))
 
     @property
-    def commands(self) -> typing.List[models.ProtocolSessionEvent]:
-        return self._commands
+    def events(self) -> typing.List[models.ProtocolSessionEvent]:
+        return self._events
 
     @property
     def current_state(self) -> 'State':
@@ -179,17 +179,17 @@ class ProtocolCommandExecutor(CommandExecutor, WorkerListener):
             name = cmd.get('name')
             if before:
                 params = {'text': deep_get(cmd, ('payload', 'text',))}
-                command = models.ProtocolSessionEvent(
+                event = models.ProtocolSessionEvent(
                     source=models.EventSource.protocol_event,
                     event=name,
                     startedAt=datetime.utcnow(),
                     params=params)
             else:
                 result = deep_get(cmd, ('payload', 'return',))
-                command = models.ProtocolSessionEvent(
+                event = models.ProtocolSessionEvent(
                     source=models.EventSource.protocol_event,
                     event=name,
                     completedAt=datetime.utcnow(),
                     result=result)
 
-            self._commands.append(command)
+            self._events.append(event)

--- a/robot-server/robot_server/service/session/session_types/protocol/execution/command_executor.py
+++ b/robot-server/robot_server/service/session/session_types/protocol/execution/command_executor.py
@@ -1,9 +1,8 @@
 import asyncio
 import logging
 import typing
-from datetime import datetime, timezone
 
-from opentrons.util.helpers import deep_get
+from opentrons.util.helpers import deep_get, utc_now
 
 if typing.TYPE_CHECKING:
     from opentrons.api.dev_types import State
@@ -178,14 +177,13 @@ class ProtocolCommandExecutor(CommandExecutor, WorkerListener):
             dollar_val = cmd.get('$')
             event_name = cmd.get('name')
             event = None
-            timestamp = datetime.now(tz=timezone.utc)
             if dollar_val == 'before':
                 event = models.ProtocolSessionEvent(
                     source=models.EventSource.protocol_event,
                     event=f'{event_name}.start',
                     commandId=self._id_maker.create_id(),
                     params={'text': deep_get(cmd, ('payload', 'text',))},
-                    timestamp=timestamp,
+                    timestamp=utc_now(),
                 )
             elif dollar_val == 'after':
                 result = deep_get(cmd, ('payload', 'return',))
@@ -193,7 +191,7 @@ class ProtocolCommandExecutor(CommandExecutor, WorkerListener):
                     source=models.EventSource.protocol_event,
                     event=f'{event_name}.end',
                     commandId=self._id_maker.use_last_id(),
-                    timestamp=timestamp,
+                    timestamp=utc_now(),
                     result=result,
                 )
 

--- a/robot-server/robot_server/service/session/session_types/protocol/models.py
+++ b/robot-server/robot_server/service/session/session_types/protocol/models.py
@@ -1,9 +1,33 @@
 import typing
-from pydantic import BaseModel
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel, Field
 
 
 class ProtocolSessionDetails(BaseModel):
-    protocolId: str
+    protocolId: str = \
+        Field(...,
+              description="The protocol used by this session")
     currentState: typing.Optional[str]
-    # TODO: Amit 8/3/2020 - proper schema for command types
-    commands: typing.List[typing.Any]
+    events: typing.List[typing.Any] =\
+        Field(...,
+              description="The events that have occurred thus far")
+
+
+class EventSource(str, Enum):
+    session_command = "sessionCommand"
+    protocol_event = "protocol"
+
+
+class ProtocolSessionEvent(BaseModel):
+    """An event occurring during a protocol session"""
+    source: EventSource = \
+        Field(..., description="Initiator of this event")
+    event: str = \
+        Field(..., description="The event that occurred")
+    commandId: typing.Optional[str] = None
+    startedAt: typing.Optional[datetime] = None
+    completedAt: typing.Optional[datetime] = None
+    params: typing.Optional[typing.Dict[str, typing.Any]] = None
+    result: typing.Optional[str] = None

--- a/robot-server/robot_server/service/session/session_types/protocol/models.py
+++ b/robot-server/robot_server/service/session/session_types/protocol/models.py
@@ -5,16 +5,6 @@ from enum import Enum
 from pydantic import BaseModel, Field
 
 
-class ProtocolSessionDetails(BaseModel):
-    protocolId: str = \
-        Field(...,
-              description="The protocol used by this session")
-    currentState: typing.Optional[str]
-    events: typing.List[typing.Any] =\
-        Field(...,
-              description="The events that have occurred thus far")
-
-
 class EventSource(str, Enum):
     session_command = "sessionCommand"
     protocol_event = "protocol"
@@ -26,8 +16,17 @@ class ProtocolSessionEvent(BaseModel):
         Field(..., description="Initiator of this event")
     event: str = \
         Field(..., description="The event that occurred")
+    timestamp: datetime
     commandId: typing.Optional[str] = None
-    startedAt: typing.Optional[datetime] = None
-    completedAt: typing.Optional[datetime] = None
     params: typing.Optional[typing.Dict[str, typing.Any]] = None
     result: typing.Optional[str] = None
+
+
+class ProtocolSessionDetails(BaseModel):
+    protocolId: str = \
+        Field(...,
+              description="The protocol used by this session")
+    currentState: typing.Optional[str]
+    events: typing.List[ProtocolSessionEvent] =\
+        Field(...,
+              description="The events that have occurred thus far")

--- a/robot-server/robot_server/service/session/session_types/protocol/session.py
+++ b/robot-server/robot_server/service/session/session_types/protocol/session.py
@@ -52,7 +52,7 @@ class ProtocolSession(BaseSession):
         return ProtocolSessionDetails(
             protocolId=self._uploaded_protocol.meta.identifier,
             currentState=self._command_executor.current_state,
-            commands=self._command_executor.commands
+            events=self._command_executor.commands
         )
 
     @property

--- a/robot-server/robot_server/service/session/session_types/protocol/session.py
+++ b/robot-server/robot_server/service/session/session_types/protocol/session.py
@@ -52,7 +52,7 @@ class ProtocolSession(BaseSession):
         return ProtocolSessionDetails(
             protocolId=self._uploaded_protocol.meta.identifier,
             currentState=self._command_executor.current_state,
-            events=self._command_executor.commands
+            events=self._command_executor.events
         )
 
     @property

--- a/robot-server/tests/integration/sessions/test_protocol.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_protocol.tavern.yaml
@@ -109,7 +109,7 @@ stages:
             details:
               protocolId: "{protocol_id}"
               currentState: !anystr
-              commands: !anylist
+              events: !anylist
         links: !anydict
   - name: Get the session
     request:

--- a/robot-server/tests/service/session/session_types/protocol/execution/test_command_executor.py
+++ b/robot-server/tests/service/session/session_types/protocol/execution/test_command_executor.py
@@ -41,8 +41,8 @@ def dt() -> datetime:
 
 @pytest.fixture
 def patch_utc_now(dt: datetime):
-    with patch.object(command_executor, 'datetime') as p:
-        p.now.side_effect = lambda tz: dt
+    with patch.object(command_executor, 'utc_now') as p:
+        p.return_value = dt
         yield p
 
 

--- a/robot-server/tests/service/session/session_types/protocol/execution/test_command_executor.py
+++ b/robot-server/tests/service/session/session_types/protocol/execution/test_command_executor.py
@@ -158,6 +158,46 @@ class TestOnProtocolEvent:
                                  params={'text': 'this is what happened'})
         ]
 
+    async def test_before_text_is_none(self, protocol_command_executor,
+                                       patch_utc_now, dt):
+        payload = {
+            '$': 'before',
+            'name': 'some event',
+            'payload': {
+                'text': None
+            }
+        }
+        await protocol_command_executor.on_protocol_event(payload)
+        assert protocol_command_executor.events == [
+            ProtocolSessionEvent(source=EventSource.protocol_event,
+                                 event="some event.start",
+                                 commandId="1",
+                                 timestamp=dt,
+                                 params={'text': None})
+        ]
+
+    async def test_before_text_is_format_string(self,
+                                                protocol_command_executor,
+                                                patch_utc_now,
+                                                dt):
+        payload = {
+            '$': 'before',
+            'name': 'some event',
+            'payload': {
+                'text': '{oh} {no}',
+                'oh': 2,
+                'no': 5
+            }
+        }
+        await protocol_command_executor.on_protocol_event(payload)
+        assert protocol_command_executor.events == [
+            ProtocolSessionEvent(source=EventSource.protocol_event,
+                                 event="some event.start",
+                                 commandId="1",
+                                 timestamp=dt,
+                                 params={'text': '2 5'})
+        ]
+
     async def test_after(self, protocol_command_executor, patch_utc_now, dt):
         payload = {
             '$': 'after',

--- a/robot-server/tests/service/session/session_types/protocol/execution/test_command_executor.py
+++ b/robot-server/tests/service/session/session_types/protocol/execution/test_command_executor.py
@@ -1,12 +1,16 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, PropertyMock
+from datetime import datetime
 import pytest
 
-from robot_server.service.session.command_execution.command import Command,\
-    CommandContent
+from robot_server.service.session.command_execution.command import Command, CommandContent  # noqa: E501
 from robot_server.service.session.errors import UnsupportedCommandException
 from robot_server.service.session.models import ProtocolCommand, EmptyModel
+from robot_server.service.session.session_types.protocol.execution import \
+    command_executor
 from robot_server.service.session.session_types.protocol.execution.command_executor import ProtocolCommandExecutor  # noqa: E501
-from robot_server.service.session.session_types.protocol.execution.worker import _Worker  # noqa:
+from robot_server.service.session.session_types.protocol.execution.worker import _Worker  # noqa: E501
+from robot_server.service.session.session_types.protocol.models import \
+    ProtocolSessionEvent, EventSource
 
 
 @pytest.fixture()
@@ -28,6 +32,18 @@ def mock_worker():
 def protocol_command_executor(mock_worker):
     ProtocolCommandExecutor.create_worker = MagicMock(return_value=mock_worker)
     return ProtocolCommandExecutor(None, None)
+
+
+@pytest.fixture
+def dt() -> datetime:
+    return datetime(200, 4, 1)
+
+
+@pytest.fixture
+def patch_utcnow(dt: datetime):
+    with patch.object(command_executor, 'datetime') as p:
+        p.utcnow.side_effect = lambda: dt
+        yield p
 
 
 @pytest.mark.parametrize(argnames="current_state,accepted_commands",
@@ -71,7 +87,7 @@ async def test_command_state_reject(loop,
 @pytest.mark.parametrize(argnames="command,worker_method_name",
                          argvalues=[
                              [ProtocolCommand.start_run, "handle_run"],
-                             [ProtocolCommand.start_simulate, "handle_simulate"],  # noqa:
+                             [ProtocolCommand.start_simulate, "handle_simulate"],  # noqa: E501
                              [ProtocolCommand.cancel, "handle_cancel"],
                              [ProtocolCommand.pause, "handle_pause"],
                              [ProtocolCommand.resume, "handle_resume"]
@@ -81,7 +97,7 @@ async def test_execute(loop, command, worker_method_name,
     # Patch the state command filter to allow all commands
     with patch.object(ProtocolCommandExecutor,
                       "STATE_COMMAND_MAP",
-                      new={protocol_command_executor.current_state: ProtocolCommand}):  # noqa:
+                      new={protocol_command_executor.current_state: ProtocolCommand}):  # noqa: E501
         protocol_command = Command(content=CommandContent(
             name=command,
             data=EmptyModel())
@@ -92,3 +108,69 @@ async def test_execute(loop, command, worker_method_name,
         # Command is added to command list
         assert len(protocol_command_executor.events) == 1
         assert protocol_command_executor.events[0].event == command
+
+
+class TestOnProtocolEvent:
+
+    async def test_topic_session_payload(self, protocol_command_executor):
+        mock_session = MagicMock()
+        mock_session.state = "some_state"
+        await protocol_command_executor.on_protocol_event({
+            'topic': 'session',
+            'payload': mock_session
+        })
+        assert protocol_command_executor.current_state == "some_state"
+
+    async def test_topic_dict_payload(self, protocol_command_executor):
+        await protocol_command_executor.on_protocol_event({
+            'topic': 'session',
+            'payload': {
+                'state': 'some_state'
+            }
+        })
+        assert protocol_command_executor.current_state == "some_state"
+
+    @pytest.mark.parametrize(argnames="payload",
+                             argvalues=[{},
+                                        {'topic': 'soosion'},
+                                        {'$': 'soosion'}
+                                        ])
+    async def test_body_invalid(self, protocol_command_executor, payload):
+        ProtocolCommandExecutor.current_state = PropertyMock()
+        await protocol_command_executor.on_protocol_event(payload)
+        assert len(protocol_command_executor.events) == 0
+        ProtocolCommandExecutor.current_state.assert_not_called()
+
+    async def test_before(self, protocol_command_executor, patch_utcnow, dt):
+        payload = {
+            '$': 'before',
+            'name': 'some event',
+            'payload': {
+                'text': 'this is what happened'
+            }
+        }
+        await protocol_command_executor.on_protocol_event(payload)
+        assert protocol_command_executor.events == [
+            ProtocolSessionEvent(source=EventSource.protocol_event,
+                                 event="some event",
+                                 startedAt=dt,
+                                 params={'text': 'this is what happened'}
+                                 )
+        ]
+
+    async def test_after(self, protocol_command_executor, patch_utcnow, dt):
+        payload = {
+            '$': 'after',
+            'name': 'some event',
+            'payload': {
+                'return': "done"
+            }
+        }
+        await protocol_command_executor.on_protocol_event(payload)
+        assert protocol_command_executor.events == [
+            ProtocolSessionEvent(source=EventSource.protocol_event,
+                                 event="some event",
+                                 completedAt=dt,
+                                 result="done"
+                                 )
+        ]

--- a/robot-server/tests/service/session/session_types/protocol/execution/test_command_executor.py
+++ b/robot-server/tests/service/session/session_types/protocol/execution/test_command_executor.py
@@ -1,4 +1,3 @@
-from dataclasses import asdict
 from unittest.mock import MagicMock, patch
 import pytest
 
@@ -91,4 +90,5 @@ async def test_execute(loop, command, worker_method_name,
         # Worker handler was called
         getattr(mock_worker, worker_method_name).assert_called_once()
         # Command is added to command list
-        assert protocol_command_executor.commands == [asdict(protocol_command)]
+        assert len(protocol_command_executor.commands) == 1
+        assert protocol_command_executor.commands[0].event == command

--- a/robot-server/tests/service/session/session_types/protocol/execution/test_command_executor.py
+++ b/robot-server/tests/service/session/session_types/protocol/execution/test_command_executor.py
@@ -90,5 +90,5 @@ async def test_execute(loop, command, worker_method_name,
         # Worker handler was called
         getattr(mock_worker, worker_method_name).assert_called_once()
         # Command is added to command list
-        assert len(protocol_command_executor.commands) == 1
-        assert protocol_command_executor.commands[0].event == command
+        assert len(protocol_command_executor.events) == 1
+        assert protocol_command_executor.events[0].event == command


### PR DESCRIPTION
# Overview

Fleshes out the model for the protocol session response. 

This is a schema and implementation that will certainly change once we dig into protocol context work. The goal is to provide a model for the beta release.

# Changelog

- Add `ProtocolSessionEvent` model. It describes an event that happened during a protocol session. This is either a protocol session command (via http) or a command executed by the protocol (via broker).  The difference is described by `source` attribute.
- Use `events` instead of `commands`.
- Unit tests

# Review requests

Questions:
- Do we want the events to be flat or do we we want an event to have a list of sub-events? 
**Answer from review discussion was yes**

- Related: this PR doesn't assign `commandId` to `protocol` sourced events. Every `protocol` event is a pair (`$: before` and `$: after` in RPC notification). For example, this is a dispense pair:
```
{
  "source":"protocol",
  "event":"command.DISPENSE",
  "startedAt":"2020-08-17T17:32:49.639580",
  "params":{"text":"Dispensing 1.0 uL into A1 of NEST 96 Well Plate 200 µL Flat on 1 at 300.0 uL/sec"}
},{
  "source":"protocol",
  "event":"command.DISPENSE",
  "completedAt":"2020-08-17T17:32:49.641238",
  "result":null
},
```
Is it worthwhile generating commandIds in the `before` and assigning them when the `after` event happens?

**From review discussion it was decided that:**
- **we would replace `startedAt` and `completedAt` with `timestamp.**
- **we would add `.start` to begin event and `.end` to after event.**
- **we would generate a unique `commandId` for protocol events.**


# Risk assessment

None. Behind a feature flag

closes #6225 