### PR TITLE
refactor(api): abstract baseclasses for module contexts

### DIFF
--- a/api/src/opentrons/protocol_api/implementation/interfaces/instrument_context.py
+++ b/api/src/opentrons/protocol_api/implementation/interfaces/instrument_context.py
@@ -4,15 +4,16 @@ from abc import abstractmethod
 import typing
 
 from opentrons import types
-from opentrons.protocol_api.transfers import TransferOptions
+from opentrons.protocols.advanced_control.transfers import TransferOptions
 from opentrons.protocol_api.implementation.interfaces.versioned import \
     ApiVersioned
 from opentrons.protocol_api.instrument_context import AdvancedLiquidHandling
 from opentrons.protocol_api.labware import Labware, Well
-from opentrons.protocol_api.util import (FlowRates, PlungerSpeeds, Clearances)
+from opentrons.protocols.api_support.util import (
+    FlowRates, PlungerSpeeds, Clearances)
 
 
-class AbstractInstrumentContextImpl(ApiVersioned):
+class AbstractInstrumentContextImplementation(ApiVersioned):
 
     @abstractmethod
     def get_starting_tip(self) -> typing.Optional[Well]:

--- a/api/src/opentrons/protocol_api/implementation/interfaces/labware.py
+++ b/api/src/opentrons/protocol_api/implementation/interfaces/labware.py
@@ -6,16 +6,16 @@ from typing import (List, Dict, Optional, Union, TYPE_CHECKING)
 
 from opentrons.protocol_api.implementation.interfaces.versioned import \
     ApiVersioned
-from opentrons.protocol_api.definitions import DeckItem
+from opentrons.protocols.geometry.deck import DeckItem
 from opentrons.protocol_api.labware import Labware, Well
-from opentrons.protocol_api.module_geometry import ModuleGeometry
+from opentrons.protocols.geometry.module_geometry import ModuleGeometry
 
 from opentrons.types import Location, Point
 if TYPE_CHECKING:
     from opentrons_shared_data.labware.dev_types import LabwareParameters
 
 
-class AbstractWell(ApiVersioned):
+class AbstractWellImplementation(ApiVersioned):
 
     @abstractmethod
     def get_parent(self) -> Labware:
@@ -50,7 +50,7 @@ class AbstractWell(ApiVersioned):
         ...
 
 
-class AbstractLabware(ApiVersioned, DeckItem):
+class AbstractLabwareImplementation(ApiVersioned, DeckItem):
 
     @abstractmethod
     def __getitem__(self, key: str) -> Well:

--- a/api/src/opentrons/protocol_api/implementation/interfaces/modules/magnetic_module_context.py
+++ b/api/src/opentrons/protocol_api/implementation/interfaces/modules/magnetic_module_context.py
@@ -1,7 +1,12 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
+
+from opentrons.protocol_api.implementation.interfaces.modules.module_context \
+    import AbstractModuleContextImplementation
 
 
-class AbstractMagneticModuleContextImplementation(ABC):
+class AbstractMagneticModuleContextImplementation(
+    AbstractModuleContextImplementation
+):
 
     @abstractmethod
     def calibrate(self) -> None:

--- a/api/src/opentrons/protocol_api/implementation/interfaces/modules/magnetic_module_context.py
+++ b/api/src/opentrons/protocol_api/implementation/interfaces/modules/magnetic_module_context.py
@@ -1,0 +1,23 @@
+from abc import ABC, abstractmethod
+
+
+class AbstractMagneticModuleContextImplementation(ABC):
+
+    @abstractmethod
+    def calibrate(self) -> None:
+        ...
+
+    @abstractmethod
+    def engage(self,
+               height: float = None,
+               offset: float = None,
+               height_from_base: float = None) -> None:
+        ...
+
+    @abstractmethod
+    def disengage(self) -> None:
+        ...
+
+    @abstractmethod
+    def get_status(self) -> str:
+        ...

--- a/api/src/opentrons/protocol_api/implementation/interfaces/modules/module_context.py
+++ b/api/src/opentrons/protocol_api/implementation/interfaces/modules/module_context.py
@@ -15,16 +15,6 @@ class AbstractModuleContextImplementation(ApiVersioned):
         ...
 
     @abstractmethod
