### PR TITLE
fix(api): limit calibration jogs when going upward

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -915,7 +915,8 @@ class API(HardwareAPILike):
     async def move_rel(self, mount: Union[top_types.Mount, PipettePair],
                        delta: top_types.Point,
                        speed: float = None,
-                       max_speeds: Dict[Axis, float] = None):
+                       max_speeds: Dict[Axis, float] = None,
+                       check_bounds: MotionChecks = MotionChecks.NONE):
         """ Move the critical point of the specified mount by a specified
         displacement in a specified direction, at the specified speed.
         'speed' sets the speed of all axes to the given value. So, if multiple
@@ -954,7 +955,8 @@ class API(HardwareAPILike):
         await self._cache_and_maybe_retract_mount(primary_mount)
         await self._move(
             target_position, speed=speed,
-            max_speeds=max_speeds, secondary_z=secondary_z)
+            max_speeds=max_speeds, secondary_z=secondary_z,
+            check_bounds=check_bounds)
 
     async def _cache_and_maybe_retract_mount(self, mount: top_types.Mount):
         """ Retract the 'other' mount if necessary

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -249,9 +249,9 @@ class Controller:
         await self.update_fw_version()
 
     @property
-    def axis_bounds(self) -> Dict[str, Tuple[float, float]]:
+    def axis_bounds(self) -> Dict[Axis, Tuple[float, float]]:
         """ The (minimum, maximum) bounds for each axis. """
-        return {ax: (0, pos + .05) for ax, pos
+        return {Axis[ax]: (0, pos) for ax, pos
                 in self._smoothie_driver.homed_position.items()
                 if ax not in 'BC'}
 

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -259,9 +259,9 @@ class Simulator:
             sim_model=sim_model)
 
     @property
-    def axis_bounds(self) -> Dict[str, Tuple[float, float]]:
+    def axis_bounds(self) -> Dict[Axis, Tuple[float, float]]:
         """ The (minimum, maximum) bounds for each axis. """
