### PR TITLE
fix(app): sync robot time with app time on connect

### DIFF
--- a/app/src/robot-admin/__fixtures__/index.js
+++ b/app/src/robot-admin/__fixtures__/index.js
@@ -2,6 +2,8 @@
 // mock HTTP responses for pipettes endpoints
 import { mockRobot } from '../../robot-api/__fixtures__'
 
+export * from './system-time'
+
 export const mockRestartSuccess = {
   host: mockRobot,
   method: 'POST',

--- a/app/src/robot-admin/__fixtures__/system-time.js
+++ b/app/src/robot-admin/__fixtures__/system-time.js
@@ -1,0 +1,35 @@
+// @flow
+import { GET } from '../../robot-api'
+import { SYSTEM_TIME_PATH } from '../constants'
+import {
+  makeResponseFixtures,
+  mockFailureBody,
+} from '../../robot-api/__fixtures__'
+
+import type { SystemTimeData, SystemTimeAttributes } from '../api-types'
+import type { ResponseFixtures } from '../../robot-api/__fixtures__'
+
+export const mockSystemTimeAttributes: SystemTimeAttributes = {
+  systemTime: '2020-09-08T18:02:01.318292+00:00',
+}
+
+export const {
+  successMeta: mockFetchSystemTimeSuccessMeta,
+  failureMeta: mockFetchSystemTimeFailureMeta,
+  success: mockFetchSystemTimeSuccess,
+  failure: mockFetchSystemTimeFailure,
+}: ResponseFixtures<
+  SystemTimeData,
+  {| message: string |}
+> = makeResponseFixtures({
+  method: GET,
+  path: SYSTEM_TIME_PATH,
+  successStatus: 200,
+  successBody: {
+    id: 'time',
+    type: 'SystemTimeAttributes',
+    attributes: mockSystemTimeAttributes,
+  },
+  failureStatus: 500,
+  failureBody: mockFailureBody,
+})

--- a/app/src/robot-admin/api-types.js
+++ b/app/src/robot-admin/api-types.js
@@ -1,0 +1,13 @@
+// @flow
+
+export type SystemTimeAttributes = {
+  systemTime: string,
+  ...
+}
+
+export type SystemTimeData = {
+  id: 'time',
+  type: 'SystemTimeAttributes',
+  attributes: SystemTimeAttributes,
+  ...
+}

--- a/app/src/robot-admin/constants.js
+++ b/app/src/robot-admin/constants.js
@@ -43,3 +43,5 @@ export const RESET_CONFIG_PATH: '/settings/reset' = '/settings/reset'
 
 export const RESET_CONFIG_OPTIONS_PATH: '/settings/reset/options' =
   '/settings/reset/options'
+
+export const SYSTEM_TIME_PATH: '/system/time' = '/system/time'

--- a/app/src/robot-admin/epic/__tests__/syncTimeOnConnectEpic.test.js
+++ b/app/src/robot-admin/epic/__tests__/syncTimeOnConnectEpic.test.js
@@ -112,7 +112,7 @@ describe('syncTimeOnConnectEpic', () => {
 
   it('should not try to update time if off by less than a minute', () => {
     const mocks = setupEpicTestMocks(
-      robotName => (RobotActions.connect(robotName): any),
+      createConnectAction,
       createTimeSuccessResponse(subSeconds(new Date(), 55))
     )
 

--- a/app/src/robot-admin/epic/__tests__/syncTimeOnConnectEpic.test.js
+++ b/app/src/robot-admin/epic/__tests__/syncTimeOnConnectEpic.test.js
@@ -1,0 +1,93 @@
+// @flow
+import { cloneDeep, set, get } from 'lodash'
+import { subSeconds, differenceInSeconds, parseISO } from 'date-fns'
+import { EMPTY } from 'rxjs'
+
+import { setupEpicTestMocks, runEpicTest } from '../../../robot-api/__utils__'
+import { GET, PUT } from '../../../robot-api'
+import { actions as RobotActions } from '../../../robot'
+import { mockFetchSystemTimeSuccess } from '../../__fixtures__'
+import { robotAdminEpic } from '..'
+
+describe('syncTimeOnConnectEpic', () => {
+  const makeTimeResponse = (time: Date) => {
+    const response = cloneDeep(mockFetchSystemTimeSuccess)
+    set(response, 'body.data.attributes.systemTime', time.toISOString())
+    return response
+  }
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it("should fetch the robot's time on connect request", () => {
+    const mocks = setupEpicTestMocks(
+      robotName => (RobotActions.connect(robotName): any),
+      makeTimeResponse(new Date())
+    )
+
+    runEpicTest(mocks, ({ hot, expectObservable, flush }) => {
+      const action$ = hot('--a', { a: mocks.action })
+      const state$ = hot('s-s', { s: mocks.state })
+      const output$ = robotAdminEpic(action$, state$)
+
+      expectObservable(output$)
+      flush()
+
+      expect(mocks.fetchRobotApi).toHaveBeenCalledTimes(1)
+      expect(mocks.fetchRobotApi).toHaveBeenCalledWith(mocks.robot, {
+        method: 'GET',
+        path: '/system/time',
+      })
+    })
+  })
+
+  it('should update time if off by more than a minute', () => {
+    const mocks = setupEpicTestMocks(
+      robotName => (RobotActions.connect(robotName): any)
+    )
+
+    runEpicTest(mocks, ({ hot, cold, expectObservable, flush }) => {
+      mocks.fetchRobotApi.mockImplementation((robot, request) => {
+        if (request.method === GET) {
+          const robotDate = subSeconds(new Date(), 61)
+          return cold('r', { r: makeTimeResponse(robotDate) })
+        }
+
+        if (request.method === PUT) {
+          return cold('r', { r: makeTimeResponse(new Date()) })
+        }
+
+        return EMPTY
+      })
+
+      const action$ = hot('--a', { a: mocks.action })
+      const state$ = hot('s-s', { s: mocks.state })
+      const output$ = robotAdminEpic(action$, state$)
+
+      expectObservable(output$, '---')
+      flush()
+
+      expect(mocks.fetchRobotApi).toHaveBeenCalledTimes(2)
+      expect(mocks.fetchRobotApi).toHaveBeenNthCalledWith(2, mocks.robot, {
+        method: 'PUT',
+        path: '/system/time',
+        body: {
+          data: {
+            type: 'SystemTimeAttributes',
+            attributes: { systemTime: expect.any(String) },
+          },
+        },
+      })
+
+      const updatedTime = get(
+        mocks.fetchRobotApi.mock.calls[1][1],
+        'body.data.attributes.systemTime'
+      )
+
+      expect(
+        Math.abs(differenceInSeconds(new Date(), parseISO(updatedTime)))
+      ).toBe(0)
+    })
+  })
+})

--- a/app/src/robot-admin/epic/index.js
+++ b/app/src/robot-admin/epic/index.js
@@ -5,6 +5,8 @@ import { combineEpics } from 'redux-observable'
 import { restartEpic, startDiscoveryOnRestartEpic } from './restartEpic'
 import { fetchResetOptionsEpic } from './fetchResetOptionsEpic'
 import { resetConfigEpic, restartOnResetConfigEpic } from './resetConfigEpic'
+import { syncTimeOnConnectEpic } from './syncTimeOnConnectEpic'
+
 import type { Epic } from '../../types'
 
 export const robotAdminEpic: Epic = combineEpics(
@@ -12,5 +14,6 @@ export const robotAdminEpic: Epic = combineEpics(
   startDiscoveryOnRestartEpic,
   fetchResetOptionsEpic,
   resetConfigEpic,
-  restartOnResetConfigEpic
+  restartOnResetConfigEpic,
+  syncTimeOnConnectEpic
 )

--- a/app/src/robot-admin/epic/syncTimeOnConnectEpic.js
+++ b/app/src/robot-admin/epic/syncTimeOnConnectEpic.js
@@ -1,0 +1,60 @@
+// @flow
+import { ofType } from 'redux-observable'
+import { filter, map, switchMap, ignoreElements } from 'rxjs/operators'
+import { parseISO, differenceInSeconds } from 'date-fns'
+
+import { GET, PUT, fetchRobotApi } from '../../robot-api'
+import { withRobotHost } from '../../robot-api/operators'
+import * as Constants from '../constants'
+
+import type { Epic } from '../../types'
+import type { RobotApiRequestOptions } from '../../robot-api/types'
+import type { ConnectAction } from '../../robot/actions'
+
+const SYNC_THRESHOLD_SEC = 60
+
+const mapActionToFetchRequest = (
+  action: ConnectAction
+): RobotApiRequestOptions => {
+  return { method: GET, path: Constants.SYSTEM_TIME_PATH }
+}
+
+const createUpdateRequest = (date: Date): RobotApiRequestOptions => {
+  return {
+    method: PUT,
+    path: Constants.SYSTEM_TIME_PATH,
+    body: {
+      data: {
+        type: 'SystemTimeAttributes',
+        attributes: { systemTime: date.toISOString() },
+      },
+    },
+  }
+}
+
+export const syncTimeOnConnectEpic: Epic = (action$, state$) => {
+  return action$.pipe(
+    ofType('robot:CONNECT'),
+    withRobotHost(state$, action => action.payload.name),
+    // TODO(mc, 2020-09-08): only fetch if health.links.systemTime exists,
+    // see TODO in robot-server/robot_server/service/legacy/models/health.py
+    switchMap(([action, state, robot]) => {
+      const fetchSystemTimeReq = mapActionToFetchRequest(action)
+
+      return fetchRobotApi(robot, fetchSystemTimeReq).pipe(
+        filter(response => response.ok),
+        map(response => response.body.data.attributes.systemTime),
+        filter(systemTimeString => {
+          const systemTime = parseISO(systemTimeString)
+          const drift = differenceInSeconds(systemTime, new Date())
+          return Math.abs(drift) > SYNC_THRESHOLD_SEC
+        }),
+        switchMap(() => {
+          const updateSystemTimeReq = createUpdateRequest(new Date())
+          return fetchRobotApi(robot, updateSystemTimeReq)
+        })
+      )
+    }),
+    ignoreElements()
+  )
+}

--- a/app/src/robot-api/__utils__/epic-test-mocks.js
+++ b/app/src/robot-api/__utils__/epic-test-mocks.js
@@ -43,7 +43,7 @@ export type EpicTestMocks<A, R> = {|
  * @returns {EpicTestMocks}
  */
 export const setupEpicTestMocks = <
-  A: { meta: { requestId: string } },
+  A: { meta: { requestId: string, ... }, ... },
   R: RobotApiResponse
 >(
   makeTriggerAction: (robotName: string) => A,

--- a/app/src/robot-api/constants.js
+++ b/app/src/robot-api/constants.js
@@ -2,6 +2,7 @@
 
 export const GET: 'GET' = 'GET'
 export const POST: 'POST' = 'POST'
+export const PUT: 'PUT' = 'PUT'
 export const PATCH: 'PATCH' = 'PATCH'
 export const DELETE: 'DELETE' = 'DELETE'
 

--- a/app/src/robot-api/types.js
+++ b/app/src/robot-api/types.js
@@ -1,7 +1,7 @@
 // @flow
 import typeof { PENDING, SUCCESS, FAILURE } from './constants'
 
-export type Method = 'GET' | 'POST' | 'PATCH' | 'DELETE'
+export type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 
 // api call + response types
 

--- a/robot-server/robot_server/service/legacy/models/health.py
+++ b/robot-server/robot_server/service/legacy/models/health.py
@@ -2,6 +2,7 @@ import typing
 from pydantic import BaseModel, Field
 
 
+# TODO(mc, 2020-09-08): add systemTime to health links
 class Links(BaseModel):
     """A set of useful links"""
     apiLog: str = \


### PR DESCRIPTION
# Overview

This PR wires the app up to the time endpoints added in #6403. When the app requests to connect over RPC, it will also hit `GET /system/time` and, if the time is mismatched by more than 60 seconds, the app will send a `PUT /system/time` request to get things sync'd.

Closes #3872

# Changelog

- feat(app): sync robot time with app time on connect

# Review requests

Smoke test:

0. Ensure your robot is running software that includes the time endpoints added in #6403
1. SSH into your robot and mess up the time
    1. `systemctl disable systemd-timesyncd`
    2. `date -s 10:10`
2. Open the Opentrons App
3. Click the connect toggle or button
    - [ ] `GET /system/time` request goes out
    - [ ] `PUT /system/time` request goes out
    - [ ] `date` in the robot's terminal reports the same time (in UTC) as your computer
4. Disconnect and connect again
    - [ ] `GET /system/time` request went out
    - [ ] `PUT /system/time` request **does not** go out because time is already synced

# Risk assessment

Medium low. Thoughts + notes:

- Time is a funny thing to mess with
- If `timesyncd` is running and the robot has NTP access, the NTP time will be reasserted quite quickly
    - The app only attempts to sync at connect, so we won't get into an edit war with the system time
- If the robot is on an older software version, `GET /system/time` will 404
    - The app will only try to send the `PUT` if the `GET` succeeds
    - We could (should?) add `systemTime` to the health links so we can check capabilities ahead of time
    - Until then, the 404 will show up in the logs like it does when the app tries to fetch calibration data from out of date robots
