### PR TITLE
refactor(robot-server): robot server resource links

### DIFF
--- a/robot-server/robot_server/service/json_api/resource_links.py
+++ b/robot-server/robot_server/service/json_api/resource_links.py
@@ -15,6 +15,11 @@ class ResourceLink(BaseModel):
 class ResourceLinkKey(str, Enum):
     # The key indicating the link to own resource
     self = "self"
+    protocols = "protocols"
+    protocol_by_id = "protocolById"
+    sessions = "sessions"
+    session_by_id = "sessionById"
+    session_command_execute = "commandExecute"
 
 
 ResourceLinks = typing.Dict[str, ResourceLink]

--- a/robot-server/robot_server/service/json_api/resource_links.py
+++ b/robot-server/robot_server/service/json_api/resource_links.py
@@ -12,7 +12,7 @@ class ResourceLink(BaseModel):
         Field(None, description="Meta data about the link")
 
 
-class ResourceLinkKeys(str, Enum):
+class ResourceLinkKey(str, Enum):
     # The key indicating the link to own resource
     self = "self"
 

--- a/robot-server/robot_server/service/json_api/resource_links.py
+++ b/robot-server/robot_server/service/json_api/resource_links.py
@@ -1,4 +1,5 @@
 import typing
+from enum import Enum
 from pydantic import BaseModel, Field
 
 
@@ -11,4 +12,9 @@ class ResourceLink(BaseModel):
         Field(None, description="Meta data about the link")
 
 
-ResourceLinks = typing.Dict[str, typing.Union[str, ResourceLink]]
+class ResourceLinkKeys(str, Enum):
+    # The key indicating the link to own resource
+    self = "self"
+
+
+ResourceLinks = typing.Dict[str, ResourceLink]

--- a/robot-server/robot_server/service/protocol/router.py
+++ b/robot-server/robot_server/service/protocol/router.py
@@ -117,13 +117,15 @@ def _to_response(uploaded_protocol: UploadedProtocol) \
     )
 
 
+ROOT_RESOURCE = ResourceLink(href=router.url_path_for(get_protocols.__name__))
+PROTOCOL_BY_ID_RESOURCE = ResourceLink(href=PATH_PROTOCOL_ID)
+
+
 def get_root_links(api_router: APIRouter) -> ResourceLinks:
     """Get resource links for root path handlers"""
     return {
-        ResourceLinkKey.self: ResourceLink(
-            href=api_router.url_path_for(get_protocols.__name__)
-        ),
-        "protocolById": ResourceLink(href=PATH_PROTOCOL_ID),
+        ResourceLinkKey.self: ROOT_RESOURCE,
+        ResourceLinkKey.protocol_by_id: PROTOCOL_BY_ID_RESOURCE,
     }
 
 
@@ -134,8 +136,6 @@ def get_protocol_links(api_router: APIRouter, protocol_id: str) \
         ResourceLinkKey.self: ResourceLink(
             href=api_router.url_path_for(get_protocol.__name__,
                                          protocolId=protocol_id)),
-        "protocols": ResourceLink(
-            href=api_router.url_path_for(get_protocols.__name__)
-        ),
-        "protocolById": ResourceLink(href=PATH_PROTOCOL_ID)
+        ResourceLinkKey.protocols: ROOT_RESOURCE,
+        ResourceLinkKey.protocol_by_id: PROTOCOL_BY_ID_RESOURCE
     }

--- a/robot-server/robot_server/service/session/router.py
+++ b/robot-server/robot_server/service/session/router.py
@@ -168,6 +168,12 @@ async def session_command_execute_handler(
     )
 
 
+ROOT_RESOURCE = ResourceLink(
+    href=router.url_path_for(get_sessions_handler.__name__)
+)
+SESSIONS_BY_ID_RESOURCE = ResourceLink(href=PATH_SESSION_BY_ID)
+
+
 def get_valid_session_links(session_id: route_models.IdentifierType,
                             api_router: APIRouter) \
         -> ResourceLinks:
