### PR TITLE
feat(protocol-designer): use window width and height

### DIFF
--- a/protocol-designer/src/resources/__tests__/useScreenSizeCheck.test.ts
+++ b/protocol-designer/src/resources/__tests__/useScreenSizeCheck.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, vi, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useScreenSizeCheck } from '../useScreenSizeCheck'
 

--- a/protocol-designer/src/resources/__tests__/useScreenSizeCheck.test.ts
+++ b/protocol-designer/src/resources/__tests__/useScreenSizeCheck.test.ts
@@ -1,44 +1,40 @@
-import { describe, it, vi, expect } from 'vitest'
-import { renderHook } from '@testing-library/react'
-import { useScreenSizeCheck } from '../useScreenSizeCheck'
+// import { describe, it, vi, expect } from 'vitest'
+// import { renderHook } from '@testing-library/react'
+// import { useScreenSizeCheck } from '../useScreenSizeCheck'
 
 describe('useScreenSizeCheck', () => {
-  it('should return true if the window size is greater than 600px x 650px', () => {
-    vi.stubGlobal('innerWidth', 1440)
-    vi.stubGlobal('innerHeight', 900)
-    const { result } = renderHook(() => useScreenSizeCheck())
-    expect(result.current).toBe(true)
-  })
-
-  it('should return false if the window height is less than 650px', () => {
-    vi.stubGlobal('innerWidth', 1440)
-    vi.stubGlobal('innerHeight', 649)
-    window.dispatchEvent(new Event('resize'))
-    const { result } = renderHook(() => useScreenSizeCheck())
-    expect(result.current).toBe(false)
-  })
-
-  it('should return true if the window width is 768px', () => {
-    vi.stubGlobal('innerWidth', 768)
-    vi.stubGlobal('innerHeight', 900)
-    window.dispatchEvent(new Event('resize'))
-    const { result } = renderHook(() => useScreenSizeCheck())
-    expect(result.current).toBe(false)
-  })
-
-  it('should return false if the window width is less than 768px', () => {
-    vi.stubGlobal('innerWidth', 767)
-    vi.stubGlobal('innerHeight', 900)
-    window.dispatchEvent(new Event('resize'))
-    const { result } = renderHook(() => useScreenSizeCheck())
-    expect(result.current).toBe(false)
-  })
-
-  it('should return false if the window width is less than 768px and height is less than 650px', () => {
-    vi.stubGlobal('innerWidth', 767)
-    vi.stubGlobal('innerHeight', 649)
-    window.dispatchEvent(new Event('resize'))
-    const { result } = renderHook(() => useScreenSizeCheck())
-    expect(result.current).toBe(false)
-  })
+  // it('should return true if the window size is greater than 600px x 650px', () => {
+  //   vi.stubGlobal('innerWidth', 1440)
+  //   vi.stubGlobal('innerHeight', 900)
+  //   const { result } = renderHook(() => useScreenSizeCheck())
+  //   expect(result.current).toBe(true)
+  // })
+  // it('should return false if the window height is less than 650px', () => {
+  //   vi.stubGlobal('innerWidth', 1440)
+  //   vi.stubGlobal('innerHeight', 649)
+  //   window.dispatchEvent(new Event('resize'))
+  //   const { result } = renderHook(() => useScreenSizeCheck())
+  //   expect(result.current).toBe(false)
+  // })
+  // it('should return true if the window width is 768px', () => {
+  //   vi.stubGlobal('innerWidth', 768)
+  //   vi.stubGlobal('innerHeight', 900)
+  //   window.dispatchEvent(new Event('resize'))
+  //   const { result } = renderHook(() => useScreenSizeCheck())
+  //   expect(result.current).toBe(false)
+  // })
+  // it('should return false if the window width is less than 768px', () => {
+  //   vi.stubGlobal('innerWidth', 767)
+  //   vi.stubGlobal('innerHeight', 900)
+  //   window.dispatchEvent(new Event('resize'))
+  //   const { result } = renderHook(() => useScreenSizeCheck())
+  //   expect(result.current).toBe(false)
+  // })
+  // it('should return false if the window width is less than 768px and height is less than 650px', () => {
+  //   vi.stubGlobal('innerWidth', 767)
+  //   vi.stubGlobal('innerHeight', 649)
+  //   window.dispatchEvent(new Event('resize'))
+  //   const { result } = renderHook(() => useScreenSizeCheck())
+  //   expect(result.current).toBe(false)
+  // })
 })

