### PR TITLE
fix(opentrons-ai-client): stop truncating send button in-progress labels (AUTH-2462)

### DIFF
--- a/opentrons-ai-client/src/components/atoms/SendButton/sendbutton.module.css
+++ b/opentrons-ai-client/src/components/atoms/SendButton/sendbutton.module.css
@@ -1,6 +1,6 @@
 .button {
   display: flex;
-  width: 5.6875rem;
+  min-width: 5.6875rem;
   height: 2.25rem;
   align-items: center;
   justify-content: center;
@@ -34,14 +34,12 @@
 }
 
 .button_text {
-  overflow: hidden;
   color: var(--white);
   font-size: var(--font-size-h3);
   font-style: normal;
   font-weight: var(--font-weight-semi-bold);
   line-height: var(--line-height-20);
   text-align: center;
-  text-overflow: ellipsis;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
# Overview

Fixes [AUTH-2462](https://opentrons.atlassian.net/browse/AUTH-2462): while a prompt is generating, the chat send button cycles through "Initializing...", "Processing...", "Generating...", "Finalizing..." — but the button had a fixed `width: 5.6875rem` sized for "Send", so all four in-progress labels were clipped with an ellipsis and unreadable, despite there being plenty of room in the footer.

CSS-only change in `sendbutton.module.css`; no TS/logic changes.

## Test Plan and Hands on Testing

- `make test` in `opentrons-ai-client`: 212 tests / 50 files, all green (existing SendButton tests already cover the label swap when `isLoading`).
- `pnpm tsc --build` from repo root: clean.
- The live chat sits behind the Auth0 login wall, so I could not drive it end-to-end. Instead I verified the layout change in headless Chromium with a scratch harness reproducing the button rules + design-token values, rendering all five labels before/after:
  - Before: every in-progress label clipped at 91px.
  - After: no label clipped; button grows to ~144–156px depending on label, and idle "Send" keeps the original 5.6875rem footprint as a `min-width` floor. (Harness used a fallback font, so measurements are ±1px vs Public Sans.)
- Layout context checked: the button sits in `InputPrompt`'s bottom flex row next to a `flex: 1` spacer, and the textarea is a separate row — the wider button eats into the spacer and cannot crowd the textarea.

A visual sanity check in the real logged-in chat would still be worthwhile from anyone with Auth0 access.

## Changelog

- `SendButton`: `.button` fixed `width: 5.6875rem` → `min-width: 5.6875rem`, so the button sizes to its content with the old size as a floor.
- `.button_text`: dropped `overflow: hidden` / `text-overflow: ellipsis`, which are inert now that the button grows; kept `white-space: nowrap` so labels stay on one line.

## Review requests

- Confirm the in-progress button looks right in a real chat session (Auth0 access needed).
- Sanity-check there's no other consumer relying on the send button's fixed width.

## Risk assessment

Low. Two-declaration CSS change scoped to one CSS module of one atom in `opentrons-ai-client`; no shared components touched. Worst case is a cosmetic layout regression in the chat footer, and the flex-row analysis plus the headless render check cover that.


[AUTH-2462]: https://opentrons.atlassian.net/browse/AUTH-2462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