### PR TITLE
fix(api): thermocycler hold_time bug

### DIFF
--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -412,6 +412,8 @@ class Thermocycler:
         """
         if new_hold_time is None:
             return True
+        if self._hold_time is None:
+            return False
         lower_bound = max(0.0, new_hold_time - HOLD_TIME_FUZZY_SECONDS)
         return lower_bound <= self._hold_time <= new_hold_time
 

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -401,7 +401,7 @@ class Thermocycler:
         self.lid_status = 'closed'
         return self.lid_status
 
-    def hold_time_probably_set(self, new_hold_time) -> bool:
+    def hold_time_probably_set(self, new_hold_time: Optional[float]) -> bool:
         """
         Since we can only get hold time *remaining* from TC, by the time we
         read hold_time after a set_temperature, the hold_time in TC could have
@@ -410,7 +410,9 @@ class Thermocycler:
         of the new hold time. The number of seconds is determined by status
         polling frequency.
         """
-        lower_bound = max(0, new_hold_time - HOLD_TIME_FUZZY_SECONDS)
+        if new_hold_time is None:
+            return True
+        lower_bound = max(0.0, new_hold_time - HOLD_TIME_FUZZY_SECONDS)
         return lower_bound <= self._hold_time <= new_hold_time
 
     async def set_temperature(self,

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -161,7 +161,7 @@ class Thermocycler(mod_abc.AbstractModule):
             self._current_cycle_index = rep + 1  # science starts at 1
             for step_idx, step in enumerate(steps):
                 await self._execute_cycle_step(step, step_idx, volume)
-                await self.wait_for_hold()  # What does this wait do?
+                await self.wait_for_hold()
 
     async def cycle_temperatures(self,
                                  steps: List[types.ThermocyclerStep],
@@ -212,7 +212,8 @@ class Thermocycler(mod_abc.AbstractModule):
         # because of the driver's status poller delays, it is impossible to
         # know for certain if self.hold_time holds the most recent value.
         # So instead of counting on the cached self.hold_time, it is better to
-        # just wait for hold_time time
+        # just wait for hold_time time. (Skip if hold_time = 0 since we don't
+        # want to wait in that case. Cached self.hold_time would be 0 anyway)
         if 0 < hold_time <= HOLD_TIME_FUZZY_SECONDS:
             await asyncio.sleep(hold_time)
         else:

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -1,10 +1,13 @@
 import asyncio
-from typing import Union, Optional, List, Callable
-from opentrons.drivers.thermocycler.driver import (
-    SimulatingDriver, Thermocycler as ThermocyclerDriver)
 import logging
+from typing import Union, Optional, List, Callable
 from ..execution_manager import ExecutionManager
 from . import types, update, mod_abc
+from opentrons.drivers.thermocycler.driver import (
+    HOLD_TIME_FUZZY_SECONDS,
+    SimulatingDriver,
+    Thermocycler as ThermocyclerDriver)
+
 
 MODULE_LOG = logging.getLogger(__name__)
 
@@ -127,7 +130,7 @@ class Thermocycler(mod_abc.AbstractModule):
                                            volume=volume)
         if hold_time:
             task = self._loop.create_task(
-                self.wait_for_hold())
+                self.wait_for_hold(hold_time))
         else:
             task = self._loop.create_task(
                 self.wait_for_temp())
@@ -158,7 +161,7 @@ class Thermocycler(mod_abc.AbstractModule):
             self._current_cycle_index = rep + 1  # science starts at 1
             for step_idx, step in enumerate(steps):
                 await self._execute_cycle_step(step, step_idx, volume)
-                await self.wait_for_hold()
+                await self.wait_for_hold()  # What does this wait do?
 
     async def cycle_temperatures(self,
                                  steps: List[types.ThermocyclerStep],
@@ -201,12 +204,20 @@ class Thermocycler(mod_abc.AbstractModule):
         while self.status != 'holding at target':
             await asyncio.sleep(0.1)
 
-    async def wait_for_hold(self):
+    async def wait_for_hold(self, hold_time=0):
         """
         This method returns only when hold time has elapsed
         """
-        while self.hold_time != 0:
-            await asyncio.sleep(0.1)
+        # If hold time is within the HOLD_TIME_FUZZY_SECONDS time gap, then,
+        # because of the driver's status poller delays, it is impossible to
+        # know for certain if self.hold_time holds the most recent value.
+        # So instead of counting on the cached self.hold_time, it is better to
+        # just wait for hold_time time
+        if 0 < hold_time <= HOLD_TIME_FUZZY_SECONDS:
+            await asyncio.sleep(hold_time)
+        else:
+            while self.hold_time != 0:
+                await asyncio.sleep(0.1)
 
     @property
     def lid_target(self):

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from unittest import mock
 from opentrons.hardware_control import modules, ExecutionManager
 
@@ -141,6 +142,17 @@ async def test_set_temperature(monkeypatch, loop):
     await hw_tc.set_temperature(40, hold_time_minutes=5.5)
     set_temp_driver_mock.assert_called_once_with(temp=40,
                                                  hold_time=330,
+                                                 volume=None,
+                                                 ramp_rate=None)
+    set_temp_driver_mock.reset_mock()
+
+    # Test hold_time < HOLD_TIME_FUZZY_SECONDS
+    start = time.time()
+    await hw_tc.set_temperature(40, hold_time_seconds=2)
+    time_taken = time.time() - start
+    assert 1.9 < time_taken < 2.1
+    set_temp_driver_mock.assert_called_once_with(temp=40,
+                                                 hold_time=2,
                                                  volume=None,
                                                  ramp_rate=None)
     set_temp_driver_mock.reset_mock()


### PR DESCRIPTION
# Overview

Closes #6392 

# Changelog

- Thermocycler driver: modified the rule that checks if `hold_time` has been updated. It now checks if `hold_time` was *probably* updated, based on the closeness of `hold_time` value read to `hold_time` value set.
- Thermocycler HW control: updated `wait_for_hold` to account for the uncertainty introduced by above logic.

# Review requests

- Are there any edge cases you can think of that could break this logic?
- Is there a better way to make this fix? (without changing the firmware preferably)
- The driver tests that raise error are time-consuming since the error is raised after waiting for 5 seconds. Is there a way to minimize this delay? Or is it okay to let it take all that time?

### Another approach: 
Since a set_temperature function exits only when hold_time has turned 0, we can count on that behavior and only check if hold_time is non-zero for a new set_temperature. This will make things simpler but will cause a problem in the case where cached hold_time was somehow non-zero; but that should never happen if the api is used as intended, should it?


# Risk assessment

High for thermocycler since it touches a core function of the thermocycler