### PR TITLE
fix(app): fix duplicated scrollbars on Windows and Slideout

### DIFF
--- a/app/src/App/DesktopApp.tsx
+++ b/app/src/App/DesktopApp.tsx
@@ -5,7 +5,7 @@ import {
   Box,
   POSITION_RELATIVE,
   COLORS,
-  OVERFLOW_SCROLL,
+  OVERFLOW_AUTO,
 } from '@opentrons/components'
 
 import { Alerts } from '../organisms/Alerts'
@@ -102,7 +102,7 @@ export const DesktopApp = (): JSX.Element => {
                     width="100%"
                     height="100%"
                     backgroundColor={COLORS.fundamentalsBackground}
-                    overflow={OVERFLOW_SCROLL}
+                    overflow={OVERFLOW_AUTO}
                   >
                     <ModalPortalRoot />
                     <Component />

--- a/app/src/atoms/Slideout/index.tsx
+++ b/app/src/atoms/Slideout/index.tsx
@@ -196,7 +196,7 @@ export const Slideout = (props: SlideoutProps): JSX.Element => {
           <Box
             padding={SPACING.spacing16}
             flex="1 1 auto"
-            overflowY="scroll"
+            overflowY="auto"
             data-testid={`Slideout_body_${
               typeof title === 'string' ? title : ''
             }`}

--- a/app/src/organisms/ConfigurePipette/ConfigForm.tsx
+++ b/app/src/organisms/ConfigurePipette/ConfigForm.tsx
@@ -7,7 +7,7 @@ import forOwn from 'lodash/forOwn'
 import keys from 'lodash/keys'
 import omit from 'lodash/omit'
 import set from 'lodash/set'
-import { Box } from '@opentrons/components'
+import { Box, OVERFLOW_AUTO } from '@opentrons/components'
 import { ConfigFormResetButton } from './ConfigFormResetButton'
 import {
   ConfigFormGroup,
@@ -209,7 +209,7 @@ export class ConfigForm extends React.Component<ConfigFormProps> {
             formProps.resetForm({ values: newValues })
           }
           return (
-            <Box overflowY="scroll">
+            <Box overflowY={OVERFLOW_AUTO}>
               <Form id={formId}>
                 <ConfigFormResetButton
                   onClick={handleReset}

--- a/app/src/pages/Devices/DeviceDetails/index.tsx
+++ b/app/src/pages/Devices/DeviceDetails/index.tsx
@@ -41,7 +41,6 @@ export function DeviceDetails(): JSX.Element | null {
       <Box
         minWidth="36rem"
         height="100%"
-        overflow={OVERFLOW_SCROLL}
         paddingX={SPACING.spacing16}
         paddingTop={SPACING.spacing16}
         paddingBottom={SPACING.spacing48}

--- a/app/src/pages/Devices/DeviceDetails/index.tsx
+++ b/app/src/pages/Devices/DeviceDetails/index.tsx
@@ -7,7 +7,6 @@ import {
   Flex,
   ALIGN_CENTER,
   DIRECTION_COLUMN,
-  OVERFLOW_SCROLL,
   SPACING,
   COLORS,
 } from '@opentrons/components'
@@ -40,7 +39,7 @@ export function DeviceDetails(): JSX.Element | null {
     >
       <Box
         minWidth="36rem"
-        height="100%"
+        height="max-content"
         paddingX={SPACING.spacing16}
         paddingTop={SPACING.spacing16}
         paddingBottom={SPACING.spacing48}

--- a/app/src/pages/Devices/RobotSettings/index.tsx
+++ b/app/src/pages/Devices/RobotSettings/index.tsx
@@ -6,7 +6,6 @@ import {
   Box,
   Flex,
   DIRECTION_COLUMN,
-  OVERFLOW_SCROLL,
   SIZE_6,
   BORDERS,
   COLORS,
@@ -107,8 +106,7 @@ export function RobotSettings(): JSX.Element | null {
   return (
     <Box
       minWidth={SIZE_6}
-      height="100%"
-      overflow={OVERFLOW_SCROLL}
+      height="max-content"
       padding={SPACING.spacing16}
     >
       <Flex

--- a/app/src/pages/Devices/RobotSettings/index.tsx
+++ b/app/src/pages/Devices/RobotSettings/index.tsx
@@ -104,11 +104,7 @@ export function RobotSettings(): JSX.Element | null {
   )
 
   return (
-    <Box
-      minWidth={SIZE_6}
-      height="max-content"
-      padding={SPACING.spacing16}
-    >
+    <Box minWidth={SIZE_6} height="max-content" padding={SPACING.spacing16}>
       <Flex
         backgroundColor={COLORS.white}
         border={BORDERS.lineBorder}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
For Mac and Ubuntu, duplicated overflowY is ignoreed but Windows doesn't so we need to remove overflowY from Device Details page and RobotSettings page. In addition currently we use overflow scroll for slideout then the Desktop app shows the scrollbar always.

related thread
https://opentrons.slack.com/archives/CSCLVUW3C/p1688741452099479

Windows screen recording
https://opentrons.slack.com/archives/CSCLVUW3C/p1689173600109049?thread_ts=1688741452.099479&cid=CSCLVUW3C


close RAUT-545
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
check all slideouts
- rename slideout
- device reset slideout
- module settings under Robot Details page
- mini robot  slideout
- Protocol slideout
- labware slideout
- Connect to a network slideout
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- remove unnecessary overflow from device details page
- change overflow in Slideout from scroll to auto 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
