### PR TITLE
fix(api, docs): remove remaining RSTcrossreferences in docstrings

### DIFF
--- a/api/src/opentrons/protocol_api/_nozzle_layout.py
+++ b/api/src/opentrons/protocol_api/_nozzle_layout.py
@@ -13,20 +13,31 @@ class NozzleLayout(enum.Enum):
 
 
 COLUMN: Final = NozzleLayout.COLUMN
-PARTIAL_COLUMN: Final = NozzleLayout.PARTIAL_COLUMN
-SINGLE: Final = NozzleLayout.SINGLE
-ROW: Final = NozzleLayout.ROW
-ALL: Final = NozzleLayout.ALL
+"""A nozzle configuration type indicating a full, single-column pickup. Predominantly meant for 96-channel pipettes.
 
-# Set __doc__ manually as a workaround. When this docstring is written the normal way, right after
-# the constant definition, Sphinx has trouble picking it up.
-COLUMN.__doc__ = """\
-A special nozzle configuration type indicating a full single column pick up. Predominantly meant for the 96 channel.
-
-See <ADD REFERENCE HERE> for details on using ``COLUMN`` with :py:obj:`InstrumentContext.configure_nozzle_layout()`.
+See [Column layout](../pipettes/partial-tip-pickup.md#column-layout) for details on using `COLUMN` with [`InstrumentContext.configure_nozzle_layout()`][opentrons.protocol_api.InstrumentContext.configure_nozzle_layout].
 """
-ALL.__doc__ = """\
-A special nozzle configuration type indicating a reset back to default where the pipette will pick up its max capacity of tips.
 
-See <ADD REFERENCE HERE> for details on using ``ALL`` with :py:obj:`InstrumentContext.configure_nozzle_layout()`.
+PARTIAL_COLUMN: Final = NozzleLayout.PARTIAL_COLUMN
+"""A nozzle configuration type indicating a pickup of 2 to 7 consecutive tips in a single column. Available on 8-channel pipettes only.
+
+See [Partial column layout](../pipettes/partial-tip-pickup.md#partial-column-layout) for details on using `PARTIAL_COLUMN` with [`InstrumentContext.configure_nozzle_layout()`][opentrons.protocol_api.InstrumentContext.configure_nozzle_layout].
+"""
+
+SINGLE: Final = NozzleLayout.SINGLE
+"""A nozzle configuration type indicating a single-tip pickup. Available on both 8-channel and 96-channel pipettes.
+
+See [Single layout](../pipettes/partial-tip-pickup.md#single-layout) for details on using `SINGLE` with [`InstrumentContext.configure_nozzle_layout()`][opentrons.protocol_api.InstrumentContext.configure_nozzle_layout].
+"""
+
+ROW: Final = NozzleLayout.ROW
+"""A nozzle configuration type indicating a full, single-row pickup. Available on 96-channel pipettes only.
+
+See [Row layout](../pipettes/partial-tip-pickup.md#row-layout) for details on using `ROW` with [`InstrumentContext.configure_nozzle_layout()`][opentrons.protocol_api.InstrumentContext.configure_nozzle_layout].
+"""
+
+ALL: Final = NozzleLayout.ALL
+"""A nozzle configuration type indicating a reset back to default where the pipette will pick up its maximum number of tips.
+
+See [Tip rack adapters](../pipettes/partial-tip-pickup.md#tip-rack-adapters) for details on using `ALL` with [`InstrumentContext.configure_nozzle_layout()`][opentrons.protocol_api.InstrumentContext.configure_nozzle_layout].
 """

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -318,7 +318,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
                     num_channels=self.get_channels(),
                 )
             except AssertionError:
