### PR TITLE
feat(api): pin JSON protocols to APIVersion 2.8

### DIFF
--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -31,6 +31,7 @@ MODULE_LOG = logging.getLogger(__name__)
 # match e.g. "2.0" but not "hi", "2", "2.0.1"
 API_VERSION_RE = re.compile(r'^(\d+)\.(\d+)$')
 MAX_SUPPORTED_JSON_SCHEMA_VERSION = 5
+API_VERSION_FOR_JSON_V5_AND_BELOW = APIVersion(2, 8)
 
 
 def _validate_v2_ast(protocol_ast: ast.Module):
@@ -77,7 +78,7 @@ def _parse_json(
     version, validated = validate_json(protocol_json)
     return JsonProtocol(
         text=protocol_contents, filename=filename, contents=validated,
-        schema_version=version)
+        schema_version=version, api_level=API_VERSION_FOR_JSON_V5_AND_BELOW)
 
 
 def _parse_python(

--- a/api/src/opentrons/protocols/types.py
+++ b/api/src/opentrons/protocols/types.py
@@ -31,6 +31,7 @@ class JsonProtocol(NamedTuple):
     filename: Optional[str]
     contents: 'JsonProtocolDef'
     schema_version: int
+    api_level: APIVersion
 
 
 class PythonProtocol(NamedTuple):

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -8,6 +8,7 @@ from opentrons.protocols.parse import (
     _get_protocol_schema_version,
     validate_json,
     parse,
+    API_VERSION_FOR_JSON_V5_AND_BELOW,
     MAX_SUPPORTED_JSON_SCHEMA_VERSION,
     version_from_metadata)
 from opentrons.protocols.types import (JsonProtocol,
@@ -258,7 +259,10 @@ def test_parse_json_details(get_json_protocol_fixture,
     assert isinstance(parsed, JsonProtocol)
     assert parsed.filename == fname
     assert parsed.contents == json.loads(protocol)
-    parsed.schema_version == int(protocol_details[0])
+    assert parsed.schema_version == int(protocol_details[0])
+    # TODO(IL, 2020-10-07): if schema v6 declares its own api_level,
+    # then those v6 fixtures will need to be asserted differently
+    assert parsed.api_level == API_VERSION_FOR_JSON_V5_AND_BELOW
 
 
 def test_parse_bundle_details(get_bundle_fixture):


### PR DESCRIPTION
# Overview

Closes #6681

# Changelog

- pin existing JSON protocols to API version 2.8

# Review requests

- Code review, including automated test

# Risk assessment

Medium. Should not affect current behavior, bc JSON protocols will already be using the latest API version. This just prevents them from using 2.9 etc when those come out.