### PR TITLE
fix(robot-server): datetime responses are missing timezone.

### DIFF
--- a/api/src/opentrons/calibration_storage/modify.py
+++ b/api/src/opentrons/calibration_storage/modify.py
@@ -5,10 +5,10 @@ This module has functions that you can import to save robot or
 labware calibration to its designated file location.
 """
 import typing
-import datetime
 from pathlib import Path
 
 from opentrons import config
+from opentrons.util.helpers import utc_now
 
 from . import (
     file_operators as io,
@@ -113,7 +113,7 @@ def create_tip_length_data(
 
     tip_length_data: 'TipLengthCalibration' = {
         'tipLength': length,
-        'lastModified': datetime.datetime.utcnow()
+        'lastModified': utc_now()
     }
 
     data = {labware_hash + parent: tip_length_data}
@@ -125,14 +125,14 @@ def _helper_offset_data_format(filepath: str, delta: 'Point') -> dict:
         calibration_data = {
             "default": {
                 "offset": [delta.x, delta.y, delta.z],
-                "lastModified": datetime.datetime.utcnow()
+                "lastModified": utc_now()
             }
         }
     else:
         calibration_data = io.read_cal_file(filepath)
         calibration_data['default']['offset'] = [delta.x, delta.y, delta.z]
         calibration_data['default']['lastModified'] =\
-            datetime.datetime.utcnow()
+            utc_now()
     return calibration_data
 
 
@@ -186,7 +186,7 @@ def save_robot_deck_attitude(
     gantry_dict: 'DeckCalibrationData' = {
         'attitude': transform,
         'pipette_calibrated_with': pip_id,
-        'last_modified': datetime.datetime.utcnow(),
+        'last_modified': utc_now(),
         'tiprack': lw_hash
     }
     io.save_to_file(gantry_path, gantry_dict)

--- a/api/src/opentrons/util/helpers.py
+++ b/api/src/opentrons/util/helpers.py
@@ -1,4 +1,5 @@
 import typing
+from datetime import datetime, timezone
 
 
 def deep_get(obj: typing.Union[typing.Mapping, typing.Sequence],
@@ -23,3 +24,8 @@ def deep_get(obj: typing.Union[typing.Mapping, typing.Sequence],
             return default
 
     return obj
+
+
+def utc_now() -> datetime:
+    """Return the UTC time with timezone"""
+    return datetime.now(tz=timezone.utc)

--- a/api/tests/opentrons/containers/test_containers.py
+++ b/api/tests/opentrons/containers/test_containers.py
@@ -1,4 +1,3 @@
-import datetime
 import math
 from unittest import mock
 
@@ -19,6 +18,8 @@ from opentrons.legacy_api.containers.placeable import (
     Deck,
     Slot,
     unpack_location)
+from opentrons.util.helpers import utc_now
+
 from tests.opentrons import generate_plate
 # TODO: Modify all calls to get a Well to use the `wells` method
 # TODO: remove `unpack_location` calls
@@ -248,7 +249,7 @@ def test_load_tip_length_calibration_v1(robot):
 
     tip_length_data = {
             'tipLength': 19.99,
-            'lastModified': datetime.datetime.utcnow()}
+            'lastModified': utc_now()}
     tip_length_cal = {hash: tip_length_data}
     pip_id = 'fake_id'
     modify.save_tip_length_calibration(

--- a/api/tests/opentrons/hardware_control/test_calibration_functions.py
+++ b/api/tests/opentrons/hardware_control/test_calibration_functions.py
@@ -1,9 +1,9 @@
-import datetime
 import numpy as np
 
 from opentrons import config
 from opentrons.calibration_storage import file_operators as io
 from opentrons.hardware_control import robot_calibration
+from opentrons.util.helpers import utc_now
 
 
 def test_save_calibration(ot_config_tempdir):
@@ -32,7 +32,7 @@ def test_load_calibration(ot_config_tempdir):
     data = {
         'attitude': [[1, 0, 1], [0, 1, -.5], [0, 0, 1]],
         'pipette_calibrated_with': 'fake',
-        'last_modified': datetime.datetime.utcnow(),
+        'last_modified': utc_now(),
         'tiprack': 'hash'
     }
     io.save_to_file(pathway, data)

--- a/api/tests/opentrons/protocol_api/test_offsets.py
+++ b/api/tests/opentrons/protocol_api/test_offsets.py
@@ -15,6 +15,7 @@ from opentrons.calibration_storage import (
     types as cs_types)
 from opentrons.protocol_api import labware
 from opentrons.types import Point, Location
+from opentrons.util.helpers import utc_now
 
 MOCK_HASH = 'mock_hash'
 PIPETTE_ID = 'pipette_id'
@@ -133,7 +134,7 @@ def test_save_labware_calibration(monkeypatch, clear_calibration):
 
 
 def test_json_datetime_encoder():
-    fake_time = datetime.datetime.utcnow()
+    fake_time = utc_now()
     original = {'mock_hash': {'tipLength': 25.0, 'lastModified': fake_time}}
 
     encoded = json.dumps(original, cls=ed.DateTimeEncoder)
@@ -143,14 +144,9 @@ def test_json_datetime_encoder():
 
 def test_create_tip_length_calibration_data(monkeypatch):
 
-    fake_time = datetime.datetime.utcnow()
+    fake_time = utc_now()
 
-    class fake_datetime:
-        @classmethod
-        def utcnow(cls):
-            return fake_time
-
-    monkeypatch.setattr(datetime, 'datetime', fake_datetime)
+    monkeypatch.setattr(modify, 'utc_now', lambda: fake_time)
 
     monkeypatch.setattr(
         helpers,
@@ -260,7 +256,7 @@ def test_clear_tip_length_calibration_data(monkeypatch):
 
 
 def test_schema_shape(monkeypatch, clear_calibration):
-    fake_time = datetime.datetime.utcnow()
+    fake_time = utc_now()
     time_string = fake_time.isoformat()
     from_iso = datetime.datetime.fromisoformat(time_string)
 
@@ -268,10 +264,6 @@ def test_schema_shape(monkeypatch, clear_calibration):
         @classmethod
         def fromisoformat(cls, obj):
             return from_iso
-
-        @classmethod
-        def utcnow(cls):
-            return fake_time
 
         @classmethod
         def isoformat(cls):

--- a/robot-server/robot_server/service/access/router.py
+++ b/robot-server/robot_server/service/access/router.py
@@ -1,11 +1,11 @@
 import secrets
-from datetime import datetime
 from starlette import status as status_codes
 from fastapi import APIRouter
 
 from robot_server.service.errors import RobotServerError, CommonErrorDef
 from robot_server.service.access import models as access
 from robot_server.service.json_api import ErrorResponse
+from robot_server.util import utc_now
 
 router = APIRouter()
 
@@ -28,7 +28,7 @@ async def create_access_token() -> access.AccessTokenResponse:
         data=access.ResponseDataModel.create(
             attributes=access.AccessTokenInfo(
                 token=token,
-                createdAt=datetime.utcnow()),
+                createdAt=utc_now()),
             resource_id=token,
         ))
 

--- a/robot-server/robot_server/service/access/router.py
+++ b/robot-server/robot_server/service/access/router.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter
 from robot_server.service.errors import RobotServerError, CommonErrorDef
 from robot_server.service.access import models as access
 from robot_server.service.json_api import ErrorResponse
-from robot_server.util import utc_now
+from opentrons.util.helpers import utc_now
 
 router = APIRouter()
 

--- a/robot-server/robot_server/service/protocol/protocol.py
+++ b/robot-server/robot_server/service/protocol/protocol.py
@@ -8,7 +8,8 @@ from pathlib import Path
 from fastapi import UploadFile
 
 from robot_server.service.protocol.errors import ProtocolAlreadyExistsException
-from robot_server.util import FileMeta, save_upload, utc_now
+from robot_server.util import FileMeta, save_upload
+from opentrons.util.helpers import utc_now
 
 log = logging.getLogger(__name__)
 

--- a/robot-server/robot_server/service/protocol/protocol.py
+++ b/robot-server/robot_server/service/protocol/protocol.py
@@ -8,8 +8,7 @@ from pathlib import Path
 from fastapi import UploadFile
 
 from robot_server.service.protocol.errors import ProtocolAlreadyExistsException
-from robot_server.util import FileMeta, save_upload
-
+from robot_server.util import FileMeta, save_upload, utc_now
 
 log = logging.getLogger(__name__)
 
@@ -20,8 +19,8 @@ class UploadedProtocolMeta:
     protocol_file: FileMeta
     directory: TemporaryDirectory
     support_files: typing.List[FileMeta] = field(default_factory=list)
-    last_modified_at: datetime = field(default_factory=datetime.utcnow)
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    last_modified_at: datetime = field(default_factory=utc_now)
+    created_at: datetime = field(default_factory=utc_now)
 
 
 class UploadedProtocol:
@@ -70,7 +69,7 @@ class UploadedProtocol:
         self._meta = replace(
             self._meta,
             support_files=self._meta.support_files + [file_meta],
-            last_modified_at=datetime.utcnow()
+            last_modified_at=utc_now()
         )
 
     def clean_up(self):

--- a/robot-server/robot_server/service/session/command_execution/command.py
+++ b/robot-server/robot_server/service/session/command_execution/command.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 
 from robot_server.service.session.models import IdentifierType, \
     create_identifier, CommandDefinitionType, CommandDataType, CommandStatus
+from robot_server.util import utc_now
 
 
 @dataclass(frozen=True)
@@ -14,7 +15,7 @@ class CommandContent:
 @dataclass(frozen=True)
 class CommandMeta:
     identifier: IdentifierType = field(default_factory=create_identifier)
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=utc_now)
 
 
 @dataclass(frozen=True)

--- a/robot-server/robot_server/service/session/command_execution/command.py
+++ b/robot-server/robot_server/service/session/command_execution/command.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 
 from robot_server.service.session.models import IdentifierType, \
     create_identifier, CommandDefinitionType, CommandDataType, CommandStatus
-from robot_server.util import utc_now
+from opentrons.util.helpers import utc_now
 
 
 @dataclass(frozen=True)

--- a/robot-server/robot_server/service/session/models.py
+++ b/robot-server/robot_server/service/session/models.py
@@ -15,7 +15,7 @@ from robot_server.service.session.session_types.protocol import \
     models as protocol_session_models
 from robot_server.service.json_api import \
     ResponseDataModel, ResponseModel, RequestDataModel, RequestModel
-
+from robot_server.util import utc_now
 
 IdentifierType = typing.NewType('IdentifierType', str)
 
@@ -314,7 +314,7 @@ class BasicSessionCommand(BaseModel):
 class SessionCommand(BasicSessionCommand):
     """A session command response"""
     status: CommandStatus
-    createdAt: datetime = Field(..., default_factory=datetime.utcnow)
+    createdAt: datetime = Field(..., default_factory=utc_now)
     startedAt: typing.Optional[datetime]
     completedAt: typing.Optional[datetime]
 

--- a/robot-server/robot_server/service/session/models.py
+++ b/robot-server/robot_server/service/session/models.py
@@ -15,7 +15,7 @@ from robot_server.service.session.session_types.protocol import \
     models as protocol_session_models
 from robot_server.service.json_api import \
     ResponseDataModel, ResponseModel, RequestDataModel, RequestModel
-from robot_server.util import utc_now
+from opentrons.util.helpers import utc_now
 
 IdentifierType = typing.NewType('IdentifierType', str)
 

--- a/robot-server/robot_server/service/session/session_types/base_session.py
+++ b/robot-server/robot_server/service/session/session_types/base_session.py
@@ -7,6 +7,7 @@ from robot_server.service.session.command_execution import CommandQueue,\
     CommandExecutor
 from robot_server.service.session.configuration import SessionConfiguration
 from robot_server.service.session import models
+from robot_server.util import utc_now
 
 
 @dataclass(frozen=True)
@@ -17,7 +18,7 @@ class SessionMetaData:
     identifier: models.IdentifierType = field(
         default_factory=models.create_identifier
     )
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=utc_now)
 
 
 class BaseSession(ABC):

--- a/robot-server/robot_server/service/session/session_types/base_session.py
+++ b/robot-server/robot_server/service/session/session_types/base_session.py
@@ -7,7 +7,7 @@ from robot_server.service.session.command_execution import CommandQueue,\
     CommandExecutor
 from robot_server.service.session.configuration import SessionConfiguration
 from robot_server.service.session import models
-from robot_server.util import utc_now
+from opentrons.util.helpers import utc_now
 
 
 @dataclass(frozen=True)

--- a/robot-server/robot_server/util.py
+++ b/robot-server/robot_server/util.py
@@ -1,20 +1,25 @@
 import hashlib
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import UploadFile
+
+
+def utc_now() -> datetime:
+    """Return the UTC time with timezone"""
+    return datetime.now(tz=timezone.utc)
 
 
 class duration:
     """Context manager to mark start and end times of a block"""
 
     def __enter__(self):
-        self.start = datetime.utcnow()
+        self.start = utc_now()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.end = datetime.utcnow()
+        self.end = utc_now()
 
 
 @dataclass(frozen=True)

--- a/robot-server/robot_server/util.py
+++ b/robot-server/robot_server/util.py
@@ -1,14 +1,9 @@
 import hashlib
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import UploadFile
-
-
-def utc_now() -> datetime:
-    """Return the UTC time with timezone"""
-    return datetime.now(tz=timezone.utc)
+from opentrons.util.helpers import utc_now
 
 
 class duration:

--- a/robot-server/tests/integration/protocols/test_protocol_upload.tavern.yaml
+++ b/robot-server/tests/integration/protocols/test_protocol_upload.tavern.yaml
@@ -22,8 +22,8 @@ stages:
               basename: phony_proto.py
             supportFiles:
               - basename: data.csv
-            lastModifiedAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
-            createdAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
+            lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
   - name: Get the protocol
     request:
       url: "{host:s}:{port:d}/protocols/phony_proto"
@@ -68,8 +68,8 @@ stages:
             protocolFile:
               basename: phony_proto.py
             supportFiles: []
-            lastModifiedAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
-            createdAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
+            lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
   - name: Get the protocol
     request:
       url: "{host:s}:{port:d}/protocols/phony_proto"
@@ -84,8 +84,8 @@ stages:
             protocolFile:
               basename: phony_proto.py
             supportFiles: []
-            lastModifiedAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
-            createdAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
+            lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
   - name: Upload a data file
     request:
       url: "{host:s}:{port:d}/protocols/phony_proto"
@@ -103,8 +103,8 @@ stages:
               basename: phony_proto.py
             supportFiles:
             - basename: 'data.csv'
-            lastModifiedAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
-            createdAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
+            lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
   - name: Delete the protocol
     request:
       url: "{host:s}:{port:d}/protocols/phony_proto"
@@ -120,8 +120,8 @@ stages:
               basename: phony_proto.py
             supportFiles:
             - basename: 'data.csv'
-            lastModifiedAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
-            createdAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
+            lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
   - name: Get all protocols to see that there are none
     request:
       url: "{host:s}:{port:d}/protocols"

--- a/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
@@ -33,7 +33,7 @@ stages:
           type: Session
           attributes: &session_data_attributes
             sessionType: calibrationCheck
-            createdAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
+            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
             createParams: null
             details: &session_data_attribute_details
               currentStep: sessionStarted
@@ -659,7 +659,7 @@ stages:
             type: Session
             attributes:
               sessionType: default
-              createdAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
+              createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
               details: {}
               createParams: null
 ---

--- a/robot-server/tests/integration/sessions/test_deck_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_deck_calibration.tavern.yaml
@@ -34,7 +34,7 @@ stages:
           type: Session
           attributes: &session_data_attributes
             sessionType: deckCalibration
-            createdAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+.\\d+"
+            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
             createParams: null
             details: &session_data_attribute_details
               currentStep: sessionStarted
@@ -353,6 +353,6 @@ stages:
             type: Session
             attributes:
               sessionType: default
-              createdAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
+              createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
               details: {}
               createParams: null

--- a/robot-server/tests/integration/sessions/test_default.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_default.tavern.yaml
@@ -56,7 +56,7 @@ stages:
           type: Session
           attributes:
             sessionType: default
-            createdAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
+            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
             details: {}
             createParams: null
 ---

--- a/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
@@ -37,7 +37,7 @@ stages:
           type: Session
           attributes:
             sessionType: tipLengthCalibration
-            createdAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+.\\d+"
+            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
             details: &session_data_attribute_details
               currentStep: sessionStarted
               instrument: !anydict
@@ -105,7 +105,7 @@ stages:
             type: Session
             attributes:
               sessionType: default
-              createdAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
+              createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
               details: {}
               createParams: null
 

--- a/robot-server/tests/integration/test_session.tavern.yaml
+++ b/robot-server/tests/integration/test_session.tavern.yaml
@@ -88,21 +88,21 @@ stages:
           type: Session
           attributes:
             sessionType: "default"
-            createdAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
+            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
             details: {}
             createParams: null
         - id: "{session_id_1}"
           type: Session
           attributes:
             sessionType: "null"
-            createdAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
+            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
             details: {}
             createParams: null
         - id: "{session_id_2}"
           type: Session
           attributes:
             sessionType: "calibrationCheck"
-            createdAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
+            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
             details: !anydict
             createParams: null
 
@@ -118,7 +118,7 @@ stages:
           type: Session
           attributes:
             sessionType: "calibrationCheck"
-            createdAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
+            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
             details: !anydict
             createParams: null
 
@@ -148,6 +148,6 @@ stages:
           type: Session
           attributes:
             sessionType: "default"
-            createdAt: !re_search "^\\d+-\\d+-\\d+T\\d+:\\d+:\\d+"
+            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
             details: {}
             createParams: null

--- a/robot-server/tests/test_util.py
+++ b/robot-server/tests/test_util.py
@@ -12,8 +12,8 @@ def mock_start_time():
 
 
 @pytest.fixture
-def mock_utcnow(mock_start_time):
-    """Mock util.datetime.utcnow.
+def mock_utc_now(mock_start_time):
+    """Mock util.utc_now.
 
     First call will be mock_start_time. Subsequent calls will increment by
     1 day."""
