### PR TITLE
chore(api): speed up thermocycler test.

### DIFF
--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -75,6 +75,7 @@ ERROR_KEYWORD = 'error'
 DEFAULT_TC_TIMEOUT = 40
 DEFAULT_COMMAND_RETRIES = 3
 DEFAULT_STABILIZE_DELAY = 0.1
+DEFAULT_POLLER_WAIT_SECONDS = 0.1
 POLLING_FREQUENCY_MS = 1000
 HOLD_TIME_FUZZY_SECONDS = POLLING_FREQUENCY_MS / 1000 * 5
 TEMP_THRESHOLD = 0.3
@@ -433,7 +434,8 @@ class Thermocycler:
         retries = 0
         while self._target_temp != temp or \
                 not self.hold_time_probably_set(hold_time):
-            await asyncio.sleep(0.1)    # Wait for the poller to update
+            # Wait for the poller to update
+            await asyncio.sleep(DEFAULT_POLLER_WAIT_SECONDS)
             retries += 1
             if retries > TEMP_UPDATE_RETRIES:
                 raise ThermocyclerError(f'Thermocycler driver set the block '
@@ -457,7 +459,8 @@ class Thermocycler:
         await self._write_and_wait(lid_temp_cmd)
         retries = 0
         while self._lid_target != _lid_target:
-            await asyncio.sleep(0.1)    # Wait for the poller to update
+            # Wait for the poller to update
+            await asyncio.sleep(DEFAULT_POLLER_WAIT_SECONDS)
             retries += 1
             if retries > TEMP_UPDATE_RETRIES:
                 raise ThermocyclerError(f'Thermocycler driver set lid temp to'

--- a/api/tests/opentrons/drivers/module_drivers/test_thermocycler_driver.py
+++ b/api/tests/opentrons/drivers/module_drivers/test_thermocycler_driver.py
@@ -11,7 +11,9 @@
 import types
 from unittest.mock import patch
 import pytest
-from opentrons.drivers.thermocycler import Thermocycler, ThermocyclerError, driver
+from opentrons.drivers.thermocycler import (
+    Thermocycler, ThermocyclerError, driver
+)
 
 
 @pytest.fixture

--- a/api/tests/opentrons/drivers/module_drivers/test_thermocycler_driver.py
+++ b/api/tests/opentrons/drivers/module_drivers/test_thermocycler_driver.py
@@ -9,11 +9,18 @@
 # expected ACK, then it'll eventually time out and return an error
 
 import types
+from unittest.mock import patch
 import pytest
-from opentrons.drivers.thermocycler import Thermocycler, ThermocyclerError
+from opentrons.drivers.thermocycler import Thermocycler, ThermocyclerError, driver
 
 
-async def test_set_block_temperature():
+@pytest.fixture
+def patch_poller_wait():
+    with patch.object(driver, 'DEFAULT_POLLER_WAIT_SECONDS', new=0) as p:
+        yield p
+
+
+async def test_set_block_temperature(patch_poller_wait):
     # set the block target temperature
 
     tc = Thermocycler(lambda x: None)
@@ -77,7 +84,7 @@ async def test_set_block_temperature():
     assert command_log.pop(0) == 'M104 S21'
 
 
-async def test_set_temperature_with_fuzzy_hold_time():
+async def test_set_temperature_with_fuzzy_hold_time(patch_poller_wait):
     tc = Thermocycler(lambda x: None)
     command_log = []
 
@@ -118,7 +125,7 @@ async def test_set_temperature_with_fuzzy_hold_time():
     assert command_log.pop(0) == 'M104 S21 H5'
 
 
-async def test_deactivates():
+async def test_deactivates(patch_poller_wait):
     tc = Thermocycler(lambda x: None)
     command_log = []
 
@@ -140,7 +147,7 @@ async def test_deactivates():
     assert command_log.pop(0) == 'M14'
 
 
-async def test_set_lid_temperature():
+async def test_set_lid_temperature(patch_poller_wait):
     tc = Thermocycler(lambda x: None)
     command_log = []
 
@@ -166,7 +173,7 @@ async def test_set_lid_temperature():
     assert command_log.pop(0) == 'M140 S60'
 
 
-def test_holding_at_target():
+def test_holding_at_target(patch_poller_wait):
     tc = Thermocycler(lambda x: None)
 
     tc._target_temp = 30


### PR DESCRIPTION
# Overview

The thermocycler driver unit tests were taking an eternity due to the retry logic and sleeps. 

# Changelog

Created a constant for `DEFAULT_POLLER_WAIT_SECONDS` and patched it to be 0.0 seconds. 

# Review requests


# Risk assessment

Zero. Just test change.