### PR TITLE
feat(api): add new pressure regulation tuning parameters for vacuum module.

### DIFF
--- a/api/src/opentrons/drivers/vacuum_module/abstract.py
+++ b/api/src/opentrons/drivers/vacuum_module/abstract.py
@@ -104,9 +104,11 @@ class AbstractVacuumModuleDriver(Protocol):
         k_velocity: Optional[float] = None,
         k_holding: Optional[float] = None,
         tolerance: Optional[float] = None,
+        approach_band: Optional[float] = None,
+        slew_end_fraction: Optional[float] = None,
         reset: bool = False,
     ) -> None:
-        """Sets the PID tuning parameters for the pressure control."""
+        """Sets the PID tuning parameters for pressure control."""
         ...
 
     async def get_pressure_control_tunings(self) -> PressureControlTunings:

--- a/api/src/opentrons/drivers/vacuum_module/driver.py
+++ b/api/src/opentrons/drivers/vacuum_module/driver.py
@@ -90,7 +90,11 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
     @classmethod
     def parse_get_pressure_pid(cls, response: str) -> PressureControlTunings:
         """Parse the get pressure pid."""
-        pattern = r"P:(?P<P>\d.+) I:(?P<I>\d.+) D:(?P<D>\d.+) O:(?P<O>-?\d.+) V:(?P<V>\d.+) H:(?P<H>\d.+) T:(?P<T>\d.+)"
+        pattern = (
+            r"P:(?P<P>\d.+) I:(?P<I>\d.+) D:(?P<D>\d.+) O:(?P<O>-?\d.+) "
+            r"V:(?P<V>\d.+) H:(?P<H>\d.+) T:(?P<T>\d.+) "
+            r"A:(?P<A>\d.+) S:(?P<S>\d.+)"
+        )
         _RE = re.compile(rf"^{GCODE.GET_PRESSURE_PID} {pattern}$")
         match = _RE.match(response)
         if not match:
@@ -103,6 +107,8 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
             float(match.group("V")),
             float(match.group("H")),
             float(match.group("T")),
+            float(match.group("A")),
+            float(match.group("S")),
         )
 
     @classmethod
@@ -377,25 +383,26 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
         k_velocity: Optional[float] = None,
         k_holding: Optional[float] = None,
         tolerance: Optional[float] = None,
+        approach_band: Optional[float] = None,
+        slew_end_fraction: Optional[float] = None,
         reset: bool = False,
     ) -> None:
-        """Sets the PID tuning parameters for the pressure control."""
+        """Sets the PID tuning parameters for pressure control."""
 
         command = GCODE.SET_PRESSURE_PID.build_command()
-        if kp is not None:
-            command.add_float("P", kp, GCODE_ROUNDING_PRECISION)
-        if ki is not None:
-            command.add_float("I", ki, GCODE_ROUNDING_PRECISION)
-        if kd is not None:
-            command.add_float("D", kd, GCODE_ROUNDING_PRECISION)
-        if overshoot is not None:
-            command.add_float("O", overshoot, GCODE_ROUNDING_PRECISION)
-        if k_velocity is not None:
-            command.add_float("V", k_velocity, GCODE_ROUNDING_PRECISION)
-        if k_holding is not None:
-            command.add_float("H", k_holding, GCODE_ROUNDING_PRECISION)
-        if tolerance is not None:
-            command.add_float("T", tolerance, GCODE_ROUNDING_PRECISION)
+        for letter, value in (
+            ("P", kp),
+            ("I", ki),
+            ("D", kd),
+            ("O", overshoot),
+            ("V", k_velocity),
+            ("H", k_holding),
+            ("T", tolerance),
+            ("A", approach_band),
+            ("S", slew_end_fraction),
+        ):
+            if value is not None:
+                command.add_float(letter, value, GCODE_ROUNDING_PRECISION)
         command.add_int("R", int(reset))
 
         resp = await self._connection.send_command(command)
@@ -409,7 +416,7 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
         )
         return self.parse_get_pressure_pid(resp)
 
