### PR TITLE
feat(app): allow app update pop-up notifications to be disabled

### DIFF
--- a/app/src/alerts/__tests__/actions.test.js
+++ b/app/src/alerts/__tests__/actions.test.js
@@ -1,52 +1,52 @@
 // @flow
+import * as Config from '../../config'
 import * as Actions from '../actions'
 
-import type { AlertId, AlertsAction } from '../types'
+import type { AlertId } from '../types'
 
 const MOCK_ALERT_ID: AlertId = ('mockAlert': any)
 
-type ActionSpec = {|
-  should: string,
-  creator: (...args: Array<any>) => AlertsAction,
-  args: Array<mixed>,
-  expected: AlertsAction,
-|}
+describe('alerts actions', () => {
+  it('should allow an alert to be triggered', () => {
+    const result = Actions.alertTriggered(MOCK_ALERT_ID)
 
-const SPECS: Array<ActionSpec> = [
-  {
-    should: 'allow an alert to be triggered',
-    creator: Actions.alertTriggered,
-    args: [MOCK_ALERT_ID],
-    expected: {
+    expect(result).toEqual({
       type: 'alerts:ALERT_TRIGGERED',
       payload: { alertId: MOCK_ALERT_ID },
-    },
-  },
-  {
-    should: 'allow an alert to be dismissed temporarily',
-    creator: Actions.alertDismissed,
-    args: [MOCK_ALERT_ID],
-    expected: {
+    })
+  })
+
+  it('should allow an alert to be dismissed temporarily', () => {
+    const result = Actions.alertDismissed(MOCK_ALERT_ID)
+
+    expect(result).toEqual({
       type: 'alerts:ALERT_DISMISSED',
       payload: { alertId: MOCK_ALERT_ID, remember: false },
-    },
-  },
-  {
-    should: 'allow an alert to be dismissed permanently',
-    creator: Actions.alertDismissed,
-    args: [MOCK_ALERT_ID, true],
-    expected: {
+    })
+  })
+
+  it('should allow an alert to be dismissed permanently', () => {
+    const result = Actions.alertDismissed(MOCK_ALERT_ID, true)
+
+    expect(result).toEqual({
       type: 'alerts:ALERT_DISMISSED',
       payload: { alertId: MOCK_ALERT_ID, remember: true },
-    },
-  },
-]
-
-describe('alerts actions', () => {
-  SPECS.forEach(({ should, creator, args, expected }) => {
-    it(`should ${should}`, () => {
-      expect(creator).toEqual(expect.any(Function))
-      expect(creator(...args)).toEqual(expected)
     })
+  })
+
+  it('should allow an alert to be ignored permanently', () => {
+    const result = Actions.alertPermanentlyIgnored(MOCK_ALERT_ID)
+
+    expect(result).toEqual(
+      Config.addUniqueConfigValue('alerts.ignored', MOCK_ALERT_ID)
+    )
+  })
+
+  it('should allow an alert to be unignored', () => {
+    const result = Actions.alertUnignored(MOCK_ALERT_ID)
+
+    expect(result).toEqual(
+      Config.subtractConfigValue('alerts.ignored', MOCK_ALERT_ID)
+    )
   })
 })

--- a/app/src/alerts/__tests__/selectors.test.js
+++ b/app/src/alerts/__tests__/selectors.test.js
@@ -15,20 +15,29 @@ const MOCK_ALERT_1: AlertId = ('mockAlert1': any)
 const MOCK_ALERT_2: AlertId = ('mockAlert2': any)
 const MOCK_IGNORED_ALERT: AlertId = ('mockIgnoredAlert': any)
 
-describe('alerts selectors', () => {
-  let state: State
+const MOCK_CONFIG: $Shape<Config> = {
+  alerts: { ignored: [MOCK_IGNORED_ALERT] },
+}
 
-  beforeEach(() => {
+describe('alerts selectors', () => {
+  const stubGetConfig = (state: State, value = MOCK_CONFIG) => {
     getConfig.mockImplementation(s => {
       expect(s).toEqual(state)
-      return { alerts: { ignored: [MOCK_IGNORED_ALERT] } }
+      return value
     })
+  }
+
+  afterEach(() => {
+    jest.resetAllMocks()
   })
 
   it('should be able to get a list of active alerts', () => {
-    state = ({
+    const state = ({
       alerts: { active: [MOCK_ALERT_1, MOCK_ALERT_2], ignored: [] },
     }: $Shape<State>)
+
+    stubGetConfig(state)
+
     expect(Selectors.getActiveAlerts(state)).toEqual([
       MOCK_ALERT_1,
       MOCK_ALERT_2,
@@ -36,26 +45,58 @@ describe('alerts selectors', () => {
   })
 
   it('should show no active alerts until config is loaded', () => {
-    getConfig.mockReturnValue(null)
-    state = ({
+    const state = ({
       alerts: { active: [MOCK_ALERT_1, MOCK_ALERT_2], ignored: [] },
     }: $Shape<State>)
+
+    stubGetConfig(state, null)
+
     expect(Selectors.getActiveAlerts(state)).toEqual([])
   })
 
   it('should filter ignored alerts from active alerts', () => {
     // the reducer should never let this state happen, but let's protect
     // against it in the selector, too
-    state = ({
+    const state = ({
       alerts: { active: [MOCK_ALERT_1, MOCK_ALERT_2], ignored: [MOCK_ALERT_2] },
     }: $Shape<State>)
+
+    stubGetConfig(state)
+
     expect(Selectors.getActiveAlerts(state)).toEqual([MOCK_ALERT_1])
   })
 
   it('should filter perma-ignored alerts from active alerts', () => {
-    state = ({
+    const state = ({
       alerts: { active: [MOCK_ALERT_1, MOCK_IGNORED_ALERT], ignored: [] },
     }: $Shape<State>)
+
+    stubGetConfig(state)
+
     expect(Selectors.getActiveAlerts(state)).toEqual([MOCK_ALERT_1])
+  })
+
+  it('should be able to tell you if an alert is perma-ignored', () => {
+    const state = ({ alerts: { active: [], ignored: [] } }: $Shape<State>)
+
+    stubGetConfig(state)
+
+    expect(
+      Selectors.getAlertIsPermanentlyIgnored(state, MOCK_IGNORED_ALERT)
+    ).toBe(true)
+
+    expect(Selectors.getAlertIsPermanentlyIgnored(state, MOCK_ALERT_1)).toBe(
+      false
+    )
+  })
+
+  it('should return null for getAlertIsPermanentlyIgnored if config not initialized', () => {
+    const state = ({ alerts: { active: [], ignored: [] } }: $Shape<State>)
+
+    stubGetConfig(state, null)
+
+    expect(
+      Selectors.getAlertIsPermanentlyIgnored(state, MOCK_IGNORED_ALERT)
+    ).toBe(null)
   })
 })

--- a/app/src/alerts/actions.js
+++ b/app/src/alerts/actions.js
@@ -1,7 +1,13 @@
 // @flow
 
+import { addUniqueConfigValue, subtractConfigValue } from '../config'
 import * as Constants from './constants'
 import * as Types from './types'
+
+import type {
+  AddUniqueConfigValueAction,
+  SubtractConfigValueAction,
+} from '../config/types'
 
 export const alertTriggered = (
   alertId: Types.AlertId
@@ -17,3 +23,15 @@ export const alertDismissed = (
   type: Constants.ALERT_DISMISSED,
   payload: { alertId, remember },
 })
+
+export const alertPermanentlyIgnored = (
+  alertId: Types.AlertId
+): AddUniqueConfigValueAction => {
+  return addUniqueConfigValue(Constants.CONFIG_PATH_ALERTS_IGNORED, alertId)
+}
+
+export const alertUnignored = (
+  alertId: Types.AlertId
+): SubtractConfigValueAction => {
+  return subtractConfigValue(Constants.CONFIG_PATH_ALERTS_IGNORED, alertId)
+}

--- a/app/src/alerts/constants.js
+++ b/app/src/alerts/constants.js
@@ -1,5 +1,8 @@
 // @flow
 
+// config path
+export const CONFIG_PATH_ALERTS_IGNORED = 'alerts.ignored'
+
 // alert types
 export const ALERT_U2E_DRIVER_OUTDATED: 'u2eDriverOutdated' =
   'u2eDriverOutdated'

--- a/app/src/alerts/epic.js
+++ b/app/src/alerts/epic.js
@@ -1,7 +1,7 @@
 // @flow
 import { filter, map } from 'rxjs/operators'
 
-import { addUniqueConfigValue } from '../config'
+import { alertPermanentlyIgnored } from './actions'
 import { ALERT_DISMISSED } from './constants'
 
 import type { Action, Epic } from '../types'
@@ -14,11 +14,6 @@ export const alertsEpic: Epic = (action$, state$) => {
     filter<Action, AlertDismissedAction>(
       a => a.type === ALERT_DISMISSED && a.payload.remember
     ),
-    map(dismissAction => {
-      return addUniqueConfigValue(
-        'alerts.ignored',
-        dismissAction.payload.alertId
-      )
-    })
+    map(dismiss => alertPermanentlyIgnored(dismiss.payload.alertId))
   )
 }

--- a/app/src/alerts/selectors.js
+++ b/app/src/alerts/selectors.js
@@ -27,3 +27,11 @@ export const getActiveAlerts: (
       : []
   }
 )
+
+export const getAlertIsPermanentlyIgnored = (
+  state: State,
+  alertId: AlertId
+): boolean | null => {
+  const permaIgnoreList = getIgnoredAlertsFromConfig(state)
+  return permaIgnoreList ? permaIgnoreList.includes(alertId) : null
+}

--- a/app/src/components/Alerts/__tests__/Alerts.test.js
+++ b/app/src/components/Alerts/__tests__/Alerts.test.js
@@ -42,7 +42,7 @@ describe('app-wide Alerts component', () => {
 
   const stubActiveAlerts = alertIds => {
     getActiveAlerts.mockImplementation(state => {
-      expect(state).toBe(MOCK_STATE)
+      expect(state).toEqual(MOCK_STATE)
       return alertIds
     })
   }
@@ -70,11 +70,11 @@ describe('app-wide Alerts component', () => {
   })
 
   it('should render a U2EDriverOutdatedAlert if alert is triggered', () => {
-    const { wrapper, store } = render()
+    const { wrapper, store, refresh } = render()
     expect(wrapper.exists(U2EDriverOutdatedAlert)).toBe(false)
 
     stubActiveAlerts([AppAlerts.ALERT_U2E_DRIVER_OUTDATED])
-    wrapper.setProps({})
+    refresh()
     expect(wrapper.exists(U2EDriverOutdatedAlert)).toBe(true)
 
     wrapper.find(U2EDriverOutdatedAlert).invoke('dismissAlert')(true)
@@ -85,11 +85,11 @@ describe('app-wide Alerts component', () => {
   })
 
   it('should render an UpdateAppModal if appUpdateAvailable alert is triggered', () => {
-    const { wrapper, store } = render()
+    const { wrapper, store, refresh } = render()
     expect(wrapper.exists(UpdateAppModal)).toBe(false)
 
     stubActiveAlerts([AppAlerts.ALERT_APP_UPDATE_AVAILABLE])
-    wrapper.setProps({})
+    refresh()
     expect(wrapper.exists(UpdateAppModal)).toBe(true)
 
     wrapper.find(UpdateAppModal).invoke('dismissAlert')(true)

--- a/app/src/components/RobotSettings/SelectNetwork/ConnectModal/__tests__/form-state.test.js
+++ b/app/src/components/RobotSettings/SelectNetwork/ConnectModal/__tests__/form-state.test.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react'
-import { act } from 'react-dom/test-utils'
 import { mount } from 'enzyme'
 import * as Formik from 'formik'
 
@@ -55,9 +54,7 @@ describe('ConnectModal state hooks', () => {
       mockFormOnce({ ssid: 'foo', securityType: 'qux', psk: 'baz' })
       const wrapper = render()
 
-      act(() => {
-        wrapper.setProps({})
-      })
+      wrapper.setProps({})
 
       expect(setValues).toHaveBeenCalledTimes(1)
       expect(setValues).toHaveBeenCalledWith({
@@ -72,9 +69,7 @@ describe('ConnectModal state hooks', () => {
       mockFormOnce({ ssid: '', securityType: 'qux', psk: 'baz' }, errors)
       const wrapper = render()
 
-      act(() => {
-        wrapper.setProps({})
-      })
+      wrapper.setProps({})
 
       expect(setErrors).toHaveBeenCalledTimes(1)
       expect(setErrors).toHaveBeenCalledWith({ ssid: 'missing!' })
@@ -86,9 +81,7 @@ describe('ConnectModal state hooks', () => {
       mockFormOnce({ ssid: '', securityType: 'qux', psk: 'baz' }, {}, touched)
       const wrapper = render()
 
-      act(() => {
-        wrapper.setProps({})
-      })
+      wrapper.setProps({})
 
       expect(setTouched).toHaveBeenCalledTimes(1)
       expect(setTouched).toHaveBeenCalledWith(

--- a/app/src/components/RobotSettings/UpdateBuildroot/SkipAppUpdateMessage.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/SkipAppUpdateMessage.js
@@ -1,6 +1,13 @@
 // @flow
 import * as React from 'react'
-import { C_BLUE, SPACING_3, Link, Text } from '@opentrons/components'
+
+import {
+  C_BLUE,
+  FONT_SIZE_INHERIT,
+  SPACING_3,
+  Btn,
+  Text,
+} from '@opentrons/components'
 
 type SkipAppUpdateMessageProps = {|
   onClick: () => mixed,
@@ -16,9 +23,9 @@ export function SkipAppUpdateMessage(
   return (
     <Text paddingLeft={SPACING_3}>
       {SKIP_APP_MESSAGE}
-      <Link href="#" color={C_BLUE} onClick={props.onClick}>
+      <Btn color={C_BLUE} onClick={props.onClick} fontSize={FONT_SIZE_INHERIT}>
         {CLICK_HERE}
-      </Link>
+      </Btn>
       .
     </Text>
   )

--- a/app/src/components/RobotSettings/__tests__/ControlsCard.test.js
+++ b/app/src/components/RobotSettings/__tests__/ControlsCard.test.js
@@ -232,7 +232,7 @@ describe('ControlsCard', () => {
       return Calibration.DECK_CAL_STATUS_BAD_CALIBRATION
     })
 
-    const { wrapper } = render()
+    const { wrapper, refresh } = render()
 
     expect(getCheckCalibrationControl(wrapper).prop('disabledReason')).toBe(
       'Bad deck calibration detected. Please perform a full deck calibration.'
@@ -241,8 +241,7 @@ describe('ControlsCard', () => {
     getDeckCalibrationStatus.mockReturnValue(
       Calibration.DECK_CAL_STATUS_SINGULARITY
     )
-    wrapper.setProps({})
-    wrapper.update()
+    refresh()
 
     expect(getCheckCalibrationControl(wrapper).prop('disabledReason')).toBe(
       'Bad deck calibration detected. Please perform a full deck calibration.'
@@ -251,8 +250,7 @@ describe('ControlsCard', () => {
     getDeckCalibrationStatus.mockReturnValue(
       Calibration.DECK_CAL_STATUS_IDENTITY
     )
-    wrapper.setProps({})
-    wrapper.update()
+    refresh()
 
     expect(getCheckCalibrationControl(wrapper).prop('disabledReason')).toBe(
       'Please perform a full deck calibration.'

--- a/app/src/components/ToggleBtn/__tests__/ToggleBtn.test.js
+++ b/app/src/components/ToggleBtn/__tests__/ToggleBtn.test.js
@@ -1,0 +1,62 @@
+// @flow
+import * as React from 'react'
+import { shallow } from 'enzyme'
+
+import {
+  C_DARK_GRAY,
+  C_DISABLED,
+  C_SELECTED_DARK,
+  Btn,
+  Icon,
+} from '@opentrons/components'
+
+import { ToggleBtn } from '..'
+
+describe('ToggleBtn', () => {
+  it('should be an Icon inside a Btn', () => {
+    const wrapper = shallow(<ToggleBtn label="my-toggle" toggledOn={false} />)
+    const button = wrapper.find(Btn)
+    const icon = button.find(Icon)
+
+    expect(button.prop('role')).toBe('switch')
+    expect(button.prop('aria-label')).toBe('my-toggle')
+    expect(button.prop('aria-checked')).toBe(false)
+    expect(button.prop('color')).toBe(C_DARK_GRAY)
+    expect(icon.prop('name')).toBe('ot-toggle-switch-off')
+  })
+
+  it('should be a toggle-switch-on icon when toggled on', () => {
+    const wrapper = shallow(<ToggleBtn label="my-toggle" toggledOn={true} />)
+    const button = wrapper.find(Btn)
+    const icon = wrapper.find(Icon)
+
+    expect(button.prop('color')).toBe(C_SELECTED_DARK)
+    expect(button.prop('aria-checked')).toBe(true)
+    expect(icon.prop('name')).toBe('ot-toggle-switch-on')
+  })
+
+  it('should set the color to disabled when disabled', () => {
+    const wrapper = shallow(
+      <ToggleBtn label="my-toggle" toggledOn={true} disabled />
+    )
+    const button = wrapper.find(Btn)
+
+    expect(button.prop('color')).toBe(C_DISABLED)
+  })
+
+  it('should pass extra props to the Btn', () => {
+    const handleClick = jest.fn()
+    const wrapper = shallow(
+      <ToggleBtn
+        label="my-toggle"
+        toggledOn={true}
+        onClick={handleClick}
+        size="100%"
+      />
+    )
+    const button = wrapper.find(Btn)
+
+    expect(button.prop('onClick')).toBe(handleClick)
+    expect(button.prop('size')).toBe('100%')
+  })
+})

--- a/app/src/components/ToggleBtn/index.js
+++ b/app/src/components/ToggleBtn/index.js
@@ -1,0 +1,47 @@
+// @flow
+// primitives based toggle button
+// TODO(mc, 2020-10-08): replace ToggleButton in CL with this component
+import * as React from 'react'
+
+import {
+  C_DARK_GRAY,
+  C_DISABLED,
+  C_SELECTED_DARK,
+  Btn,
+  Icon,
+} from '@opentrons/components'
+
+import type { StyleProps } from '@opentrons/components'
+
+export type ToggleBtnProps = {|
+  label: string,
+  toggledOn: boolean,
+  disabled?: boolean | null,
+  onClick?: (SyntheticMouseEvent<Element>) => mixed,
+  ...StyleProps,
+|}
+
+export function ToggleBtn(props: ToggleBtnProps): React.Node {
+  const { label, toggledOn, disabled, ...buttonProps } = props
+  const iconName = toggledOn ? 'ot-toggle-switch-on' : 'ot-toggle-switch-off'
+  let color = C_DARK_GRAY
+
+  if (disabled) {
+    color = C_DISABLED
+  } else if (toggledOn) {
+    color = C_SELECTED_DARK
+  }
+
+  return (
+    <Btn
+      disabled={disabled}
+      role="switch"
+      aria-label={label}
+      aria-checked={toggledOn}
+      color={color}
+      {...buttonProps}
+    >
+      <Icon name={iconName} />
+    </Btn>
+  )
+}

--- a/app/src/components/app-settings/AppAdvancedSettingsCard.js
+++ b/app/src/components/app-settings/AppAdvancedSettingsCard.js
@@ -4,14 +4,8 @@ import * as React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import startCase from 'lodash/startCase'
 
-import {
-  useMountEffect,
-  Card,
-  LabeledToggle,
-  LabeledSelect,
-} from '@opentrons/components'
+import { Card, LabeledToggle, LabeledSelect } from '@opentrons/components'
 
-import { checkShellUpdate } from '../../shell'
 import * as Config from '../../config'
 import * as Calibration from '../../calibration'
 
@@ -55,10 +49,6 @@ export function AppAdvancedSettingsCard(): React.Node {
     dispatch(Config.toggleDevInternalFlag(flag))
   const handleChannel = event =>
     dispatch(Config.updateConfigValue('update.channel', event.target.value))
-
-  useMountEffect(() => {
-    dispatch(checkShellUpdate())
-  })
 
   return (
     <>

--- a/app/src/components/app-settings/AppSoftwareSettingsCard.js
+++ b/app/src/components/app-settings/AppSoftwareSettingsCard.js
@@ -5,6 +5,7 @@ import { useSelector, useDispatch } from 'react-redux'
 
 import {
   ALIGN_START,
+  BORDER_SOLID_LIGHT,
   SPACING_3,
   SPACING_AUTO,
   Card,
@@ -22,10 +23,12 @@ import {
 
 import { Portal } from '../portal'
 import { UpdateAppModal } from './UpdateAppModal'
+import { UpdateNotificationsControl } from './UpdateNotificationsControl'
+import { DowngradeAppControl } from './DowngradeAppControl'
 
 import type { Dispatch } from '../../types'
 
-const INFORMATION = 'Information'
+const APP_SOFTWARE_SETTINGS = 'App Software Settings'
 const VERSION_LABEL = 'Software Version'
 
 const UPDATE_AVAILABLE = 'view available update'
@@ -42,7 +45,7 @@ export function AppSoftwareSettingsCard(): React.Node {
 
   return (
     <>
-      <Card title={INFORMATION}>
+      <Card title={APP_SOFTWARE_SETTINGS}>
         <Flex padding={SPACING_3} alignItems={ALIGN_START}>
           <LabeledValue label={VERSION_LABEL} value={CURRENT_VERSION} />
           <SecondaryBtn
@@ -53,6 +56,8 @@ export function AppSoftwareSettingsCard(): React.Node {
             {updateAvailable ? UPDATE_AVAILABLE : UPDATE_NOT_AVAILABLE}
           </SecondaryBtn>
         </Flex>
+        <UpdateNotificationsControl borderTop={BORDER_SOLID_LIGHT} />
+        <DowngradeAppControl borderTop={BORDER_SOLID_LIGHT} />
       </Card>
       {showUpdateModal ? (
         <Portal>

--- a/app/src/components/app-settings/DowngradeAppControl.js
+++ b/app/src/components/app-settings/DowngradeAppControl.js
@@ -1,0 +1,53 @@
+// @flow
+
+import * as React from 'react'
+import { C_BLUE, SPACING_2, Link, Text } from '@opentrons/components'
+import { TitledControl } from '../TitledControl'
+
+import type { StyleProps } from '@opentrons/components'
+
+const PREVIOUS_RELEASES_URL = 'https://github.com/Opentrons/opentrons/releases'
+
+// NOTE(mc, 2020-10-09): `en/` intentionally omitted from URL
+const UNINSTALL_SUPPORT_URL =
+  'https://support.opentrons.com/articles/2393514-uninstall-the-opentrons-app'
+
+// TOOD(mc, 2020-10-08): i18n
+const RESTORE_A_DIFFERENT_VERSION = 'Restore Different Software Version'
+
+const NEED_TO_RESTORE = (
+  <>
+    Need to restore a different version of Opentrons OT-2 or App software? While
+    Opentrons does not recommend to reverting to older software versions, you
+    can access{' '}
+    <Link external href={PREVIOUS_RELEASES_URL} color={C_BLUE}>
+      previous releases here
+    </Link>
+    .
+  </>
+)
+
+const PERFORM_A_FULL_UNINSTALL = (
+  <>
+    For best results,{' '}
+    <Link external href={UNINSTALL_SUPPORT_URL} color={C_BLUE}>
+      uninstall the existing app and remove its configuration files
+    </Link>{' '}
+    before installing the older version.
+  </>
+)
+
+export function DowngradeAppControl(props: StyleProps): React.Node {
+  return (
+    <TitledControl
+      {...props}
+      title={RESTORE_A_DIFFERENT_VERSION}
+      description={
+        <>
+          <Text marginBottom={SPACING_2}>{NEED_TO_RESTORE}</Text>
+          <Text>{PERFORM_A_FULL_UNINSTALL}</Text>
+        </>
+      }
+    />
+  )
+}

--- a/app/src/components/app-settings/UpdateAppModal.js
+++ b/app/src/components/app-settings/UpdateAppModal.js
@@ -1,22 +1,30 @@
 // @flow
 import * as React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
+import { Link as InternalLink } from 'react-router-dom'
 
 import {
   ALIGN_CENTER,
-  C_WHITE,
+  C_BLUE,
   C_TRANSPARENT,
+  C_WHITE,
   DIRECTION_COLUMN,
+  DISPLAY_FLEX,
+  FONT_SIZE_BODY_1,
   FONT_SIZE_BODY_2,
   FONT_SIZE_HEADER,
   FONT_STYLE_ITALIC,
   FONT_WEIGHT_REGULAR,
   JUSTIFY_FLEX_END,
   SIZE_4,
+  SIZE_6,
   SPACING_2,
   SPACING_3,
   SPACING_4,
+  SPACING_AUTO,
+  useMountEffect,
   BaseModal,
+  Btn,
   Box,
   Flex,
   Icon,
@@ -48,8 +56,19 @@ const DOWNLOAD_IN_PROGRESS = 'Download in progress'
 const DOWNLOAD = 'Download'
 const RESTART_APP = 'Restart App'
 const NOT_NOW = 'Not Now'
+const OK = 'OK'
 const UPDATE_ERROR = 'Update Error'
 const SOMETHING_WENT_WRONG = 'Something went wrong while updating your app'
+const TURN_OFF_UPDATE_NOTIFICATIONS = 'Turn off update notifications'
+const YOUVE_TURNED_OFF_NOTIFICATIONS = "You've Turned Off Update Notifications"
+const VIEW_APP_SOFTWARE_SETTINGS = 'View App Software Settings'
+const NOTIFICATIONS_DISABLED_DESCRIPTION = (
+  <>
+    You{"'"}ve chosen to not be notified when an app update is available. You
+    can change this setting under More {'>'} App {'>'}{' '}
+    App&nbsp;Software&nbsp;Settings.
+  </>
+)
 
 const FINISH_UPDATE_INSTRUCTIONS = (
   <>
@@ -89,21 +108,38 @@ const SPINNER = (
 
 export function UpdateAppModal(props: UpdateAppModalProps): React.Node {
   const { dismissAlert, closeModal } = props
+  const [updatesIgnored, setUpdatesIgnored] = React.useState(false)
   const dispatch = useDispatch<Dispatch>()
   const updateState = useSelector(getShellUpdateState)
   const { downloaded, downloading, error, info: updateInfo } = updateState
   const version = updateInfo?.version ?? ''
   const releaseNotes = updateInfo?.releaseNotes
 
-  const updateButtonText = downloaded ? RESTART_APP : DOWNLOAD
   const handleUpdateClick = () => {
     dispatch(downloaded ? applyShellUpdate() : downloadShellUpdate())
   }
 
+  // ensure close handlers are called on close button click or on component
+  // unmount (for safety), but not both
+  const latestHandleClose = React.useRef(null)
+
+  React.useEffect(() => {
+    latestHandleClose.current = () => {
+      if (typeof dismissAlert === 'function') dismissAlert(updatesIgnored)
+      if (typeof closeModal === 'function') closeModal()
+      latestHandleClose.current = null
+    }
+  })
+
   const handleCloseClick = () => {
-    if (typeof dismissAlert === 'function') dismissAlert(false)
-    if (typeof closeModal === 'function') closeModal()
+    latestHandleClose.current && latestHandleClose.current()
   }
+
+  useMountEffect(() => {
+    return () => {
+      latestHandleClose.current && latestHandleClose.current()
+    }
+  })
 
   if (error) {
     return (
@@ -118,37 +154,74 @@ export function UpdateAppModal(props: UpdateAppModalProps): React.Node {
 
   if (downloading) return SPINNER
 
+  // TODO(mc, 2020-10-08): refactor most of this back into a new AlertModal
+  // component built with BaseModal
   return (
     <BaseModal
+      maxWidth="38rem"
       fontSize={FONT_SIZE_BODY_2}
       header={
-        <Flex alignItems={ALIGN_CENTER}>
+        <Text
+          as="h2"
+          display={DISPLAY_FLEX}
+          alignItems={ALIGN_CENTER}
+          fontSize={FONT_SIZE_HEADER}
+          fontWeight={FONT_WEIGHT_REGULAR}
+        >
           <Icon name="alert" width="1em" marginRight={SPACING_2} />
-          <Text
-            as="h2"
-            fontSize={FONT_SIZE_HEADER}
-            fontWeight={FONT_WEIGHT_REGULAR}
-          >
-            {APP_VERSION} {version} {downloaded ? DOWNLOADED : AVAILABLE}
-          </Text>
-        </Flex>
+          {updatesIgnored
+            ? YOUVE_TURNED_OFF_NOTIFICATIONS
+            : `${APP_VERSION} ${version} ${
+                downloaded ? DOWNLOADED : AVAILABLE
+              }`}
+        </Text>
       }
       footer={
-        <Flex justifyContent={JUSTIFY_FLEX_END}>
-          <SecondaryBtn marginRight={SPACING_3} onClick={handleCloseClick}>
-            {NOT_NOW}
-          </SecondaryBtn>
-          <SecondaryBtn onClick={handleUpdateClick}>
-            {updateButtonText}
-          </SecondaryBtn>
+        <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_FLEX_END}>
+          {updatesIgnored ? (
+            <>
+              <SecondaryBtn
+                as={InternalLink}
+                to="/more/app"
+                onClick={handleCloseClick}
+                marginRight={SPACING_3}
+              >
+                {VIEW_APP_SOFTWARE_SETTINGS}
+              </SecondaryBtn>
+              <SecondaryBtn onClick={handleCloseClick}>{OK}</SecondaryBtn>
+            </>
+          ) : (
+            <>
+              {dismissAlert != null ? (
+                <Btn
+                  color={C_BLUE}
+                  marginRight={SPACING_AUTO}
+                  fontSize={FONT_SIZE_BODY_1}
+                  onClick={() => setUpdatesIgnored(true)}
+                >
+                  {TURN_OFF_UPDATE_NOTIFICATIONS}
+                </Btn>
+              ) : null}
+              <SecondaryBtn marginRight={SPACING_3} onClick={handleCloseClick}>
+                {NOT_NOW}
+              </SecondaryBtn>
+              <SecondaryBtn onClick={handleUpdateClick}>
+                {downloaded ? RESTART_APP : DOWNLOAD}
+              </SecondaryBtn>
+            </>
+          )}
         </Flex>
       }
     >
-      {downloaded ? (
-        FINISH_UPDATE_INSTRUCTIONS
-      ) : (
-        <ReleaseNotes source={releaseNotes} />
-      )}
+      <Box maxWidth={SIZE_6}>
+        {updatesIgnored ? (
+          NOTIFICATIONS_DISABLED_DESCRIPTION
+        ) : downloaded ? (
+          FINISH_UPDATE_INSTRUCTIONS
+        ) : (
+          <ReleaseNotes source={releaseNotes} />
+        )}
+      </Box>
     </BaseModal>
   )
 }

--- a/app/src/components/app-settings/UpdateAppModal.js
+++ b/app/src/components/app-settings/UpdateAppModal.js
@@ -192,7 +192,7 @@ export function UpdateAppModal(props: UpdateAppModalProps): React.Node {
             </>
           ) : (
             <>
-              {dismissAlert != null ? (
+              {dismissAlert != null && !downloaded ? (
                 <Btn
                   color={C_BLUE}
                   marginRight={SPACING_AUTO}

--- a/app/src/components/app-settings/UpdateNotificationsControl.js
+++ b/app/src/components/app-settings/UpdateNotificationsControl.js
@@ -1,0 +1,63 @@
+// @flow
+import * as React from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { SIZE_2, SPACING_3 } from '@opentrons/components'
+
+import {
+  ALERT_APP_UPDATE_AVAILABLE,
+  getAlertIsPermanentlyIgnored,
+  alertPermanentlyIgnored,
+  alertUnignored,
+} from '../../alerts'
+
+import { TitledControl } from '../TitledControl'
+import { ToggleBtn } from '../ToggleBtn'
+
+import type { StyleProps } from '@opentrons/components'
+import type { State, Dispatch } from '../../types'
+
+const APP_UPDATE_ALERTS = 'App Update Alerts'
+
+const GET_NOTIFIED_ABOUT_UPDATES =
+  'Get notified when Opentrons has an app update ready for you.'
+
+const ENABLE_APP_UPDATE_NOTIFICATIONS = 'Enable app update notifications'
+
+export function UpdateNotificationsControl(props: StyleProps): React.Node {
+  const dispatch = useDispatch<Dispatch>()
+
+  // may be enabled, disabled, or unknown (because config is loading)
+  const enabled = useSelector((s: State) => {
+    const ignored = getAlertIsPermanentlyIgnored(s, ALERT_APP_UPDATE_AVAILABLE)
+    return ignored !== null ? !ignored : null
+  })
+
+  const handleToggle = () => {
+    if (enabled !== null) {
+      dispatch(
+        enabled
+          ? alertPermanentlyIgnored(ALERT_APP_UPDATE_AVAILABLE)
+          : alertUnignored(ALERT_APP_UPDATE_AVAILABLE)
+      )
+    }
+  }
+
+  return (
+    <TitledControl
+      {...props}
+      title={APP_UPDATE_ALERTS}
+      description={GET_NOTIFIED_ABOUT_UPDATES}
+      control={
+        <ToggleBtn
+          label={ENABLE_APP_UPDATE_NOTIFICATIONS}
+          size={SIZE_2}
+          marginRight={SPACING_3}
+          disabled={enabled === null}
+          toggledOn={enabled === true}
+          onClick={handleToggle}
+        />
+      }
+    />
+  )
+}

--- a/app/src/components/app-settings/__tests__/AppAdvancedSettingsCard.test.js
+++ b/app/src/components/app-settings/__tests__/AppAdvancedSettingsCard.test.js
@@ -2,7 +2,6 @@
 import * as React from 'react'
 import { mountWithStore } from '@opentrons/components/__utils__'
 import * as Config from '../../../config'
-import * as Shell from '../../../shell'
 import { AppAdvancedSettingsCard } from '../AppAdvancedSettingsCard'
 
 import type { State } from '../../../types'
@@ -124,12 +123,5 @@ describe('AppAdvancedSettingsCard', () => {
     expect(store.dispatch).toHaveBeenCalledWith(
       Config.toggleConfigValue('calibration.useTrashSurfaceForTipCal')
     )
-  })
-
-  it('checks for updates on mount', () => {
-    const { store } = render()
-    const expectedAction = Shell.checkShellUpdate()
-
-    expect(store.dispatch).toHaveBeenCalledWith(expectedAction)
   })
 })

--- a/app/src/components/app-settings/__tests__/AppSoftwareSettingsCard.test.js
+++ b/app/src/components/app-settings/__tests__/AppSoftwareSettingsCard.test.js
@@ -3,11 +3,13 @@
 import * as React from 'react'
 
 import { mountWithStore } from '@opentrons/components/__utils__'
-import { Card, LabeledValue, SecondaryBtn } from '@opentrons/components'
+import { Card, LabeledValue, Link, SecondaryBtn } from '@opentrons/components'
 import * as Shell from '../../../shell'
 import { Portal } from '../../portal'
+import { TitledControl } from '../../TitledControl'
 import { AppSoftwareSettingsCard } from '../AppSoftwareSettingsCard'
 import { UpdateAppModal } from '../UpdateAppModal'
+import { UpdateNotificationsControl } from '../UpdateNotificationsControl'
 
 import type { State } from '../../../types'
 
@@ -47,7 +49,7 @@ describe('AppSoftwareSettingsCard', () => {
     const { wrapper } = render()
     const card = wrapper.find(Card)
 
-    expect(card.prop('title')).toBe('Information')
+    expect(card.prop('title')).toBe('App Software Settings')
   })
 
   it('should have a labeled value with the current version', () => {
@@ -96,5 +98,38 @@ describe('AppSoftwareSettingsCard', () => {
     wrapper.find(UpdateAppModal).invoke('closeModal')()
 
     expect(wrapper.exists(UpdateAppModal)).toBe(false)
+  })
+
+  it('should render a <UpdateNotificationsControl>', () => {
+    const { wrapper } = render()
+    expect(wrapper.exists(UpdateNotificationsControl)).toBe(true)
+  })
+
+  it('should have a TitledControl for downloaded previous software versions', () => {
+    const { wrapper } = render()
+    const section = wrapper
+      .find(TitledControl)
+      .filterWhere(
+        t => t.prop('title') === 'Restore Different Software Version'
+      )
+
+    const releasesLink = section
+      .find(Link)
+      .filterWhere(
+        a =>
+          a.prop('href') === 'https://github.com/Opentrons/opentrons/releases'
+      )
+
+    const articleLink = section
+      .find(Link)
+      .filterWhere(
+        a =>
+          a.prop('href') ===
+          'https://support.opentrons.com/articles/2393514-uninstall-the-opentrons-app'
+      )
+
+    expect(section.text()).toMatch(/restore a different version/i)
+    expect(articleLink.prop('external')).toBe(true)
+    expect(releasesLink.prop('external')).toBe(true)
   })
 })

--- a/app/src/components/app-settings/__tests__/UpdateAppModal.test.js
+++ b/app/src/components/app-settings/__tests__/UpdateAppModal.test.js
@@ -220,6 +220,17 @@ describe('UpdateAppModal', () => {
     expect(ignoreButton.exists()).toBe(false)
   })
 
+  it('should not show the "ignore" button if the user has proceeded with the update', () => {
+    getShellUpdateState.mockReturnValue({ downloaded: true })
+
+    const { wrapper } = render({ dismissAlert })
+    const ignoreButton = wrapper
+      .find('button')
+      .filterWhere(b => /turn off update notifications/i.test(b.text()))
+
+    expect(ignoreButton.exists()).toBe(false)
+  })
+
   it('should dismiss the alert permanently once the user clicks "OK"', () => {
     const { wrapper } = render({ dismissAlert })
 

--- a/app/src/components/app-settings/__tests__/UpdateNotificationsControl.test.js
+++ b/app/src/components/app-settings/__tests__/UpdateNotificationsControl.test.js
@@ -1,0 +1,105 @@
+// @flow
+import * as React from 'react'
+import { mountWithStore } from '@opentrons/components/__utils__'
+
+import { BORDER_SOLID_LIGHT } from '@opentrons/components'
+import * as Alerts from '../../../alerts'
+import { TitledControl } from '../../TitledControl'
+import { ToggleBtn } from '../../ToggleBtn'
+import { UpdateNotificationsControl } from '../UpdateNotificationsControl'
+
+import type { StyleProps } from '@opentrons/components'
+import type { State } from '../../../types'
+import type { AlertId } from '../../../alerts/types'
+
+jest.mock('../../../alerts/selectors')
+
+const getAlertIsPermanentlyIgnored: JestMockFn<
+  [State, AlertId],
+  boolean | null
+> = Alerts.getAlertIsPermanentlyIgnored
+
+const MOCK_STATE: $Shape<State> = {}
+
+describe('UpdateNotificationsControl', () => {
+  const render = (styleProps: $Shape<StyleProps> = {}) => {
+    return mountWithStore(<UpdateNotificationsControl {...styleProps} />, {
+      initialState: MOCK_STATE,
+    })
+  }
+
+  beforeEach(() => {
+    getAlertIsPermanentlyIgnored.mockImplementation((state, alertId) => {
+      expect(state).toBe(MOCK_STATE)
+      expect(alertId).toBe(Alerts.ALERT_APP_UPDATE_AVAILABLE)
+      return null
+    })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should be TitledControl', () => {
+    const { wrapper } = render()
+    const control = wrapper.find(TitledControl)
+
+    expect(control.prop('title')).toBe('App Update Alerts')
+    expect(control.text()).toMatch(/get notified when.+app update/i)
+  })
+
+  it('should pass style props to the TitledControl', () => {
+    const { wrapper } = render({ borderTop: BORDER_SOLID_LIGHT })
+    const control = wrapper.find(TitledControl)
+
+    expect(control.prop('borderTop')).toBe(BORDER_SOLID_LIGHT)
+  })
+
+  it('should have a ToggleBtn with state driven by alerts', () => {
+    const { wrapper, refresh } = render()
+    const getToggle = () => wrapper.find(ToggleBtn)
+
+    expect(getToggle().prop('disabled')).toBe(true)
+    expect(getToggle().prop('toggledOn')).toBe(false)
+
+    // enable notifications toggle should be on if alerts are not ignored
+    getAlertIsPermanentlyIgnored.mockReturnValue(false)
+    refresh()
+    expect(getToggle().prop('disabled')).toBe(false)
+    expect(getToggle().prop('toggledOn')).toBe(true)
+
+    // enable notifications toggle should be on if alerts are not ignored
+    getAlertIsPermanentlyIgnored.mockReturnValue(true)
+    refresh()
+    expect(getToggle().prop('disabled')).toBe(false)
+    expect(getToggle().prop('toggledOn')).toBe(false)
+  })
+
+  it('should unignore app alerts when toggled from off to on', () => {
+    // true means alert is disabled which means toggle is off
+    getAlertIsPermanentlyIgnored.mockReturnValue(true)
+
+    const { wrapper, store } = render()
+    const toggle = wrapper.find(ToggleBtn)
+
+    toggle.invoke('onClick')()
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      Alerts.alertUnignored(Alerts.ALERT_APP_UPDATE_AVAILABLE)
+    )
+  })
+
+  it('should ignore app alerts when toggled from on to off', () => {
+    // false means alert is enabled which means toggle is on
+    getAlertIsPermanentlyIgnored.mockReturnValue(false)
+
+    const { wrapper, store } = render()
+    const toggle = wrapper.find(ToggleBtn)
+
+    toggle.invoke('onClick')()
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      Alerts.alertPermanentlyIgnored(Alerts.ALERT_APP_UPDATE_AVAILABLE)
+    )
+  })
+})

--- a/components/__utils__/mountWithStore.js
+++ b/components/__utils__/mountWithStore.js
@@ -1,4 +1,5 @@
 // @flow
+import assert from 'assert'
 import * as React from 'react'
 import { Provider } from 'react-redux'
 import { mount } from 'enzyme'
@@ -14,6 +15,7 @@ export type MockStore<State, Action> = {|
 export type WrapperWithStore<Element, State, Action> = {|
   wrapper: ReactWrapper<Element>,
   store: MockStore<State, Action>,
+  refresh: (nextState?: State) => void,
 |}
 
 export type MountWithStoreOptions<State> = {
@@ -25,14 +27,12 @@ export function mountWithStore<Element: React.ElementType, State, Action>(
   node: React.Element<Element>,
   options?: MountWithStoreOptions<State>
 ): WrapperWithStore<Element, State, Action> {
+  const initialState = options?.initialState ?? (({}: any): State)
+
   const store: MockStore<State, Action> = {
-    getState: jest.fn(),
+    getState: jest.fn(() => initialState),
     subscribe: jest.fn(),
     dispatch: jest.fn(),
-  }
-
-  if (options && 'initialState' in options) {
-    store.getState.mockReturnValue(((options.initialState: any): State))
   }
 
   const wrapper = mount(node, {
@@ -40,5 +40,19 @@ export function mountWithStore<Element: React.ElementType, State, Action>(
     wrappingComponentProps: { store },
   })
 
-  return { wrapper, store }
+  // force a re-render by returning a new state to recalculate selectors
+  // and sending a blank set of new props to the wrapper
+  const refresh = maybeNextState => {
+    const nextState = maybeNextState ?? { ...initialState }
+
+    assert(
+      nextState !== initialState,
+      'nextState must be different than initialState to trigger a re-render'
+    )
+
+    store.getState.mockReturnValue(nextState)
+    wrapper.setProps({})
+  }
+
+  return { wrapper, store, refresh }
 }

--- a/components/src/modals/BaseModal.js
+++ b/components/src/modals/BaseModal.js
@@ -22,7 +22,6 @@ const MODAL_STYLE = {
   backgroundColor: Styles.C_WHITE,
   position: Styles.POSITION_RELATIVE,
   overflowY: Styles.OVERFLOW_AUTO,
-  maxWidth: Styles.SIZE_6,
   maxHeight: '100%',
   width: '100%',
 }

--- a/components/src/modals/__tests__/BaseModal.test.js
+++ b/components/src/modals/__tests__/BaseModal.test.js
@@ -70,18 +70,17 @@ describe('BaseModal', () => {
       position: 'relative',
       backgroundColor: C_WHITE,
       maxHeight: '100%',
-      maxWidth: '32rem',
       width: '100%',
       overflowY: 'auto',
     })
   })
 
   it('should apply style props to content box', () => {
-    const wrapper = shallow(<BaseModal maxWidth="60rem" />)
+    const wrapper = shallow(<BaseModal maxWidth="32rem" />)
     const modal = wrapper.find(Flex).first()
     const content = modal.children(Box).first()
 
-    expect(content.prop('maxWidth')).toBe('60rem')
+    expect(content.prop('maxWidth')).toBe('32rem')
   })
 
   it('should render a header bar if props.header is passed', () => {

--- a/components/src/styles/colors.js
+++ b/components/src/styles/colors.js
@@ -15,11 +15,13 @@ export const C_TRANSPARENT = 'transparent'
 export const C_BLUE = '#006fff'
 
 // colors by usage
-export const COLOR_DISABLED = '#9c9c9c'
+// TODO(mc, 2020-10-08): s/COLOR_/C_
 export const COLOR_WARNING = '#e28200'
 export const COLOR_WARNING_LIGHT = '#ffd58f'
 export const COLOR_ERROR = '#d12929'
 export const COLOR_SUCCESS = '#60b120'
+export const C_DISABLED = '#9c9c9c'
+export const C_SELECTED_DARK = '#00c3e6'
 
 // overlays
 export const OVERLAY_WHITE_10 = 'rgba(255, 255, 255, 0.1)'

--- a/components/src/styles/typography.js
+++ b/components/src/styles/typography.js
@@ -15,6 +15,7 @@ export const FONT_SIZE_BODY_1 = '0.75rem'
 export const FONT_SIZE_CAPTION = '0.625rem'
 export const FONT_SIZE_TINY = '0.325rem'
 export const FONT_SIZE_MICRO = '0.2rem'
+export const FONT_SIZE_INHERIT = 'inherit'
 
 // line height values
 export const LINE_HEIGHT_SOLID = 1


### PR DESCRIPTION
## overview

This PR adds the ability for a user to disable app update pop-up notifications either via the pop-up or via a toggle in More > App > App Software Settings.

Closes #6684

~This is a draft PR blocked by #6708. Will require rebase.~

## changelog

- feat(app): allow app update pop-up notifications to be disabled


## review requests

The acceptance criteria are in #6684, so take a look at that. As usual, manually editing `version` in `app-shell/package.json` to a previous version is the best way to test this with `make -C app-shell dev`

- [x] App notification pops up if app is "outdated"
- [x] Clicking on "Turn off update notifications" shows you a warning
- [x] Clicking "View App Software Settings" takes you to the App settings page
- [x] If you close and re-open the app, the notification does not pop up
- [x] If you navigate to the App settings and toggle the setting back on, the notification pops up the next time you open the app
    - **Note:** The notification will also pop up as soon as you toggle it back on the first time you make the switch
- [x] If you open the app release notes outside of the notification, there's no "Turn off..." link
    - Click "View Available Update" in More > App
    - Click "Downgrade" (or whatever it says based on your fake dev version) on a Robot settings page and click "View App Update" on the warning modal that tells you to update your app before doing any robot updates

## risk assessment

Medium risk. Mitigating factors:

- We can / should smoke test actual app updates before merging / releasing
- This PR doesn't mess with the actual plumbing of app updates at all, just the UI that hooks into it
- Unit tests in this and previous PRs ensure the plumbing is still hooked into properly
- I think this PR has very high test coverage, including of the UI and the user flows through the UI
    - Most, if not all of it was TDD'd