### PR TITLE
feat(protocol-visualization): remove time displays

### DIFF
--- a/protocol-visualization/src/molecules/PlayBackControls/index.tsx
+++ b/protocol-visualization/src/molecules/PlayBackControls/index.tsx
@@ -10,7 +10,6 @@ import {
 
 import { PerStepOverflowMenu } from '../PerStepOverflowMenu'
 import styles from './playbackcontrols.module.css'
-import { formatTime } from './utils/formatTime'
 import { getSpeedMultiplierText } from './utils/getSpeedMultiplierText'
 import { isEditableKeyboardTarget } from './utils/isEditableKeyboardTarget'
 
@@ -69,9 +68,6 @@ export function PlayBackControls(props: PlayBackControlsProps): ReactNode {
     }
   }
 
-  const elapsedSeconds = currentCommandIndex >= 0 ? currentCommandIndex : 0
-  const totalSeconds = numCommandLength >= 0 ? numCommandLength : 0
-  const forceHours = totalSeconds >= 3600
   const currentProgress =
     numCommandLength > 1
       ? (currentCommandIndex / (numCommandLength - 1)) * 100
@@ -114,23 +110,9 @@ export function PlayBackControls(props: PlayBackControlsProps): ReactNode {
           aria-label={isPlaying ? t('pause') : t('play')}
         />
 
-        {/* elapsed time */}
-        <div className={`${styles.time_label} ${styles.time_current}`}>
-          <StyledText desktopStyle="captionRegular">
-            {formatTime(elapsedSeconds, forceHours)}
-          </StyledText>
-        </div>
-
         {/* time slider */}
         <div className={styles.slider_wrapper}>
           <TimelineScrubber tracks={tracks} onTrackChange={handleTrackChange} />
-        </div>
-
-        {/* total time */}
-        <div className={`${styles.time_label} ${styles.time_total}`}>
-          <StyledText desktopStyle="captionRegular">
-            {formatTime(totalSeconds, false)}
-          </StyledText>
         </div>
 
         {/* speed switch */}

--- a/protocol-visualization/src/molecules/PlayBackControls/playbackcontrols.module.css
+++ b/protocol-visualization/src/molecules/PlayBackControls/playbackcontrols.module.css
@@ -25,21 +25,6 @@
   gap: var(--spacing-16);
 }
 
-.time_label {
-  text-align: center;
-  user-select: none;
-}
-
-.time_current {
-  min-width: 65px;
-  text-align: right;
-}
-
-.time_total {
-  min-width: 65px;
-  text-align: left;
-}
-
 .slider_wrapper {
   display: flex;
   flex: 1;


### PR DESCRIPTION


# Overview
remove time displays

<img width="1059" height="705" alt="Screenshot 2026-08-07 at 7 37 40 PM" src="https://github.com/user-attachments/assets/448b1f41-5c79-4d15-8f35-c128e017fbe0" />


closes AUTH-3148

## Test Plan and Hands on Testing
- checkout this branch
- go to `js-package-testing`
- run `make setup`
- run pnpm run dev

## Changelog
- remove time elements and styles

## Review requests

## Risk assessment
low