### PR TITLE
feat: add basic application configuration using pydantic BaseSettings.

### DIFF
--- a/notify-server/Makefile
+++ b/notify-server/Makefile
@@ -77,6 +77,7 @@ lint: $(ot_py_sources)
 	$(poetry_run) flake8 $(SRC_PATH) tests
 
 .PHONY: dev
+dev: export OT_NOTIFY_SERVER_PRODUCTION := 0
 dev:
 	$(poetry_run) python -m notify_server.main
 

--- a/notify-server/notify_server/logging.py
+++ b/notify-server/notify_server/logging.py
@@ -1,0 +1,71 @@
+"""Logging configuration."""
+
+import logging
+from logging.config import dictConfig
+from typing import Dict, Any
+
+
+def initialize_logging(production: bool) -> None:
+    """Initialize logging."""
+    if production:
+        c = _production_log_config()
+    else:
+        c = _dev_log_config()
+    dictConfig(c)
+
+
+def _production_log_config() -> Dict[str, Any]:
+    """Log configuration for robot deployment."""
+    lvl = logging.getLevelName(logging.INFO)
+    return {
+        'version': 1,
+        'disable_existing_loggers': False,
+        'formatters': {
+            'message_only': {
+                'format': '%(message)s'
+            },
+        },
+        'handlers': {
+            'notify_server': {
+                'class': 'systemd.journal.JournalHandler',
+                'level': lvl,
+                'formatter': 'message_only',
+                'SYSLOG_IDENTIFIER': 'opentrons-notify-server',
+            }
+        },
+        'loggers': {
+            'notify_server': {
+                'handlers': ['notify_server'],
+                'level': lvl,
+                'propagate': False
+            },
+        }
+    }
+
+
+def _dev_log_config() -> Dict[str, Any]:
+    """Log configuration for local dev deployment."""
+    lvl = logging.getLevelName(logging.DEBUG)
+    return {
+        'version': 1,
+        'disable_existing_loggers': False,
+        'formatters': {
+            'basic': {
+                'format': '%(asctime)s %(name)s %(levelname)s [Line %(lineno)s] %(message)s'  # noqa: E501
+            },
+        },
+        'handlers': {
+            'notify_server': {
+                'class': 'logging.StreamHandler',
+                'level': lvl,
+                'formatter': 'basic',
+            }
+        },
+        'loggers': {
+            'notify_server': {
+                'handlers': ['notify_server'],
+                'level': lvl,
+                'propagate': False
+            },
+        }
+    }

--- a/notify-server/notify_server/logging.py
+++ b/notify-server/notify_server/logging.py
@@ -16,7 +16,7 @@ def initialize_logging(production: bool) -> None:
 
 def _production_log_config() -> Dict[str, Any]:
     """Log configuration for robot deployment."""
-    lvl = logging.getLevelName(logging.INFO)
+    lvl = logging.INFO
     return {
         'version': 1,
         'disable_existing_loggers': False,
@@ -39,13 +39,17 @@ def _production_log_config() -> Dict[str, Any]:
                 'level': lvl,
                 'propagate': False
             },
+        },
+        'root': {
+            'handlers': ['notify_server'],
+            'level': lvl
         }
     }
 
 
 def _dev_log_config() -> Dict[str, Any]:
     """Log configuration for local dev deployment."""
-    lvl = logging.getLevelName(logging.DEBUG)
+    lvl = logging.DEBUG
     return {
         'version': 1,
         'disable_existing_loggers': False,
@@ -67,5 +71,9 @@ def _dev_log_config() -> Dict[str, Any]:
                 'level': lvl,
                 'propagate': False
             },
+        },
+        'root': {
+            'handlers': ['notify_server'],
+            'level': lvl
         }
     }

--- a/notify-server/notify_server/main.py
+++ b/notify-server/notify_server/main.py
@@ -1,15 +1,20 @@
 """The main entry point of the server application."""
 
+import logging
 import asyncio
 
 from notify_server.logging import initialize_logging
 from notify_server.settings import Settings
 
 
+log = logging.getLogger(__name__)
+
+
 async def run() -> None:
     """Entry point for the application."""
     settings = Settings()
     initialize_logging(settings.production)
+    log.info(settings)
 
 
 if __name__ == '__main__':

--- a/notify-server/notify_server/main.py
+++ b/notify-server/notify_server/main.py
@@ -2,10 +2,14 @@
 
 import asyncio
 
+from notify_server.logging import initialize_logging
+from notify_server.settings import Settings
+
 
 async def run() -> None:
     """Entry point for the application."""
