### PR TITLE
chore(build): Deploy docs to sandbox on push

### DIFF
--- a/.github/actions/webstack/deploy-to-sandbox/action.yaml
+++ b/.github/actions/webstack/deploy-to-sandbox/action.yaml
@@ -11,4 +11,4 @@ runs:
   using: 'composite'
   steps:
     - shell: bash
-      run: "aws s3 sync ${{ inputs.distPath }} s3://sandbox.${{ inputs.domain }}/${{ context.GITHUB_REF }} --acl=public-read"
+      run: "aws s3 sync ${{ inputs.distPath }} s3://sandbox.${{ inputs.domain }}/${{ github.ref }} --acl=public-read"

--- a/.github/actions/webstack/deploy-to-sandbox/action.yaml
+++ b/.github/actions/webstack/deploy-to-sandbox/action.yaml
@@ -1,0 +1,14 @@
+name: 'Deploy standard OT webstack to sandbox'
+description: 'Push a webstack build to the sandbox for its branch (the current ref from the workflow context). AWS creds should be set in the environment by the workflow.'
+inputs:
+  domain:
+    description: 'The domain for the webstack in question'
+    required: true
+  distPath:
+    description: 'The path to the compiled distribution to upload'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - shell: bash
+      run: "aws s3 sync ${{ inputs.distPath }} s3://sandbox.${{ inputs.domain }}/${{ context.GITHUB_REF }} --acl=public-read"

--- a/.github/actions/webstack/deploy-to-sandbox/action.yaml
+++ b/.github/actions/webstack/deploy-to-sandbox/action.yaml
@@ -12,6 +12,6 @@ runs:
   steps:
     - shell: bash
       run: |
-        SHORTSLUG=`echo ${{ github.ref }} | sed -e "s/^\/refs\/\(?:tags\|heads\)\///"`
+        SHORTSLUG=`echo ${{ github.ref }} | sed -e "s/^\/\?refs\/\(?:tags\|heads\)\///"`
         echo "Found ref slug ${SHORTSLUG}"
         "aws s3 sync ${{ inputs.distPath }} s3://sandbox.${{ inputs.domain }}/${SHORTSLUG} --acl=public-read"

--- a/.github/actions/webstack/deploy-to-sandbox/action.yaml
+++ b/.github/actions/webstack/deploy-to-sandbox/action.yaml
@@ -10,5 +10,18 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Set branch and tag name environment variables
+      shell: bash
+
+        uses: actions/github-script@v2
+        with:
+          script: |
+            const branch = context.ref.replace(/^refs\/(?:tags|heads)\//, '')
+            const tag = context.ref.startsWith('refs/tags/') ? branch : ''
+            core.exportVariable('OT_BRANCH', branch)
+            core.exportVariable('OT_TAG', tag)
     - shell: bash
-      run: "aws s3 sync ${{ inputs.distPath }} s3://sandbox.${{ inputs.domain }}/${{ github.ref }} --acl=public-read"
+      run: |
+        SHORTSLUG=`echo ${{ context.ref }} | sed -e "s/^\/refs\/\(?:tags\|heads\)\///"`
+        echo "Found ref slug ${SHORTSLUG}"
+        "aws s3 sync ${{ inputs.distPath }} s3://sandbox.${{ inputs.domain }}/${SHORTSLUG} --acl=public-read"

--- a/.github/actions/webstack/deploy-to-sandbox/action.yaml
+++ b/.github/actions/webstack/deploy-to-sandbox/action.yaml
@@ -12,6 +12,6 @@ runs:
   steps:
     - shell: bash
       run: |
-        SHORTSLUG=`echo ${{ context.ref }} | sed -e "s/^\/refs\/\(?:tags\|heads\)\///"`
+        SHORTSLUG=`echo ${{ github.ref }} | sed -e "s/^\/refs\/\(?:tags\|heads\)\///"`
         echo "Found ref slug ${SHORTSLUG}"
         "aws s3 sync ${{ inputs.distPath }} s3://sandbox.${{ inputs.domain }}/${SHORTSLUG} --acl=public-read"

--- a/.github/actions/webstack/deploy-to-sandbox/action.yaml
+++ b/.github/actions/webstack/deploy-to-sandbox/action.yaml
@@ -13,5 +13,5 @@ runs:
     - shell: bash
       run: |
         SHORTSLUG=`echo ${{ github.ref }} | sed -e "s/^\/\?refs\/\(?:tags\|heads\)\///"`
-        echo "Found ref slug ${SHORTSLUG}"
-        "aws s3 sync ${{ inputs.distPath }} s3://sandbox.${{ inputs.domain }}/${SHORTSLUG} --acl=public-read"
+        echo "Found ref slug ${SHORTSLUG} from ref ${{ github.ref }}"
+        aws s3 sync ${{ inputs.distPath }} s3://sandbox.${{ inputs.domain }}/${SHORTSLUG} --acl=public-read

--- a/.github/actions/webstack/deploy-to-sandbox/action.yaml
+++ b/.github/actions/webstack/deploy-to-sandbox/action.yaml
@@ -10,16 +10,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Set branch and tag name environment variables
-      shell: bash
-
-        uses: actions/github-script@v2
-        with:
-          script: |
-            const branch = context.ref.replace(/^refs\/(?:tags|heads)\//, '')
-            const tag = context.ref.startsWith('refs/tags/') ? branch : ''
-            core.exportVariable('OT_BRANCH', branch)
-            core.exportVariable('OT_TAG', tag)
     - shell: bash
       run: |
         SHORTSLUG=`echo ${{ context.ref }} | sed -e "s/^\/refs\/\(?:tags\|heads\)\///"`

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -9,8 +9,9 @@ on:
     paths:
       - 'api/src/opentrons/protocol_api/**'
       - 'api/docs/**'
-      - '.github/workflows/docs-push.yaml'
+      - '.github/workflows/docs-build.yaml'
       - '.github/actions/python/**'
+      - '.github/actions/webstack/deploy-to-sandbox/**'
     branches-ignore: # ignore any release-related thing (handled elsewhere)
       - 'master'
       - 'chore_release-**'

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -42,3 +42,11 @@ jobs:
       - name: 'Build docs'
         run: |
           make -C api docs
+      - name: 'Deploy docs to sandbox'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_SANDBOX_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SANDBOX_SECRET }}
+        uses: './.github/actions/webstack/deploy-to-sandbox'
+        with:
+          domain: 'docs.opentrons.com'
+          distPath: './api/docs/dist'


### PR DESCRIPTION
Adds a github action and workflow to deploy the docs to the appropriate sandbox link when they are built.

Check it out: http://sandbox.docs.opentrons.com/actions_docs-deploy-v2/

