### PR TITLE
chore(build): rebuild js gh caches

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -65,16 +65,17 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ./.npm-cache/_prebuild
-            ./.yarn-cache
+            ${{ env.HOME }}/.npm-cache/_prebuild
+            ${{ env.HOME }}./.yarn-cache
           key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: 'setup-js'
         run: |
-          npm config set cache ./.npm-cache
-          yarn config set cache-folder ./.yarn-cache
+          npm config set cache ${HOME}/.npm-cache
+          yarn config set cache-folder ${HOME}/.yarn-cache
           make setup-js
+        shell: bash
       - name: 'test frontend packages'
         run: |
           yarn jest --coverage=true --ci=true --testPathIgnorePatterns 'labware-.*' 'protocol-.*' 'app-shell' 'discovery-client'
@@ -103,16 +104,17 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ./.npm-cache/_prebuild
-            ./.yarn-cache
+            ${{ env.HOME }}/.npm-cache/_prebuild
+            ${{ env.HOME }}/.yarn-cache
           key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: setup-js
         run: |
-          npm config set cache ./.npm-cache
-          yarn config set cache-folder ./.yarn-cache
+          npm config set cache ${HOME}/.npm-cache
+          yarn config set cache-folder ${HOME}/.yarn-cache
           make setup-js
+        shell: bash
       - name: 'test native(er) packages'
         run: |
           yarn jest --coverage=true --ci=true --testPathPattern '(app-shell|discovery-client)'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -113,7 +113,6 @@ jobs:
           npm config set cache ${{ github.workspace }}/.npm-cache
           yarn config set cache-folder ${{ github.workspace }}/.yarn-cache
           make setup-js
-        shell: bash
       - name: 'test native(er) packages'
         run: |
           yarn jest --coverage=true --ci=true --testPathPattern '(app-shell|discovery-client)'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -65,9 +65,9 @@ jobs:
           path: |
             ./.npm-cache/_prebuild
             ./.yarn-cache
-          key: js-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            js-${{ runner.os }}-yarn-
+            js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: 'setup-js'
         run: |
           npm config set cache ./.npm-cache
@@ -103,9 +103,9 @@ jobs:
           path: |
             ./.npm-cache/_prebuild
             ./.yarn-cache
-          key: js-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            js-${{ runner.os }}-yarn-
+            js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: setup-js
         run: |
           npm config set cache ./.npm-cache

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -65,9 +65,9 @@ jobs:
           path: |
             ./.npm-cache/_prebuild
             ./.yarn-cache
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: js-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
+            js-${{ runner.os }}-yarn-
       - name: 'setup-js'
         run: |
           npm config set cache ./.npm-cache
@@ -103,9 +103,9 @@ jobs:
           path: |
             ./.npm-cache/_prebuild
             ./.yarn-cache
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: js-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
+            js-${{ runner.os }}-yarn-
       - name: setup-js
         run: |
           npm config set cache ./.npm-cache

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -5,6 +5,7 @@ name: 'App test, build, and deploy'
 on:
   push:
     paths:
+      - 'Makefile'
       - 'app/**/*'
       - 'app-shell/**/*'
       - 'components/**/*'
@@ -23,6 +24,7 @@ on:
       - 'v*'
   pull_request:
     paths:
+      - 'Makefile'
       - 'app/**/*'
       - 'app-shell/**/*'
       - 'components/**/*'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -65,15 +65,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ${{ env.HOME }}/.npm-cache/_prebuild
-            ${{ env.HOME }}./.yarn-cache
+            ${{ env.GITHUB_WORKSPACE }}/.npm-cache/_prebuild
+            ${{ env.GITHUB_WORKSPACE }}./.yarn-cache
           key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: 'setup-js'
         run: |
-          npm config set cache ${HOME}/.npm-cache
-          yarn config set cache-folder ${HOME}/.yarn-cache
+          npm config set cache ${GITHUB_WORKSPACE}/.npm-cache
+          yarn config set cache-folder ${GITHUB_WORKSPACE}/.yarn-cache
           make setup-js
         shell: bash
       - name: 'test frontend packages'
@@ -104,15 +104,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ${{ env.HOME }}/.npm-cache/_prebuild
-            ${{ env.HOME }}/.yarn-cache
+            ${{ env.GITHUB_WORKSPACE }}/.npm-cache/_prebuild
+            ${{ env.GITHUB_WORKSPACE }}/.yarn-cache
           key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: setup-js
         run: |
-          npm config set cache ${HOME}/.npm-cache
-          yarn config set cache-folder ${HOME}/.yarn-cache
+          npm config set cache ${GITHUB_WORKSPACE}/.npm-cache
+          yarn config set cache-folder ${GITHUB_WORKSPACE}/.yarn-cache
           make setup-js
         shell: bash
       - name: 'test native(er) packages'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -65,17 +65,16 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ${{ env.GITHUB_WORKSPACE }}/.npm-cache/_prebuild