@@ -176,21 +182,19 @@ def get_valid_session_links(session_id: route_models.IdentifierType,
         ResourceLinkKey.self: ResourceLink(href=api_router.url_path_for(
             get_session_handler.__name__,
             sessionId=session_id)),
-        "commandExecute": ResourceLink(href=api_router.url_path_for(
-            session_command_execute_handler.__name__,
-            sessionId=session_id)),
-        "sessions": ResourceLink(href=api_router.url_path_for(
-            get_sessions_handler.__name__)),
-        "sessionsById": ResourceLink(href=PATH_SESSION_BY_ID),
+        ResourceLinkKey.session_command_execute: ResourceLink(
+            href=api_router.url_path_for(
+                session_command_execute_handler.__name__,
+                sessionId=session_id)
+        ),
+        ResourceLinkKey.sessions: ROOT_RESOURCE,
+        ResourceLinkKey.session_by_id: SESSIONS_BY_ID_RESOURCE,
     }
 
 
 def get_sessions_links(api_router: APIRouter) -> ResourceLinks:
     """Get the valid links for the /sessions"""
     return {
-        ResourceLinkKey.self:
-            ResourceLink(href=api_router.url_path_for(
-                get_sessions_handler.__name__)
-            ),
-        "sessionsById": ResourceLink(href=PATH_SESSION_BY_ID),
+        ResourceLinkKey.self: ROOT_RESOURCE,
+        ResourceLinkKey.session_by_id: SESSIONS_BY_ID_RESOURCE,
     }

--- a/robot-server/robot_server/service/session/router.py
+++ b/robot-server/robot_server/service/session/router.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Query, Depends
 from robot_server.service.dependencies import get_session_manager
 from robot_server.service.errors import RobotServerError, CommonErrorDef
 from robot_server.service.json_api import ResourceLink, ResponseDataModel
-from robot_server.service.json_api.resource_links import ResourceLinkKeys
+from robot_server.service.json_api.resource_links import ResourceLinkKey
 from robot_server.service.session.command_execution import create_command
 from robot_server.service.session.errors import CommandExecutionException
 from robot_server.service.session.manager import SessionManager, BaseSession
