### PR TITLE
fix(api, app): Ensure index file exists before reading from it

### DIFF
--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -90,12 +90,6 @@ def _get_tip_length_data(
             'be loaded')
 
 
-def _maybe_add_labware_to_index_file(definition, parent, slot):
-    labware_hash = helpers.hash_labware_def(definition)
-    uri = helpers.uri_from_definition(definition)
-    modify._add_to_index_offset_file(parent, slot, uri, labware_hash)
-
-
 def get_labware_calibration(
         lookup_path: local_types.StrPath,
         definition: 'LabwareDefinition',
@@ -113,7 +107,7 @@ def get_labware_calibration(
     offset = Point(0, 0, 0)
     labware_path = offset_path / lookup_path
     if labware_path.exists():
-        _maybe_add_labware_to_index_file(definition, parent, slot)
+        modify.add_existing_labware_to_index_file(definition, parent, slot)
         migration.check_index_version(offset_path / 'index.json')
         calibration_data = io.read_cal_file(str(labware_path))
         offset_array = calibration_data['default']['offset']

--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -9,7 +9,7 @@ from opentrons.types import Point
 
 from . import (
     types as local_types,
-    file_operators as io, helpers, migration)
+    file_operators as io, helpers, migration, modify)
 if typing.TYPE_CHECKING:
     from opentrons_shared_data.labware.dev_types import LabwareDefinition
     from .dev_types import (
@@ -90,7 +90,17 @@ def _get_tip_length_data(
             'be loaded')
 
 
-def get_labware_calibration(lookup_path: local_types.StrPath) -> Point:
+def _maybe_add_labware_to_index_file(definition, parent, slot):
+    labware_hash = helpers.hash_labware_def(definition)
+    uri = helpers.uri_from_definition(definition)
+    modify._add_to_index_offset_file(parent, slot, uri, labware_hash)
+
+
+def get_labware_calibration(
+        lookup_path: local_types.StrPath,
+        definition: 'LabwareDefinition',
+        parent: str = '',
+        slot: str = '') -> Point:
     """
     Find the delta of a given labware, if it exists.
 
@@ -103,6 +113,7 @@ def get_labware_calibration(lookup_path: local_types.StrPath) -> Point:
     offset = Point(0, 0, 0)
     labware_path = offset_path / lookup_path
     if labware_path.exists():
+        _maybe_add_labware_to_index_file(definition, parent, slot)
         migration.check_index_version(offset_path / 'index.json')
         calibration_data = io.read_cal_file(str(labware_path))
         offset_array = calibration_data['default']['offset']

--- a/api/src/opentrons/calibration_storage/migration.py
+++ b/api/src/opentrons/calibration_storage/migration.py
@@ -6,10 +6,13 @@ MAX_VERSION = 1
 
 
 def check_index_version(index_path: local_types.StrPath):
-    index_file = io.read_cal_file(str(index_path))
-    version = index_file.get('version', 0)
-    if version == 0:
-        migrate_index_0_to_1(index_path)
+    try:
+        index_file = io.read_cal_file(str(index_path))
+        version = index_file.get('version', 0)
+        if version == 0:
+            migrate_index_0_to_1(index_path)
+    except FileNotFoundError:
+        pass
 
 
 def migrate_index_0_to_1(index_path: local_types.StrPath):

--- a/api/src/opentrons/calibration_storage/modify.py
+++ b/api/src/opentrons/calibration_storage/modify.py
@@ -41,23 +41,26 @@ def _add_to_index_offset_file(parent: str, slot: str, uri: str, lw_hash: str):
     else:
         blob = {}
 
-    if parent:
-        mod_dict = {
-            'parent': parent,
-            'fullParent': f'{slot}-{parent}'}
-    else:
-        mod_dict = {}
     full_id = f'{lw_hash}{parent}'
-    new_index_data = {
-        "uri": f'{uri}',
-        "slot": full_id,
-        "module": mod_dict}
-    if blob.get('data'):
-        blob['data'][full_id] = new_index_data
-    else:
-        blob['data'] = {full_id: new_index_data}
-    blob['version'] = migration.MAX_VERSION
-    io.save_to_file(index_file, blob)
+    try:
+        blob['data'][full_id]
+    except KeyError:
+        if parent:
+            mod_dict = {
+                'parent': parent,
+                'fullParent': f'{slot}-{parent}'}
+        else:
+            mod_dict = {}
+        new_index_data = {
+            "uri": f'{uri}',
+            "slot": full_id,
+            "module": mod_dict}
+        if blob.get('data'):
+            blob['data'][full_id] = new_index_data
+        else:
+            blob['data'] = {full_id: new_index_data}
+        blob['version'] = migration.MAX_VERSION
+        io.save_to_file(index_file, blob)
 
 
 def save_labware_calibration(

--- a/api/src/opentrons/calibration_storage/modify.py
+++ b/api/src/opentrons/calibration_storage/modify.py
@@ -63,6 +63,13 @@ def _add_to_index_offset_file(parent: str, slot: str, uri: str, lw_hash: str):
         io.save_to_file(index_file, blob)
 
 
+def add_existing_labware_to_index_file(
+        definition: 'LabwareDefinition', parent: str = '', slot: str = ''):
+    labware_hash = helpers.hash_labware_def(definition)
+    uri = helpers.uri_from_definition(definition)
+    _add_to_index_offset_file(parent, slot, uri, labware_hash)
+
+
 def save_labware_calibration(
         labware_path: local_types.StrPath,
         definition: 'LabwareDefinition',

--- a/api/src/opentrons/legacy_api/containers/__init__.py
+++ b/api/src/opentrons/legacy_api/containers/__init__.py
@@ -212,11 +212,11 @@ def _load_new_well(well_data, saved_offset, lw_quirks):
     return (well, well_tuple)
 
 
-def _look_up_offsets(labware_hash):
+def _look_up_offsets(labware_hash, definition):
     calibration_path = CONFIG['labware_calibration_offsets_dir_v2']
     labware_offset_path = calibration_path / '{}.json'.format(labware_hash)
     if labware_offset_path.exists():
-        return get.get_labware_calibration(labware_offset_path)
+        return get.get_labware_calibration(labware_offset_path, definition)
     else:
         return Point(x=0, y=0, z=0)
 
@@ -225,7 +225,7 @@ def save_new_offsets(labware_hash, delta, definition):
     calibration_path = CONFIG['labware_calibration_offsets_dir_v2']
     if not calibration_path.exists():
         calibration_path.mkdir(parents=True, exist_ok=True)
-    old_delta = _look_up_offsets(labware_hash)
+    old_delta = _look_up_offsets(labware_hash, definition)
     uri = cal_helpers.uri_from_definition(definition)
 
     # Note that the next line looks incorrect (like it's letting the prior
@@ -267,7 +267,7 @@ def load_new_labware_def(definition):
     """ Load a labware definition in the new schema into a placeable
     """
     labware_hash = cal_helpers.hash_labware_def(definition)
-    saved_offset = _look_up_offsets(labware_hash)
+    saved_offset = _look_up_offsets(labware_hash, definition)
     container = Container()
     container_name = definition['parameters']['loadName']
     log.info(f"Container name {container_name}, hash {labware_hash}")

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1110,6 +1110,14 @@ def _get_labware_path(labware: 'Labware') -> str:
     return f'{get_labware_hash_with_parent(labware)}.json'
 
 
+def _get_index_file_information(
+        labware: 'Labware') -> Tuple[str, 'LabwareDefinition', str]:
+    definition = labware._definition
+    labware_path = _get_labware_path(labware)
+    parent = _get_parent_identifier(labware)
+    return labware_path, definition, parent
+
+
 def load_from_definition(
         definition: 'LabwareDefinition',
         parent: Location,
@@ -1135,18 +1143,17 @@ def load_from_definition(
                                  defaults to :py:attr:`.MAX_SUPPORTED_VERSION`.
     """
     labware = Labware(definition, parent, label, api_level)
-    lookup_path = _get_labware_path(labware)
-    offset = get.get_labware_calibration(lookup_path)
+    index_info = _get_index_file_information(labware)
+    offset = get.get_labware_calibration(
+        index_info[0], index_info[1], parent=index_info[2])
     labware.set_calibration(offset)
     return labware
 
 
 def save_calibration(labware: 'Labware', delta: Point):
-    definition = labware._definition
-    labware_path = _get_labware_path(labware)
-    parent = _get_parent_identifier(labware)
+    index_info = _get_index_file_information(labware)
     modify.save_labware_calibration(
-        labware_path, definition, delta, parent=parent)
+        index_info[0], index_info[1], delta, parent=index_info[2])
     labware.set_calibration(delta)
 
 

--- a/api/tests/opentrons/protocol_api/test_offsets.py
+++ b/api/tests/opentrons/protocol_api/test_offsets.py
@@ -324,7 +324,8 @@ def test_load_calibration(monkeypatch, clear_calibration):
     test_labware.set_calibration(Point(0, 0, 0))
     test_labware.tip_length = 46.8
     lookup_path = labware._get_labware_path(test_labware)
-    calibration_point = get.get_labware_calibration(lookup_path)
+    calibration_point =\
+        get.get_labware_calibration(lookup_path, test_labware._definition)
     assert calibration_point == test_offset
 
 

--- a/api/tests/opentrons/robot/test_robot.py
+++ b/api/tests/opentrons/robot/test_robot.py
@@ -3,6 +3,7 @@ import pytest
 from numpy import isclose
 from unittest import mock
 
+from opentrons.protocol_api.labware import _get_standard_labware_definition
 from opentrons.legacy_api.containers import load as containers_load
 from opentrons.legacy_api.containers import _look_up_offsets
 from opentrons.trackers import pose_tracker
@@ -235,7 +236,7 @@ def test_calibrate_labware(robot, instruments, labware, monkeypatch):
 def test_calibrate_multiple(robot, instruments, labware, offsets_tempdir):
     # Note: labware_name must be a v2 labware definition
     labware_name = 'agilent_1_reservoir_290ml'
-
+    definition = _get_standard_labware_definition(labware_name)
     reservoir1 = labware.load(labware_name, '1')
     reservoir2 = labware.load(labware_name, '2')
 
@@ -261,7 +262,7 @@ def test_calibrate_multiple(robot, instruments, labware, offsets_tempdir):
         old_x2 + delta_x1, old_y2 + delta_y1, old_z2 + delta_z1)).all()
 
     lw_hash = reservoir1.properties.get('labware_hash')
