### PR TITLE
chore(app-shell): bump electron-devtools-installer to 3.1.1

### DIFF
--- a/app-shell/package.json
+++ b/app-shell/package.json
@@ -37,7 +37,7 @@
     "dateformat": "3.0.3",
     "electron-context-menu": "0.15.1",
     "electron-debug": "3.0.1",
-    "electron-devtools-installer": "3.0.0",
+    "electron-devtools-installer": "3.1.1",
     "electron-dl": "1.14.0",
     "electron-store": "5.1.1",
     "electron-updater": "4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7013,14 +7013,14 @@ electron-debug@3.0.1:
     electron-is-dev "^1.1.0"
     electron-localshortcut "^3.1.0"
 
-electron-devtools-installer@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-3.0.0.tgz#b5c439708746ed36f7b0220e18657567bca275d8"
-  integrity sha512-zll3w/8PvnPiGmL5tBtgSSoSjWnUljsOjJYsYYU12PKLljzWyfD6S75LKTZFn21VYxVbae2OwmjM5uFStLp6nQ==
+electron-devtools-installer@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-3.1.1.tgz#7b56c8c86475c5e4e10de6917d150c53c9ceb55e"
+  integrity sha512-g2D4J6APbpsiIcnLkFMyKZ6bOpEJ0Ltcc2m66F7oKUymyGAt628OWeU9nRZoh1cNmUs/a6Cls2UfOmsZtE496Q==
   dependencies:
     rimraf "^3.0.2"
     semver "^7.2.1"
-    unzip-crx "^0.2.0"
+    unzip-crx-3 "^0.2.0"
 
 electron-dl@1.14.0, electron-dl@^1.2.0:
   version "1.14.0"
@@ -19246,10 +19246,10 @@ unused-filename@^1.0.0:
     modify-filename "^1.1.0"
     path-exists "^3.0.0"
 
-unzip-crx@^0.2.0:
+unzip-crx-3@^0.2.0:
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/unzip-crx/-/unzip-crx-0.2.0.tgz#4c0baa8bdac756256754beca7843c13d7b858c18"
-  integrity sha1-TAuqi9rHViVnVL7KeEPBPXuFjBg=
+  resolved "https://registry.yarnpkg.com/unzip-crx-3/-/unzip-crx-3-0.2.0.tgz#d5324147b104a8aed9ae8639c95521f6f7cda292"
+  integrity sha512-0+JiUq/z7faJ6oifVB5nSwt589v1KCduqIJupNVDoWSXZtWDmjDGO3RAEOvwJ07w90aoXoP4enKsR7ecMrJtWQ==
   dependencies:
     jszip "^3.1.0"
     mkdirp "^0.5.1"


### PR DESCRIPTION
e-d-i 3.1.1 includes
https://github.com/MarshallOfSound/electron-devtools-installer/pull/140,
a fix for an issue where google bumped the version of their chrome
extension format and the unpacker that r-d-i used therefore stopped
working. The PR uses a new version of that unzipper library that
functions.

Fixes an issue where addon devtools would never be installed.
