### PR TITLE
refactor(api): use pytest mark parametrize in instrument context test

### DIFF
--- a/api/tests/opentrons/protocol_api/test_instrument.py
+++ b/api/tests/opentrons/protocol_api/test_instrument.py
@@ -19,7 +19,11 @@ def make_context_and_labware():
     return _make_context_and_labware
 
 
-def test_blowout_location_unsupported_version(make_context_and_labware):
+@pytest.mark.parametrize(
+    'liquid_handling_command',
+    ['transfer', 'consolidate', 'distribute'])
+def test_blowout_location_unsupported_version(
+        make_context_and_labware, liquid_handling_command):
     # not supported in versions below 2.8
     context_and_labware = make_context_and_labware(APIVersion(2, 7))
     context_and_labware['ctx'].home()
@@ -29,59 +33,72 @@ def test_blowout_location_unsupported_version(make_context_and_labware):
             ValueError,
             match='Cannot specify blowout location when using api version ' +
             'below 2.8, current version is 2.7'):
-        instr.transfer(
+        getattr(instr, liquid_handling_command)(
             100,
             lw1['A1'],
             lw1['A2'],
-            blowout_location='foo nonsense')
+            blowout_location='should not matter')
 
 
-def test_blowout_location_invalid(make_context_and_labware):
+@pytest.mark.parametrize(
+    argnames='liquid_handling_command,'
+             'blowout_location,'
+             'expected_error_match,',
+    argvalues=[
+        [
+            'transfer',
+            'some invalid location',
+            'blowout location should be either'
+        ],
+        [
+            'consolidate',
+            'source well',
+            'blowout location for consolidate cannot be source well'
+        ],
+        [
+            'distribute',
+            'destination well',
+            'blowout location for distribute cannot be destination well'
+        ],
+    ]
+)
+def test_blowout_location_invalid(
+        make_context_and_labware,
+        liquid_handling_command,
+        blowout_location,
+        expected_error_match):
     context_and_labware = make_context_and_labware(APIVersion(2, 8))
     context_and_labware['ctx'].home()
     lw1 = context_and_labware['lw1']
     instr = context_and_labware['instr']
-    with pytest.raises(ValueError, match='blowout location should be either'):
-        instr.transfer(
+    with pytest.raises(ValueError, match=expected_error_match):
+
+        getattr(instr, liquid_handling_command)(
             100,
             lw1['A1'],
             lw1['A2'],
-            blowout_location='foo nonsense')
+            blowout_location=blowout_location)
 
 
-def test_source_blowout_location_invalid_for_consolidate(
-        make_context_and_labware):
-    context_and_labware = make_context_and_labware(APIVersion(2, 8))
-    context_and_labware['ctx'].home()
-    lw1 = context_and_labware['lw1']
-    instr = context_and_labware['instr']
-    with pytest.raises(ValueError, match='blowout location for ' +
-                       'consolidate cannot be'):
-        instr.consolidate(
-            100,
-            [lw1['A1'], lw1['B1']],
-            lw1['A2'],
-            blow_out=True,
-            blowout_location='source well')
-
-
-def test_dest_blowout_location_invalid_for_distribute(
-        make_context_and_labware):
-    context_and_labware = make_context_and_labware(APIVersion(2, 8))
-    context_and_labware['ctx'].home()
-    lw1 = context_and_labware['lw1']
-    instr = context_and_labware['instr']
-    with pytest.raises(ValueError, match='blowout location for ' +
-                       'distribute cannot be'):
-        instr.distribute(
-            100,
-            lw1['A2'],
-            [lw1['A1'], lw1['B1']],
-            blow_out=True,
-            blowout_location='destination well')
-
-
-def test_valid_transfer_blowout_location(make_context_and_labware):
+@pytest.mark.parametrize(
+    argnames='liquid_handling_command,'
+             'blowout_location,'
+             'expected_strat,',
+    argvalues=[
+        ['transfer', 'destination well', transfers.BlowOutStrategy.DEST],
+        ['transfer', 'source well', transfers.BlowOutStrategy.SOURCE],
+        ['transfer', 'trash', transfers.BlowOutStrategy.TRASH],
+        ['consolidate', 'destination well', transfers.BlowOutStrategy.DEST],
+        ['consolidate', 'trash', transfers.BlowOutStrategy.TRASH],
+        ['distribute', 'source well', transfers.BlowOutStrategy.SOURCE],
+        ['distribute', 'trash', transfers.BlowOutStrategy.TRASH],
+    ]
+)
+def test_valid_blowout_location(
+        make_context_and_labware,
+        liquid_handling_command,
+        blowout_location,
+        expected_strat):
     context_and_labware = make_context_and_labware(APIVersion(2, 8))
     context_and_labware['ctx'].home()
     lw1 = context_and_labware['lw1']
