### PR TITLE
fix(app): cache robot releases manifest for offline usage

### DIFF
--- a/app-shell/src/buildroot/__tests__/release-files.test.js
+++ b/app-shell/src/buildroot/__tests__/release-files.test.js
@@ -33,6 +33,22 @@ describe('buildroot release files utilities', () => {
         })
     })
 
+    it('should leave support files alone', () => {
+      const dir = makeEmptyDir()
+      const releaseDir = path.join(dir, '4.0.0')
+      const releaseManifest = path.join(dir, 'releases.json')
+
+      return Promise.all([
+        fs.mkdir(releaseDir),
+        fse.writeJson(releaseManifest, { hello: 'world' }),
+      ])
+        .then(() => cleanupReleaseFiles(dir, '4.0.0'))
+        .then(() => fs.readdir(dir))
+        .then(files => {
+          expect(files).toEqual(['4.0.0', 'releases.json'])
+        })
+    })
+
     it('should delete other directories', () => {
       const dir = makeEmptyDir()
       const releaseDir = path.join(dir, '4.0.0')

--- a/app-shell/src/buildroot/__tests__/release-manifest.test.js
+++ b/app-shell/src/buildroot/__tests__/release-manifest.test.js
@@ -1,0 +1,57 @@
+// @flow
+import fse from 'fs-extra'
+import tempy from 'tempy'
+import * as Http from '../../http'
+import { downloadManifest } from '../release-manifest'
+
+jest.mock('../../http')
+
+const fetchJson: JestMockFn<[string], mixed> = Http.fetchJson
+
+describe('release manifest utilities', () => {
+  let manifestFile
+
+  beforeEach(() => {
+    manifestFile = tempy.file({ extension: 'json' })
+  })
+
+  afterEach(() => {
+    return fse.remove(manifestFile)
+  })
+
+  it('should download the manifest from a url', () => {
+    const result = { mockResult: true }
+    const manifestUrl = 'http://example.com/releases.json'
+
+    fetchJson.mockImplementation(url => {
+      if (url === manifestUrl) return Promise.resolve(result)
+    })
+
+    return expect(downloadManifest(manifestUrl, manifestFile)).resolves.toBe(
+      result
+    )
+  })
+
+  it('should save the manifest to the given path', () => {
+    const result = { mockResult: true }
+    const manifestUrl = 'http://example.com/releases.json'
+
+    fetchJson.mockResolvedValue(result)
+
+    return downloadManifest(manifestUrl, manifestFile)
+      .then(() => fse.readJson(manifestFile))
+      .then(file => expect(file).toEqual(result))
+  })
+
+  it('should pull the manifest from the file if the manifest download fails', () => {
+    const manifest = { mockResult: true }
+    const manifestUrl = 'http://example.com/releases.json'
+
+    fse.writeJsonSync(manifestFile, manifest)
+    fetchJson.mockRejectedValue(new Error('AH'))
+
+    return downloadManifest(manifestUrl, manifestFile).then(result =>
+      expect(result).toEqual(manifest)
+    )
+  })
+})

--- a/app-shell/src/buildroot/release-files.js
+++ b/app-shell/src/buildroot/release-files.js
@@ -129,11 +129,11 @@ export function cleanupReleaseFiles(
   downloadsDir: string,
   currentRelease: string
 ): void {
-  return readdir(downloadsDir)
+  return readdir(downloadsDir, { withFileTypes: true })
     .then(files => {
       return files
-        .filter(f => f !== currentRelease)
-        .map(f => path.join(downloadsDir, f))
+        .filter(f => f.isDirectory() && f.name !== currentRelease)
+        .map(f => path.join(downloadsDir, f.name))
     })
     .then(removals => Promise.all(removals.map(f => remove(f))))
 }

--- a/app-shell/src/buildroot/release-manifest.js
+++ b/app-shell/src/buildroot/release-manifest.js
@@ -1,13 +1,18 @@
 // @flow
 // functions and utilities for retrieving the releases manifest
+import fse from 'fs-extra'
 import { fetchJson } from '../http'
 import type { ReleaseManifest, ReleaseSetUrls } from './types'
 
-// TODO(mc, 2019-07-02): cache downloaded manifest
 export function downloadManifest(
-  manifestUrl: string
+  manifestUrl: string,
+  cacheFilePath: string
 ): Promise<ReleaseManifest> {
   return fetchJson(manifestUrl)
+    .then(result => {
+      return fse.writeJson(cacheFilePath, result).then(() => result)
+    })
+    .catch(() => fse.readJson(cacheFilePath))
 }
 
 // TODO(mc, 2019-07-02): retrieve something other than "production"


### PR DESCRIPTION
# Overview

Companion PR to #6483. This PR adds functionality to the app to cache the Robot OS releases manifest (`releases.json`) to the filesystem so that the app can know about robot updates (most importantly, robot updates it has already downloaded to disk) even if the app is not instantaneously online.

Fixes #5992

# Changelog

- fix(app): cache robot releases manifest for offline usage

# Review requests

Smoke test:

1. Get a robot (or dev server) to report that it is out of date
    - With the dev server, manually mess with `api/src/opentrons/package.json::version`
2. Open the Opentrons App with your computer connected to internet
    - The app should report that the robot needs to be updated
3. Close the app and disable your computer's internet
4. Re-open the app
    - The app should still report that the robot needs to be updated

# Risk assessment

Please give the tests a look and let me know if there seems to be any cases missing. This PR needs a robot update + Balena robot migration smoke test before merge
