### PR TITLE
fix(app): add analytics and support tracking to ignore app update

### DIFF
--- a/app/src/analytics/__tests__/alerts-events.test.js
+++ b/app/src/analytics/__tests__/alerts-events.test.js
@@ -1,0 +1,43 @@
+// @flow
+
+import { makeEvent } from '../make-event'
+
+import * as Alerts from '../../alerts'
+
+import type { State } from '../../types'
+import type { AlertId } from '../../alerts/types'
+
+const MOCK_STATE: State = ({ mockState: true }: any)
+const MOCK_ALERT_ID: AlertId = ('fizzbuzz': any)
+
+describe('custom labware analytics events', () => {
+  it('should not trigger an event for random alerts', () => {
+    const action = Alerts.alertDismissed(MOCK_ALERT_ID)
+    const result = makeEvent(action, MOCK_STATE)
+
+    return expect(result).resolves.toBe(null)
+  })
+
+  it('should trigger an event on alerts:ALERT_DISMISSED for appUpdateAvailable', () => {
+    const action = Alerts.alertDismissed(Alerts.ALERT_APP_UPDATE_AVAILABLE)
+    const result = makeEvent(action, MOCK_STATE)
+
+    return expect(result).resolves.toEqual({
+      name: 'appUpdateDismissed',
+      properties: { updatesIgnored: false },
+    })
+  })
+
+  it('should trigger an appUpdateDismissed event with ignored: true', () => {
+    const action = Alerts.alertDismissed(
+      Alerts.ALERT_APP_UPDATE_AVAILABLE,
+      true
+    )
+    const result = makeEvent(action, MOCK_STATE)
+
+    return expect(result).resolves.toEqual({
+      name: 'appUpdateDismissed',
+      properties: { updatesIgnored: true },
+    })
+  })
+})

--- a/app/src/analytics/__tests__/system-info-events.test.js
+++ b/app/src/analytics/__tests__/system-info-events.test.js
@@ -25,7 +25,7 @@ const MOCK_ANALYTICS_PROPS = {
   'U2E IPv4 Address': '10.0.0.1',
 }
 