-    new_offset1 = _look_up_offsets(lw_hash)
+    new_offset1 = _look_up_offsets(lw_hash, definition)
     expected1 = Point(delta_x1, delta_y1, delta_z1)
     assert isclose(new_offset1, expected1).all()
 
@@ -281,7 +282,7 @@ def test_calibrate_multiple(robot, instruments, labware, offsets_tempdir):
         old_x2, old_y2, old_z2)).all()
 
     lw_hash = reservoir1.properties.get('labware_hash')
-    new_offset2 = _look_up_offsets(lw_hash)
+    new_offset2 = _look_up_offsets(lw_hash, definition)
     expected2 = Point(0, 0, 0)
     assert isclose(new_offset2, expected2).all()
 

--- a/app/src/components/FileInfo/index.js
+++ b/app/src/components/FileInfo/index.js
@@ -38,7 +38,7 @@ export function FileInfo(props: FileInfoProps): React.Node {
       <InformationCard />
       <ProtocolPipettesCard robotName={robot.name} />
       <ProtocolModulesCard robot={robot} />
-      <ProtocolLabwareCard robotName={robot.name} />
+      {sessionLoaded && <ProtocolLabwareCard robotName={robot.name} />}
       {uploadError && <UploadError uploadError={uploadError} />}
       {sessionLoaded && !uploadError && <Continue />}
     </Box>


### PR DESCRIPTION
# Overview

Closes #6394. A bug has been popping up for users upgrading from a server version other than 3.19.0. Previously, when the index file does not exist, but a labware calibration file does, the migration check for the index file would fail because there are no protections to ensure that we are reading from a file that exists.

# Changelog

- Check that the file passed into the migration function exists before reading from it
- Only update the index file if that particular entry does not exist yet
- Update some tests to reflect the changes

# Review requests

I wasn't sure if I should just get rid of all the file exists checks at the call sites of `read_cal_file` and just put the check in here, or rely on the `FileNotFoundError`.  Also any other refactors we want to do while we're here?

Please test on a robot by:
1. deleting an index file, but not labware calibrations and,
2. Then uploading a protocol with _previously_ calibrated labware
Result: you should see the index file update with all of the labware from this protocol and your calibration data should appear in the app

# Risk assessment
Medium

