### PR TITLE
chore(robot-server): enable pydantic mypy plugin and suppress new errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,4 +110,5 @@ calibrations/
 *.ipynb
 
 # local IDE configs
-**/.vscode
+.vscode
+*.code-workspace

--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -1,24 +1,25 @@
 [mypy]
-ignore_missing_imports=False
-check_untyped_defs=True
+ignore_missing_imports = False
+check_untyped_defs = True
+show_error_codes = True
 
 [mypy-opentrons.legacy_api.*]
-check_untyped_defs=False
+check_untyped_defs = False
 
 [mypy-opentrons.server.serialize]
-check_untyped_defs=False
+check_untyped_defs = False
 
 [mypy-opentrons.server.rpc]
-check_untyped_defs=False
+check_untyped_defs = False
 
 [mypy-opentrons.tools.*]
-check_untyped_defs=False
+check_untyped_defs = False
 
 [mypy-opentrons.commands.*]
-check_untyped_defs=False
+check_untyped_defs = False
 
 [mypy-opentrons.helpers.*]
-check_untyped_defs=False
+check_untyped_defs = False
 
 [mypy-opentrons.deck_calibration.*]
-check_untyped_defs=False
+check_untyped_defs = False

--- a/robot-server/mypy.ini
+++ b/robot-server/mypy.ini
@@ -1,3 +1,11 @@
 [mypy]
-ignore_missing_imports=False
-check_untyped_defs=True
+plugins = pydantic.mypy
+check_untyped_defs = True
+ignore_missing_imports = False
+show_error_codes = True
+
+[pydantic-mypy]
+init_forbid_extra = True
+init_typed = True
+warn_required_dynamic_aliases = True
+warn_untyped_fields = True

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -110,12 +110,15 @@ class DeckCalibrationUserFlow:
         return self._current_state
 
     def get_pipette(self) -> Optional[AttachedPipette]:
-        return AttachedPipette(
+        # TODO(mc, 2020-09-17): s/tip_length/tipLength
+        # TODO(mc, 2020-09-17): type of pipette_id does not match expected
+        # type of AttachedPipette.serial
+        return AttachedPipette(  # type: ignore[call-arg]
             model=self._hw_pipette.model,
             name=self._hw_pipette.name,
             tip_length=self._hw_pipette.config.tip_length,
             mount=str(self._mount),
-            serial=self._hw_pipette.pipette_id)
+            serial=self._hw_pipette.pipette_id)  # type: ignore[arg-type]
 
     def get_required_labware(self) -> List[RequiredLabware]:
         lw = self._get_tip_rack_lw()

--- a/robot-server/robot_server/robot/calibration/helper_classes.py
+++ b/robot-server/robot_server/robot/calibration/helper_classes.py
@@ -150,14 +150,18 @@ class RequiredLabware(BaseModel):
                 lw: labware.Labware,
                 slot: typing.Optional[DeckLocation] = None):
         if not slot:
-            slot = lw._parent  # type: ignore
+            slot = lw._parent  # type: ignore[assignment]
         return cls(
-            slot=slot,
+            # TODO(mc, 2020-09-17): DeckLocation does not match
+            #  Union[int,str,None] expected by cls
+            slot=slot,  # type: ignore[arg-type]
             loadName=lw.load_name,
             namespace=lw._definition['namespace'],
             version=str(lw._definition['version']),
             isTiprack=lw.is_tiprack,
-            definition=lw._definition)
+            # TODO(mc, 2020-09-17): LabwareDefinition does not match
+            # Dict[any,any] expected by cls
+            definition=lw._definition)  # type: ignore[arg-type]
 
 
 class NextStepLink(BaseModel):

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -83,7 +83,8 @@ class PipetteOffsetCalibrationUserFlow:
         return self._current_state
 
     def get_pipette(self) -> AttachedPipette:
