### PR TITLE
refactor(mono): Add "no nested ternary" eslint rule

### DIFF
--- a/.cursor/skills/opentrons-typescript/SKILL.md
+++ b/.cursor/skills/opentrons-typescript/SKILL.md
@@ -413,3 +413,20 @@ function AppContent({ isOnChatPage }: { isOnChatPage: boolean }) {
 - Do NOT use semicolons (Prettier removes them)
 - Do NOT use `console.log` or `debugger` in committed code
 - Do NOT omit curly braces for control statements — ESLint `curly` rule enforces braces for all `if`, `else`, `for`, `while`, and `do` blocks
+- Do NOT use nested ternary expressions — extract to a function with early returns:
+
+```typescript
+// Bad
+const x = a ? 'a' : b ? 'b' : 'c'
+
+// Good
+const getX = (): string => {
+  if (a) {
+    return 'a'
+  }
+  if (b) {
+    return 'b'
+  }
+  return 'c'
+}
+```

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
   reportUnusedDisableDirectives: true,
 
   rules: {
+    'no-nested-ternary': 'error',
     curly: 'error',
     camelcase: 'off',
     'no-var': 'error',

--- a/app-shell-odd/src/system-update/from-usb/scan-device.ts
+++ b/app-shell-odd/src/system-update/from-usb/scan-device.ts
@@ -7,8 +7,15 @@ import type { FileDetails } from './scan-zip'
 
 const log = createLogger('system-udpate/from-usb/scan-device')
 
-const higherVersion = (a: FileDetails | null, b: FileDetails): FileDetails =>
-  a == null ? b : Semver.gt(a.version, b.version) ? a : b
+const higherVersion = (a: FileDetails | null, b: FileDetails): FileDetails => {
+  if (a == null) {
+    return b
+  }
+  if (Semver.gt(a.version, b.version)) {
+    return a
+  }
+  return b
+}
 
 const mostRecentUpdateOf = (candidates: FileDetails[]): FileDetails | null =>
   candidates.reduce<FileDetails | null>(

--- a/app/scripts/visualizeReduxConnections.js
+++ b/app/scripts/visualizeReduxConnections.js
@@ -35,11 +35,16 @@ assert(process.argv.length === 3, USAGE)
         if (m) {
           const reduxDep = m[1]
           const key = dir.match(new RegExp(`${searchDirPath}([^/]*)/?`))[1]
-          const value = map[key]
-            ? map[key].includes(reduxDep)
-              ? map[key]
-              : [...map[key], reduxDep]
-            : [reduxDep]
+          const getValue = () => {
+            if (!map[key]) {
+              return [reduxDep]
+            }
+            if (map[key].includes(reduxDep)) {
+              return map[key]
+            }
+            return [...map[key], reduxDep]
+          }
+          const value = getValue()
           map = { ...map, [key]: value }
         }
       }

--- a/app/src/atoms/buttons/TouchControlButton.tsx
+++ b/app/src/atoms/buttons/TouchControlButton.tsx
@@ -54,6 +54,16 @@ const getFocusBorderColor = (
   return COLORS.white
 }
 
+const getTextColor = (isActive: boolean, isOnDevice: boolean): string => {
+  if (isActive && !isOnDevice) {
+    return COLORS.blue50
+  }
+  if (isOnDevice && isActive) {
+    return COLORS.white
+  }
+  return COLORS.black90
+}
+
 const StyledTouchButton = styled(Btn)<{
   isActive: boolean
   isOnDevice: boolean
@@ -115,13 +125,7 @@ export function TouchControlButton(props: TouchControlProps): JSX.Element {
       <StyledText
         oddStyle="bodyTextSemiBold"
         desktopStyle="bodyDefaultSemiBold"
-        color={
-          isActive && !isOnDevice
-            ? COLORS.blue50
-            : isOnDevice && isActive
-              ? COLORS.white
-              : COLORS.black90
-        }
+        color={getTextColor(isActive, isOnDevice)}
       >
         {title}
       </StyledText>

--- a/app/src/molecules/Command/Command.tsx
+++ b/app/src/molecules/Command/Command.tsx
@@ -50,13 +50,18 @@ export type CommandProps = SkeletonCommandProps | NonSkeletonCommandProps
 export function Command(props: CommandProps): JSX.Element {
   // This uses the dynamic function variant to work with storybook
   const isOnDevice = RESPONSIVENESS.isTouchscreenDynamic()
-  return props.state === 'loading' ? (
-    <Skeleton width="100%" height={SKELETON_HEIGHT} backgroundSize="47rem" />
-  ) : props.aligned === 'left' ? (
-    <LeftAlignedCommand {...props} isOnDevice={isOnDevice} />
-  ) : (
-    <CenteredCommand {...props} isOnDevice={isOnDevice} />
-  )
+
+  if (props.state === 'loading') {
+    return (
+      <Skeleton width="100%" height={SKELETON_HEIGHT} backgroundSize="47rem" />
+    )
+  }
+
+  if (props.aligned === 'left') {
+    return <LeftAlignedCommand {...props} isOnDevice={isOnDevice} />
+  }
+
+  return <CenteredCommand {...props} isOnDevice={isOnDevice} />
 }
 
 const ICON_SIZE_ODD = SPACING.spacing32

--- a/app/src/molecules/DeckInfoLabelTextTag/DeckInfoLabelTextTag.stories.tsx
+++ b/app/src/molecules/DeckInfoLabelTextTag/DeckInfoLabelTextTag.stories.tsx
@@ -40,9 +40,15 @@ const Template: Story<DeckInfoLabelTextTagStoryProps> = args => {
       <RobotInfoLabel
         key={`deck-label-${i}`}
         highlight={i === 1}
-        iconName={
-          i === 0 ? 'stacked' : i === 1 ? 'ot-heater-shaker' : 'ot-absorbance'
-        }
+        iconName={(() => {
+          if (i === 0) {
+            return 'stacked'
+          }
+          if (i === 1) {
+            return 'ot-heater-shaker'
+          }
+          return 'ot-absorbance'
+        })()}
       />
     )
   }

--- a/app/src/molecules/GenericWizardTile/index.tsx
+++ b/app/src/molecules/GenericWizardTile/index.tsx
@@ -134,38 +134,37 @@ export function GenericWizardTile(props: GenericWizardTileProps): JSX.Element {
           />
         ) : null}
         {getHelp != null ? <NeedHelpLink href={getHelp} /> : null}
-        {proceed != null && proceedButton == null ? (
-          isOnDevice ? (
-            <>
-              <SmallButton
-                disabled={proceedIsDisabled}
-                buttonText={proceedButtonText}
-                onClick={proceed}
-                {...targetProps}
-              />
-              {disableProceedReason != null && (
-                <Tooltip tooltipProps={tooltipProps}>
-                  {disableProceedReason}
-                </Tooltip>
-              )}
-            </>
-          ) : (
-            <>
-              <PrimaryButton
-                disabled={proceedIsDisabled}
-                css={CAPITALIZE_FIRST_LETTER_STYLE}
-                onClick={proceed}
-                {...targetProps}
-              >
-                {proceedButtonText}
-              </PrimaryButton>
-              {disableProceedReason != null && (
-                <Tooltip tooltipProps={tooltipProps}>
-                  {disableProceedReason}
-                </Tooltip>
-              )}
-            </>
-          )
+        {proceed != null && proceedButton == null && isOnDevice ? (
+          <>
+            <SmallButton
+              disabled={proceedIsDisabled}
+              buttonText={proceedButtonText}
+              onClick={proceed}
+              {...targetProps}
+            />
+            {disableProceedReason != null && (
+              <Tooltip tooltipProps={tooltipProps}>
+                {disableProceedReason}
+              </Tooltip>
+            )}
+          </>
+        ) : null}
+        {proceed != null && proceedButton == null && !isOnDevice ? (
+          <>
+            <PrimaryButton
+              disabled={proceedIsDisabled}
+              css={CAPITALIZE_FIRST_LETTER_STYLE}
+              onClick={proceed}
+              {...targetProps}
+            >
+              {proceedButtonText}
+            </PrimaryButton>
+            {disableProceedReason != null && (
+              <Tooltip tooltipProps={tooltipProps}>
+                {disableProceedReason}
+              </Tooltip>
+            )}
+          </>
         ) : null}
         {proceed == null && proceedButton != null ? proceedButton : null}
       </Flex>

--- a/app/src/molecules/MultiDeckLabelTagBtns/MultiDeckLabelTagBtns.stories.tsx
+++ b/app/src/molecules/MultiDeckLabelTagBtns/MultiDeckLabelTagBtns.stories.tsx
@@ -71,9 +71,15 @@ const Template: Story<MultiDeckLabelTagBtnsStoryProps> = args => {
       <RobotInfoLabel
         key={`deck-label-${i}`}
         highlight={i === 1}
-        iconName={
-          i === 0 ? 'stacked' : i === 1 ? 'ot-heater-shaker' : 'ot-absorbance'
-        }
+        iconName={(() => {
+          if (i === 0) {
+            return 'stacked'
+          }
+          if (i === 1) {
+            return 'ot-heater-shaker'
+          }
+          return 'ot-absorbance'
+        })()}
       />
     )
   }

--- a/app/src/molecules/TaskList/index.tsx
+++ b/app/src/molecules/TaskList/index.tsx
@@ -28,6 +28,34 @@ export type * from './types'
 
 const TASK_CONNECTOR_STYLE = `1px solid ${COLORS.grey40}`
 
+const getSubTaskBackgroundColor = (
+  isTaskListComplete: boolean,
+  isPastSubTask: boolean,
+  isSubTaskComplete: boolean | undefined
+): string => {
+  if (isTaskListComplete || isPastSubTask) {
+    return COLORS.blue50
+  }
+  if (isSubTaskComplete === true) {
+    return COLORS.grey40
+  }
+  return 'initial'
+}
+
+const getSubTaskConnectorColor = (
+  isFinalSubTaskOfTaskList: boolean,
+  isTaskListComplete: boolean,
+  isPastSubTask: boolean
+): string => {
+  if (isFinalSubTaskOfTaskList) {
+    return COLORS.transparent
+  }
+  if (isTaskListComplete || isPastSubTask) {
+    return COLORS.blue50
+  }
+  return COLORS.grey40
+}
+
 interface ProgressTrackerItemProps {
   activeIndex: [number, number] | null
   subTasks: SubTaskProps[]
@@ -143,14 +171,11 @@ function ProgressTrackerItem({
                   alignItems={ALIGN_CENTER}
                   justifyContent={JUSTIFY_CENTER}
                   // fill in circle for past or completed subtasks
-                  backgroundColor={
-                    // is in the past or list is complete
-                    isTaskListComplete || isPastSubTask
-                      ? COLORS.blue50
-                      : subTask.isComplete === true
-                        ? COLORS.grey40
-                        : 'initial'
-                  }
+                  backgroundColor={getSubTaskBackgroundColor(
+                    isTaskListComplete,
+                    isPastSubTask,
+                    subTask.isComplete
+                  )}
                   border={TASK_CONNECTOR_STYLE}
                   borderColor={isFutureSubTask ? COLORS.grey40 : COLORS.blue50}
                   borderWidth={SPACING.spacing2}
@@ -164,14 +189,11 @@ function ProgressTrackerItem({
                 <Flex
                   flex="1"
                   borderLeft={TASK_CONNECTOR_STYLE}
-                  borderColor={
-                    // do not show the subtask connector if it's the final subtask of the task list
-                    isFinalSubTaskOfTaskList
-                      ? COLORS.transparent
-                      : isTaskListComplete || isPastSubTask
-                        ? COLORS.blue50
-                        : COLORS.grey40
-                  }
+                  borderColor={getSubTaskConnectorColor(
+                    isFinalSubTaskOfTaskList,
+                    isTaskListComplete,
+                    isPastSubTask
+                  )}
                   marginTop={`-${SPACING.spacing8}`}
                   marginBottom={
                     // extend connector for last subtask
@@ -431,7 +453,8 @@ function Task({
               name={isTaskOpen ? 'chevron-up' : 'chevron-down'}
               height="15px"
             />
-          ) : (isTaskListComplete || isPastTask) && cta != null ? (
+          ) : null}
+          {!hasSubTasks && (isTaskListComplete || isPastTask) && cta != null ? (
             <>
               <Link
                 {...targetProps}

--- a/app/src/organisms/Desktop/CalibrateDeck/index.tsx
+++ b/app/src/organisms/Desktop/CalibrateDeck/index.tsx
@@ -156,36 +156,43 @@ export function CalibrateDeck({
         />
       }
     >
-      {showSpinner || currentStep == null || Panel == null ? (
-        <LoadingState />
-      ) : showConfirmExit ? (
-        <ConfirmExit
-          exit={confirmExit}
-          back={cancelExit}
-          heading={t('progress_will_be_lost', {
-            sessionType: t('deck_calibration'),
-          })}
-          body={t('confirm_exit_before_completion', {
-            sessionType: t('deck_calibration'),
-          })}
-        />
-      ) : errorInfo != null ? (
-        <CalibrationError {...errorInfo} onClose={cleanUpAndExit} />
-      ) : (
-        <Panel
-          sendCommands={sendCommands}
-          cleanUpAndExit={cleanUpAndExit}
-          tipRack={tipRack}
-          isMulti={isMulti}
-          mount={instrument?.mount.toLowerCase() as Mount}
-          currentStep={currentStep}
-          sessionType={session.sessionType}
-          supportedCommands={supportedCommands}
-          defaultTipracks={instrument?.defaultTipracks}
-          calInvalidationHandler={offsetInvalidationHandler}
-          allowChangeTipRack
-        />
-      )}
+      {(() => {
+        if (showSpinner || currentStep == null || Panel == null) {
+          return <LoadingState />
+        }
+        if (showConfirmExit) {
+          return (
+            <ConfirmExit
+              exit={confirmExit}
+              back={cancelExit}
+              heading={t('progress_will_be_lost', {
+                sessionType: t('deck_calibration'),
+              })}
+              body={t('confirm_exit_before_completion', {
+                sessionType: t('deck_calibration'),
+              })}
+            />
+          )
+        }
+        if (errorInfo != null) {
+          return <CalibrationError {...errorInfo} onClose={cleanUpAndExit} />
+        }
+        return (
+          <Panel
+            sendCommands={sendCommands}
+            cleanUpAndExit={cleanUpAndExit}
+            tipRack={tipRack}
+            isMulti={isMulti}
+            mount={instrument?.mount.toLowerCase() as Mount}
+            currentStep={currentStep}
+            sessionType={session.sessionType}
+            supportedCommands={supportedCommands}
+            defaultTipracks={instrument?.defaultTipracks}
+            calInvalidationHandler={offsetInvalidationHandler}
+            allowChangeTipRack
+          />
+        )
+      })()}
     </ModalShell>,
     getTopPortalEl()
   )

--- a/app/src/organisms/Desktop/CalibratePipetteOffset/index.tsx
+++ b/app/src/organisms/Desktop/CalibratePipetteOffset/index.tsx
@@ -149,36 +149,43 @@ export function CalibratePipetteOffset({
         />
       }
     >
-      {showSpinner || currentStep == null || Panel == null ? (
-        <LoadingState />
-      ) : showConfirmExit ? (
-        <ConfirmExit
-          exit={confirmExit}
-          back={cancelExit}
-          heading={t('progress_will_be_lost', {
-            sessionType: t('pipette_offset_calibration'),
-          })}
-          body={t('confirm_exit_before_completion', {
-            sessionType: t('pipette_offset_calibration'),
-          })}
-        />
-      ) : errorInfo != null ? (
-        <CalibrationError {...errorInfo} onClose={cleanUpAndExit} />
-      ) : (
-        <Panel
-          sendCommands={sendCommands}
-          cleanUpAndExit={cleanUpAndExit}
-          tipRack={tipRack}
-          isMulti={isMulti}
-          mount={instrument?.mount.toLowerCase() as Mount}
-          calBlock={calBlock}
-          currentStep={currentStep}
-          sessionType={session.sessionType}
-          robotName={robotName}
-          supportedCommands={supportedCommands}
-          defaultTipracks={instrument?.defaultTipracks}
-        />
-      )}
+      {(() => {
+        if (showSpinner || currentStep == null || Panel == null) {
+          return <LoadingState />
+        }
+        if (showConfirmExit) {
+          return (
+            <ConfirmExit
+              exit={confirmExit}
+              back={cancelExit}
+              heading={t('progress_will_be_lost', {
+                sessionType: t('pipette_offset_calibration'),
+              })}
+              body={t('confirm_exit_before_completion', {
+                sessionType: t('pipette_offset_calibration'),
+              })}
+            />
+          )
+        }
+        if (errorInfo != null) {
+          return <CalibrationError {...errorInfo} onClose={cleanUpAndExit} />
+        }
+        return (
+          <Panel
+            sendCommands={sendCommands}
+            cleanUpAndExit={cleanUpAndExit}
+            tipRack={tipRack}
+            isMulti={isMulti}
+            mount={instrument?.mount.toLowerCase() as Mount}
+            calBlock={calBlock}
+            currentStep={currentStep}
+            sessionType={session.sessionType}
+            robotName={robotName}
+            supportedCommands={supportedCommands}
+            defaultTipracks={instrument?.defaultTipracks}
+          />
+        )
+      })()}
     </ModalShell>,
     getTopPortalEl()
   )

--- a/app/src/organisms/Desktop/CalibrateTipLength/index.tsx
+++ b/app/src/organisms/Desktop/CalibrateTipLength/index.tsx
@@ -154,36 +154,43 @@ export function CalibrateTipLength({
         />
       }
     >
-      {showSpinner || currentStep == null || Panel == null ? (
-        <LoadingState />
-      ) : showConfirmExit ? (
-        <ConfirmExit
-          exit={confirmExit}
-          back={cancelExit}
-          heading={t('progress_will_be_lost', {
-            sessionType: t('tip_length_calibration'),
-          })}
-          body={t('confirm_exit_before_completion', {
-            sessionType: t('tip_length_calibration'),
-          })}
-        />
-      ) : errorInfo != null ? (
-        <CalibrationError {...errorInfo} onClose={cleanUpAndExit} />
-      ) : (
-        <Panel
-          sendCommands={sendCommands}
-          cleanUpAndExit={cleanUpAndExit}
-          isMulti={isMulti}
-          mount={instrument?.mount.toLowerCase() as Mount}
-          tipRack={tipRack}
-          calBlock={calBlock}
-          currentStep={currentStep}
-          sessionType={session.sessionType}
-          supportedCommands={supportedCommands}
-          calInvalidationHandler={offsetInvalidationHandler}
-          allowChangeTipRack={allowChangeTipRack}
-        />
-      )}
+      {(() => {
+        if (showSpinner || currentStep == null || Panel == null) {
+          return <LoadingState />
+        }
+        if (showConfirmExit) {
+          return (
+            <ConfirmExit
+              exit={confirmExit}
+              back={cancelExit}
+              heading={t('progress_will_be_lost', {
+                sessionType: t('tip_length_calibration'),
+              })}
+              body={t('confirm_exit_before_completion', {
+                sessionType: t('tip_length_calibration'),
+              })}
+            />
+          )
+        }
+        if (errorInfo != null) {
+          return <CalibrationError {...errorInfo} onClose={cleanUpAndExit} />
+        }
+        return (
+          <Panel
+            sendCommands={sendCommands}
+            cleanUpAndExit={cleanUpAndExit}
+            isMulti={isMulti}
+            mount={instrument?.mount.toLowerCase() as Mount}
+            tipRack={tipRack}
+            calBlock={calBlock}
+            currentStep={currentStep}
+            sessionType={session.sessionType}
+            supportedCommands={supportedCommands}
+            calInvalidationHandler={offsetInvalidationHandler}
+            allowChangeTipRack={allowChangeTipRack}
+          />
+        )
+      })()}
     </ModalShell>,
     getTopPortalEl()
   )

--- a/app/src/organisms/Desktop/CheckCalibration/ResultsSummary/CalibrationResult.tsx
+++ b/app/src/organisms/Desktop/CheckCalibration/ResultsSummary/CalibrationResult.tsx
@@ -33,11 +33,13 @@ export function CalibrationResult({
   const { t } = useTranslation('robot_calibration')
 
   const switchText = (calType: CalibrationType): string => {
-    return calType === 'deck'
-      ? 'deck_calibration'
-      : calType === 'pipetteOffset'
-        ? 'pipette_offset_title'
-        : 'tip_length'
+    if (calType === 'deck') {
+      return 'deck_calibration'
+    }
+    if (calType === 'pipetteOffset') {
+      return 'pipette_offset_title'
+    }
+    return 'tip_length'
   }
   return (
     <Flex

--- a/app/src/organisms/Desktop/CheckCalibration/index.tsx
+++ b/app/src/organisms/Desktop/CheckCalibration/index.tsx
@@ -193,35 +193,41 @@ export function CheckCalibration(
         />
       }
     >
-      {showSpinner || currentStep == null || Panel == null ? (
-        <LoadingState />
-      ) : showConfirmExit ? (
-        <ConfirmExit
-          exit={confirmExit}
-          back={cancelExit}
-          heading={t('progress_will_be_lost', {
-            sessionType: t('calibration_health_check'),
-          })}
-          body={t('confirm_exit_before_completion', {
-            sessionType: t('calibration_health_check'),
-          })}
-        />
-      ) : (
-        <Panel
-          sendCommands={sendCommands}
-          cleanUpAndExit={cleanUpAndExit}
-          tipRack={activeTipRack}
-          calBlock={calBlock}
-          isMulti={isMulti}
-          mount={activePipette?.mount.toLowerCase() as Mount}
-          currentStep={currentStep}
-          sessionType={session.sessionType}
-          checkBothPipettes={checkBothPipettes}
-          instruments={instruments}
-          comparisonsByPipette={comparisonsByPipette}
-          activePipette={activePipette}
-        />
-      )}
+      {(() => {
+        if (showSpinner || currentStep == null || Panel == null) {
+          return <LoadingState />
+        }
+        if (showConfirmExit) {
+          return (
+            <ConfirmExit
+              exit={confirmExit}
+              back={cancelExit}
+              heading={t('progress_will_be_lost', {
+                sessionType: t('calibration_health_check'),
+              })}
+              body={t('confirm_exit_before_completion', {
+                sessionType: t('calibration_health_check'),
+              })}
+            />
+          )
+        }
+        return (
+          <Panel
+            sendCommands={sendCommands}
+            cleanUpAndExit={cleanUpAndExit}
+            tipRack={activeTipRack}
+            calBlock={calBlock}
+            isMulti={isMulti}
+            mount={activePipette?.mount.toLowerCase() as Mount}
+            currentStep={currentStep}
+            sessionType={session.sessionType}
+            checkBothPipettes={checkBothPipettes}
+            instruments={instruments}
+            comparisonsByPipette={comparisonsByPipette}
+            activePipette={activePipette}
+          />
+        )
+      })()}
     </ModalShell>,
     getTopPortalEl()
   )

--- a/app/src/organisms/Desktop/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseProtocolSlideout/index.tsx
@@ -707,22 +707,19 @@ export function ChooseProtocolSlideoutComponent(
         </ApiHostProvider>
       }
     >
-      {showSlideout ? (
-        currentPage === 1 ? (
-          <StoredProtocolList
-            handleSelectProtocol={storedProtocol => {
-              if (!isCreatingRun) {
-                resetCreateRun()
-                setSelectedProtocol(storedProtocol)
-              }
-            }}
-            robot={robot}
-            {...{ selectedProtocol, runCreationError, runCreationErrorCode }}
-          />
-        ) : (
-          pageTwoBody
-        )
+      {showSlideout && currentPage === 1 ? (
+        <StoredProtocolList
+          handleSelectProtocol={storedProtocol => {
+            if (!isCreatingRun) {
+              resetCreateRun()
+              setSelectedProtocol(storedProtocol)
+            }
+          }}
+          robot={robot}
+          {...{ selectedProtocol, runCreationError, runCreationErrorCode }}
+        />
       ) : null}
+      {showSlideout && currentPage !== 1 ? pageTwoBody : null}
     </MultiSlideout>
   )
 }

--- a/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -239,71 +239,71 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
 
   const footer = (
     <Flex flexDirection={DIRECTION_COLUMN}>
-      {hasRunTimeParameters ? (
-        currentPage === 1 ? (
-          <>
-            {offsetsComponent}
-            <PrimaryButton
-              onClick={() => {
-                setCurrentPage(2)
-              }}
-              width="100%"
-              disabled={
-                isCreatingRun ||
-                selectedRobot == null ||
-                isSelectedRobotOnDifferentSoftwareVersion
-              }
-            >
-              {t('shared:continue_to_param')}
-            </PrimaryButton>
-          </>
-        ) : (
-          <Flex
-            gridGap={SPACING.spacing8}
-            flexDirection={DIRECTION_ROW}
-            whiteSpace={NO_WRAP}
+      {hasRunTimeParameters && currentPage === 1 ? (
+        <>
+          {offsetsComponent}
+          <PrimaryButton
+            onClick={() => {
+              setCurrentPage(2)
+            }}
+            width="100%"
+            disabled={
+              isCreatingRun ||
+              selectedRobot == null ||
+              isSelectedRobotOnDifferentSoftwareVersion
+            }
           >
-            <SecondaryButton
-              onClick={() => {
-                setCurrentPage(1)
-              }}
-              width="50%"
-            >
-              {t('shared:change_robot')}
-            </SecondaryButton>
-            <PrimaryButton
-              width="50%"
-              onClick={handleProceed}
-              disabled={hasParamError || hasMissingFileParam}
-              {...targetProps}
-            >
-              {isCreatingRun ? (
-                <Flex
-                  gridGap={SPACING.spacing4}
-                  alignItems={ALIGN_CENTER}
-                  whiteSpace={NO_WRAP}
-                  marginLeft={`-${SPACING.spacing4}`}
-                >
-                  <Icon name="ot-spinner" spin size="1rem" />
-                  {t('shared:confirm_values')}
-                </Flex>
-              ) : (
-                t('shared:confirm_values')
-              )}
-            </PrimaryButton>
-            {hasMissingFileParam ? (
-              <Tooltip tooltipProps={tooltipProps}>
-                {t('add_required_csv_file')}
-              </Tooltip>
-            ) : null}
-          </Flex>
-        )
-      ) : (
+            {t('shared:continue_to_param')}
+          </PrimaryButton>
+        </>
+      ) : null}
+      {hasRunTimeParameters && currentPage !== 1 ? (
+        <Flex
+          gridGap={SPACING.spacing8}
+          flexDirection={DIRECTION_ROW}
+          whiteSpace={NO_WRAP}
+        >
+          <SecondaryButton
+            onClick={() => {
+              setCurrentPage(1)
+            }}
+            width="50%"
+          >
+            {t('shared:change_robot')}
+          </SecondaryButton>
+          <PrimaryButton
+            width="50%"
+            onClick={handleProceed}
+            disabled={hasParamError || hasMissingFileParam}
+            {...targetProps}
+          >
+            {isCreatingRun ? (
+              <Flex
+                gridGap={SPACING.spacing4}
+                alignItems={ALIGN_CENTER}
+                whiteSpace={NO_WRAP}
+                marginLeft={`-${SPACING.spacing4}`}
+              >
+                <Icon name="ot-spinner" spin size="1rem" />
+                {t('shared:confirm_values')}
+              </Flex>
+            ) : (
+              t('shared:confirm_values')
+            )}
+          </PrimaryButton>
+          {hasMissingFileParam ? (
+            <Tooltip tooltipProps={tooltipProps}>
+              {t('add_required_csv_file')}
+            </Tooltip>
+          ) : null}
+        </Flex>
+      ) : null}
+      {!hasRunTimeParameters ? (
         <>
           {offsetsComponent}
           {singlePageButton}
         </>
-      )}
+      ) : null}
     </Flex>
   )
 

--- a/app/src/organisms/Desktop/Devices/ChangePipette/Instructions.tsx
+++ b/app/src/organisms/Desktop/Devices/ChangePipette/Instructions.tsx
@@ -144,37 +144,40 @@ export function Instructions(props: Props): JSX.Element {
                     }}
                   />
 
-                  {direction === 'attach' && currentStepCount === 1 ? (
-                    channels === 8 ? (
-                      <Flex flexDirection={DIRECTION_ROW}>
-                        <Trans
-                          t={t}
-                          i18nKey="tighten_screws_multi"
-                          components={{
-                            strong: (
-                              <strong
-                                style={{
-                                  fontWeight: TYPOGRAPHY.fontWeightSemiBold,
-                                }}
-                              />
-                            ),
-                            block: (
-                              <LegacyStyledText
-                                forwardedAs="p"
-                                marginTop={SPACING.spacing16}
-                              />
-                            ),
-                          }}
-                        />
-                      </Flex>
-                    ) : (
-                      <LegacyStyledText
-                        marginTop={SPACING.spacing16}
-                        forwardedAs="p"
-                      >
-                        {t('tighten_screws_single')}
-                      </LegacyStyledText>
-                    )
+                  {direction === 'attach' &&
+                  currentStepCount === 1 &&
+                  channels === 8 ? (
+                    <Flex flexDirection={DIRECTION_ROW}>
+                      <Trans
+                        t={t}
+                        i18nKey="tighten_screws_multi"
+                        components={{
+                          strong: (
+                            <strong
+                              style={{
+                                fontWeight: TYPOGRAPHY.fontWeightSemiBold,
+                              }}
+                            />
+                          ),
+                          block: (
+                            <LegacyStyledText
+                              forwardedAs="p"
+                              marginTop={SPACING.spacing16}
+                            />
+                          ),
+                        }}
+                      />
+                    </Flex>
+                  ) : null}
+                  {direction === 'attach' &&
+                  currentStepCount === 1 &&
+                  channels !== 8 ? (
+                    <LegacyStyledText
+                      marginTop={SPACING.spacing16}
+                      forwardedAs="p"
+                    >
+                      {t('tighten_screws_single')}
+                    </LegacyStyledText>
                   ) : null}
                 </Flex>
               </InstructionStep>

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ErrorContent.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ErrorContent.tsx
@@ -36,18 +36,22 @@ export function ErrorContent({
         forwardedAs="p"
         fontWeight={TYPOGRAPHY.fontWeightSemiBold}
       >
-        {isSingleError
-          ? t('error_info', {
+        {(() => {
+          if (isSingleError) {
+            return t('error_info', {
               errorType: errors[0].errorType,
               errorCode: errors[0].errorCode,
             })
-          : runStatus === RUN_STATUS_SUCCEEDED
-            ? t(errors.length > 1 ? 'no_of_warnings' : 'no_of_warning', {
-                count: errors.length,
-              })
-            : t(errors.length > 1 ? 'no_of_errors' : 'no_of_error', {
-                count: errors.length,
-              })}
+          }
+          if (runStatus === RUN_STATUS_SUCCEEDED) {
+            return t(errors.length > 1 ? 'no_of_warnings' : 'no_of_warning', {
+              count: errors.length,
+            })
+          }
+          return t(errors.length > 1 ? 'no_of_errors' : 'no_of_error', {
+            count: errors.length,
+          })
+        })()}
       </LegacyStyledText>
       <Flex css={ERROR_MESSAGE_STYLE}>
         {' '}

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/RunFailedModal.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/RunFailedModal.tsx
@@ -69,14 +69,18 @@ export function RunFailedModal({
   const { commandErrorList, highestPriorityError } = runErrors
 
   const { i18n, t } = useTranslation(['run_details', 'shared', 'branded'])
+  const getModalTitle = (): string => {
+    if (commandErrorList == null || commandErrorList?.length === 0) {
+      return t('run_failed_modal_title')
+    }
+    if (runStatus === RUN_STATUS_SUCCEEDED) {
+      return t('warning_details')
+    }
+    return t('error_details')
+  }
   const modalProps: ModalProps = {
     type: runStatus === RUN_STATUS_SUCCEEDED ? 'warning' : 'error',
-    title:
-      commandErrorList == null || commandErrorList?.length === 0
-        ? t('run_failed_modal_title')
-        : runStatus === RUN_STATUS_SUCCEEDED
-          ? t('warning_details')
-          : t('error_details'),
+    title: getModalTitle(),
     onClose: () => {
       toggleModal()
     },
@@ -100,13 +104,15 @@ export function RunFailedModal({
     <Modal {...modalProps}>
       <Flex flexDirection={DIRECTION_COLUMN}>
         <ErrorContent
-          errors={
-            highestPriorityError != null
-              ? [highestPriorityError]
-              : commandErrorList != null && commandErrorList.length > 0
-                ? commandErrorList
-                : []
-          }
+          errors={(() => {
+            if (highestPriorityError != null) {
+              return [highestPriorityError]
+            }
+            if (commandErrorList != null && commandErrorList.length > 0) {
+              return commandErrorList
+            }
+            return []
+          })()}
           isSingleError={!!highestPriorityError}
           runStatus={runStatus}
         />

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -586,26 +586,30 @@ function StepRightElement(props: StepRightElementProps): JSX.Element | null {
       <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_CENTER}>
         <Icon
           size="1rem"
-          color={
-            props.disabledHardware
-              ? COLORS.red60
-              : props.missingHardware
-                ? COLORS.yellow60
-                : COLORS.grey60
-          }
+          color={(() => {
+            if (props.disabledHardware) {
+              return COLORS.red60
+            }
+            if (props.missingHardware) {
+              return COLORS.yellow60
+            }
+            return COLORS.grey60
+          })()}
           marginRight={SPACING.spacing8}
           name="ot-alert"
           id={`RunSetupCard_${props.stepKey}_missingHardwareIcon`}
         />
         <StyledText
           desktopStyle="bodyDefaultSemiBold"
-          color={
-            props.disabledHardware
-              ? COLORS.red60
-              : props.missingHardware
-                ? COLORS.yellow60
-                : COLORS.grey60
-          }
+          color={(() => {
+            if (props.disabledHardware) {
+              return COLORS.red60
+            }
+            if (props.missingHardware) {
+              return COLORS.yellow60
+            }
+            return COLORS.grey60
+          })()}
           marginRight={SPACING.spacing16}
           id={`RunSetupCard_${props.stepKey}_missingHardwareText`}
         >

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupModuleAndDeck/SetupModulesList.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupModuleAndDeck/SetupModulesList.tsx
@@ -471,39 +471,45 @@ export function ModulesListItem({
             flexDirection={DIRECTION_COLUMN}
             gridGap={SPACING.spacing10}
           >
-            {conflictedFixture && isFlex ? (
-              <Flex
-                flexDirection={DIRECTION_COLUMN}
-                gridGap={SPACING.spacing10}
-              >
-                <StatusLabel
-                  status={t('location_conflict')}
-                  backgroundColor={COLORS.yellow30}
-                  iconColor={COLORS.yellow60}
-                  textColor={COLORS.yellow60}
-                />
-                <TertiaryButton
-                  width="max-content"
-                  onClick={() => {
-                    setShowLocationConflictModal(true)
-                  }}
-                >
-                  <LegacyStyledText forwardedAs="label" cursor="pointer">
-                    {t('resolve')}
-                  </LegacyStyledText>
-                </TertiaryButton>
-              </Flex>
-            ) : moduleModel === MAGNETIC_BLOCK_V1 ? (
-              <StatusLabel
-                status={t('n_a')}
-                backgroundColor={COLORS.grey30}
-                textColor={COLORS.grey60}
-                showIcon={false}
-                capitalizeStatus={false}
-              />
-            ) : (
-              renderModuleStatus
-            )}
+            {(() => {
+              if (conflictedFixture && isFlex) {
+                return (
+                  <Flex
+                    flexDirection={DIRECTION_COLUMN}
+                    gridGap={SPACING.spacing10}
+                  >
+                    <StatusLabel
+                      status={t('location_conflict')}
+                      backgroundColor={COLORS.yellow30}
+                      iconColor={COLORS.yellow60}
+                      textColor={COLORS.yellow60}
+                    />
+                    <TertiaryButton
+                      width="max-content"
+                      onClick={() => {
+                        setShowLocationConflictModal(true)
+                      }}
+                    >
+                      <LegacyStyledText forwardedAs="label" cursor="pointer">
+                        {t('resolve')}
+                      </LegacyStyledText>
+                    </TertiaryButton>
+                  </Flex>
+                )
+              }
+              if (moduleModel === MAGNETIC_BLOCK_V1) {
+                return (
+                  <StatusLabel
+                    status={t('n_a')}
+                    backgroundColor={COLORS.grey30}
+                    textColor={COLORS.grey60}
+                    showIcon={false}
+                    capitalizeStatus={false}
+                  />
+                )
+              }
+              return renderModuleStatus
+            })()}
           </Flex>
         </Flex>
       </Box>

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupModuleAndDeck/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupModuleAndDeck/index.tsx
@@ -150,11 +150,17 @@ export const SetupModuleAndDeck = ({
       runHasStarted ||
       !moduleCalibrationStatus.complete ? (
         <Tooltip tooltipProps={tooltipProps}>
-          {runHasStarted
-            ? t('protocol_run_started')
-            : missingModuleIds.length > 0
-              ? t('plug_in_required_module', { count: missingModuleIds.length })
-              : t('calibrate_module_failure_reason')}
+          {(() => {
+            if (runHasStarted) {
+              return t('protocol_run_started')
+            }
+            if (missingModuleIds.length > 0) {
+              return t('plug_in_required_module', {
+                count: missingModuleIds.length,
+              })
+            }
+            return t('calibrate_module_failure_reason')
+          })()}
         </Tooltip>
       ) : null}
     </>

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedStepsRowItem.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedStepsRowItem.tsx
@@ -16,62 +16,70 @@ export function AnnotatedStepsRowItem(
   return (
     <div style={style} {...ariaAttributes}>
       <div className={styles.annotated_steps_row}>
-        {row.type === 'group' ? (
-          <AnnotatedGroup
-            scrollTargetId={data.scrollTargetId}
-            listElement={data.listElement}
-            analysis={data.analysis}
-            annotationType={row.annotationType}
-            subCommands={row.group.subCommands}
-            commandStartNumber={row.commandStartNumber}
-            allRunDefs={data.allRunDefs}
-            setSelectedCommand={data.setSelectedCommand}
-            handlePause={data.handlePause}
-            annotationDescription={row.annotationDescription}
-          />
-        ) : row.type === 'command' ? (
-          <IndividualCommand
-            scrollTargetId={data.scrollTargetId}
-            listElement={data.listElement}
-            fromGroup={false}
-            command={row.command}
-            isHighlighted={row.isHighlighted}
-            analysis={data.analysis}
-            allRunDefs={data.allRunDefs}
-            setSelectedCommand={data.setSelectedCommand}
-            commandNumber={row.commandNumber}
-          />
-        ) : (
-          <div className={styles.annotated_steps_error_wrapper}>
-            {row.errors.map(error => (
-              <div
-                className={styles.annotated_steps_error_container}
-                key={error.id}
-                onClick={() => {
-                  data.onShowErrorDetails()
-                }}
-              >
-                <div className={styles.annotated_steps_header}>
-                  <Icon name="ot-alert" size="1rem" color={COLORS.red60} />
-                  <StyledText
-                    desktopStyle="captionSemiBold"
-                    color={COLORS.red60}
-                  >
-                    {data.t('step_error')}
+        {(() => {
+          if (row.type === 'group') {
+            return (
+              <AnnotatedGroup
+                scrollTargetId={data.scrollTargetId}
+                listElement={data.listElement}
+                analysis={data.analysis}
+                annotationType={row.annotationType}
+                subCommands={row.group.subCommands}
+                commandStartNumber={row.commandStartNumber}
+                allRunDefs={data.allRunDefs}
+                setSelectedCommand={data.setSelectedCommand}
+                handlePause={data.handlePause}
+                annotationDescription={row.annotationDescription}
+              />
+            )
+          }
+          if (row.type === 'command') {
+            return (
+              <IndividualCommand
+                scrollTargetId={data.scrollTargetId}
+                listElement={data.listElement}
+                fromGroup={false}
+                command={row.command}
+                isHighlighted={row.isHighlighted}
+                analysis={data.analysis}
+                allRunDefs={data.allRunDefs}
+                setSelectedCommand={data.setSelectedCommand}
+                commandNumber={row.commandNumber}
+              />
+            )
+          }
+          return (
+            <div className={styles.annotated_steps_error_wrapper}>
+              {row.errors.map(error => (
+                <div
+                  className={styles.annotated_steps_error_container}
+                  key={error.id}
+                  onClick={() => {
+                    data.onShowErrorDetails()
+                  }}
+                >
+                  <div className={styles.annotated_steps_header}>
+                    <Icon name="ot-alert" size="1rem" color={COLORS.red60} />
+                    <StyledText
+                      desktopStyle="captionSemiBold"
+                      color={COLORS.red60}
+                    >
+                      {data.t('step_error')}
+                    </StyledText>
+                  </div>
+                  <StyledText desktopStyle="bodyDefaultRegular">
+                    {error.detail}
                   </StyledText>
                 </div>
+              ))}
+              <div className={styles.annotated_steps_final_command}>
                 <StyledText desktopStyle="bodyDefaultRegular">
-                  {error.detail}
+                  {data.t('unable_to_show_steps_past_errors')}
                 </StyledText>
               </div>
-            ))}
-            <div className={styles.annotated_steps_final_command}>
-              <StyledText desktopStyle="bodyDefaultRegular">
-                {data.t('unable_to_show_steps_past_errors')}
-              </StyledText>
             </div>
-          </div>
-        )}
+          )
+        })()}
       </div>
     </div>
   )

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewDetails.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewDetails.tsx
@@ -115,19 +115,22 @@ export function DeckViewDetails(props: DeckViewDetailsProps): JSX.Element {
       {/* when commandSummary happens on a trash bin */}
       {isPipetteOverTrashBin &&
       selectedRunTimeCommand != null &&
-      trashCutoutId != null ? (
-        robotType === FLEX_ROBOT_TYPE ? (
-          <FixtureCommandSummary
-            commandType={selectedRunTimeCommand.commandType}
-            cutoutId={trashCutoutId as CutoutId}
-            type="trashBin"
-          />
-        ) : (
-          <Ot2FixedTrashCommandSummary
-            commandType={selectedRunTimeCommand.commandType}
-            cutoutId={trashCutoutId as CutoutId}
-          />
-        )
+      trashCutoutId != null &&
+      robotType === FLEX_ROBOT_TYPE ? (
+        <FixtureCommandSummary
+          commandType={selectedRunTimeCommand.commandType}
+          cutoutId={trashCutoutId as CutoutId}
+          type="trashBin"
+        />
+      ) : null}
+      {isPipetteOverTrashBin &&
+      selectedRunTimeCommand != null &&
+      trashCutoutId != null &&
+      robotType !== FLEX_ROBOT_TYPE ? (
+        <Ot2FixedTrashCommandSummary
+          commandType={selectedRunTimeCommand.commandType}
+          cutoutId={trashCutoutId as CutoutId}
+        />
       ) : null}
       {/* when commandSummary happens on a waste chute */}
       {isPipetteOverWasteChute &&

--- a/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/LabwareSlot/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/LabwareSlot/index.tsx
@@ -153,12 +153,16 @@ export function LabwareSlot(props: LabwareSlotContainerProps): JSX.Element {
     id =>
       labware[id] != null && labwareEntities[id].labwareDefURI === topLabwareURI
   ).length
-  const quantity =
-    hopperGroups != null
-      ? hopperGroups.length
-      : stackQuantity > 0
-        ? stackQuantity
-        : (lidStackCommand?.params?.quantity ?? 1)
+  const getQuantity = (): number => {
+    if (hopperGroups != null) {
+      return hopperGroups.length
+    }
+    if (stackQuantity > 0) {
+      return stackQuantity
+    }
+    return lidStackCommand?.params?.quantity ?? 1
+  }
+  const quantity = getQuantity()
   const adapterId = labware[topLabwareOnSlotId].stack.find(
     id =>
       labwareEntities[id]?.def.allowedRoles?.includes('adapter') &&

--- a/app/src/organisms/EmergencyStop/EstopTakeover.tsx
+++ b/app/src/organisms/EmergencyStop/EstopTakeover.tsx
@@ -55,24 +55,32 @@ export function EstopTakeover({ robotName }: EstopTakeoverProps): JSX.Element {
   const localRobot = useSelector(getLocalRobot)
   const localRobotName = localRobot?.name ?? 'no name'
 
-  const targetEstopModal =
-    estopState === NOT_PRESENT ? (
-      <EstopMissingModal
-        robotName={robotName != null ? robotName : localRobotName}
-        closeModal={closeModal}
-        isDismissedModal={isDismissedModal}
-        setIsDismissedModal={setIsDismissedModal}
-      />
-    ) : estopState !== DISENGAGED || isWaitingForResumeOperation ? (
-      <EstopPressedModal
-        isEngaged={estopState === PHYSICALLY_ENGAGED}
-        closeModal={closeModal}
-        isWaitingForResumeOperation={isWaitingForResumeOperation}
-        setIsWaitingForResumeOperation={() => {
-          setIsWatingForResumeOperation(true)
-        }}
-      />
-    ) : null
+  const getTargetEstopModal = (): JSX.Element | null => {
+    if (estopState === NOT_PRESENT) {
+      return (
+        <EstopMissingModal
+          robotName={robotName != null ? robotName : localRobotName}
+          closeModal={closeModal}
+          isDismissedModal={isDismissedModal}
+          setIsDismissedModal={setIsDismissedModal}
+        />
+      )
+    }
+    if (estopState !== DISENGAGED || isWaitingForResumeOperation) {
+      return (
+        <EstopPressedModal
+          isEngaged={estopState === PHYSICALLY_ENGAGED}
+          closeModal={closeModal}
+          isWaitingForResumeOperation={isWaitingForResumeOperation}
+          setIsWaitingForResumeOperation={() => {
+            setIsWatingForResumeOperation(true)
+          }}
+        />
+      )
+    }
+    return null
+  }
+  const targetEstopModal = getTargetEstopModal()
 
   return (
     <>

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedPipetteUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedPipetteUtils.ts
@@ -25,19 +25,25 @@ export function useFailedPipetteUtils(
 ): UseFailedPipetteUtilsResult {
   const { failedCommandByRunRecord, runId } = props
 
-  const failedPipetteId =
-    failedCommandByRunRecord != null
-      ? 'pipetteId' in failedCommandByRunRecord.params
-        ? failedCommandByRunRecord.params.pipetteId
-        : null
-      : null
+  const getFailedPipetteId = (): string | null => {
+    if (failedCommandByRunRecord == null) {
+      return null
+    }
+    if ('pipetteId' in failedCommandByRunRecord.params) {
+      return failedCommandByRunRecord.params.pipetteId
+    }
+    return null
+  }
+  const failedPipetteId = getFailedPipetteId()
 
   const { data: runCurrentState } = useRunCurrentState(runId, {
     enabled: failedPipetteId != null,
   })
 
   const relevantActiveNozzleLayout =
-    runCurrentState?.data.activeNozzleLayouts[failedPipetteId] ?? null
+    failedPipetteId != null
+      ? (runCurrentState?.data.activeNozzleLayouts[failedPipetteId] ?? null)
+      : null
 
   const failedPipetteInfo = getFailedCommandPipetteInfo(props)
 

--- a/app/src/organisms/ErrorRecoveryFlows/shared/FailedStepNextStep.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/FailedStepNextStep.tsx
@@ -27,12 +27,15 @@ export function FailedStepNextStep({
     stepCounts.currentStepNumber == null
       ? undefined
       : stepCounts.currentStepNumber + n
-  const nthCommand = (n: number): typeof failedCommandByAnalysis =>
-    commandsAfterFailedCommand != null
-      ? n < commandsAfterFailedCommand.length
-        ? commandsAfterFailedCommand[n]
-        : null
-      : null
+  const nthCommand = (n: number): typeof failedCommandByAnalysis => {
+    if (commandsAfterFailedCommand == null) {
+      return null
+    }
+    if (n < commandsAfterFailedCommand.length) {
+      return commandsAfterFailedCommand[n]
+    }
+    return null
+  }
 
   const commandsAfter = [nthCommand(0), nthCommand(1)] as const
 

--- a/app/src/organisms/InterventionModal/InterventionCommandMessage.tsx
+++ b/app/src/organisms/InterventionModal/InterventionCommandMessage.tsx
@@ -54,11 +54,15 @@ export function InterventionCommandMessage({
         {t('notes')}
       </LegacyStyledText>
       <LegacyStyledText css={INTERVENTION_COMMAND_MESSAGE_STYLE}>
-        {commandMessage != null && commandMessage !== ''
-          ? commandMessage.length > 220
-            ? `${commandMessage.substring(0, 217)}...`
-            : commandMessage
-          : t('wait_for_resume')}
+        {(() => {
+          if (commandMessage == null || commandMessage === '') {
+            return t('wait_for_resume')
+          }
+          if (commandMessage.length > 220) {
+            return `${commandMessage.substring(0, 217)}...`
+          }
+          return commandMessage
+        })()}
       </LegacyStyledText>
     </Flex>
   )

--- a/app/src/organisms/LegacyApplyHistoricOffsets/index.tsx
+++ b/app/src/organisms/LegacyApplyHistoricOffsets/index.tsx
@@ -165,28 +165,27 @@ export function LegacyApplyHistoricOffsets(
                 >
                   {t('see_how_offsets_work')}
                 </ExternalLink>
-                {!noOffsetData ? (
-                  isLabwareOffsetCodeSnippetsOn ? (
-                    <LegacyLabwareOffsetTabs
-                      TableComponent={
-                        <LegacyLabwareOffsetTable
-                          offsetCandidates={offsetCandidates}
-                          labwareDefinitions={getLabwareDefinitionsFromCommands(
-                            commands
-                          )}
-                        />
-                      }
-                      JupyterComponent={JupyterSnippet}
-                      CommandLineComponent={CommandLineSnippet}
-                    />
-                  ) : (
-                    <LegacyLabwareOffsetTable
-                      offsetCandidates={offsetCandidates}
-                      labwareDefinitions={getLabwareDefinitionsFromCommands(
-                        commands
-                      )}
-                    />
-                  )
+                {!noOffsetData && isLabwareOffsetCodeSnippetsOn ? (
+                  <LegacyLabwareOffsetTabs
+                    TableComponent={
+                      <LegacyLabwareOffsetTable
+                        offsetCandidates={offsetCandidates}
+                        labwareDefinitions={getLabwareDefinitionsFromCommands(
+                          commands
+                        )}
+                      />
+                    }
+                    JupyterComponent={JupyterSnippet}
+                    CommandLineComponent={CommandLineSnippet}
+                  />
+                ) : null}
+                {!noOffsetData && !isLabwareOffsetCodeSnippetsOn ? (
+                  <LegacyLabwareOffsetTable
+                    offsetCandidates={offsetCandidates}
+                    labwareDefinitions={getLabwareDefinitionsFromCommands(
+                      commands
+                    )}
+                  />
                 ) : null}
               </Flex>
             </ModalShell>,

--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -377,7 +377,11 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
                 updatePipetteFWRequired={updatePipetteFWRequired}
                 isTooHot={isTooHot}
               />
-            ) : !hideBanners && module.hasAvailableUpdate && showFWBanner ? (
+            ) : null}
+            {!hideBanners &&
+            !(requireModuleCalibration || requireModuleSetup) &&
+            module.hasAvailableUpdate &&
+            showFWBanner ? (
               <UpdateBanner
                 robotName={robotName}
                 updateType="firmware"

--- a/app/src/organisms/ModuleWizardFlows/PlaceAdapter.tsx
+++ b/app/src/organisms/ModuleWizardFlows/PlaceAdapter.tsx
@@ -237,21 +237,27 @@ export function PlaceAdapter(props: PlaceAdapterProps): JSX.Element {
             </AnimationVideo>
           </Flex>
         }
-        bodyText={
-          attachedModule.moduleType === HEATERSHAKER_MODULE_TYPE ? (
-            <LegacyStyledText css={BODY_STYLE}>
-              {t('place_flush_heater_shaker')}
-            </LegacyStyledText>
-          ) : attachedModule.moduleType === THERMOCYCLER_MODULE_TYPE ? (
-            <LegacyStyledText css={BODY_STYLE}>
-              {t('place_flush_thermocycler')}
-            </LegacyStyledText>
-          ) : (
+        bodyText={(() => {
+          if (attachedModule.moduleType === HEATERSHAKER_MODULE_TYPE) {
+            return (
+              <LegacyStyledText css={BODY_STYLE}>
+                {t('place_flush_heater_shaker')}
+              </LegacyStyledText>
+            )
+          }
+          if (attachedModule.moduleType === THERMOCYCLER_MODULE_TYPE) {
+            return (
+              <LegacyStyledText css={BODY_STYLE}>
+                {t('place_flush_thermocycler')}
+              </LegacyStyledText>
+            )
+          }
+          return (
             <LegacyStyledText css={BODY_STYLE}>
               {t('place_flush')}
             </LegacyStyledText>
           )
-        }
+        })()}
         proceedButtonText={t('confirm_placement')}
         proceed={handleOnClick}
         proceedIsDisabled={maintenanceRunId == null}

--- a/app/src/organisms/ModuleWizardFlows/Success.tsx
+++ b/app/src/organisms/ModuleWizardFlows/Success.tsx
@@ -71,25 +71,28 @@ export function Success(props: SuccessProps): JSX.Element {
     >
       <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing8}>
         <>
-          {newModules.length > 0 && attachedModuleOnLaunch == null ? (
-            isOnDevice ? (
-              <SmallButton
-                buttonType="secondary"
-                onClick={() => {
-                  handleOnClick(true)
-                }}
-                buttonText={t('setup_another_module')}
-              />
-            ) : (
-              <SecondaryButton
-                disabled={isRobotMoving}
-                onClick={() => {
-                  handleOnClick(true)
-                }}
-              >
-                {t('setup_another_module')}
-              </SecondaryButton>
-            )
+          {newModules.length > 0 &&
+          attachedModuleOnLaunch == null &&
+          isOnDevice ? (
+            <SmallButton
+              buttonType="secondary"
+              onClick={() => {
+                handleOnClick(true)
+              }}
+              buttonText={t('setup_another_module')}
+            />
+          ) : null}
+          {newModules.length > 0 &&
+          attachedModuleOnLaunch == null &&
+          !isOnDevice ? (
+            <SecondaryButton
+              disabled={isRobotMoving}
+              onClick={() => {
+                handleOnClick(true)
+              }}
+            >
+              {t('setup_another_module')}
+            </SecondaryButton>
           ) : null}
 
           {isOnDevice ? (

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/getPipetteNameFromSpecs.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/getPipetteNameFromSpecs.ts
@@ -5,14 +5,19 @@ export const getPipetteNameFromSpecs = (
 ): string => {
   const { model, channels, displayCategory } = pipetteSpecs
 
-  const channelSuffix =
-    channels === 1
-      ? 'single'
-      : channels === 8
-        ? 'multi'
-        : channels === 96
-          ? '96'
-          : 'single'
+  const getChannelSuffix = (): string => {
+    if (channels === 1) {
+      return 'single'
+    }
+    if (channels === 8) {
+      return 'multi'
+    }
+    if (channels === 96) {
+      return '96'
+    }
+    return 'single'
+  }
+  const channelSuffix = getChannelSuffix()
 
   // Note(kk:2025-09-05): This is used for Flex only
   const robotSuffix = displayCategory === 'FLEX' && 'flex'

--- a/app/src/organisms/ODD/RobotDashboard/RecentRunProtocolCard.tsx
+++ b/app/src/organisms/ODD/RobotDashboard/RecentRunProtocolCard.tsx
@@ -190,13 +190,15 @@ export function ProtocolWithLastRun({
       flexDirection={DIRECTION_COLUMN}
       padding={SPACING.spacing24}
       gridGap={SPACING.spacing24}
-      backgroundColor={
-        isOk
-          ? isReadyToBeReRun
-            ? COLORS.green35
-            : COLORS.yellow35
-          : COLORS.red35
-      }
+      backgroundColor={(() => {
+        if (!isOk) {
+          return COLORS.red35
+        }
+        if (isReadyToBeReRun) {
+          return COLORS.green35
+        }
+        return COLORS.yellow35
+      })()}
       width="25.8125rem"
       height="24.5rem"
       borderRadius={BORDERS.borderRadius16}
@@ -205,7 +207,15 @@ export function ProtocolWithLastRun({
       <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
         <Chip
           paddingLeft="0"
-          type={isOk ? (isReadyToBeReRun ? 'success' : 'warning') : 'error'}
+          type={(() => {
+            if (!isOk) {
+              return 'error'
+            }
+            if (isReadyToBeReRun) {
+              return 'success'
+            }
+            return 'warning'
+          })()}
           background={false}
           text={i18n.format(chipText, 'capitalize')}
         />

--- a/app/src/organisms/ODD/RunningProtocol/RunFailedModal/ErrorContent.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/RunFailedModal/ErrorContent.tsx
@@ -22,18 +22,22 @@ export function ErrorContent({
   return (
     <>
       <LegacyStyledText forwardedAs="p" className={styles.error_info_text}>
-        {isSingleError
-          ? t('error_info', {
+        {(() => {
+          if (isSingleError) {
+            return t('error_info', {
               errorType: errors[0].errorType,
               errorCode: errors[0].errorCode,
             })
-          : runStatus === RUN_STATUS_SUCCEEDED
-            ? t(errors.length > 1 ? 'no_of_warnings' : 'no_of_warning', {
-                count: errors.length,
-              })
-            : t(errors.length > 1 ? 'no_of_errors' : 'no_of_error', {
-                count: errors.length,
-              })}
+          }
+          if (runStatus === RUN_STATUS_SUCCEEDED) {
+            return t(errors.length > 1 ? 'no_of_warnings' : 'no_of_warning', {
+              count: errors.length,
+            })
+          }
+          return t(errors.length > 1 ? 'no_of_errors' : 'no_of_error', {
+            count: errors.length,
+          })
+        })()}
       </LegacyStyledText>
       <div className={styles.error_container}>
         <div className={styles.error_list}>

--- a/app/src/organisms/ODD/RunningProtocol/RunFailedModal/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/RunFailedModal/index.tsx
@@ -46,13 +46,17 @@ export function RunFailedModal({
   ) {
     return null
   }
+  const getModalTitle = (): string => {
+    if (commandErrorList == null || commandErrorList?.data.length === 0) {
+      return t('run_failed_modal_title')
+    }
+    if (runStatus === RUN_STATUS_SUCCEEDED) {
+      return t('warning_details')
+    }
+    return t('error_details')
+  }
   const modalHeader: OddModalHeaderBaseProps = {
-    title:
-      commandErrorList == null || commandErrorList?.data.length === 0
-        ? t('run_failed_modal_title')
-        : runStatus === RUN_STATUS_SUCCEEDED
-          ? t('warning_details')
-          : t('error_details'),
+    title: getModalTitle(),
   }
 
   const highestPriorityError = getHighestPriorityError(errors ?? [])
@@ -83,13 +87,15 @@ export function RunFailedModal({
       <div className={styles.container}>
         <div className={styles.error_content}>
           <ErrorContent
-            errors={
-              highestPriorityError
-                ? [highestPriorityError]
-                : commandErrorList?.data && commandErrorList?.data.length > 0
-                  ? commandErrorList?.data
-                  : []
-            }
+            errors={(() => {
+              if (highestPriorityError) {
+                return [highestPriorityError]
+              }
+              if (commandErrorList?.data && commandErrorList?.data.length > 0) {
+                return commandErrorList?.data
+              }
+              return []
+            })()}
             isSingleError={!!highestPriorityError}
             runStatus={runStatus}
           />

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -255,22 +255,24 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
           }`
         )
       }
-      rightHandBody={
-        isFetching ? (
-          <Skeleton
-            width="100%"
-            height="14.375rem"
-            backgroundSize={BACKGROUND_SIZE}
-          />
-        ) : is96ChannelPipette ? (
-          getPipetteAnimations96({
+      rightHandBody={(() => {
+        if (isFetching) {
+          return (
+            <Skeleton
+              width="100%"
+              height="14.375rem"
+              backgroundSize={BACKGROUND_SIZE}
+            />
+          )
+        }
+        if (is96ChannelPipette) {
+          return getPipetteAnimations96({
             section: pipetteWizardStep.section,
             flowType,
           })
-        ) : (
-          getPipetteAnimations({ pipetteWizardStep, channel })
-        )
-      }
+        }
+        return getPipetteAnimations({ pipetteWizardStep, channel })
+      })()}
       bodyText={bodyText}
       backIsDisabled={isFetching}
       back={goBack}

--- a/app/src/pages/ODD/ProtocolDashboard/index.tsx
+++ b/app/src/pages/ODD/ProtocolDashboard/index.tsx
@@ -161,6 +161,19 @@ export function ProtocolDashboard(): JSX.Element {
     }
   }
 
+  const getSortIconName = (
+    activeSortKeys: ProtocolsOnDeviceSortKey[],
+    ascendingKey: ProtocolsOnDeviceSortKey
+  ): 'arrow-down' | 'arrow-up' | undefined => {
+    if (!activeSortKeys.includes(sortBy)) {
+      return undefined
+    }
+    if (sortBy === ascendingKey) {
+      return 'arrow-down'
+    }
+    return 'arrow-up'
+  }
+
   return (
     <>
       {showDeleteConfirmationModal ? (
@@ -235,13 +248,10 @@ export function ProtocolDashboard(): JSX.Element {
                         ? 'secondary'
                         : 'tertiaryLowLight'
                     }
-                    iconName={
-                      sortBy === 'alphabetical' || sortBy === 'reverse'
-                        ? sortBy === 'alphabetical'
-                          ? 'arrow-down'
-                          : 'arrow-up'
-                        : undefined
-                    }
+                    iconName={getSortIconName(
+                      ['alphabetical', 'reverse'],
+                      'alphabetical'
+                    )}
                     iconPlacement="endIcon"
                     onClick={handleSortByName}
                   />
@@ -254,13 +264,10 @@ export function ProtocolDashboard(): JSX.Element {
                         ? 'secondary'
                         : 'tertiaryLowLight'
                     }
-                    iconName={
-                      sortBy === 'recentRun' || sortBy === 'oldRun'
-                        ? sortBy === 'recentRun'
-                          ? 'arrow-down'
-                          : 'arrow-up'
-                        : undefined
-                    }
+                    iconName={getSortIconName(
+                      ['recentRun', 'oldRun'],
+                      'recentRun'
+                    )}
                     iconPlacement="endIcon"
                     onClick={handleSortByLastRun}
                   />
@@ -273,13 +280,10 @@ export function ProtocolDashboard(): JSX.Element {
                         ? 'secondary'
                         : 'tertiaryLowLight'
                     }
-                    iconName={
-                      sortBy === 'recentCreated' || sortBy === 'oldCreated'
-                        ? sortBy === 'recentCreated'
-                          ? 'arrow-down'
-                          : 'arrow-up'
-                        : undefined
-                    }
+                    iconName={getSortIconName(
+                      ['recentCreated', 'oldCreated'],
+                      'recentCreated'
+                    )}
                     iconPlacement="endIcon"
                     onClick={handleSortByDate}
                   />
@@ -308,7 +312,8 @@ export function ProtocolDashboard(): JSX.Element {
                 })}
               </Flex>
             </>
-          ) : pinnedProtocols.length === 0 ? (
+          ) : null}
+          {sortedProtocols.length === 0 && pinnedProtocols.length === 0 ? (
             <NoProtocols />
           ) : null}
           <FloatingActionButton

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -599,11 +599,16 @@ function PrepareToRun({
 
   const doorStatus = useIsDoorOpen(robotName)
 
-  const parametersDetail = hasRunTimeParameters
-    ? hasCustomRunTimeParameters
-      ? t('custom_values')
-      : t('default_values')
-    : t('no_parameters_specified')
+  const getParametersDetail = (): string => {
+    if (!hasRunTimeParameters) {
+      return t('no_parameters_specified')
+    }
+    if (hasCustomRunTimeParameters) {
+      return t('custom_values')
+    }
+    return t('default_values')
+  }
+  const parametersDetail = getParametersDetail()
 
   return (
     <>

--- a/app/src/pages/ODD/UpdateRobot/UpdateRobot.tsx
+++ b/app/src/pages/ODD/UpdateRobot/UpdateRobot.tsx
@@ -38,42 +38,52 @@ export function UpdateRobot(): JSX.Element {
 
   return (
     <Flex padding={SPACING.spacing40}>
-      {errorString !== null ? (
-        <ErrorUpdateSoftware errorMessage={errorString}>
-          <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing8}>
-            <MediumButton
-              flex="1"
-              buttonType="secondary"
-              buttonText={t('cancel_software_update')}
-              onClick={() => {
-                dispatch(clearRobotUpdateSession())
+      {(() => {
+        if (errorString !== null) {
+          return (
+            <ErrorUpdateSoftware errorMessage={errorString}>
+              <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing8}>
+                <MediumButton
+                  flex="1"
+                  buttonType="secondary"
+                  buttonText={t('cancel_software_update')}
+                  onClick={() => {
+                    dispatch(clearRobotUpdateSession())
+                    navigate(-1)
+                  }}
+                />
+                <MediumButton
+                  flex="1"
+                  onClick={() => {
+                    setErrorString(null)
+                    dispatchStartRobotUpdate(robotName)
+                  }}
+                  buttonText={i18n.format(t('shared:try_again'), 'capitalize')}
+                />
+              </Flex>
+            </ErrorUpdateSoftware>
+          )
+        }
+        if (
+          localRobot === null ||
+          localRobot.status === UNREACHABLE ||
+          robotUpdateType !== 'upgrade'
+        ) {
+          return (
+            <NoUpdateFound
+              onContinue={() => {
                 navigate(-1)
               }}
             />
-            <MediumButton
-              flex="1"
-              onClick={() => {
-                setErrorString(null)
-                dispatchStartRobotUpdate(robotName)
-              }}
-              buttonText={i18n.format(t('shared:try_again'), 'capitalize')}
-            />
-          </Flex>
-        </ErrorUpdateSoftware>
-      ) : localRobot === null ||
-        localRobot.status === UNREACHABLE ||
-        robotUpdateType !== 'upgrade' ? (
-        <NoUpdateFound
-          onContinue={() => {
-            navigate(-1)
-          }}
-        />
-      ) : (
-        <UpdateRobotSoftware
-          localRobot={localRobot}
-          afterError={setErrorString}
-        />
-      )}
+          )
+        }
+        return (
+          <UpdateRobotSoftware
+            localRobot={localRobot}
+            afterError={setErrorString}
+          />
+        )
+      })()}
     </Flex>
   )
 }

--- a/app/src/pages/ODD/UpdateRobot/UpdateRobotDuringOnboarding.tsx
+++ b/app/src/pages/ODD/UpdateRobot/UpdateRobotDuringOnboarding.tsx
@@ -79,44 +79,55 @@ export function UpdateRobotDuringOnboarding(): JSX.Element {
 
   return (
     <Flex padding={SPACING.spacing40}>
-      {errorString !== null ? (
-        <ErrorUpdateSoftware errorMessage={errorString}>
-          <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing8}>
-            <MediumButton
-              flex="1"
-              buttonType="secondary"
-              buttonText={t('proceed_without_updating')}
-              onClick={() => {
-                dispatch(clearRobotUpdateSession())
+      {(() => {
+        if (errorString !== null) {
+          return (
+            <ErrorUpdateSoftware errorMessage={errorString}>
+              <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing8}>
+                <MediumButton
+                  flex="1"
+                  buttonType="secondary"
+                  buttonText={t('proceed_without_updating')}
+                  onClick={() => {
+                    dispatch(clearRobotUpdateSession())
+                    navigate('/emergency-stop')
+                  }}
+                />
+                <MediumButton
+                  flex="1"
+                  onClick={() => {
+                    dispatchStartRobotUpdate(robotName)
+                  }}
+                  buttonText={i18n.format(t('shared:try_again'), 'capitalize')}
+                />
+              </Flex>
+            </ErrorUpdateSoftware>
+          )
+        }
+        if (isShowCheckingUpdates && robotUpdateType !== 'upgrade') {
+          return <CheckUpdates />
+        }
+        if (
+          localRobot === null ||
+          localRobot.status === UNREACHABLE ||
+          robotUpdateType !== 'upgrade'
+        ) {
+          return (
+            <NoUpdateFound
+              onContinue={() => {
                 navigate('/emergency-stop')
               }}
             />
-            <MediumButton
-              flex="1"
-              onClick={() => {
-                dispatchStartRobotUpdate(robotName)
-              }}
-              buttonText={i18n.format(t('shared:try_again'), 'capitalize')}
-            />
-          </Flex>
-        </ErrorUpdateSoftware>
-      ) : isShowCheckingUpdates && robotUpdateType !== 'upgrade' ? (
-        <CheckUpdates />
-      ) : localRobot === null ||
-        localRobot.status === UNREACHABLE ||
-        robotUpdateType !== 'upgrade' ? (
-        <NoUpdateFound
-          onContinue={() => {
-            navigate('/emergency-stop')
-          }}
-        />
-      ) : (
-        <UpdateRobotSoftware
-          localRobot={localRobot}
-          afterError={setErrorString}
-          beforeCommittingSuccessfulUpdate={handleSuccessfulUpdate}
-        />
-      )}
+          )
+        }
+        return (
+          <UpdateRobotSoftware
+            localRobot={localRobot}
+            afterError={setErrorString}
+            beforeCommittingSuccessfulUpdate={handleSuccessfulUpdate}
+          />
+        )
+      })()}
     </Flex>
   )
 }

--- a/components/src/atoms/Toast/index.tsx
+++ b/components/src/atoms/Toast/index.tsx
@@ -231,12 +231,16 @@ export function Toast(props: ToastProps): JSX.Element {
     },
   }
 
-  const headingText =
-    heading !== undefined
-      ? showODDStyle
-        ? truncateString(heading, 45, 40)
-        : heading
-      : ''
+  const getHeadingText = (): string => {
+    if (heading === undefined) {
+      return ''
+    }
+    if (showODDStyle) {
+      return truncateString(heading, 45, 40)
+    }
+    return heading
+  }
+  const headingText = getHeadingText()
 
   const calculatedDuration = (
     message: string,

--- a/components/src/atoms/buttons/LargeButton.tsx
+++ b/components/src/atoms/buttons/LargeButton.tsx
@@ -204,11 +204,15 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
         .hoverBackgroundColor};
 
-      border: ${buttonType === 'stroke'
-        ? `2px solid ${COLORS.blue55}`
-        : buttonType === 'primary'
-          ? `4px solid ${COLORS.blue55}`
-          : computedBorderStyle()};
+      border: ${(() => {
+        if (buttonType === 'stroke') {
+          return `2px solid ${COLORS.blue55}`
+        }
+        if (buttonType === 'primary') {
+          return `4px solid ${COLORS.blue55}`
+        }
+        return computedBorderStyle()
+      })()};
     }
 
     &:focus-visible {

--- a/components/src/atoms/buttons/RadioButton.tsx
+++ b/components/src/atoms/buttons/RadioButton.tsx
@@ -231,11 +231,15 @@ const SUBBUTTON_LABEL_STYLE = (
   isSelected: boolean,
   buttonSubLabel: RadioButtonSubLabel
 ): FlattenSimpleInterpolation => css`
-  color: ${disabled
-    ? COLORS.grey50
-    : isSelected
-      ? COLORS.white
-      : COLORS.grey60};
+  color: ${(() => {
+    if (disabled) {
+      return COLORS.grey50
+    }
+    if (isSelected) {
+      return COLORS.white
+    }
+    return COLORS.grey60
+  })()};
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: ${buttonSubLabel?.align === 'vertical' ? 2 : 1};

--- a/components/src/forms/DeprecatedCheckboxField.tsx
+++ b/components/src/forms/DeprecatedCheckboxField.tsx
@@ -59,13 +59,15 @@ export function DeprecatedCheckboxField(
     <label className={outerClassName}>
       <div className={innerDivClassName}>
         <Icon
-          name={
-            props.isIndeterminate
-              ? 'minus-box'
-              : props.value
-                ? 'ot-checkbox'
-                : 'checkbox-blank-outline'
-          }
+          name={(() => {
+            if (props.isIndeterminate) {
+              return 'minus-box'
+            }
+            if (props.value) {
+              return 'ot-checkbox'
+            }
+            return 'checkbox-blank-outline'
+          })()}
           width="100%"
         />
       </div>

--- a/components/src/hardware-sim/Labware/LabwareRender.tsx
+++ b/components/src/hardware-sim/Labware/LabwareRender.tsx
@@ -160,13 +160,15 @@ export const LabwareRender = (props: LabwareRenderProps): JSX.Element => {
         }
       >
         <g
-          transform={
-            positioningMode === 'offsetInSlot'
-              ? shouldRotateAdapterOrientation
-                ? `translate(${-cornerOffsetFromSlot.x}, ${-cornerOffsetFromSlot.y})`
-                : `translate(${cornerOffsetFromSlot.x}, ${cornerOffsetFromSlot.y})`
-              : undefined
-          }
+          transform={(() => {
+            if (positioningMode !== 'offsetInSlot') {
+              return undefined
+            }
+            if (shouldRotateAdapterOrientation) {
+              return `translate(${-cornerOffsetFromSlot.x}, ${-cornerOffsetFromSlot.y})`
+            }
+            return `translate(${cornerOffsetFromSlot.x}, ${cornerOffsetFromSlot.y})`
+          })()}
           ref={gRef}
           onClick={onLabwareClick}
         >

--- a/components/src/molecules/ParametersTable/index.tsx
+++ b/components/src/molecules/ParametersTable/index.tsx
@@ -41,11 +41,13 @@ export function ParametersTable({
     const count = choices.length
 
     if (count > 0) {
-      return count > 2
-        ? t != null
-          ? t('num_options', { num: count })
-          : `${count} options`
-        : orderRuntimeParameterRangeOptions(choices)
+      if (count > 2) {
+        if (t != null) {
+          return t('num_options', { num: count })
+        }
+        return `${count} options`
+      }
+      return orderRuntimeParameterRangeOptions(choices)
     }
 
     switch (type) {

--- a/components/src/organisms/CommandText/useCommandTextString/utils/getWellRange.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/getWellRange.ts
@@ -9,12 +9,16 @@ import type {
 const usedChannelsFromCommand = (
   command: ConfigureNozzleLayoutRunTimeCommand | undefined,
   defaultChannels: number
-): number =>
-  command?.params?.configurationParams?.style === 'SINGLE'
-    ? 1
-    : command?.params?.configurationParams?.style === 'COLUMN'
-      ? 8
-      : defaultChannels
+): number => {
+  const style = command?.params?.configurationParams?.style
+  if (style === 'SINGLE') {
+    return 1
+  }
+  if (style === 'COLUMN') {
+    return 8
+  }
+  return defaultChannels
+}
 
 const usedChannelsForPipette = (
   pipetteId: string,

--- a/components/src/organisms/ProtocolDeck/index.tsx
+++ b/components/src/organisms/ProtocolDeck/index.tsx
@@ -95,8 +95,10 @@ export function ProtocolDeck(props: ProtocolDeckProps): JSX.Element | null {
                 protocolAnalysis.commands
               )
             : undefined,
-        moduleChildren: showLabwareLabels ? (
-          topLabwareDefinition != null && topLabwareInfo != null ? (
+        moduleChildren:
+          showLabwareLabels &&
+          topLabwareDefinition != null &&
+          topLabwareInfo != null ? (
             <AlignToModuleChildSlot
               deckId={deckDef.otId}
               slotId={slotName}
@@ -114,8 +116,7 @@ export function ProtocolDeck(props: ProtocolDeckProps): JSX.Element | null {
                 }
               />
             </AlignToModuleChildSlot>
-          ) : null
-        ) : null,
+          ) : null,
       }
     }
   )

--- a/opentrons-ai-client/src/components/molecules/FeedbackModal/index.tsx
+++ b/opentrons-ai-client/src/components/molecules/FeedbackModal/index.tsx
@@ -30,12 +30,15 @@ import type { AxiosRequestConfig } from 'axios'
 
 type Env = 'production' | 'development' | 'staging'
 
-const getEnv = (): Env =>
-  _NODE_ENV_ === 'production'
-    ? 'production'
-    : _NODE_ENV_ === 'development'
-      ? 'development'
-      : 'staging'
+const getEnv = (): Env => {
+  if (_NODE_ENV_ === 'production') {
+    return 'production'
+  }
+  if (_NODE_ENV_ === 'development') {
+    return 'development'
+  }
+  return 'staging'
+}
 
 const pickEndpoint = (endpoints: {
   production: string

--- a/opentrons-ai-client/src/resources/utils/buildRequestConfig.ts
+++ b/opentrons-ai-client/src/resources/utils/buildRequestConfig.ts
@@ -32,12 +32,15 @@ interface EnvEndpoints {
   staging: string
 }
 
-const getEnv = (): Env =>
-  _NODE_ENV_ === 'production'
-    ? 'production'
-    : _NODE_ENV_ === 'development'
-      ? 'development'
-      : 'staging'
+const getEnv = (): Env => {
+  if (_NODE_ENV_ === 'production') {
+    return 'production'
+  }
+  if (_NODE_ENV_ === 'development') {
+    return 'development'
+  }
+  return 'staging'
+}
 
 const pickEndpoint = (endpoints: EnvEndpoints): string => endpoints[getEnv()]
 

--- a/opentrons-ai-client/src/resources/utils/createProtocolUtils.tsx
+++ b/opentrons-ai-client/src/resources/utils/createProtocolUtils.tsx
@@ -43,12 +43,16 @@ export function generatePromptPreviewApplicationItems(
     application: { scientificApplication, otherApplication, description },
   } = watch()
 
-  const scientificOrOtherApplication =
-    scientificApplication === OTHER
-      ? otherApplication
-      : scientificApplication !== ''
-        ? t(scientificApplication)
-        : ''
+  const getScientificOrOtherApplication = (): string => {
+    if (scientificApplication === OTHER) {
+      return otherApplication
+    }
+    if (scientificApplication !== '') {
+      return t(scientificApplication)
+    }
+    return ''
+  }
+  const scientificOrOtherApplication = getScientificOrOtherApplication()
 
   return [
     scientificOrOtherApplication !== '' && scientificOrOtherApplication,
@@ -359,33 +363,41 @@ export function generateChatPrompt(
   const rightPipettePromptName =
     rightPipetteApiLoadName ?? values.instruments.rightPipette
 
-  const mounts: string[] =
-    values.instruments.pipettes === TWO_PIPETTES
-      ? [
-          values.instruments.leftPipette !== NO_PIPETTES
-            ? `left pipette ${leftPipettePromptName}`
-            : '',
-          values.instruments.rightPipette !== NO_PIPETTES
-            ? `right pipette ${rightPipettePromptName}`
-            : '',
-        ].filter(Boolean)
-      : values.instruments.pipettes === NINETY_SIX_CHANNEL_PIPETTE
-        ? [values.instruments.ninetySixChannelPipette]
-        : [values.instruments.pipettes]
+  const getMounts = (): string[] => {
+    if (values.instruments.pipettes === TWO_PIPETTES) {
+      return [
+        values.instruments.leftPipette !== NO_PIPETTES
+          ? `left pipette ${leftPipettePromptName}`
+          : '',
+        values.instruments.rightPipette !== NO_PIPETTES
+          ? `right pipette ${rightPipettePromptName}`
+          : '',
+      ].filter(Boolean)
+    }
+    if (values.instruments.pipettes === NINETY_SIX_CHANNEL_PIPETTE) {
+      return [values.instruments.ninetySixChannelPipette]
+    }
+    return [values.instruments.pipettes]
+  }
+  const mounts: string[] = getMounts()
 
-  const pipetteMounts =
-    values.instruments.pipettes === TWO_PIPETTES
-      ? [
-          values.instruments.leftPipette !== NO_PIPETTES &&
-            `- ${leftPipettePromptName} ${t('mounted_left')}`,
-          values.instruments.rightPipette !== NO_PIPETTES &&
-            `- ${rightPipettePromptName} ${t('mounted_right')}`,
-        ]
-          .filter(Boolean)
-          .join('\n')
-      : values.instruments.pipettes === NINETY_SIX_CHANNEL_PIPETTE
-        ? `- ${t(values.instruments.ninetySixChannelPipette)}`
-        : `- ${t(values.instruments.pipettes)}`
+  const getPipetteMounts = (): string => {
+    if (values.instruments.pipettes === TWO_PIPETTES) {
+      return [
+        values.instruments.leftPipette !== NO_PIPETTES &&
+          `- ${leftPipettePromptName} ${t('mounted_left')}`,
+        values.instruments.rightPipette !== NO_PIPETTES &&
+          `- ${rightPipettePromptName} ${t('mounted_right')}`,
+      ]
+        .filter(Boolean)
+        .join('\n')
+    }
+    if (values.instruments.pipettes === NINETY_SIX_CHANNEL_PIPETTE) {
+      return `- ${t(values.instruments.ninetySixChannelPipette)}`
+    }
+    return `- ${t(values.instruments.pipettes)}`
+  }
+  const pipetteMounts = getPipetteMounts()
   const flexGripper =
     values.instruments.flexGripper === FLEX_GRIPPER &&
     values.instruments.robot === OPENTRONS_FLEX

--- a/protocol-designer/src/components/molecules/InputStepFormField/index.tsx
+++ b/protocol-designer/src/components/molecules/InputStepFormField/index.tsx
@@ -44,13 +44,19 @@ export function InputStepFormField(
     fillQuantityLocalState,
     ...otherProps
   } = props
-  const verifiedValue: string | number | null =
-    fillQuantityLocalState ??
-    (Array.isArray(value)
-      ? value.length
-      : typeof value === 'string' || typeof value === 'number'
-        ? value
-        : null)
+  const getVerifiedValue = (): string | number | null => {
+    if (fillQuantityLocalState != null) {
+      return fillQuantityLocalState
+    }
+    if (Array.isArray(value)) {
+      return value.length
+    }
+    if (typeof value === 'string' || typeof value === 'number') {
+      return value
+    }
+    return null
+  }
+  const verifiedValue = getVerifiedValue()
   const { t } = useTranslation('tooltip')
   return (
     <Flex padding={padding} width="100%">

--- a/protocol-designer/src/components/organisms/FlexHardware/util.ts
+++ b/protocol-designer/src/components/organisms/FlexHardware/util.ts
@@ -281,11 +281,16 @@ function handleWasteChuteStagingAreaComboRemoval(
   state: CutoutFixtureState,
   props: UpdateInitialDeckSetupProps
 ): void {
-  const targetFixtureName = WASTE_CHUTE_FIXTURES.includes(state.newFixtureName!)
-    ? 'stagingArea'
-    : STAGING_AREA_FIXTURES.includes(state.newFixtureName!)
-      ? 'wasteChute'
-      : null
+  const getTargetFixtureName = (): string | null => {
+    if (WASTE_CHUTE_FIXTURES.includes(state.newFixtureName!)) {
+      return 'stagingArea'
+    }
+    if (STAGING_AREA_FIXTURES.includes(state.newFixtureName!)) {
+      return 'wasteChute'
+    }
+    return null
+  }
+  const targetFixtureName = getTargetFixtureName()
   const fixtureToDelete =
     targetFixtureName != null
       ? state.matchingFixturesOnDeck.find(f => f.name === targetFixtureName)

--- a/protocol-designer/src/components/organisms/TipPositionModal/ZTipPositionModal.tsx
+++ b/protocol-designer/src/components/organisms/TipPositionModal/ZTipPositionModal.tsx
@@ -197,20 +197,24 @@ export function ZTipPositionModal(props: ZTipPositionModalProps): JSX.Element {
         </Flex>
         <Flex>
           <TipPositionZOnlyView
-            mmFromBottom={
-              isPositionFromTop
-                ? undefined
-                : value !== null
-                  ? Number(value)
-                  : defaultMm
-            }
-            mmFromTop={
-              isPositionFromTop
-                ? value !== null
-                  ? Number(value)
-                  : defaultMm
-                : undefined
-            }
+            mmFromBottom={(() => {
+              if (isPositionFromTop) {
+                return undefined
+              }
+              if (value !== null) {
+                return Number(value)
+              }
+              return defaultMm
+            })()}
+            mmFromTop={(() => {
+              if (!isPositionFromTop) {
+                return undefined
+              }
+              if (value !== null) {
+                return Number(value)
+              }
+              return defaultMm
+            })()}
             wellDepthMm={wellDepthMm}
           />
         </Flex>

--- a/protocol-designer/src/components/organisms/utils.ts
+++ b/protocol-designer/src/components/organisms/utils.ts
@@ -106,12 +106,16 @@ export const getLabwareCompatibleForEditHardware = (
 ): boolean => {
   const labwareDef = getLabwareOnSlot(labware, cutoutId)
   const labwareDefB1 = getLabwareOnSlot(labware, 'cutoutB1')
-  const moduleType =
-    newModule != null
-      ? newModule.addressableAreaId === 'thermocyclerModuleV2'
-        ? THERMOCYCLER_MODULE_TYPE
-        : getModuleType(newModule.cutoutFixtureId as ModuleModel)
-      : null
+  const getModuleTypeFromConfig = (): ModuleType | null => {
+    if (newModule == null) {
+      return null
+    }
+    if (newModule.addressableAreaId === 'thermocyclerModuleV2') {
+      return THERMOCYCLER_MODULE_TYPE
+    }
+    return getModuleType(newModule.cutoutFixtureId as ModuleModel)
+  }
+  const moduleType = getModuleTypeFromConfig()
 
   let labwareCompatible = true
   if (moduleType != null && moduleType === THERMOCYCLER_MODULE_TYPE) {

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -103,12 +103,19 @@ const getClippedFlowRateForMoveLiquid = (args: {
   )
   let correctionVolume: number = 0
   if (tipLiquidSpecs != null && flowRateType !== 'blowout') {
-    const liquidClassLookup =
-      flowRateType === 'dispense'
-        ? path === 'multiDispense'
-          ? (tipLiquidSpecs.multiDispense ?? tipLiquidSpecs.singleDispense)
-          : tipLiquidSpecs.singleDispense
-        : tipLiquidSpecs.aspirate
+    const getLiquidClassLookup = ():
+      | typeof tipLiquidSpecs.aspirate
+      | typeof tipLiquidSpecs.singleDispense
+      | typeof tipLiquidSpecs.multiDispense => {
+      if (flowRateType !== 'dispense') {
+        return tipLiquidSpecs.aspirate
+      }
+      if (path === 'multiDispense') {
+        return tipLiquidSpecs.multiDispense ?? tipLiquidSpecs.singleDispense
+      }
+      return tipLiquidSpecs.singleDispense
+    }
+    const liquidClassLookup = getLiquidClassLookup()
     const conditioningByVolume =
       path === 'multiDispense'
         ? (tipLiquidSpecs.multiDispense?.conditioningByVolume ?? [])
@@ -134,10 +141,12 @@ const getClippedFlowRateForMoveLiquid = (args: {
     })
 
     correctionVolume =
-      linearInterpolate(
-        referenceVolumes.correction[flowRateType],
-        liquidClassLookup.correctionByVolume as Array<[number, number]>
-      ) ?? 0
+      liquidClassLookup != null
+        ? (linearInterpolate(
+            referenceVolumes.correction[flowRateType],
+            liquidClassLookup.correctionByVolume as Array<[number, number]>
+          ) ?? 0)
+        : 0
   }
 
   const matchingTipLiquidSpecs = getMatchingTipLiquidSpecs(

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MagnetTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MagnetTools/index.tsx
@@ -42,14 +42,18 @@ export function MagnetTools(props: StepFormProps): JSX.Element {
         low: `${MIN_ENGAGE_HEIGHT_V2} ${mmUnits}`,
         high: `${MAX_ENGAGE_HEIGHT_V2} ${mmUnits}`,
       })
-  const engageHeightDefault =
-    defaultEngageHeight != null
-      ? isGen1
-        ? t('magnet_recommended', { default: defaultEngageHeight })
-        : t('magnet_recommended', {
-            default: `${defaultEngageHeight} ${mmUnits}`,
-          })
-      : ''
+  const getEngageHeightDefault = (): string => {
+    if (defaultEngageHeight == null) {
+      return ''
+    }
+    if (isGen1) {
+      return t('magnet_recommended', { default: defaultEngageHeight })
+    }
+    return t('magnet_recommended', {
+      default: `${defaultEngageHeight} ${mmUnits}`,
+    })
+  }
+  const engageHeightDefault = getEngageHeightDefault()
   const engageHeightCaption = `${engageHeightMinMax} ${engageHeightDefault}`
 
   return (

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -285,15 +285,19 @@ export function ProtocolSteps({
             <Flex
               flexDirection={DIRECTION_COLUMN}
               gridGap={SPACING.spacing24}
-              width={
-                (isZoomedIn && !isOffDeck) ||
-                (selectedTerminalItemId === HARDWARE_ID &&
-                  robotType === OT2_ROBOT_TYPE)
-                  ? '90%'
-                  : isZoomedIn && isOffDeck
-                    ? '100%'
-                    : CONTENT_MAX_WIDTH
-              }
+              width={(() => {
+                if (
+                  (isZoomedIn && !isOffDeck) ||
+                  (selectedTerminalItemId === HARDWARE_ID &&
+                    robotType === OT2_ROBOT_TYPE)
+                ) {
+                  return '90%'
+                }
+                if (isZoomedIn && isOffDeck) {
+                  return '100%'
+                }
+                return CONTENT_MAX_WIDTH
+              })()}
               justifyContent={JUSTIFY_CENTER}
               paddingTop={
                 isZoomedIn || showTimelineAlerts ? '0' : SPACING.spacing60
@@ -340,22 +344,26 @@ export function ProtocolSteps({
                 flexDirection={DIRECTION_COLUMN}
                 gridGap={SPACING.spacing16}
               >
-                {selectedTerminalItemId === HARDWARE_ID ? (
-                  <TimelineEditHardware />
-                ) : deckView === leftString ? (
-                  <DeckSetupContainer
-                    viewBox={viewBox}
-                    setViewBox={setViewBox}
-                    deckDef={deckDef}
-                    initialViewBox={initialViewBox}
-                    hoverSlot={hoverSlot}
-                    setHoverSlot={setHoverSlot}
-                    robotType={robotType}
-                    currentStep={currentStep}
-                  />
-                ) : (
-                  <OffDeck setOverflowMenu={showLiquidOverflowMenu} />
-                )}
+                {(() => {
+                  if (selectedTerminalItemId === HARDWARE_ID) {
+                    return <TimelineEditHardware />
+                  }
+                  if (deckView === leftString) {
+                    return (
+                      <DeckSetupContainer
+                        viewBox={viewBox}
+                        setViewBox={setViewBox}
+                        deckDef={deckDef}
+                        initialViewBox={initialViewBox}
+                        hoverSlot={hoverSlot}
+                        setHoverSlot={setHoverSlot}
+                        robotType={robotType}
+                        currentStep={currentStep}
+                      />
+                    )
+                  }
+                  return <OffDeck setOverflowMenu={showLiquidOverflowMenu} />
+                })()}
                 {isZoomedIn || selectedTerminalItemId === HARDWARE_ID ? null : (
                   <>
                     {/* avoid shifting the deck view container */}

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -221,12 +221,15 @@ export const getSlotInformation = (
     slotPosition: slotPosition,
     isSlotAHopper,
     matchingLabwareFor4thColumn: matchingLabware,
-    createdStackForSlot:
-      slot === 'offDeck'
-        ? []
-        : offDeckLabware != null
-          ? [offDeckLabware.id]
-          : remainingLabwareIds,
+    createdStackForSlot: (() => {
+      if (slot === 'offDeck') {
+        return []
+      }
+      if (offDeckLabware != null) {
+        return [offDeckLabware.id]
+      }
+      return remainingLabwareIds
+    })(),
     createdLidForSlot:
       lidIdFromStack != null ? deckSetupLabware[lidIdFromStack] : undefined,
   }

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -732,11 +732,13 @@ export const pauseForTimeOrUntilTold = (
     )
     // user selected pause for amount of time
     const totalSeconds = hours * 3600 + minutes * 60 + seconds
-    return totalSeconds <= 0
-      ? TIME_PARAM_REQUIRED
-      : isTimeFormat(fields.pauseTime)
-        ? null
-        : PAUSE_TIME_FORMAT
+    if (totalSeconds <= 0) {
+      return TIME_PARAM_REQUIRED
+    }
+    if (isTimeFormat(fields.pauseTime)) {
+      return null
+    }
+    return PAUSE_TIME_FORMAT
   } else if (
     'pauseAction' in fields &&
     fields.pauseAction === PAUSE_UNTIL_TEMP

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -318,15 +318,19 @@ const clampDispenseAirGapVolume = (
   const appliedPatch = { ...(stepData as FormPatch), ...patch, id, stepType }
   // @ts-expect-error(sa, 2021-6-14): appliedPatch.pipette does not exist. Address in #3161
   const pipetteId: string = appliedPatch.pipette
-  const disposalVolume =
+  const getDisposalVolume = (): number => {
+    // @ts-expect-error(sa, 2021-6-14): appliedPatch.disposalVolume_checkbox does not exist. Address in #3161
+    if (appliedPatch.disposalVolume_checkbox == null) {
+      return 0
+    }
     // @ts-expect-error(sa, 2021-6-14): appliedPatch.disposalVolume_volume does not exist. Address in #3161
-    appliedPatch.disposalVolume_checkbox != null
-      ? // @ts-expect-error(sa, 2021-6-14): appliedPatch.disposalVolume_volume does not exist. Address in #3161
-        isNaN(Number(appliedPatch.disposalVolume_volume))
-        ? 0
-        : // @ts-expect-error(sa, 2021-6-14): appliedPatch.disposalVolume_volume does not exist. Address in #3161
-          Number(appliedPatch.disposalVolume_volume)
-      : 0
+    if (isNaN(Number(appliedPatch.disposalVolume_volume))) {
+      return 0
+    }
+    // @ts-expect-error(sa, 2021-6-14): appliedPatch.disposalVolume_volume does not exist. Address in #3161
+    return Number(appliedPatch.disposalVolume_volume)
+  }
+  const disposalVolume = getDisposalVolume()
   // @ts-expect-error(sa, 2021-6-14): appliedPatch.volume does not exist. Address in #3161
   const transferVolume = Number(appliedPatch.volume)
   // @ts-expect-error(sa, 2021-6-14): appliedPatch.dispense_airGap_volume does not exist. Address in #3161

--- a/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedStepsRowItem.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedStepsRowItem.tsx
@@ -15,61 +15,69 @@ export function AnnotatedStepsRowItem(
   return (
     <div style={style} {...ariaAttributes}>
       <div className={styles.annotated_steps_row}>
-        {row.type === 'group' ? (
-          <AnnotatedGroup
-            scrollTargetId={data.scrollTargetId}
-            listElement={data.listElement}
-            analysis={data.analysis}
-            annotationType={row.annotationType}
-            subCommands={row.group.subCommands}
-            commandStartNumber={row.commandStartNumber}
-            allRunDefs={data.allRunDefs}
-            setSelectedCommand={data.setSelectedCommand}
-            handlePause={data.handlePause}
-          />
-        ) : row.type === 'command' ? (
-          <IndividualCommand
-            scrollTargetId={data.scrollTargetId}
-            listElement={data.listElement}
-            fromGroup={row.fromGroup}
-            command={row.command}
-            isHighlighted={row.isHighlighted}
-            analysis={data.analysis}
-            allRunDefs={data.allRunDefs}
-            setSelectedCommand={data.setSelectedCommand}
-            commandNumber={row.commandNumber}
-          />
-        ) : (
-          <div className={styles.annotated_steps_error_wrapper}>
-            {row.errors.map(error => (
-              <div
-                className={styles.annotated_steps_error_container}
-                key={error.id}
-                onClick={() => {
-                  data.onShowErrorDetails()
-                }}
-              >
-                <div className={styles.annotated_steps_header}>
-                  <Icon name="ot-alert" size="1rem" color={COLORS.red60} />
-                  <StyledText
-                    desktopStyle="captionSemiBold"
-                    color={COLORS.red60}
-                  >
-                    {data.t('step_error')}
+        {(() => {
+          if (row.type === 'group') {
+            return (
+              <AnnotatedGroup
+                scrollTargetId={data.scrollTargetId}
+                listElement={data.listElement}
+                analysis={data.analysis}
+                annotationType={row.annotationType}
+                subCommands={row.group.subCommands}
+                commandStartNumber={row.commandStartNumber}
+                allRunDefs={data.allRunDefs}
+                setSelectedCommand={data.setSelectedCommand}
+                handlePause={data.handlePause}
+              />
+            )
+          }
+          if (row.type === 'command') {
+            return (
+              <IndividualCommand
+                scrollTargetId={data.scrollTargetId}
+                listElement={data.listElement}
+                fromGroup={row.fromGroup}
+                command={row.command}
+                isHighlighted={row.isHighlighted}
+                analysis={data.analysis}
+                allRunDefs={data.allRunDefs}
+                setSelectedCommand={data.setSelectedCommand}
+                commandNumber={row.commandNumber}
+              />
+            )
+          }
+          return (
+            <div className={styles.annotated_steps_error_wrapper}>
+              {row.errors.map(error => (
+                <div
+                  className={styles.annotated_steps_error_container}
+                  key={error.id}
+                  onClick={() => {
+                    data.onShowErrorDetails()
+                  }}
+                >
+                  <div className={styles.annotated_steps_header}>
+                    <Icon name="ot-alert" size="1rem" color={COLORS.red60} />
+                    <StyledText
+                      desktopStyle="captionSemiBold"
+                      color={COLORS.red60}
+                    >
+                      {data.t('step_error')}
+                    </StyledText>
+                  </div>
+                  <StyledText desktopStyle="bodyDefaultRegular">
+                    {error.detail}
                   </StyledText>
                 </div>
+              ))}
+              <div className={styles.annotated_steps_final_command}>
                 <StyledText desktopStyle="bodyDefaultRegular">
-                  {error.detail}
+                  {data.t('unable_to_show_steps_past_errors')}
                 </StyledText>
               </div>
-            ))}
-            <div className={styles.annotated_steps_final_command}>
-              <StyledText desktopStyle="bodyDefaultRegular">
-                {data.t('unable_to_show_steps_past_errors')}
-              </StyledText>
             </div>
-          </div>
-        )}
+          )
+        })()}
       </div>
     </div>
   )

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -236,11 +236,15 @@ export const mixInPlaceUtil = (args: {
           pipetteId: pipette,
           volume,
           flowRate: dispenseFlowRateUlSec,
-          ...(i < times - 1
-            ? { pushOut: 0 }
-            : finalPushOut == null
-              ? {}
-              : { pushOut: finalPushOut }), // only push out if final repetition
+          ...(() => {
+            if (i < times - 1) {
+              return { pushOut: 0 }
+            }
+            if (finalPushOut == null) {
+              return {}
+            }
+            return { pushOut: finalPushOut }
+          })(), // only push out if final repetition
           ...(correctionVolumeDispense > 0
             ? { correctionVolume: correctionVolumeDispense }
             : {}),


### PR DESCRIPTION
# Overview

Nested ternaries are often difficult to parse, and there's an [eslint rule](https://eslint.org/docs/latest/rules/no-nested-ternary) for enforcing not using them programmatically. Let's use it.

Let's prefer helper functions when possible.

b83e744d4737a8174f3445cfde903f992f14afbb - Adds the eslint rule
74df6d7433f02a2d6763b163a0542fcfaae286af - Updates the typescript cursor skill

Subsequent commit(s) target CI fixes, converting them to helper functions.

## Test Plan and Hands on Testing

- CI passing is sufficient.

## Risk assessment

- none