### PR TITLE
feat(protocol-designer): remove mix delay FF

### DIFF
--- a/protocol-designer/src/components/StepEditForm/forms/MixForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MixForm.js
@@ -1,9 +1,7 @@
 // @flow
 import * as React from 'react'
 import cx from 'classnames'
-import { useSelector } from 'react-redux'
 import { FormGroup } from '@opentrons/components'
-import { selectors as featureFlagSelectors } from '../../../feature-flags'
 import { i18n } from '../../../localization'
 import {
   TextField,
@@ -30,8 +28,6 @@ export const MixForm = (props: Props): React.Node => {
   const { focusHandlers } = props
 
   const [collapsed, setCollapsed] = React.useState(true)
-
-  const mixDelayEnabled = useSelector(featureFlagSelectors.getEnabledMixDelay)
 
   const toggleCollapsed = (): void =>
     setCollapsed(prevCollapsed => !prevCollapsed)
@@ -110,13 +106,11 @@ export const MixForm = (props: Props): React.Node => {
                 label={i18n.t('form.step_edit_form.field.well_order.label')}
               />
             </div>
-            {mixDelayEnabled && (
-              <DelayFields
-                checkboxFieldName={'aspirate_delay_checkbox'}
-                secondsFieldName={'aspirate_delay_seconds'}
-                focusHandlers={focusHandlers}
-              />
-            )}
+            <DelayFields
+              checkboxFieldName={'aspirate_delay_checkbox'}
+              secondsFieldName={'aspirate_delay_seconds'}
+              focusHandlers={focusHandlers}
+            />
           </div>
 
           <div className={styles.section_column}>
@@ -128,13 +122,11 @@ export const MixForm = (props: Props): React.Node => {
               />
             </div>
             <div className={styles.checkbox_column}>
-              {mixDelayEnabled && (
-                <DelayFields
-                  checkboxFieldName={'dispense_delay_checkbox'}
-                  secondsFieldName={'dispense_delay_seconds'}
-                  focusHandlers={focusHandlers}
-                />
-              )}
+              <DelayFields
+                checkboxFieldName={'dispense_delay_checkbox'}
+                secondsFieldName={'dispense_delay_seconds'}
+                focusHandlers={focusHandlers}
+              />
               <CheckboxRowField
                 className={styles.small_field}
                 label={i18n.t('form.step_edit_form.field.touchTip.label')}

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/MixForm.test.js
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/MixForm.test.js
@@ -2,13 +2,11 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import { Provider } from 'react-redux'
-import { selectors as featureSelectors } from '../../../../feature-flags'
 import { MixForm } from '../MixForm'
 import { AspDispSection } from '../AspDispSection'
 
 const { DelayFields } = jest.requireActual('../../fields')
 
-jest.mock('../../../../feature-flags')
 jest.mock('../../fields/', () => {
   const actualFields = jest.requireActual('../../fields')
 
@@ -28,9 +26,6 @@ jest.mock('../../fields/', () => {
 jest.mock('../../fields/FieldConnector', () => ({
   FieldConnector: () => <div></div>,
 }))
-
-const getEnabledMixDelayMock: JestMockFn<any, any> =
-  featureSelectors.getEnabledMixDelay
 
 const mockStore = {
   dispatch: jest.fn(),
@@ -55,7 +50,6 @@ describe('MixForm', () => {
   let props
 
   beforeEach(() => {
-    getEnabledMixDelayMock.mockReturnValue(false)
     props = {
       focusHandlers: {
         focusedField: '',
@@ -65,72 +59,45 @@ describe('MixForm', () => {
       },
     }
   })
-  describe('when mix delay FF is disabled', () => {
-    beforeEach(() => {
-      getEnabledMixDelayMock.mockReturnValue(false)
-    })
-    it('should NOT render delay fields initially', () => {
-      const wrapper = render(props)
-      const delayFields = wrapper.find(DelayFields)
-      expect(delayFields).toHaveLength(0)
-    })
+  it('should NOT render delay fields initially', () => {
+    const wrapper = render(props)
 
-    describe('when advanced settings are visible', () => {
-      it('should NOT render the aspirate delay fields when advanced settings are visible', () => {
-        const wrapper = render(props)
-
-        showAdvancedSettings(wrapper)
-        wrapper.update()
-
-        const delayFields = wrapper.find(DelayFields)
-        expect(delayFields).toHaveLength(0)
-      })
-    })
+    const delayFields = wrapper.find(DelayFields)
+    expect(delayFields).toHaveLength(0)
   })
-  describe('when mix delay FF is enabled', () => {
-    beforeEach(() => {
-      getEnabledMixDelayMock.mockReturnValue(true)
-    })
-    it('should NOT render delay fields initially', () => {
+
+  describe('when advanced settings are visible', () => {
+    it('should render the aspirate delay fields when advanced settings are visible', () => {
       const wrapper = render(props)
 
+      showAdvancedSettings(wrapper)
+      wrapper.update()
+
       const delayFields = wrapper.find(DelayFields)
-      expect(delayFields).toHaveLength(0)
+
+      const aspirateDelayFields = delayFields.at(0)
+      expect(aspirateDelayFields.prop('checkboxFieldName')).toBe(
+        'aspirate_delay_checkbox'
+      )
+      expect(aspirateDelayFields.prop('secondsFieldName')).toBe(
+        'aspirate_delay_seconds'
+      )
+      // no tip position field
+      expect(aspirateDelayFields.prop('tipPositionFieldName')).toBe(undefined)
     })
-
-    describe('when advanced settings are visible', () => {
-      it('should render the aspirate delay fields when advanced settings are visible', () => {
-        const wrapper = render(props)
-
-        showAdvancedSettings(wrapper)
-        wrapper.update()
-
-        const delayFields = wrapper.find(DelayFields)
-
-        const aspirateDelayFields = delayFields.at(0)
-        expect(aspirateDelayFields.prop('checkboxFieldName')).toBe(
-          'aspirate_delay_checkbox'
-        )
-        expect(aspirateDelayFields.prop('secondsFieldName')).toBe(
-          'aspirate_delay_seconds'
-        )
-        // no tip position field
-        expect(aspirateDelayFields.prop('tipPositionFieldName')).toBe(undefined)
-      })
-      it('should render the dispense delay fields', () => {
-        const wrapper = render(props)
-        showAdvancedSettings(wrapper)
-        const delayFields = wrapper.find(DelayFields)
-        const aspirateDelayFields = delayFields.at(1)
-        expect(aspirateDelayFields.prop('checkboxFieldName')).toBe(
-          'dispense_delay_checkbox'
-        )
-        expect(aspirateDelayFields.prop('secondsFieldName')).toBe(
-          'dispense_delay_seconds'
-        )
-        // no tip position field
-        expect(aspirateDelayFields.prop('tipPositionFieldName')).toBe(undefined)
-      })
+    it('should render the dispense delay fields', () => {
+      const wrapper = render(props)
+      showAdvancedSettings(wrapper)
+      const delayFields = wrapper.find(DelayFields)
+      const aspirateDelayFields = delayFields.at(1)
+      expect(aspirateDelayFields.prop('checkboxFieldName')).toBe(
+        'dispense_delay_checkbox'
+      )
+      expect(aspirateDelayFields.prop('secondsFieldName')).toBe(
+        'dispense_delay_seconds'
+      )
+      // no tip position field
+      expect(aspirateDelayFields.prop('tipPositionFieldName')).toBe(undefined)
     })
   })
 })

--- a/protocol-designer/src/feature-flags/reducers.js
+++ b/protocol-designer/src/feature-flags/reducers.js
@@ -23,7 +23,6 @@ const initialFlags: Flags = {
   PRERELEASE_MODE: process.env.OT_PD_PRERELEASE_MODE === '1' || false,
   OT_PD_DISABLE_MODULE_RESTRICTIONS:
     process.env.OT_PD_DISABLE_MODULE_RESTRICTIONS === '1' || false,
-  OT_PD_ENABLE_MIX_DELAY: process.env.OT_PD_ENABLE_MIX_DELAY === '1' || false,
 }
 
 // NOTE(mc, 2020-06-04): `handleActions` cannot be strictly typed

--- a/protocol-designer/src/feature-flags/selectors.js
+++ b/protocol-designer/src/feature-flags/selectors.js
@@ -16,8 +16,3 @@ export const getDisableModuleRestrictions: Selector<?boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_DISABLE_MODULE_RESTRICTIONS
 )
-
-export const getEnabledMixDelay: Selector<?boolean> = createSelector(
-  getFeatureFlagData,
-  flags => flags.OT_PD_ENABLE_MIX_DELAY
-)

--- a/protocol-designer/src/feature-flags/types.js
+++ b/protocol-designer/src/feature-flags/types.js
@@ -12,6 +12,7 @@ export const DEPRECATED_FLAGS = [
   'OT_PD_ENABLE_CUSTOM_TIPRACKS',
   'OT_PD_ENABLE_THERMOCYCLER',
   'OT_PD_ENABLE_AIR_GAP_AND_DELAY',
+  'OT_PD_ENABLE_MIX_DELAY',
 ]
 
 // union of feature flag string constant IDs

--- a/protocol-designer/src/feature-flags/types.js
+++ b/protocol-designer/src/feature-flags/types.js
@@ -15,10 +15,7 @@ export const DEPRECATED_FLAGS = [
 ]
 
 // union of feature flag string constant IDs
-export type FlagTypes =
-  | 'PRERELEASE_MODE'
-  | 'OT_PD_DISABLE_MODULE_RESTRICTIONS'
-  | 'OT_PD_ENABLE_MIX_DELAY'
+export type FlagTypes = 'PRERELEASE_MODE' | 'OT_PD_DISABLE_MODULE_RESTRICTIONS'
 
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: Array<FlagTypes> = [

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -7,9 +7,5 @@
     "title": "Disable module placement restrictions",
     "description_1": "Turn off all restrictions on module placement and related pipette crash guidance.",
     "description_2": "NOT recommended! Switching from default positions may cause crashes and the Protocol Designer cannot yet give guidance on what to expect. Use at your own discretion. "
-  },
-  "OT_PD_ENABLE_MIX_DELAY": {
-    "title": "Enable Mix > Delay advanced settings for Mix step",
-    "description": "Enable Delay advanced settings for Mix step"
   }
 }

--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
@@ -9,20 +9,12 @@ import {
 } from '@opentrons/shared-data'
 import { fixtureP10Single } from '@opentrons/shared-data/pipette/fixtures/name'
 import fixture_tiprack_10_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_10_ul'
-import { getPrereleaseFeatureFlag } from '../../persist'
 import { getStateAndContextTempTCModules } from '../../step-generation/__fixtures__'
 import { DEFAULT_DELAY_SECONDS } from '../../constants'
 import {
   createPresavedStepForm,
   type CreatePresavedStepFormArgs,
 } from '../utils/createPresavedStepForm'
-
-jest.mock('../../persist')
-
-const getPrereleaseFeatureFlagMock: JestMockFn<
-  any,
-  any
-> = getPrereleaseFeatureFlag
 
 const stepId = 'stepId123'
 const EXAMPLE_ENGAGE_HEIGHT = '18'
@@ -184,70 +176,32 @@ describe('createPresavedStepForm', () => {
   })
 
   describe('mix step', () => {
-    describe('when mix delay FF is enabled', () => {
-      it('should call handleFormChange with a default pipette for mix step', () => {
-        getPrereleaseFeatureFlagMock.mockImplementation(FF => {
-          expect(FF).toBe('OT_PD_ENABLE_MIX_DELAY')
-          return true
-        })
+    it('should call handleFormChange with a default pipette for mix step', () => {
+      const args = {
+        ...defaultArgs,
+        stepType: 'mix',
+      }
 
-        const args = {
-          ...defaultArgs,
-          stepType: 'mix',
-        }
-
-        expect(createPresavedStepForm(args)).toEqual({
-          id: stepId,
-          pipette: 'leftPipetteId',
-          stepType: 'mix',
-          // default fields
-          labware: null,
-          wells: [],
-          aspirate_delay_checkbox: false,
-          aspirate_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
-          dispense_delay_checkbox: false,
-          dispense_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
-          mix_mmFromBottom: '0.5',
-          mix_wellOrder_first: 't2b',
-          mix_wellOrder_second: 'l2r',
-          blowout_checkbox: false,
-          blowout_location: 'trashId',
-          changeTip: 'always',
-          stepDetails: '',
-          stepName: 'mix',
-          // TODO(IL, 2020-04-27): mix defaults are missing volume, etc!!! Investigate in #3161
-        })
-      })
-    })
-    describe('when mix delay FF is disabled', () => {
-      it('should call handleFormChange with a default pipette for mix step', () => {
-        getPrereleaseFeatureFlagMock.mockImplementation(FF => {
-          expect(FF).toBe('OT_PD_ENABLE_MIX_DELAY')
-          return false
-        })
-
-        const args = {
-          ...defaultArgs,
-          stepType: 'mix',
-        }
-
-        expect(createPresavedStepForm(args)).toEqual({
-          id: stepId,
-          pipette: 'leftPipetteId',
-          stepType: 'mix',
-          // default fields
-          labware: null,
-          wells: [],
-          mix_mmFromBottom: '0.5',
-          mix_wellOrder_first: 't2b',
-          mix_wellOrder_second: 'l2r',
-          blowout_checkbox: false,
-          blowout_location: 'trashId',
-          changeTip: 'always',
-          stepDetails: '',
-          stepName: 'mix',
-          // TODO(IL, 2020-04-27): mix defaults are missing volume, etc!!! Investigate in #3161
-        })
+      expect(createPresavedStepForm(args)).toEqual({
+        id: stepId,
+        pipette: 'leftPipetteId',
+        stepType: 'mix',
+        // default fields
+        labware: null,
+        wells: [],
+        aspirate_delay_checkbox: false,
+        aspirate_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
+        dispense_delay_checkbox: false,
+        dispense_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
+        mix_mmFromBottom: '0.5',
+        mix_wellOrder_first: 't2b',
+        mix_wellOrder_second: 'l2r',
+        blowout_checkbox: false,
+        blowout_location: 'trashId',
+        changeTip: 'always',
+        stepDetails: '',
+        stepName: 'mix',
+        // TODO(IL, 2020-04-27): mix defaults are missing volume, etc!!! Investigate in #3161
       })
     })
   })

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -8,12 +8,8 @@ import {
   DEFAULT_DELAY_SECONDS,
   FIXED_TRASH_ID,
 } from '../../constants'
-import { getPrereleaseFeatureFlag } from '../../persist'
 
 import type { StepType, StepFieldName } from '../../form-types'
-
-const isMixDelayEnabled = () =>
-  getPrereleaseFeatureFlag('OT_PD_ENABLE_MIX_DELAY')
 
 export function getDefaultsForStepType(
   stepType: StepType
@@ -31,14 +27,10 @@ export function getDefaultsForStepType(
         pipette: null,
         volume: undefined,
         wells: [],
-        ...(isMixDelayEnabled()
-          ? {
-              aspirate_delay_checkbox: false,
-              aspirate_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
-              dispense_delay_checkbox: false,
-              dispense_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
-            }
-          : {}),
+        aspirate_delay_checkbox: false,
+        aspirate_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
+        dispense_delay_checkbox: false,
+        dispense_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
       }
     case 'moveLiquid':
       return {

--- a/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.js
+++ b/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.js
@@ -8,15 +8,7 @@ import {
   DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
   DEFAULT_DELAY_SECONDS,
 } from '../../../constants'
-import { getPrereleaseFeatureFlag } from '../../../persist'
 import { getDefaultsForStepType } from '..'
-
-jest.mock('../../../persist')
-
-const getPrereleaseFeatureFlagMock: JestMockFn<
-  any,
-  any
-> = getPrereleaseFeatureFlag
 
 describe('getDefaultsForStepType', () => {
   afterEach(() => {
@@ -72,50 +64,22 @@ describe('getDefaultsForStepType', () => {
     })
   })
   describe('mix step', () => {
-    describe('when mix delay FF is enabled', () => {
-      it('should get the correct defaults', () => {
-        getPrereleaseFeatureFlagMock.mockImplementation(FF => {
-          expect(FF).toBe('OT_PD_ENABLE_MIX_DELAY')
-          return true
-        })
-
-        expect(getDefaultsForStepType('mix')).toEqual({
-          changeTip: DEFAULT_CHANGE_TIP_OPTION,
-          labware: null,
-          aspirate_delay_checkbox: false,
-          aspirate_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
-          dispense_delay_checkbox: false,
-          dispense_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
-          mix_wellOrder_first: DEFAULT_WELL_ORDER_FIRST_OPTION,
-          mix_wellOrder_second: DEFAULT_WELL_ORDER_SECOND_OPTION,
-          blowout_checkbox: false,
-          blowout_location: FIXED_TRASH_ID,
-          mix_mmFromBottom: `${DEFAULT_MM_FROM_BOTTOM_DISPENSE}`, // NOTE: mix uses dispense for both asp + disp, for now
-          pipette: null,
-          volume: undefined,
-          wells: [],
-        })
-      })
-    })
-    describe('when mix delay FF is disabled', () => {
-      it('should get the correct defaults', () => {
-        getPrereleaseFeatureFlagMock.mockImplementation(FF => {
-          expect(FF).toBe('OT_PD_ENABLE_MIX_DELAY')
-          return false
-        })
-
-        expect(getDefaultsForStepType('mix')).toEqual({
-          changeTip: DEFAULT_CHANGE_TIP_OPTION,
-          labware: null,
-          mix_wellOrder_first: DEFAULT_WELL_ORDER_FIRST_OPTION,
-          mix_wellOrder_second: DEFAULT_WELL_ORDER_SECOND_OPTION,
-          blowout_checkbox: false,
-          blowout_location: FIXED_TRASH_ID,
-          mix_mmFromBottom: `${DEFAULT_MM_FROM_BOTTOM_DISPENSE}`, // NOTE: mix uses dispense for both asp + disp, for now
-          pipette: null,
-          volume: undefined,
-          wells: [],
-        })
+    it('should get the correct defaults', () => {
+      expect(getDefaultsForStepType('mix')).toEqual({
+        changeTip: DEFAULT_CHANGE_TIP_OPTION,
+        labware: null,
+        aspirate_delay_checkbox: false,
+        aspirate_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
+        dispense_delay_checkbox: false,
+        dispense_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
+        mix_wellOrder_first: DEFAULT_WELL_ORDER_FIRST_OPTION,
+        mix_wellOrder_second: DEFAULT_WELL_ORDER_SECOND_OPTION,
+        blowout_checkbox: false,
+        blowout_location: FIXED_TRASH_ID,
+        mix_mmFromBottom: `${DEFAULT_MM_FROM_BOTTOM_DISPENSE}`, // NOTE: mix uses dispense for both asp + disp, for now
+        pipette: null,
+        volume: undefined,
+        wells: [],
       })
     })
   })


### PR DESCRIPTION
# Overview

This PR removes the mix delay FF. Do not merge until we're ready to cut a QA tag.

closes #6634

# Changelog
- Remove mix delay FF

# Review requests

Mix delay FF should no longer be in the FF page
When creating a mix step, the delay field should be visible and working as expected

# Risk assessment
Low