-    def load_labware(
-            self,
-            name: str,
-            label: str = None,
-            namespace: str = None,
-            version: int = 1,
-    ) -> Labware:
-        ...
-
-    @abstractmethod
     def load_labware_from_definition(
             self,
             definition: LabwareDefinition,

--- a/api/src/opentrons/protocol_api/implementation/interfaces/modules/module_context.py
+++ b/api/src/opentrons/protocol_api/implementation/interfaces/modules/module_context.py
@@ -1,0 +1,40 @@
+from abc import abstractmethod
+from typing import Optional
+
+from opentrons.protocol_api.implementation.interfaces.versioned import \
+    ApiVersioned
+from opentrons.protocol_api.labware import Labware
+from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+from opentrons_shared_data.labware import LabwareDefinition
+
+
+class AbstractModuleContextImplementation(ApiVersioned):
+
+    @abstractmethod
+    def load_labware_object(self, labware: Labware) -> Labware:
+        ...
+
+    @abstractmethod
+    def load_labware(
+            self,
+            name: str,
+            label: str = None,
+            namespace: str = None,
+            version: int = 1,
+    ) -> Labware:
+        ...
+
+    @abstractmethod
+    def load_labware_from_definition(
+            self,
+            definition: LabwareDefinition,
+            label: str = None) -> Labware:
+        ...
+
+    @abstractmethod
+    def get_labware(self) -> Optional[Labware]:
+        ...
+
+    @abstractmethod
+    def get_geometry(self) -> ModuleGeometry:
+        ...

--- a/api/src/opentrons/protocol_api/implementation/interfaces/modules/temperature_module_context.py
+++ b/api/src/opentrons/protocol_api/implementation/interfaces/modules/temperature_module_context.py
@@ -1,0 +1,32 @@
+from abc import abstractmethod, ABC
+
+
+class AbstractTemperatureModuleContextImplementation(ABC):
+
+    @abstractmethod
+    def set_temperature(self, celsius: float) -> None:
+        ...
+
+    @abstractmethod
+    def start_set_temperature(self, celsius: float) -> None:
+        ...
+
+    @abstractmethod
+    def await_temperature(self, celsius: float) -> None:
+        ...
+
+    @abstractmethod
+    def deactivate(self) -> None:
+        ...
+
+    @abstractmethod
+    def get_temperature(self) -> float:
+        ...
+
+    @abstractmethod
+    def get_target_temperature(self) -> float:
+        ...
+
+    @abstractmethod
+    def get_status(self) -> str:
+        ...

--- a/api/src/opentrons/protocol_api/implementation/interfaces/modules/temperature_module_context.py
+++ b/api/src/opentrons/protocol_api/implementation/interfaces/modules/temperature_module_context.py
@@ -1,7 +1,12 @@
-from abc import abstractmethod, ABC
+from abc import abstractmethod
+
+from opentrons.protocol_api.implementation.interfaces.modules.module_context \
+    import AbstractModuleContextImplementation
 
 
-class AbstractTemperatureModuleContextImplementation(ABC):
+class AbstractTemperatureModuleContextImplementation(
+    AbstractModuleContextImplementation
+):
 
     @abstractmethod
     def set_temperature(self, celsius: float) -> None:

--- a/api/src/opentrons/protocol_api/implementation/interfaces/modules/thermocycler_module_context.py
+++ b/api/src/opentrons/protocol_api/implementation/interfaces/modules/thermocycler_module_context.py
@@ -1,0 +1,99 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+from opentrons.hardware_control.modules import ThermocyclerStep
+
+
+class AbstractThermocyclerContextImplementation(ABC):
+
+    @abstractmethod
+    def open_lid(self) -> None:
+        ...
+
+    @abstractmethod
+    def close_lid(self) -> None:
+        ...
+
+    @abstractmethod
+    def set_block_temperature(self,
+                              temperature: float,
+                              hold_time_seconds: float = None,
+                              hold_time_minutes: float = None,
+                              ramp_rate: float = None,
+                              block_max_volume: float = None) -> None:
+        ...
+
+    @abstractmethod
+    def set_lid_temperature(self, temperature: float) -> None:
+        ...
+
+    @abstractmethod
+    def execute_profile(self,
+                        steps: List[ThermocyclerStep],
+                        repetitions: int,
+                        block_max_volume: float = None) -> None:
+        ...
+
+    @abstractmethod
+    def deactivate_lid(self) -> None:
+        ...
+
+    @abstractmethod
+    def deactivate_block(self) -> None:
+        ...
+
+    @abstractmethod
+    def deactivate(self) -> None:
+        ...
+
+    @abstractmethod
+    def get_lid_status(self) -> str:
+        ...
+
+    @abstractmethod
+    def get_block_temperature_status(self) -> str:
+        ...
+
+    @abstractmethod
+    def get_lid_temperature_status(self) -> str:
+        ...
+
+    @abstractmethod
+    def get_block_temperature(self) -> float:
+        ...
+
+    @abstractmethod
+    def get_block_target_temperature(self) -> float:
+        ...
+
+    @abstractmethod
+    def get_lid_temperature(self) -> float:
+        ...
+
+    @abstractmethod
+    def get_lid_target_temperature(self) -> float:
+        ...
+
+    @abstractmethod
+    def get_ramp_rate(self) -> float:
+        ...
+
+    @abstractmethod
+    def get_hold_time(self) -> int:
+        ...
+
+    @abstractmethod
+    def get_total_cycle_count(self) -> int:
+        ...
+
+    @abstractmethod
+    def get_current_cycle_index(self) -> int:
+        ...
+
+    @abstractmethod
+    def get_total_step_count(self) -> int:
+        ...
+
+    @abstractmethod
+    def get_current_step_index(self) -> int:
+        ...

--- a/api/src/opentrons/protocol_api/implementation/interfaces/modules/thermocycler_module_context.py
+++ b/api/src/opentrons/protocol_api/implementation/interfaces/modules/thermocycler_module_context.py
@@ -1,10 +1,14 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import List
 
 from opentrons.hardware_control.modules import ThermocyclerStep
+from opentrons.protocol_api.implementation.interfaces.modules.module_context \
+    import AbstractModuleContextImplementation
 
 
-class AbstractThermocyclerContextImplementation(ABC):
+class AbstractThermocyclerContextImplementation(
+    AbstractModuleContextImplementation
+):
 
     @abstractmethod
     def open_lid(self) -> None:

--- a/api/src/opentrons/protocol_api/implementation/interfaces/protocol_context.py
+++ b/api/src/opentrons/protocol_api/implementation/interfaces/protocol_context.py
@@ -9,16 +9,16 @@ from opentrons.hardware_control import API
 from opentrons.protocol_api.implementation.interfaces.versioned import \
     ApiVersioned
 from opentrons.protocol_api.labware import Labware
-from opentrons.protocol_api.module_geometry import ModuleGeometry
-from opentrons.protocol_api.geometry import Deck
+from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocol_api.instrument_context import InstrumentContext
 from opentrons.protocol_api.protocol_context import ModuleTypes
 from opentrons.protocol_api.module_contexts import ModuleContext
-from opentrons.protocol_api.util import AxisMaxSpeeds
+from opentrons.protocols.api_support.util import AxisMaxSpeeds
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 
-class AbstractProtocolContext(ApiVersioned):
+class AbstractProtocolContextImplementation(ApiVersioned):
 
     @abstractmethod
     def get_bundled_data(self) -> Dict[str, bytes]:


### PR DESCRIPTION
# Overview

Adding abstract interfaces for implementation of `ModuleContext` and it's derived classes. 

Even though we've put this epic aside for now, I still think it's worth doing. So going to chip away at it.

closes #6330

# Review requests

Feedback I am looking for:
- are inputs and outputs of functions okay. Some of them should be more specifically typed (`ThermocyclerStep` for example).
- are there methods that don't belong.

Note that the target branch is a feature branch.

The purpose of this PR is to get these interfaces written. There could (will) end up being quite a bit of shuffling once I try to continue to the next step which is to have the Context classes delegate their work to implementations of these interfaces. 

# Risk assessment

None