### PR TITLE
refactor(app): update TouchControlButton to use cursor:pointer on hover

### DIFF
--- a/app/src/atoms/buttons/TouchControlButton.tsx
+++ b/app/src/atoms/buttons/TouchControlButton.tsx
@@ -4,7 +4,7 @@ import {
   BORDERS,
   Btn,
   COLORS,
-  CURSOR_DEFAULT,
+  CURSOR_POINTER,
   SPACING,
   StyledText,
 } from '@opentrons/components'
@@ -64,7 +64,7 @@ const StyledTouchButton = styled(Btn)<{
   border: ${({ isActive, isOnDevice }) =>
     `1px ${getBorderColor(isActive, isOnDevice)} solid`};
 
-  cursor: ${CURSOR_DEFAULT};
+  cursor: ${CURSOR_POINTER};
   border-radius: ${({ isOnDevice }) =>
     isOnDevice ? BORDERS.borderRadius16 : BORDERS.borderRadius8};
   padding: ${SPACING.spacing8} ${SPACING.spacing20};


### PR DESCRIPTION
Closes [EXEC-2212](https://opentrons.atlassian.net/browse/EXEC-2212)

# Overview

The newer `TouchControlButton` [component](https://www.figma.com/design/PDkgB4AZ9PiLLJkwBATcU3/Feature--Camera-Enablement?node-id=4047-5738&t=vzxQe5C7EnKHAgHH-4) was missing a `cursor: pointer` on hover. This PR just adds it!

## Risk assessment

no functional changes


[EXEC-2212]: https://opentrons.atlassian.net/browse/EXEC-2212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