### PR TITLE
chore: ignore shared-data python in flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,6 +7,7 @@
 <PROJECT_ROOT>/audio/.*
 <PROJECT_ROOT>/compute/.*
 <PROJECT_ROOT>/update-server/.*
+<PROJECT_ROOT>/shared-data/python/.*
 
 [untyped]
 ; TODO(mc, 2019-06-28): react-select uses an old version of flow


### PR DESCRIPTION
Flow would pick up on the json files interned in the shared-data python
bindings at least on my system. Get them outta here
