### PR TITLE
feat(api): add bottom-center locating feature

### DIFF
--- a/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
+++ b/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
@@ -1,5 +1,7 @@
 """Utilities for calculating the labware origin offset position."""
+from dataclasses import dataclass
 from typing import Union, overload
+
 
 from typing_extensions import assert_type
 
@@ -10,6 +12,7 @@ from opentrons_shared_data.labware.labware_definition import (
     LabwareDefinition3,
     Vector3D,
 )
+from opentrons_shared_data.labware.types import LocatingFeatures
 from opentrons_shared_data.deck.types import DeckDefinitionV5
 from ..types import (
     LabwareParentDefinition,
@@ -17,12 +20,34 @@ from ..types import (
     ModuleModel,
     LabwareOffsetVector,
     DeckLocationDefinition,
-    LabwareLocation,
     ModuleLocation,
     DeckSlotLocation,
     AddressableAreaLocation,
     OnLabwareLocation,
 )
+
+_LabwareOriginLocation = Union[
+    ModuleLocation, DeckSlotLocation, AddressableAreaLocation, OnLabwareLocation
+]
+
+
+@dataclass()
+class _Point2D:
+    x: float = 0.0
+    y: float = 0.0
+
+
+@dataclass()
+class _BoundingBox2D:
+    back_left: _Point2D
+    front_right: _Point2D
+
+
+@dataclass()
+class _ParentEntityInfo:
+    locating_features_as_parent: LocatingFeatures
+    child_contact_plane: Union[_BoundingBox2D, None] = None
+    """The parent entity's 2D plane on which the labware resides."""
 
 
 @overload
@@ -67,7 +92,7 @@ def get_parent_placement_origin_to_lw_origin(
     module_parent_to_child_offset: Union[LabwareOffsetVector, None],
     deck_definition: DeckDefinitionV5,
     is_topmost_labware: bool,
-    labware_location: LabwareLocation,
+    labware_location: _LabwareOriginLocation,
 ) -> Point:
     """Returns the offset from parent entity's placement origin to child labware origin.
 
@@ -104,13 +129,18 @@ def get_parent_placement_origin_to_lw_origin(
     else:
         # For v3 definitions, get the vector from the back left bottom to the front right bottom.
         assert_type(child_labware, LabwareDefinition3)
-        parent_entity_origin_to_child_labware_origin = (
-            _get_back_left_bottom_position(child_labware) * -1
+
+        parent_origin_to_locating_feature = _get_parent_origin_to_locating_feature(
+            parent_entity_info=_get_parent_entity_info(parent_entity, labware_location),  # type: ignore[arg-type]
+        )
+        locating_feature_to_lw_origin = _get_locating_feature_to_lw_origin(
+            child_labware,
         )
 
         return (
             parent_entity_origin_to_child_labware_placement_origin
-            + parent_entity_origin_to_child_labware_origin
+            + parent_origin_to_locating_feature
+            + locating_feature_to_lw_origin
         )
 
 
@@ -119,7 +149,7 @@ def _get_parent_entity_origin_to_child_labware_placement_origin(
     parent_entity: LabwareParentDefinition,
     module_parent_to_child_offset: Union[LabwareOffsetVector, None],
     deck_definition: DeckDefinitionV5,
-    labware_location: LabwareLocation,
+    labware_location: _LabwareOriginLocation,
 ) -> Point:
     """Get the offset vector from parent entity origin to child labware placement origin."""
     if isinstance(labware_location, (DeckSlotLocation, AddressableAreaLocation)):
@@ -172,6 +202,133 @@ def _get_parent_entity_origin_to_child_labware_placement_origin(
         raise TypeError(f"Unsupported labware location type: {labware_location}")
 
 
+def _get_parent_origin_to_locating_feature(
+    parent_entity_info: _ParentEntityInfo,
+) -> Point:
+    """Returns the offset from parent origin to the locating feature position."""
+    return _get_parent_origin_to_bottom_center(parent_entity_info)
+
+
+def _get_locating_feature_to_lw_origin(
+    child_labware: LabwareDefinition3,
+) -> Point:
+    """Returns the offset from the locating feature position to the labware origin."""
+    return _get_bottom_center_to_lw_origin(child_labware)
+
+
+@overload
+def _get_parent_entity_info(
+    parent_entity: ModuleDefinition,
+    labware_location: ModuleLocation,
+) -> _ParentEntityInfo:
+    ...
+
+
+@overload
+def _get_parent_entity_info(
+    parent_entity: Union[LabwareDefinition2, LabwareDefinition3],
+    labware_location: OnLabwareLocation,
+) -> _ParentEntityInfo:
+    ...
+
+
+@overload
+def _get_parent_entity_info(
+    parent_entity: DeckLocationDefinition,
+    labware_location: Union[DeckSlotLocation, AddressableAreaLocation],
+) -> _ParentEntityInfo:
+    ...
+
+
+def _get_parent_entity_info(
+    parent_entity: LabwareParentDefinition,
+    labware_location: _LabwareOriginLocation,
+) -> _ParentEntityInfo:
+    """Returns a standardized interface of relevant parent entity information given various parent entity types."""
+    if isinstance(labware_location, OnLabwareLocation):
+        assert isinstance(parent_entity, (LabwareDefinition2, LabwareDefinition3))
+
+        if isinstance(parent_entity, LabwareDefinition2):
+            raise NotImplementedError()
+        else:
+            footprint = parent_entity.extents.footprint
+            back_left = _Point2D(x=footprint.backLeft.x, y=footprint.backLeft.y)
+            front_right = _Point2D(x=footprint.frontRight.x, y=footprint.frontRight.y)
+            contact_plane = _BoundingBox2D(back_left=back_left, front_right=front_right)
+
+            return _ParentEntityInfo(
+                child_contact_plane=contact_plane,
+                locating_features_as_parent=parent_entity.locatingFeaturesAsParent,
+            )
+
+    elif isinstance(labware_location, ModuleLocation):
+        assert isinstance(parent_entity, ModuleDefinition)
+
+        dimensions = parent_entity.dimensions
+        x_dim = dimensions.labwareInterfaceXDimension
+        y_dim = dimensions.labwareInterfaceYDimension
+
+        if x_dim is None or y_dim is None:
+            return _ParentEntityInfo(
+                locating_features_as_parent=parent_entity.locatingFeaturesAsParent
+            )
+        else:
+            back_left = _Point2D(0, 0)
+            front_right = _Point2D(x=x_dim, y=y_dim * -1)
+            contact_plane = _BoundingBox2D(back_left=back_left, front_right=front_right)
+
+            return _ParentEntityInfo(
+                child_contact_plane=contact_plane,
+                locating_features_as_parent=parent_entity.locatingFeaturesAsParent,
+            )
+
+    else:
+        if hasattr(parent_entity, "bounding_box"):
+            definition_bounding_box = _Point2D(
+                parent_entity.bounding_box.x, parent_entity.bounding_box.y  # type: ignore[union-attr]
+            )
+        else:
+            definition_bounding_box = _Point2D(
+                parent_entity["boundingBox"]["xDimension"],  # type: ignore[index]
+                parent_entity["boundingBox"]["yDimension"],  # type: ignore[index]
+            )
+
+        back_left = _Point2D(0, 0)
+        front_right = _Point2D(
+            x=definition_bounding_box.x,
+            y=definition_bounding_box.y * -1,
+        )
+        contact_plane = _BoundingBox2D(back_left=back_left, front_right=front_right)
+
+        if hasattr(parent_entity, "locating_features_as_parent"):
+            locating_features_as_parent = parent_entity.locating_features_as_parent  # type: ignore[union-attr]
+        else:
+            locating_features_as_parent = parent_entity["locatingFeaturesAsParent"]  # type: ignore[index]
+
+        return _ParentEntityInfo(
+            child_contact_plane=contact_plane,
+            locating_features_as_parent=locating_features_as_parent,
+        )
+
+
+def _get_parent_origin_to_bottom_center(
+    parent_entity_info: _ParentEntityInfo,
+) -> Point:
+    """Returns offset from parent origin to parent's bottom-center point."""
+    child_contact_plane = parent_entity_info.child_contact_plane
+
+    if child_contact_plane is None:
+        raise ValueError(
+            "Bottom center locating feature is not supported when no child labware contact plane is defined."
+        )
+    else:
+        x = child_contact_plane.front_right.x / 2
+        y = child_contact_plane.front_right.y / 2
+        z = 0
+
+        return Point(x, y, z)
+
+
 def _get_child_labware_overlap_with_parent_labware(
     child_labware: LabwareDefinition, parent_labware_name: str
 ) -> Point:
@@ -220,6 +377,18 @@ def _is_thermocycler_on_ot2(
     )
 
 
+def _get_bottom_center_to_lw_origin(child_labware: LabwareDefinition3) -> Point:
+    """Returns offset from labware's bottom-center point to labware origin."""
+    extents = child_labware.extents.total
+    lw_origin_to_bottom_center = Point(
+        x=extents.frontRightTop.x / 2,
+        y=extents.frontRightTop.y / 2,
+        z=extents.backLeftBottom.z,
+    )
+
+    return -1 * lw_origin_to_bottom_center
+
+
 def _to_point(vector: Vector3D) -> Point:
     """Convert a Vector3D to a Point."""
     return Point(x=vector.x, y=vector.y, z=vector.z)
@@ -228,12 +397,3 @@ def _to_point(vector: Vector3D) -> Point:
 def _to_point_from_lw_offset_vector(offset_vector: LabwareOffsetVector) -> Point:
     """Convert a LabwareOffsetVector to a Point."""
     return Point(x=offset_vector.x, y=offset_vector.y, z=offset_vector.z)
-
-
-def _get_back_left_bottom_position(labware: LabwareDefinition3) -> Point:
-    """Get the back left bottom position from a v3 labware definition."""
-    return Point(
-        x=labware.extents.footprint.backLeft.x,
-        y=labware.extents.footprint.frontRight.y,
-        z=labware.extents.total.backLeftBottom.z,
-    )

--- a/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
+++ b/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
@@ -293,7 +293,7 @@ def _get_parent_entity_info(
             )
         else:
             back_left = _Point2D(0, 0)
-            front_right = _Point2D(x=x_dim, y=y_dim * -1)
+            front_right = _Point2D(x=x_dim, y=y_dim)
             contact_plane = _BoundingBox2D(back_left=back_left, front_right=front_right)
 
             return _ParentEntityInfo(
@@ -306,7 +306,7 @@ def _get_parent_entity_info(
         back_left = _Point2D(0, 0)
         front_right = _Point2D(
             x=parent_entity.bounding_box.x,
-            y=parent_entity.bounding_box.y * -1,
+            y=parent_entity.bounding_box.y,
         )
         contact_plane = _BoundingBox2D(back_left=back_left, front_right=front_right)
 
@@ -324,7 +324,7 @@ def _get_parent_entity_info(
         back_left = _Point2D(0, 0)
         front_right = _Point2D(
             x=definition_bounding_box.x,
-            y=definition_bounding_box.y * -1,
+            y=definition_bounding_box.y,
         )
         contact_plane = _BoundingBox2D(back_left=back_left, front_right=front_right)
         locating_features_as_parent = parent_entity["locatingFeaturesAsParent"]  # type: ignore[index]

--- a/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
+++ b/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
@@ -2,7 +2,6 @@
 from dataclasses import dataclass
 from typing import Union, overload
 
-
 from typing_extensions import assert_type
 
 from opentrons.types import Point
@@ -13,17 +12,17 @@ from opentrons_shared_data.labware.labware_definition import (
     Vector3D,
 )
 from opentrons_shared_data.labware.types import LocatingFeatures
-from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV5, SlotDefV3
 from ..types import (
     LabwareParentDefinition,
     ModuleDefinition,
     ModuleModel,
     LabwareOffsetVector,
-    DeckLocationDefinition,
     ModuleLocation,
     DeckSlotLocation,
     AddressableAreaLocation,
     OnLabwareLocation,
+    AddressableArea,
 )
 
 _LabwareOriginLocation = Union[
@@ -65,11 +64,23 @@ def get_parent_placement_origin_to_lw_origin(
 @overload
 def get_parent_placement_origin_to_lw_origin(
     child_labware: LabwareDefinition,
-    parent_entity: DeckLocationDefinition,
+    parent_entity: SlotDefV3,
     module_parent_to_child_offset: None,
     deck_definition: DeckDefinitionV5,
     is_topmost_labware: bool,
-    labware_location: Union[DeckSlotLocation, AddressableAreaLocation],
+    labware_location: DeckSlotLocation,
+) -> Point:
+    ...
+
+
+@overload
+def get_parent_placement_origin_to_lw_origin(
+    child_labware: LabwareDefinition,
+    parent_entity: AddressableArea,
+    module_parent_to_child_offset: None,
+    deck_definition: DeckDefinitionV5,
+    is_topmost_labware: bool,
+    labware_location: AddressableAreaLocation,
 ) -> Point:
     ...
 
@@ -234,8 +245,16 @@ def _get_parent_entity_info(
 
 @overload
 def _get_parent_entity_info(
-    parent_entity: DeckLocationDefinition,
-    labware_location: Union[DeckSlotLocation, AddressableAreaLocation],
+    parent_entity: SlotDefV3,
+    labware_location: DeckSlotLocation,
+) -> _ParentEntityInfo:
+    ...
+
+
+@overload
+def _get_parent_entity_info(
+    parent_entity: AddressableArea,
+    labware_location: DeckSlotLocation,
 ) -> _ParentEntityInfo:
     ...
 
@@ -251,9 +270,9 @@ def _get_parent_entity_info(
         if isinstance(parent_entity, LabwareDefinition2):
             raise NotImplementedError()
         else:
-            footprint = parent_entity.extents.footprint
-            back_left = _Point2D(x=footprint.backLeft.x, y=footprint.backLeft.y)
-            front_right = _Point2D(x=footprint.frontRight.x, y=footprint.frontRight.y)
+            total = parent_entity.extents.total
+            back_left = _Point2D(x=total.backLeftBottom.x, y=total.backLeftBottom.y)
+            front_right = _Point2D(x=total.frontRightTop.x, y=total.frontRightTop.y)
             contact_plane = _BoundingBox2D(back_left=back_left, front_right=front_right)
 
             return _ParentEntityInfo(
@@ -282,16 +301,25 @@ def _get_parent_entity_info(
                 locating_features_as_parent=parent_entity.locatingFeaturesAsParent,
             )
 
-    else:
-        if hasattr(parent_entity, "bounding_box"):
-            definition_bounding_box = _Point2D(
-                parent_entity.bounding_box.x, parent_entity.bounding_box.y  # type: ignore[union-attr]
-            )
-        else:
-            definition_bounding_box = _Point2D(
-                parent_entity["boundingBox"]["xDimension"],  # type: ignore[index]
-                parent_entity["boundingBox"]["yDimension"],  # type: ignore[index]
-            )
+    elif isinstance(labware_location, AddressableAreaLocation):
+        assert isinstance(parent_entity, AddressableArea)
+        back_left = _Point2D(0, 0)
+        front_right = _Point2D(
+            x=parent_entity.bounding_box.x,
+            y=parent_entity.bounding_box.y * -1,
+        )
+        contact_plane = _BoundingBox2D(back_left=back_left, front_right=front_right)
+
+        return _ParentEntityInfo(
+            child_contact_plane=contact_plane,
+            locating_features_as_parent=parent_entity.locating_features_as_parent,
+        )
+
+    elif isinstance(labware_location, DeckSlotLocation):
+        definition_bounding_box = _Point2D(
+            parent_entity["boundingBox"]["xDimension"],  # type: ignore[index]
+            parent_entity["boundingBox"]["yDimension"],  # type: ignore[index]
+        )
 
         back_left = _Point2D(0, 0)
         front_right = _Point2D(
@@ -299,16 +327,14 @@ def _get_parent_entity_info(
             y=definition_bounding_box.y * -1,
         )
         contact_plane = _BoundingBox2D(back_left=back_left, front_right=front_right)
-
-        if hasattr(parent_entity, "locating_features_as_parent"):
-            locating_features_as_parent = parent_entity.locating_features_as_parent  # type: ignore[union-attr]
-        else:
-            locating_features_as_parent = parent_entity["locatingFeaturesAsParent"]  # type: ignore[index]
+        locating_features_as_parent = parent_entity["locatingFeaturesAsParent"]  # type: ignore[index]
 
         return _ParentEntityInfo(
             child_contact_plane=contact_plane,
             locating_features_as_parent=locating_features_as_parent,
         )
+    else:
+        raise TypeError(f"Unsupported labware location type: {labware_location}")
 
 
 def _get_parent_origin_to_bottom_center(

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -477,7 +477,7 @@ class GeometryView:
                 is_topmost_labware=is_topmost_labware,
                 labware_location=labware_location,
             )
-        elif isinstance(labware_location, (DeckSlotLocation, AddressableAreaLocation)):
+        elif isinstance(labware_location, DeckSlotLocation):
             return get_parent_placement_origin_to_lw_origin(
                 child_labware=labware_definition,
                 parent_entity=parent_entity,  # type: ignore[arg-type]
@@ -486,6 +486,16 @@ class GeometryView:
                 is_topmost_labware=is_topmost_labware,
                 labware_location=labware_location,
             )
+        elif isinstance(labware_location, AddressableAreaLocation):
+            return get_parent_placement_origin_to_lw_origin(
+                child_labware=labware_definition,
+                parent_entity=parent_entity,  # type: ignore[arg-type]
+                module_parent_to_child_offset=None,
+                deck_definition=self._addressable_areas.deck_definition,
+                is_topmost_labware=is_topmost_labware,
+                labware_location=labware_location,
+            )
+
         else:
             raise ValueError(f"Invalid labware location: {labware_location}")
 

--- a/api/src/opentrons/protocol_engine/types/__init__.py
+++ b/api/src/opentrons/protocol_engine/types/__init__.py
@@ -43,7 +43,6 @@ from .deck_configuration import (
     AddressableArea,
     DeckConfigurationType,
     DeckType,
-    DeckLocationDefinition,
 )
 from .liquid_class import LiquidClassRecord, LiquidClassRecordWithId
 from .module import (
@@ -184,7 +183,6 @@ __all__ = [
     "AddressableArea",
     "DeckConfigurationType",
     "DeckType",
-    "DeckLocationDefinition",
     # Liquid classes
     "LiquidClassRecord",
     "LiquidClassRecordWithId",

--- a/api/src/opentrons/protocol_engine/types/deck_configuration.py
+++ b/api/src/opentrons/protocol_engine/types/deck_configuration.py
@@ -1,13 +1,12 @@
 """Protocol engine types to do with deck configuration."""
 
 from dataclasses import dataclass
-from typing import FrozenSet, List, Tuple, Optional, Union
+from typing import FrozenSet, List, Tuple, Optional
 from enum import Enum
 
 from opentrons.types import DeckSlotName
 
 from opentrons_shared_data.module.types import ModuleType as SharedDataModuleType
-from opentrons_shared_data.deck.types import SlotDefV3
 from opentrons_shared_data.labware.types import LocatingFeatures
 
 
@@ -74,7 +73,3 @@ class DeckType(str, Enum):
     OT2_STANDARD = "ot2_standard"
     OT2_SHORT_TRASH = "ot2_short_trash"
     OT3_STANDARD = "ot3_standard"
-
-
-DeckLocationDefinition = Union[AddressableArea, SlotDefV3]
-"""Union of locations that contain deck definition information."""

--- a/api/src/opentrons/protocol_engine/types/labware.py
+++ b/api/src/opentrons/protocol_engine/types/labware.py
@@ -11,6 +11,8 @@ from pydantic import BaseModel, Field
 from opentrons_shared_data.labware.labware_definition import (
     LabwareDefinition,
 )
+from opentrons_shared_data.deck.types import SlotDefV3
+from .deck_configuration import AddressableArea
 
 from .location import LabwareLocation
 from .labware_offset_location import (
@@ -20,7 +22,6 @@ from .labware_offset_location import (
 from .labware_offset_vector import LabwareOffsetVector
 from .util import Vec3f
 from .module import ModuleDefinition
-from .deck_configuration import DeckLocationDefinition
 
 
 class OverlapOffset(Vec3f):
@@ -118,6 +119,6 @@ class LoadedLabware(BaseModel):
 
 
 LabwareParentDefinition = Union[
-    DeckLocationDefinition, ModuleDefinition, LabwareDefinition
+    SlotDefV3, AddressableArea, ModuleDefinition, LabwareDefinition
 ]
 """Information pertaining to a labware's parent (deck slot, module, or another labware) location."""

--- a/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
@@ -406,7 +406,7 @@ LABWARE_V3_SPECS: List[LabwareV3Spec] = [
         module_parent_to_child_offset=None,
         is_topmost_labware=True,
         labware_location=AddressableAreaLocation(addressableAreaName="test_area"),
-        expected_total_offset=Point(x=-50, y=-350, z=-300),
+        expected_total_offset=Point(x=-50, y=1150, z=-300),
     ),
     LabwareV3Spec(
         child_definition=_LABWARE_DEF_V3_WITH_OFFSET,
@@ -414,7 +414,7 @@ LABWARE_V3_SPECS: List[LabwareV3Spec] = [
         module_parent_to_child_offset=None,
         is_topmost_labware=True,
         labware_location=AddressableAreaLocation(addressableAreaName="test_area"),
-        expected_total_offset=Point(x=75, y=-400, z=-25),
+        expected_total_offset=Point(x=75, y=1100, z=-25),
     ),
     LabwareV3Spec(
         child_definition=_LABWARE_DEF_V3,
@@ -422,7 +422,7 @@ LABWARE_V3_SPECS: List[LabwareV3Spec] = [
         module_parent_to_child_offset=LabwareOffsetVector(x=100, y=200, z=50),
         is_topmost_labware=True,
         labware_location=ModuleLocation(moduleId="module-1"),
-        expected_total_offset=Point(x=50, y=250, z=-250),
+        expected_total_offset=Point(x=50, y=950, z=-250),
     ),
     LabwareV3Spec(
         child_definition=_LABWARE_DEF_V3_CHILD_WITH_STACKING,

--- a/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
@@ -23,6 +23,7 @@ from opentrons_shared_data.labware.types import LocatingFeatures
 from opentrons.types import Point
 from opentrons.protocol_engine.state._labware_origin_math import (
     get_parent_placement_origin_to_lw_origin,
+    _LabwareOriginLocation,
 )
 from opentrons.protocol_engine.types import (
     ModuleModel,
@@ -38,7 +39,6 @@ from opentrons.protocol_engine.types import (
     OnLabwareLocation,
 )
 from opentrons.types import DeckSlotName
-
 
 _LABWARE_DEF_V2 = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
     namespace="test",
@@ -85,6 +85,66 @@ _LABWARE_DEF_V3 = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
             frontRight=Vector2D(x=1100, y=-800),
         ),
     ),
+    stackingOffsetWithLabware={
+        "default": Vector3D(x=0, y=0, z=0),
+    },
+    locatingFeaturesAsParent=LocatingFeatures(),
+)
+
+_LABWARE_DEF_V3_WITH_OFFSET = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+    namespace="test",
+    version=1,
+    schemaVersion=3,
+    extents=Extents(
+        total=AxisAlignedBoundingBox3D(
+            backLeftBottom=Vector3D(x=50, y=100, z=25),
+            frontRightTop=Vector3D(x=850, y=-700, z=525),
+        ),
+        footprint=AxisAlignedBoundingBox2D(
+            backLeft=Vector2D(x=50, y=100),
+            frontRight=Vector2D(x=850, y=-700),
+        ),
+    ),
+    locatingFeaturesAsParent=LocatingFeatures(),
+)
+
+_LABWARE_DEF_V3_PARENT = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+    namespace="test",
+    version=1,
+    schemaVersion=3,
+    parameters=type("MockParams", (), {"loadName": "parent-labware"})(),
+    extents=Extents(
+        total=AxisAlignedBoundingBox3D(
+            backLeftBottom=Vector3D(x=0, y=0, z=0),
+            frontRightTop=Vector3D(x=2000, y=-1500, z=800),
+        ),
+        footprint=AxisAlignedBoundingBox2D(
+            backLeft=Vector2D(x=0, y=0),
+            frontRight=Vector2D(x=2000, y=-1500),
+        ),
+    ),
+    locatingFeaturesAsParent=LocatingFeatures(),
+)
+
+_LABWARE_DEF_V3_CHILD_WITH_STACKING = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+    namespace="test",
+    version=1,
+    schemaVersion=3,
+    extents=Extents(
+        total=AxisAlignedBoundingBox3D(
+            backLeftBottom=Vector3D(x=25, y=50, z=10),
+            frontRightTop=Vector3D(x=525, y=-450, z=310),
+        ),
+        footprint=AxisAlignedBoundingBox2D(
+            backLeft=Vector2D(x=25, y=50),
+            frontRight=Vector2D(x=525, y=-450),
+        ),
+    ),
+    stackingOffsetWithLabware={
+        "parent-labware": Vector3D(x=100, y=150, z=75),
+        "default": Vector3D(x=200, y=250, z=125),
+    },
+    locatingFeaturesAsParent=LocatingFeatures(),
 )
 
 _LABWARE_DEF_V2_2 = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
@@ -116,6 +176,7 @@ _MODULE_DEF_TEMP_V2 = ModuleDefinition.model_construct(  # type: ignore[call-arg
         labwareInterfaceXDimension=1000,
         labwareInterfaceYDimension=700,
     ),
+    locatingFeaturesAsParent=LocatingFeatures(),
 )
 
 _MODULE_DEF_TC_V1 = ModuleDefinition.model_construct(  # type: ignore[call-arg]
@@ -124,7 +185,10 @@ _MODULE_DEF_TC_V1 = ModuleDefinition.model_construct(  # type: ignore[call-arg]
     dimensions=ModuleDimensions(
         bareOverallHeight=800,
         overLabwareHeight=900,
+        labwareInterfaceXDimension=1200,
+        labwareInterfaceYDimension=900,
     ),
+    locatingFeaturesAsParent=LocatingFeatures(),
 )
 
 _MODULE_DEF_TC_V2 = ModuleDefinition.model_construct(  # type: ignore[call-arg]
@@ -133,7 +197,10 @@ _MODULE_DEF_TC_V2 = ModuleDefinition.model_construct(  # type: ignore[call-arg]
     dimensions=ModuleDimensions(
         bareOverallHeight=1000,
         overLabwareHeight=1100,
+        labwareInterfaceXDimension=1400,
+        labwareInterfaceYDimension=1100,
     ),
+    locatingFeaturesAsParent=LocatingFeatures(),
 )
 
 _ADDRESSABLE_AREA = AddressableArea(
@@ -177,6 +244,17 @@ class AddressableAreaSpec(NamedTuple):
     addressable_area: AddressableArea
     is_topmost_labware: bool
     labware_location: AddressableAreaLocation
+    expected_total_offset: Point
+
+
+class LabwareV3Spec(NamedTuple):
+    """Spec data to test LabwareDefinition3 behavior through get_parent_placement_origin_to_lw_origin."""
+
+    child_definition: LabwareDefinition3
+    parent_entity: object
+    module_parent_to_child_offset: LabwareOffsetVector | None
+    is_topmost_labware: bool
+    labware_location: _LabwareOriginLocation
     expected_total_offset: Point
 
 
@@ -321,6 +399,41 @@ ADDRESSABLE_AREA_SPECS: List[AddressableAreaSpec] = [
     ),
 ]
 
+LABWARE_V3_SPECS: List[LabwareV3Spec] = [
+    LabwareV3Spec(
+        child_definition=_LABWARE_DEF_V3,
+        parent_entity=_ADDRESSABLE_AREA,
+        module_parent_to_child_offset=None,
+        is_topmost_labware=True,
+        labware_location=AddressableAreaLocation(addressableAreaName="test_area"),
+        expected_total_offset=Point(x=-50, y=-350, z=-300),
+    ),
+    LabwareV3Spec(
+        child_definition=_LABWARE_DEF_V3_WITH_OFFSET,
+        parent_entity=_ADDRESSABLE_AREA,
+        module_parent_to_child_offset=None,
+        is_topmost_labware=True,
+        labware_location=AddressableAreaLocation(addressableAreaName="test_area"),
+        expected_total_offset=Point(x=75, y=-400, z=-25),
+    ),
+    LabwareV3Spec(
+        child_definition=_LABWARE_DEF_V3,
+        parent_entity=_MODULE_DEF_TEMP_V2,
+        module_parent_to_child_offset=LabwareOffsetVector(x=100, y=200, z=50),
+        is_topmost_labware=True,
+        labware_location=ModuleLocation(moduleId="module-1"),
+        expected_total_offset=Point(x=50, y=250, z=-250),
+    ),
+    LabwareV3Spec(
+        child_definition=_LABWARE_DEF_V3_CHILD_WITH_STACKING,
+        parent_entity=_LABWARE_DEF_V3_PARENT,
+        module_parent_to_child_offset=None,
+        is_topmost_labware=True,
+        labware_location=OnLabwareLocation(labwareId="parent-labware"),
+        expected_total_offset=Point(x=837.5, y=-375, z=715),
+    ),
+]
+
 
 @pytest.mark.parametrize(
     argnames=ModuleOverlapSpec._fields,
@@ -396,16 +509,66 @@ def test_get_parent_placement_origin_to_lw_origin_with_addressable_area(
     assert result == expected_total_offset
 
 
-def test_get_parent_placement_origin_to_lw_origin_v3_definition() -> None:
-    """It should handle LabwareDefinition3 correctly."""
-    result = get_parent_placement_origin_to_lw_origin(
-        child_labware=_LABWARE_DEF_V3,
-        parent_entity=_ADDRESSABLE_AREA,
-        module_parent_to_child_offset=None,
+@pytest.mark.parametrize(
+    argnames=LabwareV3Spec._fields,
+    argvalues=LABWARE_V3_SPECS,
+)
+def test_get_parent_placement_origin_to_lw_origin_bottom_center_lf(
+    child_definition: LabwareDefinition3,
+    parent_entity: object,
+    module_parent_to_child_offset: LabwareOffsetVector | None,
+    is_topmost_labware: bool,
+    labware_location: _LabwareOriginLocation,
+    expected_total_offset: Point,
+) -> None:
+    """It should calculate the correct offset for LabwareDefinition3 using bottom-center locating feature."""
+    result = get_parent_placement_origin_to_lw_origin(  # type: ignore[call-overload]
+        child_labware=child_definition,
+        parent_entity=parent_entity,
+        module_parent_to_child_offset=module_parent_to_child_offset,
         deck_definition=load_deck(STANDARD_OT3_DECK, 5),
-        is_topmost_labware=True,
-        labware_location=AddressableAreaLocation(addressableAreaName="test_area"),
+        is_topmost_labware=is_topmost_labware,
+        labware_location=labware_location,
     )
 
-    expected_offset = Point(x=-100, y=800, z=-300)
-    assert result == expected_offset
+    assert result == expected_total_offset
+
+
+def test_labware_v3_on_module_with_none_dimensions() -> None:
+    """It should handle modules with None labware interface dimensions by raising an error."""
+    module_with_none_dims = ModuleDefinition.model_construct(  # type: ignore[call-arg]
+        schemaVersion=2,
+        model=ModuleModel.TEMPERATURE_MODULE_V1,
+        dimensions=ModuleDimensions(
+            bareOverallHeight=100,
+            overLabwareHeight=150,
+            labwareInterfaceXDimension=None,
+            labwareInterfaceYDimension=None,
+        ),
+        locatingFeaturesAsParent=LocatingFeatures(),
+    )
+
+    with pytest.raises(
+        ValueError, match="Bottom center locating feature is not supported"
+    ):
+        get_parent_placement_origin_to_lw_origin(
+            child_labware=_LABWARE_DEF_V3,
+            parent_entity=module_with_none_dims,
+            module_parent_to_child_offset=LabwareOffsetVector(x=0, y=0, z=0),
+            deck_definition=load_deck(STANDARD_OT3_DECK, 5),
+            is_topmost_labware=True,
+            labware_location=ModuleLocation(moduleId="module-1"),
+        )
+
+
+def test_labware_v2_on_labware_v3_not_implemented() -> None:
+    """It should raise NotImplementedError for LabwareDefinition2 as parent entity to a LabwareDefinition3 child labware."""
+    with pytest.raises(NotImplementedError):
+        get_parent_placement_origin_to_lw_origin(
+            child_labware=_LABWARE_DEF_V3,
+            parent_entity=_LABWARE_DEF_V2_2,
+            module_parent_to_child_offset=None,
+            deck_definition=load_deck(STANDARD_OT3_DECK, 5),
+            is_topmost_labware=True,
+            labware_location=OnLabwareLocation(labwareId="parent-labware"),
+        )

--- a/api/tests/opentrons/protocol_engine/state/test_stackup_testing/stackup_coordinates_snapshot.json
+++ b/api/tests/opentrons/protocol_engine/state/test_stackup_testing/stackup_coordinates_snapshot.json
@@ -1314,7 +1314,7 @@
   "Flex,None,None,schema3test_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       342.5,
-      -11.5,
+      74.5,
       16.0
     ],
     "spec": {
@@ -1330,7 +1330,7 @@
   "Flex,None,None,schema3test_flex_96_tiprack_200ul": {
     "coordinates": [
       342.505,
-      -11.495,
+      74.505,
       99.0
     ],
     "spec": {
@@ -2038,7 +2038,7 @@
   "Flex,absorbanceReaderV1,None,schema3test_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       344.38,
-      -11.24,
+      74.24,
       16.65
     ],
     "spec": {
@@ -3366,7 +3366,7 @@
   "Flex,flexStackerModuleV1,None,schema3test_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       503.5,
-      -11.5,
+      74.5,
       47.0
     ],
     "spec": {
@@ -3382,7 +3382,7 @@
   "Flex,flexStackerModuleV1,None,schema3test_flex_96_tiprack_200ul": {
     "coordinates": [
       503.505,
-      -11.495,
+      74.505,
       130.0
     ],
     "spec": {
@@ -5322,7 +5322,7 @@
   "Flex,heaterShakerModuleV1,None,schema3test_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       342.5,
-      -11.5,
+      74.5,
       34.95
     ],
     "spec": {
@@ -5338,7 +5338,7 @@
   "Flex,heaterShakerModuleV1,None,schema3test_flex_96_tiprack_200ul": {
     "coordinates": [
       342.505,
-      -11.495,
+      74.505,
       117.95
     ],
     "spec": {
@@ -7278,7 +7278,7 @@
   "Flex,magneticBlockV1,None,schema3test_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       342.375,
-      -11.375,
+      74.375,
       50.46
     ],
     "spec": {
@@ -7294,7 +7294,7 @@
   "Flex,magneticBlockV1,None,schema3test_flex_96_tiprack_200ul": {
     "coordinates": [
       342.38,
-      -11.37,
+      74.38,
       137.0
     ],
     "spec": {
@@ -9234,7 +9234,7 @@
   "Flex,temperatureModuleV2,None,schema3test_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       342.5,
-      -11.5,
+      74.5,
       25.0
     ],
     "spec": {
@@ -9250,7 +9250,7 @@
   "Flex,temperatureModuleV2,None,schema3test_flex_96_tiprack_200ul": {
     "coordinates": [
       342.505,
-      -11.495,
+      74.505,
       108.0
     ],
     "spec": {
@@ -11190,7 +11190,7 @@
   "Flex,thermocyclerModuleV2,None,schema3test_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       -5.625,
-      270.72,
+      356.2,
       16.26
     ],
     "spec": {
@@ -11206,7 +11206,7 @@
   "Flex,thermocyclerModuleV2,None,schema3test_flex_96_tiprack_200ul": {
     "coordinates": [
       -5.62,
-      270.725,
+      356.205,
       109.96
     ],
     "spec": {
@@ -13146,7 +13146,7 @@
   "OT-2,None,None,schema3test_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       279.5,
-      -11.5,
+      74.5,
       16.0
     ],
     "spec": {
@@ -13162,7 +13162,7 @@
   "OT-2,None,None,schema3test_flex_96_tiprack_200ul": {
     "coordinates": [
       279.505,
-      -11.495,
+      74.505,
       99.0
     ],
     "spec": {
@@ -14646,7 +14646,7 @@
   "OT-2,heaterShakerModuleV1,None,schema3test_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       279.625,
-      -12.625,
+      73.375,
       84.275
     ],
     "spec": {
@@ -14662,7 +14662,7 @@
   "OT-2,heaterShakerModuleV1,None,schema3test_flex_96_tiprack_200ul": {
     "coordinates": [
       279.63,
-      -12.62,
+      73.38,
       167.275
     ],
     "spec": {

--- a/api/tests/opentrons/protocol_engine/state/test_stackup_testing/stackup_coordinates_snapshot.json
+++ b/api/tests/opentrons/protocol_engine/state/test_stackup_testing/stackup_coordinates_snapshot.json
@@ -1311,6 +1311,38 @@
       "robot_type": "Flex"
     }
   },
+  "Flex,None,None,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      342.5,
+      -11.5,
+      16.0
+    ],
+    "spec": {
+      "adapter_load_info": null,
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
+      ],
+      "module_load_name": null,
+      "robot_type": "Flex"
+    }
+  },
+  "Flex,None,None,schema3test_flex_96_tiprack_200ul": {
+    "coordinates": [
+      342.505,
+      -11.495,
+      99.0
+    ],
+    "spec": {
+      "adapter_load_info": null,
+      "labware_load_info": [
+        "schema3test_flex_96_tiprack_200ul",
+        999
+      ],
+      "module_load_name": null,
+      "robot_type": "Flex"
+    }
+  },
   "Flex,None,None,thermoscientificnunc_96_wellplate_1300ul": {
     "coordinates": [
       342.4,
@@ -1998,6 +2030,22 @@
       "labware_load_info": [
         "opentrons_96_wellplate_200ul_pcr_full_skirt",
         3
+      ],
+      "module_load_name": "absorbanceReaderV1",
+      "robot_type": "Flex"
+    }
+  },
+  "Flex,absorbanceReaderV1,None,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      344.38,
+      -11.24,
+      16.65
+    ],
+    "spec": {
+      "adapter_load_info": null,
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
       ],
       "module_load_name": "absorbanceReaderV1",
       "robot_type": "Flex"
@@ -3310,6 +3358,38 @@
       "labware_load_info": [
         "opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat",
         1
+      ],
+      "module_load_name": "flexStackerModuleV1",
+      "robot_type": "Flex"
+    }
+  },
+  "Flex,flexStackerModuleV1,None,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      503.5,
+      -11.5,
+      47.0
+    ],
+    "spec": {
+      "adapter_load_info": null,
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
+      ],
+      "module_load_name": "flexStackerModuleV1",
+      "robot_type": "Flex"
+    }
+  },
+  "Flex,flexStackerModuleV1,None,schema3test_flex_96_tiprack_200ul": {
+    "coordinates": [
+      503.505,
+      -11.495,
+      130.0
+    ],
+    "spec": {
+      "adapter_load_info": null,
+      "labware_load_info": [
+        "schema3test_flex_96_tiprack_200ul",
+        999
       ],
       "module_load_name": "flexStackerModuleV1",
       "robot_type": "Flex"
@@ -5239,6 +5319,38 @@
       "robot_type": "Flex"
     }
   },
+  "Flex,heaterShakerModuleV1,None,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      342.5,
+      -11.5,
+      34.95
+    ],
+    "spec": {
+      "adapter_load_info": null,
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
+      ],
+      "module_load_name": "heaterShakerModuleV1",
+      "robot_type": "Flex"
+    }
+  },
+  "Flex,heaterShakerModuleV1,None,schema3test_flex_96_tiprack_200ul": {
+    "coordinates": [
+      342.505,
+      -11.495,
+      117.95
+    ],
+    "spec": {
+      "adapter_load_info": null,
+      "labware_load_info": [
+        "schema3test_flex_96_tiprack_200ul",
+        999
+      ],
+      "module_load_name": "heaterShakerModuleV1",
+      "robot_type": "Flex"
+    }
+  },
   "Flex,heaterShakerModuleV1,None,thermoscientificnunc_96_wellplate_1300ul": {
     "coordinates": [
       342.4,
@@ -7158,6 +7270,38 @@
       "labware_load_info": [
         "opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat",
         1
+      ],
+      "module_load_name": "magneticBlockV1",
+      "robot_type": "Flex"
+    }
+  },
+  "Flex,magneticBlockV1,None,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      342.375,
+      -11.375,
+      50.46
+    ],
+    "spec": {
+      "adapter_load_info": null,
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
+      ],
+      "module_load_name": "magneticBlockV1",
+      "robot_type": "Flex"
+    }
+  },
+  "Flex,magneticBlockV1,None,schema3test_flex_96_tiprack_200ul": {
+    "coordinates": [
+      342.38,
+      -11.37,
+      137.0
+    ],
+    "spec": {
+      "adapter_load_info": null,
+      "labware_load_info": [
+        "schema3test_flex_96_tiprack_200ul",
+        999
       ],
       "module_load_name": "magneticBlockV1",
       "robot_type": "Flex"
@@ -9087,6 +9231,38 @@
       "robot_type": "Flex"
     }
   },
+  "Flex,temperatureModuleV2,None,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      342.5,
+      -11.5,
+      25.0
+    ],
+    "spec": {
+      "adapter_load_info": null,
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
+      ],
+      "module_load_name": "temperatureModuleV2",
+      "robot_type": "Flex"
+    }
+  },
+  "Flex,temperatureModuleV2,None,schema3test_flex_96_tiprack_200ul": {
+    "coordinates": [
+      342.505,
+      -11.495,
+      108.0
+    ],
+    "spec": {
+      "adapter_load_info": null,
+      "labware_load_info": [
+        "schema3test_flex_96_tiprack_200ul",
+        999
+      ],
+      "module_load_name": "temperatureModuleV2",
+      "robot_type": "Flex"
+    }
+  },
   "Flex,temperatureModuleV2,None,thermoscientificnunc_96_wellplate_1300ul": {
     "coordinates": [
       342.4,
@@ -11006,6 +11182,38 @@
       "labware_load_info": [
         "opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat",
         1
+      ],
+      "module_load_name": "thermocyclerModuleV2",
+      "robot_type": "Flex"
+    }
+  },
+  "Flex,thermocyclerModuleV2,None,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      -5.625,
+      270.72,
+      16.26
+    ],
+    "spec": {
+      "adapter_load_info": null,
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
+      ],
+      "module_load_name": "thermocyclerModuleV2",
+      "robot_type": "Flex"
+    }
+  },
+  "Flex,thermocyclerModuleV2,None,schema3test_flex_96_tiprack_200ul": {
+    "coordinates": [
+      -5.62,
+      270.725,
+      109.96
+    ],
+    "spec": {
+      "adapter_load_info": null,
+      "labware_load_info": [
+        "schema3test_flex_96_tiprack_200ul",
+        999
       ],
       "module_load_name": "thermocyclerModuleV2",
       "robot_type": "Flex"
@@ -12935,6 +13143,38 @@
       "robot_type": "OT-2"
     }
   },
+  "OT-2,None,None,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      279.5,
+      -11.5,
+      16.0
+    ],
+    "spec": {
+      "adapter_load_info": null,
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
+      ],
+      "module_load_name": null,
+      "robot_type": "OT-2"
+    }
+  },
+  "OT-2,None,None,schema3test_flex_96_tiprack_200ul": {
+    "coordinates": [
+      279.505,
+      -11.495,
+      99.0
+    ],
+    "spec": {
+      "adapter_load_info": null,
+      "labware_load_info": [
+        "schema3test_flex_96_tiprack_200ul",
+        999
+      ],
+      "module_load_name": null,
+      "robot_type": "OT-2"
+    }
+  },
   "OT-2,None,None,thermoscientificnunc_96_wellplate_1300ul": {
     "coordinates": [
       279.4,
@@ -14398,6 +14638,38 @@
       "labware_load_info": [
         "opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat",
         1
+      ],
+      "module_load_name": "heaterShakerModuleV1",
+      "robot_type": "OT-2"
+    }
+  },
+  "OT-2,heaterShakerModuleV1,None,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      279.625,
+      -12.625,
+      84.275
+    ],
+    "spec": {
+      "adapter_load_info": null,
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
+      ],
+      "module_load_name": "heaterShakerModuleV1",
+      "robot_type": "OT-2"
+    }
+  },
+  "OT-2,heaterShakerModuleV1,None,schema3test_flex_96_tiprack_200ul": {
+    "coordinates": [
+      279.63,
+      -12.62,
+      167.275
+    ],
+    "spec": {
+      "adapter_load_info": null,
+      "labware_load_info": [
+        "schema3test_flex_96_tiprack_200ul",
+        999
       ],
       "module_load_name": "heaterShakerModuleV1",
       "robot_type": "OT-2"

--- a/api/tests/opentrons/protocol_engine/state/test_stackup_testing/test_stackup_testing.py
+++ b/api/tests/opentrons/protocol_engine/state/test_stackup_testing/test_stackup_testing.py
@@ -38,6 +38,9 @@ ROBOT_TYPES = ["Flex", "OT-2"]
 
 # Labware URI, version
 TEST_LATEST_LABWARE: List[Tuple[str, int]] = [
+    ("schema3test_flex_96_tiprack_200ul", 999),
+    ("schema3test_96_wellplate_200ul_pcr_full_skirt", 999),
+    ("schema3test_96_well_aluminum_block", 999),
     ("agilent_1_reservoir_290ml", 3),
     ("appliedbiosystemsmicroamp_384_wellplate_40ul", 2),
     ("armadillo_96_wellplate_200ul_pcr_full_skirt", 3),


### PR DESCRIPTION
Works toward [EXEC-77](https://opentrons.atlassian.net/browse/EXEC-77)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Adds support for the bottom-center locating feature, which will typically act as the "default" locating feature if no specific locating feature is defined. See the [confluence doc](https://opentrons.atlassian.net/wiki/spaces/PER/pages/5044142110/Proposal+Reducing+Labware+Offset+Error+Locating+Features#center) for more details. Note that modules without `labwareInterfaceXDimension` or `labwareInterfaceYDimension` defined cannot support bottom-center.

While `_get_parent_origin_to_locating_feature` and `_get_locating_feature_to_lw_origin` are empty encapsulations currently, they will serve in future LF PRs as the coordinating utility for selecting the appropriate LF calculation helper.

Most of this PR serves to flesh out some of structure for LFs. After fiddling around with overloads, generics, separate functions based on types, etc., I've decided to create a `_get_parent_entity_info` helper that serves as an adapter to standardize the `parent_entity` info that other internals actually care about, which will cut down on the amount of code exponentially down the road. That being said, I'm open to feedback on this approach (and everything else, of course!). 

I've updated the stacking testing test and snapshot as well with some of the dummy schema 3 labware. These snapshots don't serve any real purpose right now, but will help act as a "baseline" when we add additional LFs, so we can more readily track how much offsets change as more LFs are added, and whether we are on the right track (or not). Comparing the schema3 labware to their opentrons equivalents, it's possible to verify the math gets us to where we expect to be on the deck.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Compared snapshots of the schema 3 labware stackups to their opentrons namespace equivalents, verifying coordinates are different within reason.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Added the bottom-center locating feature.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
- Are we ok with the overall structure? Most of this PR is just me fighting Python's typing system.
- Does the `_get_parent_entity_info` adapter seem reasonable?
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
- none with the assumption that there is no real labware that uses lwdefsv3 yet.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-77]: https://opentrons.atlassian.net/browse/EXEC-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