### PR TITLE
fix(app): fix protocol run header banner render issue

### DIFF
--- a/app/src/App/DesktopApp.tsx
+++ b/app/src/App/DesktopApp.tsx
@@ -144,7 +144,7 @@ function RobotControlTakeover(): JSX.Element | null {
   const isOT3 = useIsOT3(robotName)
 
   // E-stop is not supported on OT2
-  if (isOT3) return null
+  if (!isOT3) return null
 
   if (deviceRouteMatch == null || robot == null || robotName == null)
     return null

--- a/app/src/App/DesktopApp.tsx
+++ b/app/src/App/DesktopApp.tsx
@@ -26,7 +26,7 @@ import { Navbar } from './Navbar'
 import { EstopTakeover, EmergencyStopContext } from '../organisms/EmergencyStop'
 import { OPENTRONS_USB } from '../redux/discovery'
 import { appShellRequestor } from '../redux/shell/remote'
-import { useRobot } from '../organisms/Devices/hooks'
+import { useRobot, useIsOT3 } from '../organisms/Devices/hooks'
 import { PortalRoot as ModalPortalRoot } from './portal'
 
 import type { RouteProps, DesktopRouteParams } from './types'
@@ -141,6 +141,10 @@ function RobotControlTakeover(): JSX.Element | null {
   const params = deviceRouteMatch?.params as DesktopRouteParams
   const robotName = params?.robotName
   const robot = useRobot(robotName)
+  const isOT3 = useIsOT3(robotName)
+
+  // E-stop is not supported on OT2
+  if (isOT3) return null
 
   if (deviceRouteMatch == null || robot == null || robotName == null)
     return null

--- a/app/src/App/__tests__/DesktopApp.test.tsx
+++ b/app/src/App/__tests__/DesktopApp.test.tsx
@@ -14,6 +14,7 @@ import { ProtocolRunDetails } from '../../pages/Devices/ProtocolRunDetails'
 import { RobotSettings } from '../../pages/Devices/RobotSettings'
 import { GeneralSettings } from '../../pages/AppSettings/GeneralSettings'
 import { Alerts } from '../../organisms/Alerts'
+import { useIsOT3 } from '../../organisms/Devices/hooks'
 import { useSoftwareUpdatePoll } from '../hooks'
 import { DesktopApp } from '../DesktopApp'
 
@@ -55,6 +56,7 @@ const mockBreadcrumbs = Breadcrumbs as jest.MockedFunction<typeof Breadcrumbs>
 const mockUseSoftwareUpdatePoll = useSoftwareUpdatePoll as jest.MockedFunction<
   typeof useSoftwareUpdatePoll
 >
+const mockUseIsOT3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
 
 const render = (path = '/') => {
   return renderWithProviders(
@@ -78,6 +80,7 @@ describe('DesktopApp', () => {
     mockAlerts.mockReturnValue(<div>Mock Alerts</div>)
     mockAppSettings.mockReturnValue(<div>Mock AppSettings</div>)
     mockBreadcrumbs.mockReturnValue(<div>Mock Breadcrumbs</div>)
+    mockUseIsOT3.mockReturnValue(true)
   })
   afterEach(() => {
     jest.resetAllMocks()

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -83,6 +83,7 @@ import {
   useIsRobotViewable,
   useTrackProtocolRunEvent,
   useRobotAnalyticsData,
+  useIsOT3,
 } from '../hooks'
 import { formatTimestamp } from '../utils'
 import { RunTimer } from './RunTimer'
@@ -149,6 +150,8 @@ export function ProtocolRunHeader({
     showEmergencyStopRunBanner,
     setShowEmergencyStopRunBanner,
   ] = React.useState<boolean>(false)
+  const isOT3 = useIsOT3(robotName)
+
   React.useEffect(() => {
     if (estopStatus?.data.status !== DISENGAGED) {
       setShowEmergencyStopRunBanner(true)
@@ -288,7 +291,8 @@ export function ProtocolRunHeader({
           />
         ) : null}
         {estopStatus?.data.status !== DISENGAGED &&
-        showEmergencyStopRunBanner ? (
+        showEmergencyStopRunBanner &&
+        isOT3 ? (
           <EmergencyStopRunBanner
             setShowEmergencyStopRunBanner={setShowEmergencyStopRunBanner}
           />

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -66,6 +66,7 @@ import {
   useRunCreatedAtTimestamp,
   useUnmatchedModulesForProtocol,
   useIsRobotViewable,
+  useIsOT3,
 } from '../../hooks'
 import { useIsHeaterShakerInProtocol } from '../../../ModuleCard/hooks'
 import { ConfirmAttachmentModal } from '../../../ModuleCard/ConfirmAttachmentModal'
@@ -192,6 +193,7 @@ const mockRunFailedModal = RunFailedModal as jest.MockedFunction<
 const mockUseEstopQuery = useEstopQuery as jest.MockedFunction<
   typeof useEstopQuery
 >
+const mockUseIsOT3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
 
 const ROBOT_NAME = 'otie'
 const RUN_ID = '95e67900-bc9f-4fbf-92c6-cc4d7226a51b'
@@ -345,6 +347,7 @@ describe('ProtocolRunHeader', () => {
     when(mockUseRunCalibrationStatus)
       .calledWith(ROBOT_NAME, RUN_ID)
       .mockReturnValue({ complete: true })
+    mockUseIsOT3.mockReturnValue(true)
     mockRunFailedModal.mockReturnValue(<div>mock RunFailedModal</div>)
     mockUseEstopQuery.mockReturnValue({ data: mockEstopStatus } as any)
   })


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The current E-stop related components don't support well. This PR fix that issue.
close RQA-1314 and RQA-1325
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
run a protocol on OT-2 and `Run Failed` banner from E-stop won't show up in the header
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- update EstopTakeover component to return null when a robot is OT-2
- update ProtocolRunHeader component to avoid rendering `Run Failed.` banner when running a protocol on OT-2
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