-        return {ax: (0, pos + 0.5) for ax, pos in _HOME_POSITION.items()
+        return {Axis[ax]: (0, pos) for ax, pos in _HOME_POSITION.items()
                 if ax not in 'BC'}
 
     @property

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -12,6 +12,25 @@ if TYPE_CHECKING:
 MODULE_LOG = logging.getLogger(__name__)
 
 
+class OutOfBoundsMove(RuntimeError):
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__()
+
+    def __str__(self) -> str:
+        return f'OutOfBoundsMove: {self.message}'
+
+    def __repr__(self) -> str:
+        return f'<{str(self.__class__)}: {self.message}>'
+
+
+class MotionChecks(enum.Enum):
+    NONE = 0
+    LOW = 1
+    HIGH = 2
+    BOTH = 3
+
+
 class Axis(enum.Enum):
     X = 0
     Y = 1

--- a/api/src/opentrons/hardware_control/util.py
+++ b/api/src/opentrons/hardware_control/util.py
@@ -86,7 +86,7 @@ def check_motion_bounds(
                 tsp=target_smoothie[ax],
                 tdp=target_deck.get(ax, 'unknown'),
                 dir='high',
-                limsp=bounds.get(ax, (None,'unknown'))[1],
+                limsp=bounds.get(ax, (None, 'unknown'))[1],
             )
             mod_log.warning(bounds_message)
             if checks.value & MotionChecks.HIGH.value:

--- a/api/src/opentrons/hardware_control/util.py
+++ b/api/src/opentrons/hardware_control/util.py
@@ -2,9 +2,9 @@
 import asyncio
 import logging
 from enum import Enum
-from typing import Dict, Any, Optional, List, Tuple
+from typing import Dict, Any, Optional, List, Mapping, Tuple
 
-from .types import CriticalPoint
+from .types import CriticalPoint, MotionChecks, OutOfBoundsMove, Axis
 from opentrons.types import Point
 
 mod_log = logging.getLogger(__name__)
@@ -48,3 +48,46 @@ class DeckTransformState(Enum):
 
     def __str__(self):
         return self.name
+
+
+def check_motion_bounds(
+        target_smoothie: Mapping[Axis, float],
+        target_deck: Mapping[Axis, float],
+        bounds: Mapping[Axis, Tuple[float, float]],
+        checks: MotionChecks):
+    """
+    Log or raise an error (depending on checks) if a specified
+    target position is outside the acceptable bounds of motion
+
+    Which axes are checked is defined by the elements of
+    target_smoothie.
+
+    The target_deck and mapping does not need to be
+    entirely filled; it is used only for logging
+    """
+    bounds_message_format = (
+        'Out of bounds move: {axis}=({tsp} motor controller, {tdp} deck) too '
+        '{dir} for limit {limsp}')
+    for ax in target_smoothie.keys():
+        if target_smoothie[ax] < bounds[ax][0]:
+            bounds_message = bounds_message_format.format(
+                axis=ax,
+                tsp=target_smoothie[ax],
+                tdp=target_deck.get(ax, 'unknown'),
+                dir='low',
+                limsp=bounds.get(ax, ('unknown',))[0],
+            )
+            mod_log.warning(bounds_message)
+            if checks.value & MotionChecks.LOW.value:
+                raise OutOfBoundsMove(bounds_message)
+        elif target_smoothie[ax] > bounds[ax][1]:
+            bounds_message = bounds_message_format.format(
+                axis=ax,
+                tsp=target_smoothie[ax],
+                tdp=target_deck.get(ax, 'unknown'),
+                dir='high',
+                limsp=bounds.get(ax, (None,'unknown'))[1],
+            )
+            mod_log.warning(bounds_message)
+            if checks.value & MotionChecks.HIGH.value:
+                raise OutOfBoundsMove(bounds_message)

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -7,6 +7,7 @@ from opentrons.protocol_api import labware
 from opentrons.api import models
 from opentrons.types import Point, Location, Mount
 from opentrons.hardware_control import CriticalPoint, API
+from opentrons.hardware_control.types import MotionChecks
 
 state = partial(state, 'calibration')
 
@@ -282,7 +283,7 @@ async def test_jog_api2(main_router, model):
             )
 
         expected = [
-            mock.call(Mount.RIGHT, point)
+            mock.call(Mount.RIGHT, point, check_bounds=MotionChecks.HIGH)
             for point in [Point(x=1), Point(y=2), Point(z=3)]]
 
         assert jog.mock_calls == expected

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -387,4 +387,5 @@ async def test_move_rel_bounds(
         hardware_api, toggle_new_calibration):
     with pytest.raises(OutOfBoundsMove):
         await hardware_api.move_rel(
-            types.Mount.RIGHT, types.Point(0, 0, 2000), check_bounds=MotionChecks.HIGH)
+            types.Mount.RIGHT, types.Point(0, 0, 2000),
+            check_bounds=MotionChecks.HIGH)

--- a/api/tests/opentrons/hardware_control/test_util.py
+++ b/api/tests/opentrons/hardware_control/test_util.py
@@ -76,20 +76,20 @@ def test_cp_blending():
     'xformed,deck,bounds,check,catch,phrase',
     [
         # acceptable moves, iterating through checks
-        ({Axis.X: 2}, {Axis.X: -15}, {Axis.X: (1, 4)}, MotionChecks.NONE, False, ''),
-        ({Axis.X: 2}, {Axis.X: -10}, {Axis.X: (1, 4)}, MotionChecks.LOW, False, ''),
-        ({Axis.X: 2}, {Axis.X: 0}, {Axis.X: (1, 4)}, MotionChecks.HIGH, False, ''),
-        ({Axis.X: 2}, {Axis.X: 10}, {Axis.X: (1, 4)}, MotionChecks.BOTH, False, ''),
+        ({Axis.X: 2}, {Axis.X: -15}, {Axis.X: (1, 4)}, MotionChecks.NONE, False, ''),  # noqa(E501)
+        ({Axis.X: 2}, {Axis.X: -10}, {Axis.X: (1, 4)}, MotionChecks.LOW, False, ''),  # noqa(E501)
+        ({Axis.X: 2}, {Axis.X: 0}, {Axis.X: (1, 4)}, MotionChecks.HIGH, False, ''),  # noqa(E501)
+        ({Axis.X: 2}, {Axis.X: 10}, {Axis.X: (1, 4)}, MotionChecks.BOTH, False, ''),  # noqa(E501)
         # unacceptable low, with and without checking
-        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.NONE, False, ''),
-        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.LOW, True, 'low'),
-        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.HIGH, False, ''),
-        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.BOTH, True, 'low'),
+        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.NONE, False, ''),  # noqa(E501)
+        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.LOW, True, 'low'),  # noqa(E501)
+        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.HIGH, False, ''),  # noqa(E501)
+        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.BOTH, True, 'low'),  # noqa(E501)
         # unacceptable high, with and without checking
