### PR TITLE
feat(robot-server): http basic pipetting- load labware

### DIFF
--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -12,6 +12,7 @@ from robot_server.service.legacy.models.control import Mount
 from robot_server.service.json_api import (
     ResponseModel, RequestModel)
 from opentrons.util.helpers import utc_now
+from robot_server.service.labware.models import LabwareCalibration
 
 
 class LoadLabwareRequest(BaseModel):
@@ -67,7 +68,9 @@ class LiquidRequest(PipetteRequestBase):
 
 
 class LoadLabwareResponse(BaseModel):
-    labwareId: str
+    labwareId: IdentifierType
+    definition: typing.Dict[str, typing.Any]
+    calibration: LabwareCalibration
 
 
 class LoadInstrumentResponse(BaseModel):

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -70,7 +70,7 @@ class LiquidRequest(PipetteRequestBase):
 class LoadLabwareResponse(BaseModel):
     labwareId: IdentifierType
     definition: typing.Dict[str, typing.Any]
-    calibration: Point
+    calibration: OffsetVector
 
 
 class LoadInstrumentResponse(BaseModel):

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -3,6 +3,7 @@ from enum import Enum
 import typing
 from functools import lru_cache
 
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from opentrons_shared_data.pipette.dev_types import PipetteName
 from robot_server.service.session.models.common import (
     EmptyModel, JogPosition, IdentifierType, OffsetVector)
@@ -67,7 +68,7 @@ class LiquidRequest(PipetteRequestBase):
 
 class LoadLabwareResponse(BaseModel):
     labwareId: IdentifierType
-    definition: typing.Dict[str, typing.Any]
+    definition: LabwareDefinition
     calibration: OffsetVector
 
 

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -4,11 +4,9 @@ import typing
 from functools import lru_cache
 
 from opentrons_shared_data.pipette.dev_types import PipetteName
-from opentrons.types import Point
-from pydantic import BaseModel, Field, validator
-
 from robot_server.service.session.models.common import (
-    EmptyModel, JogPosition, IdentifierType)
+    EmptyModel, JogPosition, IdentifierType, OffsetVector)
+from pydantic import BaseModel, Field, validator
 from robot_server.service.legacy.models.control import Mount
 from robot_server.service.json_api import (
     ResponseModel, RequestModel)

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -4,15 +4,15 @@ import typing
 from functools import lru_cache
 
 from opentrons_shared_data.pipette.dev_types import PipetteName
+from opentrons.types import Point
 from pydantic import BaseModel, Field, validator
 
 from robot_server.service.session.models.common import (
-    EmptyModel, JogPosition)
+    EmptyModel, JogPosition, IdentifierType)
 from robot_server.service.legacy.models.control import Mount
 from robot_server.service.json_api import (
     ResponseModel, RequestModel)
 from opentrons.util.helpers import utc_now
-from robot_server.service.labware.models import LabwareCalibration
 
 
 class LoadLabwareRequest(BaseModel):
@@ -70,7 +70,7 @@ class LiquidRequest(PipetteRequestBase):
 class LoadLabwareResponse(BaseModel):
     labwareId: IdentifierType
     definition: typing.Dict[str, typing.Any]
-    calibration: LabwareCalibration
+    calibration: Point
 
 
 class LoadInstrumentResponse(BaseModel):

