### PR TITLE
feat(robot-server): create models for basic pipetting session commands

### DIFF
--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -5,24 +5,12 @@ from functools import lru_cache
 
 from opentrons_shared_data.pipette.dev_types import PipetteName
 from pydantic import BaseModel, Field, validator
-from robot_server.service.json_api import ResponseModel, RequestModel
-from opentrons.util.helpers import utc_now
 
-from robot_server.service.session.models.common import EmptyModel, \
-    JogPosition
-from robot_server.robot.calibration.check import (
-    models as calibration_check_models)
-from robot_server.robot.calibration.tip_length import (
-    models as tip_length_calibration_models)
-from robot_server.robot.calibration.deck import (
-    models as deck_calibration_models)
-from robot_server.robot.calibration.pipette_offset import (
-    models as pipette_offset_calibration_models)
+from robot_server.service.session.models.common import (
+    EmptyModel, JogPosition)
 from robot_server.service.legacy.models.control import Mount
-from robot_server.service.session.session_types.protocol import \
-    models as protocol_session_models
-from robot_server.service.json_api import \
-    ResponseDataModel, ResponseModel, RequestDataModel, RequestModel
+from robot_server.service.json_api import (
+    ResponseModel, RequestModel)
 from opentrons.util.helpers import utc_now
 
 
@@ -226,7 +214,7 @@ CommandDataType = typing.Union[
     LoadLabware,
     LoadInstrument,
     LiquidCommand,
-    PipetteCommand,
+    PipetteCommandBase,
     EmptyModel
 ]
 

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -3,7 +3,6 @@ from enum import Enum
 import typing
 from functools import lru_cache
 
-from opentrons import types
 from pydantic import BaseModel, Field, validator
 from robot_server.service.json_api import ResponseModel, RequestModel
 from opentrons.util.helpers import utc_now
@@ -27,16 +26,21 @@ from opentrons.util.helpers import utc_now
 
 
 class LoadLabware(BaseModel):
-    location: int = Field(...,
-                          description="Deck slot", ge=1, lt=12)
-    loadName: str = Field(...,
-                          description="Name used to reference a labware definition")
-    displayName: str = Field(...,
-                             description="User-readable name for labware")
-    namespace: str = Field(...,
-                           description="The namespace the labware definition belongs to.")
-    version: int = Field(...,
-                         description="")
+    location: int = Field(
+        ...,
+        description="Deck slot", ge=1, lt=12)
+    loadName: str = Field(
+        ...,
+        description="Name used to reference a labware definition")
+    displayName: str = Field(
+        ...,
+        description="User-readable name for labware")
+    namespace: str = Field(
+        ...,
+        description="The namespace the labware definition belongs to")
+    version: int = Field(
+        ...,
+        description="The labware definition version")
 
 
 class LoadInstrument(BaseModel):
@@ -137,13 +141,13 @@ class ProtocolCommand(CommandDefinition):
         return "protocol"
 
 
-class NEW(CommandDefinition):
+class EquipmentCommand(CommandDefinition):
     load_labware = ("loadLabware", LoadLabware)
     load_instrument = ("loadInstrument", LoadInstrument)
 
     @staticmethod
     def namespace():
-        return "NEW!"
+        return "equipment"
 
 
 class PipetteCommand(CommandDefinition):
@@ -231,7 +235,7 @@ CommandDefinitionType = typing.Union[
     DeckCalibrationCommand,
     ProtocolCommand,
     PipetteCommand,
-    NEW,
+    EquipmentCommand,
 ]
 
 

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -3,6 +3,7 @@ from enum import Enum
 import typing
 from functools import lru_cache
 
+from opentrons_shared_data.pipette.dev_types import PipetteName
 from pydantic import BaseModel, Field, validator
 from robot_server.service.json_api import ResponseModel, RequestModel
 from opentrons.util.helpers import utc_now
@@ -32,7 +33,7 @@ class LoadLabware(BaseModel):
     loadName: str = Field(
         ...,
         description="Name used to reference a labware definition")
-    displayName: str = Field(
+    displayName: typing.Optional[str] = Field(
         ...,
         description="User-readable name for labware")
     namespace: str = Field(
@@ -44,8 +45,9 @@ class LoadLabware(BaseModel):
 
 
 class LoadInstrument(BaseModel):
-    instrumentName: str = Field(...,
-                                description="The name of the instrument model")
+    instrumentName: PipetteName = Field(
+        ...,
+        description="The name of the instrument model")
     mount: Mount
 
 
@@ -58,7 +60,8 @@ class PipetteCommandBase(BaseModel):
 class LiquidCommand(PipetteCommandBase):
     volume: float = Field(
         ...,
-        description="Amount of liquid in uL",
+        description="Amount of liquid in uL. Must be greater than 0 and less "
+                    "than a pipette-specific maximum volume.",
         gt=0,
     )
     offsetFromBottom: float = Field(
@@ -68,7 +71,9 @@ class LiquidCommand(PipetteCommandBase):
     )
     flowRate: float = Field(
         ...,
-        description="The absolute flow rate in uL/second.",
+        description="The absolute flow rate in uL/second. Must be greater "
+                    "than 0 and less than a pipette-specific maximum flow "
+                    "rate.",
         gt=0
     )
 


### PR DESCRIPTION
# Overview

Create models for commands used in basic pipetting protocol: load instrument, load labware, aspirate, dispense, pick up tip, and drop tip.

# Changelog

Just adding new models.

# Risk assessment

None

closes #6556

