### PR TITLE
fix(app): do not set the user's Intercom name to "Unknown User"

### DIFF
--- a/app-shell/src/config/__fixtures__/index.js
+++ b/app-shell/src/config/__fixtures__/index.js
@@ -4,6 +4,7 @@ import type {
   ConfigV0,
   ConfigV1,
   ConfigV2,
+  ConfigV3,
 } from '@opentrons/app/src/config/types'
 
 export const MOCK_CONFIG_V0: ConfigV0 = {
@@ -77,5 +78,15 @@ export const MOCK_CONFIG_V2: ConfigV2 = {
   version: 2,
   calibration: {
     useTrashSurfaceForTipCal: null,
+  },
+}
+
+export const MOCK_CONFIG_V3: ConfigV3 = {
+  ...MOCK_CONFIG_V2,
+  version: 3,
+  support: {
+    ...MOCK_CONFIG_V2.support,
+    name: null,
+    email: null,
   },
 }

--- a/app-shell/src/config/__tests__/migrate.test.js
+++ b/app-shell/src/config/__tests__/migrate.test.js
@@ -1,6 +1,11 @@
 // @flow
 // config migration tests
-import { MOCK_CONFIG_V0, MOCK_CONFIG_V2 } from '../__fixtures__'
+import {
+  MOCK_CONFIG_V0,
+  MOCK_CONFIG_V1,
+  MOCK_CONFIG_V2,
+  MOCK_CONFIG_V3,
+} from '../__fixtures__'
 import { migrate } from '../migrate'
 
 describe('config migration', () => {
@@ -8,21 +13,38 @@ describe('config migration', () => {
     const v0Config = MOCK_CONFIG_V0
     const result = migrate(v0Config)
 
-    expect(result.version).toBe(2)
-    expect(result).toEqual(MOCK_CONFIG_V2)
+    expect(result.version).toBe(3)
+    expect(result).toEqual(MOCK_CONFIG_V3)
   })
 
-  it('should keep version 2 unchanged', () => {
-    const v2Config = {
-      ...MOCK_CONFIG_V2,
-      calibration: {
-        ...MOCK_CONFIG_V2.calibration,
-        useTrashSurfaceForTipCal: true,
-      },
-    }
+  it('should migrate version 1 to latest', () => {
+    const v1Config = MOCK_CONFIG_V1
+    const result = migrate(v1Config)
+
+    expect(result.version).toBe(3)
+    expect(result).toEqual(MOCK_CONFIG_V3)
+  })
+
+  it('should migrate version 2 to latest', () => {
+    const v2Config = MOCK_CONFIG_V2
     const result = migrate(v2Config)
 
-    expect(result.version).toBe(2)
-    expect(result).toEqual(v2Config)
+    expect(result.version).toBe(3)
+    expect(result).toEqual(MOCK_CONFIG_V3)
+  })
+
+  it('should keep version 3 unchanged', () => {
+    const v3Config = {
+      ...MOCK_CONFIG_V3,
+      support: {
+        ...MOCK_CONFIG_V3.support,
+        name: 'Known Kname',
+        email: 'hello@example.com',
+      },
+    }
+    const result = migrate(v3Config)
+
+    expect(result.version).toBe(3)
+    expect(result).toEqual(v3Config)
   })
 })

--- a/app/src/config/schema-types.js
+++ b/app/src/config/schema-types.js
@@ -104,4 +104,15 @@ export type ConfigV2 = $ReadOnly<{|
   |}>,
 |}>
 
-export type Config = ConfigV2
+// v3 config changes default values but does not change schema
+export type ConfigV3 = $ReadOnly<{|
+  ...ConfigV2,
+  version: 3,
+  support: $ReadOnly<{|
+    ...$PropertyType<ConfigV2, 'support'>,
+    name: string | null,
+    email: string | null,
+  |}>,
+|}>
+
+export type Config = ConfigV3

--- a/app/src/support/__tests__/profile.test.js
+++ b/app/src/support/__tests__/profile.test.js
@@ -22,7 +22,7 @@ describe('support profile tests', () => {
   const CONFIG: SupportConfig = {
     userId: 'some-user-id',
     createdAt: 1234,
-    name: 'Some Name',
+    name: null,
     email: null,
   }
 
@@ -40,7 +40,6 @@ describe('support profile tests', () => {
     expect(bootIntercom).toHaveBeenCalledWith({
       app_id: 'some-intercom-app-id',
       created_at: 1234,
-      name: 'Some Name',
       'App Version': version,
     })
   })

--- a/app/src/support/profile.js
+++ b/app/src/support/profile.js
@@ -26,7 +26,6 @@ export function initializeProfile(config: SupportConfig): void {
   bootIntercom({
     app_id: getIntercomAppId(),
     created_at: config.createdAt,
-    name: config.name,
     [Constants.PROFILE_APP_VERSION]: appVersion,
   })
 }


### PR DESCRIPTION
# Overview

This PR fixes #6461. See ticket for rationale and acceptance criteria 

# Changelog

- fix(app): do not set the user's Intercom name to "Unknown User"

# Review requests

- The app has never had logic to set `config.support.name` nor `config.support.email`, which is why I think its ok that we brute-force `null` them out rather than checking if the value matches the default before nulling it out
- **For support team members**: This will cause new users to show up in Intercom with their display name (not their actual name) defaulting to the user ID. See https://github.com/Opentrons/opentrons/issues/6461#issuecomment-685019078 for a screenshot of what this looks like
- **For QA team**: This might require a change to existing manual test procedure depending on what the existing test for the Intercom integration looks like

# Risk assessment

- Low; we have good unit test coverage of this behavior
- **Support team sign-off required for merge** since this changes the Opentrons-facing experience in Intercom