@@ -30,7 +30,7 @@ def get_session(manager: SessionManager,
         raise RobotServerError(
             definition=CommonErrorDef.RESOURCE_NOT_FOUND,
             links={
-                ResourceLinkKeys.self:
+                ResourceLinkKey.self:
                     ResourceLink(href=api_router.url_path_for(
                         create_session_handler.__name__)
                     )
@@ -86,7 +86,7 @@ async def delete_session_handler(
             attributes=session_obj.get_response_model(),
             resource_id=sessionId),
         links={
-            ResourceLinkKeys.self:
+            ResourceLinkKey.self:
                 ResourceLink(href=router.url_path_for(
                     create_session_handler.__name__
                 )),
@@ -180,7 +180,7 @@ def get_valid_session_links(session_id: route_models.IdentifierType,
         -> typing.Dict[str, ResourceLink]:
     """Get the valid links for a session"""
     return {
-        ResourceLinkKeys.self: ResourceLink(href=api_router.url_path_for(
+        ResourceLinkKey.self: ResourceLink(href=api_router.url_path_for(
             get_session_handler.__name__,
             sessionId=session_id)),
         "commandExecute": ResourceLink(href=api_router.url_path_for(

--- a/robot-server/robot_server/service/session/router.py
+++ b/robot-server/robot_server/service/session/router.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Query, Depends
 from robot_server.service.dependencies import get_session_manager
 from robot_server.service.errors import RobotServerError, CommonErrorDef
 from robot_server.service.json_api import ResourceLink, ResponseDataModel
+from robot_server.service.json_api.resource_links import ResourceLinkKeys
 from robot_server.service.session.command_execution import create_command
 from robot_server.service.session.errors import CommandExecutionException
 from robot_server.service.session.manager import SessionManager, BaseSession
@@ -29,8 +30,10 @@ def get_session(manager: SessionManager,
         raise RobotServerError(
             definition=CommonErrorDef.RESOURCE_NOT_FOUND,
             links={
-                "POST":
-                    api_router.url_path_for(create_session_handler.__name__)
+                ResourceLinkKeys.self:
+                    ResourceLink(href=api_router.url_path_for(
+                        create_session_handler.__name__)
+                    )
             },
             resource='session',
             id=session_id
@@ -83,8 +86,10 @@ async def delete_session_handler(
             attributes=session_obj.get_response_model(),
             resource_id=sessionId),
         links={
-            "POST": ResourceLink(href=router.url_path_for(
-                create_session_handler.__name__)),
+            ResourceLinkKeys.self:
+                ResourceLink(href=router.url_path_for(
+                    create_session_handler.__name__
+                )),
         }
     )
 
@@ -175,13 +180,10 @@ def get_valid_session_links(session_id: route_models.IdentifierType,
         -> typing.Dict[str, ResourceLink]:
     """Get the valid links for a session"""
     return {
-        "GET": ResourceLink(href=api_router.url_path_for(
+        ResourceLinkKeys.self: ResourceLink(href=api_router.url_path_for(
             get_session_handler.__name__,
             sessionId=session_id)),
-        "POST": ResourceLink(href=api_router.url_path_for(
+        "commandExecute": ResourceLink(href=api_router.url_path_for(
             session_command_execute_handler.__name__,
-            sessionId=session_id)),
-        "DELETE": ResourceLink(href=api_router.url_path_for(
-            delete_session_handler.__name__,
             sessionId=session_id)),
     }

--- a/robot-server/robot_server/service/session/router.py
+++ b/robot-server/robot_server/service/session/router.py
@@ -1,5 +1,4 @@
 import logging
-import typing
 
 from starlette import status as http_status_codes
 from fastapi import APIRouter, Query, Depends
@@ -7,17 +6,21 @@ from fastapi import APIRouter, Query, Depends
 from robot_server.service.dependencies import get_session_manager
 from robot_server.service.errors import RobotServerError, CommonErrorDef
 from robot_server.service.json_api import ResourceLink, ResponseDataModel
-from robot_server.service.json_api.resource_links import ResourceLinkKey
+from robot_server.service.json_api.resource_links import ResourceLinkKey, \
+    ResourceLinks
 from robot_server.service.session.command_execution import create_command
 from robot_server.service.session.errors import CommandExecutionException
 from robot_server.service.session.manager import SessionManager, BaseSession
 from robot_server.service.session import models as route_models
 from robot_server.service.session.session_types import SessionMetaData
 
+
 router = APIRouter()
 
 
 log = logging.getLogger(__name__)
+
+PATH_SESSION_BY_ID = "/sessions/{sessionId}"
 
 
 def get_session(manager: SessionManager,
@@ -29,12 +32,7 @@ def get_session(manager: SessionManager,
         # There is no session raise error
         raise RobotServerError(
             definition=CommonErrorDef.RESOURCE_NOT_FOUND,
-            links={
-                ResourceLinkKey.self:
-                    ResourceLink(href=api_router.url_path_for(
-                        create_session_handler.__name__)
-                    )
-            },
+            links=get_sessions_links(api_router),
             resource='session',
             id=session_id
         )
@@ -66,7 +64,7 @@ async def create_session_handler(
     )
 
 
-@router.delete("/sessions/{sessionId}",
+@router.delete(PATH_SESSION_BY_ID,
                description="Delete a session",
                response_model_exclude_unset=True,
                response_model=route_models.SessionResponse)
@@ -85,16 +83,11 @@ async def delete_session_handler(
         data=ResponseDataModel.create(
             attributes=session_obj.get_response_model(),
             resource_id=sessionId),
-        links={
-            ResourceLinkKey.self:
-                ResourceLink(href=router.url_path_for(
-                    create_session_handler.__name__
-                )),
-        }
+        links=get_sessions_links(router),
     )
 
 
-@router.get("/sessions/{sessionId}",
+@router.get(PATH_SESSION_BY_ID,
             description="Get session",
             response_model_exclude_unset=True,
             response_model=route_models.SessionResponse)
@@ -134,7 +127,7 @@ async def get_sessions_handler(
     )
 
 
-@router.post("/sessions/{sessionId}/commands/execute",
+@router.post(f"{PATH_SESSION_BY_ID}/commands/execute",
              description="Create and execute a command immediately",
              response_model_exclude_unset=True,
              response_model=route_models.CommandResponse)
@@ -177,7 +170,7 @@ async def session_command_execute_handler(
 
 def get_valid_session_links(session_id: route_models.IdentifierType,
                             api_router: APIRouter) \
-        -> typing.Dict[str, ResourceLink]:
+        -> ResourceLinks:
     """Get the valid links for a session"""
     return {
         ResourceLinkKey.self: ResourceLink(href=api_router.url_path_for(
@@ -186,4 +179,18 @@ def get_valid_session_links(session_id: route_models.IdentifierType,
         "commandExecute": ResourceLink(href=api_router.url_path_for(
             session_command_execute_handler.__name__,
             sessionId=session_id)),
+        "sessions": ResourceLink(href=api_router.url_path_for(
+            get_sessions_handler.__name__)),
+        "sessionsById": ResourceLink(href=PATH_SESSION_BY_ID),
+    }
+
+
+def get_sessions_links(api_router: APIRouter) -> ResourceLinks:
+    """Get the valid links for the /sessions"""
+    return {
+        ResourceLinkKey.self:
+            ResourceLink(href=api_router.url_path_for(
+                get_sessions_handler.__name__)
+            ),
+        "sessionsById": ResourceLink(href=PATH_SESSION_BY_ID),
     }

--- a/robot-server/robot_server/service/system/router.py
+++ b/robot-server/robot_server/service/system/router.py
@@ -1,6 +1,9 @@
 import logging
 from datetime import datetime
 from fastapi import APIRouter
+
+from robot_server.service.json_api.resource_links import (
+    ResourceLinkKey, ResourceLink)
 from robot_server.system import time
 from robot_server.service.system import models as time_models
 
@@ -22,7 +25,9 @@ def _create_response(dt: datetime) \
             ),
             resource_id="time"
         ),
-        links={'self': '/system/time'}
+        links={
+            ResourceLinkKey.self: ResourceLink(href='/system/time')
+        }
     )
 
 

--- a/robot-server/tests/integration/protocols/test_protocol_upload.tavern.yaml
+++ b/robot-server/tests/integration/protocols/test_protocol_upload.tavern.yaml
@@ -13,8 +13,8 @@ stages:
         supportFiles: "tests/integration/protocols/data.csv"
     response:
       status_code: 201
-      json: &response
-        data:
+      json:
+        data: &response_data
           id: phony_proto
           type: ProtocolResponseAttributes
           attributes:
@@ -24,20 +24,31 @@ stages:
               - basename: data.csv
             lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
             createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+        links:
+          self:
+            href: '/protocols/phony_proto'
   - name: Get the protocol
     request:
       url: "{host:s}:{port:d}/protocols/phony_proto"
       method: GET
     response:
       status_code: 200
-      json: *response
+      json:
+        data: *response_data
+        links:
+          self:
+            href: '/protocols/phony_proto'
   - name: Delete the protocol
     request:
       url: "{host:s}:{port:d}/protocols/phony_proto"
       method: DELETE
     response:
       status_code: 200
-      json: *response
+      json:
+        data: *response_data
+        links:
+          self:
+            href: '/protocols'
   - name: Get all protocols to see that there are none
     request:
       url: "{host:s}:{port:d}/protocols"
@@ -46,6 +57,9 @@ stages:
       status_code: 200
       json:
         data: []
+        links:
+          self:
+             href: '/protocols'
 ---
 test_name: Protocol lifecycle upload support
 marks:
@@ -70,6 +84,9 @@ stages:
             supportFiles: []
             lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
             createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+        links:
+          self:
+            href: '/protocols/phony_proto'
   - name: Get the protocol
     request:
       url: "{host:s}:{port:d}/protocols/phony_proto"
@@ -86,6 +103,9 @@ stages:
             supportFiles: []
             lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
             createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+        links:
+          self:
+            href: '/protocols/phony_proto'
   - name: Upload a data file
     request:
       url: "{host:s}:{port:d}/protocols/phony_proto"
@@ -105,6 +125,9 @@ stages:
             - basename: 'data.csv'
             lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
             createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+        links:
+          self:
+            href: '/protocols/phony_proto'
   - name: Delete the protocol
     request:
       url: "{host:s}:{port:d}/protocols/phony_proto"
@@ -122,6 +145,9 @@ stages:
             - basename: 'data.csv'
             lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
             createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+        links:
+          self:
+            href: '/protocols'
   - name: Get all protocols to see that there are none
     request:
       url: "{host:s}:{port:d}/protocols"
@@ -130,3 +156,6 @@ stages:
       status_code: 200
       json:
         data: []
+        links:
+          self:
+            href: '/protocols'

--- a/robot-server/tests/integration/protocols/test_protocol_upload.tavern.yaml
+++ b/robot-server/tests/integration/protocols/test_protocol_upload.tavern.yaml
@@ -27,6 +27,10 @@ stages:
         links:
           self:
             href: '/protocols/phony_proto'
+          protocols:
+            href: '/protocols'
+          protocolById:
+            href: '/protocols/{{protocolId}}'
   - name: Get the protocol
     request:
       url: "{host:s}:{port:d}/protocols/phony_proto"
@@ -38,6 +42,10 @@ stages:
         links:
           self:
             href: '/protocols/phony_proto'
+          protocols:
+            href: '/protocols'
+          protocolById:
+            href: '/protocols/{{protocolId}}'
   - name: Delete the protocol
     request:
       url: "{host:s}:{port:d}/protocols/phony_proto"
@@ -49,6 +57,8 @@ stages:
         links:
           self:
             href: '/protocols'
+          protocolById:
+            href: '/protocols/{{protocolId}}'
   - name: Get all protocols to see that there are none
     request:
       url: "{host:s}:{port:d}/protocols"
@@ -60,6 +70,8 @@ stages:
         links:
           self:
              href: '/protocols'
+          protocolById:
+            href: '/protocols/{{protocolId}}'
 ---
 test_name: Protocol lifecycle upload support
 marks:
@@ -87,6 +99,10 @@ stages:
         links:
           self:
             href: '/protocols/phony_proto'
+          protocols:
+            href: '/protocols'
+          protocolById:
+            href: '/protocols/{{protocolId}}'
   - name: Get the protocol
     request:
       url: "{host:s}:{port:d}/protocols/phony_proto"
@@ -106,6 +122,10 @@ stages:
         links:
           self:
             href: '/protocols/phony_proto'
+          protocols:
+            href: '/protocols'
+          protocolById:
+            href: '/protocols/{{protocolId}}'
   - name: Upload a data file
     request:
       url: "{host:s}:{port:d}/protocols/phony_proto"
@@ -128,6 +148,10 @@ stages:
         links:
           self:
             href: '/protocols/phony_proto'
+          protocols:
+            href: '/protocols'
+          protocolById:
+            href: '/protocols/{{protocolId}}'
   - name: Delete the protocol
     request:
       url: "{host:s}:{port:d}/protocols/phony_proto"
@@ -148,6 +172,8 @@ stages:
         links:
           self:
             href: '/protocols'
+          protocolById:
+            href: '/protocols/{{protocolId}}'
   - name: Get all protocols to see that there are none
     request:
       url: "{host:s}:{port:d}/protocols"
@@ -159,3 +185,5 @@ stages:
         links:
           self:
             href: '/protocols'
+          protocolById:
+            href: '/protocols/{{protocolId}}'

--- a/robot-server/tests/integration/system/test_system_time.tavern.yaml
+++ b/robot-server/tests/integration/system/test_system_time.tavern.yaml
@@ -17,7 +17,9 @@ stages:
           id: 'time'
           type: 'SystemTimeAttributes'
         links:
-          self: '/system/time'
+          self:
+            href: '/system/time'
+            meta: null
         meta: null
 
 ---

--- a/robot-server/tests/service/json_api/test_errors.py
+++ b/robot-server/tests/service/json_api/test_errors.py
@@ -15,7 +15,7 @@ valid_error_objects = [
     {'title': 'Something went wrong'},
     {'detail': "oh wow, there's a few things we messed up there"},
     {'meta': {'num_errors_today': 10000}},
-    {'links': {'self': '/my/error-info?code=1005'}},
+    {'links': {'self': {'href': '/my/error-info?code=1005'}}},
     {'source': {'pointer': '/data/attributes/price'}},
 ]
 

--- a/robot-server/tests/service/json_api/test_resource_links.py
+++ b/robot-server/tests/service/json_api/test_resource_links.py
@@ -11,7 +11,7 @@ class ThingWithLink(BaseModel):
 def test_follows_structure():
     structure_to_validate = {
         'links': {
-            'self': '/items/1',
+            'self': {'href': '/items/1', 'meta': None},
         }
     }
     validated = ThingWithLink(**structure_to_validate)

--- a/robot-server/tests/service/session/test_router.py
+++ b/robot-server/tests/service/session/test_router.py
@@ -157,6 +157,12 @@ def test_create_session(api_client,
             },
             'self': {
                 'href': f'/sessions/{mock_session_meta.identifier}',
+            },
+            'sessions': {
+                'href': '/sessions'
+            },
+            'sessionsById': {
+                'href': '/sessions/{sessionId}'
             }
         }
     }
@@ -170,7 +176,10 @@ def test_delete_session_not_found(api_client):
     assert response.json() == {
         'errors': [{
             'detail': "Resource type 'session' with id 'check' was not found",
-            'links': {'self': {'href': '/sessions'}},
+            'links': {
+                'self': {'href': '/sessions'},
+                'sessionsById': {'href': '/sessions/{sessionId}'}
+            },
             'status': '404',
             'title': 'Resource Not Found'
         }]
@@ -191,6 +200,9 @@ def test_delete_session(api_client,
             'self': {
                 'href': '/sessions',
             },
+            'sessionsById': {
+                'href': '/sessions/{sessionId}'
+            },
         }
     }
     assert response.status_code == 200
@@ -201,7 +213,10 @@ def test_get_session_not_found(api_client):
     assert response.json() == {
         'errors': [{
             'detail': "Resource type 'session' with id '1234' was not found",
-            'links': {'self': {'href': '/sessions'}},
+            'links': {
+                'self': {'href': '/sessions'},
+                'sessionsById': {'href': '/sessions/{sessionId}'}
+            },
             'status': '404',
             'title': 'Resource Not Found'
         }]
@@ -223,6 +238,12 @@ def test_get_session(api_client,
             'self': {
                 'href': f'/sessions/{mock_session_meta.identifier}',
             },
+            'sessions': {
+                'href': '/sessions'
+            },
+            'sessionsById': {
+                'href': '/sessions/{sessionId}'
+            }
         }
     }
     assert response.status_code == 200
@@ -268,7 +289,10 @@ def test_execute_command_no_session(api_client, mock_session_meta):
     assert response.json() == {
         'errors': [{
             'detail': f"Resource type 'session' with id '{mock_session_meta.identifier}' was not found",  # noqa: e5011
-            'links': {'self': {'href': '/sessions'}},
+            'links': {
+                'self': {'href': '/sessions'},
+                'sessionsById': {'href': '/sessions/{sessionId}'}
+            },
             'status': '404',
             'title': 'Resource Not Found'
         }]
@@ -319,6 +343,12 @@ def test_execute_command(api_client,
             'self': {
                 'href': f'/sessions/{mock_session_meta.identifier}',
             },
+            'sessions': {
+                'href': '/sessions'
+            },
+            'sessionsById': {
+                'href': '/sessions/{sessionId}'
+            },
         }
     }
     assert response.status_code == 200
@@ -365,6 +395,12 @@ def test_execute_command_no_body(api_client,
             },
             'self': {
                 'href': f'/sessions/{mock_session_meta.identifier}',
+            },
+            'sessions': {
+                'href': '/sessions'
+            },
+            'sessionsById': {
+                'href': '/sessions/{sessionId}'
             },
         }
     }

--- a/robot-server/tests/service/session/test_router.py
+++ b/robot-server/tests/service/session/test_router.py
@@ -152,15 +152,12 @@ def test_create_session(api_client,
     assert response.json() == {
         'data': session_response,
         'links': {
-            'POST': {
+            'commandExecute': {
                 'href': f'/sessions/{mock_session_meta.identifier}/commands/execute',  # noqa: E501
             },
-            'GET': {
+            'self': {
                 'href': f'/sessions/{mock_session_meta.identifier}',
-            },
-            'DELETE': {
-                'href': f'/sessions/{mock_session_meta.identifier}',
-            },
+            }
         }
     }
     assert response.status_code == 201
@@ -173,7 +170,7 @@ def test_delete_session_not_found(api_client):
     assert response.json() == {
         'errors': [{
             'detail': "Resource type 'session' with id 'check' was not found",
-            'links': {'POST': '/sessions'},
+            'links': {'self': {'href': '/sessions'}},
             'status': '404',
             'title': 'Resource Not Found'
         }]
@@ -191,7 +188,7 @@ def test_delete_session(api_client,
     assert response.json() == {
         'data': session_response,
         'links': {
-            'POST': {
+            'self': {
                 'href': '/sessions',
             },
         }
@@ -204,7 +201,7 @@ def test_get_session_not_found(api_client):
     assert response.json() == {
         'errors': [{
             'detail': "Resource type 'session' with id '1234' was not found",
-            'links': {'POST': '/sessions'},
+            'links': {'self': {'href': '/sessions'}},
             'status': '404',
             'title': 'Resource Not Found'
         }]
@@ -220,13 +217,10 @@ def test_get_session(api_client,
     assert response.json() == {
         'data': session_response,
         'links': {
-            'POST': {
+            'commandExecute': {
                 'href': f'/sessions/{mock_session_meta.identifier}/commands/execute',  # noqa: e5011
             },
-            'GET': {
-                'href': f'/sessions/{mock_session_meta.identifier}',
-            },
-            'DELETE': {
+            'self': {
                 'href': f'/sessions/{mock_session_meta.identifier}',
             },
         }
@@ -274,7 +268,7 @@ def test_execute_command_no_session(api_client, mock_session_meta):
     assert response.json() == {
         'errors': [{
             'detail': f"Resource type 'session' with id '{mock_session_meta.identifier}' was not found",  # noqa: e5011
-            'links': {'POST': '/sessions'},
+            'links': {'self': {'href': '/sessions'}},
             'status': '404',
             'title': 'Resource Not Found'
         }]
@@ -319,13 +313,10 @@ def test_execute_command(api_client,
             'id': command_id,
         },
         'links': {
-            'POST': {
+            'commandExecute': {
                 'href': f'/sessions/{mock_session_meta.identifier}/commands/execute',  # noqa: e501
             },
-            'GET': {
-                'href': f'/sessions/{mock_session_meta.identifier}',
-            },
-            'DELETE': {
+            'self': {
                 'href': f'/sessions/{mock_session_meta.identifier}',
             },
         }
@@ -369,13 +360,10 @@ def test_execute_command_no_body(api_client,
             'id': command_id
         },
         'links': {
-            'POST': {
+            'commandExecute': {
                 'href': f'/sessions/{mock_session_meta.identifier}/commands/execute',  # noqa: e501
             },
-            'GET': {
-                'href': f'/sessions/{mock_session_meta.identifier}',
-            },
-            'DELETE': {
+            'self': {
                 'href': f'/sessions/{mock_session_meta.identifier}',
             },
         }

--- a/robot-server/tests/service/session/test_router.py
+++ b/robot-server/tests/service/session/test_router.py
@@ -161,7 +161,7 @@ def test_create_session(api_client,
             'sessions': {
                 'href': '/sessions'
             },
-            'sessionsById': {
+            'sessionById': {
                 'href': '/sessions/{sessionId}'
             }
         }
@@ -178,7 +178,7 @@ def test_delete_session_not_found(api_client):
             'detail': "Resource type 'session' with id 'check' was not found",
             'links': {
                 'self': {'href': '/sessions'},
-                'sessionsById': {'href': '/sessions/{sessionId}'}
+                'sessionById': {'href': '/sessions/{sessionId}'}
             },
             'status': '404',
             'title': 'Resource Not Found'
@@ -200,7 +200,7 @@ def test_delete_session(api_client,
             'self': {
                 'href': '/sessions',
             },
-            'sessionsById': {
+            'sessionById': {
                 'href': '/sessions/{sessionId}'
             },
         }
@@ -215,7 +215,7 @@ def test_get_session_not_found(api_client):
             'detail': "Resource type 'session' with id '1234' was not found",
             'links': {
                 'self': {'href': '/sessions'},
-                'sessionsById': {'href': '/sessions/{sessionId}'}
+                'sessionById': {'href': '/sessions/{sessionId}'}
             },
             'status': '404',
             'title': 'Resource Not Found'
@@ -241,7 +241,7 @@ def test_get_session(api_client,
             'sessions': {
                 'href': '/sessions'
             },
-            'sessionsById': {
+            'sessionById': {
                 'href': '/sessions/{sessionId}'
             }
         }
@@ -291,7 +291,7 @@ def test_execute_command_no_session(api_client, mock_session_meta):
             'detail': f"Resource type 'session' with id '{mock_session_meta.identifier}' was not found",  # noqa: e5011
             'links': {
                 'self': {'href': '/sessions'},
-                'sessionsById': {'href': '/sessions/{sessionId}'}
+                'sessionById': {'href': '/sessions/{sessionId}'}
             },
             'status': '404',
             'title': 'Resource Not Found'
@@ -346,7 +346,7 @@ def test_execute_command(api_client,
             'sessions': {
                 'href': '/sessions'
             },
-            'sessionsById': {
+            'sessionById': {
                 'href': '/sessions/{sessionId}'
             },
         }
@@ -399,7 +399,7 @@ def test_execute_command_no_body(api_client,
             'sessions': {
                 'href': '/sessions'
             },
-            'sessionsById': {
+            'sessionById': {
                 'href': '/sessions/{sessionId}'
             },
         }

--- a/robot-server/tests/service/system/test_router.py
+++ b/robot-server/tests/service/system/test_router.py
@@ -17,7 +17,12 @@ def mock_set_system_time(mock_system_time):
 
 @pytest.fixture
 def response_links():
-    return {'self': '/system/time'}
+    return {
+        'self': {
+            'href': '/system/time',
+            'meta': None
+        }
+    }
 
 
 def test_raise_system_synchronized_error(api_client,


### PR DESCRIPTION
# Overview

Standardize the `links` returned in v2 responses according to changes in `/system/time` endpoint.

# Changelog

- `ResourceLinks` is a dict of string to `ResourceLink` object rather than a union of `str` and `ResourceLink`. 
- The keys used in `/sessions` router are not the HTTP verb but the resources.
- `self` is reserved as the key indicating the link to the requested or created link
- Added link attribute to `/protocols` responses

# Review requests

How does the naming look?

# Risk assessment
Very low. These are not used yet.

closes #6518 