### PR TITLE
chore(build): bump required pipenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ clean-py:
 
 .PHONY: setup-py
 setup-py:
-	$(OT_PYTHON) -m pip install pipenv==2018.10.9
+	$(OT_PYTHON) -m pip install pipenv==2020.8.13
 	$(MAKE) -C $(API_DIR) setup
 	$(MAKE) -C $(UPDATE_SERVER_DIR) setup
 	$(MAKE) -C $(ROBOT_SERVER_DIR) setup

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,7 @@ module.exports = {
     '\\.(jpg|png|gif|svg|woff|woff2|webm)$':
       '@opentrons/components/src/__mocks__/file.js',
   },
+  modulePathIgnorePatterns: ['shared-data/python/**'],
   transformIgnorePatterns: ['/node_modules/(?!@opentrons/)'],
   collectCoverageFrom: [
     'app/src/**/*.js',

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,7 +16,7 @@ module.exports = {
     '\\.(jpg|png|gif|svg|woff|woff2|webm)$':
       '@opentrons/components/src/__mocks__/file.js',
   },
-  modulePathIgnorePatterns: ['shared-data/python/**'],
+  modulePathIgnorePatterns: ['/shared-data/python/.*'],
   transformIgnorePatterns: ['/node_modules/(?!@opentrons/)'],
   collectCoverageFrom: [
     'app/src/**/*.js',

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,7 +16,12 @@ module.exports = {
     '\\.(jpg|png|gif|svg|woff|woff2|webm)$':
       '@opentrons/components/src/__mocks__/file.js',
   },
-  modulePathIgnorePatterns: ['/shared-data/python/.*'],
+  modulePathIgnorePatterns: [
+    '/shared-data/python/.*',
+    '/api/.*',
+    '/robot-server/.*',
+    '/update-server/.*',
+  ],
   transformIgnorePatterns: ['/node_modules/(?!@opentrons/)'],
   collectCoverageFrom: [
     'app/src/**/*.js',


### PR DESCRIPTION
It would be really nice to have a modern pipenv, so let's see if it works.

## Testing
- See if you can still `make setup-py` with this version of pipenv
- See if you can change something in a `Pipfile` and then `pipenv update`