### PR TITLE
chore(python): pin uv to 0.12.1 for local and CI

### DIFF
--- a/.cursor/skills/ai-server/SKILL.md
+++ b/.cursor/skills/ai-server/SKILL.md
@@ -26,10 +26,11 @@ All endpoints require a Bearer token in `Authorization`. Setting `"fake": true` 
 
 ## Package Manager — uv
 
-This project uses **uv** for Python dependency management (not pipenv, pip-tools, or poetry).
+This project uses **uv** for Python dependency management (not pipenv, pip-tools, or poetry). The uv **tool** version is pinned by `required-version` in this project's own `[tool.uv]`, matching the monorepo root [`uv.toml`](../uv.toml); CI installs that version via `astral-sh/setup-uv` `version-file`. uv does not inherit config across directories, so the two must be bumped together.
 
 | File               | Role                                                        | Committed?      |
 | ------------------ | ----------------------------------------------------------- | --------------- |
+| `../uv.toml`       | Pinned uv tool version for projects without `[tool.uv]`     | Yes             |
 | `pyproject.toml`   | Single source of truth for dependencies AND all tool config | Yes             |
 | `uv.lock`          | Locked dependency graph                                     | Yes             |
 | `requirements.txt` | Generated pip-format file for Docker builds                 | No (gitignored) |

--- a/.github/actions/python/setup-uv/action.yaml
+++ b/.github/actions/python/setup-uv/action.yaml
@@ -29,11 +29,14 @@ runs:
     - name: Setup Python and UV
       uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       with:
+        # Keep in sync with repo-root uv.toml required-version
+        version-file: uv.toml
         python-version: ${{ inputs.python-version }}
         enable-cache: true
         cache-dependency-glob: |
           ${{ inputs.project }}/pyproject.toml
           ${{ inputs.project }}/uv.lock
+
     - name: Setup Python Environment
       id: setup-env
       shell: bash

--- a/.github/workflows/analyses-snapshot-lint.yaml
+++ b/.github/workflows/analyses-snapshot-lint.yaml
@@ -26,6 +26,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
           enable-cache: true
           cache-dependency-glob: './analyses-snapshot-testing/uv.lock'

--- a/.github/workflows/analyses-snapshot-test.yaml
+++ b/.github/workflows/analyses-snapshot-test.yaml
@@ -44,6 +44,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
           enable-cache: true
           cache-dependency-glob: './analyses-snapshot-testing/uv.lock'
@@ -99,6 +100,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
           enable-cache: true
           cache-dependency-glob: './analyses-snapshot-testing/uv.lock'
@@ -136,6 +138,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
           enable-cache: true
           cache-dependency-glob: './analyses-snapshot-testing/uv.lock'

--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -52,6 +52,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
       - name: Setup Deploy Dependencies
         working-directory: scripts/static-deploy
@@ -108,6 +109,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
       - name: Setup Deploy Dependencies
         working-directory: scripts/static-deploy

--- a/.github/workflows/docs-build-deploy.yaml
+++ b/.github/workflows/docs-build-deploy.yaml
@@ -49,6 +49,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
           enable-cache: true
           cache-dependency-glob: './docs/uv.lock'
@@ -85,6 +86,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
           enable-cache: true
       - name: Setup Deploy Dependencies
@@ -118,6 +120,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
           enable-cache: true
       - name: Setup Deploy Dependencies

--- a/.github/workflows/e2e-test-checks.yaml
+++ b/.github/workflows/e2e-test-checks.yaml
@@ -32,6 +32,7 @@ jobs:
       - name: 'Setup UV'
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
           cache-dependency-glob: |
             e2e-testing/uv.lock

--- a/.github/workflows/ll-e2e-test.yaml
+++ b/.github/workflows/ll-e2e-test.yaml
@@ -55,6 +55,7 @@ jobs:
       - name: 'Setup UV for E2E tests'
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
           cache-dependency-glob: |
             e2e-testing/uv.lock

--- a/.github/workflows/ll-test-build-deploy.yaml
+++ b/.github/workflows/ll-test-build-deploy.yaml
@@ -54,6 +54,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
       - name: Setup Deploy Dependencies
         working-directory: scripts/static-deploy
