### PR TITLE
feat(app): support filtering robots that are not OT-2s

### DIFF
--- a/app/src/redux/discovery/__tests__/selectors.test.ts
+++ b/app/src/redux/discovery/__tests__/selectors.test.ts
@@ -25,6 +25,9 @@ import * as discovery from '../selectors'
 import type { State } from '../../types'
 
 const MOCK_STATE: State = {
+  config: {
+    devInternal: {},
+  },
   discovery: {
     robotsByName: {
       foo: {
@@ -261,6 +264,17 @@ const EXPECTED_FIZZBUZZ = {
   robotModel: ROBOT_MODEL_OT3,
 }
 
+const MOCK_STATE_WITH_IGNORE_OT2: State = {
+  config: {
+    devInternal: {
+      ignoreOT2App: true,
+    },
+  },
+  discovery: {
+    ...MOCK_STATE.discovery,
+  },
+} as any
+
 describe('discovery selectors', () => {
   const SPECS: Array<{
     name: string
@@ -296,6 +310,36 @@ describe('discovery selectors', () => {
       ],
     },
     {
+      name: 'getDiscoveredRobots filters out OT-2 robots when ignoreOT2App is true',
+      selector: discovery.getDiscoveredRobots,
+      state: MOCK_STATE_WITH_IGNORE_OT2,
+      expected: [EXPECTED_QUX, EXPECTED_FIZZBUZZ],
+    },
+    {
+      name: 'getConnectableRobots filters out OT-2 robots when ignoreOT2App is true',
+      selector: discovery.getConnectableRobots,
+      state: MOCK_STATE_WITH_IGNORE_OT2,
+      expected: [EXPECTED_FIZZBUZZ],
+    },
+    {
+      name: 'getReachableRobots filters out OT-2 robots when ignoreOT2App is true',
+      selector: discovery.getReachableRobots,
+      state: MOCK_STATE_WITH_IGNORE_OT2,
+      expected: [EXPECTED_QUX],
+    },
+    {
+      name: 'getUnreachableRobots filters out OT-2 robots when ignoreOT2App is true',
+      selector: discovery.getUnreachableRobots,
+      state: MOCK_STATE_WITH_IGNORE_OT2,
+      expected: [],
+    },
+    {
+      name: 'getViewableRobots filters out OT-2 robots when ignoreOT2App is true',
+      selector: discovery.getViewableRobots,
+      state: MOCK_STATE_WITH_IGNORE_OT2,
+      expected: [EXPECTED_FIZZBUZZ, EXPECTED_QUX],
+    },
+    {
       name: 'getConnectableRobots grabs robots with connectable status',
       selector: discovery.getConnectableRobots,
       state: MOCK_STATE,
@@ -317,6 +361,7 @@ describe('discovery selectors', () => {
       name: 'display name removes opentrons- from connectable robot names',
       selector: discovery.getDiscoveredRobots,
       state: {
+        config: { devInternal: {} },
         discovery: {
           robotsByName: {
             'opentrons-foo': {
@@ -337,6 +382,7 @@ describe('discovery selectors', () => {
       name: 'handles legacy IPv6 robots by wrapping IP in [] and setting as local',
       selector: discovery.getDiscoveredRobots,
       state: {
+        config: { devInternal: {} },
         discovery: {
           robotsByName: {
             'opentrons-foo': {
@@ -372,6 +418,7 @@ describe('discovery selectors', () => {
       name: 'handles opentrons-usb robots by setting as local',
       selector: discovery.getDiscoveredRobots,
       state: {
+        config: { devInternal: {} },
         discovery: {
           robotsByName: {
             'opentrons-foo': {

--- a/app/src/redux/discovery/selectors.ts
+++ b/app/src/redux/discovery/selectors.ts
@@ -7,6 +7,7 @@ import orderBy from 'lodash/orderBy'
 import { createSelector, createSelectorCreator, defaultMemoize } from 'reselect'
 import semver from 'semver'
 
+import { getFeatureFlags } from '../config/selectors'
 import {
   CONNECTABLE,
   HEALTH_STATUS_OK,
@@ -84,11 +85,24 @@ export function getScanning(state: State): boolean {
   return state.discovery.scanning
 }
 
+const getRobotModelDisplayName = (robot: DiscoveredRobot): string | null => {
+  const robotModelName = robot.robotModel?.split(/\s/)[0] ?? null
+
+  return robotModelName === 'OT-3' ? 'Opentrons Flex' : robotModelName
+}
+
+const isNotOT2Robot = (robot: DiscoveredRobot): boolean => {
+  const displayName = getRobotModelDisplayName(robot)
+
+  return displayName !== 'OT-2' && displayName !== null
+}
+
 export const getDiscoveredRobots: (state: State) => DiscoveredRobot[] =
   createSelector(
     state => state.discovery.robotsByName,
-    robotsMap => {
-      return Object.keys(robotsMap).map((robotName: string) => {
+    state => getFeatureFlags(state).ignoreOT2App ?? false,
+    (robotsMap, ignoreOT2App) => {
+      const robots = Object.keys(robotsMap).map((robotName: string) => {
         const robot = robotsMap[robotName]
         const { addresses, ...robotState } = robot
         const { health, serverHealth } = robotState
@@ -149,6 +163,10 @@ export const getDiscoveredRobots: (state: State) => DiscoveredRobot[] =
           status: UNREACHABLE,
         }
       })
+
+      return ignoreOT2App
+        ? robots.filter(robot => isNotOT2Robot(robot))
+        : robots
     }
   )
 
@@ -276,9 +294,8 @@ export const getRobotModelByName = (
   robotName: string
 ): string | null => {
   const robot = getDiscoverableRobotByName(state, robotName)
-  const robotModelName =
-    robot != null ? getRobotModel(robot)?.split(/\s/)[0] : null
-  return robotModelName === 'OT-3' ? 'Opentrons Flex' : robotModelName
+
+  return robot != null ? getRobotModelDisplayName(robot) : null
 }
 
 export const getRobotAddressesByName: (


### PR DESCRIPTION
Closes [EXEC-2277](https://opentrons.atlassian.net/browse/EXEC-2277)

# Overview

Filters out OT-2 robots from the monorepo app, utilizing "not OT-2 robot" conditions. It seems most direct/cleanest to do this on the Redux layer. Changes are behind a FF.

https://github.com/user-attachments/assets/17840772-b0c5-41f0-abef-68941a0c012f

## Test Plan and Hands on Testing

- See video.

## Changelog

- The app filters out OT-2 robots from the devices view.

## Risk assessment

- low - simple filtering out of OT-2 robots, which the app should be able to handle already


[EXEC-2277]: https://opentrons.atlassian.net/browse/EXEC-2277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