### PR TITLE
fix(app): fix deck view diff between deck and labware deck map modal

### DIFF
--- a/app/src/organisms/ProtocolSetupLabware/__tests__/LabwareMapViewModal.test.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/__tests__/LabwareMapViewModal.test.tsx
@@ -10,7 +10,6 @@ import {
   FLEX_ROBOT_TYPE,
   getSimplestDeckConfigForProtocol,
 } from '@opentrons/shared-data'
-import deckDefFixture from '@opentrons/shared-data/deck/fixtures/3/deckExample.json'
 import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_300_ul.json'
 import { i18n } from '../../../i18n'
 import { getLabwareRenderInfo } from '../../Devices/ProtocolRun/utils/getLabwareRenderInfo'
@@ -20,7 +19,6 @@ import { LabwareMapViewModal } from '../LabwareMapViewModal'
 
 import type {
   CompletedProtocolAnalysis,
-  DeckDefinition,
   LabwareDefinition2,
   ModuleModel,
 } from '@opentrons/shared-data'
@@ -68,7 +66,6 @@ describe('LabwareMapViewModal', () => {
     const props = {
       handleLabwareClick: jest.fn(),
       onCloseClick: jest.fn(),
-      deckDef: (deckDefFixture as unknown) as DeckDefinition,
       mostRecentAnalysis: ({
         commands: [],
         labware: [],
@@ -85,6 +82,29 @@ describe('LabwareMapViewModal', () => {
   })
 
   it('should render a deck with modules and labware', () => {
+    const mockMostRecentAnalysis = ({
+      commands: [
+        {
+          id: 'mockId',
+          createdAt: '2023-12-06T20:52:54.901662+00:00',
+          commandType: 'loadLabware',
+          key: 'mockKey',
+          status: 'succeeded',
+          params: {
+            location: {
+              slotName: 'C1',
+            },
+            loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
+            namespace: 'opentrons',
+            version: 2,
+            labwareId: '300_ul_tiprack_id',
+            displayName: 'mock',
+          },
+          results: {},
+        },
+      ],
+      labware: [],
+    } as unknown) as CompletedProtocolAnalysis
     const mockLabwareOnDeck = [
       {
         labwareLocation: { slotName: 'C1' },
@@ -127,8 +147,7 @@ describe('LabwareMapViewModal', () => {
     render({
       handleLabwareClick: jest.fn(),
       onCloseClick: jest.fn(),
-      deckDef: (deckDefFixture as unknown) as DeckDefinition,
-      mostRecentAnalysis: ({} as unknown) as CompletedProtocolAnalysis,
+      mostRecentAnalysis: mockMostRecentAnalysis,
       initialLoadedLabwareByAdapter: {},
       attachedProtocolModuleMatches: [
         {

--- a/app/src/organisms/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/index.tsx
@@ -215,7 +215,6 @@ export function ProtocolSetupLabware({
         {showDeckMapModal ? (
           <LabwareMapViewModal
             mostRecentAnalysis={mostRecentAnalysis}
-            deckDef={deckDef}
             attachedProtocolModuleMatches={attachedProtocolModuleMatches}
             handleLabwareClick={handleLabwareClick}
             onCloseClick={() => setShowDeckMapModal(false)}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Fix deck map with staging area labware different for protocol details vs protocol setup.
The issue is the current implementation does not consider `addressableAreaName`.
close RQA-2008


https://github.com/Opentrons/opentrons/assets/474225/b93cfbff-885c-4634-9471-4915f28417de



<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- compare Deck in Protocol Details screen and Deck map in the modal from Labware - Protocol Setup screen
- The deck map in the modal allows us to check a labware details when tapping it
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
