### PR TITLE
fix(app): fix stale analysis RTPs in ChooseRobotToRunProtocolSlideout

### DIFF
--- a/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
@@ -82,8 +82,10 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
     storedProtocolData,
     selectedRobot?.name ?? ''
   )
-  const runTimeParameters =
-    storedProtocolData.mostRecentAnalysis?.runTimeParameters ?? []
+  const runTimeParameters = useMemo(
+    () => mostRecentAnalysis?.runTimeParameters ?? [],
+    [mostRecentAnalysis]
+  )
 
   const [runTimeParametersOverrides, setRunTimeParametersOverrides] =
     useState<RunTimeParameter[]>(runTimeParameters)
@@ -91,14 +93,12 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
   const [hasMissingFileParam, setHasMissingFileParam] = useState<boolean>(
     runTimeParameters?.some(parameter => parameter.type === 'csv_file') ?? false
   )
-  useEffect(
-    () => {
-      setRunTimeParametersOverrides(runTimeParameters)
-    },
-    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [protocolKey]
-  )
+  useEffect(() => {
+    setRunTimeParametersOverrides(runTimeParameters)
+    setHasMissingFileParam(
+      runTimeParameters.some(parameter => parameter.type === 'csv_file')
+    )
+  }, [protocolKey, runTimeParameters])
 
   const [targetProps, tooltipProps] = useHoverTooltip()
 


### PR DESCRIPTION
# Overview

Fix stale runtime parameter logic in ChooseRobotToRunProtocolSlideout, such that the slideout correctly shows updated RTPs following a new analysis.

Closes RQA-5818

https://github.com/user-attachments/assets/ab993766-03e6-4360-8785-2373de1d1ce5


## Test Plan and Hands on Testing


## Changelog


## Review requests

see test plan

## Risk assessment

low