### PR TITLE
chore(build): Remove stray mypy caches

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -59,7 +59,7 @@ ot_sources := $(ot_py_sources) $(ot_shared_data_sources) $(ot_resources)
 
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target
-clean_cmd = $(SHX) rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc'
+clean_cmd = $(SHX) rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc' 'src/**/.mypy_cache'
 
 plot_type ?=
 

--- a/notify-server/Makefile
+++ b/notify-server/Makefile
@@ -41,7 +41,7 @@ ot_sources := $(ot_py_sources)
 
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target
-clean_cmd = $(SHX) rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc'
+clean_cmd = $(SHX) rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc' 'notify_server/**/.mypy_cache'
 
 .PHONY: all
 all: clean wheel

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -42,7 +42,7 @@ ot_sources := $(ot_py_sources)
 
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target
-clean_cmd = $(SHX) rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc'
+clean_cmd = $(SHX) rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc' 'robot_server/**/.mypy_cache'
 
 .PHONY: all
 all: clean wheel

--- a/shared-data/python/Makefile
+++ b/shared-data/python/Makefile
@@ -36,7 +36,7 @@ json_sources = $(filter %.json,$(shell $(SHX) find ..))
 twine_auth_args := --username $(pypi_username) --password $(pypi_password)
 twine_repository_url ?= $(pypi_test_upload_url)
 
-clean_cmd = $(SHX) rm -rf build $(BUILD_DIR) .coverage coverage.xml '*.egg-info' ' **/__pycache__' '**/*.pyc'
+clean_cmd = $(SHX) rm -rf build $(BUILD_DIR) .coverage coverage.xml '*.egg-info' ' **/__pycache__' '**/*.pyc' 'opentrons_shared_data/**/.mypy_cache'
 
 .PHONY: setup
 setup: setup-py


### PR DESCRIPTION
Some editor support systems have a bad habit of invoking mypy and adding
mypy caches in the directory of whatever file you happen to be visiting,
and then those caches stick around and go into the wheels, and then
they're really big and hard to install. Add mypy_caches in locations
where they should not be (anywhere except subproject roots, basically)
to the clean_cmds for each python project.

## testing
Try invoking mypy in some random subdir of a python project then do a `make wheel` and make sure the `.mypy_cache` folder that results doesn't make it in.