### PR TITLE
feat(app): Always apply historic offset data setting [RAUT-437]

### DIFF
--- a/app-shell-odd/src/config/__fixtures__/index.ts
+++ b/app-shell-odd/src/config/__fixtures__/index.ts
@@ -8,6 +8,7 @@ import type {
   ConfigV14,
   ConfigV15,
   ConfigV16,
+  ConfigV17,
 } from '@opentrons/app/src/redux/config/types'
 
 export const MOCK_CONFIG_V12: ConfigV12 = {
@@ -91,5 +92,14 @@ export const MOCK_CONFIG_V16: ConfigV16 = {
   onDeviceDisplaySettings: {
     ...MOCK_CONFIG_V15.onDeviceDisplaySettings,
     unfinishedUnboxingFlowRoute: '/welcome',
+  },
+}
+
+export const MOCK_CONFIG_V17: ConfigV17 = {
+  ...MOCK_CONFIG_V16,
+  version: 17,
+  protocols: {
+    ...MOCK_CONFIG_V16.protocols,
+    applyHistoricOffsets: true,
   },
 }

--- a/app-shell-odd/src/config/__tests__/migrate.test.ts
+++ b/app-shell-odd/src/config/__tests__/migrate.test.ts
@@ -5,6 +5,7 @@ import {
   MOCK_CONFIG_V14,
   MOCK_CONFIG_V15,
   MOCK_CONFIG_V16,
+  MOCK_CONFIG_V17,
 } from '../__fixtures__'
 import { migrate } from '../migrate'
 
@@ -13,39 +14,47 @@ describe('config migration', () => {
     const v12Config = MOCK_CONFIG_V12
     const result = migrate(v12Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(MOCK_CONFIG_V16)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
   })
 
   it('should migrate version 13 to latest', () => {
     const v13Config = MOCK_CONFIG_V13
     const result = migrate(v13Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(MOCK_CONFIG_V16)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
   })
 
   it('should migrate version 14 to latest', () => {
     const v14Config = MOCK_CONFIG_V14
     const result = migrate(v14Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(MOCK_CONFIG_V16)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
   })
 
   it('should migrate version 15 to latest', () => {
     const v15Config = MOCK_CONFIG_V15
     const result = migrate(v15Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(MOCK_CONFIG_V16)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
   })
 
-  it('should keep version 16', () => {
+  it('should migrate version 16 to latest', () => {
     const v16Config = MOCK_CONFIG_V16
     const result = migrate(v16Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(v16Config)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
+  })
+
+  it('should keep version 17', () => {
+    const v17Config = MOCK_CONFIG_V17
+    const result = migrate(v17Config)
+
+    expect(result.version).toBe(17)
+    expect(result).toEqual(v17Config)
   })
 })

--- a/app-shell-odd/src/config/migrate.ts
+++ b/app-shell-odd/src/config/migrate.ts
@@ -14,6 +14,7 @@ import type {
   ConfigV14,
   ConfigV15,
   ConfigV16,
+  ConfigV17,
 } from '@opentrons/app/src/redux/config/types'
 // format
 // base config v12 defaults
@@ -124,17 +125,37 @@ const toVersion16 = (prevConfig: ConfigV15): ConfigV16 => {
   return nextConfig
 }
 
+// config version 17 migration and defaults
+const toVersion17 = (prevConfig: ConfigV16): ConfigV17 => {
+  const nextConfig = {
+    ...prevConfig,
+    version: 17 as const,
+    protocols: {
+      ...prevConfig.protocols,
+      applyHistoricOffsets: true,
+    },
+  }
+  return nextConfig
+}
+
 const MIGRATIONS: [
   (prevConfig: ConfigV12) => ConfigV13,
   (prevConfig: ConfigV13) => ConfigV14,
   (prevConfig: ConfigV14) => ConfigV15,
-  (prevConfig: ConfigV15) => ConfigV16
-] = [toVersion13, toVersion14, toVersion15, toVersion16]
+  (prevConfig: ConfigV15) => ConfigV16,
+  (prevConfig: ConfigV16) => ConfigV17
+] = [toVersion13, toVersion14, toVersion15, toVersion16, toVersion17]
 
 export const DEFAULTS: Config = migrate(DEFAULTS_V12)
 
 export function migrate(
-  prevConfig: ConfigV12 | ConfigV13 | ConfigV14 | ConfigV15 | ConfigV16
+  prevConfig:
+    | ConfigV12
+    | ConfigV13
+    | ConfigV14
+    | ConfigV15
+    | ConfigV16
+    | ConfigV17
 ): Config {
   let result = prevConfig
   // loop through the migrations, skipping any migrations that are unnecessary

--- a/app-shell/src/config/__fixtures__/index.ts
+++ b/app-shell/src/config/__fixtures__/index.ts
@@ -20,6 +20,7 @@ import type {
   ConfigV14,
   ConfigV15,
   ConfigV16,
+  ConfigV17,
 } from '@opentrons/app/src/redux/config/types'
 
 export const MOCK_CONFIG_V0: ConfigV0 = {
@@ -223,5 +224,14 @@ export const MOCK_CONFIG_V16: ConfigV16 = {
   onDeviceDisplaySettings: {
     ...MOCK_CONFIG_V15.onDeviceDisplaySettings,
     unfinishedUnboxingFlowRoute: '/welcome',
+  },
+}
+
+export const MOCK_CONFIG_V17: ConfigV17 = {
+  ...MOCK_CONFIG_V16,
+  version: 17,
+  protocols: {
+    ...MOCK_CONFIG_V16.protocols,
+    applyHistoricOffsets: true,
   },
 }

--- a/app-shell/src/config/__tests__/migrate.test.ts
+++ b/app-shell/src/config/__tests__/migrate.test.ts
@@ -17,6 +17,7 @@ import {
   MOCK_CONFIG_V14,
   MOCK_CONFIG_V15,
   MOCK_CONFIG_V16,
+  MOCK_CONFIG_V17,
 } from '../__fixtures__'
 import { migrate } from '../migrate'
 
@@ -25,135 +26,143 @@ describe('config migration', () => {
     const v0Config = MOCK_CONFIG_V0
     const result = migrate(v0Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(MOCK_CONFIG_V16)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
   })
 
   it('should migrate version 1 to latest', () => {
     const v1Config = MOCK_CONFIG_V1
     const result = migrate(v1Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(MOCK_CONFIG_V16)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
   })
 
   it('should migrate version 2 to latest', () => {
     const v2Config = MOCK_CONFIG_V2
     const result = migrate(v2Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(MOCK_CONFIG_V16)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
   })
 
   it('should migrate version 3 to latest', () => {
     const v3Config = MOCK_CONFIG_V3
     const result = migrate(v3Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(MOCK_CONFIG_V16)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
   })
 
   it('should migrate version 4 to latest', () => {
     const v4Config = MOCK_CONFIG_V4
     const result = migrate(v4Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(MOCK_CONFIG_V16)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
   })
 
   it('should migrate version 5 to latest', () => {
     const v5Config = MOCK_CONFIG_V5
     const result = migrate(v5Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(MOCK_CONFIG_V16)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
   })
 
   it('should migrate version 6 to latest', () => {
     const v6Config = MOCK_CONFIG_V6
     const result = migrate(v6Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(MOCK_CONFIG_V16)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
   })
 
   it('should migrate version 7 to latest', () => {
     const v7Config = MOCK_CONFIG_V7
     const result = migrate(v7Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(MOCK_CONFIG_V16)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
   })
 
   it('should migrate version 8 to latest', () => {
     const v8Config = MOCK_CONFIG_V8
     const result = migrate(v8Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(MOCK_CONFIG_V16)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
   })
 
   it('should migrate version 9 to latest', () => {
     const v9Config = MOCK_CONFIG_V9
     const result = migrate(v9Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(MOCK_CONFIG_V16)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
   })
 
   it('should migrate version 10 to latest', () => {
     const v10Config = MOCK_CONFIG_V10
     const result = migrate(v10Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(MOCK_CONFIG_V16)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
   })
 
   it('should migrate version 11 to latest', () => {
     const v11Config = MOCK_CONFIG_V11
     const result = migrate(v11Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(MOCK_CONFIG_V16)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
   })
 
   it('should migrate version 12 to latest', () => {
     const v12Config = MOCK_CONFIG_V12
     const result = migrate(v12Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(MOCK_CONFIG_V16)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
   })
 
   it('should migrate version 13 to latest', () => {
     const v13Config = MOCK_CONFIG_V13
     const result = migrate(v13Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(MOCK_CONFIG_V16)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
   })
 
   it('should migrate version 14 to latest', () => {
     const v14Config = MOCK_CONFIG_V14
     const result = migrate(v14Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(MOCK_CONFIG_V16)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
   })
 
   it('should migrate version 15 to latest', () => {
     const v15Config = MOCK_CONFIG_V15
     const result = migrate(v15Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(MOCK_CONFIG_V16)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
   })
 
-  it('should keep version 16', () => {
+  it('should migrate version 16 to latest', () => {
     const v16Config = MOCK_CONFIG_V16
     const result = migrate(v16Config)
 
-    expect(result.version).toBe(16)
-    expect(result).toEqual(v16Config)
+    expect(result.version).toBe(17)
+    expect(result).toEqual(MOCK_CONFIG_V17)
+  })
+
+  it('should keep version 17', () => {
+    const v17Config = MOCK_CONFIG_V17
+    const result = migrate(v17Config)
+
+    expect(result.version).toBe(17)
+    expect(result).toEqual(v17Config)
   })
 })

--- a/app-shell/src/config/migrate.ts
+++ b/app-shell/src/config/migrate.ts
@@ -26,6 +26,7 @@ import type {
   ConfigV14,
   ConfigV15,
   ConfigV16,
+  ConfigV17,
 } from '@opentrons/app/src/redux/config/types'
 // format
 // base config v0 defaults
@@ -324,6 +325,19 @@ const toVersion16 = (prevConfig: ConfigV15): ConfigV16 => {
   return nextConfig
 }
 
+// config version 17 migration and defaults
+const toVersion17 = (prevConfig: ConfigV16): ConfigV17 => {
+  const nextConfig = {
+    ...prevConfig,
+    version: 17 as const,
+    protocols: {
+      ...prevConfig.protocols,
+      applyHistoricOffsets: true,
+    },
+  }
+  return nextConfig
+}
+
 const MIGRATIONS: [
   (prevConfig: ConfigV0) => ConfigV1,
   (prevConfig: ConfigV1) => ConfigV2,
@@ -340,7 +354,8 @@ const MIGRATIONS: [
   (prevConfig: ConfigV12) => ConfigV13,
   (prevConfig: ConfigV13) => ConfigV14,
   (prevConfig: ConfigV14) => ConfigV15,
-  (prevConfig: ConfigV15) => ConfigV16
+  (prevConfig: ConfigV15) => ConfigV16,
+  (prevConfig: ConfigV16) => ConfigV17
 ] = [
   toVersion1,
   toVersion2,
@@ -358,6 +373,7 @@ const MIGRATIONS: [
   toVersion14,
   toVersion15,
   toVersion16,
+  toVersion17,
 ]
 
 export const DEFAULTS: Config = migrate(DEFAULTS_V0)
@@ -381,6 +397,7 @@ export function migrate(
     | ConfigV14
     | ConfigV15
     | ConfigV16
+    | ConfigV17
 ): Config {
   const prevVersion = prevConfig.version
   let result = prevConfig

--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -14,7 +14,6 @@
   "analytics_description": "Help Opentrons improve its products and services by automatically sending anonymous diagnostics and usage data.",
   "app_changes": "App Changes in ",
   "app_settings": "App Settings",
-  "apply_historic_offsets": "Apply labware offsets",
   "bug_fixes": "Bug Fixes",
   "cal_block": "Always use calibration block to calibrate",
   "change_folder_button": "Change labware source folder",

--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -14,6 +14,7 @@
   "analytics_description": "Help Opentrons improve its products and services by automatically sending anonymous diagnostics and usage data.",
   "app_changes": "App Changes in ",
   "app_settings": "App Settings",
+  "apply_historic_offsets": "Always Apply Historic Offset Data",
   "bug_fixes": "Bug Fixes",
   "cal_block": "Always use calibration block to calibrate",
   "change_folder_button": "Change labware source folder",

--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -14,7 +14,7 @@
   "analytics_description": "Help Opentrons improve its products and services by automatically sending anonymous diagnostics and usage data.",
   "app_changes": "App Changes in ",
   "app_settings": "App Settings",
-  "apply_historic_offsets": "Always Apply Historic Offset Data",
+  "apply_historic_offsets": "Apply labware offsets",
   "bug_fixes": "Bug Fixes",
   "cal_block": "Always use calibration block to calibrate",
   "change_folder_button": "Change labware source folder",

--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -8,6 +8,7 @@
   "alternative_security_types_description": "The Opentrons App supports connecting Flex to various enterprise access points. Connect via USB and finish setup in the app.",
   "alternative_security_types": "Alternative security types",
   "app_change_in": "App Changes in {{version}}",
+  "apply_historic_offsets": "Apply labware offsets",
   "are_you_sure_you_want_to_disconnect": "Are you sure you want to disconnect from {{ssid}}?",
   "attach_a_pipette_before_calibrating": "Attach a pipette in order to perform calibration",
   "boot_scripts": "Boot scripts",

--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -109,7 +109,7 @@
   "gripper_calibration_title": "Gripper Calibration",
   "health_check": "Check health",
   "hide": "Hide",
-  "historic_offsets_description": "Apply stored labware offset data when setting up and running protocols.",
+  "historic_offsets_description": "Use stored data when setting up a protocol.",
   "incorrect_password_for_ssid": "Oops! Incorrect password for {{ssid}}",
   "installing_software": "Installing software...",
   "ip_address": "IP Address",

--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -109,6 +109,7 @@
   "gripper_calibration_title": "Gripper Calibration",
   "health_check": "Check health",
   "hide": "Hide",
+  "historic_offsets_description": "Apply stored labware offset data when setting up and running protocols.",
   "incorrect_password_for_ssid": "Oops! Incorrect password for {{ssid}}",
   "installing_software": "Installing software...",
   "ip_address": "IP Address",

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
@@ -37,7 +37,11 @@ import { StyledText } from '../../../atoms/text'
 import { useMissingHardwareText } from '../../../organisms/OnDeviceDisplay/RobotDashboard/hooks'
 import { Modal, SmallModalChildren } from '../../../molecules/Modal'
 import { useToaster } from '../../../organisms/ToasterOven'
-import { getPinnedProtocolIds, updateConfigValue } from '../../../redux/config'
+import {
+  getApplyHistoricOffsets,
+  getPinnedProtocolIds,
+  updateConfigValue,
+} from '../../../redux/config'
 import { useMissingProtocolHardware } from '../../Protocols/hooks'
 import { Deck } from './Deck'
 import { Hardware } from './Hardware'
@@ -279,6 +283,10 @@ export function ProtocolDetails(): JSX.Element | null {
         (analysis): analysis is CompletedProtocolAnalysis =>
           analysis.status === 'completed'
       ) ?? null
+  const shouldApplyOffsets = useSelector(getApplyHistoricOffsets)
+  // I'd love to skip scraping altogether if we aren't applying
+  // conditional offsets, but React won't let us use hooks conditionally.
+  // So, we'll scrape regardless and just toss them if we don't need them.
   const scrapedLabwareOffsets = useOffsetCandidatesForAnalysis(
     mostRecentAnalysis
   ).map(({ vector, location, definitionUri }) => ({
@@ -286,6 +294,7 @@ export function ProtocolDetails(): JSX.Element | null {
     location,
     definitionUri,
   }))
+  const labwareOffsets = shouldApplyOffsets ? scrapedLabwareOffsets : []
 
   const { createRun } = useCreateRunMutation({
     onSuccess: data => {
@@ -315,7 +324,7 @@ export function ProtocolDetails(): JSX.Element | null {
   }
 
   const handleRunProtocol = (): void => {
-    createRun({ protocolId, labwareOffsets: scrapedLabwareOffsets })
+    createRun({ protocolId, labwareOffsets })
   }
   const [
     showConfirmDeleteProtocol,

--- a/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/RobotSettingButton.tsx
+++ b/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/RobotSettingButton.tsx
@@ -22,7 +22,7 @@ import {
 
 import { StyledText } from '../../../atoms/text'
 import { InlineNotification } from '../../../atoms/InlineNotification'
-import { toggleDevtools } from '../../../redux/config'
+import { toggleDevtools, toggleHistoricOffsets } from '../../../redux/config'
 
 import type { IconName } from '@opentrons/components'
 import type { Dispatch } from '../../../redux/types'
@@ -45,7 +45,9 @@ interface RobotSettingButtonProps {
   robotName?: string
   isUpdateAvailable?: boolean
   enabledDevTools?: boolean
+  enabledHistoricOffests?: boolean
   devToolsOn?: boolean
+  historicOffsetsOn?: boolean
   ledLights?: boolean
   lightsOn?: boolean
   toggleLights?: () => void
@@ -59,7 +61,9 @@ export function RobotSettingButton({
   isUpdateAvailable,
   iconName,
   enabledDevTools,
+  enabledHistoricOffests,
   devToolsOn,
+  historicOffsetsOn,
   ledLights,
   lightsOn,
   toggleLights,
@@ -72,6 +76,8 @@ export function RobotSettingButton({
       setCurrentOption(currentOption)
     } else if (Boolean(enabledDevTools)) {
       dispatch(toggleDevtools())
+    } else if (Boolean(enabledHistoricOffests)) {
+      dispatch(toggleHistoricOffsets())
     } else if (Boolean(ledLights)) {
       if (toggleLights != null) toggleLights()
     }
@@ -128,7 +134,20 @@ export function RobotSettingButton({
           </StyledText>
         </Flex>
       ) : null}
-
+      {enabledHistoricOffests != null ? (
+        <Flex
+          flexDirection={DIRECTION_ROW}
+          gridGap={SPACING.spacing12}
+          alignItems={ALIGN_CENTER}
+          backgroundColor={COLORS.transparent}
+          padding={`${SPACING.spacing12} ${SPACING.spacing4}`}
+          borderRadius={BORDERS.borderRadiusSize4}
+        >
+          <StyledText as="h4" fontWeight={TYPOGRAPHY.fontWeightRegular}>
+            {Boolean(historicOffsetsOn) ? t('shared:on') : t('shared:off')}
+          </StyledText>
+        </Flex>
+      ) : null}
       {ledLights != null ? (
         <Flex
           flexDirection={DIRECTION_ROW}
@@ -151,7 +170,9 @@ export function RobotSettingButton({
             hug={true}
           />
         ) : null}
-        {enabledDevTools == null && ledLights == null ? (
+        {enabledDevTools == null &&
+        enabledHistoricOffests == null &&
+        ledLights == null ? (
           <Icon name="more" size="3rem" color={COLORS.darkBlack100} />
         ) : null}
       </Flex>

--- a/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/RobotSettingButton.tsx
+++ b/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/RobotSettingButton.tsx
@@ -104,6 +104,7 @@ export function RobotSettingButton({
           gridGap={SPACING.spacing2}
           alignItems={ALIGN_FLEX_START}
           justifyContent={JUSTIFY_CENTER}
+          width="46.25rem"
         >
           <StyledText as="h4" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
             {settingName}

--- a/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/RobotSettingsList.tsx
+++ b/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/RobotSettingsList.tsx
@@ -99,7 +99,7 @@ export function RobotSettingsList(props: RobotSettingsListProps): JSX.Element {
           iconName="brightness"
         />
         <RobotSettingButton
-          settingName={t('app_settings:apply_historic_offsets')}
+          settingName={t('apply_historic_offsets')}
           settingInfo={t('historic_offsets_description')}
           iconName="reticle"
           enabledHistoricOffests

--- a/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/RobotSettingsList.tsx
+++ b/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/RobotSettingsList.tsx
@@ -99,6 +99,13 @@ export function RobotSettingsList(props: RobotSettingsListProps): JSX.Element {
           iconName="brightness"
         />
         <RobotSettingButton
+          settingName={t('app_settings:apply_historic_offsets')}
+          settingInfo={t('historic_offsets_description')}
+          iconName="reticle"
+          enabledHistoricOffests
+          historicOffsetsOn={historicOffsetsOn}
+        />
+        <RobotSettingButton
           settingName={t('device_reset')}
           currentOption="DeviceReset"
           setCurrentOption={setCurrentOption}
@@ -109,13 +116,6 @@ export function RobotSettingsList(props: RobotSettingsListProps): JSX.Element {
           currentOption="UpdateChannel"
           setCurrentOption={setCurrentOption}
           iconName="update-channel"
-        />
-        <RobotSettingButton
-          settingName={t('app_settings:apply_historic_offsets')}
-          settingInfo={t('historic_offsets_description')}
-          iconName="settings"
-          enabledHistoricOffests
-          historicOffsetsOn={historicOffsetsOn}
         />
         <RobotSettingButton
           settingName={t('app_settings:enable_dev_tools')}

--- a/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/RobotSettingsList.tsx
+++ b/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/RobotSettingsList.tsx
@@ -7,7 +7,10 @@ import { Flex, DIRECTION_COLUMN, SPACING } from '@opentrons/components'
 
 import { getLocalRobot, getRobotApiVersion } from '../../../redux/discovery'
 import { getBuildrootUpdateAvailable } from '../../../redux/buildroot'
-import { getDevtoolsEnabled } from '../../../redux/config'
+import {
+  getApplyHistoricOffsets,
+  getDevtoolsEnabled,
+} from '../../../redux/config'
 import { UNREACHABLE } from '../../../redux/discovery/constants'
 import { Navigation } from '../../../organisms/Navigation'
 import { useLEDLights } from '../../../organisms/Devices/hooks'
@@ -39,6 +42,7 @@ export function RobotSettingsList(props: RobotSettingsListProps): JSX.Element {
   })
   const isUpdateAvailable = robotUpdateType === 'upgrade'
   const devToolsOn = useSelector(getDevtoolsEnabled)
+  const historicOffsetsOn = useSelector(getApplyHistoricOffsets)
   const { lightsEnabled, toggleLights } = useLEDLights(robotName)
 
   return (
@@ -105,6 +109,13 @@ export function RobotSettingsList(props: RobotSettingsListProps): JSX.Element {
           currentOption="UpdateChannel"
           setCurrentOption={setCurrentOption}
           iconName="update-channel"
+        />
+        <RobotSettingButton
+          settingName={t('app_settings:apply_historic_offsets')}
+          settingInfo={t('historic_offsets_description')}
+          iconName="settings"
+          enabledHistoricOffests
+          historicOffsetsOn={historicOffsetsOn}
         />
         <RobotSettingButton
           settingName={t('app_settings:enable_dev_tools')}

--- a/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/__tests__/RobotSettingsDashboard.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/__tests__/RobotSettingsDashboard.test.tsx
@@ -7,7 +7,7 @@ import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
 import { getRobotSettings } from '../../../../redux/robot-settings'
 import { getLocalRobot } from '../../../../redux/discovery'
-import { toggleDevtools } from '../../../../redux/config'
+import { toggleDevtools, toggleHistoricOffsets } from '../../../../redux/config'
 import { mockConnectedRobot } from '../../../../redux/discovery/__fixtures__'
 import { Navigation } from '../../../../organisms/Navigation'
 import {
@@ -48,6 +48,9 @@ const mockGetRobotSettings = getRobotSettings as jest.MockedFunction<
 >
 const mockToggleDevtools = toggleDevtools as jest.MockedFunction<
   typeof toggleDevtools
+>
+const mockToggleHistoricOffsets = toggleHistoricOffsets as jest.MockedFunction<
+  typeof toggleHistoricOffsets
 >
 const mockNavigation = Navigation as jest.MockedFunction<typeof Navigation>
 const mockTouchScreenSleep = TouchScreenSleep as jest.MockedFunction<
@@ -125,9 +128,11 @@ describe('RobotSettingsDashboard', () => {
     getByText('Touchscreen Brightness')
     getByText('Device Reset')
     getByText('Update Channel')
+    getByText('Always Apply Historic Offset Data')
+    getByText('Apply stored labware offset data when setting up and running protocols.')
     getByText('Enable Developer Tools')
     getByText('Enable additional logging and allow access to feature flags.')
-    expect(getAllByText('Off').length).toBe(2) // LED & DEV tools
+    expect(getAllByText('Off').length).toBe(3) // LED & DEV tools & historic offsets
   })
 
   // Note(kj: 02/03/2023) This case will be changed in a following PR
@@ -194,6 +199,13 @@ describe('RobotSettingsDashboard', () => {
     const button = getByText('Update Channel')
     fireEvent.click(button)
     getByText('Mock Update Channel')
+  })
+
+  it('should call a mock function when tapping enable historic offset', () => {
+    const [{ getByText }] = render()
+    const button = getByText('Always Apply Historic Offset Data')
+    fireEvent.click(button)
+    expect(mockToggleHistoricOffsets).toHaveBeenCalled()
   })
 
   it('should call a mock function when tapping enable dev tools', () => {

--- a/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/__tests__/RobotSettingsDashboard.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/__tests__/RobotSettingsDashboard.test.tsx
@@ -129,7 +129,9 @@ describe('RobotSettingsDashboard', () => {
     getByText('Device Reset')
     getByText('Update Channel')
     getByText('Always Apply Historic Offset Data')
-    getByText('Apply stored labware offset data when setting up and running protocols.')
+    getByText(
+      'Apply stored labware offset data when setting up and running protocols.'
+    )
     getByText('Enable Developer Tools')
     getByText('Enable additional logging and allow access to feature flags.')
     expect(getAllByText('Off').length).toBe(3) // LED & DEV tools & historic offsets

--- a/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/__tests__/RobotSettingsDashboard.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/__tests__/RobotSettingsDashboard.test.tsx
@@ -128,10 +128,8 @@ describe('RobotSettingsDashboard', () => {
     getByText('Touchscreen Brightness')
     getByText('Device Reset')
     getByText('Update Channel')
-    getByText('Always Apply Historic Offset Data')
-    getByText(
-      'Apply stored labware offset data when setting up and running protocols.'
-    )
+    getByText('Apply labware offsets')
+    getByText('Use stored data when setting up a protocol.')
     getByText('Enable Developer Tools')
     getByText('Enable additional logging and allow access to feature flags.')
     expect(getAllByText('Off').length).toBe(3) // LED & DEV tools & historic offsets
@@ -205,7 +203,7 @@ describe('RobotSettingsDashboard', () => {
 
   it('should call a mock function when tapping enable historic offset', () => {
     const [{ getByText }] = render()
-    const button = getByText('Always Apply Historic Offset Data')
+    const button = getByText('Apply labware offsets')
     fireEvent.click(button)
     expect(mockToggleHistoricOffsets).toHaveBeenCalled()
   })

--- a/app/src/redux/config/__tests__/selectors.test.ts
+++ b/app/src/redux/config/__tests__/selectors.test.ts
@@ -222,4 +222,28 @@ describe('shell selectors', () => {
       })
     })
   })
+
+  describe('applyHistoricOffsets', () => {
+    it('should return false if applyHistoricOffsets is selected', () => {
+      const state: State = {
+        config: {
+          protocols: {
+            applyHistoricOffsets: false,
+          },
+        },
+      } as any
+      expect(Selectors.getApplyHistoricOffsets(state)).toEqual(false)
+    })
+
+    it('should return true if applyHistoricOffsets is selected', () => {
+      const state: State = {
+        config: {
+          protocols: {
+            applyHistoricOffsets: true,
+          },
+        },
+      } as any
+      expect(Selectors.getApplyHistoricOffsets(state)).toEqual(true)
+    })
+  })
 })

--- a/app/src/redux/config/actions.ts
+++ b/app/src/redux/config/actions.ts
@@ -76,6 +76,10 @@ export function toggleDevInternalFlag(
   return toggleConfigValue(`devInternal.${flag}`)
 }
 
+export function toggleHistoricOffsets(): Types.ToggleConfigValueAction {
+  return toggleConfigValue('protocols.applyHistoricOffsets')
+}
+
 // TODO(mc, 2020-02-05): move to `discovery` module
 export function addManualIp(ip: string): Types.AddUniqueConfigValueAction {
   return addUniqueConfigValue('discovery.candidates', ip)

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -207,4 +207,11 @@ export interface ConfigV16 extends Omit<ConfigV15, 'version'> {
   }
 }
 
-export type Config = ConfigV16
+export interface ConfigV17 extends Omit<ConfigV16, 'version'> {
+  version: 17
+  protocols: ConfigV15['protocols'] & {
+    applyHistoricOffsets: boolean
+  }
+}
+
+export type Config = ConfigV17

--- a/app/src/redux/config/selectors.ts
+++ b/app/src/redux/config/selectors.ts
@@ -17,7 +17,7 @@ export const getApplyHistoricOffsets: (
   state: State
 ) => boolean = createSelector(
   getConfig,
-  config => config?.protocols.applyHistoricOffsets ?? false
+  config => config?.protocols.applyHistoricOffsets ?? true
 )
 
 export const getDevtoolsEnabled = (state: State): boolean => {

--- a/app/src/redux/config/selectors.ts
+++ b/app/src/redux/config/selectors.ts
@@ -13,6 +13,13 @@ import type { ProtocolSort } from '../../organisms/ProtocolsLanding/hooks'
 
 export const getConfig = (state: State): Config | null => state.config
 
+export const getApplyHistoricOffsets: (
+  state: State
+) => boolean = createSelector(
+  getConfig,
+  config => config?.protocols.applyHistoricOffsets ?? false
+)
+
 export const getDevtoolsEnabled = (state: State): boolean => {
   return state.config?.devtools ?? false
 }


### PR DESCRIPTION
# Overview

This PR has three main bits of functionality:

- Add a config setting to always apply historic offset data
- Add a toggle to the ODD settings screen to set that config setting
- Use that config setting to determine if historic offset data is used when running a protocol on the ODD

Closes RAUT-437

# Test Plan

I performed a mix of unit and manual testing, but further testing should be done on an actual robot or DevKit capable of fully running protocols (mine is not at the moment).

# Changelog

- Added protocols.applyHistoricOffsets config setting defaulting to true
- Added setting schema migrations
- Added ODD settings toggle for that config item
- Made ODD protocol setup use that setting for applying offset data

# Review requests

Please ensure the toggle defaults to true, that historic offset data is applied when it is true, and that no historic data is applied when false

# Risk assessment

Low risk as the default is the same as the previous behavior.

![Screenshot 2023-06-30 at 3 09 17 PM](https://github.com/Opentrons/opentrons/assets/2960/d985fddf-4c9b-4b2e-9f6a-e42aa8944b17)

