### PR TITLE
refactor(robot-server): add time link to /health, refactor system/time links

### DIFF
--- a/robot-server/robot_server/service/errors.py
+++ b/robot-server/robot_server/service/errors.py
@@ -154,7 +154,7 @@ class CommonErrorDef(ErrorDef):
     NOT_IMPLEMENTED = ErrorCreateDef(
         status_code=status_codes.HTTP_501_NOT_IMPLEMENTED,
         title='Not implemented',
-        format_string='Method not implemented')
+        format_string='Method not implemented. {error}')
     RESOURCE_NOT_FOUND = ErrorCreateDef(
         status_code=status_codes.HTTP_404_NOT_FOUND,
         title='Resource Not Found',

--- a/robot-server/robot_server/service/legacy/models/health.py
+++ b/robot-server/robot_server/service/legacy/models/health.py
@@ -13,6 +13,9 @@ class Links(BaseModel):
     apiSpec: str = \
         Field(...,
               description="The URI to this API specification")
+    systemTime: str = \
+        Field(...,
+              description="The URI for system time information")
 
 
 class Health(BaseModel):
@@ -60,7 +63,8 @@ class Health(BaseModel):
                   "links": {
                     "apiLog": "/logs/api.log",
                     "serialLog": "/logs/serial.log",
-                    "apiSpec": "/openapi.json"
+                    "apiSpec": "/openapi.json",
+                    "systemTime": "/system/time"
                   }
                 }
         }

--- a/robot-server/robot_server/service/legacy/routers/health.py
+++ b/robot-server/robot_server/service/legacy/routers/health.py
@@ -47,5 +47,6 @@ async def get_health(
                   links=Links(
                       apiLog='/logs/api.log',
                       serialLog='/logs/serial.log',
-                      apiSpec="/openapi.json"
+                      apiSpec="/openapi.json",
+                      systemTime="/system/time"
                   ))

--- a/robot-server/robot_server/service/system/models.py
+++ b/robot-server/robot_server/service/system/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from robot_server.service.json_api import ResponseModel, ResponseDataModel, \
     RequestDataModel, RequestModel
@@ -7,13 +7,6 @@ from robot_server.service.json_api import ResponseModel, ResponseDataModel, \
 
 class SystemTimeAttributes(BaseModel):
     systemTime: datetime
-
-
-class SystemTimeLinks(BaseModel):
-    """A set of useful links"""
-    systemTime: str = \
-        Field(...,
-              description="The URI for system time information")
 
 
 SystemTimeResponseDataModel = ResponseDataModel[SystemTimeAttributes]

--- a/robot-server/robot_server/service/system/models.py
+++ b/robot-server/robot_server/service/system/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from robot_server.service.json_api import ResponseModel, ResponseDataModel, \
     RequestDataModel, RequestModel
@@ -7,6 +7,13 @@ from robot_server.service.json_api import ResponseModel, ResponseDataModel, \
 
 class SystemTimeAttributes(BaseModel):
     systemTime: datetime
+
+
+class SystemTimeLinks(BaseModel):
+    """A set of useful links"""
+    systemTime: str = \
+        Field(...,
+              description="The URI for system time information")
 
 
 SystemTimeResponseDataModel = ResponseDataModel[SystemTimeAttributes]

--- a/robot-server/robot_server/service/system/router.py
+++ b/robot-server/robot_server/service/system/router.py
@@ -22,15 +22,8 @@ def _create_response(dt: datetime) \
             ),
             resource_id="time"
         ),
-        links=_get_valid_time_links(router)
+        links={'self': '/system/time'}
     )
