### PR TITLE
chore(actions): switch to new environment setting

### DIFF
--- a/.github/actions/python/pypi-deploy/action.yaml
+++ b/.github/actions/python/pypi-deploy/action.yaml
@@ -16,7 +16,6 @@ runs:
       run: |
         echo "::add-mask::${{ inputs.password }}"
         if [[ ${{ inputs.repository_url }} =~ "test" ]]; then
-          echo 'SWALLOW_FAILURE=|| echo "Duplicate upload allowed on test' >> $GITHUB_ENV
           echo "Uploading to test pypi"
         else if [[ ${{ inputs.repository_url }} =~ "upload.pypi.org" ]]; then
                  echo "Uploading to prod pypi"

--- a/.github/actions/python/pypi-deploy/action.yaml
+++ b/.github/actions/python/pypi-deploy/action.yaml
@@ -16,12 +16,12 @@ runs:
       run: |
         echo "::add-mask::${{ inputs.password }}"
         if [[ ${{ inputs.repository_url }} =~ "test" ]]; then
-          echo '::set-env name=SWALLOW_FAILURE::|| echo "Duplicate upload allowed on test"'
+          echo 'SWALLOW_FAILURE=|| echo "Duplicate upload allowed on test' >> $GITHUB_ENV
           echo "Uploading to test pypi"
         else if [[ ${{ inputs.repository_url }} =~ "upload.pypi.org" ]]; then
                  echo "Uploading to prod pypi"
                  # this needs to be cleared otherwise the makefiles append a dev tag
-                 echo ::set-env name=OT_BUILD::""
+                 echo 'OT_BUILD=' >> $GITHUB_ENV
              else
                  echo "::error ::Invalid repository url ${{ inputs.repository_url }}"
                  exit 1


### PR DESCRIPTION
Per
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
to account for CVE-2020-15228