-    pass
+    settings = Settings()
+    initialize_logging(settings.production)
 
 
 if __name__ == '__main__':

--- a/notify-server/notify_server/settings.py
+++ b/notify-server/notify_server/settings.py
@@ -13,7 +13,7 @@ class ServerBindAddress(BaseModel):
 class Settings(BaseSettings):
     """Application Settings."""
 
-    publisher_address: ServerBindAddress = ServerBindAddress(scheme="ipc",
+    publisher_address: ServerBindAddress = ServerBindAddress(scheme="tcp",
                                                              port=5555)
     subscriber_address: ServerBindAddress = ServerBindAddress(scheme="tcp",
                                                               port=5556)

--- a/notify-server/notify_server/settings.py
+++ b/notify-server/notify_server/settings.py
@@ -1,0 +1,30 @@
+"""Settings class."""
+
+from pydantic import BaseSettings, BaseModel, Field
+
+
+class ServerBindAddress(BaseModel):
+    """A bind address for server zmq socket."""
+
+    scheme: str
+    port: int
+
+
+class Settings(BaseSettings):
+    """Application Settings."""
+
+    publisher_address: ServerBindAddress = ServerBindAddress(scheme="ipc",
+                                                             port=5555)
+    subscriber_address: ServerBindAddress = ServerBindAddress(scheme="tcp",
+                                                              port=5556)
+
+    production: bool = Field(
+        True,
+        description="Whether this the application is running in a "
+                    "development environment"
+    )
+
+    class Config:
+        """Configuration for settings class."""
+
+        env_prefix = "OT_NOTIFY_SERVER_"

--- a/notify-server/poetry.lock
+++ b/notify-server/poetry.lock
@@ -214,6 +214,19 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.6.0"
 
 [[package]]
+category = "main"
+description = "Data validation and settings management using python 3.6 type hinting"
+name = "pydantic"
+optional = false
+python-versions = ">=3.6"
+version = "1.4"
+
+[package.extras]
+dotenv = ["python-dotenv (>=0.10.4)"]
+email = ["email-validator (>=1.0.3)"]
+typing_extensions = ["typing-extensions (>=3.7.2)"]
+
+[[package]]
 category = "dev"
 description = "Python docstring style checker"
 name = "pydocstyle"
@@ -371,7 +384,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "83eb4a4ff7780d3b4a62e0adf688ec1ad05669fe4c5d7b5848a349090b8df008"
+content-hash = "e3538ec3034b92e6bd5a674328977b8fdd3078fee2e74505f701e67dac4e5b69"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -491,6 +504,22 @@ py = [
 pycodestyle = [
     {file = "pycodestyle-2.6.0-py2.py3-none-any.whl", hash = "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367"},
     {file = "pycodestyle-2.6.0.tar.gz", hash = "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"},
+]
+pydantic = [
+    {file = "pydantic-1.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:07911aab70f3bc52bb845ce1748569c5e70478ac977e106a150dd9d0465ebf04"},
+    {file = "pydantic-1.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:012c422859bac2e03ab3151ea6624fecf0e249486be7eb8c6ee69c91740c6752"},
+    {file = "pydantic-1.4-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:61d22d36808087d3184ed6ac0d91dd71c533b66addb02e4a9930e1e30833202f"},
+    {file = "pydantic-1.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:f863456d3d4bf817f2e5248553dee3974c5dc796f48e6ddb599383570f4215ac"},
+    {file = "pydantic-1.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:bbbed364376f4a0aebb9ea452ff7968b306499a9e74f4db69b28ff2cd4043a11"},
+    {file = "pydantic-1.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e27559cedbd7f59d2375bfd6eea29a330ea1a5b0589c34d6b4e0d7bec6027bbf"},
+    {file = "pydantic-1.4-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:50e4e948892a6815649ad5a9a9379ad1e5f090f17842ac206535dfaed75c6f2f"},
+    {file = "pydantic-1.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:8848b4eb458469739126e4c1a202d723dd092e087f8dbe3104371335f87ba5df"},
+    {file = "pydantic-1.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:831a0265a9e3933b3d0f04d1a81bba543bafbe4119c183ff2771871db70524ab"},
+    {file = "pydantic-1.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:47b8db7024ba3d46c3d4768535e1cf87b6c8cf92ccd81e76f4e1cb8ee47688b3"},
+    {file = "pydantic-1.4-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:51f11c8bbf794a68086540da099aae4a9107447c7a9d63151edbb7d50110cf21"},
+    {file = "pydantic-1.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:6100d7862371115c40be55cc4b8d766a74b1d0dbaf99dbfe72bb4bac0faf89ed"},
+    {file = "pydantic-1.4-py36.py37.py38-none-any.whl", hash = "sha256:72184c1421103cca128300120f8f1185fb42a9ea73a1c9845b1c53db8c026a7d"},
+    {file = "pydantic-1.4.tar.gz", hash = "sha256:f17ec336e64d4583311249fb179528e9a2c27c8a2eaf590ec6ec2c6dece7cb3f"},
 ]
 pydocstyle = [
     {file = "pydocstyle-5.1.1-py3-none-any.whl", hash = "sha256:aca749e190a01726a4fb472dd4ef23b5c9da7b9205c0a7857c06533de13fd678"},

--- a/notify-server/pyproject.toml
+++ b/notify-server/pyproject.toml
@@ -7,6 +7,7 @@ authors = ["amit lissack <amit@opentrons.com>"]
 [tool.poetry.dependencies]
 python = "^3.7"
 pyzmq = "^19.0.2"
+pydantic = "1.4"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1"

--- a/notify-server/tests/test_logging.py
+++ b/notify-server/tests/test_logging.py
@@ -1,0 +1,44 @@
+"""Logging config unit tests."""
+
+from unittest.mock import patch, MagicMock
+import pytest
+from notify_server import logging
+
+
+@pytest.fixture
+def patch_production_log_config() -> MagicMock:
+    """Patch _production_log_config."""
+    with patch.object(logging, '_production_log_config') as p:
+        yield p
+
+
+@pytest.fixture
+def patch_dev_log_config() -> MagicMock:
+    """Patch _dev_log_config."""
+    with patch.object(logging, '_dev_log_config') as p:
+        yield p
+
+
+@pytest.fixture
+def patch_dictconfig() -> MagicMock:
+    """Patch dictConfig."""
+    with patch.object(logging, 'dictConfig') as p:
+        yield p
+
+
+def test_prod(patch_dictconfig: MagicMock,
+              patch_dev_log_config: MagicMock,
+              patch_production_log_config: MagicMock) -> None:
+    """Test that the correct log function is called."""
+    logging.initialize_logging(True)
+    patch_dev_log_config.assert_not_called()
+    patch_production_log_config.assert_called_once()
+
+
+def test_dev(patch_dictconfig: MagicMock,
+             patch_dev_log_config: MagicMock,
+             patch_production_log_config: MagicMock) -> None:
+    """Test that the correct log function is called."""
+    logging.initialize_logging(False)
+    patch_dev_log_config.assert_called_once()
+    patch_production_log_config.assert_not_called()

--- a/notify-server/tests/test_settings.py
+++ b/notify-server/tests/test_settings.py
@@ -1,0 +1,59 @@
+"""Settings unit tests."""
+
+import json
+import os
+from unittest.mock import patch, MagicMock
+import pytest
+from _pytest.fixtures import FixtureRequest
+
+from notify_server.settings import Settings
+
+
+@pytest.fixture
+def envvar_patch() -> MagicMock:
+    """Patch os.environ."""
+    with patch.object(os, "environ", new=dict()) as p:
+        yield p
+
+
+@pytest.fixture
+def port() -> int:
+    """Port fixture."""
+    return 4444
+
+
+@pytest.fixture
+def scheme() -> str:
+    """Scheme fixture."""
+    return "ftp"
+
+
+@pytest.fixture
+def server_address_override(request: FixtureRequest,
+                            envvar_patch: MagicMock,
+                            port: int,
+                            scheme: str) -> None:
+    """Fixture that overrides a server address environment variable."""
+    marker = request.node.get_closest_marker("env_var")
+    obj = {"scheme": "ftp", "port": 4444}
+    envvar_patch[marker.args[0]] = json.dumps(obj)
+
+
+@pytest.mark.env_var('OT_NOTIFY_SERVER_publisher_address')
+def test_override_publisher_address(server_address_override: None,
+                                    port: int,
+                                    scheme: str) -> None:
+    """Test environment var override."""
+    s = Settings()
+    assert s.publisher_address.port == port
+    assert s.publisher_address.scheme == scheme
+
+
+@pytest.mark.env_var('OT_NOTIFY_SERVER_subscriber_address')
+def test_override_subscriber_address(server_address_override: None,
+                                     port: int,
+                                     scheme: str) -> None:
+    """Test environment var override."""
+    s = Settings()
+    assert s.subscriber_address.port == port
+    assert s.subscriber_address.scheme == scheme


### PR DESCRIPTION
# Overview

Adding configuration for the two server addresses and dev vs prod flag.

closes #6704 

# Changelog

Using pydantic's `BaseSettings` since it manages the whole environment variable override nicely.

# Risk assessment

None