### PR TITLE
feat(app): audit logs UI updates

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -20,6 +20,7 @@
   "an_error_occurred_while_updating_please_try_again": "An error occurred while updating your pipette's settings. Please try again.",
   "attach_gripper": "Attach gripper",
   "attach_pipette": "Attach pipette",
+  "audit_logs": "Audit Logs",
   "bad_run": "run could not be loaded",
   "both_mounts": "Left+Right Mounts",
   "bundle_firmware_file_not_found": "Bundled fw file not found for module of type: {{module}}",

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/LogPeriodRow.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/LogPeriodRow.tsx
@@ -2,7 +2,6 @@ import { useTranslation } from 'react-i18next'
 
 import {
   CheckboxBasic,
-  Chip,
   COLORS,
   Icon,
   ListItem,
@@ -33,7 +32,6 @@ export function LogPeriodRow({
   onToggle,
 }: LogPeriodRowProps): ReactNode {
   const { t } = useTranslation('device_details')
-  const isComplete = period.endedAt != null
   const { data: protocolsData } = useAllProtocolsQuery()
   const { data: runsData } = useNotifyAllRunsQuery()
   const protocols = protocolsData?.data ?? []
@@ -73,19 +71,10 @@ export function LogPeriodRow({
               text={
                 period.endedAt != null
                   ? formatTimestamp(period.endedAt)
-                  : t('na')
+                  : t('in_progress')
               }
               type="default"
               shrinkToContent
-            />
-          </div>
-          <div className={styles.log_status_col}>
-            <Chip
-              text={isComplete ? t('complete') : t('in_progress')}
-              type={isComplete ? 'success' : 'info'}
-              hasIcon={false}
-              chipSize="small"
-              width="max-content"
             />
           </div>
         </div>

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/compliancereadysoftwarefiles.module.css
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/compliancereadysoftwarefiles.module.css
@@ -23,7 +23,7 @@
   flex: 1;
   align-items: center;
   gap: var(--spacing-24);
-  grid-template-columns: 25% 25% 25% 25%;
+  grid-template-columns: 33% 33% 33%;
 }
 
 .log_date_col {

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
@@ -175,7 +175,7 @@ export function ComplianceReadySoftwareFiles({
       )}
       <div className={fileManagerStyles.file_management_group}>
         <FileManagementSectionHeader
-          titleText={t('compliance_ready_audit_logs')}
+          titleText={t('audit_logs')}
           showButtons={isSomeSelected || isAllSelected}
           onDownloadSelected={handleDownloadSelected}
           onDeleteSelected={handleClickDeleteSelected}
@@ -207,12 +207,6 @@ export function ComplianceReadySoftwareFiles({
                   className={styles.log_date_col}
                 >
                   {t('log_period_end')}
-                </StyledText>
-                <StyledText
-                  desktopStyle="bodyDefaultRegular"
-                  className={styles.log_status_col}
-                >
-                  {t('status')}
                 </StyledText>
               </div>
             </div>

--- a/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/ComplianceReadyFiles/LogPeriodRow.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/ComplianceReadyFiles/LogPeriodRow.tsx
@@ -1,0 +1,60 @@
+import { useTranslation } from 'react-i18next'
+
+import {
+  ALIGN_FLEX_END,
+  ListItem,
+  OverflowBtn,
+  StyledText,
+  Tag,
+} from '@opentrons/components'
+
+import { formatTimestamp } from '/app/transformations/runs'
+
+import styles from './compliancereadyfiles.module.css'
+
+import type { ReactNode } from 'react'
+import type { LogPeriodSummary } from '@opentrons/api-client'
+
+interface LogPeriodRowProps {
+  logPeriodSummary: LogPeriodSummary
+  protocolName: string | null
+  handleOverflowClick: (logPeriodSummary: LogPeriodSummary) => void
+}
+
+export function LogPeriodRow(props: LogPeriodRowProps): ReactNode {
+  const { logPeriodSummary, protocolName, handleOverflowClick } = props
+  const { t } = useTranslation('device_details')
+
+  return (
+    <ListItem type="default" className={styles.record_container}>
+      <div className={styles.record_content}>
+        <StyledText
+          oddStyle="bodyTextSemiBold"
+          className={styles.protocol_name}
+        >
+          {protocolName ?? t('na')}
+        </StyledText>
+        <Tag
+          type="default"
+          text={formatTimestamp(logPeriodSummary.startedAt)}
+          shrinkToContent
+        />
+        <Tag
+          type="default"
+          text={
+            logPeriodSummary.endedAt != null
+              ? formatTimestamp(logPeriodSummary.endedAt)
+              : t('in_progress')
+          }
+          shrinkToContent
+        />
+      </div>
+      <OverflowBtn
+        justifySelf={ALIGN_FLEX_END}
+        onClick={() => {
+          handleOverflowClick(logPeriodSummary)
+        }}
+      />
+    </ListItem>
+  )
+}

--- a/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/ComplianceReadyFiles/index.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/ComplianceReadyFiles/index.tsx
@@ -1,34 +1,61 @@
-import { useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { StyledText } from '@opentrons/components'
 import {
-  ALIGN_FLEX_END,
-  ListItem,
-  OverflowBtn,
-  StyledText,
-  Tag,
-} from '@opentrons/components'
-import { useLogPeriodSummariesQuery } from '@opentrons/react-api-client'
+  useAllProtocolsQuery,
+  useLogPeriodSummariesQuery,
+} from '@opentrons/react-api-client'
 
 import { OddInfoScreen } from '/app/molecules/ODDInfoScreen'
-import { formatTimestamp } from '/app/transformations/runs'
+import { useNotifyAllRunsQuery } from '/app/resources/runs'
 
 import { ConfirmLogPeriodModal } from '../FileManagerWizardFlows/ConfirmLogPeriodModal'
 import { DownloadDeleteLogPeriodWizard } from '../FileManagerWizardFlows/DownloadDeleteLogPeriodWizard'
 import styles from './compliancereadyfiles.module.css'
+import { LogPeriodRow } from './LogPeriodRow'
 
 import type { ReactNode } from 'react'
 import type { LogPeriodSummary } from '@opentrons/api-client'
 
 export function ComplianceReadyFiles(): ReactNode {
   const { t } = useTranslation('device_details')
-  const { data } = useLogPeriodSummariesQuery()
-  const { data: logPeriodSummaries } = data ?? { data: [] }
+  const { data: logPeriodSummariesData } = useLogPeriodSummariesQuery()
 
-  const logPeriodSummariesMutable = [...logPeriodSummaries]
-  const logPeriodSummariesSorted = logPeriodSummariesMutable.sort((a, b) => {
-    return new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()
-  })
+  const logPeriodSummariesSorted = useMemo(() => {
+    const logPeriodSummaries = logPeriodSummariesData?.data ?? []
+
+    return [...logPeriodSummaries].sort(
+      (a, b) =>
+        new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()
+    )
+  }, [logPeriodSummariesData])
+
+  const { data: protocolsData } = useAllProtocolsQuery()
+  const { data: runsData } = useNotifyAllRunsQuery()
+
+  // resolve protocol names once for the whole list
+  const protocolNameByLogPeriodId = useMemo(() => {
+    const protocols = protocolsData?.data ?? []
+    const runs = runsData?.data ?? []
+
+    const protocolNameById = protocols.reduce<Map<string, string>>(
+      (acc, { id, metadata }) => {
+        return metadata.protocolName != null
+          ? { ...acc, [id]: metadata.protocolName }
+          : acc
+      },
+      new Map()
+    )
+    return runs.reduce<Record<string, string>>((acc, run) => {
+      const protocolName =
+        run.protocolId != null ? protocolNameById.get(run.protocolId) : null
+      if (run.logPeriodId != null && protocolName != null) {
+        acc[run.logPeriodId] = protocolName
+      }
+      return acc
+    }, {})
+  }, [protocolsData, runsData])
 
   const [selectedLogPeriod, setSelectedLogPeriod] =
     useState<LogPeriodSummary | null>(null)
@@ -36,9 +63,12 @@ export function ComplianceReadyFiles(): ReactNode {
   const [initialDeleteAfterDownload, setInitialDeleteAfterDownload] =
     useState(true)
 
-  const handleOverflowClick = (logPeriodSummary: LogPeriodSummary): void => {
-    setSelectedLogPeriod(logPeriodSummary)
-  }
+  const handleOverflowClick = useCallback(
+    (logPeriodSummary: LogPeriodSummary): void => {
+      setSelectedLogPeriod(logPeriodSummary)
+    },
+    []
+  )
 
   const handleCloseConfirmModal = (): void => {
     setSelectedLogPeriod(null)
@@ -72,48 +102,18 @@ export function ComplianceReadyFiles(): ReactNode {
   return (
     <div className={styles.container}>
       <div className={styles.header}>
-        <StyledText oddStyle="bodyTextSemiBold">{t('file_type')}</StyledText>
+        <StyledText oddStyle="bodyTextSemiBold">{t('protocol')}</StyledText>
         <StyledText oddStyle="bodyTextSemiBold">{t('period_start')}</StyledText>
         <StyledText oddStyle="bodyTextSemiBold">{t('period_end')}</StyledText>
       </div>
-      {logPeriodSummariesSorted.map(logPeriodSummary => {
-        return (
-          <ListItem
-            key={logPeriodSummary.id}
-            type="default"
-            className={styles.record_container}
-          >
-            <div className={styles.record_content}>
-              <StyledText
-                oddStyle="bodyTextSemiBold"
-                className={styles.protocol_name}
-              >
-                {t('user_action_logs')}
-              </StyledText>
-              <Tag
-                type="default"
-                text={formatTimestamp(logPeriodSummary.startedAt)}
-                shrinkToContent
-              />
-              <Tag
-                type="default"
-                text={
-                  logPeriodSummary.endedAt != null
-                    ? formatTimestamp(logPeriodSummary.endedAt)
-                    : t('in_progress')
-                }
-                shrinkToContent
-              />
-            </div>
-            <OverflowBtn
-              justifySelf={ALIGN_FLEX_END}
-              onClick={() => {
-                handleOverflowClick(logPeriodSummary)
-              }}
-            />
-          </ListItem>
-        )
-      })}
+      {logPeriodSummariesSorted.map(logPeriodSummary => (
+        <LogPeriodRow
+          key={logPeriodSummary.id}
+          logPeriodSummary={logPeriodSummary}
+          protocolName={protocolNameByLogPeriodId[logPeriodSummary.id]}
+          handleOverflowClick={handleOverflowClick}
+        />
+      ))}
       {selectedLogPeriod != null ? (
         <ConfirmLogPeriodModal
           onClose={handleCloseConfirmModal}

--- a/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/index.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/index.tsx
@@ -36,7 +36,6 @@ export function FileManager({
   setCurrentOption,
 }: FileManagerProps): JSX.Element {
   const { t } = useTranslation('device_details')
-  const [activeTab, setActiveTab] = useState<FileManagerTab>('diagnostic')
   const [showDownloadModal, setShowDownloadModal] = useState(false)
   const [showDownloadRecordsWizard, setShowDownloadRecordsWizard] =
     useState(false)
@@ -54,6 +53,9 @@ export function FileManager({
   const { data: accessControlData } = useAccessControlEnabledQuery()
   const isComplianceReady =
     accessControlData?.data?.accessControlEnabled ?? false
+  const [activeTab, setActiveTab] = useState<FileManagerTab>(
+    isComplianceReady ? 'compliance' : 'diagnostic'
+  )
 
   const hasLogPeriods =
     (useLogPeriodSummariesQuery().data?.data ?? []).length > 0
@@ -73,7 +75,7 @@ export function FileManager({
       ...(isComplianceReady
         ? [
             {
-              text: t('compliance_ready_files'),
+              text: t('audit_logs'),
               onClick: () => {
                 setActiveTab('compliance')
               },


### PR DESCRIPTION
# Overview

Makes design-requested UI updates to File Manager on both Desktop and ODD. Specifically, updates copy from "Compliance ready software files" to "Audit logs", and prioritizes this section relative to diagnostic files and protocol run history. Also, updates audit logs columns to remove status and add an audit-log linked protocol name if possible (via associated run record), falling back to "N/A" safely.

<img width="2230" height="1336" alt="image" src="https://github.com/user-attachments/assets/6fb8cdc3-9a3c-4388-aefc-16bb44754a2f" />

<img width="1966" height="988" alt="image" src="https://github.com/user-attachments/assets/d6b921be-ca71-482c-b2db-f50c2b987adc" />

## Test Plan and Hands on Testing

#### Desktop
- on a CRS robot's settings, navigate to file manager
- verify that audit logs section is now named as such, and is moved to directly below robot storage section
- verify that the new columns for audit logs match designs (protocol (if found), start time, end time, _no_ status)

#### ODD
- on a CRS robot's settings, navigate to file manager
- verify that Audit Logs section is now named as such, is moved to the be the first tab, and is preselected
- verify that the new columns for audit logs match designs (protocol (if found), start time, end time, _no_ status)

## Changelog

- add logic to link protocol to log period (via intermediate run record linking given the presence of the new optional `logPeriodId` property on `RunData`)
- rename "compliance ready files " to "audit logs"
- refactor audit logs columns (remove status, add protocol)
- prioritize audit logs section on desktop file manager and tab on ODD file manager

## Review requests

see test plan

## Risk assessment

low. cosmetic