@@ -113,6 +114,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
       - name: Setup Deploy Dependencies
         working-directory: scripts/static-deploy

--- a/.github/workflows/locize-sync.yaml
+++ b/.github/workflows/locize-sync.yaml
@@ -43,6 +43,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
 
       - name: Run Locize ${{ inputs.locize_action }}

--- a/.github/workflows/opentrons-ai-production-deploy.yaml
+++ b/.github/workflows/opentrons-ai-production-deploy.yaml
@@ -69,6 +69,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
           enable-cache: true
           cache-dependency-glob: './opentrons-ai-server/uv.lock'

--- a/.github/workflows/opentrons-ai-server-lint-test.yaml
+++ b/.github/workflows/opentrons-ai-server-lint-test.yaml
@@ -33,6 +33,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
           enable-cache: true
           cache-dependency-glob: './opentrons-ai-server/uv.lock'

--- a/.github/workflows/opentrons-ai-server-staging-continuous-deploy.yaml
+++ b/.github/workflows/opentrons-ai-server-staging-continuous-deploy.yaml
@@ -43,6 +43,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
           enable-cache: true
           cache-dependency-glob: './opentrons-ai-server/uv.lock'

--- a/.github/workflows/pd-e2e-test-cron-edge.yaml
+++ b/.github/workflows/pd-e2e-test-cron-edge.yaml
@@ -39,6 +39,7 @@ jobs:
       - name: 'Setup UV for E2E tests'
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
           cache-dependency-glob: |
             e2e-testing/uv.lock

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -59,6 +59,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
       - name: Setup Deploy Dependencies
         working-directory: scripts/static-deploy
@@ -170,6 +171,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
       - name: Setup Deploy Dependencies
         working-directory: scripts/static-deploy

--- a/.github/workflows/static-deploy-lint-test.yaml
+++ b/.github/workflows/static-deploy-lint-test.yaml
@@ -20,6 +20,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
+          version-file: uv.toml
           python-version: '3.12'
           enable-cache: true
           cache-dependency-glob: 'scripts/static-deploy/uv.lock'

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -148,16 +148,16 @@ eval "$(pyenv init -)"
 
 [uv][] is a fast Python package installer and resolver that we use for dependency management in all Python projects (`api`, `update-server`, `robot-server`, `server-utils`, `shared-data`, `g-code-testing`, `hardware`, `usb-bridge`, `system-server`).
 
-Install `uv` using the official installer:
+Install the pinned `uv` version from the repo-root [`uv.toml`](./uv.toml) (`required-version`) using the official installer:
 
 ```shell
-curl -LsSf https://astral.sh/uv/install.sh | sh
+curl -LsSf https://astral.sh/uv/0.12.1/install.sh | sh
 ```
 
-Close and re-open your terminal to verify that `uv` is installed:
+Close and re-open your terminal to verify that `uv` is installed and matches the pin:
 
 ```shell
-uv --version
+uv --version  # should report 0.12.1
 ```
 
 If the `uv` command isn't working, make sure `~/.local/bin` (or `~/.cargo/bin` on some systems) is in your `PATH`. You may need to add it to your `~/.zprofile`:
@@ -195,16 +195,16 @@ On Windows, we rely on:
 
 [uv][] is a fast Python package installer and resolver that we use for dependency management in all Python projects (`api`, `update-server`, `robot-server`, `server-utils`, `shared-data`, `g-code-testing`, `hardware`, `usb-bridge`, `system-server`).
 
-Install `uv` using the official installer:
+Install the pinned `uv` version from the repo-root [`uv.toml`](./uv.toml) (`required-version`) using the official installer:
 
 ```powershell
-powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/0.12.1/install.ps1 | iex"
 ```
 
-Close and re-open your terminal to verify that `uv` is installed:
+Close and re-open your terminal to verify that `uv` is installed and matches the pin:
 
 ```powershell
-uv --version
+uv --version  # should report 0.12.1
 ```
 
 #### 4. Install build tools via Visual Studio Installer