@@ -89,110 +106,15 @@ def test_valid_transfer_blowout_location(make_context_and_labware):
 
     with mock.patch.object(
             papi.InstrumentContext, '_execute_transfer') as patch:
-        instr.transfer(
+        getattr(instr, liquid_handling_command)(
             100,
             lw1['A2'],
             [lw1['A1'], lw1['B1']],
             blow_out=True,
-            blowout_location='destination well',
+            blowout_location=blowout_location,
             new_tip='never'
         )
-        blowout_strat_1 = patch.call_args_list[0][0][0]._options.transfer \
+        blowout_strat = patch.call_args[0][0]._options.transfer \
             .blow_out_strategy
 
-        assert blowout_strat_1 == transfers.BlowOutStrategy.DEST
-
-        instr.transfer(
-            100,
-            lw1['A2'],
-            [lw1['A1'], lw1['B1']],
-            blow_out=True,
-            blowout_location='source well',
-            new_tip='never'
-        )
-        blowout_strat_2 = patch.call_args_list[1][0][0]._options.transfer \
-            .blow_out_strategy
-
-        assert blowout_strat_2 == transfers.BlowOutStrategy.SOURCE
-
-        instr.transfer(
-            100,
-            lw1['A2'],
-            [lw1['A1'], lw1['B1']],
-            blow_out=True,
-            blowout_location='trash',
-            new_tip='never'
-        )
-        blowout_strat_3 = patch.call_args_list[2][0][0]._options.transfer \
-            .blow_out_strategy
-
-        assert blowout_strat_3 == transfers.BlowOutStrategy.TRASH
-
-
-def test_valid_consolidate_blowout_location(make_context_and_labware):
-    context_and_labware = make_context_and_labware(APIVersion(2, 8))
-    context_and_labware['ctx'].home()
-    lw1 = context_and_labware['lw1']
-    instr = context_and_labware['instr']
-
-    with mock.patch.object(
-            papi.InstrumentContext, '_execute_transfer') as patch:
-        instr.consolidate(
-            100,
-            lw1['A2'],
-            [lw1['A1'], lw1['B1']],
-            blow_out=True,
-            blowout_location='destination well',
-            new_tip='never'
-        )
-        blowout_strat_1 = patch.call_args_list[0][0][0]._options.transfer \
-            .blow_out_strategy
-
-        assert blowout_strat_1 == transfers.BlowOutStrategy.DEST
-
-        instr.consolidate(
-            100,
-            lw1['A2'],
-            [lw1['A1'], lw1['B1']],
-            blow_out=True,
-            blowout_location='trash',
-            new_tip='never'
-        )
-        blowout_strat_2 = patch.call_args_list[1][0][0]._options.transfer \
-            .blow_out_strategy
-
-        assert blowout_strat_2 == transfers.BlowOutStrategy.TRASH
-
-
-def test_valid_distribute_blowout_location(make_context_and_labware):
-    context_and_labware = make_context_and_labware(APIVersion(2, 8))
-    context_and_labware['ctx'].home()
-    lw1 = context_and_labware['lw1']
-    instr = context_and_labware['instr']
-
-    with mock.patch.object(
-            papi.InstrumentContext, '_execute_transfer') as patch:
-        instr.distribute(
-            100,
-            lw1['A2'],
-            [lw1['A1'], lw1['B1']],
-            blow_out=True,
-            blowout_location='source well',
-            new_tip='never'
-        )
-        blowout_strat_1 = patch.call_args_list[0][0][0]._options.transfer \
-            .blow_out_strategy
-        assert blowout_strat_1 == transfers.BlowOutStrategy.SOURCE
-
-        instr.distribute(
-            100,
-            lw1['A2'],
-            [lw1['A1'], lw1['B1']],
-            blow_out=True,
-            blowout_location='trash',
-            new_tip='never'
-        )
-
-        blowout_strat_2 = patch.call_args_list[1][0][0]._options.transfer \
-            .blow_out_strategy
-        assert blowout_strat_2 == transfers.BlowOutStrategy.TRASH
+        assert blowout_strat == expected_strat


### PR DESCRIPTION
# Overview

As per [this awesome suggestion](https://github.com/Opentrons/opentrons/pull/6670#discussion_r502649429) by @amitlissack, I've refactored the instrument context test to to use `pytest.mark.parametrize` to cut down on redundant code.

# Changelog

- Use pytest mark parametrize in instrument context test

# Review requests

Code review on test, make sure I didn't lose any coverage

# Risk assessment

Low, just refactoring a test
