### PR TITLE
docs: fix indent in code-block directives

### DIFF
--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -307,21 +307,21 @@ For example:
 .. code-block:: python
     :substitutions:
 
-   from opentrons import types
+    from opentrons import types
 
-   metadata = {'apiLevel': '|apiLevel|'}
+    metadata = {'apiLevel': '|apiLevel|'}
 
-   def run(protocol):
-        plate = protocol.load_labware(
-           'corning_24_wellplate_3.4ml_flat', slot='1')
+    def run(protocol):
+            plate = protocol.load_labware(
+            'corning_24_wellplate_3.4ml_flat', slot='1')
 
-        # Get the center of well A1.
-        center_location = plate['A1'].center()
+            # Get the center of well A1.
+            center_location = plate['A1'].center()
 
-        # Get a location 1 mm right, 1 mm back, and 1 mm up from the center of well A1.
-        adjusted_location = center_location.move(types.Point(x=1, y=1, z=1))
+            # Get a location 1 mm right, 1 mm back, and 1 mm up from the center of well A1.
+            adjusted_location = center_location.move(types.Point(x=1, y=1, z=1))
 
-        # Move to 1 mm right, 1 mm back, and 1 mm up from the center of well A1.
-        pipette.move_to(adjusted_location)
+            # Move to 1 mm right, 1 mm back, and 1 mm up from the center of well A1.
+            pipette.move_to(adjusted_location)
 
 .. versionadded:: 2.0

--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -312,16 +312,16 @@ For example:
     metadata = {'apiLevel': '|apiLevel|'}
 
     def run(protocol):
-            plate = protocol.load_labware(
-            'corning_24_wellplate_3.4ml_flat', slot='1')
+        plate = protocol.load_labware(
+        'corning_24_wellplate_3.4ml_flat', slot='1')
 
-            # Get the center of well A1.
-            center_location = plate['A1'].center()
+        # Get the center of well A1.
+        center_location = plate['A1'].center()
 
-            # Get a location 1 mm right, 1 mm back, and 1 mm up from the center of well A1.
-            adjusted_location = center_location.move(types.Point(x=1, y=1, z=1))
+        # Get a location 1 mm right, 1 mm back, and 1 mm up from the center of well A1.
+        adjusted_location = center_location.move(types.Point(x=1, y=1, z=1))
 
-            # Move to 1 mm right, 1 mm back, and 1 mm up from the center of well A1.
-            pipette.move_to(adjusted_location)
+        # Move to 1 mm right, 1 mm back, and 1 mm up from the center of well A1.
+        pipette.move_to(adjusted_location)
 
 .. versionadded:: 2.0

--- a/api/docs/v2/writing.rst
+++ b/api/docs/v2/writing.rst
@@ -163,10 +163,10 @@ In your Jupyter notebook, you can use the Python Protocol API simulator by doing
 .. code-block:: python
    :substitutions:
 
-    from opentrons import simulate
-    protocol = simulate.get_protocol_api('|apiLevel|')
-    p300 = protocol.load_instrument('p300_single', 'right')
-    ...
+   from opentrons import simulate
+   protocol = simulate.get_protocol_api('|apiLevel|')
+   p300 = protocol.load_instrument('p300_single', 'right')
+   # ...
 
 The ``protocol`` object, which is an instance of :py:class:`.ProtocolContext`, is the same thing that gets passed to your protocol's ``run`` function, but set to simulate rather than control an OT-2. You can call all your protocol's functions on that object.
 

--- a/api/docs/v2/writing.rst
+++ b/api/docs/v2/writing.rst
@@ -161,12 +161,12 @@ Using Jupyter
 In your Jupyter notebook, you can use the Python Protocol API simulator by doing
 
 .. code-block:: python
-   :substitutions:
+    :substitutions:
 
-   from opentrons import simulate
-   protocol = simulate.get_protocol_api('|apiLevel|')
-   p300 = protocol.load_instrument('p300_single', 'right')
-   # ...
+    from opentrons import simulate
+    protocol = simulate.get_protocol_api('|apiLevel|')
+    p300 = protocol.load_instrument('p300_single', 'right')
+    # ...
 
 The ``protocol`` object, which is an instance of :py:class:`.ProtocolContext`, is the same thing that gets passed to your protocol's ``run`` function, but set to simulate rather than control an OT-2. You can call all your protocol's functions on that object.
 


### PR DESCRIPTION
# Overview

reST syntax for `.. code-block` directives requires the code to be at the same indent as the options. When code block substitutions were introduced per #6292, the convention used a 4 space indent for the `:substitutions:` option. These two code blocks did not get the proper indentation.

Since the example code had a 3 space indent and the option had a 4 space indent, the mismatch caused Sphinx to see the `.. code-block` in the `move_to()` example as empty.

Closes #6506 

# Risk assessment

none, docs only