@@ -225,16 +225,16 @@ Linux setup is broadly similar to macOS setup, but it will depend heavily on you
 
 [uv][] is a fast Python package installer and resolver that we use for dependency management in all Python projects (`api`, `update-server`, `robot-server`, `server-utils`, `shared-data`, `g-code-testing`, `hardware`, `usb-bridge`, `system-server`).
 
-Install `uv` using the official installer:
+Install the pinned `uv` version from the repo-root [`uv.toml`](./uv.toml) (`required-version`) using the official installer:
 
 ```shell
-curl -LsSf https://astral.sh/uv/install.sh | sh
+curl -LsSf https://astral.sh/uv/0.12.1/install.sh | sh
 ```
 
-Close and re-open your terminal to verify that `uv` is installed:
+Close and re-open your terminal to verify that `uv` is installed and matches the pin:
 
 ```shell
-uv --version
+uv --version  # should report 0.12.1
 ```
 
 If the `uv` command isn't working, make sure `~/.local/bin` (or `~/.cargo/bin` on some systems) is in your `PATH`. You may need to add it to your `~/.bashrc` or `~/.profile`:

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -158,6 +158,8 @@ known-first-party = ["opentrons_shared_data", "opentrons_hardware"]
 known-local-folder = ["opentrons"]
 
 [tool.uv]
+# Keep in sync with repo-root uv.toml and oe-core's Dockerfile
+required-version = "==0.12.1"
 exclude-newer = "1 week"
 
 # local editable sources satisfying the 0.0.0 placeholders

--- a/audit-server/pyproject.toml
+++ b/audit-server/pyproject.toml
@@ -80,6 +80,8 @@ exclude = ["audit_server/_version.py"]
 
 # uv: global settings and dependency tweaks
 [tool.uv]