--- a/robot-server/robot_server/service/session/router.py
+++ b/robot-server/robot_server/service/session/router.py
@@ -154,8 +154,10 @@ async def session_command_execute_handler(
     command = create_command(command_request.data.attributes.command,
                              command_request.data.attributes.data)
     command_result = await session_obj.command_executor.execute(command)
-    log.info(f"Command completed {command}")
 
+    log.info(f"Command completed: {command}")
+    log.debug(f"Command result: {command_result}")
+    
     return CommandResponse(
         data=ResponseDataModel.create(
             attributes=SessionCommand(
@@ -164,7 +166,8 @@ async def session_command_execute_handler(
                 status=command_result.result.status,
                 createdAt=command_result.meta.created_at,
                 startedAt=command_result.result.started_at,
-                completedAt=command_result.result.completed_at
+                completedAt=command_result.result.completed_at,
+                result=command_result.result.data,
             ),
             resource_id=command_result.meta.identifier
         ),

--- a/robot-server/robot_server/service/session/router.py
+++ b/robot-server/robot_server/service/session/router.py
@@ -134,6 +134,7 @@ async def get_sessions_handler(
 @router.post(f"{PATH_SESSION_BY_ID}/commands/execute",
              description="Create and execute a command immediately",
              response_model_exclude_unset=True,
+             response_model_exclude_defaults=True,
              response_model=CommandResponse)
 async def session_command_execute_handler(
         sessionId: IdentifierType,
@@ -157,7 +158,7 @@ async def session_command_execute_handler(
 
     log.info(f"Command completed: {command}")
     log.debug(f"Command result: {command_result}")
-    
+
     return CommandResponse(
         data=ResponseDataModel.create(
             attributes=SessionCommand(

--- a/robot-server/robot_server/service/session/session_types/live_protocol/command_interface.py
+++ b/robot-server/robot_server/service/session/session_types/live_protocol/command_interface.py
@@ -2,6 +2,7 @@ from opentrons import ThreadManager
 
 from robot_server.service.session.models import command as models
 from robot_server.service.session.errors import UnsupportedCommandException
+from robot_server.service.session.models.common import create_identifier
 from robot_server.service.session.session_types.live_protocol.state_store\
     import StateStore
 from opentrons.protocol_api.labware import get_labware_definition
@@ -25,7 +26,7 @@ class CommandInterface:
         labware_path = f'{helpers.hash_labware_def(labware_def)}.json'
         calibration = get.get_labware_calibration(labware_path, labware_def,
                                                   '')
-        return models.LoadLabwareResponse(labwareId=models.create_identifier(),
+        return models.LoadLabwareResponse(labwareId=create_identifier(),
                                           definition=labware_def,
                                           calibration=calibration)
 

--- a/robot-server/robot_server/service/session/session_types/live_protocol/command_interface.py
+++ b/robot-server/robot_server/service/session/session_types/live_protocol/command_interface.py
@@ -4,6 +4,8 @@ from robot_server.service.session.models import command as models
 from robot_server.service.session.errors import UnsupportedCommandException
 from robot_server.service.session.session_types.live_protocol.state_store\
     import StateStore
+from opentrons.protocol_api.labware import get_labware_definition
+from opentrons.calibration_storage import helpers, get
 
 
 class CommandInterface:
@@ -15,7 +17,17 @@ class CommandInterface:
     async def handle_load_labware(
             self,
             command: models.LoadLabwareRequest) -> models.LoadLabwareResponse:
-        raise UnsupportedCommandException("")
+
+        labware_def = get_labware_definition(load_name=command.loadName,
+                                             namespace=command.namespace,
+                                             version=command.version)
+        # TODO (spp, 09-22-2020): update calibration fetching code
+        labware_path = f'{helpers.hash_labware_def(labware_def)}.json'
+        calibration = get.get_labware_calibration(labware_path, labware_def,
+                                                  '')
+        return models.LoadLabwareResponse(labwareId=models.create_identifier(),
+                                          definition=labware_def,
+                                          calibration=calibration)
 
     async def handle_load_instrument(
             self,

--- a/robot-server/robot_server/service/session/session_types/live_protocol/state_store.py
+++ b/robot-server/robot_server/service/session/session_types/live_protocol/state_store.py
@@ -1,14 +1,18 @@
-from typing import Dict, List, Optional, Callable, Any, cast
+from typing import Dict, List, Optional, Callable, cast
 from dataclasses import dataclass
-from robot_server.service.session import models
+
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
+
+from robot_server.service.session.models.common import OffsetVector
+from robot_server.service.session.models import command as models
 from robot_server.service.session.command_execution import (
     Command, CommandResult)
 
 
 @dataclass
 class LabwareEntry:
-    definition: Dict[str, Any]
-    calibration: models.OffsetVector
+    definition: LabwareDefinition
+    calibration: OffsetVector
     deckLocation: int
 
 
@@ -55,6 +59,10 @@ class StateStore:
             definition=result_data.definition,
             calibration=result_data.calibration,
             deckLocation=command_data.location)
+
+    def get_labware_by_id(self, labware_id: models.IdentifierType) -> \
+            Optional[LabwareEntry]:
+        return self._labware.get(labware_id)
 
     def get_commands(self) -> List[Command]:
         """

--- a/robot-server/robot_server/service/session/session_types/live_protocol/state_store.py
+++ b/robot-server/robot_server/service/session/session_types/live_protocol/state_store.py
@@ -1,12 +1,31 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Callable, Any, cast
+from dataclasses import dataclass
+from robot_server.service.session import models
 from robot_server.service.session.command_execution import (
     Command, CommandResult)
+
+
+@dataclass
+class LabwareEntry:
+    definition: Dict[str, Any]
+    calibration: models.OffsetVector
+    deckLocation: int
 
 
 class StateStore:
     def __init__(self):
         self._commands: List[Command] = []
         self._command_results_map: Dict[str, CommandResult] = dict()
+        self._handler_map: Dict[
+            models.CommandDefinition,
+            Callable[[Command, CommandResult], None]
+        ] = {
+            # TODO AL 2020-09-22. mypy is mysteriously complaining about the
+            #  types of these keys.
+            models.EquipmentCommand.load_labware:  # type: ignore
+                self.handle_load_labware,  # noqa: E131
+        }
+        self._labware: Dict[models.IdentifierType, LabwareEntry] = {}
 
     def handle_command_request(self, command: Command) -> None:
         """
@@ -21,6 +40,21 @@ class StateStore:
         Update the state upon completion of a handled command.
         """
         self._command_results_map[command.meta.identifier] = result
+        handler = self._handler_map.get(command.content.name)
+        if handler:
+            handler(command, result)
+
+    def handle_load_labware(self, command: Command,
+                            result: CommandResult) -> None:
+        """
+        Update state according to load_labware() command result.
+        """
+        result_data = cast(models.LoadLabwareResponse, result.data)
+        command_data = cast(models.LoadLabwareRequest, command.content.data)
+        self._labware[result_data.labwareId] = LabwareEntry(
+            definition=result_data.definition,
+            calibration=result_data.calibration,
+            deckLocation=command_data.location)
 
     def get_commands(self) -> List[Command]:
         """

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -4,6 +4,8 @@ import sys
 import tempfile
 import os
 import shutil
+import json
+import pathlib
 from unittest.mock import MagicMock
 
 import requests
@@ -170,3 +172,14 @@ def set_enable_http_protocol_sessions():
     yield None
     data['value'] = None
     requests.post(url, json=data)
+
+
+@pytest.fixture
+def get_labware_fixture():
+    def _get_labware_fixture(fixture_name):
+        with open((pathlib.Path(__file__).parent/'..'/'..'/'shared-data' /
+                   'labware' / 'fixtures'/'2'/f'{fixture_name}.json'), 'rb'
+                  ) as f:
+            return json.loads(f.read().decode('utf-8'))
+
+    return _get_labware_fixture

--- a/robot-server/tests/integration/sessions/test_live_protocol.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_live_protocol.tavern.yaml
@@ -29,15 +29,31 @@ stages:
           type: SessionCommand
           attributes:
             command: equipment.loadLabware
-            data:
+            data: &labware_data
               location: 2
               loadName: corning_96_wellplate_360ul_flat
               displayName: my well plate
               namespace: Opentrons
               version: 1
     response:
-      status_code: 403
-  - name: Load well plate tip rack command
+      status_code: 200
+      json:
+        links: !anydict
+        data:
+          id: !anystr
+          type: SessionCommand
+          attributes:
+            data: *labware_data
+            command: equipment.loadLabware
+            status: executed
+            createdAt: !anystr
+            startedAt: !anystr
+            completedAt: !anystr
+            result:
+              labwareId: !anystr
+              definition: !anydict
+              calibration: !anylist
+  - name: Load tip rack command
     request:
       url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"
       method: POST
@@ -46,15 +62,30 @@ stages:
           type: SessionCommand
           attributes:
             command: equipment.loadLabware
-            data:
+            data: &tiprack_data
               location: 1
               loadName: opentrons_96_tiprack_300ul
               displayName: my tip rack
               namespace: Opentrons
               version: 1
     response:
-      status_code: 403
-      json: { }
+      status_code: 200
+      json:
+        links: !anydict
+        data:
+          id: !anystr
+          type: SessionCommand
+          attributes:
+            data: *tiprack_data
+            command: equipment.loadLabware
+            status: executed
+            createdAt: !anystr
+            startedAt: !anystr
+            completedAt: !anystr
+            result:
+              labwareId: !anystr
+              definition: !anydict
+              calibration: !anylist
   - name: Load instrument command
     request:
       url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"

--- a/robot-server/tests/service/session/session_types/live_protocol/test_command_executor.py
+++ b/robot-server/tests/service/session/session_types/live_protocol/test_command_executor.py
@@ -47,7 +47,9 @@ def command_executor(mock_command_interface, mock_state_store)\
 
 
 async def test_load_labware(command_executor, mock_command_interface):
-    expected_response = models.LoadLabwareResponse(labwareId="your labware")
+    expected_response = models.LoadLabwareResponse(labwareId="your labware",
+                                                   definition={},
+                                                   calibration=(1, 2, 3))
 
     async def handler(command):
         return expected_response

--- a/robot-server/tests/service/session/session_types/live_protocol/test_load_labware.py
+++ b/robot-server/tests/service/session/session_types/live_protocol/test_load_labware.py
@@ -1,0 +1,34 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from opentrons.protocol_api.labware import get_labware_definition
+from robot_server.service.session.session_types.live_protocol import command_interface
+from robot_server.service.session.session_types.live_protocol.state_store \
+    import StateStore
+from robot_server.service.session import models
+from opentrons_shared_data.labware import load_definition
+
+
+@pytest.fixture
+def get_labware(get_labware_fixture):
+    with patch.object(command_interface, "get_labware_definition",
+                      return_value=get_labware_fixture("fixture_12_trough")) \
+            as p:
+        yield p
+
+
+async def test_handle_load_labware(get_labware_fixture, get_labware, hardware):
+    # Test that get_labware_def is called & responds correctly
+    state_store = StateStore()
+    ci = command_interface.CommandInterface(hardware, state_store)
+    command = models.LoadLabwareRequest(
+            location=1,
+            loadName="labware-load-name",
+            displayName="labware display name",
+            namespace="opentrons test",
+            version=1,
+        )
+    response = await ci.handle_load_labware(command)
+    get_labware.assert_called_once_with(load_name=command.loadName,
+                                        namespace=command.namespace,
+                                        version=command.version)
+    assert response.definition == get_labware_fixture("fixture_12_trough")

--- a/robot-server/tests/service/session/session_types/live_protocol/test_load_labware.py
+++ b/robot-server/tests/service/session/session_types/live_protocol/test_load_labware.py
@@ -1,15 +1,11 @@
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-from opentrons.calibration_storage.get import get_labware_calibration
-from opentrons.protocol_api.labware import get_labware_definition
-from opentrons.types import Point
-
-from robot_server.service.session.session_types.live_protocol import command_interface
+from robot_server.service.session.session_types.live_protocol \
+    import command_interface
 from robot_server.service.session.session_types.live_protocol.state_store \
     import StateStore
 from robot_server.service.session import models
-from opentrons_shared_data.labware import load_definition
 
 
 @pytest.fixture
@@ -23,7 +19,7 @@ def get_labware(get_labware_fixture):
 @pytest.fixture
 def labware_calibration_mock():
     with patch.object(command_interface.get, "get_labware_calibration",
-                      return_value=Point(1, 2, 3)) as p:
+                      return_value=(1, 2, 3)) as p:
         yield p
 
 
@@ -77,4 +73,3 @@ async def test_handle_load_labware_response(get_labware, hardware,
                                         "fixture_12_trough")
         assert response.labwareId == mock_id()
         assert response.calibration == labware_calibration_mock()
-

--- a/robot-server/tests/service/session/session_types/live_protocol/test_load_labware.py
+++ b/robot-server/tests/service/session/session_types/live_protocol/test_load_labware.py
@@ -5,7 +5,7 @@ from robot_server.service.session.session_types.live_protocol \
     import command_interface
 from robot_server.service.session.session_types.live_protocol.state_store \
     import StateStore
-from robot_server.service.session import models
+from robot_server.service.session.models import command as models
 
 
 @pytest.fixture
@@ -65,7 +65,7 @@ async def test_handle_load_labware_response(get_labware, hardware,
                                             command_handler, load_labware_cmd,
                                             get_labware_fixture,
                                             labware_calibration_mock):
-    with patch.object(command_interface.models, "create_identifier",
+    with patch.object(command_interface, "create_identifier",
                       return_value="1234") as mock_id:
         response = await command_handler.handle_load_labware(
                             load_labware_cmd)

--- a/robot-server/tests/service/session/session_types/live_protocol/test_state_store.py
+++ b/robot-server/tests/service/session/session_types/live_protocol/test_state_store.py
@@ -1,8 +1,11 @@
+import pytest
+from unittest.mock import patch
+from robot_server.service.session import models
 from robot_server.service.session.models import command as models
 from robot_server.service.session.command_execution \
     import create_command, CommandResult
 from robot_server.service.session.session_types.live_protocol.state_store \
-    import StateStore
+    import StateStore, LabwareEntry
 
 
 def test_handle_command_request():
@@ -23,23 +26,66 @@ def test_handle_command_request():
 
 
 def test_store_has_handle_command_response_method():
+    with patch.object(StateStore, "handle_load_labware"):
+        store = StateStore()
+        command = create_command(
+            name=models.EquipmentCommand.load_labware,
+            data=models.LoadLabwareRequest(
+                location=1,
+                loadName="labware-load-name",
+                displayName="labware display name",
+                namespace="opentrons test",
+                version=1,
+            ),
+        )
+        command_result = CommandResult(
+            started_at=command.meta.created_at,
+            completed_at=command.meta.created_at,
+        )
+
+        store.handle_command_result(command, command_result)
+
+        assert store.get_command_result_by_id(
+            command.meta.identifier) == command_result
+
+
+@pytest.mark.parametrize(
+    argnames="command_name, handler",
+    argvalues=[[models.EquipmentCommand.load_labware, "handle_load_labware"]]
+)
+def test_command_result_state_handler(command_name, handler):
+
+    with patch.object(StateStore, handler) as handler_mock:
+        store = StateStore()
+        command = create_command(name=command_name, data=None)
+        command_result = CommandResult(
+            started_at=command.meta.created_at,
+            completed_at=command.meta.created_at,
+        )
+        store.handle_command_result(command, command_result)
+        handler_mock.assert_called_once_with(command, command_result)
+
+
+def test_store_property_update():
     store = StateStore()
-    command = create_command(
-        name=models.EquipmentCommand.load_labware,
-        data=models.LoadLabwareRequest(
-            location=1,
-            loadName="labware-load-name",
-            displayName="labware display name",
-            namespace="opentrons test",
-            version=1,
-        ),
-    )
+    command = create_command(name=models.EquipmentCommand.load_labware,
+                             data=models.LoadLabwareRequest(
+                                    location=1,
+                                    loadName="labware-load-name",
+                                    displayName="labware display name",
+                                    namespace="opentrons test",
+                                    version=1,
+                                    ))
     command_result = CommandResult(
         started_at=command.meta.created_at,
         completed_at=command.meta.created_at,
-    )
-
+        data=models.LoadLabwareResponse(labwareId="1234",
+                                        definition={"myLabware": "definition"},
+                                        calibration=(1, 2, 3)))
+    assert command_result.data.labwareId not in store._labware.keys()
     store.handle_command_result(command, command_result)
-
-    assert store.get_command_result_by_id(
-        command.meta.identifier) == command_result
+    assert command_result.data.labwareId in store._labware.keys()
+    assert store._labware.get(command_result.data.labwareId) == \
+        LabwareEntry(definition={"myLabware": "definition"},
+                     calibration=(1, 2, 3),
+                     deckLocation=1)

--- a/robot-server/tests/service/session/session_types/live_protocol/test_state_store.py
+++ b/robot-server/tests/service/session/session_types/live_protocol/test_state_store.py
@@ -1,6 +1,5 @@
 import pytest
 from unittest.mock import patch
-from robot_server.service.session import models
 from robot_server.service.session.models import command as models
 from robot_server.service.session.command_execution \
     import create_command, CommandResult
@@ -82,10 +81,9 @@ def test_store_property_update():
         data=models.LoadLabwareResponse(labwareId="1234",
                                         definition={"myLabware": "definition"},
                                         calibration=(1, 2, 3)))
-    assert command_result.data.labwareId not in store._labware.keys()
+    assert store.get_labware_by_id(command_result.data.labwareId) is None
     store.handle_command_result(command, command_result)
-    assert command_result.data.labwareId in store._labware.keys()
-    assert store._labware.get(command_result.data.labwareId) == \
+    assert store.get_labware_by_id(command_result.data.labwareId) == \
         LabwareEntry(definition={"myLabware": "definition"},
                      calibration=(1, 2, 3),
                      deckLocation=1)


### PR DESCRIPTION
# Overview

Live protocol session continued! This PR adds the ability to load labware.
Closes #6591 

# Changelog

- added load_labware handler
- added LoadLabwareResponse model
- added labware state handler to store
- added unit tests & tavern integration tests

# Risk assessment

Low. Adds a 'result' router field to sessions command executor. Everything else is still isolated.
