### PR TITLE
refactor(app,robot-server): move disk status to server

### DIFF
--- a/api-client/src/health/types.ts
+++ b/api-client/src/health/types.ts
@@ -2,6 +2,8 @@ export interface DiskDetails {
   systemAvailableMb: number
   systemTotalMb: number
   imagesDirectorySizeMb: number
+  runStartLimitFreeSpaceMb: number
+  isDiskSpaceBelowRunStartLimit: boolean
 }
 
 export interface Health {

--- a/app/src/resources/devices/hooks/__tests__/useIsRobotOutOfStorage.test.ts
+++ b/app/src/resources/devices/hooks/__tests__/useIsRobotOutOfStorage.test.ts
@@ -25,29 +25,18 @@ describe('useIsRobotOutOfStorage', () => {
       data: { data: { accessControlEnabled: true } },
     } as any)
     vi.mocked(useHealth).mockReturnValue({
-      disk_details: { systemTotalMb: 100, systemAvailableMb: 90 },
+      disk_details: { isDiskSpaceBelowRunStartLimit: false },
     } as any)
     const { result } = renderHook(useIsRobotOutOfStorage)
     expect(result.current).toBe(false)
   })
 
-  it('returns true if robot is in access control mode and used space is greater than limit', () => {
+  it('returns true if robot is in access control mode and limit is breached', () => {
     vi.mocked(useAccessControlEnabledQuery).mockReturnValue({
       data: { data: { accessControlEnabled: true } },
     } as any)
     vi.mocked(useHealth).mockReturnValue({
-      disk_details: { systemTotalMb: 100, systemAvailableMb: 5 },
-    } as any)
-    const { result } = renderHook(useIsRobotOutOfStorage)
-    expect(result.current).toBe(true)
-  })
-
-  it('returns true if robot is in access control mode and used space equals limit', () => {
-    vi.mocked(useAccessControlEnabledQuery).mockReturnValue({
-      data: { data: { accessControlEnabled: true } },
-    } as any)
-    vi.mocked(useHealth).mockReturnValue({
-      disk_details: { systemTotalMb: 100, systemAvailableMb: 10 },
+      disk_details: { isDiskSpaceBelowRunStartLimit: true },
     } as any)
     const { result } = renderHook(useIsRobotOutOfStorage)
     expect(result.current).toBe(true)

--- a/app/src/resources/devices/hooks/useIsRobotOutOfStorage.ts
+++ b/app/src/resources/devices/hooks/useIsRobotOutOfStorage.ts
@@ -3,9 +3,6 @@ import {
   useHealth,
 } from '@opentrons/react-api-client'
 
-// subject to change
-const MAX_STORAGE_PERCENTAGE = 90
-
 export function useIsRobotOutOfStorage(): boolean {
   const health = useHealth()
   const { data } = useAccessControlEnabledQuery()
@@ -13,11 +10,5 @@ export function useIsRobotOutOfStorage(): boolean {
     return false
   }
 
-  const totalMb = health?.disk_details?.systemTotalMb
-  const availableMb = health?.disk_details?.systemAvailableMb
-  if (totalMb == null || availableMb == null) {
-    return false
-  }
-  const percentUsed = ((totalMb - availableMb) / totalMb) * 100
-  return percentUsed >= MAX_STORAGE_PERCENTAGE
+  return health?.disk_details?.isDiskSpaceBelowRunStartLimit ?? false
 }

--- a/robot-server/robot_server/disk_monitor/models.py
+++ b/robot-server/robot_server/disk_monitor/models.py
@@ -1,0 +1,25 @@
+"""Models for disk monitors."""
+
+from pydantic import BaseModel, Field
+
+
+class DiskDetails(BaseModel):
+    """System disk usage details."""
+
+    systemAvailableMb: float = Field(
+        ..., description="The system's available disk space in MB."
+    )
+    systemTotalMb: float = Field(
+        ..., description="The total disk space of the /data partition in MB."
+    )
+    imagesDirectorySizeMb: float = Field(
+        ..., description="The system's images directory disk size in MB."
+    )
+    runStartLimitFreeSpaceMb: float = Field(
+        ...,
+        description="The amount of free disk space below which runs will not start.",
+    )
+    isDiskSpaceBelowRunStartLimit: bool = Field(
+        ...,
+        description="True if a run cannot currently be started because the robot is low on disk space.",
+    )

--- a/robot-server/robot_server/disk_monitor/monitor.py
+++ b/robot-server/robot_server/disk_monitor/monitor.py
@@ -7,6 +7,7 @@ from typing import Annotated
 
 from fastapi import Depends
 
+from .models import DiskDetails
 from robot_server.persistence.fastapi_dependencies import get_images_directory
 from robot_server.settings import RobotServerSettings, get_settings
 
@@ -24,6 +25,20 @@ class DiskMonitor:
         self._images_directory = images_directory
         self._settings = settings
 
+    def get_details(self) -> DiskDetails:
+        """Get a summary of disk usage."""
+        used_space = self.get_total_disk_space_mb()
+        available_space = self.get_available_disk_space_mb()
+        images_size = self.get_images_directory_size_mb()
+        limit = self._settings.system_low_space_threshold_mb
+        return DiskDetails(
+            systemAvailableMb=available_space,
+            systemTotalMb=used_space,
+            imagesDirectorySizeMb=images_size,
+            runStartLimitFreeSpaceMb=limit,
+            isDiskSpaceBelowRunStartLimit=self._disk_space_below_limit(available_space),
+        )
+
     def get_available_disk_space_mb(self) -> float:
         """Get the available disk space in megabytes."""
         if sys.platform == "win32" or not hasattr(os, "statvfs"):
@@ -33,6 +48,14 @@ class DiskMonitor:
         available_bytes = stat.f_bavail * stat.f_frsize
 
         return available_bytes / (1024 * 1024)
+
+    def is_disk_space_below_run_start_limit(self) -> bool:
+        """True if a run should fail because we're out of space."""
+        available_space = self.get_available_disk_space_mb()
+        return self._disk_space_below_limit(available_space)
+
+    def _disk_space_below_limit(self, available_space_mb: float) -> bool:
+        return available_space_mb < self._settings.run_start_limit_free_space_mb
 
     def get_total_disk_space_mb(self) -> float:
         """Get the total disk space of the /data partition in megabytes."""

--- a/robot-server/robot_server/health/models.py
+++ b/robot-server/robot_server/health/models.py
@@ -7,19 +7,7 @@ from pydantic import BaseModel, Field
 from opentrons_shared_data.deck.types import RobotModel
 from server_utils.fastapi_utils.models.json_api import BaseResponseBody
 
-
-class DiskDetails(BaseModel):
-    """System disk usage details."""
-
-    systemAvailableMb: float = Field(
-        ..., description="The system's available disk space in MB."
-    )
-    systemTotalMb: float = Field(
-        ..., description="The total disk space of the /data partition in MB."
-    )
-    imagesDirectorySizeMb: float = Field(
-        ..., description="The system's images directory disk size in MB."
-    )
+from robot_server.disk_monitor.models import DiskDetails
 
 
 class HealthLinks(BaseModel):

--- a/robot-server/robot_server/health/router.py
+++ b/robot-server/robot_server/health/router.py
@@ -12,7 +12,7 @@ from opentrons.hardware_control import HardwareControlAPI
 from opentrons_shared_data.robot.types import RobotType
 from server_utils.util import call_once
 
-from .models import DiskDetails, Health, HealthLinks
+from .models import Health, HealthLinks
 from robot_server.disk_monitor.dependencies import get_disk_monitor
 from robot_server.disk_monitor.monitor import DiskMonitor
 from robot_server.hardware import get_hardware, get_robot_type
@@ -179,9 +179,5 @@ async def get_health(
         robot_model=robot_type,
         links=health_links,
         robot_serial=(await hardware.get_serial_number()),
-        disk_details=DiskDetails(
-            systemAvailableMb=disk_monitor.get_available_disk_space_mb(),
-            systemTotalMb=disk_monitor.get_total_disk_space_mb(),
-            imagesDirectorySizeMb=disk_monitor.get_images_directory_size_mb(),
-        ),
+        disk_details=disk_monitor.get_details(),
     )

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -110,6 +110,8 @@ from robot_server.deck_configuration.fastapi_dependencies import (
     get_deck_configuration_store,
 )
 from robot_server.deck_configuration.store import DeckConfigurationStore
+from robot_server.disk_monitor.dependencies import get_disk_monitor
+from robot_server.disk_monitor.monitor import DiskMonitor
 from robot_server.errors.error_responses import ErrorBody, ErrorDetails
 from robot_server.hardware import (
     HardwareStateStore,
@@ -211,6 +213,14 @@ class CurrentStateLinks(BaseModel):
     )
 
 
+class NoSpaceForRun(ErrorDetails):
+    """An error if there is not enough space on the robot to start a new run."""
+
+    id: Literal["NoSpaceForRun"] = "NoSpaceForRun"
+    title: str = "No Space For Run"
+    errorCode: str = ErrorCodes.GENERAL_ERROR.value.code
+
+
 async def get_run_data_from_url(
     runId: str,
     run_data_manager: Annotated[RunDataManager, Depends(get_run_data_manager)],
@@ -271,6 +281,7 @@ async def create_run(  # noqa: C901
     notify_publishers: Annotated[Callable[[], None], Depends(get_pe_notify_publishers)],
     access_control_status: Annotated[bool, Depends(get_access_control_status)],
     audit_client: Annotated[AuditClient, Depends(get_audit_client)],
+    disk_monitor: Annotated[DiskMonitor, Depends(get_disk_monitor)],
     request_body: Optional[RequestModel[RunCreate]] = None,
 ) -> PydanticResponse[SimpleBody[Union[Run, BadRun]]]:
     """Create a new run.
@@ -293,6 +304,7 @@ async def create_run(  # noqa: C901
         access_control_status: Whether access control (Compliance Ready Software) is
             currently enabled on the robot.
         audit_client: Client to get log period info from
+        disk_monitor: Disk monitor for checking if we have enough space.
     """
     protocol_id = request_body.data.protocolId if request_body is not None else None
     offsets = request_body.data.labwareOffsets if request_body is not None else []
@@ -344,6 +356,13 @@ async def create_run(  # noqa: C901
     # to pass to `RunDataManager.create`. Right now, runs may be deleted
     # even if a new create is unable to succeed due to a conflict
     run_auto_deleter.make_room_for_new_run()
+
+    if disk_monitor.is_disk_space_below_run_start_limit() and access_control_status:
+        log_line = f"Disk free space is {disk_monitor.get_available_disk_space_mb()}MB which is below the limit for starting a run."
+        log.error(log_line)
+        raise NoSpaceForRun(detail=log_line).as_error(
+            status.HTTP_507_INSUFFICIENT_STORAGE
+        )
 
     try:
         run_data = await run_data_manager.create(

--- a/robot-server/robot_server/settings.py
+++ b/robot-server/robot_server/settings.py
@@ -169,3 +169,9 @@ class RobotServerSettings(BaseSettings):
             "The maximum number of uploaded data files to allow before auto-deleting old ones."
         ),
     )
+
+    run_start_limit_free_space_mb: int = Field(
+        default=2048,
+        gt=0,
+        description="The minimum free space required to launch a run.",
+    )

--- a/robot-server/tests/disk_monitor/test_disk_monitor.py
+++ b/robot-server/tests/disk_monitor/test_disk_monitor.py
@@ -144,3 +144,13 @@ def test_is_images_directory_over_limit_when_above_limit(
     """It should return True when directory size exceeds limit."""
     with patch.object(subject, "get_images_directory_size_mb", return_value=600.0):
         assert subject.is_images_directory_over_limit() is True
+
+
+def test_is_run_start_limit_respected(
+    subject: DiskMonitor, mock_settings: RobotServerSettings
+) -> None:
+    """It should treat the run start limit separately from the system."""
+    mock_settings.run_start_limit_free_space_mb = 2048
+    mock_settings.system_low_space_threshold_mb = 500
+    with patch.object(subject, "get_available_disk_space_mb", return_value=2040):
+        assert subject.is_disk_space_below_run_start_limit()

--- a/robot-server/tests/health/test_health_router.py
+++ b/robot-server/tests/health/test_health_router.py
@@ -10,6 +10,7 @@ from mock import MagicMock, patch
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION, MIN_SUPPORTED_VERSION
 from opentrons_shared_data.robot.types import RobotType
 
+from robot_server.disk_monitor.models import DiskDetails
 from robot_server.disk_monitor.monitor import DiskMonitor
 from robot_server.health.router import (
     ComponentVersions,
@@ -31,9 +32,15 @@ def images_directory(tmp_path: Path) -> Path:
 def disk_monitor(decoy: Decoy) -> DiskMonitor:
     """Get a mocked out DiskMonitor interface."""
     mock = decoy.mock(cls=DiskMonitor)
-    decoy.when(mock.get_available_disk_space_mb()).then_return(1000.0)
-    decoy.when(mock.get_total_disk_space_mb()).then_return(5000.0)
-    decoy.when(mock.get_images_directory_size_mb()).then_return(500.0)
+    decoy.when(mock.get_details()).then_return(
+        DiskDetails(
+            systemAvailableMb=1000.0,
+            systemTotalMb=5000.0,
+            imagesDirectorySizeMb=500.0,
+            runStartLimitFreeSpaceMb=100.0,
+            isDiskSpaceBelowRunStartLimit=True,
+        )
+    )
     return mock
 
 
@@ -88,6 +95,8 @@ async def test_get_health(
             "systemAvailableMb": 1000.0,
             "systemTotalMb": 5000.0,
             "imagesDirectorySizeMb": 500.0,
+            "runStartLimitFreeSpaceMb": 100.0,
+            "isDiskSpaceBelowRunStartLimit": True,
         },
     }
 
@@ -144,6 +153,8 @@ async def test_get_health_with_none_version(
             "systemAvailableMb": 1000.0,
             "systemTotalMb": 5000.0,
             "imagesDirectorySizeMb": 500.0,
+            "runStartLimitFreeSpaceMb": 100.0,
+            "isDiskSpaceBelowRunStartLimit": True,
         },
     }
 

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -61,6 +61,7 @@ from robot_server.data_files.data_files_store import (
     DataFilesStore,
 )
 from robot_server.deck_configuration.store import DeckConfigurationStore
+from robot_server.disk_monitor.monitor import DiskMonitor
 from robot_server.errors.error_responses import ApiError
 from robot_server.file_provider.provider import FileProviderExecutor
 from robot_server.hardware import HardwareStateStore
@@ -157,6 +158,12 @@ def labware_definition(minimal_labware_def: LabwareDefDict) -> LabwareDefinition
     return labware_definition_type_adapter.validate_python(minimal_labware_def)
 
 
+@pytest.fixture
+def mock_disk_monitor(decoy: Decoy) -> DiskMonitor:
+    """Get a mock disk monitor."""
+    return decoy.mock(cls=DiskMonitor)
+
+
 async def test_create_run(
     decoy: Decoy,
     mock_run_data_manager: RunDataManager,
@@ -169,6 +176,7 @@ async def test_create_run(
     mock_file_provider: FileProvider,
     mock_camera_provider: CameraProvider,
     mock_audit_client: AuditClient,
+    mock_disk_monitor: DiskMonitor,
 ) -> None:
     """It should be able to create a basic run."""
     run_id = "run-id"
@@ -206,6 +214,9 @@ async def test_create_run(
             endedAt=None,
         )
     )
+    decoy.when(mock_disk_monitor.is_disk_space_below_run_start_limit()).then_return(
+        False
+    )
 
     decoy.when(
         await mock_run_data_manager.create(
@@ -240,6 +251,7 @@ async def test_create_run(
         audit_client=mock_audit_client,
         check_estop=True,
         access_control_status=False,
+        disk_monitor=mock_disk_monitor,
     )
 
     assert result.content.data == expected_response
@@ -258,6 +270,7 @@ async def test_create_protocol_run(
     mock_file_provider: FileProvider,
     mock_camera_provider: CameraProvider,
     mock_audit_client: AuditClient,
+    mock_disk_monitor: DiskMonitor,
 ) -> None:
     """It should be able to create a protocol run."""
     run_id = "run-id"
@@ -297,6 +310,9 @@ async def test_create_protocol_run(
         liquidClasses=[],
         outputFileIds=[],
         hasEverEnteredErrorRecovery=False,
+    )
+    decoy.when(mock_disk_monitor.is_disk_space_below_run_start_limit()).then_return(
+        False
     )
     decoy.when(mock_data_files_store.get("file-id")).then_return(
         DataFileInfo(
@@ -364,6 +380,7 @@ async def test_create_protocol_run(
         audit_client=mock_audit_client,
         check_estop=True,
         access_control_status=False,
+        disk_monitor=mock_disk_monitor,
     )
 
     assert result.content.data == expected_response
@@ -383,6 +400,7 @@ async def test_create_protocol_run_bad_protocol_id(
     mock_file_provider: FileProvider,
     mock_camera_provider: CameraProvider,
     mock_audit_client: AuditClient,
+    mock_disk_monitor: DiskMonitor,
 ) -> None:
     """It should 404 if a protocol for a run does not exist."""
     error = ProtocolNotFoundError("protocol-id")
@@ -393,7 +411,9 @@ async def test_create_protocol_run_bad_protocol_id(
         GetLoggingEnabledData(loggingEnabled=False)
     )
     decoy.when(mock_protocol_store.get(protocol_id="protocol-id")).then_raise(error)
-
+    decoy.when(mock_disk_monitor.is_disk_space_below_run_start_limit()).then_return(
+        False
+    )
     with pytest.raises(ApiError) as exc_info:
         await create_run(
             request_body=RequestModel(data=RunCreate(protocolId="protocol-id")),
@@ -410,6 +430,7 @@ async def test_create_protocol_run_bad_protocol_id(
             check_estop=True,
             notify_publishers=mock_notify_publishers,
             access_control_status=False,
+            disk_monitor=mock_disk_monitor,
         )
 
     assert exc_info.value.status_code == 404
@@ -427,6 +448,7 @@ async def test_create_run_conflict(
     mock_file_provider: FileProvider,
     mock_camera_provider: CameraProvider,
     mock_audit_client: AuditClient,
+    mock_disk_monitor: DiskMonitor,
 ) -> None:
     """It should respond with a conflict error if multiple engines are created."""
     created_at = datetime(year=2021, month=1, day=1)
@@ -436,6 +458,9 @@ async def test_create_run_conflict(
     ).then_return([])
     decoy.when(await mock_audit_client.get_logging_enabled()).then_return(
         GetLoggingEnabledData(loggingEnabled=False)
+    )
+    decoy.when(mock_disk_monitor.is_disk_space_below_run_start_limit()).then_return(
+        False
     )
     decoy.when(
         await mock_run_data_manager.create(
@@ -469,10 +494,189 @@ async def test_create_run_conflict(
             audit_client=mock_audit_client,
             check_estop=True,
             access_control_status=False,
+            disk_monitor=mock_disk_monitor,
         )
 
     assert exc_info.value.status_code == 409
     assert exc_info.value.content["errors"][0]["id"] == "RunAlreadyActive"
+
+
+async def create_run_fails_when_out_of_space_under_acm(
+    decoy: Decoy,
+    mock_run_data_manager: RunDataManager,
+    mock_run_auto_deleter: RunAutoDeleter,
+    mock_deck_configuration_store: DeckConfigurationStore,
+    mock_protocol_store: ProtocolStore,
+    mock_data_files_store: DataFilesStore,
+    mock_data_files_directory: Path,
+    mock_file_provider: FileProvider,
+    mock_camera_provider: CameraProvider,
+    mock_audit_client: AuditClient,
+    mock_disk_monitor: DiskMonitor,
+) -> None:
+    """It should refuse to create a run when out of space and ACM is enabled."""
+    created_at = datetime(year=2021, month=1, day=1)
+
+    decoy.when(
+        await mock_deck_configuration_store.get_deck_configuration()
+    ).then_return([])
+    decoy.when(await mock_audit_client.get_logging_enabled()).then_return(
+        GetLoggingEnabledData(loggingEnabled=False)
+    )
+    decoy.when(mock_disk_monitor.is_disk_space_below_run_start_limit()).then_return(
+        True
+    )
+
+    with pytest.raises(ApiError) as exc_info:
+        await create_run(
+            run_id="run-id",
+            created_at=created_at,
+            request_body=None,
+            protocol_store=mock_protocol_store,
+            run_data_manager=mock_run_data_manager,
+            run_auto_deleter=mock_run_auto_deleter,
+            deck_configuration_store=mock_deck_configuration_store,
+            data_files_store=mock_data_files_store,
+            data_files_directory=mock_data_files_directory,
+            camera_provider=mock_camera_provider,
+            notify_publishers=mock_notify_publishers,
+            audit_client=mock_audit_client,
+            check_estop=True,
+            access_control_status=True,
+            disk_monitor=mock_disk_monitor,
+        )
+
+    assert exc_info.value.status_code == 507
+    assert exc_info.value.content["errors"][0]["id"] == "NoSpaceForRun"
+
+
+async def test_create_protocol_run_succeeds_when_out_of_space_with_acm_off(
+    decoy: Decoy,
+    mock_protocol_store: ProtocolStore,
+    mock_run_data_manager: RunDataManager,
+    mock_run_auto_deleter: RunAutoDeleter,
+    mock_deck_configuration_store: DeckConfigurationStore,
+    mock_data_files_store: DataFilesStore,
+    mock_file_provider: FileProvider,
+    mock_camera_provider: CameraProvider,
+    mock_audit_client: AuditClient,
+    mock_disk_monitor: DiskMonitor,
+) -> None:
+    """It should be able to create a protocol run."""
+    run_id = "run-id"
+    run_created_at = datetime(year=2021, month=1, day=1)
+    protocol_id = "protocol-id"
+
+    protocol_resource = ProtocolResource(
+        protocol_id=protocol_id,
+        protocol_key=None,
+        protocol_kind=ProtocolKind.STANDARD,
+        created_at=datetime(year=2022, month=2, day=2),
+        source=ProtocolSource(
+            directory=Path("/dev/null"),
+            main_file=Path("/dev/null/abc.json"),
+            config=JsonProtocolConfig(schema_version=123),
+            files=[],
+            metadata={},
+            robot_type="OT-2 Standard",
+            content_hash="abc123",
+        ),
+    )
+
+    expected_response = Run(
+        id=run_id,
+        createdAt=run_created_at,
+        protocolId=protocol_id,
+        logPeriodId="123",
+        current=True,
+        actions=[],
+        errors=[],
+        pipettes=[],
+        modules=[],
+        labware=[],
+        labwareOffsets=[],
+        status=pe_types.EngineStatus.IDLE,
+        liquids=[],
+        liquidClasses=[],
+        outputFileIds=[],
+        hasEverEnteredErrorRecovery=False,
+    )
+    decoy.when(mock_disk_monitor.is_disk_space_below_run_start_limit()).then_return(
+        True
+    )
+    decoy.when(mock_data_files_store.get("file-id")).then_return(
+        DataFileInfo(
+            id="123",
+            name="abc.xyz",
+            file_hash="987",
+            created_at=datetime(month=1, day=2, year=2024),
+            mime_type=MimeType.TEXT_CSV,
+            generated=False,
+            stored=True,
+            path="/dev/null/123/abc.xyz",
+        )
+    )
+    decoy.when(
+        await mock_deck_configuration_store.get_deck_configuration()
+    ).then_return([])
+    decoy.when(mock_protocol_store.get(protocol_id=protocol_id)).then_return(
+        protocol_resource
+    )
+    decoy.when(await mock_audit_client.get_logging_enabled()).then_return(
+        GetLoggingEnabledData(loggingEnabled=True)
+    )
+    decoy.when(await mock_audit_client.get_current_log_period()).then_return(
+        GetLogPeriodsData(
+            id=123,
+            startedAt=datetime(year=2021, month=1, day=1),
+            endedAt=None,
+        )
+    )
+
+    decoy.when(
+        await mock_run_data_manager.create(
+            run_id=run_id,
+            created_at=run_created_at,
+            labware_offsets=[],
+            deck_configuration=[],
+            camera_provider=mock_camera_provider,
+            protocol=protocol_resource,
+            run_time_param_values={"foo": "bar"},
+            run_time_param_paths={"my-csv-param": Path("/dev/null/file-id/abc.xyz")},
+            notify_publishers=mock_notify_publishers,
+            access_control_status=False,
+            log_period_id="123",
+        )
+    ).then_return(expected_response)
+
+    result = await create_run(
+        request_body=RequestModel(
+            data=RunCreate(
+                protocolId="protocol-id",
+                runTimeParameterValues={"foo": "bar"},
+                runTimeParameterFiles={"my-csv-param": "file-id"},
+            )
+        ),
+        protocol_store=mock_protocol_store,
+        run_data_manager=mock_run_data_manager,
+        data_files_store=mock_data_files_store,
+        data_files_directory=Path("/dev/null"),
+        run_id=run_id,
+        created_at=run_created_at,
+        run_auto_deleter=mock_run_auto_deleter,
+        deck_configuration_store=mock_deck_configuration_store,
+        camera_provider=mock_camera_provider,
+        notify_publishers=mock_notify_publishers,
+        audit_client=mock_audit_client,
+        check_estop=True,
+        access_control_status=False,
+        disk_monitor=mock_disk_monitor,
+    )
+
+    assert result.content.data == expected_response
+    assert result.status_code == 201
+
+    decoy.verify(mock_run_auto_deleter.make_room_for_new_run(), times=1)
 
 
 async def test_get_run_data_from_url(


### PR DESCRIPTION
# Overview

We were inhibiting run creation and showing a modal if the app calculated the robot had less than 10% storage remaining. We should make it 20%, and also the robot should be the one doing it (the app can enhance that check with UI, though). 

Instead, let's make the server calculate it, put the result of the calculation in the health response, and then actually inhibit the run-create endpoint if there's not enough space. Plus the app can use the calculation result, which gets rid of a magic number.

## Test Plan and Hands on Testing

- [x] put the server code on a robot and make a really big file in /data. without crs, a run should still be creatable. with crs, a run should not be creatable.

## Changelog

- Add functionality to disk monitor to calculate whether a run should be started
- Use that in the run router to prevent a run being started if it shouldn't be
- Use that in the app to have a single source of truth of run-create status

## Review requests

- Look good?

## Risk assessment

- Low, moves some already-existing stuff around