+# Keep in sync with repo-root uv.toml and oe-core's Dockerfile
+required-version = "==0.12.1"
 # Provide static metadata so uv can resolve systemd-python without building its sdist on
 # macOS, where libsystemd headers are unavailable; Linux installs still see the real wheel.
 dependency-metadata = [

--- a/auth-server/pyproject.toml
+++ b/auth-server/pyproject.toml
@@ -79,6 +79,8 @@ exclude = ["auth_server/_version.py"]
 
 # uv: global settings and dependency tweaks
 [tool.uv]
+# Keep in sync with repo-root uv.toml and oe-core's Dockerfile
+required-version = "==0.12.1"
 # Provide static metadata so uv can resolve systemd-python without building its sdist on
 # macOS, where libsystemd headers are unavailable; Linux installs still see the real wheel.
 dependency-metadata = [

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ This directory contains:
 ## Development setup
 
 1. Install `make`, if necessary.
-2. [Install `uv`](https://docs.astral.sh/uv/getting-started/installation/).
+2. Install the pinned [`uv`](https://docs.astral.sh/uv/getting-started/installation/) version from the repo-root [`uv.toml`](../uv.toml) (`curl -LsSf https://astral.sh/uv/0.12.1/install.sh | sh`).
 3. In this directory, run `make setup` to install dependencies.
 
 ## Building and serving

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -20,6 +20,8 @@ dependencies = [
 ]
 
 [tool.uv]
+# Keep in sync with repo-root uv.toml and oe-core's Dockerfile
+required-version = "==0.12.1"
 # cooldown time for security
 exclude-newer = "1 week"
 

--- a/g-code-testing/pyproject.toml
+++ b/g-code-testing/pyproject.toml
@@ -60,6 +60,8 @@ exclude = ["g_code_parsing/_version.py"]
 
 # uv: global settings and dependency tweaks
 [tool.uv]
+# Keep in sync with repo-root uv.toml and oe-core's Dockerfile
+required-version = "==0.12.1"
 # Provide static metadata so uv can resolve systemd-python without building its sdist on
 # macOS, where libsystemd headers are unavailable; Linux installs still see the real wheel.
 dependency-metadata = [

--- a/hardware-testing/pyproject.toml
+++ b/hardware-testing/pyproject.toml
@@ -61,6 +61,8 @@ include = ['hardware_testing', 'LICENSE', 'tests', 'mypy.ini', 'pytest.ini', '.f
 'LICENSE' = 'hardware_testing/LICENSE'
 
 [tool.uv]
+# Keep in sync with repo-root uv.toml and oe-core's Dockerfile
+required-version = "==0.12.1"
 # cooldown time for security
 exclude-newer = "1 week"
 

--- a/hardware/pyproject.toml
+++ b/hardware/pyproject.toml
@@ -119,6 +119,8 @@ warn_unused_configs = true
 strict = true
 
 [tool.uv]
+# Keep in sync with repo-root uv.toml and oe-core's Dockerfile
+required-version = "==0.12.1"
 # cooldown time for security
 exclude-newer = "1 week"
 

--- a/key-server/pyproject.toml
+++ b/key-server/pyproject.toml
@@ -72,6 +72,8 @@ exclude = ["key_server/_version.py"]
 
 # uv: global settings and dependency tweaks
 [tool.uv]
+# Keep in sync with repo-root uv.toml and oe-core's Dockerfile
+required-version = "==0.12.1"
 # Provide static metadata so uv can resolve systemd-python without building its sdist on
 # macOS, where libsystemd headers are unavailable; Linux installs still see the real wheel.
 dependency-metadata = [

--- a/opentrons-ai-server/README.md
+++ b/opentrons-ai-server/README.md
@@ -53,7 +53,7 @@ The opentrons-ai-server/api/settings.py file manages environment variables and s
 1. select the python version `pyenv local 3.12.6`.
    1. This will create a `.python-version` file in this directory.
 1. select the node version with `nvs` or `nvm` currently 22.11\*.
-1. Install [uv](https://docs.astral.sh/uv/getting-started/installation/) and python dependencies using `make setup`.
+1. Install the pinned [uv](https://docs.astral.sh/uv/getting-started/installation/) version from the repo-root [`uv.toml`](../uv.toml) (`curl -LsSf https://astral.sh/uv/0.12.1/install.sh | sh`) and python dependencies using `make setup`.
    1. `make setup` also syncs Python API docs from the pinned mkdocs tag in the Makefile (`DOCS_TAG`).
 1. Install docker if you plan to run and build the docker container locally.
 1. `make teardown` will remove the virtual environment.

--- a/opentrons-ai-server/pyproject.toml
+++ b/opentrons-ai-server/pyproject.toml
@@ -95,5 +95,7 @@ module = "llama_index.llms.openai"
 ignore_missing_imports = true
 
 [tool.uv]
+# Keep in sync with repo-root uv.toml and oe-core's Dockerfile
+required-version = "==0.12.1"
 # cooldown time for security
 exclude-newer = "1 week"

--- a/robot-server/pyproject.toml
+++ b/robot-server/pyproject.toml
@@ -109,6 +109,8 @@ exclude = ["tests/integration/persistence_snapshots", "robot_server/_version.py"
 
 # uv: global settings and dependency tweaks
 [tool.uv]
+# Keep in sync with repo-root uv.toml and oe-core's Dockerfile
+required-version = "==0.12.1"
 # Provide static metadata so uv can resolve systemd-python without building its sdist on
 # macOS, where libsystemd headers are unavailable; Linux installs still see the real wheel.
 dependency-metadata = [

--- a/scripts/python-uv.mk
+++ b/scripts/python-uv.mk
@@ -1,4 +1,5 @@
-# UV is required for Python dependency management
+# UV is required for Python dependency management.
+# The uv tool version is pinned in the repo-root uv.toml (required-version).
 UV ?= uv
 UV_PYTHON = 3.12
 # todo(mm, 2026-04-03): This export will implicitly affect uv behavior in any Makefile

--- a/server-utils/pyproject.toml
+++ b/server-utils/pyproject.toml
@@ -71,6 +71,8 @@ exclude = ["server_utils/_version.py"]
 
 # uv: global settings and dependency tweaks
 [tool.uv]
+# Keep in sync with repo-root uv.toml and oe-core's Dockerfile
+required-version = "==0.12.1"
 # Provide static metadata so uv can resolve systemd-python without building its sdist on
 # macOS, where libsystemd headers are unavailable; Linux installs still see the real wheel.
 dependency-metadata = [

--- a/shared-data/pyproject.toml
+++ b/shared-data/pyproject.toml
@@ -202,5 +202,7 @@ module = ["PIL", "PIL.*"]
 ignore_missing_imports = true
 
 [tool.uv]
+# Keep in sync with repo-root uv.toml and oe-core's Dockerfile
+required-version = "==0.12.1"
 # cooldown time for security
 exclude-newer = "1 week"

--- a/system-server/pyproject.toml
+++ b/system-server/pyproject.toml
@@ -129,6 +129,8 @@ server-utils = { path = "../server-utils", editable = true }
 
 # uv: global settings and dependency tweaks
 [tool.uv]
+# Keep in sync with repo-root uv.toml and oe-core's Dockerfile
+required-version = "==0.12.1"
 # Provide static metadata so uv can resolve systemd-python without building its sdist on
 # macOS, where libsystemd headers are unavailable; Linux installs still see the real wheel.
 dependency-metadata = [

--- a/update-server/pyproject.toml
+++ b/update-server/pyproject.toml
@@ -58,6 +58,8 @@ dev = [
 "Source Code On Github" = "https://github.com/Opentrons/opentrons/tree/edge/update-server"
 
 [tool.uv]
+# Keep in sync with repo-root uv.toml and oe-core's Dockerfile
+required-version = "==0.12.1"
 # Stub for systemd-python so uv can resolve on macOS (no libsystemd).
 dependency-metadata = [
     { name = "systemd-python", version = "234", requires-python = ">=3.7", requires-dist = [] },

--- a/usb-bridge/pyproject.toml
+++ b/usb-bridge/pyproject.toml
@@ -112,5 +112,7 @@ warn_required_dynamic_aliases = true
 warn_untyped_fields = true
 
 [tool.uv]
+# Keep in sync with repo-root uv.toml and oe-core's Dockerfile
+required-version = "==0.12.1"
 # cooldown time for security
 exclude-newer = "1 week"

--- a/uv.toml
+++ b/uv.toml
@@ -1,0 +1,8 @@
+# Pinned uv version for local development and CI (astral-sh/setup-uv version-file).
+#
+# uv does not merge config files: the nearest uv.toml or pyproject.toml with a
+# [tool.uv] table wins outright. This file therefore only covers projects that have
+# no [tool.uv] of their own; every project that does have one repeats
+# required-version. Bump all of them together, along with oe-core's Dockerfile,
+# which runs `uv export --frozen` inside this tree for Flex builds.
+required-version = "==0.12.1"


### PR DESCRIPTION
## Summary
- Pin uv to `0.12.1` via root `uv.toml` and `required-version` in each project that has `[tool.uv]`
- Wire `version-file: uv.toml` through the shared `setup-uv` action and all direct `astral-sh/setup-uv` callers
- Document the pinned install in `DEV_SETUP.md`, docs, and AI server README

## Why
Local and CI were floating on whatever uv the installer/`setup-uv` latest returned, while Flex oe-core pinned `0.9.17`. Lock regenerations and `uv export --frozen` could disagree for no good reason.

uv does not merge config across directories (nearest `[tool.uv]` wins), so the pin is repeated in each project's `pyproject.toml` as well as the root `uv.toml`.

## Dependency
**Do not merge until [Opentrons/oe-core#365](https://github.com/Opentrons/oe-core/pull/365) is merged.** That bumps the Flex build image to uv `0.12.1`. With this PR alone, oe-core's `uv export` inside robot projects fails on `required-version`.

## Test plan
- [x] Wait for oe-core#365 to land
- [ ] Confirm CI installs uv `0.12.1` (`Successfully installed uv version 0.12.1`)
- [ ] Confirm robot Python CI still passes (`uv sync` / lint / test)
- [x] Confirm Flex image build still runs `uv export --group robot --frozen` successfully after oe-core bump
- [x] Local: `uv --version` reports `0.12.1` after `curl -LsSf https://astral.sh/uv/0.12.1/install.sh | sh`