@@ -26,12 +26,12 @@ def mock_utcnow(mock_start_time):
             self._time += timedelta(days=1)
             return ret
 
-    with patch.object(util, 'datetime') as p:
-        p.now.side_effect = _TimeIncrementer(mock_start_time)
+    with patch.object(util, 'utc_now') as p:
+        p.side_effect = _TimeIncrementer(mock_start_time)
         yield p
 
 
-def test_duration(mock_utcnow, mock_start_time):
+def test_duration(mock_utc_now, mock_start_time):
     with util.duration() as t:
         pass
 
@@ -39,7 +39,7 @@ def test_duration(mock_utcnow, mock_start_time):
     assert t.end == mock_start_time + timedelta(days=1)
 
 
-def test_duration_raises(mock_utcnow, mock_start_time):
+def test_duration_raises(mock_utc_now, mock_start_time):
     try:
         with util.duration() as t:
             raise AssertionError()

--- a/robot-server/tests/test_util.py
+++ b/robot-server/tests/test_util.py
@@ -27,7 +27,7 @@ def mock_utcnow(mock_start_time):
             return ret
 
     with patch.object(util, 'datetime') as p:
-        p.utcnow.side_effect = _TimeIncrementer(mock_start_time)
+        p.now.side_effect = _TimeIncrementer(mock_start_time)
         yield p
 
 


### PR DESCRIPTION
# Overview

`datetime.utcnow()` does not set the time zone to utc. The JSON serialized datetime strings were missing the `+00:00` indicator of UTC time zone. Using `datetime.now(tz=timezone.utc)` remedies this.

# Risk assessment

None

closes #6374 