### PR TITLE
refactor(robot-server): use camel case for http params

### DIFF
--- a/robot-server/robot_server/service/protocol/router.py
+++ b/robot-server/robot_server/service/protocol/router.py
@@ -21,15 +21,15 @@ router = APIRouter()
              response_model=route_models.ProtocolResponse,
              status_code=http_status_codes.HTTP_201_CREATED)
 async def create_protocol(
-        protocol_file: UploadFile = File(..., description="The protocol file"),
-        support_files: typing.List[UploadFile] = Body(
+        protocolFile: UploadFile = File(..., description="The protocol file"),
+        supportFiles: typing.List[UploadFile] = Body(
             default=list(),
             description="Any support files needed by the protocol (ie data "
                         "files, additional python files)"),
         protocol_manager=Depends(get_protocol_manager)):
     """Create protocol from proto file plus optional support files"""
-    new_proto = protocol_manager.create(protocol_file=protocol_file,
-                                        support_files=support_files,)
+    new_proto = protocol_manager.create(protocol_file=protocolFile,
+                                        support_files=supportFiles,)
     return route_models.ProtocolResponse(data=_to_response(new_proto))
 
 
@@ -44,38 +44,38 @@ async def get_protocols(
     )
 
 
-@router.get("/protocols/{protocol_id}",
+@router.get("/protocols/{protocolId}",
             description="Get a protocol",
             response_model_exclude_unset=True,
             response_model=route_models.ProtocolResponse)
 async def get_protocol(
-        protocol_id: str,
+        protocolId: str,
         protocol_manager: ProtocolManager = Depends(get_protocol_manager)):
-    proto = protocol_manager.get(protocol_id)
+    proto = protocol_manager.get(protocolId)
     return route_models.ProtocolResponse(data=_to_response(proto))
 
 
-@router.delete("/protocols/{protocol_id}",
+@router.delete("/protocols/{protocolId}",
                description="Delete a protocol",
                response_model_exclude_unset=True,
                response_model=route_models.ProtocolResponse)
 async def delete_protocol(
-        protocol_id: str,
+        protocolId: str,
         protocol_manager: ProtocolManager = Depends(get_protocol_manager)):
-    proto = protocol_manager.remove(protocol_id)
+    proto = protocol_manager.remove(protocolId)
     return route_models.ProtocolResponse(data=_to_response(proto))
 
 
-@router.post("/protocols/{protocol_id}",
+@router.post("/protocols/{protocolId}",
              description="Add a file to protocol",
              response_model_exclude_unset=True,
              response_model=route_models.ProtocolResponse,
              status_code=http_status_codes.HTTP_201_CREATED)
 async def create_protocol_file(
-        protocol_id: str,
+        protocolId: str,
         file: UploadFile = File(...),
         protocol_manager: ProtocolManager = Depends(get_protocol_manager)):
-    proto = protocol_manager.get(protocol_id)
+    proto = protocol_manager.get(protocolId)
     proto.add(file)
     return route_models.ProtocolResponse(data=_to_response(proto))
 

--- a/robot-server/robot_server/service/session/router.py
+++ b/robot-server/robot_server/service/session/router.py
@@ -63,17 +63,17 @@ async def create_session_handler(
     )
 
 
-@router.delete("/sessions/{session_id}",
+@router.delete("/sessions/{sessionId}",
                description="Delete a session",
                response_model_exclude_unset=True,
                response_model=route_models.SessionResponse)
 async def delete_session_handler(
-        session_id: route_models.IdentifierType,
+        sessionId: route_models.IdentifierType,
         session_manager: SessionManager = Depends(get_session_manager)) \
         -> route_models.SessionResponse:
     """Delete a session"""
     session_obj = get_session(manager=session_manager,
-                              session_id=session_id,
+                              session_id=sessionId,
                               api_router=router)
 
     await session_manager.remove(session_obj.meta.identifier)
@@ -81,7 +81,7 @@ async def delete_session_handler(
     return route_models.SessionResponse(
         data=ResponseDataModel.create(
             attributes=session_obj.get_response_model(),
-            resource_id=session_id),
+            resource_id=sessionId),
         links={
             "POST": ResourceLink(href=router.url_path_for(
                 create_session_handler.__name__)),
@@ -89,23 +89,23 @@ async def delete_session_handler(
     )
 
 
-@router.get("/sessions/{session_id}",
+@router.get("/sessions/{sessionId}",
             description="Get session",
             response_model_exclude_unset=True,
             response_model=route_models.SessionResponse)
 async def get_session_handler(
-        session_id: route_models.IdentifierType,
+        sessionId: route_models.IdentifierType,
         session_manager: SessionManager = Depends(get_session_manager))\
         -> route_models.SessionResponse:
     session_obj = get_session(manager=session_manager,
-                              session_id=session_id,
+                              session_id=sessionId,
                               api_router=router)
 
     return route_models.SessionResponse(
         data=ResponseDataModel.create(
             attributes=session_obj.get_response_model(),
-            resource_id=session_id),
-        links=get_valid_session_links(session_id, router)
+            resource_id=sessionId),
+        links=get_valid_session_links(sessionId, router)
     )
 
 
@@ -129,12 +129,12 @@ async def get_sessions_handler(
     )
 
 
-@router.post("/sessions/{session_id}/commands/execute",
+@router.post("/sessions/{sessionId}/commands/execute",
              description="Create and execute a command immediately",
              response_model_exclude_unset=True,
              response_model=route_models.CommandResponse)
 async def session_command_execute_handler(
-        session_id: route_models.IdentifierType,
+        sessionId: route_models.IdentifierType,
         command_request: route_models.CommandRequest,
         session_manager: SessionManager = Depends(get_session_manager),
 ) -> route_models.CommandResponse:
@@ -142,11 +142,11 @@ async def session_command_execute_handler(
     Execute a session command
     """
     session_obj = get_session(manager=session_manager,
-                              session_id=session_id,
+                              session_id=sessionId,
                               api_router=router)
     if not session_manager.is_active(session_obj.meta.identifier):
         raise CommandExecutionException(
-            reason=f"Session '{session_id}' is not active. "
+            reason=f"Session '{sessionId}' is not active. "
                    "Only the active session can execute commands")
 
     command = create_command(command_request.data.attributes.command,
@@ -166,7 +166,7 @@ async def session_command_execute_handler(
             ),
             resource_id=command_result.meta.identifier
         ),
-        links=get_valid_session_links(session_id, router)
+        links=get_valid_session_links(sessionId, router)
     )
 
 
@@ -177,11 +177,11 @@ def get_valid_session_links(session_id: route_models.IdentifierType,
     return {
         "GET": ResourceLink(href=api_router.url_path_for(
             get_session_handler.__name__,
-            session_id=session_id)),
+            sessionId=session_id)),
         "POST": ResourceLink(href=api_router.url_path_for(
             session_command_execute_handler.__name__,
-            session_id=session_id)),
+            sessionId=session_id)),
         "DELETE": ResourceLink(href=api_router.url_path_for(
             delete_session_handler.__name__,
-            session_id=session_id)),
+            sessionId=session_id)),
     }

--- a/robot-server/tests/integration/protocols/test_protocol_upload.tavern.yaml
+++ b/robot-server/tests/integration/protocols/test_protocol_upload.tavern.yaml
@@ -9,8 +9,8 @@ stages:
       url: "{host:s}:{port:d}/protocols"
       method: POST
       files:
-        protocol_file: "tests/integration/protocols/phony_proto.py"
-        support_files: "tests/integration/protocols/data.csv"
+        protocolFile: "tests/integration/protocols/phony_proto.py"
+        supportFiles: "tests/integration/protocols/data.csv"
     response:
       status_code: 201
       json: &response
@@ -57,7 +57,7 @@ stages:
       url: "{host:s}:{port:d}/protocols"
       method: POST
       files:
-        protocol_file: "tests/integration/protocols/phony_proto.py"
+        protocolFile: "tests/integration/protocols/phony_proto.py"
     response:
       status_code: 201
       json:

--- a/robot-server/tests/integration/sessions/test_protocol.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_protocol.tavern.yaml
@@ -33,7 +33,7 @@ stages:
       url: "{host:s}:{port:d}/protocols"
       method: POST
       files:
-        protocol_file: "tests/integration/protocols/phony_proto.py"
+        protocolFile: "tests/integration/protocols/phony_proto.py"
     response:
       save:
         json:
@@ -75,7 +75,7 @@ stages:
       url: "{host:s}:{port:d}/protocols"
       method: POST
       files:
-        protocol_file: "tests/integration/protocols/phony_proto.py"
+        protocolFile: "tests/integration/protocols/phony_proto.py"
     response:
       save:
         json:


### PR DESCRIPTION
# Overview

There are instances where we are still using snake case in HTTP parameters when we should be using camel case.

# Risk assessment

None