-    async def set_waste_configs(  # noqa: C901
+    async def set_waste_configs(
         self,
         enable_waste_full_detection: bool,
         p_window_start: Optional[float] = None,
@@ -425,24 +432,19 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
         """Sets the Waste Full detection algorithm parameters"""
 
         command = GCODE.SET_WASTE_CONFIG.build_command()
-        if p_window_start is not None:
-            command.add_float("S", p_window_start, GCODE_ROUNDING_PRECISION)
-        if p_window_end is not None:
-            command.add_float("P", p_window_end, GCODE_ROUNDING_PRECISION)
-        if baseline_fast_factor is not None:
-            command.add_float("F", baseline_fast_factor, GCODE_ROUNDING_PRECISION)
-        if max_delta_per_tick is not None:
-            command.add_float("D", max_delta_per_tick, GCODE_ROUNDING_PRECISION)
-        if max_rise_per_tick is not None:
-            command.add_float("R", max_rise_per_tick, GCODE_ROUNDING_PRECISION)
-        if max_cummulative_rise is not None:
-            command.add_float("C", max_cummulative_rise, GCODE_ROUNDING_PRECISION)
-        if p_filter_alpha is not None:
-            command.add_float("A", p_filter_alpha, GCODE_ROUNDING_PRECISION)
-        if min_window_time is not None:
-            command.add_float("M", min_window_time, GCODE_ROUNDING_PRECISION)
-        if max_window_time is not None:
-            command.add_float("X", max_window_time, GCODE_ROUNDING_PRECISION)
+        for letter, value in (
+            ("S", p_window_start),
+            ("P", p_window_end),
+            ("F", baseline_fast_factor),
+            ("D", max_delta_per_tick),
+            ("R", max_rise_per_tick),
+            ("C", max_cummulative_rise),
+            ("A", p_filter_alpha),
+            ("M", min_window_time),
+            ("X", max_window_time),
+        ):
+            if value is not None:
+                command.add_float(letter, value, GCODE_ROUNDING_PRECISION)
         command.add_int("E", int(enable_waste_full_detection))
 
         resp = await self._connection.send_command(command)

--- a/api/src/opentrons/drivers/vacuum_module/simulator.py
+++ b/api/src/opentrons/drivers/vacuum_module/simulator.py
@@ -162,14 +162,16 @@ class SimulatingDriver(AbstractVacuumModuleDriver):
         k_velocity: Optional[float] = None,
         k_holding: Optional[float] = None,
         tolerance: Optional[float] = None,
+        approach_band: Optional[float] = None,
+        slew_end_fraction: Optional[float] = None,
         reset: bool = False,
     ) -> None:
-        """Sets the PID tuning parameters for the pressure control."""
+        """Sets the PID tuning parameters for pressure control."""
         pass
 
     async def get_pressure_control_tunings(self) -> PressureControlTunings:
         """Get the pressure control pid tunings."""
-        return PressureControlTunings(0, 0, 0, 0, 0, 0, 0)
+        return PressureControlTunings(0, 0, 0, 0, 0, 0, 0, 0, 0)
 
     async def set_waste_configs(
         self,

--- a/api/src/opentrons/drivers/vacuum_module/types.py
+++ b/api/src/opentrons/drivers/vacuum_module/types.py
@@ -147,6 +147,8 @@ class PressureControlTunings:
     k_velocity: float
     k_holding: float
     tolerance_error: float
+    approach_band: float
+    slew_end_fraction: float
 
 
 @dataclass

--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -104,7 +104,7 @@ PRESSURE_TOL = 5.0
 EQUALIZE_PRESSURE_TOL = 10.0
 POWER_TOL = 1.0
 
-# Pressure-control PID defaults
+# Pressure-control tuning defaults
 # See pressure_task.hpp and pressure_controller.hpp in opentrons-modules for details
 DEFAULT_PRESSURE_CONTROL_TUNINGS = PressureControlTunings(
     kp=13.1,
@@ -114,6 +114,8 @@ DEFAULT_PRESSURE_CONTROL_TUNINGS = PressureControlTunings(
     k_velocity=20.0,
     k_holding=43.0,
     tolerance_error=2.0,  # rel_tol_pct (%)
+    approach_band=80.0,
+    slew_end_fraction=0.30,
 )
 
 # Waste-full detection defaults
@@ -314,16 +316,18 @@ class VacuumModule(mod_abc.AbstractModule):
             waste.max_window_time,
         )
 
-        # Pressure control PID parameters
+        # Pressure control parameters
         pid = DEFAULT_PRESSURE_CONTROL_TUNINGS
         await self._driver.set_pressure_control_tunings(
-            pid.kp,
-            pid.ki,
-            pid.kd,
-            pid.overshoot_error,
-            pid.k_velocity,
-            pid.k_holding,
-            pid.tolerance_error,
+            kp=pid.kp,
+            ki=pid.ki,
+            kd=pid.kd,
+            overshoot=pid.overshoot_error,
+            k_velocity=pid.k_velocity,
+            k_holding=pid.k_holding,
+            tolerance=pid.tolerance_error,
+            approach_band=pid.approach_band,
+            slew_end_fraction=pid.slew_end_fraction,
         )
 
     async def attempt_reconnect(self) -> None:

--- a/api/tests/opentrons/drivers/vacuum_module/test_driver.py
+++ b/api/tests/opentrons/drivers/vacuum_module/test_driver.py
@@ -329,12 +329,34 @@ async def test_set_pressure_control_tunings(
     connection.reset_mock()
 
 
+async def test_set_pressure_control_band_tunings(
+    subject: VacuumModuleDriver, connection: AsyncMock
+) -> None:
+    """It should send M125 with approach band (A) and slew end fraction (S)."""
+    connection.send_command.return_value = "M125"
+
+    await subject.set_pressure_control_tunings(
+        approach_band=80.0,
+        slew_end_fraction=0.30,
+    )
+
+    set_pressure_pid = (
+        types.GCODE.SET_PRESSURE_PID.build_command()
+        .add_float("A", 80.0)
+        .add_float("S", 0.30)
+        .add_int("R", 0)
+    )
+
+    connection.send_command.assert_any_call(set_pressure_pid)
+    connection.reset_mock()
+
+
 async def test_get_pressure_control_tunings(
     subject: VacuumModuleDriver, connection: AsyncMock
 ) -> None:
-    """It should send a get pressure pid command"""
+    """It should send a get pressure pid command and parse A/S fields."""
     connection.send_command.return_value = (
-        "M126 P:1.0 I:0.0 D:0.0 O:-2.0 V:20.0 H:43.0 T:0.2"
+        "M126 P:1.0 I:0.0 D:0.0 O:-2.0 V:20.0 H:43.0 T:0.2 A:80.0 S:0.30"
     )
 
     pressure_state = await subject.get_pressure_control_tunings()
@@ -343,7 +365,17 @@ async def test_get_pressure_control_tunings(
     connection.send_command.assert_any_call(get_pressure)
     connection.reset_mock()
 
-    assert pressure_state == types.PressureControlTunings(1, 0, 0, -2, 20, 43, 0.2)
+    assert pressure_state == types.PressureControlTunings(
+        1,
+        0,
+        0,
+        -2,
+        20,
+        43,
+        0.2,
+        80.0,
+        0.30,
+    )
 
 
 async def test_move_port(subject: VacuumModuleDriver, connection: AsyncMock) -> None:

--- a/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
@@ -960,6 +960,8 @@ async def test_configure_device_applies_waste_and_pressure_defaults(
             k_velocity=pid.k_velocity,
             k_holding=pid.k_holding,
             tolerance=pid.tolerance_error,
+            approach_band=pid.approach_band,
+            slew_end_fraction=pid.slew_end_fraction,
         ),
     )
 


### PR DESCRIPTION
# Overview

The [Opentrons/opentrons-modules#575](https://github.com/Opentrons/opentrons-modules/pull/575) vacuum module pr exposes approach band (A) and slew end fraction (S) parameters in the pressure controller. So let's expose them through the M125 and M126 vacuum module gcodes so the hardware testing team can use them.

## Test Plan and Hands on Testing

- [x] Make sure we can parse the new arguments on existing M125 and M126 gcodes

## Changelog

- Added new pressure regulation parameters to M125 and M126 vacuum module GCODES

## Review requests
## Risk assessment