### PR TITLE
chore(shared-data): clean build directory and check json changes during make wheel

### DIFF
--- a/shared-data/python/Makefile
+++ b/shared-data/python/Makefile
@@ -36,6 +36,8 @@ json_sources = $(filter %.json,$(shell $(SHX) find ..))
 twine_auth_args := --username $(pypi_username) --password $(pypi_password)
 twine_repository_url ?= $(pypi_test_upload_url)
 
+clean_cmd = $(SHX) rm -rf build $(BUILD_DIR) .coverage coverage.xml '*.egg-info' ' **/__pycache__' '**/*.pyc'
+
 .PHONY: setup
 setup: setup-py
 
@@ -47,17 +49,18 @@ setup-py:
 
 .PHONY: clean
 clean:
-	shx rm -rf $(BUILD_DIR)
+	$(clean_cmd)
 
 
 .PHONY: wheel
 wheel: $(wheel_file)
 
 
-$(BUILD_DIR)/opentrons_shared_data-%-py2.py3-none-any.whl: setup.py $(py_sources)
+$(BUILD_DIR)/opentrons_shared_data-%-py2.py3-none-any.whl: setup.py $(py_sources) $(json_sources)
+	$(clean_cmd)
 	$(SHX) mkdir -p build
 	$(python) setup.py $(wheel_opts) bdist_wheel
-	$(SHX) rm -rf build *.egg_info
+	$(SHX) rm -rf build
 	$(SHX) ls $(BUILD_DIR)
 
 

--- a/shared-data/python/Makefile
+++ b/shared-data/python/Makefile
@@ -57,10 +57,9 @@ wheel: $(wheel_file)
 
 
 $(BUILD_DIR)/opentrons_shared_data-%-py2.py3-none-any.whl: setup.py $(py_sources) $(json_sources)
-	$(clean_cmd)
+	$(clean)
 	$(SHX) mkdir -p build
 	$(python) setup.py $(wheel_opts) bdist_wheel
-	$(SHX) rm -rf build
 	$(SHX) ls $(BUILD_DIR)
 
 

--- a/shared-data/python/Makefile
+++ b/shared-data/python/Makefile
@@ -56,8 +56,7 @@ clean:
 wheel: $(wheel_file)
 
 
-$(BUILD_DIR)/opentrons_shared_data-%-py2.py3-none-any.whl: setup.py $(py_sources) $(json_sources)
-	$(clean)
+$(BUILD_DIR)/opentrons_shared_data-%-py2.py3-none-any.whl: setup.py $(py_sources) $(json_sources) clean
 	$(SHX) mkdir -p build
 	$(python) setup.py $(wheel_opts) bdist_wheel
 	$(SHX) ls $(BUILD_DIR)


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR fixes the two following issues with `make push` in shared-data:
1. old wheel files are not being cleared and accumulate in `python/dist`
2. a new wheel file is only generated when changes to python files are detected but not json files

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- add `clean_cmd` that is found in both api and robot-server Makefiles to clear the shared-data build directory
- use the `json_sources` filter to look for changes
<!--


Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Am I understanding and fixing this correctly?
<!--
Describe any requests for your reviewers here.
-->