-            ${{ env.GITHUB_WORKSPACE }}./.yarn-cache
+            ${{ github.workspace }}/.npm-cache/_prebuild
+            ${{ github.workspace }}/.yarn-cache
           key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: 'setup-js'
         run: |
-          npm config set cache ${GITHUB_WORKSPACE}/.npm-cache
-          yarn config set cache-folder ${GITHUB_WORKSPACE}/.yarn-cache
+          npm config set cache ${{ github.workspace }}/.npm-cache
+          yarn config set cache-folder ${{ github.workspace }}/.yarn-cache
           make setup-js
-        shell: bash
       - name: 'test frontend packages'
         run: |
           yarn jest --coverage=true --ci=true --testPathIgnorePatterns 'labware-.*' 'protocol-.*' 'app-shell' 'discovery-client'
@@ -104,15 +103,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ${{ env.GITHUB_WORKSPACE }}/.npm-cache/_prebuild
-            ${{ env.GITHUB_WORKSPACE }}/.yarn-cache
+            ${{ github.workspace }}/.npm-cache/_prebuild
+            ${{ github.workspace }}/.yarn-cache
           key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: setup-js
         run: |
-          npm config set cache ${GITHUB_WORKSPACE}/.npm-cache
-          yarn config set cache-folder ${GITHUB_WORKSPACE}/.yarn-cache
+          npm config set cache ${{ github.workspace }}/.npm-cache
+          yarn config set cache-folder ${{ github.workspace }}/.yarn-cache
           make setup-js
         shell: bash
       - name: 'test native(er) packages'

--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -48,15 +48,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ${{ env.GITHUB_WORKSPACE }}/.yarn-cache
-            ${{ env.GITHUB_WORKSPACE }}/.npm-cache
+            ${{ github.workspace }}/.yarn-cache
+            ${{ github.workspace }}/.npm-cache
           key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: 'setup-js'
         run: |
-          npm config set cache ${GITHUB_WORKSPACE}/.npm-cache
-          yarn config set cache-folder ${GITHUB_WORKSPACE}/.yarn-cache
+          npm config set cache ${{ github.workspace }}/.npm-cache
+          yarn config set cache-folder ${{ github.workspace }}/.yarn-cache
           make setup-js
         shell: bash
       - name: 'lint js'

--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -48,16 +48,17 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ./.yarn-cache
-            ./.npm-cache
+            ${{ env.GITHUB_WORKSPACE }}/.yarn-cache
+            ${{ env.GITHUB_WORKSPACE }}/.npm-cache
           key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: 'setup-js'
         run: |
-          npm config set cache ./.npm-cache
-          yarn config set cache-folder ./.yarn-cache
+          npm config set cache ${GITHUB_WORKSPACE}/.npm-cache
+          yarn config set cache-folder ${GITHUB_WORKSPACE}/.yarn-cache
           make setup-js
+        shell: bash
       - name: 'lint js'
         run: make lint-js
       - name: 'typechecks'

--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -50,9 +50,9 @@ jobs:
           path: |
             ./.yarn-cache
             ./.npm-cache
-          key: new-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            js-${{ runner.os }}-yarn-
+            js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
       - name: 'setup-js'
         run: |
           npm config set cache ./.npm-cache

--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -50,9 +50,9 @@ jobs:
           path: |
             ./.yarn-cache
             ./.npm-cache
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: new-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
+            js-${{ runner.os }}-yarn-
       - name: 'setup-js'
         run: |
           npm config set cache ./.npm-cache

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ setup-py:
 # front-end dependecies handled by yarn
 .PHONY: setup-js
 setup-js:
+	yarn config set network-timeout 60000
 	yarn
 	$(MAKE) -j 1 -C $(APP_SHELL_DIR) setup
 	$(MAKE) -j 1 -C $(SHARED_DATA_DIR) setup-js

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ setup-py:
 # front-end dependecies handled by yarn
 .PHONY: setup-js
 setup-js:
-	yarn
+	yarn --verbose
 	$(MAKE) -j 1 -C $(APP_SHELL_DIR) setup
 	$(MAKE) -j 1 -C $(SHARED_DATA_DIR) setup-js
 	$(MAKE) -j 1 -C $(DISCOVERY_CLIENT_DIR) setup

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ setup-py:
 # front-end dependecies handled by yarn
 .PHONY: setup-js
 setup-js:
-	yarn --verbose
+	yarn
 	$(MAKE) -j 1 -C $(APP_SHELL_DIR) setup
 	$(MAKE) -j 1 -C $(SHARED_DATA_DIR) setup-js
 	$(MAKE) -j 1 -C $(DISCOVERY_CLIENT_DIR) setup


### PR DESCRIPTION
We somehow stored some invalid cache data for our js workflows, I think
because I was changing what was cached without changing the cache keys.
This PR changes the cache keys to
a) actually reflect what they're caching, which would be important if we
start caching python stuff for instance
b) rebuild the cache with the current config

Ugh.