### PR TITLE
fix(api): Stop caching module offsets across pyro processes

### DIFF
--- a/api/src/opentrons/calibration_storage/ot3/module_offset.py
+++ b/api/src/opentrons/calibration_storage/ot3/module_offset.py
@@ -84,7 +84,6 @@ def save_module_calibration(
 def get_module_offset(
     module: ModuleType, module_id: str, slot: Optional[str] = None
 ) -> Optional[v1.ModuleOffsetModel]:
-    """Load a module offset from disk."""
     try:
         module_calibration_filepath = (
             config.get_opentrons_path("module_calibration_dir") / f"{module_id}.json"

--- a/api/src/opentrons/calibration_storage/ot3/module_offset.py
+++ b/api/src/opentrons/calibration_storage/ot3/module_offset.py
@@ -84,6 +84,7 @@ def save_module_calibration(
 def get_module_offset(
     module: ModuleType, module_id: str, slot: Optional[str] = None
 ) -> Optional[v1.ModuleOffsetModel]:
+    """Always read from disk as robot-server and HW process may be separate processes."""
     try:
         module_calibration_filepath = (
             config.get_opentrons_path("module_calibration_dir") / f"{module_id}.json"
@@ -103,7 +104,10 @@ def get_module_offset(
 
 
 def load_all_module_offsets() -> List[v1.ModuleOffsetModel]:
-    """Load all module offsets from the disk."""
+    """Load all module offsets from the disk.
+
+    Always read from disk as robot-server and HW process may be separate processes.
+    """
 
     calibrations: List[v1.ModuleOffsetModel] = []
     files = os.listdir(config.get_opentrons_path("module_calibration_dir"))

--- a/api/src/opentrons/calibration_storage/ot3/module_offset.py
+++ b/api/src/opentrons/calibration_storage/ot3/module_offset.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 from dataclasses import asdict
-from functools import lru_cache
 from pathlib import Path
 from typing import List, Optional, Union, no_type_check
 
@@ -30,9 +29,6 @@ def delete_module_offset_file(module_id: str) -> None:
     offset_dir = config.get_opentrons_path("module_calibration_dir")
     offset_path = offset_dir / f"{module_id}.json"
     io.delete_file(offset_path)
-    # something changed, clear lru cache
-    get_module_offset.cache_clear()
-    load_all_module_offsets.cache_clear()
 
 
 def clear_module_offset_calibrations() -> None:
@@ -42,9 +38,6 @@ def clear_module_offset_calibrations() -> None:
 
     offset_dir = config.get_opentrons_path("module_calibration_dir")
     io._remove_json_files_in_directories(offset_dir)
-    # something changed, clear lru cache
-    get_module_offset.cache_clear()
-    load_all_module_offsets.cache_clear()
 
 
 # Save Module Offset Calibrations
@@ -82,19 +75,21 @@ def save_module_calibration(
         status=cal_status_model,
     )
     io.save_to_file(module_dir, module_id, module_calibration)
-    # something changed, clear lru cache
-    get_module_offset.cache_clear()
-    load_all_module_offsets.cache_clear()
 
 
 # Get Module Offset Calibrations
 
 
 @no_type_check
-@lru_cache(maxsize=10)
 def get_module_offset(
     module: ModuleType, module_id: str, slot: Optional[str] = None
 ) -> Optional[v1.ModuleOffsetModel]:
+    """Load a module offset from disk.
+
+    Intentionally uncached as pyro, saves clear cache only in the
+    HW process while robot-server /modules reads in another process.
+    LRU cache would make the modules appear uncalibrated after setup.
+    """
     try:
         module_calibration_filepath = (
             config.get_opentrons_path("module_calibration_dir") / f"{module_id}.json"
@@ -113,9 +108,11 @@ def get_module_offset(
         return None
 
 
-@lru_cache(maxsize=10)
 def load_all_module_offsets() -> List[v1.ModuleOffsetModel]:
-    """Load all module offsets from the disk."""
+    """Load all module offsets from the disk.
+
+    Intentionally uncached for the same cross-process reason as get_module_offset.
+    """
 
     calibrations: List[v1.ModuleOffsetModel] = []
     files = os.listdir(config.get_opentrons_path("module_calibration_dir"))

--- a/api/src/opentrons/calibration_storage/ot3/module_offset.py
+++ b/api/src/opentrons/calibration_storage/ot3/module_offset.py
@@ -84,12 +84,7 @@ def save_module_calibration(
 def get_module_offset(
     module: ModuleType, module_id: str, slot: Optional[str] = None
 ) -> Optional[v1.ModuleOffsetModel]:
-    """Load a module offset from disk.
-
-    Intentionally uncached as pyro, saves clear cache only in the
-    HW process while robot-server /modules reads in another process.
-    LRU cache would make the modules appear uncalibrated after setup.
-    """
+    """Load a module offset from disk."""
     try:
         module_calibration_filepath = (
             config.get_opentrons_path("module_calibration_dir") / f"{module_id}.json"
@@ -109,10 +104,7 @@ def get_module_offset(
 
 
 def load_all_module_offsets() -> List[v1.ModuleOffsetModel]:
-    """Load all module offsets from the disk.
-
-    Intentionally uncached for the same cross-process reason as get_module_offset.
-    """
+    """Load all module offsets from the disk."""
 
     calibrations: List[v1.ModuleOffsetModel] = []
     files = os.listdir(config.get_opentrons_path("module_calibration_dir"))


### PR DESCRIPTION
# Overview

Module offset used to load a local @lru_cache. With pyro, calibration saves (and cache clears) the run in the HW process, while GET /modules reads in robot-server. Because HW process is now separated, robot-server kept serving stale empty offsets even though /data/robot/modules/<serial>.json was written. Removed the cache so /modules always reads from disk. Fixes RQA-5830.

## Test Plan and Hands on Testing

With the fix we now see that modules appear as calibrated after setup.
<img width="926" height="539" alt="Screenshot 2026-08-10 at 6 44 40 PM" src="https://github.com/user-attachments/assets/02f4bfc9-c0f0-4325-929f-512e267cf587" />

Tested with Pyro off, functionality is as expected.

## Changelog

Remove process-local LRU cache from module offset load/save.

## Review requests

- Confirming this change will not affect non-pyro users (it shouldn't, we still save the JSON file with this info, we are just no longer serving a stale in-process copy of those reads).
- Should there be more detailed commenting.
- Any other associated risks of no longer cacheing this and always reading the JSON from the disc?
- Confirmation this is pushing to the right branch.

## Risk assessment

- Low, could impact module calibration and non-pyro users.
