### PR TITLE
feat(api): Use more human-friendly names in "API version too low" error messages

### DIFF
--- a/api/src/opentrons/protocols/api_support/util.py
+++ b/api/src/opentrons/protocols/api_support/util.py
@@ -399,10 +399,15 @@ def requires_version(
             slf = args[0]
             added_in = decorated_obj.__opentrons_version_added  # type: ignore
             current_version = slf._api_version
+
+            # __qualname__ is *probably* set on every kind of object we care
+            # about, but the docs leave it ambiguous, so fall back to str().
+            name = getattr(decorated_obj, "__qualname__", str(decorated_obj))
+
             if current_version >= APIVersion(2, 0)\
                and current_version < added_in:
                 raise APIVersionError(
-                    f'{decorated_obj} was added in {added_in}, but your '
+                    f'{name} was added in {added_in}, but your '
                     f'protocol requested version {current_version}. You '
                     f'must increase your API version to {added_in} to '
                     'use this functionality.')


### PR DESCRIPTION
# Overview

Tweak the error message that shows up in the Opentrons App (and `opentrons_simulate`) when you try to use an API feature that's unsupported in your chosen `apiLevel`.

# Changelog

This test protocol:

```python
metadata = {"apiLevel": "2.4"}

def run(protocol):
    # Error. Added in apiLevel 2.5.
    protocol.set_rail_lights(True)
```

Currently shows the error:

> <function ProtocolContext.set_rail_lights at 0x11207fdd0> was added in 2.5, but your protocol requested version 2.4. You must increase your API version to 2.5 to use this functionality.

With this PR, it's changed to:

> ProtocolContext.set_rail_lights was added in 2.5, but your protocol requested version 2.4. You must increase your API version to 2.5 to use this functionality.

# Review requests

* Does the new error message look good?
* For the changelog, is this a `feat` or a `fix`?

# Risk assessment

Low.