### PR TITLE
fix(robot-server): make systemd startup more tolerant

### DIFF
--- a/robot-server/opentrons-robot-server.service
+++ b/robot-server/opentrons-robot-server.service
@@ -9,6 +9,8 @@ ExecStart=uvicorn robot_server.service.app:app --uds /run/aiohttp.sock --ws wspr
 # Stop the button blinking
 ExecStartPost=systemctl stop opentrons-gpio-setup.service
 Environment=OT_SMOOTHIE_ID=AMA RUNNING_ON_PI=true
+Restart=on-failure
+TimeoutStartSec=3min
 
 [Install]
 WantedBy=opentrons.target


### PR DESCRIPTION
We see occasional problems where the robot server may be crashing (it's
hard to debug since most of the time users don't remember their robot's
ip, and the app can't display ip addresses until the robot server is
up). This bumps the timeout before the robot server is considered failed
to 3 minutes, which should be sufficient for whatever is going wrong;
and it also commands a restart if the unit fails, just in case.

## Testing
Put this on a robot (`make push` should work, but double check, and you may have to run `systemctl daemon-reload`; if make push doesn't work, copy it over manually) and reboot the robot, making sure everything comes up.