-        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.NONE, False, ''),
-        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.LOW, False, ''),
-        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.HIGH, True, 'high'),
-        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.BOTH, True, 'high')
+        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.NONE, False, ''),  # noqa(E501)
+        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.LOW, False, ''),  # noqa(E501)
+        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.HIGH, True, 'high'),  # noqa(E501)
+        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.BOTH, True, 'high')  # noqa(E501)
     ])
 def test_check_motion_bounds(xformed, deck, bounds, check, catch, phrase):
     if catch:

--- a/api/tests/opentrons/hardware_control/test_util.py
+++ b/api/tests/opentrons/hardware_control/test_util.py
@@ -1,8 +1,10 @@
 from typing import List
 
-from opentrons.hardware_control.util import plan_arc
-from opentrons.hardware_control.types import CriticalPoint
+from opentrons.hardware_control.util import plan_arc, check_motion_bounds
+from opentrons.hardware_control.types import (
+    CriticalPoint, MotionChecks, OutOfBoundsMove, Axis)
 from opentrons.types import Point
+
 
 import pytest
 
@@ -68,3 +70,30 @@ def test_cp_blending():
     assert arc2[0][1] == CriticalPoint.TIP
     assert arc2[1][1] is None
     assert arc2[2][1] is None
+
+
+@pytest.mark.parametrize(
+    'xformed,deck,bounds,check,catch,phrase',
+    [
+        # acceptable moves, iterating through checks
+        ({Axis.X: 2}, {Axis.X: -15}, {Axis.X: (1, 4)}, MotionChecks.NONE, False, ''),
+        ({Axis.X: 2}, {Axis.X: -10}, {Axis.X: (1, 4)}, MotionChecks.LOW, False, ''),
+        ({Axis.X: 2}, {Axis.X: 0}, {Axis.X: (1, 4)}, MotionChecks.HIGH, False, ''),
+        ({Axis.X: 2}, {Axis.X: 10}, {Axis.X: (1, 4)}, MotionChecks.BOTH, False, ''),
+        # unacceptable low, with and without checking
+        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.NONE, False, ''),
+        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.LOW, True, 'low'),
+        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.HIGH, False, ''),
+        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.BOTH, True, 'low'),
+        # unacceptable high, with and without checking
+        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.NONE, False, ''),
+        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.LOW, False, ''),
+        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.HIGH, True, 'high'),
+        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.BOTH, True, 'high')
+    ])
+def test_check_motion_bounds(xformed, deck, bounds, check, catch, phrase):
+    if catch:
+        with pytest.raises(OutOfBoundsMove, match=phrase):
+            check_motion_bounds(xformed, deck, bounds, check)
+    else:
+        check_motion_bounds(xformed, deck, bounds, check)


### PR DESCRIPTION
Certain calibration workflows involve jogging pipettes up pretty high. Especially with GEN2 pipettes, the upwards range of motion can be pretty limited, and jogging up like that can cause hard limit errors which poison the system.

Use the motion checking system we already have (after a bit of a light refactor) to actually raise errors during jog, albeit swallowing them before returning them to the app, to implement a system where the robot just won't move if you jog it too high specifically during labware calibraiton (in V2 protocols, anyway).

## Impact
Medium - this affects a pretty core part of the system in labware calibration, but in a very limited way. The checks can only raise exceptions specifically when jogging in labware calibration, not in any of the new flows.

## Testing
- Make sure you can still jog around when calibrating one of the classic almost-too-tall labware stacks, like a deep well plate on a magdeck when using a GEN2 P20 Multi