-                # Similarly to :py:meth:`return_tips`, the failure case here
+                # Similarly to `return_tips()`, the failure case here
                 # just means the tip can't be reused, so don't actually stop
                 # the protocol
                 _log.warning(

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -57,7 +57,7 @@ class LegacyProtocolCore(
         bundled_labware: Optional[Dict[str, LabwareDefinition]] = None,
         extra_labware: Optional[Dict[str, LabwareDefinition]] = None,
     ) -> None:
-        """Build a :py:class:`.LegacyProtocolCore`.
+        """Build a `LegacyProtocolCore`.
 
         :param api_version: The API version to use. If this is ``None``, uses
                             the max supported version.
@@ -71,9 +71,9 @@ class LegacyProtocolCore(
         :param bundled_data: A dict mapping filenames to the contents of data
                              files. Can be used by the protocol, since it is
                              exposed as
-                             :py:attr:`.ProtocolContext.bundled_data`
+                             [`ProtocolContext.bundled_data`][opentrons.protocol_api.ProtocolContext.bundled_data]
         :param extra_labware: A dict mapping labware URIs to definitions. These
-                              URIs are searched during :py:meth:`.load_labware`
+                              URIs are searched during `load_labware()`
                               in addition to the system definitions (if
                               ``bundled_labware`` was not specified). Used to
                               provide custom labware definitions.

--- a/api/src/opentrons/protocol_api/core/legacy/module_geometry.py
+++ b/api/src/opentrons/protocol_api/core/legacy/module_geometry.py
@@ -1,10 +1,10 @@
 """opentrons.protocol_api.module_geometry: classes and functions for modules
 as deck objects
 
-This module provides things like :py:class:`ModuleGeometry` and
-:py:func:`load_module` to create and manipulate module objects as geometric
+This module provides things like `ModuleGeometry` and
+`load_module()` to create and manipulate module objects as geometric
 objects on the deck (as opposed to calling commands on them, which is handled
-by :py:mod:`.module_contexts`)
+by `module_contexts`)
 """
 
 from __future__ import annotations
@@ -86,10 +86,10 @@ class ModuleGeometry:
 
         Note that modules do not currently have a concept of calibration apart
         from calibration of labware on top of the module. The practical result
-        of this is that if the module parent :py:class:`.Location` is
+        of this is that if the module parent [`Location`][opentrons.types.Location] is
         incorrect, then a correct calibration of one labware on the deck would
         be incorrect on the module, and vice-versa. Currently, the way around
-        this would be to correct the :py:class:`.Location` so that the
+        this would be to correct the [`Location`][opentrons.types.Location] so that the
         calibrated labware is targeted accurately in both positions.
 
         :param display_name: A human-readable display name of only the module
@@ -104,7 +104,7 @@ class ModuleGeometry:
         :param parent: A location representing location of the front left of
                        the outside of the module (usually the front-left corner
                        of a slot on the deck).
-        :type parent: :py:class:`.Location`
+        :type parent: [`Location`][opentrons.types.Location]
         """
         self._parent = parent
         self._module_type = module_type
@@ -157,14 +157,14 @@ class ModuleGeometry:
     @property
     def location(self) -> Location:
         """
-        :return: a :py:class:`.Location` representing the top of the module
+        :return: a [`Location`][opentrons.types.Location] representing the top of the module
         """
         return self._location
 
     @property
     def labware_offset(self) -> Point:
         """
-        :return: a :py:class:`.Point` representing the transformation
+        :return: a [`Point`][opentrons.types.Point] representing the transformation
         between the critical point of the module and the critical
         point of its contained labware
         """
@@ -200,10 +200,10 @@ class ThermocyclerGeometry(ModuleGeometry):
 
         Note that modules do not currently have a concept of calibration apart
         from calibration of labware on top of the module. The practical result
-        of this is that if the module parent :py:class:`.Location` is
+        of this is that if the module parent [`Location`][opentrons.types.Location] is
         incorrect, then a correct calibration of one labware on the deck would
         be incorrect on the module, and vice-versa. Currently, the way around
-        this would be to correct the :py:class:`.Location` so that the
+        this would be to correct the [`Location`][opentrons.types.Location] so that the
         calibrated labware is targeted accurately in both positions.
 
         :param display_name: A human-readable display name of only the module
@@ -218,10 +218,10 @@ class ThermocyclerGeometry(ModuleGeometry):
         :param parent: A location representing location of the front left of
                        the outside of the module (usually the front-left corner
                        of a slot on the deck).
-        :type parent: :py:class:`.Location`
+        :type parent: [`Location`][opentrons.types.Location]
         :param configuration: Used to specify the slot configuration of
                               the Thermocycler. It should by of type
-                              :py:class:`.ThermocyclerConfiguration` and can
+                              `ThermocyclerConfiguration` and can
                               either be FULL or SEMI.
         """
         super().__init__(

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -282,7 +282,7 @@ class LegacyInstrumentCoreSimulator(
                     num_channels=self.get_channels(),
                 )
             except AssertionError:
-                # Similarly to :py:meth:`return_tips`, the failure case here
+                # Similarly to `return_tips()`, the failure case here
                 # just means the tip can't be reused, so don't actually stop
                 # the protocol
                 _log.warning(

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -238,13 +238,13 @@ class AbstractThermocyclerCore(
         Profile defined as a cycle of ``steps`` to repeat for a given number of ``repetitions``
 
         Note:
-            Unlike the :py:meth:`set_block_temperature`, either or both of
+            Unlike [`set_block_temperature()`][opentrons.protocol_api.ThermocyclerContext.set_block_temperature], either or both of
             'hold_time_minutes' and 'hold_time_seconds' must be defined
             and finite for each step.
         Args:
             steps: List of unique steps that make up a single cycle.
                 Each list item should be a dictionary that maps to
-                the parameters of the :py:meth:`set_block_temperature`
+                the parameters of the [`set_block_temperature()`][opentrons.protocol_api.ThermocyclerContext.set_block_temperature]
                 method with keys 'temperature', 'hold_time_seconds',
                 and 'hold_time_minutes'.
             repetitions: The number of times to repeat the cycled steps.
@@ -265,13 +265,13 @@ class AbstractThermocyclerCore(
         Profile defined as a cycle of ``steps`` to repeat for a given number of ``repetitions``
 
         Note:
-            Unlike the :py:meth:`execute_profile`, once the profile has started
+            Unlike [`execute_profile()`][opentrons.protocol_api.ThermocyclerContext.execute_profile], once the profile has started
             the protocol will immediately move on to the next command, rather than waiting
             for it to finish.
         Args:
             steps: List of unique steps that make up a single cycle.
                 Each list item should be a dictionary that maps to
-                the parameters of the :py:meth:`set_block_temperature`
+                the parameters of the [`set_block_temperature()`][opentrons.protocol_api.ThermocyclerContext.set_block_temperature]
                 method with keys 'temperature', 'hold_time_seconds',
                 and 'hold_time_minutes'.
             repetitions: The number of times to repeat the cycled steps.

--- a/api/src/opentrons/protocol_api/deck.py
+++ b/api/src/opentrons/protocol_api/deck.py
@@ -53,7 +53,7 @@ def _get_slot_name(
 class Deck(Mapping[DeckLocation, Optional[DeckItem]]):
     """A dictionary-like object to access Protocol API objects loaded on the deck.
 
-    Accessible via :py:meth:`ProtocolContext.deck`.
+    Accessible via [`ProtocolContext.deck`][opentrons.protocol_api.ProtocolContext.deck].
     """
 
     def __init__(

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1,6 +1,6 @@
 """opentrons.protocol_api.labware: classes and functions for labware handling
 
-This module provides things like :py:class:`Labware`, and :py:class:`Well`
+This module provides things like [`Labware`][opentrons.protocol_api.Labware], and [`Well`][opentrons.protocol_api.Well]
 to encapsulate labware instances used in protocols
 and their wells. It also provides helper functions to load and save labware
 and labware calibration offsets. It contains all the code necessary to
@@ -464,10 +464,10 @@ class Labware:
         :param core: The class that implements the public interface
                                of the class.
         :param APIVersion api_level: the API version to set for the instance.
-                                     The :py:class:`.Labware` will
+                                     The [`Labware`][opentrons.protocol_api.Labware] will
                                      conform to this level. If not specified,
                                      defaults to
-                                     :py:attr:`.MAX_SUPPORTED_VERSION`.
+                                     `MAX_SUPPORTED_VERSION`.
         """
         if api_version <= _IGNORE_API_VERSION_BREAKPOINT:
             api_version = _IGNORE_API_VERSION_BREAKPOINT
@@ -1312,7 +1312,7 @@ class Labware:
                 current_version=f"{self._api_version}",
             )
 
-        # This logic is the inverse of :py:meth:`next_tip`
+        # This logic is the inverse of `next_tip()`
         assert num_tips > 0, "Bad call to previous_tip: num_tips <= 0"
         assert isinstance(self._core, LegacyLabwareCore)
         well_core = self._core.get_tip_tracker().previous_tip(num_tips=num_tips)
@@ -1351,7 +1351,7 @@ class Labware:
                 extra_message="Use Labware.reset() instead.",
             )
 
-        # This logic is the inverse of :py:meth:`use_tips`
+        # This logic is the inverse of `use_tips()`
         assert num_channels > 0, "Bad call to return_tips: num_channels <= 0"
 
         assert isinstance(self._core, LegacyLabwareCore)
@@ -1618,13 +1618,13 @@ def load_from_definition(
         (shape, physical dimensions, etc), and so on. The correct shape of
         this definition is governed by the "labware-designer" project in
         the Opentrons/opentrons repo.
-    :param parent: A :py:class:`.Location` representing the location where
+    :param parent: A [`Location`][opentrons.types.Location] representing the location where
                    the front and left most point of the outside of labware is
                    (often the front-left corner of a slot on the deck).
     :param str label: An optional label that will override the labware's
                       display name from its definition
     :param api_level: the API version to set for the loaded labware
-                      instance. The :py:class:`.Labware` will
+                      instance. The [`Labware`][opentrons.protocol_api.Labware] will
                       conform to this level. If not specified,
                       defaults to ``APIVersion(2, 13)``.
     """
@@ -1660,7 +1660,7 @@ def load(
     :param load_name: A string to use for looking up a labware definition
         previously saved to disc. The definition file must have been saved in a
         known location
-    :param parent: A :py:class:`.Location` representing the location where
+    :param parent: A [`Location`][opentrons.types.Location] representing the location where
                    the front and left most point of the outside of labware is
                    (often the front-left corner of a slot on the deck).
     :param str label: An optional label that will override the labware's
@@ -1675,7 +1675,7 @@ def load(
         definitions. If no bundle is passed, these definitions will also be
         searched.
     :param api_level: the API version to set for the loaded labware
-                      instance. The :py:class:`.Labware` will
+                      instance. The [`Labware`][opentrons.protocol_api.Labware] will
                       conform to this level. If not specified,
                       defaults to ``APIVersion(2, 13)``.
     """

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -1203,7 +1203,7 @@ class HeaterShakerContext(ModuleContext):
     @requires_version(2, 27)
     @publish(command=cmds.heater_shaker_set_shake_speed)
     def set_shake_speed(self, rpm: int) -> Task:
-        """Sets the Heater-Shaker's shake speed in RPM and returns a :py:class:`Task` that represents concurrent shaking.
+        """Sets the Heater-Shaker's shake speed in RPM and returns a [`Task`][opentrons.protocol_api.Task] that represents concurrent shaking.
 
         !!! note
             Before shaking, this command will retract the pipettes upward if they are

--- a/docs/python-api/docs/modules/vacuum.md
+++ b/docs/python-api/docs/modules/vacuum.md
@@ -1,6 +1,8 @@
 ---
 Title: "Python API: Vacuum Module"
 description: How to use the Vacuum Module in a Python protocol.
+search:
+  exclude: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. 

--- a/docs/python-api/docs/reference/vacuum.md
+++ b/docs/python-api/docs/reference/vacuum.md
@@ -1,6 +1,8 @@
 ---
 title: "Python API Reference: Vacuum Module"
 description: "Vacuum Module class reference for the Python Protocol API."
+search:
+  exclude: true
 ---
 
 ::: opentrons.protocol_api.VacuumModuleContext

--- a/docs/python-api/mkdocs.yml
+++ b/docs/python-api/mkdocs.yml
@@ -17,7 +17,7 @@ nav:
       - Magnetic Module: modules/magnetic-module.md
       - Temperature Module: modules/temperature-module.md
       - Thermocycler Module: modules/thermocycler.md
-      - Vacuum Module: modules/vacuum.md
+      # - Vacuum Module: modules/vacuum.md
       - Concurrent Module Actions: modules/concurrent.md
       - Loading Multiple Modules of the Same Type: modules/multiple-same-type.md
   - Deck Slots: deck-slots.md
@@ -75,7 +75,7 @@ nav:
         - Magnetic Module: reference/magnetic-module.md
         - Temperature Module: reference/temperature-module.md
         - Thermocycler: reference/thermocycler.md
-        - Vacuum Module: reference/vacuum.md
+        # - Vacuum Module: reference/vacuum.md
       - Useful Types: reference/types.md
       - Execute and Simulate: reference/execute-simulate.md
 


### PR DESCRIPTION
# Overview

Removes RST-formatted, Sphinx-style crossreferences in Python API docstrings. One public and several hidden docstrings still had these, of the form `:py:meth:`, `:py:obj:`, `:py:class:` etc.

## Test Plan and Hands on Testing

Docs build and lint.

## Changelog

- Relink most refs with autorefs-style markdown links.
- Remove some links entirely as unneeded.
- Undo a Sphinx-specific workaround in the nozzle layout constant docstrings, and document the ones that had no docstring at all.

## Review requests

- Zero flags of Paraguay in the docs output?
- All changes properly limited to docstrings and comments?

## Risk assessment

v low