### PR TITLE
feat(components): add useDebounce

### DIFF
--- a/components/src/hooks/__tests__/useDebounce.test.ts
+++ b/components/src/hooks/__tests__/useDebounce.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, beforeEach, afterEach, vi, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useDebounce } from '../useDebounce' // Adjust the import path as necessary
+
+describe('useDebounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('should return the initial value immediately', () => {
+    const { result } = renderHook(() => useDebounce('initial', 500))
+    expect(result.current).toBe('initial')
+  })
+
+  it('should return the updated value after the delay', () => {
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      {
+        initialProps: { value: 'initial', delay: 500 },
+      }
+    )
+
+    expect(result.current).toBe('initial')
+
+    // Update the value
+    rerender({ value: 'updated', delay: 500 })
+
+    // Fast-forward time by 499ms (just before the delay)
+    act(() => {
+      vi.advanceTimersByTime(499)
+    })
+
+    // Value should still be the initial one
+    expect(result.current).toBe('initial')
+
+    // Fast-forward time by 1ms (total 500ms)
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+
+    // Value should now be updated
+    expect(result.current).toBe('updated')
+  })
+
+  it('should cancel the previous timeout if the value changes within the delay', () => {
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      {
+        initialProps: { value: 'initial', delay: 500 },
+      }
+    )
+
+    expect(result.current).toBe('initial')
+
+    // Update the value
+    rerender({ value: 'updated', delay: 500 })
+
+    // Fast-forward time by 250ms (halfway through the delay)
+    act(() => {
+      vi.advanceTimersByTime(250)
+    })
+
+    // Update the value again
+    rerender({ value: 'final', delay: 500 })
+
+    // Fast-forward time by 499ms (just before the new delay)
+    act(() => {
+      vi.advanceTimersByTime(499)
+    })
+
+    // Value should still be the initial one
+    expect(result.current).toBe('initial')
+
+    // Fast-forward time by 1ms (total 500ms from the last update)
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+
+    // Value should now be the final one
+    expect(result.current).toBe('final')
+  })
+
+  it('should clear the timeout on unmount', () => {
+    const { result, unmount } = renderHook(() => useDebounce('initial', 500))
+
+    expect(result.current).toBe('initial')
+
+    // Unmount the hook
+    unmount()
+
+    // Fast-forward time by 500ms
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    // No state update should have occurred after unmount
+    expect(result.current).toBe('initial')
+  })
+})

--- a/components/src/hooks/useDebounce.ts
+++ b/components/src/hooks/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react'
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+
+    return () => {
+      clearTimeout(handler)
+    }
+  }, [value, delay])
+
+  return debouncedValue
+}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
add useDebounce + its test

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
low
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
