### PR TITLE
refactor(app, api, shared-data, robot-server): do not capture images on errors during QT runs

### DIFF
--- a/api/src/opentrons/protocol_engine/resources/file_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/file_provider.py
@@ -10,6 +10,7 @@ from opentrons_shared_data.data_files import (
     MimeType,
     RunFileMetadata,
 )
+from opentrons_shared_data.protocol.constants import ProtocolKind
 
 SPECIAL_CHARACTERS = {
     "#",
@@ -205,8 +206,11 @@ class FileProvider:
         Raises:
             Note that the callback may raise a StorageLimitReachedError.
         """
-        if self._data_files_write_file_cb is not None:
-            assert self._run_metadata is not None
+        if (
+            self._data_files_write_file_cb is not None
+            and self._run_metadata is not None
+            and self._run_metadata.protocol_kind != ProtocolKind.QUICK_TRANSFER
+        ):
             file_data = FileData.build(
                 data=data,
                 mime_type=mime_type,
@@ -215,7 +219,7 @@ class FileProvider:
             )
 
             return await self._data_files_write_file_cb(file_data)
-        # If we are in an analysis or simulation state, return an empty `DataFileInfo`
+        # If we are in an analysis, a QT run, or simulation state, return an empty `DataFileInfo`.
         return DataFileInfo(
             id="",
             name="",

--- a/api/src/opentrons/protocol_engine/resources/file_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/file_provider.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from opentrons_shared_data.data_files import (
     DataFileInfo,
     MimeType,
-    RunFileNameMetadata,
+    RunFileMetadata,
 )
 
 SPECIAL_CHARACTERS = {
@@ -69,14 +69,14 @@ class FileData:
 
     data: bytes
     mime_type: MimeType
-    run_metadata: RunFileNameMetadata
+    run_metadata: RunFileMetadata
     command_metadata: CommandFileNameMetadata
 
     @staticmethod
     def build(
         data: bytes,
         mime_type: MimeType,
-        run_metadata: RunFileNameMetadata,
+        run_metadata: RunFileMetadata,
         command_metadata: CommandFileNameMetadata,
     ) -> "FileData":
         """Build a generic file data class."""
@@ -190,7 +190,7 @@ class FileProvider:
             data_files_filecount: Callback to check the amount of data files already present in the data files directory.
         """
         self._data_files_write_file_cb = data_files_write_file_cb
-        self._run_metadata: RunFileNameMetadata | None = None
+        self._run_metadata: RunFileMetadata | None = None
 
     async def write_file(
         self,
@@ -227,7 +227,7 @@ class FileProvider:
             mime_type=mime_type,
         )
 
-    def set_run_metadata(self, metadata: RunFileNameMetadata) -> None:
+    def set_run_metadata(self, metadata: RunFileMetadata) -> None:
         """Sets metadata specific to the run."""
         self._run_metadata = metadata
 

--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -98,6 +98,7 @@
   "enable_camera_to_proceed": "Enable the camera to proceed",
   "enabled": "Enabled",
   "error_confirming_camera": "Error confirming camera preferences",
+  "no_camera_during_quick_transfer": "No images are captured during Quick Transfer",
   "example": "Example",
   "exit_to_deck_configuration": "Exit to deck configuration",
   "extension_mount": "extension mount",

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -418,6 +418,7 @@ export function ProtocolRunSetup({
             )
             setExpandedStepKey(null)
           }}
