### PR TITLE
fix(app): Record certain user actions as "creating run" instead of "playing run"

### DIFF
--- a/app/src/assets/localization/en/audit_log.json
+++ b/app/src/assets/localization/en/audit_log.json
@@ -18,6 +18,7 @@
   "create_camera_image_settings": "Updating camera image settings",
   "create_offsets": "Saving new labware offsets",
   "create_protocol": "Creating protocol",
+  "create_run": "Creating run",
   "create_user": "Creating user",
   "delete_log_period": "Deleting log period",
   "delete_log_periods": "Deleting log periods",

--- a/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol.ts
+++ b/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol.ts
@@ -53,7 +53,7 @@ export function useCreateRunFromProtocol(
   )
 
   const { documentationState, clearDocreport } = useLinkedDocumentationState(
-    [...(actionsToDocument ?? []), 'create_protocol', 'play_run'],
+    [...(actionsToDocument ?? []), 'create_protocol', 'create_run'],
     host?.robotName ?? null,
     host?.robotName,
     host

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -149,6 +149,7 @@ type AuditLogAction =
   | 'create_protocol'
   | 'launching_error_recovery'
   | 'resume_run_from_recovery'
+  | 'create_run'
   | 'dismiss_run'
   | 'retry_action'
   | 'shutdown_robot'

--- a/react-api-client/src/runs/useCreateRunMutation.ts
+++ b/react-api-client/src/runs/useCreateRunMutation.ts
@@ -41,7 +41,7 @@ export function useCreateRunMutation(
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
   const mutation = useDocumentedMutation<Run, AxiosError, CreateRunData>(
     documentationState,
-    [...(actionsToDocument ?? []), 'play_run'],
+    [...(actionsToDocument ?? []), 'create_run'],
     getQueryKey(host, 'runs'),
     ({
       variables: createRunData,


### PR DESCRIPTION
## Overview

A run can be _created_, which basically means setting the stage, preparing it, setting it up; and it can be _played_, which means actually making the robot start to move. Our frontend copy said "playing run" for both of these user actions. This adds separate copy for "creating run."

## Test Plan and Hands on Testing

None needed.

## Review requests

None in particular.

## Risk assessment

Low.