-        return AttachedPipette(
+        # TODO(mc, 2020-09-17): s/tip_length/tipLength
+        return AttachedPipette(  # type: ignore[call-arg]
             model=self._hw_pipette.model,
             name=self._hw_pipette.name,
             tip_length=self._hw_pipette.config.tip_length,

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -99,11 +99,14 @@ class TipCalibrationUserFlow:
         return self._current_state
 
     def get_pipette(self) -> AttachedPipette:
-        return AttachedPipette(model=self._hw_pipette.model,
-                               name=self._hw_pipette.name,
-                               tip_length=self._hw_pipette.config.tip_length,
-                               mount=str(self._mount),
-                               serial=self._hw_pipette.pipette_id)
+        # TODO(mc, 2020-09-17): s/tip_length/tipLength
+        return AttachedPipette(  # type: ignore[call-arg]
+            model=self._hw_pipette.model,
+            name=self._hw_pipette.name,
+            tip_length=self._hw_pipette.config.tip_length,
+            mount=str(self._mount),
+            serial=self._hw_pipette.pipette_id
+        )
 
     def get_required_labware(self) -> List[RequiredLabware]:
         slots = self._deck.get_non_fixture_slots()

--- a/robot-server/robot_server/service/labware/router.py
+++ b/robot-server/robot_server/service/labware/router.py
@@ -33,9 +33,11 @@ def _format_calibrations(
         # TODO: Integrate datetime methods
         # to ensure that last_modified is the expected
         # value.
+        # TODO(mc, 2020-09-17): lw_offset types do not match the types
+        # expected by OffsetData
         offset = lw_models.OffsetData(
-            value=lw_offset.value,
-            lastModified=lw_offset.last_modified)
+            value=lw_offset.value,  # type: ignore[arg-type]
+            lastModified=lw_offset.last_modified)  # type: ignore[arg-type]
 
         tip_cal = calInfo.calibration.tip_length
         tip_length = lw_models.TipData(
@@ -114,7 +116,11 @@ async def get_all_labware_calibrations(
     all_calibrations = get_cal.get_all_calibrations()
 
     if not all_calibrations:
-        return lw_models.MultipleCalibrationsResponse(data=all_calibrations)
+        # TODO(mc, 2020-09-17): the type of all_calibrations does not match
+        # what MultipleCalibrationsResponse expects for data
+        return lw_models.MultipleCalibrationsResponse(
+            data=all_calibrations  # type: ignore[arg-type]
+        )
 
     if namespace:
         all_calibrations = list(filter(
@@ -134,7 +140,11 @@ async def get_all_labware_calibrations(
           all_calibrations))
     calibrations = _format_calibrations(all_calibrations)
 
-    return lw_models.MultipleCalibrationsResponse(data=calibrations)
+    # TODO(mc, 2020-09-17): the type of all_calibrations does not match
+    # what MultipleCalibrationsResponse expects for data
+    return lw_models.MultipleCalibrationsResponse(
+        data=calibrations  # type: ignore[arg-type]
+    )
 
 
 @router.get("/labware/calibrations/{calibrationId}",

--- a/robot-server/robot_server/service/labware/router.py
+++ b/robot-server/robot_server/service/labware/router.py
@@ -164,8 +164,10 @@ async def get_specific_labware_calibration(
                                id=calibrationId)
 
     formatted_calibrations = _format_calibrations([calibration])
+    # TODO(mc, 2020-09-17): type of formatted_calibrations[0] does not match
+    # what SingleCalibrationResponse expects for data
     return lw_models.SingleCalibrationResponse(
-        data=formatted_calibrations[0])
+        data=formatted_calibrations[0])  # type: ignore[arg-type]
 
 
 @router.delete("/labware/calibrations/{calibrationId}",

--- a/robot-server/robot_server/service/legacy/routers/modules.py
+++ b/robot-server/robot_server/service/legacy/routers/modules.py
@@ -62,7 +62,13 @@ async def get_module_serial(
     if not res:
         raise V1HandlerError(status_code=status.HTTP_404_NOT_FOUND,
                              message="Module not found")
-    return ModuleSerial(status=res.get('status'), data=res.get('data'))
+
+    # TODO(mc, 2020-09-17): types of res.get(...) do not match what
+    # ModuleSerial expects
+    return ModuleSerial(
+        status=res.get('status'),  # type: ignore[arg-type]
+        data=res.get('data')  # type: ignore[arg-type]
+    )
 
 
 @router.post("/modules/{serial}",

--- a/robot-server/robot_server/service/legacy/routers/settings.py
+++ b/robot-server/robot_server/service/legacy/routers/settings.py
@@ -254,6 +254,9 @@ def _pipette_settings_from_config(pc, pipette_id: str) -> PipetteSettings:
         **{k: v for k, v in mutuble_configs.items()}
     )
     c, m = pc.load_config_dict(pipette_id)
-    return PipetteSettings(info=PipetteSettingsInfo(name=c.get('name'),
-                                                    model=m),
-                           fields=fields)
+
+    # TODO(mc, 2020-09-17): s/fields/setting_fields (?)
+    return PipetteSettings(  # type: ignore[call-arg]
+        info=PipetteSettingsInfo(name=c.get('name'), model=m),
+        fields=fields
+    )

--- a/robot-server/robot_server/service/session/session_types/check_session.py
+++ b/robot-server/robot_server/service/session/session_types/check_session.py
@@ -80,10 +80,12 @@ class CheckSession(BaseSession):
             self._calibration_check.labware_status.values()
         ]
 
+        # TODO(mc, 2020-09-17): type of get_comparisons_by_step doesn't quite
+        # match what CalibrationSessionStatus expects for comparisonsByStep
         return calibration_models.CalibrationSessionStatus(
             instruments=instruments,
             currentStep=self._calibration_check.current_state_name,
-            comparisonsByStep=self._calibration_check.get_comparisons_by_step(),  # noqa: e501
+            comparisonsByStep=self._calibration_check.get_comparisons_by_step(),  # type: ignore[arg-type] # noqa: e501
             labware=labware,
         )
 

--- a/robot-server/robot_server/service/session/session_types/deck_calibration_session.py
+++ b/robot-server/robot_server/service/session/session_types/deck_calibration_session.py
@@ -75,8 +75,10 @@ class DeckCalibrationSession(BaseSession):
         return SessionType.deck_calibration
 
     def _get_response_details(self) -> SessionDetails:
+        # TODO(mc, 2020-09-17): get_pipette() returns an Optional value but
+        # DeckCalibrationSessionStatus has an exact type for instrument
         return DeckCalibrationSessionStatus(
-            instrument=self._deck_cal_user_flow.get_pipette(),
+            instrument=self._deck_cal_user_flow.get_pipette(),  # type: ignore[arg-type] # noqa: e501
             currentStep=self._deck_cal_user_flow.current_state,
             labware=self._deck_cal_user_flow.get_required_labware())
 

--- a/update-server/mypy.ini
+++ b/update-server/mypy.ini
@@ -1,2 +1,3 @@
 [mypy]
-ignore_missing_imports=true
+ignore_missing_imports = True
+show_error_codes = True


### PR DESCRIPTION
## Overview

Hey look, I'm figuring out how to set up my editor for Python dev! Turns out that there is a [pydantic plugin for mypy](https://pydantic-docs.helpmanual.io/mypy_plugin/) that we're not using. When I enabled it, 20 new type errors showed up in `robot-server`.

Most are pretty minor, but there are a couple bad looking ones that I've commented on in a PR review below. I resisted the urge to fix any of them and instead added `# type: ignore[...]` suppression comments along with `TODO`s with a little more detail about how to fix them.

I also took this opportunity to:

- Make our `mypy.ini` files use a consistent style that matches the examples in the mypy documentation
- Enable error code output from mypy so we can write more specific type error suppression comments

## Changelog

- chore(robot-server): enable pydantic mypy plugin and suppress new errors

## Review requests

- [ ] Changes look good (e.g. don't actually change any source code)

## Risk assessment

N/A, formatting + comment only changes. Type check suppressions are all applied to already existing errors 