+          protocolRecord={protocolRecord ?? null}
         />
       ),
       description: t(`${CAMERA_SETUP_STEP_KEY}_description`),

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupCamera/__tests__/SetupCamera.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupCamera/__tests__/SetupCamera.test.tsx
@@ -51,6 +51,7 @@ describe('SetupCamera', () => {
       cameraConfirmed: false,
       confirmCameraSettings: vi.fn(),
       robotName: 'test-robot',
+      protocolRecord: { data: { protocolKind: 'standard' } } as any,
     }
     vi.mocked(SetupRunCameraControls).mockReturnValue(
       <div>MOCK_SETUP_RUN_CAMERA_CONTROLS</div>

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupCamera/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupCamera/index.tsx
@@ -27,6 +27,7 @@ import { useRobotStorageInfo } from '/app/resources/health/useIsImageStorageLow'
 
 import styles from './setupcamera.module.css'
 
+import type { Protocol } from '@opentrons/api-client'
 import type { UseCameraUsageSettingsResult } from '/app/local-resources/images/hooks/useCameraUsageSettings'
 import type { State } from '/app/redux/types'
 
@@ -38,6 +39,7 @@ export interface SetupCameraProps {
   isCameraRequired: boolean
   cameraConfirmed: boolean
   confirmCameraSettings: () => void
+  protocolRecord: Protocol | null
 }
 
 export function SetupCamera({
@@ -46,6 +48,7 @@ export function SetupCamera({
   isCameraRequired,
   cameraConfirmed,
   confirmCameraSettings,
+  protocolRecord,
 }: SetupCameraProps): JSX.Element {
   const { t } = useTranslation('protocol_setup')
   const isCameraSettingsEnabled = useFeatureFlag('camera')
@@ -55,19 +58,28 @@ export function SetupCamera({
   const { addCameraSettingsToRun } = useAddCameraSettingsToRunMutation()
 
   const [isConfirmPending, setIsConfirmPending] = useState(false)
+  const isQuickTransfer = protocolRecord?.data.protocolKind === 'quick-transfer'
 
   const {
     liveStreamEnabled,
     enabled: cameraEnabled,
     recoveryEnabled,
   } = useSelector((state: State) => getCameraUsageState(state, runId))
+  const recoveryEnabledByRunType = isQuickTransfer ? false : recoveryEnabled
 
   const toggleCameraEnabled = (): void => {
     dispatch(updateCameraEnablement(runId, !cameraEnabled))
   }
 
   const toggleRecoveryEnabled = (): void => {
-    dispatch(updateCameraRecoveryEnablement(runId, !recoveryEnabled))
+    if (isQuickTransfer) {
+      makeSnackbar(
+        t('no_camera_during_quick_transfer') as string,
+        TOAST_DURATION_MS
+      )
+    } else {
+      dispatch(updateCameraRecoveryEnablement(runId, !recoveryEnabled))
+    }
   }
 
   const toggleLiveStreamEnabled = (): void => {
@@ -83,7 +95,7 @@ export function SetupCamera({
         settings: {
           cameraEnabled,
           liveStreamEnabled,
-          errorRecoveryCameraEnabled: recoveryEnabled,
+          errorRecoveryCameraEnabled: recoveryEnabledByRunType,
         },
       },
       {
@@ -123,7 +135,7 @@ export function SetupCamera({
           <SetupRunCameraUsage
             robotName={robotName}
             liveStreamEnabled={liveStreamEnabled}
-            recoveryEnabled={recoveryEnabled}
+            recoveryEnabled={recoveryEnabledByRunType}
             toggleRecoveryEnabled={toggleRecoveryEnabled}
             toggleLiveStreamEnabled={toggleLiveStreamEnabled}
             cameraConfirmed={cameraConfirmed}

--- a/app/src/organisms/ODD/CameraSettings/index.tsx
+++ b/app/src/organisms/ODD/CameraSettings/index.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { InlineNotification, StyledText } from '@opentrons/components'
 
+import { useToaster } from '/app/organisms/ToasterOven'
 import {
   SOURCE_ROBOT_SETTINGS,
   useCameraAnalytics,
@@ -17,7 +18,10 @@ import styles from './preferences.module.css'
 import { UsagePreferencesSettings } from './UsagePreferencesSettings'
 
 import type { ReactNode } from 'react'
+import type { Protocol } from '@opentrons/api-client'
 import type { RobotStorageInfo } from '/app/resources/health/useIsImageStorageLow'
+
+const TOAST_DURATION_MS = 3000
 
 export interface CameraSettingsProps {
   /* A header element for the page content. */
@@ -34,6 +38,7 @@ export interface CameraSettingsProps {
   not general settings context. */
   storageInfo: RobotStorageInfo | null
   isCameraRequired: boolean | null
+  protocolRecord: Protocol | null
 }
 
 export function CameraSettings({
@@ -48,8 +53,12 @@ export function CameraSettings({
   toggleLiveStreamEnabled,
   isRecoveryCaptureEnabled,
   isLiveVideoEnabled,
+  protocolRecord,
 }: CameraSettingsProps): JSX.Element {
+  const { t } = useTranslation('protocol_setup')
   const isCameraSettingsEnabled = useFeatureFlag('camera')
+  const isQuickTransfer = protocolRecord?.data.protocolKind === 'quick-transfer'
+  const { makeSnackbar } = useToaster()
   const [showControls, setShowControls] = useState(false)
   const toggleShowControls = (): void => {
     setShowControls(!showControls)
@@ -59,6 +68,9 @@ export function CameraSettings({
     robotType: robotType,
     source: SOURCE_ROBOT_SETTINGS,
   })
+  const recoveryEnabledByRunType = isQuickTransfer
+    ? false
+    : isRecoveryCaptureEnabled
 
   const handleToggleCamera = (): void => {
     toggleCameraEnabled()
@@ -66,7 +78,7 @@ export function CameraSettings({
       reportCameraEnablementSettings({
         cameraEnabled: !isCameraEnabled,
         liveFeedEnabled: isLiveVideoEnabled,
-        recoveryCaptureEnabled: isRecoveryCaptureEnabled,
+        recoveryCaptureEnabled: recoveryEnabledByRunType,
       })
     }
   }
@@ -76,19 +88,26 @@ export function CameraSettings({
       reportCameraEnablementSettings({
         cameraEnabled: isCameraEnabled,
         liveFeedEnabled: !isLiveVideoEnabled,
-        recoveryCaptureEnabled: isRecoveryCaptureEnabled,
+        recoveryCaptureEnabled: recoveryEnabledByRunType,
       })
     }
   }
 
   const handleToggleRecovery = (): void => {
-    toggleRecoveryEnabled()
-    if (isCameraRequired === null) {
-      reportCameraEnablementSettings({
-        cameraEnabled: isCameraEnabled,
-        liveFeedEnabled: isLiveVideoEnabled,
-        recoveryCaptureEnabled: !isRecoveryCaptureEnabled,
-      })
+    if (isQuickTransfer) {
+      makeSnackbar(
+        t('no_camera_during_quick_transfer') as string,
+        TOAST_DURATION_MS
+      )
+    } else {
+      toggleRecoveryEnabled()
+      if (isCameraRequired === null) {
+        reportCameraEnablementSettings({
+          cameraEnabled: isCameraEnabled,
+          liveFeedEnabled: isLiveVideoEnabled,
+          recoveryCaptureEnabled: !isRecoveryCaptureEnabled,
+        })
+      }
     }
   }
   if (showControls) {
@@ -123,7 +142,7 @@ export function CameraSettings({
                 toggleLiveVideoEnabled={handleToggleLiveStream}
                 toggleRecoveryCaptureEnabled={handleToggleRecovery}
                 isLiveVideoEnabled={isLiveVideoEnabled}
-                isRecoveryCaptureEnabled={isRecoveryCaptureEnabled}
+                isRecoveryCaptureEnabled={recoveryEnabledByRunType}
                 robotName={robotName}
               />
               {isCameraSettingsEnabled && (

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupCamera/__tests__/ProtocolSetupCamera.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupCamera/__tests__/ProtocolSetupCamera.test.tsx
@@ -39,6 +39,7 @@ describe('ProtocolSetupCamera', () => {
       cameraConfirmed: false,
       setSetupScreen: vi.fn(),
       storageInfo: {} as any,
+      protocolRecord: { data: { protocolKind: 'standard' } } as any,
     }
     vi.mocked(CameraSettings).mockImplementation(({ headerElement }) => (
       <div>

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupCamera/index.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupCamera/index.tsx
@@ -19,6 +19,7 @@ import {
 import styles from './setupcamera.module.css'
 
 import type { Dispatch, SetStateAction } from 'react'
+import type { Protocol } from '@opentrons/api-client'
 import type { SetupScreens } from '/app/organisms/ODD/ProtocolSetup'
 import type { State } from '/app/redux/types'
 import type { RobotStorageInfo } from '/app/resources/health/useIsImageStorageLow'
@@ -33,6 +34,7 @@ export interface ProtocolSetupCameraProps {
   confirmCameraSettings: () => void
   storageInfo: RobotStorageInfo | null
   setSetupScreen: Dispatch<SetStateAction<SetupScreens>>
+  protocolRecord: Protocol | null
 }
 
 export function ProtocolSetupCamera(

--- a/app/src/organisms/ODD/RobotSettingsDashboard/CameraPreferences.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/CameraPreferences.tsx
@@ -36,6 +36,7 @@ export function CameraPreferences({
       toggleLiveStreamEnabled={settings.toggleLiveVideoEnabled}
       storageInfo={null}
       isCameraRequired={null}
+      protocolRecord={null}
     />
   )
 }

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -1010,6 +1010,7 @@ export function ProtocolSetup(): JSX.Element {
         confirmCameraSettings={confirmCameraSettings}
         setSetupScreen={setSetupScreen}
         storageInfo={storageInfo}
+        protocolRecord={protocolRecord ?? null}
       />
     ),
     'view only parameters': (

--- a/robot-server/robot_server/protocols/dependencies.py
+++ b/robot-server/robot_server/protocols/dependencies.py
@@ -7,7 +7,7 @@ from typing_extensions import Annotated
 
 from anyio import Path as AsyncPath
 from fastapi import Depends
-from robot_server.protocols.protocol_models import ProtocolKind
+from opentrons_shared_data.protocol.constants import ProtocolKind
 from sqlalchemy.engine import Engine as SQLEngine
 
 from opentrons.protocol_reader import ProtocolReader, FileReaderWriter, FileHasher

--- a/robot-server/robot_server/protocols/protocol_auto_deleter.py
+++ b/robot-server/robot_server/protocols/protocol_auto_deleter.py
@@ -4,7 +4,7 @@
 from logging import getLogger
 
 from robot_server.deletion_planner import ProtocolDeletionPlanner
-from robot_server.protocols.protocol_models import ProtocolKind
+from opentrons_shared_data.protocol.constants import ProtocolKind
 from .protocol_store import ProtocolStore
 
 

--- a/robot-server/robot_server/protocols/protocol_models.py
+++ b/robot-server/robot_server/protocols/protocol_models.py
@@ -3,7 +3,6 @@
 from datetime import datetime
 from pydantic import ConfigDict, BaseModel, Field
 from typing import Any, List, Optional
-from enum import Enum
 
 from opentrons.protocol_reader import (
     ProtocolType as ProtocolType,
@@ -11,16 +10,10 @@ from opentrons.protocol_reader import (
 )
 
 from opentrons_shared_data.robot.types import RobotType
+from opentrons_shared_data.protocol.constants import ProtocolKind
 
 from robot_server.service.json_api import ResourceModel
 from .analysis_models import AnalysisSummary
-
-
-class ProtocolKind(str, Enum):
-    """Kind of protocol, standard or quick-transfer."""
-
-    STANDARD = "standard"
-    QUICK_TRANSFER = "quick-transfer"
 
 
 class ProtocolFile(BaseModel):

--- a/robot-server/robot_server/protocols/protocol_store.py
+++ b/robot-server/robot_server/protocols/protocol_store.py
@@ -29,8 +29,7 @@ from robot_server.persistence.tables import (
     run_csv_rtp_table,
     ProtocolKindSQLEnum,
 )
-from robot_server.protocols.protocol_models import ProtocolKind
-
+from opentrons_shared_data.protocol.constants import ProtocolKind
 
 _CACHE_ENTRIES = 32
 

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -57,7 +57,8 @@ from robot_server.data_files.models import DataFile, FileIdNotFound, FileIdNotFo
 from .analyses_manager import AnalysesManager, FailedToInitializeAnalyzer
 
 from .protocol_auto_deleter import ProtocolAutoDeleter
-from .protocol_models import Protocol, ProtocolFile, Metadata, ProtocolKind
+from .protocol_models import Protocol, ProtocolFile, Metadata
+from opentrons_shared_data.protocol.constants import ProtocolKind
 from .analysis_store import AnalysisStore, AnalysisNotFoundError, AnalysisIsPendingError
 from .analysis_models import (
     ProtocolAnalysis,

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -12,7 +12,7 @@ from robot_server.camera.settings.store import (
     get_camera_setting_store,
 )
 from robot_server.protocols.dependencies import get_protocol_store
-from robot_server.protocols.protocol_models import ProtocolKind
+from opentrons_shared_data.protocol.constants import ProtocolKind
 from robot_server.protocols.protocol_store import ProtocolStore
 from robot_server.data_files.file_auto_deleter import DataFileAutoDeleter
 from robot_server.data_files.dependencies import get_data_file_auto_deleter

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -32,7 +32,7 @@ from robot_server.data_files.dependencies import (
 )
 from robot_server.data_files.data_files_store import DataFilesStore
 from robot_server.errors.error_responses import ErrorDetails, ErrorBody
-from robot_server.protocols.protocol_models import ProtocolKind
+from opentrons_shared_data.protocol.constants import ProtocolKind
 from robot_server.service.dependencies import get_current_time, get_unique_id
 from robot_server.robot.control.dependencies import require_estop_in_good_state
 from robot_server.hardware import get_hardware, get_robot_type_enum

--- a/robot-server/robot_server/runs/run_auto_deleter.py
+++ b/robot-server/robot_server/runs/run_auto_deleter.py
@@ -2,7 +2,7 @@
 from logging import getLogger
 
 from robot_server.deletion_planner import RunDeletionPlanner
-from robot_server.protocols.protocol_models import ProtocolKind
+from opentrons_shared_data.protocol.constants import ProtocolKind
 from robot_server.protocols.protocol_store import ProtocolStore
 from robot_server.data_files.file_auto_deleter import DataFileAutoDeleter
 from .run_store import RunStore

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -251,6 +251,7 @@ class RunDataManager:
                 run_id=run_id,
                 run_created_at=created_at,
                 protocol_name=protocol_name,
+                protocol_kind=protocol.protocol_kind if protocol else None,
             )
         )
 

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Callable, Union, Mapping, Sequence
 
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.errors.exceptions import InvalidStoredData, EnumeratedError
-from opentrons_shared_data.data_files import RunFileNameMetadata
+from opentrons_shared_data.data_files import RunFileMetadata
 
 from opentrons import config
 from opentrons.types import NozzleMapInterface
@@ -246,7 +246,7 @@ class RunDataManager:
             else None
         )
         self._file_provider.set_run_metadata(
-            RunFileNameMetadata(
+            RunFileMetadata(
                 robot_name=config.name(),
                 run_id=run_id,
                 run_created_at=created_at,

--- a/robot-server/tests/data_files/test_data_files_store.py
+++ b/robot-server/tests/data_files/test_data_files_store.py
@@ -35,7 +35,7 @@ from robot_server.protocols.completed_analysis_store import (
     CompletedAnalysisStore,
     CompletedAnalysisResource,
 )
-from robot_server.protocols.protocol_models import ProtocolKind
+from opentrons_shared_data.protocol.constants import ProtocolKind
 from robot_server.protocols.protocol_store import ProtocolResource, ProtocolStore
 from robot_server.protocols.rtp_resources import CSVParameterResource
 

--- a/robot-server/tests/protocols/test_analyses_manager.py
+++ b/robot-server/tests/protocols/test_analyses_manager.py
@@ -11,7 +11,7 @@ from opentrons_shared_data.errors import EnumeratedError, ErrorCodes
 from opentrons_shared_data.robot.types import RobotType
 
 from robot_server.protocols import protocol_analyzer
-from robot_server.protocols.protocol_models import ProtocolKind
+from opentrons_shared_data.protocol.constants import ProtocolKind
 from robot_server.protocols.analyses_manager import (
     AnalysesManager,
     FailedToInitializeAnalyzer,

--- a/robot-server/tests/protocols/test_analysis_store.py
+++ b/robot-server/tests/protocols/test_analysis_store.py
@@ -50,7 +50,7 @@ from robot_server.protocols.completed_analysis_store import (
     CompletedAnalysisStore,
     CompletedAnalysisResource,
 )
-from robot_server.protocols.protocol_models import ProtocolKind
+from opentrons_shared_data.protocol.constants import ProtocolKind
 from robot_server.protocols.protocol_store import (
     ProtocolStore,
     ProtocolResource,

--- a/robot-server/tests/protocols/test_completed_analysis_store.py
+++ b/robot-server/tests/protocols/test_completed_analysis_store.py
@@ -32,7 +32,7 @@ from robot_server.protocols.analysis_models import (
     AnalysisStatus,
     RunTimeParameterAnalysisData,
 )
-from robot_server.protocols.protocol_models import ProtocolKind
+from opentrons_shared_data.protocol.constants import ProtocolKind
 from robot_server.protocols.protocol_store import (
     ProtocolStore,
     ProtocolResource,

--- a/robot-server/tests/protocols/test_protocol_analyzer.py
+++ b/robot-server/tests/protocols/test_protocol_analyzer.py
@@ -182,11 +182,7 @@ async def test_analyze(
     await subject.load_orchestrator(
         run_time_param_values={"rtp_var": 123}, run_time_param_paths={}
     )
-    decoy.when(
-        await orchestrator.run(
-            deck_configuration=[],
-        )
-    ).then_return(
+    decoy.when(await orchestrator.run(deck_configuration=[],)).then_return(
         protocol_runner.RunResult(
             commands=[analysis_command],
             state_summary=StateSummary(

--- a/robot-server/tests/protocols/test_protocol_analyzer.py
+++ b/robot-server/tests/protocols/test_protocol_analyzer.py
@@ -29,7 +29,7 @@ from opentrons.protocol_runner.run_orchestrator import ParseMode
 import opentrons.util.helpers as datetime_helper
 
 from robot_server.protocols.analysis_store import AnalysisStore
-from robot_server.protocols.protocol_models import ProtocolKind
+from opentrons_shared_data.protocol.constants import ProtocolKind
 from robot_server.protocols.protocol_store import ProtocolResource
 from robot_server.protocols.protocol_analyzer import ProtocolAnalyzer
 import robot_server.errors.error_mappers as em
@@ -182,7 +182,11 @@ async def test_analyze(
     await subject.load_orchestrator(
         run_time_param_values={"rtp_var": 123}, run_time_param_paths={}
     )
-    decoy.when(await orchestrator.run(deck_configuration=[],)).then_return(
+    decoy.when(
+        await orchestrator.run(
+            deck_configuration=[],
+        )
+    ).then_return(
         protocol_runner.RunResult(
             commands=[analysis_command],
             state_summary=StateSummary(

--- a/robot-server/tests/protocols/test_protocol_auto_deleter.py
+++ b/robot-server/tests/protocols/test_protocol_auto_deleter.py
@@ -9,7 +9,7 @@ from decoy import Decoy
 
 from robot_server.deletion_planner import ProtocolDeletionPlanner
 from robot_server.protocols.protocol_auto_deleter import ProtocolAutoDeleter
-from robot_server.protocols.protocol_models import ProtocolKind
+from opentrons_shared_data.protocol.constants import ProtocolKind
 from robot_server.protocols.protocol_store import (
     ProtocolResource,
     ProtocolStore,

--- a/robot-server/tests/protocols/test_protocol_store.py
+++ b/robot-server/tests/protocols/test_protocol_store.py
@@ -31,7 +31,7 @@ from robot_server.protocols.completed_analysis_store import (
     CompletedAnalysisResource,
     CompletedAnalysisStore,
 )
-from robot_server.protocols.protocol_models import ProtocolKind
+from opentrons_shared_data.protocol.constants import ProtocolKind
 from robot_server.protocols.protocol_store import (
     ProtocolStore,
     ProtocolResource,

--- a/robot-server/tests/protocols/test_protocols_router.py
+++ b/robot-server/tests/protocols/test_protocols_router.py
@@ -58,9 +58,9 @@ from robot_server.protocols.protocol_models import (
     Metadata,
     Protocol,
     ProtocolFile,
-    ProtocolKind,
     ProtocolType,
 )
+from opentrons_shared_data.protocol.constants import ProtocolKind
 from robot_server.protocols.protocol_store import (
     ProtocolStore,
     ProtocolResource,

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -37,7 +37,7 @@ from robot_server.service.json_api import (
     ResourceLink,
 )
 
-from robot_server.protocols.protocol_models import ProtocolKind
+from opentrons_shared_data.protocol.constants import ProtocolKind
 from robot_server.protocols.protocol_store import (
     ProtocolNotFoundError,
     ProtocolResource,

--- a/robot-server/tests/runs/test_run_auto_deleter.py
+++ b/robot-server/tests/runs/test_run_auto_deleter.py
@@ -11,7 +11,7 @@ from decoy import Decoy
 from opentrons.protocol_reader import ProtocolSource
 
 from robot_server.deletion_planner import RunDeletionPlanner
-from robot_server.protocols.protocol_models import ProtocolKind
+from opentrons_shared_data.protocol.constants import ProtocolKind
 from robot_server.protocols.protocol_store import ProtocolResource, ProtocolStore
 from robot_server.runs.run_auto_deleter import RunAutoDeleter
 from robot_server.runs.run_store import RunStore, RunResource, BadRunResource

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -370,6 +370,7 @@ async def test_create(
                 run_id=run_id,
                 run_created_at=created_at,
                 protocol_name="test_protocol",
+                protocol_kind=ProtocolKind.STANDARD,
             )
         )
     )

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -7,7 +7,7 @@ from unittest.mock import sentinel, Mock
 import pytest
 from decoy import Decoy, matchers
 
-from opentrons_shared_data.data_files import RunFileNameMetadata
+from opentrons_shared_data.data_files import RunFileMetadata
 from opentrons.protocol_engine import (
     EngineStatus,
     StateSummary,
@@ -37,7 +37,7 @@ from opentrons_shared_data.errors.exceptions import InvalidStoredData
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition2
 
 from robot_server.error_recovery.settings.store import ErrorRecoverySettingStore
-from robot_server.protocols.protocol_models import ProtocolKind
+from opentrons_shared_data.protocol.constants import ProtocolKind
 from robot_server.protocols.protocol_store import ProtocolResource
 from robot_server.runs import error_recovery_mapping
 from robot_server.runs.error_recovery_models import ErrorRecoveryRule
@@ -365,7 +365,7 @@ async def test_create(
     )
     decoy.verify(
         mock_file_provider.set_run_metadata(
-            RunFileNameMetadata(
+            RunFileMetadata(
                 robot_name=config.name(),
                 run_id=run_id,
                 run_created_at=created_at,

--- a/robot-server/tests/runs/test_run_orchestrator_store.py
+++ b/robot-server/tests/runs/test_run_orchestrator_store.py
@@ -35,7 +35,7 @@ from robot_server.runs.run_orchestrator_store import (
     handle_hardware_event,
 )
 from robot_server.protocols.protocol_store import ProtocolResource
-from robot_server.protocols.protocol_models import ProtocolKind
+from opentrons_shared_data.protocol.constants import ProtocolKind
 
 
 def mock_notify_publishers() -> None:

--- a/shared-data/python/opentrons_shared_data/data_files/__init__.py
+++ b/shared-data/python/opentrons_shared_data/data_files/__init__.py
@@ -9,7 +9,7 @@ from .types import (
     IODataFileInfo,
     DataFileSource,
     DataFileInfoWithCommands,
-    RunFileNameMetadata,
+    RunFileMetadata,
 )
 
 
@@ -21,6 +21,6 @@ __all__ = [
     "CmdDataFileInfo",
     "MimeType",
     "DataFileSource",
-    "RunFileNameMetadata",
+    "RunFileMetadata",
     "DataFileInfoWithCommands",
 ]

--- a/shared-data/python/opentrons_shared_data/data_files/types.py
+++ b/shared-data/python/opentrons_shared_data/data_files/types.py
@@ -5,14 +5,17 @@ from datetime import datetime
 from enum import Enum
 from typing import Union, Optional
 
+from opentrons_shared_data.protocol.constants import ProtocolKind
+
 
 @dataclass(frozen=True)
-class RunFileNameMetadata:
+class RunFileMetadata:
     """Data from the run used that may be used to build a finalized file name."""
 
     robot_name: str
     run_id: str
     run_created_at: datetime
+    protocol_kind: Optional[ProtocolKind]
     protocol_name: Optional[str]
 
 

--- a/shared-data/python/opentrons_shared_data/protocol/constants.py
+++ b/shared-data/python/opentrons_shared_data/protocol/constants.py
@@ -96,3 +96,10 @@ class JsonThermocyclerCommand(Enum):
     thermocyclerAwaitProfileComplete: "ThermocyclerAwaitProfileCommandId" = (
         "thermocycler/awaitProfileComplete"
     )
+
+
+class ProtocolKind(str, Enum):
+    """Kind of protocol, standard or quick-transfer."""
+
+    STANDARD = "standard"
+    QUICK_TRANSFER = "quick-transfer"


### PR DESCRIPTION
Closes [RQA-4903](https://opentrons.atlassian.net/browse/RQA-4903)

# Overview

Users currently have the ability to take an image capture on error during Quick Transfer runs. Because QT runs are not persisted in the run store, their run id is ephemeral, and that makes it impossible for the `DataFileAutoDeleter` to age out any image data associated with that run when a future run is created. 

We have a few options on how we could solve this:

1. Persist QT runs in some fashion so their image data can be persisted. 
2. Since image files are stored under a directory with a name that ought to be a run id, we could cross reference a directory name and see if its run id exists in the database, and if they are not, we delete them.
3. Don't take photos if the run is a QT run.

The first option requires a fundamental overhaul of QT, so it seems wise to avoid that path. The second option is a bit hacky and results in an unintuitive user experience. The third option is consistent with how we handle QT runs anyway, which is we don't persist them past the immediate "run complete" UI. 

UI affordances are added when users attempt to enable images during an error by means of a snackbar.

<img width="1020" height="767" alt="Screenshot 2025-12-01 at 3 54 53 PM" src="https://github.com/user-attachments/assets/c227f129-2dbf-49d1-a141-ad0904ed79fd" />

<img width="1008" height="572" alt="Screenshot 2025-12-01 at 3 58 29 PM" src="https://github.com/user-attachments/assets/cbad1ced-9cd0-41ff-bf33-f95deba82cdf" />

## Test Plan and Hands on Testing

- [x] QT runs do not store images on error.
- [x] The UI properly disables images on error for QT runs.

## Changelog

- The robot no longer stores images generated on error during a Quick Transfer run indefinitely.

## Risk assessment

- lowish -- these changes are relatively orthogonal...they do require a bit of conditional code though.  

[RQA-4903]: https://opentrons.atlassian.net/browse/RQA-4903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