### PR TITLE
chore: Exclude Sublime Text project files from Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,8 @@ calibrations/
 # local IDE configs
 .vscode
 *.code-workspace
+*.sublime-project
+*.sublime-workspace
 
 # TODO(mc, 2020-10-30): remove this ignore when we need pyproject.toml
 # recent versions of setuptools create pyproject.toml automatically


### PR DESCRIPTION
Prevent `*.sublime-project` and `*.sublime-workspace` files from being added to Git, in the same way we prevent `.vscode`
and `*.code-workspace` files from being added.

-----

If we wanted, we *could* check in the `.sublime-project` file, to share tedious settings like which directories to keep out of the index and how to normalize whitespace on file save. I'm assuming we don't, though, since I haven't seen anyone else use Sublime Text.
