### PR TITLE
refactor(app): remove data-testid from molecules components

### DIFF
--- a/app/src/assets/localization/en/protocol_info.json
+++ b/app/src/assets/localization/en/protocol_info.json
@@ -23,6 +23,7 @@
   "exit_modal_go_back": "No, go back",
   "exit_modal_heading": "Confirm Close Protocol",
   "failed_analysis": "failed analysis",
+  "file_upload_drop_zone": "File upload drop zone",
   "get_labware_offset_data": "Get Labware Offset Data",
   "import": "Import",
   "import_a_file": "Import a protocol to get started",

--- a/app/src/molecules/CardButton/__tests__/CardButton.test.tsx
+++ b/app/src/molecules/CardButton/__tests__/CardButton.test.tsx
@@ -53,7 +53,6 @@ describe('CardButton', () => {
     render(props)
     screen.getByText('Wi-Fi')
     screen.getByText('Find a network in your lab or enter your own.')
-    expect(screen.getByTestId('cardButton_icon_wifi')).toBeInTheDocument()
     const button = screen.getByRole('button')
     expect(button).toHaveStyle(`background-color: ${COLORS.blue35}`)
   })

--- a/app/src/molecules/CardButton/index.tsx
+++ b/app/src/molecules/CardButton/index.tsx
@@ -94,7 +94,6 @@ export function CardButton(props: CardButtonProps): JSX.Element {
       <Icon
         name={iconName}
         size="3.75rem"
-        data-testid={`cardButton_icon_${String(iconName)}`}
         color={disabled ? COLORS.grey50 : COLORS.blue50}
       />
       <Flex marginTop={SPACING.spacing16}>

--- a/app/src/molecules/CollapsibleSection/index.tsx
+++ b/app/src/molecules/CollapsibleSection/index.tsx
@@ -55,14 +55,10 @@ export function CollapsibleSection(
           {title}
         </LegacyStyledText>
         <Btn
+          aria-label={title}
           onClick={() => {
             setIsExpanded(!isExpanded)
           }}
-          data-testid={
-            isExpanded
-              ? `CollapsibleSection_collapse_${title}`
-              : `CollapsibleSection_expand_${title}`
-          }
         >
           <Icon
             size="1.5rem"

--- a/app/src/molecules/InfoMessage/index.tsx
+++ b/app/src/molecules/InfoMessage/index.tsx
@@ -27,7 +27,6 @@ export function InfoMessage({ title, body }: InfoMessageProps): JSX.Element {
       borderRadius={BORDERS.borderRadius4}
       gridGap={SPACING.spacing8}
       padding={SPACING.spacing16}
-      data-testid={`InfoMessage_${title}`}
     >
       <Icon
         color={COLORS.blue60}

--- a/app/src/molecules/LiquidDetailCard/LiquidDetailCard.tsx
+++ b/app/src/molecules/LiquidDetailCard/LiquidDetailCard.tsx
@@ -215,7 +215,7 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
       onClick={handleSelectedValue}
       width="10.3rem"
       minHeight="max-content"
-      data-testid="LiquidDetailCard_box"
+      role="button"
     >
       <Flex
         flexDirection={DIRECTION_COLUMN}

--- a/app/src/molecules/LiquidDetailCard/__tests__/LiquidDetailCard.test.tsx
+++ b/app/src/molecules/LiquidDetailCard/__tests__/LiquidDetailCard.test.tsx
@@ -58,7 +58,11 @@ describe('LiquidDetailCard', () => {
 
   it('renders clickable box, clicking on it calls track event', () => {
     render(props)
-    fireEvent.click(screen.getByTestId('LiquidDetailCard_box'))
+    const clickableCard = screen.getByRole('button', {
+      name: /Mock Liquid/,
+    })
+
+    fireEvent.click(clickableCard)
     expect(mockTrackEvent).toHaveBeenCalledWith({
       name: ANALYTICS_HIGHLIGHT_LIQUID_IN_DETAIL_MODAL,
       properties: {},

--- a/app/src/molecules/ODDBackButton/__tests__/ODDBackButton.test.tsx
+++ b/app/src/molecules/ODDBackButton/__tests__/ODDBackButton.test.tsx
@@ -26,7 +26,6 @@ describe('ODDBackButton', () => {
   it('should render text and icon', () => {
     render(props)
     screen.getByText('button label')
-    expect(screen.getByTestId('back_icon')).toBeInTheDocument()
     const button = screen.getByRole('button')
     fireEvent.click(button)
     expect(props.onClick).toHaveBeenCalled()

--- a/app/src/molecules/ODDBackButton/index.tsx
+++ b/app/src/molecules/ODDBackButton/index.tsx
@@ -19,12 +19,7 @@ export function ODDBackButton(
   return (
     <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing16}>
       <Btn onClick={onClick}>
-        <Icon
-          color={COLORS.black90}
-          data-testid="back_icon"
-          name="back"
-          width="3rem"
-        />
+        <Icon color={COLORS.black90} name="back" width="3rem" />
       </Btn>
       <LegacyStyledText forwardedAs="h2" fontWeight={TYPOGRAPHY.fontWeightBold}>
         {label}

--- a/app/src/molecules/ODDFixtureOption/index.tsx
+++ b/app/src/molecules/ODDFixtureOption/index.tsx
@@ -41,14 +41,12 @@ export function ODDFixtureOption(props: ODDFixtureOptionProps): JSX.Element {
           <SmallButton
             buttonType="secondary"
             onClick={secondaryOnClickHandler}
-            data-testid={optionName}
             buttonText={secondaryButtonText}
             buttonCategory="rounded"
           />
         ) : null}
         <SmallButton
           onClick={onClickHandler}
-          data-testid={optionName}
           buttonText={buttonText}
           buttonCategory="rounded"
         />

--- a/app/src/molecules/ODDFixtureOption/tests/ODDFixtureOption.test.tsx
+++ b/app/src/molecules/ODDFixtureOption/tests/ODDFixtureOption.test.tsx
@@ -23,7 +23,7 @@ describe('ODDFixtureOption', () => {
     render(props)
     screen.getByText('mockOption')
     screen.getByText('mockText')
-    fireEvent.click(screen.getByTestId('mockOption'))
+    fireEvent.click(screen.getByRole('button', { name: 'mockText' }))
     expect(props.onClickHandler).toHaveBeenCalled()
   })
   it('should render text and buttons for odd', () => {

--- a/app/src/molecules/ODDInfoScreen/OddInfoScreen.tsx
+++ b/app/src/molecules/ODDInfoScreen/OddInfoScreen.tsx
@@ -80,6 +80,7 @@ export function OddInfoScreen(props: OddInfoScreenProps): JSX.Element {
   const iconSize = INFO_SCREEN_PROPS_BY_SIZE[textSize].iconSize
   const headerStyle = INFO_SCREEN_PROPS_BY_SIZE[textSize].headerStyle
   const subTextStyle = INFO_SCREEN_PROPS_BY_SIZE[textSize].subTextStyle
+  const roleType = type === 'error' || type === 'warning' ? 'alert' : 'status'
 
   return (
     <Flex
@@ -91,7 +92,7 @@ export function OddInfoScreen(props: OddInfoScreenProps): JSX.Element {
       backgroundColor={backgroundColor}
       borderRadius={BORDERS.borderRadius12}
       padding={`${SPACING.spacing40} ${SPACING.spacing80} `}
-      data-testid="InfoScreen"
+      role={roleType}
       {...styleProps}
     >
       {hasIcon ? (

--- a/app/src/molecules/ODDInfoScreen/__tests__/OddInfoScreen.test.tsx
+++ b/app/src/molecules/ODDInfoScreen/__tests__/OddInfoScreen.test.tsx
@@ -3,9 +3,9 @@ import { describe, expect, it } from 'vitest'
 
 import { COLORS } from '@opentrons/components'
 
-import { OddInfoScreen } from './OddInfoScreen'
+import { OddInfoScreen } from '../OddInfoScreen'
 
-import type { OddInfoScreenType } from './OddInfoScreen'
+import type { OddInfoScreenType } from '../OddInfoScreen'
 
 describe('OddInfoScreen', () => {
   const renderComponent = (
@@ -48,7 +48,9 @@ describe('OddInfoScreen', () => {
       const expectedIcon = type === 'success' ? 'ot-check' : 'ot-alert'
       const icon = screen.getByLabelText(`icon-${expectedIcon}`)
       expect(icon).toBeInTheDocument()
-      const infoScreen = screen.getByTestId('InfoScreen')
+      const expectedRole =
+        type === 'error' || type === 'warning' ? 'alert' : 'status'
+      const infoScreen = screen.getByRole(expectedRole)
       let expectedBgColor = ''
       if (type === 'neutral') expectedBgColor = COLORS.grey35
       else if (type === 'error') expectedBgColor = COLORS.red35

--- a/app/src/molecules/UploadInput/__tests__/UploadInput.test.tsx
+++ b/app/src/molecules/UploadInput/__tests__/UploadInput.test.tsx
@@ -73,11 +73,18 @@ describe('UploadInput', () => {
       }
     )
     const button = screen.getByRole('button', { name: 'Upload' })
-    const input = screen.getByTestId('file_input')
-    input.click = vi.fn()
+    const dropZone = screen.getByLabelText('File upload drop zone')
+    const fileInput = dropZone.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement
+    if (fileInput == null) {
+      throw new Error('Input element not found')
+    }
+    fileInput.click = vi.fn()
     fireEvent.click(button)
-    expect(input.click).toHaveBeenCalled()
+    expect(fileInput.click).toHaveBeenCalled()
   })
+
   it('calls create session on choose file', () => {
     renderWithProviders(
       <BrowserRouter>
@@ -87,8 +94,10 @@ describe('UploadInput', () => {
         i18nInstance: i18n,
       }
     )
-    const input = screen.getByTestId('file_input')
-    fireEvent.change(input, { target: { files: ['dummyFile'] } })
+    const dropZone = screen.getByLabelText('File upload drop zone')
+    fireEvent.drop(dropZone, {
+      dataTransfer: { files: ['dummyFile'] },
+    })
     expect(onUpload).toHaveBeenCalledWith('dummyFile')
   })
 })

--- a/app/src/molecules/UploadInput/__tests__/UploadInput.test.tsx
+++ b/app/src/molecules/UploadInput/__tests__/UploadInput.test.tsx
@@ -73,13 +73,9 @@ describe('UploadInput', () => {
       }
     )
     const button = screen.getByRole('button', { name: 'Upload' })
-    const dropZone = screen.getByLabelText('File upload drop zone')
-    const fileInput = dropZone.querySelector(
-      'input[type="file"]'
+    const fileInput = screen.getByLabelText(
+      'Choose File...'
     ) as HTMLInputElement
-    if (fileInput == null) {
-      throw new Error('Input element not found')
-    }
     fileInput.click = vi.fn()
     fireEvent.click(button)
     expect(fileInput.click).toHaveBeenCalled()

--- a/app/src/molecules/UploadInput/index.tsx
+++ b/app/src/molecules/UploadInput/index.tsx
@@ -157,6 +157,7 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
         {dragAndDropText}
         <StyledInput
           id="file_input"
+          aria-label={t('choose_file')}
           ref={fileInput}
           type="file"
           onChange={onChange}

--- a/app/src/molecules/UploadInput/index.tsx
+++ b/app/src/molecules/UploadInput/index.tsx
@@ -134,7 +134,8 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
       </PrimaryButton>
 
       <StyledLabel
-        data-testid="file_drop_zone"
+        htmlFor="file_input"
+        aria-label={t('file_upload_drop_zone')}
         onDrop={handleDrop}
         onDragOver={handleDragOver}
         onDragEnter={handleDragEnter}
@@ -156,7 +157,6 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
         {dragAndDropText}
         <StyledInput
           id="file_input"
-          data-testid="file_input"
           ref={fileInput}
           type="file"
           onChange={onChange}

--- a/app/src/organisms/Desktop/ProtocolsLanding/__tests__/UploadInput.test.tsx
+++ b/app/src/organisms/Desktop/ProtocolsLanding/__tests__/UploadInput.test.tsx
@@ -60,20 +60,31 @@ describe('ProtocolUploadInput', () => {
   it('opens file select on button click', () => {
     render()
     const button = screen.getByRole('button', { name: 'Upload' })
-    const input = screen.getByTestId('file_input')
-    input.click = vi.fn()
+    // const input = screen.getByTestId('file_input')
+    // input.click = vi.fn()
+    const dropZone = screen.getByLabelText('File upload drop zone')
+    const fileInput = dropZone.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement
+    if (fileInput == null) {
+      throw new Error('Input element not found')
+    }
+    fileInput.click = vi.fn()
     fireEvent.click(button)
-    expect(input.click).toHaveBeenCalled()
+    expect(fileInput.click).toHaveBeenCalled()
   })
+
   it('calls onUpload callback on choose file and trigger analytics event', async () => {
     render()
-    const input = screen.getByTestId('file_input')
-
+    const dropZone = screen.getByLabelText('File upload drop zone')
+    const fileInput = dropZone.querySelector('input[type="file"]')
+    if (!fileInput) {
+      throw new Error('Input element not found')
+    }
     const mockFile = new File(['mockContent'], 'mockFileName', {
       type: 'text/plain',
     })
-
-    fireEvent.change(input, {
+    fireEvent.change(fileInput, {
       target: { files: [mockFile] },
     })
 

--- a/app/src/organisms/Desktop/ProtocolsLanding/__tests__/UploadInput.test.tsx
+++ b/app/src/organisms/Desktop/ProtocolsLanding/__tests__/UploadInput.test.tsx
@@ -60,15 +60,9 @@ describe('ProtocolUploadInput', () => {
   it('opens file select on button click', () => {
     render()
     const button = screen.getByRole('button', { name: 'Upload' })
-    // const input = screen.getByTestId('file_input')
-    // input.click = vi.fn()
-    const dropZone = screen.getByLabelText('File upload drop zone')
-    const fileInput = dropZone.querySelector(
-      'input[type="file"]'
+    const fileInput = screen.getByLabelText(
+      'Choose File...'
     ) as HTMLInputElement
-    if (fileInput == null) {
-      throw new Error('Input element not found')
-    }
     fileInput.click = vi.fn()
     fireEvent.click(button)
     expect(fileInput.click).toHaveBeenCalled()
@@ -76,11 +70,7 @@ describe('ProtocolUploadInput', () => {
 
   it('calls onUpload callback on choose file and trigger analytics event', async () => {
     render()
-    const dropZone = screen.getByLabelText('File upload drop zone')
-    const fileInput = dropZone.querySelector('input[type="file"]')
-    if (!fileInput) {
-      throw new Error('Input element not found')
-    }
+    const fileInput = screen.getByLabelText('Choose File...')
     const mockFile = new File(['mockContent'], 'mockFileName', {
       type: 'text/plain',
     })

--- a/app/src/pages/Desktop/Devices/DevicesLanding/__tests__/DevicesLanding.test.tsx
+++ b/app/src/pages/Desktop/Devices/DevicesLanding/__tests__/DevicesLanding.test.tsx
@@ -97,14 +97,14 @@ describe('DevicesLanding', () => {
     expect(screen.queryByText('Mock Robot unreachableRobot')).toBeNull()
     expect(screen.queryByText('Mock Robot reachableRobot')).toBeNull()
 
-    const expandButton = screen.getByTestId(
-      'CollapsibleSection_expand_Not available (2)'
-    )
+    const expandButton = screen.getByRole('button', {
+      name: 'Not available (2)',
+    })
     fireEvent.click(expandButton)
-
     screen.getByText('Mock Robot unreachableRobot')
     screen.getByText('Mock Robot reachableRobot')
   })
+
   it('does not render available or not available sections when none are present', () => {
     vi.mocked(getConnectableRobots).mockReturnValue([])
     vi.mocked(getReachableRobots).mockReturnValue([])


### PR DESCRIPTION
# Overview
remove data-testid from molecules components

closes AUTH-3051

## Test Plan and Hands on Testing
pass the followings
- make check-js
- make test-js
- make lint-js

## Changelog
- remove data-testid from molecules components

## Review requests

## Risk assessment
low
