### PR TITLE
fix(api): prevent pipette movement to contained labware.

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -91,6 +91,11 @@ class MovementHandler:
         self._state_store.labware.raise_if_labware_has_labware_on_top(
             labware_id=labware_id
         )
+
+        # Block pipette access to labware that is physically contained inside
+        # another labware (e.g. a collection plate inside a vacuum collar).
+        self._state_store.labware.raise_if_labware_is_contained(labware_id=labware_id)
+
         await self._tc_movement_flagger.ensure_labware_in_open_thermocycler(
             labware_parent=self._state_store.labware.get_location(labware_id=labware_id)
         )

--- a/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
@@ -10,6 +10,7 @@ from opentrons_shared_data.errors.exceptions import PositionUnknownError
 from opentrons.hardware_control import API as HardwareAPI
 from opentrons.hardware_control.types import CriticalPoint
 from opentrons.motion_planning import Waypoint
+from opentrons.protocol_engine import errors
 from opentrons.protocol_engine.execution.equipment import EquipmentHandler
 from opentrons.protocol_engine.execution.gantry_mover import GantryMover
 from opentrons.protocol_engine.execution.heater_shaker_movement_flagger import (
@@ -191,6 +192,13 @@ async def test_move_to_well(
     assert result == Point(x=4, y=5, z=6)
 
     decoy.verify(
+        state_store.geometry.raise_if_labware_inaccessible_by_pipette(
+            labware_id="labware-id"
+        ),
+        state_store.labware.raise_if_labware_has_labware_on_top(
+            labware_id="labware-id"
+        ),
+        state_store.labware.raise_if_labware_is_contained(labware_id="labware-id"),
         await thermocycler_movement_flagger.ensure_labware_in_open_thermocycler(
             labware_parent=DeckSlotLocation(slotName=DeckSlotName.SLOT_1)
         ),
@@ -200,6 +208,35 @@ async def test_move_to_well(
             is_multi_channel=False,
             destination_is_tip_rack=False,
         ),
+    )
+
+
+async def test_move_to_well_raises_when_labware_is_contained(
+    decoy: Decoy,
+    state_store: StateStore,
+    mock_gantry_mover: GantryMover,
+    subject: MovementHandler,
+) -> None:
+    """It should raise when pipetting to labware that is physically contained."""
+    decoy.when(
+        state_store.labware.raise_if_labware_is_contained(labware_id="labware-id")
+    ).then_raise(
+        errors.LabwareIsContainedError(
+            'Cannot move "collection-plate" because it is currently contained '
+            'inside "collar".'
+        )
+    )
+
+    with pytest.raises(errors.LabwareIsContainedError):
+        await subject.move_to_well(
+            pipette_id="pipette-id",
+            labware_id="labware-id",
+            well_name="A1",
+        )
+
+    decoy.verify(
+        await mock_gantry_mover.get_position(pipette_id="pipette-id"),
+        times=0,
     )
 
 
@@ -300,6 +337,13 @@ async def test_move_to_well_from_starting_location(
     assert result == Point(4, 5, 6)
 
     decoy.verify(
+        state_store.geometry.raise_if_labware_inaccessible_by_pipette(
+            labware_id="labware-id"
+        ),
+        state_store.labware.raise_if_labware_has_labware_on_top(
+            labware_id="labware-id"
+        ),
+        state_store.labware.raise_if_labware_is_contained(labware_id="labware-id"),
         await thermocycler_movement_flagger.ensure_labware_in_open_thermocycler(
             labware_parent=DeckSlotLocation(slotName=DeckSlotName.SLOT_1)
         ),


### PR DESCRIPTION
# Overview

Block pipette movement to contained labware; this prevents us from moving through filter plates on top of collars.

Closes: [RQA-5826](https://opentrons.atlassian.net/browse/RQA-5826)

## Test Plan and Hands on Testing

- [x] Make sure we can't pipette to/from collection plates inside a vacuum module collar

## Changelog

- add `raise_if_labware_is_contained` check to `move_to_well` function

## Review requests
## Risk assessment

[RQA-5826]: https://opentrons.atlassian.net/browse/RQA-5826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