### PR TITLE
feat(audit-server): add disk usage monitoring

### DIFF
--- a/audit-server/audit_server/log_export/router.py
+++ b/audit-server/audit_server/log_export/router.py
@@ -41,6 +41,7 @@ from audit_server.log_storage.log_data_manager import (
 from audit_server.log_storage.models import (
     LogPeriodDetails,
     LogPeriodSummary,
+    TotalUsageSummary,
 )
 from audit_server.log_storage.store import NoPeriodById, PeriodIsActiveError
 from audit_server.persistence.fastapi_dependencies import get_persistence_directory_root
@@ -52,6 +53,19 @@ _DOWNLOAD_STAGING_PREFIX: Final = "temp-download-staging-"
 # Response header carrying the one-time deletion key for a downloaded log period.
 # Must match ``LOG_PERIOD_DELETION_KEY_HEADER`` in api-client/src/audit/constants.ts.
 _DELETION_KEY_HEADER: Final = "opentrons-log-period-deletion-key"
+
+
+@router.get(
+    "/audit/external/diskUsage",
+    summary="Get the disk usage of stored audit logs",
+    description="Return a summary of disk usage and a breakdown by period",
+)
+async def get_usage_summary(
+    log_data_manager: Annotated[LogDataManager, fastapi.Depends(get_log_data_manager)],
+) -> SimpleBody[TotalUsageSummary]:
+    """Get the disk usage of the audit server."""
+    summary = log_data_manager.get_total_fs_usage()
+    return SimpleBody.model_construct(data=summary)
 
 
 @router.get(

--- a/audit-server/audit_server/log_self_client.py
+++ b/audit-server/audit_server/log_self_client.py
@@ -28,6 +28,9 @@ from server_utils.audit.audit_server import (
 from server_utils.audit.audit_server import (
     SubmitAuditLogSuccessData as SUSuccessData,
 )
+from server_utils.audit.audit_server import (
+    TotalUsageSummaryData as SUTotalUsageSummaryData,
+)
 
 from .log_ingest.models import AuditLogMessage
 from audit_server.log_storage.log_data_manager import LogDataManager
@@ -89,4 +92,8 @@ class LocalClient(SUClient):
 
     @override
     async def get_current_log_period(self) -> SULogPeriodsData:
+        raise NotImplementedError("Do not use the self client for this")
+
+    @override
+    async def get_filesystem_usage_summary(self) -> SUTotalUsageSummaryData:
         raise NotImplementedError("Do not use the self client for this")

--- a/audit-server/audit_server/log_storage/log_data_manager.py
+++ b/audit-server/audit_server/log_storage/log_data_manager.py
@@ -18,7 +18,7 @@ from server_utils.keys.key_server import Client as KeyClient
 from server_utils.keys.key_server import SignMessageData
 
 from . import constants
-from .models import LogPeriodDetails, LogPeriodSummary
+from .models import LogPeriodDetails, LogPeriodSummary, TotalUsageSummary
 from .store import (
     LogStore,
     NoActivePeriodError,
@@ -114,6 +114,15 @@ class LogDataManager:
         if isinstance(details, Exception):
             raise details
         return details
+
+    def get_total_fs_usage(self) -> TotalUsageSummary:
+        """Get a summary of filesystem usage by stored logs."""
+        periods = self.get_log_periods()
+        details = [self.get_log_period_details(period.id) for period in periods]
+        return TotalUsageSummary(
+            totalUsageBytes=sum([period.totalSizeBytes for period in details]),
+            totalPeriods=len(details),
+        )
 
     def create_deletion_key(self, period_id: str) -> str:
         """Mint a new one-time deletion key linked to a log period.

--- a/audit-server/audit_server/log_storage/models.py
+++ b/audit-server/audit_server/log_storage/models.py
@@ -67,3 +67,14 @@ class UserLogForExport(pydantic.BaseModel):
     endedAt: Optional[datetime] = pydantic.Field(
         description="The time this period ended, or null if the period is still active."
     )
+
+
+class TotalUsageSummary(pydantic.BaseModel):
+    """Information about disk usage."""
+
+    totalUsageBytes: int = pydantic.Field(
+        description="Approximate total size in bytes of all log periods and attached log files."
+    )
+    totalPeriods: int = pydantic.Field(
+        description="Number of stored log periods, including the current."
+    )

--- a/audit-server/audit_server/log_storage/models.py
+++ b/audit-server/audit_server/log_storage/models.py
@@ -9,7 +9,7 @@ import pydantic
 class LogPeriodSummary(pydantic.BaseModel):
     """Summary of a single audit log period."""
 
-    id: int = pydantic.Field(
+    id: str = pydantic.Field(
         description=(
             "A monotonically increasing integer that uniquely identifies this log period. "
             "Use this value to reference the period in other API calls. "
@@ -25,7 +25,7 @@ class LogPeriodSummary(pydantic.BaseModel):
 class LogPeriodDetails(pydantic.BaseModel):
     """Detailed information about a single audit log period."""
 
-    id: int = pydantic.Field(
+    id: str = pydantic.Field(
         description=(
             "A monotonically increasing integer that uniquely identifies this log period. "
             "Use this value to reference the period in other API calls. "

--- a/audit-server/audit_server/log_storage/store.py
+++ b/audit-server/audit_server/log_storage/store.py
@@ -308,7 +308,7 @@ class LogStore:
                     pass
 
             return LogPeriodDetails(
-                id=details[0],
+                id=str(details[0]),
                 startedAt=details[1],
                 endedAt=details[2],
                 recordCount=details[3],
@@ -324,7 +324,7 @@ class LogStore:
             ).all()
             return [
                 LogPeriodSummary(
-                    id=period.id,
+                    id=str(period.id),
                     startedAt=period.started_at,
                     endedAt=period.ended_at,
                 )

--- a/audit-server/tests/integration/test_logPeriods.tavern.yaml
+++ b/audit-server/tests/integration/test_logPeriods.tavern.yaml
@@ -14,7 +14,7 @@ stages:
       status_code: 200
       json:
         data:
-          - id: 1
+          - id: '1'
             startedAt: !anystr
             endedAt: null
         meta:

--- a/audit-server/tests/integration/test_log_period_download_and_delete.tavern.yaml
+++ b/audit-server/tests/integration/test_log_period_download_and_delete.tavern.yaml
@@ -69,7 +69,7 @@ stages:
       status_code: 200
       json:
         data:
-          - id: 2
+          - id: '2'
             endedAt: null
             startedAt: !anystr
         meta:

--- a/audit-server/tests/log_export/test_router.py
+++ b/audit-server/tests/log_export/test_router.py
@@ -30,13 +30,13 @@ from audit_server.log_storage.store import NoPeriodById
 from audit_server.log_storage.types import LogPeriodEntries
 
 _OLDER_PERIOD = LogPeriodSummary(
-    id=1,
+    id="1",
     startedAt=datetime(2024, 1, 1, tzinfo=timezone.utc),
     endedAt=datetime(2024, 1, 2, tzinfo=timezone.utc),
 )
 
 _NEWER_PERIOD = LogPeriodSummary(
-    id=2,
+    id="2",
     startedAt=datetime(2024, 2, 1, tzinfo=timezone.utc),
     endedAt=None,
 )
@@ -90,7 +90,7 @@ async def test_get_log_period_summary(
 ) -> None:
     """It should return period details including size and attached filenames."""
     period_details = LogPeriodDetails(
-        id=1,
+        id="1",
         startedAt=datetime(2024, 1, 1, tzinfo=timezone.utc),
         endedAt=datetime(2024, 1, 2, tzinfo=timezone.utc),
         recordCount=2,
@@ -106,7 +106,7 @@ async def test_get_log_period_summary(
         log_data_manager=mock_log_data_manager,
     )
 
-    assert result.data.id == 1
+    assert result.data.id == "1"
     assert result.data.startedAt == datetime(2024, 1, 1, tzinfo=timezone.utc)
     assert result.data.endedAt == datetime(2024, 1, 2, tzinfo=timezone.utc)
     assert result.data.recordCount == 2
@@ -153,7 +153,7 @@ async def test_download_log_period_stages_under_persistence_temp(
     )
     decoy.when(mock_log_data_manager.get_log_period_details(period_id="1")).then_return(
         LogPeriodDetails(
-            id=1,
+            id="1",
             startedAt=datetime(2024, 1, 1, tzinfo=timezone.utc),
             endedAt=datetime(2024, 1, 2, tzinfo=timezone.utc),
             recordCount=123,

--- a/audit-server/tests/log_storage/test_log_data_manager.py
+++ b/audit-server/tests/log_storage/test_log_data_manager.py
@@ -18,7 +18,7 @@ from audit_server.log_storage.log_data_manager import (
     LogDataManager,
     _GetTime,
 )
-from audit_server.log_storage.models import LogPeriodDetails
+from audit_server.log_storage.models import LogPeriodDetails, LogPeriodSummary
 from audit_server.log_storage.store import (
     LogStore,
     NoActivePeriodError,
@@ -1022,3 +1022,64 @@ async def test_delete_log_period_deletes_log_collateral(
     assert result == "1"
     for file in files:
         assert not file.exists()
+
+
+def test_usage_summary_adds_up(
+    subject: LogDataManager, mock_store: LogStore, decoy: Decoy
+) -> None:
+    """It should sum up usage of each log period."""
+
+    def _build_summary(id: str) -> LogPeriodSummary:
+        return LogPeriodSummary(
+            id=id,
+            startedAt=datetime.now(tz=timezone.utc),
+            endedAt=datetime.now(tz=timezone.utc),
+        )
+
+    def _build_details(id: str, usage: int) -> LogPeriodDetails:
+        return LogPeriodDetails(
+            id=id,
+            startedAt=datetime.now(tz=timezone.utc),
+            endedAt=datetime.now(tz=timezone.utc),
+            recordCount=usage // 1000,
+            totalSizeBytes=usage,
+            attachedFilenames=["a"] * 10,
+        )
+
+    decoy.when(mock_store.list_periods()).then_return(
+        [
+            _build_summary("1"),
+            _build_summary(
+                id="-5",
+            ),
+            _build_summary(
+                id="steve",
+            ),
+            _build_summary(
+                id="nazgul",
+            ),
+            _build_summary(
+                id="8589934583",
+            ),
+        ]
+    )
+    decoy.when(mock_store.get_period_details("1")).then_return(
+        _build_details("1", 1000000)
+    )
+    decoy.when(mock_store.get_period_details("-5")).then_return(
+        _build_details("-5", 5000000)
+    )
+    decoy.when(mock_store.get_period_details("steve")).then_return(
+        _build_details("steve", 123123123123)
+    )
+    decoy.when(mock_store.get_period_details("nazgul")).then_return(
+        _build_details("nazgul", 9000000)
+    )
+    decoy.when(mock_store.get_period_details("8589934583")).then_return(
+        _build_details("8589934583", 8589934583)
+    )
+    result = subject.get_total_fs_usage()
+    assert result.totalUsageBytes == (
+        1000000 + 5000000 + 123123123123 + 9000000 + 8589934583
+    )
+    assert result.totalPeriods == 5

--- a/audit-server/tests/log_storage/test_log_data_manager.py
+++ b/audit-server/tests/log_storage/test_log_data_manager.py
@@ -86,7 +86,7 @@ def test_get_log_period_details(
 ) -> None:
     """It should get aggregate period details from the store."""
     details = LogPeriodDetails(
-        id=1,
+        id="1",
         startedAt=datetime(2024, 1, 1, tzinfo=timezone.utc),
         endedAt=None,
         recordCount=10,
@@ -895,7 +895,7 @@ def test_create_deletion_key_mints_a_key(
     """It should mint a non-empty deletion key for a completed log period."""
     decoy.when(mock_store.get_period_details("1")).then_return(
         LogPeriodDetails(
-            id=1,
+            id="1",
             startedAt=datetime.now(),
             endedAt=datetime.now(),
             recordCount=10,
@@ -914,7 +914,7 @@ def test_create_deletion_key_mints_distinct_keys(
     """Each call should mint a new, distinct key for the same period."""
     decoy.when(mock_store.get_period_details("1")).then_return(
         LogPeriodDetails(
-            id=1,
+            id="1",
             startedAt=datetime.now(),
             endedAt=datetime.now(),
             recordCount=10,
@@ -934,7 +934,7 @@ def test_create_deletion_key_fails_if_period_is_active(
     """Deletion keys cannot be created for active periods."""
     decoy.when(mock_store.get_period_details("1")).then_return(
         LogPeriodDetails(
-            id=1,
+            id="1",
             startedAt=datetime.now(),
             endedAt=None,
             recordCount=10,
@@ -962,7 +962,7 @@ async def test_delete_log_period_requires_deletion_key(
     period_id = "2"
     decoy.when(mock_store.get_period_details(period_id)).then_return(
         LogPeriodDetails(
-            id=1,
+            id="1",
             startedAt=datetime(2024, 1, 1, tzinfo=timezone.utc),
             endedAt=datetime(2025, 1, 1, tzinfo=timezone.utc),
             recordCount=10,
@@ -1008,7 +1008,7 @@ async def test_delete_log_period_deletes_log_collateral(
     period_id = "1"
     decoy.when(mock_store.get_period_details(period_id)).then_return(
         LogPeriodDetails(
-            id=1,
+            id="1",
             startedAt=datetime(2024, 1, 1, tzinfo=timezone.utc),
             endedAt=datetime(2025, 1, 1, tzinfo=timezone.utc),
             recordCount=10,

--- a/server-utils/server_utils/audit/audit_server.py
+++ b/server-utils/server_utils/audit/audit_server.py
@@ -21,6 +21,7 @@ SETTINGS_ENDPOINT_PATH: typing.Final = "audit/external/settings"
 STORE_ROBOT_LOG_ENDPOINT_PATH = "/audit/internal/storeRobotLog"
 GET_LOGGING_ENABLED_ENDPOINT_PATH = "/audit/internal/loggingEnabled"
 GET_LOG_PERIODS = "/audit/external/logPeriods"
+GET_FILESYSTEM_USAGE = "/audit/external/diskUsage"
 
 _log = logging.getLogger(__name__)
 
@@ -69,6 +70,11 @@ class Client(ABC):
     @abstractmethod
     async def get_current_log_period(self) -> GetLogPeriodsData:
         """Get the current log period, if any."""
+        pass
+
+    @abstractmethod
+    async def get_filesystem_usage_summary(self) -> TotalUsageSummaryData:
+        """Get disk usage from the audit server."""
         pass
 
 
@@ -199,6 +205,15 @@ class LocalHTTPClient(Client):
                 return log_period
         raise NoCurrentLogPeriodError("Could not find a current log period.")
 
+    @typing.override
+    async def get_filesystem_usage_summary(self) -> TotalUsageSummaryData:
+        """Get disk usage from the audit server."""
+        async with self._session.get(GET_FILESYSTEM_USAGE) as response:
+            response_bytes = await response.read()
+        response.raise_for_status()
+        parsed_response = TotalUsageSummaryResponse.model_validate_json(response_bytes)
+        return parsed_response.data
+
 
 class NoOpClient(Client):
     """A client implementation that doesn't actually contact audit-server.
@@ -259,6 +274,14 @@ class NoOpClient(Client):
             startedAt=datetime.now(timezone.utc),
             endedAt=None,
         )
+
+    @typing.override
+    async def get_filesystem_usage_summary(self) -> TotalUsageSummaryData:
+        """Get disk usage from the audit server."""
+        _log.info(
+            "Get filesystem usage summary (audit-server not configured): Returning 0 usage"
+        )
+        return TotalUsageSummaryData(totalUsageBytes=0, totalPeriods=0)
 
 
 class _StrictBaseModel(pydantic.BaseModel):
@@ -373,3 +396,16 @@ class GetLogPeriodsResponseBody(_StrictBaseModel):
     """Response envelope for get log periods."""
 
     data: list[GetLogPeriodsData]
+
+
+class TotalUsageSummaryData(_StrictBaseModel):
+    """Information about disk usage."""
+
+    totalUsageBytes: int
+    totalPeriods: int
+
+
+class TotalUsageSummaryResponse(_StrictBaseModel):
+    """Response envelope for disk usage,."""
+
+    data: TotalUsageSummaryData

--- a/server-utils/tests/audit/test_fastapi.py
+++ b/server-utils/tests/audit/test_fastapi.py
@@ -20,6 +20,7 @@ from server_utils.audit.audit_server import (
     StoreRobotLogSuccessData,
     SubmitAuditLogMessageData,
     SubmitAuditLogSuccessData,
+    TotalUsageSummaryData,
 )
 from server_utils.audit.fastapi import (
     build_audit_client,
@@ -88,7 +89,10 @@ def test_install_and_get_audit_client_via_dependency() -> None:
             raise NotImplementedError()
 
         async def get_current_log_period(self) -> GetLogPeriodsData:
-            raise NotImplementedError
+            raise NotImplementedError()
+
+        async def get_filesystem_usage_summary(self) -> TotalUsageSummaryData:
+            raise NotImplementedError()
 
     stub_client = StubClient()
 


### PR DESCRIPTION
# Overview

Add a disk usage monitor to the audit server. We probably don't actually need this since we gate runs on overall disk usage percentage, but it could be handy for the future.

## Test Plan and Hands on Testing

Unit tests since it's not actually used anywhere and is just reformatting other internal data.

## Risk assessment

Low, unused.

Closes EXEC-2663