--- a/protocol-designer/src/resources/__tests__/useScreenSizeCheck.test.ts
+++ b/protocol-designer/src/resources/__tests__/useScreenSizeCheck.test.ts
@@ -1,6 +1,6 @@
-// import { describe, it, vi, expect } from 'vitest'
-// import { renderHook } from '@testing-library/react'
-// import { useScreenSizeCheck } from '../useScreenSizeCheck'
+import { describe, it, vi, expect, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useScreenSizeCheck } from '../useScreenSizeCheck'
 
 describe('useScreenSizeCheck', () => {
   // it('should return true if the window size is greater than 600px x 650px', () => {
@@ -37,4 +37,72 @@ describe('useScreenSizeCheck', () => {
   //   const { result } = renderHook(() => useScreenSizeCheck())
   //   expect(result.current).toBe(false)
   // })
+  const originalWidth = window.screen.width
+  const originalHeight = window.screen.height
+
+  beforeEach(() => {
+    Object.defineProperty(window.screen, 'width', {
+      writable: true,
+      configurable: true,
+      value: originalWidth,
+    })
+    Object.defineProperty(window.screen, 'height', {
+      writable: true,
+      configurable: true,
+      value: originalHeight,
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window.screen, 'width', {
+      writable: true,
+      configurable: true,
+      value: originalWidth,
+    })
+    Object.defineProperty(window.screen, 'height', {
+      writable: true,
+      configurable: true,
+      value: originalHeight,
+    })
+  })
+
+  it('should return true if screen size is larger than breakpoints', () => {
+    Object.defineProperty(window.screen, 'width', { value: 800 })
+    Object.defineProperty(window.screen, 'height', { value: 700 })
+
+    const { result } = renderHook(() => useScreenSizeCheck())
+
+    expect(result.current).toBe(true)
+  })
+
+  it('should return false if screen size is smaller than breakpoints', () => {
+    Object.defineProperty(window.screen, 'width', { value: 700 })
+    Object.defineProperty(window.screen, 'height', { value: 600 })
+
+    const { result } = renderHook(() => useScreenSizeCheck())
+
+    expect(result.current).toBe(false)
+  })
+
+  it('should update value on window resize', () => {
+    const { result } = renderHook(() => useScreenSizeCheck())
+
+    expect(result.current).toBe(originalWidth > 768 && originalHeight > 650)
+
+    act(() => {
+      Object.defineProperty(window.screen, 'width', { value: 800 })
+      Object.defineProperty(window.screen, 'height', { value: 700 })
+      window.dispatchEvent(new Event('resize'))
+    })
+
+    expect(result.current).toBe(true)
+
+    act(() => {
+      Object.defineProperty(window.screen, 'width', { value: 700 })
+      Object.defineProperty(window.screen, 'height', { value: 600 })
+      window.dispatchEvent(new Event('resize'))
+    })
+
+    expect(result.current).toBe(false)
+  })
 })

--- a/protocol-designer/src/resources/useScreenSizeCheck.ts
+++ b/protocol-designer/src/resources/useScreenSizeCheck.ts
@@ -5,15 +5,18 @@ const BREAKPOINT_WIDTH = 768
 
 export const useScreenSizeCheck = (): boolean => {
   const [isValidSize, setValidSize] = useState<boolean>(
-    window.innerWidth > BREAKPOINT_WIDTH &&
-      window.innerHeight > BREAKPOINT_HEIGHT
+    window.screen.width > BREAKPOINT_WIDTH &&
+      window.screen.height > BREAKPOINT_HEIGHT
   )
 
   useEffect(() => {
     const handleResize = (): void => {
+      // delete this before merging, this is for debugging
+      console.log(window.screen.width)
+      console.log(window.screen.height)
       setValidSize(
-        window.innerWidth > BREAKPOINT_WIDTH &&
-          window.innerHeight > BREAKPOINT_HEIGHT
+        window.screen.width > BREAKPOINT_WIDTH &&
+          window.screen.height > BREAKPOINT_HEIGHT
       )
     }
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
