### PR TITLE
docs(api): change labware in Location.move example from 'Hi' to None

### DIFF
--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -103,7 +103,7 @@ class Location(NamedTuple):
 
         .. code-block:: python
 
-            >>> loc = Location(Point(1, 1, 1), 'Hi')
+            >>> loc = Location(Point(1, 1, 1), None)
             >>> new_loc = loc.move(Point(1, 1, 1))
             >>> assert loc_2.point == Point(2, 2, 2)  # True
             >>> assert loc.point == Point(1, 1, 1)  # True


### PR DESCRIPTION
This changes the labware used to define an arbitrary point-based location from 'Hi' to None. `None` is the better format to use to ensure retraction (thanks @sfoster1 ). Since this is the only place in the documentation that an example of point labware is given, users are likely to develop the bad habit of using random strings (as I did in #6655).

# Risk assessment

Very low: just docs