-
-
-def _get_valid_time_links(api_router: APIRouter) \
-        -> time_models.SystemTimeLinks:
-    """ Get valid links for time resource"""
-    return time_models.SystemTimeLinks(systemTime=api_router.url_path_for(
-            get_time.__name__))
 
 
 @router.get("/system/time",

--- a/robot-server/robot_server/service/system/router.py
+++ b/robot-server/robot_server/service/system/router.py
@@ -2,9 +2,7 @@ import logging
 from datetime import datetime
 from fastapi import APIRouter
 from robot_server.system import time
-from typing import Dict
 from robot_server.service.system import models as time_models
-from robot_server.service.json_api import ResourceLink
 
 router = APIRouter()
 log = logging.getLogger(__name__)
@@ -28,14 +26,11 @@ def _create_response(dt: datetime) \
     )
 
 
-def _get_valid_time_links(api_router: APIRouter) -> Dict[str, ResourceLink]:
+def _get_valid_time_links(api_router: APIRouter) \
+        -> time_models.SystemTimeLinks:
     """ Get valid links for time resource"""
-    return {
-        "GET": ResourceLink(href=api_router.url_path_for(
-            get_time.__name__)),
-        "PUT": ResourceLink(href=api_router.url_path_for(
-            set_time.__name__))
-    }
+    return time_models.SystemTimeLinks(systemTime=api_router.url_path_for(
+            get_time.__name__))
 
 
 @router.get("/system/time",

--- a/robot-server/robot_server/system/errors.py
+++ b/robot-server/robot_server/system/errors.py
@@ -1,4 +1,5 @@
-from robot_server.service.errors import RobotServerError, CommonErrorDef
+from robot_server.service.errors import RobotServerError, \
+                                        CommonErrorDef, ErrorDef
 
 
 class SystemException(RobotServerError):
@@ -18,6 +19,8 @@ class SystemTimeAlreadySynchronized(SystemException):
 
 class SystemSetTimeException(SystemException):
     """Server process Failure"""
-    def __init__(self, msg: str):
-        super().__init__(definition=CommonErrorDef.INTERNAL_SERVER_ERROR,
+    def __init__(self, msg: str, definition: ErrorDef = None):
+        if definition is None:
+            definition = CommonErrorDef.INTERNAL_SERVER_ERROR
+        super().__init__(definition=definition,
                          error=msg)

--- a/robot-server/robot_server/system/time.py
+++ b/robot-server/robot_server/system/time.py
@@ -3,7 +3,9 @@ import logging
 from typing import Dict, Tuple, Union
 from datetime import datetime, timezone
 from opentrons.util.helpers import utc_now
+from opentrons.config import IS_ROBOT
 from robot_server.system import errors
+from robot_server.service.errors import CommonErrorDef
 
 log = logging.getLogger(__name__)
 
@@ -47,6 +49,10 @@ async def _set_time(time: str,
     :return: tuple of output of date --set (usually the new date)
         & error, if any.
     """
+    if not IS_ROBOT:
+        raise errors.SystemSetTimeException(
+            msg="Not supported on dev server.",
+            definition=CommonErrorDef.NOT_IMPLEMENTED)
     proc = await asyncio.create_subprocess_shell(
         f'date --utc --set \"{time}\"',
         stdout=asyncio.subprocess.PIPE,

--- a/robot-server/robot_server/system/time.py
+++ b/robot-server/robot_server/system/time.py
@@ -49,10 +49,6 @@ async def _set_time(time: str,
     :return: tuple of output of date --set (usually the new date)
         & error, if any.
     """
-    if not IS_ROBOT:
-        raise errors.SystemSetTimeException(
-            msg="Not supported on dev server.",
-            definition=CommonErrorDef.NOT_IMPLEMENTED)
     proc = await asyncio.create_subprocess_shell(
         f'date --utc --set \"{time}\"',
         stdout=asyncio.subprocess.PIPE,
@@ -79,6 +75,11 @@ async def set_system_time(new_time_dt: datetime,
     Raise error with message, if any.
     :return: current date read.
     """
+    if not IS_ROBOT:
+        raise errors.SystemSetTimeException(
+            msg="Not supported on dev server.",
+            definition=CommonErrorDef.NOT_IMPLEMENTED)
+
     status = await _time_status(loop)
     if status.get('LocalRTC') is True or status.get('NTPSynchronized') is True:
         # TODO: Update this to handle RTC sync correctly once we introduce RTC

--- a/robot-server/tests/integration/system/test_system_time.tavern.yaml
+++ b/robot-server/tests/integration/system/test_system_time.tavern.yaml
@@ -17,7 +17,7 @@ stages:
           id: 'time'
           type: 'SystemTimeAttributes'
         links:
-          systemTime: '/system/time'
+          self: '/system/time'
         meta: null
 
 ---
@@ -44,3 +44,20 @@ stages:
             detail: "field required"
             source:
               pointer: "/body/new_time/data/attributes/systemTime"
+  - name: System Time PUT request on a dev server raises error
+    request:
+      url: "{host:s}:{port:d}/system/time"
+      method: PUT
+      json:
+        data:
+          id: "time"
+          type: "SystemTimeAttributes"
+          attributes:
+            systemTime: "2020-09-10T21:00:15.741Z"
+    response:
+      status_code: 501
+      json:
+        errors:
+          - status: "501"
+            title: "Not implemented"
+            detail: "Method not implemented. Not supported on dev server."

--- a/robot-server/tests/integration/system/test_system_time.tavern.yaml
+++ b/robot-server/tests/integration/system/test_system_time.tavern.yaml
@@ -17,12 +17,7 @@ stages:
           id: 'time'
           type: 'SystemTimeAttributes'
         links:
-          GET:
-            href: "/system/time"
-            meta: null
-          PUT:
-            href: "/system/time"
-            meta: null
+          systemTime: '/system/time'
         meta: null
 
 ---

--- a/robot-server/tests/integration/test_health_check.tavern.yaml
+++ b/robot-server/tests/integration/test_health_check.tavern.yaml
@@ -28,3 +28,4 @@ stages:
           serialLog: /logs/serial.log
           # Specific link can change.
           apiSpec: !re_match "/openapi.*"
+          systemTime: /system/time

--- a/robot-server/tests/service/legacy/routers/test_health.py
+++ b/robot-server/tests/service/legacy/routers/test_health.py
@@ -17,7 +17,8 @@ def test_health(api_client, hardware):
         "links": {
             "apiLog": "/logs/api.log",
             "serialLog": "/logs/serial.log",
-            "apiSpec": "/openapi.json"
+            "apiSpec": "/openapi.json",
+            "systemTime": "/system/time"
         }
     }
     resp = api_client.get('/health')

--- a/robot-server/tests/service/system/test_router.py
+++ b/robot-server/tests/service/system/test_router.py
@@ -17,16 +17,7 @@ def mock_set_system_time(mock_system_time):
 
 @pytest.fixture
 def response_links():
-    return {
-        "GET": {
-            "href": "/system/time",
-            "meta": None
-        },
-        "PUT": {
-            "href": "/system/time",
-            "meta": None
-        }
-    }
+    return {'systemTime': '/system/time'}
 
 
 def test_raise_system_synchronized_error(api_client,

--- a/robot-server/tests/service/system/test_router.py
+++ b/robot-server/tests/service/system/test_router.py
@@ -17,7 +17,7 @@ def mock_set_system_time(mock_system_time):
 
 @pytest.fixture
 def response_links():
-    return {'systemTime': '/system/time'}
+    return {'self': '/system/time'}
 
 
 def test_raise_system_synchronized_error(api_client,


### PR DESCRIPTION
# Overview

PR #6501 uses the time endpoints to check & update robot's system time. In the absence of a time endpoint, which is true for all versions < 3.21, the app would get a 404 for this endpoint. This PR adds a time link to the health endpoint so that the app can check for the presence of time endpoints and only then attempt to use them.

# Changelog

- added time link to /health
- updated link for /system/time to be more accurate with the expected format
- raise error to prohibit setting time on dev server
- updated tests


# Risk assessment

Low. Doesn't touch any critical components
