### PR TITLE
fix(app,robot-server): Require authentication and documentation for robot-side protocol analysis

### DIFF
--- a/api-client/src/protocols/createProtocolAnalysis.ts
+++ b/api-client/src/protocols/createProtocolAnalysis.ts
@@ -23,7 +23,8 @@ export function createProtocolAnalysis(
   protocolKey: string,
   runTimeParameterValues?: RunTimeParameterValuesCreateData,
   runTimeParameterFiles?: RunTimeParameterFilesCreateData,
-  forceReAnalyze?: boolean
+  forceReAnalyze?: boolean,
+  userNotes?: string
 ): ResponsePromise<ProtocolAnalysisSummaryResult> {
   const data = {
     runTimeParameterValues: runTimeParameterValues ?? {},
@@ -33,6 +34,9 @@ export function createProtocolAnalysis(
   const response = request<
     ProtocolAnalysisSummaryResult,
     { data: CreateProtocolAnalysisData }
-  >(POST, `/protocols/${protocolKey}/analyses`, config, { body: { data } })
+  >(POST, `/protocols/${protocolKey}/analyses`, config, {
+    body: { data },
+    userNotes,
+  })
   return response
 }

--- a/app/src/assets/localization/en/audit_log.json
+++ b/app/src/assets/localization/en/audit_log.json
@@ -18,6 +18,7 @@
   "create_camera_image_settings": "Updating camera image settings",
   "create_offsets": "Saving new labware offsets",
   "create_protocol": "Creating protocol",
+  "create_protocol_analysis": "Analyzing protocol on robot",
   "create_run": "Creating run",
   "create_user": "Creating user",
   "delete_log_period": "Deleting log period",

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useCompatibleAnalysis.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useCompatibleAnalysis.ts
@@ -13,6 +13,7 @@ import {
 import { getRunTimeParameterDataFromRun } from './utils'
 
 import type { Run } from '@opentrons/api-client'
+import type { DocumentationState } from '@opentrons/react-api-client'
 import type {
   CompletedProtocolAnalysis,
   RunTimeCommand,
@@ -21,13 +22,16 @@ import type {
 // TODO(jh, 03-14-25): Remove this adapter logic and Mixpanel event once analytics
 //  indicate that users no longer run old analyses.
 
-// If analysis is incompatible with LPC, force reanalysis and use that fresh analysis,
-// otherwise, use the current analysis.
+/**
+ * If analysis is incompatible with LPC, force reanalysis and use that fresh analysis,
+ * otherwise, use the current analysis.
+ */
 export function useCompatibleAnalysis(
   runId: string | null,
   runRecord: Run | undefined,
   mostRecentAnalysis: CompletedProtocolAnalysis | null,
-  isFlex: boolean
+  isFlex: boolean,
+  documentationState: DocumentationState
 ): CompletedProtocolAnalysis | null {
   const [compatibleAnalysis, setCompatibleAnalysis] =
     useState<CompletedProtocolAnalysis | null>(null)
@@ -38,8 +42,10 @@ export function useCompatibleAnalysis(
 
   const trackEvent = useTrackEvent()
   const protocolId = runRecord?.data.protocolId ?? ''
-  const { createProtocolAnalysis } =
-    useCreateProtocolAnalysisMutation(protocolId)
+  const { createProtocolAnalysis } = useCreateProtocolAnalysisMutation(
+    documentationState,
+    protocolId
+  )
   const { data: freshAnalysis } = useProtocolAnalysisAsDocumentQuery(
     protocolId,
     compatibleAnalysisId,

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
@@ -7,6 +7,7 @@ import {
 } from '@opentrons/react-api-client'
 import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useMaintenanceRunDocumentation } from '/app/local-resources/access-control/useMaintenanceRunDocumentation'
 import { isDocumentationProvided } from '/app/local-resources/access-control/utils'
 import { useInitLPCStore } from '/app/organisms/LabwarePositionCheck/LPCFlows/hooks/useInitLPCStore'
@@ -112,12 +113,23 @@ export function useLPCFlows({
   const { data: runRecord } = useNotifyRunQuery(runId ?? null, {
     refetchInterval: RUN_RECORD_INTERVAL_MS,
   })
+
   const mostRecentAnalysis = useMostRecentCompletedAnalysis(runId)
+
+  // useCompatibleAnalysis() may need to trigger a new analysis, and that may require
+  // the user to log in and enter a reason for interaction.
+  //
+  // todo(mm, 2026-08-10): This could perhaps be combined with our call to
+  // useMaintenanceRunDocumentation() to avoid prompting the user twice,
+  // but it's unclear which hook should be responsible for that.
+  const analysisDocumentationState = useDocumentationState()
+
   const compatibleFlexAnalysis = useCompatibleAnalysis(
     runId,
     runRecord,
     mostRecentAnalysis,
-    isFlex
+    isFlex,
+    analysisDocumentationState
   )
   const compatibleRobotAnalysis = isFlex
     ? compatibleFlexAnalysis

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ProtocolSetupParameters.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ProtocolSetupParameters.tsx
@@ -172,10 +172,13 @@ export function ProtocolSetupParameters({
     }
   }
 
-  const { createProtocolAnalysis, isLoading: isAnalysisLoading } =
-    useCreateProtocolAnalysisMutation(protocolId, host)
-
+  // todo(mm, 2026-08-10): This could perhaps be useLinkedDocumentationState so a single
+  // prompt could be reused across the multiple setup requests, but the promise chaining
+  // inside handleConfirmValues is hurting my brain.
   const documentationState = useDocumentationState()
+
+  const { createProtocolAnalysis, isLoading: isAnalysisLoading } =
+    useCreateProtocolAnalysisMutation(documentationState, protocolId, host)
 
   const { uploadCsvFile } = useUploadCsvFileMutation(
     documentationState,

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ProtocolSetupParameters.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ProtocolSetupParameters.tsx
@@ -286,6 +286,7 @@ export function ProtocolSetupParameters({
       setChooseCsvFileScreen(parameter)
     } else {
       // bad param
+      parameter.type satisfies never
       console.error('error: bad param. not expected to reach this')
     }
   }

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/__tests__/ProtocolSetupParameters.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/__tests__/ProtocolSetupParameters.test.tsx
@@ -77,7 +77,11 @@ describe('ProtocolSetupParameters', () => {
     vi.mocked(ChooseCsvFile).mockReturnValue(<div>mock ChooseCsvFile</div>)
     vi.mocked(useHost).mockReturnValue(MOCK_HOST_CONFIG)
     when(vi.mocked(useCreateProtocolAnalysisMutation))
-      .calledWith(expect.anything(), expect.anything())
+      .calledWith(
+        ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+        expect.anything(),
+        expect.anything()
+      )
       .thenReturn({ createProtocolAnalysis: mockCreateProtocolAnalysis } as any)
     when(vi.mocked(useCreateRunMutation))
       .calledWith(

--- a/app/src/resources/runs/useCloneRun.ts
+++ b/app/src/resources/runs/useCloneRun.ts
@@ -8,7 +8,7 @@ import {
   useHost,
 } from '@opentrons/react-api-client'
 
-import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
 import {
   getRunTimeParameterFilesForRun,
   getRunTimeParameterValuesForRun,
@@ -33,7 +33,10 @@ export function useCloneRun(
   const queryClient = useQueryClient()
   const { data: runRecord, isLoading: isLoadingRun } = useNotifyRunQuery(runId)
   const protocolKey = runRecord?.data.protocolId ?? null
-  const documentationState = useDocumentationState()
+  const { documentationState, clearDocreport } = useLinkedDocumentationState(
+    ['create_protocol_analysis', 'create_run'],
+    null
+  )
   const { createRun, isLoading: isCloning } = useCreateRunMutation(
     documentationState,
     {
@@ -54,11 +57,13 @@ export function useCloneRun(
     }
   )
   const { createProtocolAnalysis } = useCreateProtocolAnalysisMutation(
+    documentationState,
     protocolKey,
     host
   )
   const cloneRun = (options?: { onError?: (error: unknown) => void }): void => {
     if (runRecord != null) {
+      clearDocreport()
       const { protocolId, labwareOffsets } = runRecord.data
       const runTimeParameters =
         'runTimeParameters' in runRecord.data

--- a/auth-server/auth_server/users/scopes.py
+++ b/auth-server/auth_server/users/scopes.py
@@ -37,6 +37,7 @@ def get_scope_set_of_account_type(
 
         elif account_type == AccountType.USER:
             result = {
+                Scope.PROTOCOL_ANALYSES_WRITE,
                 Scope.RESTART_WRITE,
                 Scope.ROBOT_CONTROL_WRITE,
                 Scope.ROBOT_SETTINGS_WRITE,

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -147,6 +147,7 @@ type AuditLogAction =
   | 'attach_pipette_left'
   | 'attach_pipette_right'
   | 'create_protocol'
+  | 'create_protocol_analysis'
   | 'launching_error_recovery'
   | 'resume_run_from_recovery'
   | 'create_run'

--- a/react-api-client/src/protocols/__tests__/useCreateProtocolAnalysisMutation.test.tsx
+++ b/react-api-client/src/protocols/__tests__/useCreateProtocolAnalysisMutation.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createProtocolAnalysis } from '@opentrons/api-client'
 
 import { useCreateProtocolAnalysisMutation } from '..'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../../accessControl/__fixtures__/documentationState'
 import { useHost } from '../../api'
 
 import type * as React from 'react'
@@ -42,7 +43,11 @@ describe('useCreateProtocolAnalysisMutation hook', () => {
     vi.mocked(createProtocolAnalysis).mockRejectedValue('oh no')
 
     const { result } = renderHook(
-      () => useCreateProtocolAnalysisMutation('fake-protocol-key'),
+      () =>
+        useCreateProtocolAnalysisMutation(
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+          'fake-protocol-key'
+        ),
       {
         wrapper,
       }
@@ -65,7 +70,11 @@ describe('useCreateProtocolAnalysisMutation hook', () => {
     } as Response<ProtocolAnalysisSummaryResult>)
 
     const { result } = renderHook(
-      () => useCreateProtocolAnalysisMutation('fake-protocol-key'),
+      () =>
+        useCreateProtocolAnalysisMutation(
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+          'fake-protocol-key'
+        ),
       {
         wrapper,
       }

--- a/react-api-client/src/protocols/useCreateProtocolAnalysisMutation.ts
+++ b/react-api-client/src/protocols/useCreateProtocolAnalysisMutation.ts
@@ -1,7 +1,8 @@
-import { useMutation, useQueryClient } from 'react-query'
+import { useQueryClient } from 'react-query'
 
 import { createProtocolAnalysis } from '@opentrons/api-client'
 
+import { useDocumentedMutation } from '../accessControl'
 import { getQueryKey, useHost } from '../api'
 
 import type { AxiosError } from 'axios'
@@ -17,6 +18,7 @@ import type {
   RunTimeParameterFilesCreateData,
   RunTimeParameterValuesCreateData,
 } from '@opentrons/api-client'
+import type { DocumentationState } from '../accessControl'
 
 export interface CreateProtocolAnalysisVariables {
   protocolKey: string
@@ -43,6 +45,7 @@ export type UseCreateProtocolAnalysisMutationOptions = UseMutationOptions<
 >
 
 export function useCreateProtocolAnalysisMutation(
+  documentationState: DocumentationState,
   protocolId: string | null,
   hostOverride?: HostConfig | null,
   options: UseCreateProtocolAnalysisMutationOptions | undefined = {}
@@ -51,26 +54,28 @@ export function useCreateProtocolAnalysisMutation(
   const host =
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
   const queryClient = useQueryClient()
-  // Protocol analysis endpoint, does not require documentation.
-  // eslint-disable-next-line opentrons/no-direct-use-mutation
-  const mutation = useMutation<
+  const mutation = useDocumentedMutation<
     ProtocolAnalysisSummaryResult,
     AxiosError<ErrorResponse>,
     CreateProtocolAnalysisVariables
   >(
+    documentationState,
+    ['create_protocol_analysis'],
     getQueryKey(host, 'protocols', protocolId, 'analyses'),
-    async ({
-      protocolKey,
-      runTimeParameterValues,
-      runTimeParameterFiles,
-      forceReAnalyze,
-    }) => {
+    async ({ variables, userNotes }) => {
+      const {
+        protocolKey,
+        runTimeParameterValues,
+        runTimeParameterFiles,
+        forceReAnalyze,
+      } = variables
       const response = await createProtocolAnalysis(
         host!,
         protocolKey,
         runTimeParameterValues,
         runTimeParameterFiles,
-        forceReAnalyze
+        forceReAnalyze,
+        userNotes
       )
       // Note: Not awaiting invalidateQueries() to preserve prior behavior.
       // Not sure this is what we actually want.

--- a/react-api-client/src/protocols/useCreateProtocolAnalysisMutation.ts
+++ b/react-api-client/src/protocols/useCreateProtocolAnalysisMutation.ts
@@ -59,30 +59,24 @@ export function useCreateProtocolAnalysisMutation(
     CreateProtocolAnalysisVariables
   >(
     getQueryKey(host, 'protocols', protocolId, 'analyses'),
-    ({
+    async ({
       protocolKey,
       runTimeParameterValues,
       runTimeParameterFiles,
       forceReAnalyze,
-    }) =>
-      createProtocolAnalysis(
+    }) => {
+      const response = await createProtocolAnalysis(
         host!,
         protocolKey,
         runTimeParameterValues,
         runTimeParameterFiles,
         forceReAnalyze
       )
-        .then(response => {
-          queryClient
-            .invalidateQueries(getQueryKey(host, 'protocols'))
-            .catch((e: Error) => {
-              throw e
-            })
-          return response.data
-        })
-        .catch((e: Error) => {
-          throw e
-        }),
+      // Note: Not awaiting invalidateQueries() to preserve prior behavior.
+      // Not sure this is what we actually want.
+      void queryClient.invalidateQueries(getQueryKey(host, 'protocols'))
+      return response.data
+    },
     options
   )
   return {

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -33,7 +33,7 @@ from opentrons.util.performance_helpers import TrackingFunctions
 from opentrons_shared_data.robot import user_facing_robot_type
 from opentrons_shared_data.robot.types import RobotType
 from server_utils.audit.audit_logger import AuditLogger
-from server_utils.audit.fastapi import get_audit_logger, skip_audit_logger
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import (
     get_access_control_status,
     require_scopes,
@@ -766,7 +766,7 @@ async def delete_protocol_by_id(
         status.HTTP_422_UNPROCESSABLE_ENTITY: {"model": ErrorBody[FileIdNotFound]},
         status.HTTP_503_SERVICE_UNAVAILABLE: {"model": ErrorBody[LastAnalysisPending]},
     },
-    dependencies=[Depends(skip_audit_logger)],
+    dependencies=[Depends(require_scopes(Scope.PROTOCOL_ANALYSES_WRITE))],
 )
 async def create_protocol_analysis(
     protocolId: str,

--- a/robot-server/tests/test_access_control_coverage.py
+++ b/robot-server/tests/test_access_control_coverage.py
@@ -17,8 +17,6 @@ IGNORED_ENDPOINTS: set[tuple[str, str]] = {
     ("delete", "/clientData/{key}"),
     # This is spiritually a GET endpoint. It doesn't actually control or modify anything.
     ("post", "/labwareOffsets/searches"),
-    # Protocol analyses are just disposable simulations.
-    ("post", "/protocols/{protocolId}/analyses"),
 }
 
 

--- a/server-utils/server_utils/auth/scopes.py
+++ b/server-utils/server_utils/auth/scopes.py
@@ -27,6 +27,11 @@ class Scope(enum.Enum):
         "Edit settings related to authentication, authorization, and access control.",
     )
 
+    PROTOCOL_ANALYSES_WRITE = (
+        "protocol_analyses.write",
+        "Create robot-side protocol analyses.",
+    )
+
     PROTOCOLS_WRITE = (
         "protocols.write",
         "Upload or delete protocols.",


### PR DESCRIPTION
## Overview

This closes EXEC-2877.

## Changelog

* On the backend, the `POST /protocols/{id}/analyses` endpoint is now gated behind access control. When Compliance Ready Software is enabled, it requires the client to be logged in and to provide a reason for interaction.
* Various places in the frontend are modified to account for this:
  * When the user clones a run and we reanalyze, we pop a modal. We were already popping a modal for the run clone itself, so this reuses it.
  * When the user confirms run time parameter values, and we reanalyze, we pop a modal.
  * Some LPC hooks automatically pop a modal when the page loads, unfortunately.

## Test Plan and Hands on Testing

* [x] When an analysis is "old," visiting the run setup screen should pop a login/documentation modal. (Those screens need a "new" analysis for LPC reasons.) For testing purposes, it turns out that you can trick the frontend into thinking that an analysis is "old" by using a protocol without any labware, like this:

  ```python
   requirements = {
       "apiLevel": "2.20",
       "robotType": "Flex"
   }

   def run(protocol):
       protocol.comment("This is a comment.")
       protocol.comment("This is another comment.")
   ``` 

* [x] After confirming run time parameter values on the on-device display, it should pop a login/documentation modal. Demo protocol.

* [x] The "run again" button should include reanalysis in its documentation prompt.

## Review requests

This creates a pretty disruptive user experience, adding modals that are redundant with preexisting modals. Some of these are harder to fix than others.

For example, there are LPC-related hooks that trigger reanalysis on component mount, not tied to any explicit user action. Because those requests aren't tied to any explicit user action, we can't combine them with preexisting modals. These are hard to fix without intrusively rethinking how all of that LPC stuff works.

On the other hand, there is a sequence of modals related to runtime parameter values. This could probably be simplified with some more local refactors. I haven't done that in this PR, though.

Right now, this PR leans towards bad UX, but correct compliance readiness, and minimal code changes. Agreed that this is the correct tradeoff?

## Risk assessment

High.

In addition to the spammy UX, this introduces a way for reanalysis to fail (if the user cancels the modal), where before, in practice, it could not fail. The frontend...probably does not handle that gracefully.