-describe('custom labware analytics events', () => {
+describe('system info analytics events', () => {
   beforeEach(() => {
     getU2EDeviceAnalyticsProps.mockImplementation(state => {
       expect(state).toBe(MOCK_STATE)

--- a/app/src/analytics/epic.js
+++ b/app/src/analytics/epic.js
@@ -4,7 +4,7 @@ import { combineEpics, ofType } from 'redux-observable'
 import { of, from, zip } from 'rxjs'
 import {
   map,
-  switchMap,
+  mergeMap,
   filter,
   tap,
   withLatestFrom,
@@ -35,7 +35,9 @@ const initialzeAnalyticsEpic: Epic = (action$, state$) => {
 const sendAnalyticsEventEpic: Epic = (action$, state$) => {
   return action$.pipe(
     withLatestFrom(state$),
-    switchMap<[Action, State], _, TrackEventArgs>(([action, state]) => {
+    // use a merge map to ensure actions dispatched in the same tick do
+    // not clobber each other
+    mergeMap<[Action, State], _, TrackEventArgs>(([action, state]) => {
       const event$ = from(makeEvent(action, state))
       return zip(event$, of(getAnalyticsConfig(state)))
     }),

--- a/app/src/analytics/make-event.js
+++ b/app/src/analytics/make-event.js
@@ -7,6 +7,8 @@ import * as CustomLabware from '../custom-labware'
 import * as SystemInfo from '../system-info'
 import * as brActions from '../buildroot/constants'
 import * as Sessions from '../sessions'
+import * as Alerts from '../alerts'
+
 import {
   getProtocolAnalyticsData,
   getRobotAnalyticsData,
@@ -17,6 +19,8 @@ import type { State, Action } from '../types'
 import type { AnalyticsEvent } from './types'
 
 const log = createLogger(__filename)
+
+const EVENT_APP_UPDATE_DISMISSED = 'appUpdateDismissed'
 
 export function makeEvent(
   action: Action,
@@ -286,6 +290,19 @@ export function makeEvent(
       } else {
         return Promise.resolve(null)
       }
+    }
+
+    case Alerts.ALERT_DISMISSED: {
+      const { alertId, remember } = action.payload
+
+      if (alertId === Alerts.ALERT_APP_UPDATE_AVAILABLE) {
+        return Promise.resolve({
+          name: EVENT_APP_UPDATE_DISMISSED,
+          properties: { updatesIgnored: remember },
+        })
+      }
+
+      return Promise.resolve(null)
     }
   }
 

--- a/app/src/components/app-settings/UpdateNotificationsControl.js
+++ b/app/src/components/app-settings/UpdateNotificationsControl.js
@@ -25,7 +25,7 @@ const GET_NOTIFIED_ABOUT_UPDATES =
 
 const ENABLE_APP_UPDATE_NOTIFICATIONS = 'Enable app update notifications'
 
-const EVENT_APP_UPDATE_NOTIFICATIONS_TOGGLE = 'appUpdateNotificationsToggle'
+const EVENT_APP_UPDATE_NOTIFICATIONS_TOGGLED = 'appUpdateNotificationsToggled'
 
 export function UpdateNotificationsControl(props: StyleProps): React.Node {
   const dispatch = useDispatch<Dispatch>()
@@ -46,8 +46,11 @@ export function UpdateNotificationsControl(props: StyleProps): React.Node {
       )
 
       trackEvent({
-        name: EVENT_APP_UPDATE_NOTIFICATIONS_TOGGLE,
-        properties: { enabled: !enabled },
+        name: EVENT_APP_UPDATE_NOTIFICATIONS_TOGGLED,
+        // this looks wierd, but the control is a toggle, which makes the next
+        // "enabled" setting `!enabled`. Therefore the next "ignored" setting is
+        // `!!enabled`, or just `enabled`
+        properties: { updatesIgnored: enabled },
       })
     }
   }

--- a/app/src/components/app-settings/UpdateNotificationsControl.js
+++ b/app/src/components/app-settings/UpdateNotificationsControl.js
@@ -11,6 +11,7 @@ import {
   alertUnignored,
 } from '../../alerts'
 
+import { useTrackEvent } from '../../analytics'
 import { TitledControl } from '../TitledControl'
 import { ToggleBtn } from '../ToggleBtn'
 
@@ -24,8 +25,11 @@ const GET_NOTIFIED_ABOUT_UPDATES =
 
 const ENABLE_APP_UPDATE_NOTIFICATIONS = 'Enable app update notifications'
 
+const EVENT_APP_UPDATE_NOTIFICATIONS_TOGGLE = 'appUpdateNotificationsToggle'
+
 export function UpdateNotificationsControl(props: StyleProps): React.Node {
   const dispatch = useDispatch<Dispatch>()
+  const trackEvent = useTrackEvent()
 
   // may be enabled, disabled, or unknown (because config is loading)
   const enabled = useSelector((s: State) => {
@@ -40,6 +44,11 @@ export function UpdateNotificationsControl(props: StyleProps): React.Node {
           ? alertPermanentlyIgnored(ALERT_APP_UPDATE_AVAILABLE)
           : alertUnignored(ALERT_APP_UPDATE_AVAILABLE)
       )
+
+      trackEvent({
+        name: EVENT_APP_UPDATE_NOTIFICATIONS_TOGGLE,
+        properties: { enabled: !enabled },
+      })
     }
   }
 

--- a/app/src/components/app-settings/__tests__/UpdateNotificationsControl.test.js
+++ b/app/src/components/app-settings/__tests__/UpdateNotificationsControl.test.js
@@ -112,7 +112,7 @@ describe('UpdateNotificationsControl', () => {
     )
   })
 
-  it('should send an appUpdateNotificationsToggle analytics event when toggled from on to off', () => {
+  it('should send an appUpdateNotificationsToggled analytics event when toggled from on to off', () => {
     // false means alert is enabled which means toggle is currently on
     getAlertIsPermanentlyIgnored.mockReturnValue(false)
 
@@ -122,12 +122,12 @@ describe('UpdateNotificationsControl', () => {
     toggle.invoke('onClick')()
 
     expect(trackEvent).toHaveBeenCalledWith({
-      name: 'appUpdateNotificationsToggle',
-      properties: { enabled: false },
+      name: 'appUpdateNotificationsToggled',
+      properties: { updatesIgnored: true },
     })
   })
 
-  it('should send an appUpdateNotificationsToggle analytics event when toggled from off to on', () => {
+  it('should send an appUpdateNotificationsToggled analytics event when toggled from off to on', () => {
     // true means alert is disabled which means toggle is currently off
     getAlertIsPermanentlyIgnored.mockReturnValue(true)
 
@@ -137,8 +137,8 @@ describe('UpdateNotificationsControl', () => {
     toggle.invoke('onClick')()
 
     expect(trackEvent).toHaveBeenCalledWith({
-      name: 'appUpdateNotificationsToggle',
-      properties: { enabled: true },
+      name: 'appUpdateNotificationsToggled',
+      properties: { updatesIgnored: false },
     })
   })
 })

--- a/app/src/components/app-settings/__tests__/UpdateNotificationsControl.test.js
+++ b/app/src/components/app-settings/__tests__/UpdateNotificationsControl.test.js
@@ -4,6 +4,7 @@ import { mountWithStore } from '@opentrons/components/__utils__'
 
 import { BORDER_SOLID_LIGHT } from '@opentrons/components'
 import * as Alerts from '../../../alerts'
+import * as Analytics from '../../../analytics'
 import { TitledControl } from '../../TitledControl'
 import { ToggleBtn } from '../../ToggleBtn'
 import { UpdateNotificationsControl } from '../UpdateNotificationsControl'
@@ -11,17 +12,24 @@ import { UpdateNotificationsControl } from '../UpdateNotificationsControl'
 import type { StyleProps } from '@opentrons/components'
 import type { State } from '../../../types'
 import type { AlertId } from '../../../alerts/types'
+import type { AnalyticsEvent } from '../../../analytics/types'
 
 jest.mock('../../../alerts/selectors')
+jest.mock('../../../analytics/hooks')
 
 const getAlertIsPermanentlyIgnored: JestMockFn<
   [State, AlertId],
   boolean | null
 > = Alerts.getAlertIsPermanentlyIgnored
 
+const useTrackEvent: JestMockFn<[], JestMockFn<[AnalyticsEvent], void>> =
+  Analytics.useTrackEvent
+
 const MOCK_STATE: $Shape<State> = {}
 
 describe('UpdateNotificationsControl', () => {
+  const trackEvent = jest.fn()
+
   const render = (styleProps: $Shape<StyleProps> = {}) => {
     return mountWithStore(<UpdateNotificationsControl {...styleProps} />, {
       initialState: MOCK_STATE,
@@ -29,6 +37,7 @@ describe('UpdateNotificationsControl', () => {
   }
 
   beforeEach(() => {
+    useTrackEvent.mockReturnValue(trackEvent)
     getAlertIsPermanentlyIgnored.mockImplementation((state, alertId) => {
       expect(state).toBe(MOCK_STATE)
       expect(alertId).toBe(Alerts.ALERT_APP_UPDATE_AVAILABLE)
@@ -101,5 +110,35 @@ describe('UpdateNotificationsControl', () => {
     expect(store.dispatch).toHaveBeenCalledWith(
       Alerts.alertPermanentlyIgnored(Alerts.ALERT_APP_UPDATE_AVAILABLE)
     )
+  })
+
+  it('should send an appUpdateNotificationsToggle analytics event when toggled from on to off', () => {
+    // false means alert is enabled which means toggle is currently on
+    getAlertIsPermanentlyIgnored.mockReturnValue(false)
+
+    const { wrapper } = render()
+    const toggle = wrapper.find(ToggleBtn)
+
+    toggle.invoke('onClick')()
+
+    expect(trackEvent).toHaveBeenCalledWith({
+      name: 'appUpdateNotificationsToggle',
+      properties: { enabled: false },
+    })
+  })
+
+  it('should send an appUpdateNotificationsToggle analytics event when toggled from off to on', () => {
+    // true means alert is disabled which means toggle is currently off
+    getAlertIsPermanentlyIgnored.mockReturnValue(true)
+
+    const { wrapper } = render()
+    const toggle = wrapper.find(ToggleBtn)
+
+    toggle.invoke('onClick')()
+
+    expect(trackEvent).toHaveBeenCalledWith({
+      name: 'appUpdateNotificationsToggle',
+      properties: { enabled: true },
+    })
   })
 })

--- a/app/src/support/__tests__/config-profile.test.js
+++ b/app/src/support/__tests__/config-profile.test.js
@@ -35,13 +35,13 @@ describe('app config profile updates', () => {
     const action = Config.configValueUpdated('does not', 'matter')
     const result = makeProfileUpdate(action, MOCK_STATE)
 
-    expect(result).toMatchObject({ appUpdateIgnored: true })
+    expect(result).toMatchObject({ appUpdatesIgnored: true })
   })
 
   it('should trigger an profile update if appUpdateAvailable is not ignored', () => {
     const action = Config.configValueUpdated('does not', 'matter')
     const result = makeProfileUpdate(action, MOCK_STATE)
 
-    expect(result).toMatchObject({ appUpdateIgnored: false })
+    expect(result).toMatchObject({ appUpdatesIgnored: false })
   })
 })

--- a/app/src/support/__tests__/config-profile.test.js
+++ b/app/src/support/__tests__/config-profile.test.js
@@ -1,0 +1,47 @@
+// @flow
+
+import { makeProfileUpdate } from '../profile'
+
+import * as Alerts from '../../alerts'
+import * as Config from '../../config'
+
+import type { State } from '../../types'
+import type { AlertId } from '../../alerts/types'
+
+jest.mock('../../alerts/selectors')
+
+const MOCK_STATE: State = ({ mockState: true }: any)
+
+const getAlertIsPermanentlyIgnored: JestMockFn<
+  [State, AlertId],
+  boolean | null
+> = Alerts.getAlertIsPermanentlyIgnored
+
+describe('app config profile updates', () => {
+  beforeEach(() => {
+    getAlertIsPermanentlyIgnored.mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should trigger an profile update if appUpdateAvailable is ignored', () => {
+    getAlertIsPermanentlyIgnored.mockImplementation((state, alertId) => {
+      expect(state).toEqual(MOCK_STATE)
+      return alertId === Alerts.ALERT_APP_UPDATE_AVAILABLE
+    })
+
+    const action = Config.configValueUpdated('does not', 'matter')
+    const result = makeProfileUpdate(action, MOCK_STATE)
+
+    expect(result).toMatchObject({ appUpdateIgnored: true })
+  })
+
+  it('should trigger an profile update if appUpdateAvailable is not ignored', () => {
+    const action = Config.configValueUpdated('does not', 'matter')
+    const result = makeProfileUpdate(action, MOCK_STATE)
+
+    expect(result).toMatchObject({ appUpdateIgnored: false })
+  })
+})

--- a/app/src/support/__tests__/system-info-profile.test.js
+++ b/app/src/support/__tests__/system-info-profile.test.js
@@ -25,7 +25,7 @@ const MOCK_ANALYTICS_PROPS = {
   'U2E IPv4 Address': '10.0.0.1',
 }
 
-describe('custom labware analytics events', () => {
+describe('system info support profile updates', () => {
   beforeEach(() => {
     getU2EDeviceAnalyticsProps.mockImplementation(state => {
       expect(state).toBe(MOCK_STATE)

--- a/app/src/support/profile.js
+++ b/app/src/support/profile.js
@@ -1,6 +1,8 @@
 // @flow
 // functions for managing the user's Intercom profile
 import { version as appVersion } from '../../package.json'
+import * as Cfg from '../config'
+import * as Alerts from '../alerts'
 import { FF_PREFIX, getRobotAnalyticsData } from '../analytics'
 import { getConnectedRobot } from '../discovery'
 import {
@@ -86,6 +88,16 @@ export function makeProfileUpdate(
     case SystemInfo.NETWORK_INTERFACES_CHANGED: {
       return SystemInfo.getU2EDeviceAnalyticsProps(state)
     }
+
+    case Cfg.VALUE_UPDATED: {
+      return {
+        appUpdateIgnored: Alerts.getAlertIsPermanentlyIgnored(
+          state,
+          Alerts.ALERT_APP_UPDATE_AVAILABLE
+        ),
+      }
+    }
   }
+
   return null
 }

--- a/app/src/support/profile.js
+++ b/app/src/support/profile.js
@@ -91,7 +91,7 @@ export function makeProfileUpdate(
 
     case Cfg.VALUE_UPDATED: {
       return {
-        appUpdateIgnored: Alerts.getAlertIsPermanentlyIgnored(
+        appUpdatesIgnored: Alerts.getAlertIsPermanentlyIgnored(
           state,
           Alerts.ALERT_APP_UPDATE_AVAILABLE
         ),


### PR DESCRIPTION
## Overview

This PR fixes an oversight in the "Ignore App Updates" buildout. Setting the app to silence the update pop-ups should:

- Send an anonymous analytics tracking event (if the user has opted in to anonymous usage tracking)
- Set a flag on the user's support profile to note that they've disabled app updates 

# Changelog

- fix(app): add analytics and support tracking to ignore app update
    - Also fixed a race condition in the analytics event epic that I found during smoke testing of this PR

# Review requests

- [ ] Code and tests look good

Smoke testing this is annoying, but here is the plan I followed:

- [x] You see an analytics tracking debug logs from the app update auto-pop-up modal
    - Click "Ignore app updates" in the modal and close the warning modal
        - Event: `appUpdateDismissed`, property `updatesIgnored: true`
    - Click "Not now" in the app update modal
       - Event: `appUpdateDismissed`, property `updatesIgnored: false`
- [x] You see analytics tracking debug logs from the app setttings page if you toggle notifications
    - Event: `appUpdateNotificationsToggled`, property `updatesIgnored: {opposite_of_enabled_toggle}`
- [x] You see support profile update logs from both the app settings page and the auto pop up

# Risk assessment

Low. Adding analytics observers to already existing (and tested) interactions. Good unit test coverage
