### PR TITLE
feat(app): add loading states during audit logs fetching

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/compliancereadysoftwarefiles.module.css
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/compliancereadysoftwarefiles.module.css
@@ -37,3 +37,10 @@
   flex: 2;
   align-items: center;
 }
+
+.skeleton_container {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
@@ -176,7 +176,7 @@ export function ComplianceReadySoftwareFiles({
     }
   }, [])
 
-  // loading skeleton since log period summary query can take a noticible amount of time
+  // loading skeleton since log period summary query can take a noticeable amount of time
   const skeletonContent = (
     <div className={styles.skeleton_container} ref={observer}>
       <Skeleton width="100%" height="3rem" backgroundSize={`${width}px`} />

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
@@ -185,41 +185,50 @@ export function ComplianceReadySoftwareFiles({
       <Skeleton width="100%" height="3rem" backgroundSize={`${width}px`} />
     </div>
   )
+  const header = (
+    <div className={styles.compliance_table_header_row}>
+      <CheckboxBasic
+        checked={isSomeSelected ? 'indeterminate' : isAllSelected}
+        onChange={handleToggleAll}
+      />
+
+      <div className={styles.log_period_columns}>
+        <StyledText
+          desktopStyle="bodyDefaultRegular"
+          className={styles.log_date_col}
+        >
+          {t('protocol')}
+        </StyledText>
+        <StyledText
+          desktopStyle="bodyDefaultRegular"
+          className={styles.log_date_col}
+        >
+          {t('log_period_start')}
+        </StyledText>
+        <StyledText
+          desktopStyle="bodyDefaultRegular"
+          className={styles.log_date_col}
+        >
+          {t('log_period_end')}
+        </StyledText>
+      </div>
+    </div>
+  )
 
   let content: ReactNode = <></>
   if (logPeriodSummaryStatus === 'loading') {
-    content = skeletonContent
+    content = (
+      <div className={fileManagerStyles.log_table}>
+        {header}
+        {skeletonContent}
+      </div>
+    )
   } else if (logPeriodSummariesData?.data.length === 0) {
     content = <InfoScreen content={t('no_user_action_logs')} />
   } else {
     content = (
       <div className={fileManagerStyles.log_table}>
-        <div className={styles.compliance_table_header_row}>
-          <CheckboxBasic
-            checked={isSomeSelected ? 'indeterminate' : isAllSelected}
-            onChange={handleToggleAll}
-          />
-          <div className={styles.log_period_columns}>
-            <StyledText
-              desktopStyle="bodyDefaultRegular"
-              className={styles.log_date_col}
-            >
-              {t('protocol')}
-            </StyledText>
-            <StyledText
-              desktopStyle="bodyDefaultRegular"
-              className={styles.log_date_col}
-            >
-              {t('log_period_start')}
-            </StyledText>
-            <StyledText
-              desktopStyle="bodyDefaultRegular"
-              className={styles.log_date_col}
-            >
-              {t('log_period_end')}
-            </StyledText>
-          </div>
-        </div>
+        {header}
         {periods.map(period => (
           <LogPeriodRow
             key={period.id}

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -15,6 +15,7 @@ import {
   useLogPeriodSummariesQuery,
 } from '@opentrons/react-api-client'
 
+import { Skeleton } from '/app/atoms/Skeleton'
 import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useToaster } from '/app/organisms/ToasterOven'
 import { useDeleteSelectedLogPeriods } from '/app/resources/devices/hooks/useDeleteSelectedLogPeriods'
@@ -27,6 +28,7 @@ import fileManagerStyles from '../robotsettingsfilemanager.module.css'
 import styles from './compliancereadysoftwarefiles.module.css'
 import { LogPeriodRow } from './LogPeriodRow'
 
+import type { ReactNode } from 'react'
 import type { IconProps } from '@opentrons/components'
 import type { MakeToastOptions } from '/app/organisms/ToasterOven/ToasterContext'
 import type { DownloadedLogPeriod } from '/app/resources/devices/hooks/useDownloadSelectedLogPeriods'
@@ -42,14 +44,16 @@ interface ComplianceReadySoftwareFilesProps {
 
 export function ComplianceReadySoftwareFiles({
   robotName,
-}: ComplianceReadySoftwareFilesProps): JSX.Element {
+}: ComplianceReadySoftwareFilesProps): ReactNode {
   const { t } = useTranslation('device_details')
-  const { data: logPeriodSummariesData } = useLogPeriodSummariesQuery()
+  const { data: logPeriodSummariesData, status: logPeriodSummaryStatus } =
+    useLogPeriodSummariesQuery()
   const documentationState = useDocumentationState()
   const downloadLogPeriodsMutation = useDownloadSelectedLogPeriods(robotName)
   const { deleteSelectedLogPeriods, deletingIds } =
     useDeleteSelectedLogPeriods(documentationState)
   const { makeToast, eatToast } = useToaster()
+  const observer = useRef<HTMLDivElement>(null)
 
   // API returns periods oldest-to-newest; reverse for newest-first display.
   const periods = useMemo(
@@ -161,6 +165,75 @@ export function ComplianceReadySoftwareFiles({
         }
       })
   }
+  const [width, setWidth] = useState(0)
+
+  // width updates on mount only right now; known limitation that should be fine in practice
+  useEffect(() => {
+    if (observer.current != null) {
+      // Get the width of the element
+      const currentWidth = observer.current.getBoundingClientRect().width
+      setWidth(currentWidth)
+    }
+  }, [])
+
+  // loading skeleton since log period summary query can take a noticible amount of time
+  const skeletonContent = (
+    <div className={styles.skeleton_container} ref={observer}>
+      <Skeleton width="100%" height="3rem" backgroundSize={`${width}px`} />
+      <Skeleton width="100%" height="3rem" backgroundSize={`${width}px`} />
+      <Skeleton width="100%" height="3rem" backgroundSize={`${width}px`} />
+      <Skeleton width="100%" height="3rem" backgroundSize={`${width}px`} />
+    </div>
+  )
+
+  let content: ReactNode = <></>
+  if (logPeriodSummaryStatus === 'loading') {
+    content = skeletonContent
+  } else if (logPeriodSummariesData?.data.length === 0) {
+    content = <InfoScreen content={t('no_user_action_logs')} />
+  } else {
+    content = (
+      <div className={fileManagerStyles.log_table}>
+        <div className={styles.compliance_table_header_row}>
+          <CheckboxBasic
+            checked={isSomeSelected ? 'indeterminate' : isAllSelected}
+            onChange={handleToggleAll}
+          />
+          <div className={styles.log_period_columns}>
+            <StyledText
+              desktopStyle="bodyDefaultRegular"
+              className={styles.log_date_col}
+            >
+              {t('protocol')}
+            </StyledText>
+            <StyledText
+              desktopStyle="bodyDefaultRegular"
+              className={styles.log_date_col}
+            >
+              {t('log_period_start')}
+            </StyledText>
+            <StyledText
+              desktopStyle="bodyDefaultRegular"
+              className={styles.log_date_col}
+            >
+              {t('log_period_end')}
+            </StyledText>
+          </div>
+        </div>
+        {periods.map(period => (
+          <LogPeriodRow
+            key={period.id}
+            period={period}
+            isSelected={selectedIds.has(period.id)}
+            isDeleting={deletingIds.has(period.id)}
+            onToggle={() => {
+              togglePeriod(period.id)
+            }}
+          />
+        ))}
+      </div>
+    )
+  }
 
   return (
     <>
@@ -180,49 +253,7 @@ export function ComplianceReadySoftwareFiles({
           onDownloadSelected={handleDownloadSelected}
           onDeleteSelected={handleClickDeleteSelected}
         />
-        {periods.length === 0 ? (
-          <InfoScreen content={t('no_user_action_logs')} />
-        ) : (
-          <div className={fileManagerStyles.log_table}>
-            <div className={styles.compliance_table_header_row}>
-              <CheckboxBasic
-                checked={isSomeSelected ? 'indeterminate' : isAllSelected}
-                onChange={handleToggleAll}
-              />
-              <div className={styles.log_period_columns}>
-                <StyledText
-                  desktopStyle="bodyDefaultRegular"
-                  className={styles.log_date_col}
-                >
-                  {t('protocol')}
-                </StyledText>
-                <StyledText
-                  desktopStyle="bodyDefaultRegular"
-                  className={styles.log_date_col}
-                >
-                  {t('log_period_start')}
-                </StyledText>
-                <StyledText
-                  desktopStyle="bodyDefaultRegular"
-                  className={styles.log_date_col}
-                >
-                  {t('log_period_end')}
-                </StyledText>
-              </div>
-            </div>
-            {periods.map(period => (
-              <LogPeriodRow
-                key={period.id}
-                period={period}
-                isSelected={selectedIds.has(period.id)}
-                isDeleting={deletingIds.has(period.id)}
-                onToggle={() => {
-                  togglePeriod(period.id)
-                }}
-              />
-            ))}
-          </div>
-        )}
+        {content}
       </div>
     </>
   )

--- a/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/ComplianceReadyFiles/index.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/ComplianceReadyFiles/index.tsx
@@ -7,6 +7,7 @@ import {
   useLogPeriodSummariesQuery,
 } from '@opentrons/react-api-client'
 
+import { Skeleton } from '/app/atoms/Skeleton'
 import { OddInfoScreen } from '/app/molecules/ODDInfoScreen'
 import { useNotifyAllRunsQuery } from '/app/resources/runs'
 
@@ -20,7 +21,8 @@ import type { LogPeriodSummary } from '@opentrons/api-client'
 
 export function ComplianceReadyFiles(): ReactNode {
   const { t } = useTranslation('device_details')
-  const { data: logPeriodSummariesData } = useLogPeriodSummariesQuery()
+  const { data: logPeriodSummariesData, status: logPeriodSummaryQueryStatus } =
+    useLogPeriodSummariesQuery()
 
   const logPeriodSummariesSorted = useMemo(() => {
     const logPeriodSummaries = logPeriodSummariesData?.data ?? []
@@ -89,7 +91,10 @@ export function ComplianceReadyFiles(): ReactNode {
     setSelectedLogPeriod(null)
   }
 
-  if (logPeriodSummariesSorted.length === 0) {
+  if (
+    logPeriodSummaryQueryStatus !== 'loading' &&
+    logPeriodSummariesData?.data.length === 0
+  ) {
     return (
       <OddInfoScreen
         type="neutral"
@@ -99,6 +104,15 @@ export function ComplianceReadyFiles(): ReactNode {
     )
   }
 
+  // loading skeleton since log period summary query can take a noticible amount of time
+  const skeletonContent = (
+    <>
+      <Skeleton width="100%" height="5.75rem" backgroundSize="59rem" />
+      <Skeleton width="100%" height="5.75rem" backgroundSize="59rem" />
+      <Skeleton width="100%" height="5.75rem" backgroundSize="59rem" />
+    </>
+  )
+
   return (
     <div className={styles.container}>
       <div className={styles.header}>
@@ -106,14 +120,16 @@ export function ComplianceReadyFiles(): ReactNode {
         <StyledText oddStyle="bodyTextSemiBold">{t('period_start')}</StyledText>
         <StyledText oddStyle="bodyTextSemiBold">{t('period_end')}</StyledText>
       </div>
-      {logPeriodSummariesSorted.map(logPeriodSummary => (
-        <LogPeriodRow
-          key={logPeriodSummary.id}
-          logPeriodSummary={logPeriodSummary}
-          protocolName={protocolNameByLogPeriodId[logPeriodSummary.id]}
-          handleOverflowClick={handleOverflowClick}
-        />
-      ))}
+      {logPeriodSummaryQueryStatus === 'loading'
+        ? skeletonContent
+        : logPeriodSummariesSorted.map(logPeriodSummary => (
+            <LogPeriodRow
+              key={logPeriodSummary.id}
+              logPeriodSummary={logPeriodSummary}
+              protocolName={protocolNameByLogPeriodId[logPeriodSummary.id]}
+              handleOverflowClick={handleOverflowClick}
+            />
+          ))}
       {selectedLogPeriod != null ? (
         <ConfirmLogPeriodModal
           onClose={handleCloseConfirmModal}

--- a/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/ComplianceReadyFiles/index.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/ComplianceReadyFiles/index.tsx
@@ -41,17 +41,19 @@ export function ComplianceReadyFiles(): ReactNode {
     const protocols = protocolsData?.data ?? []
     const runs = runsData?.data ?? []
 
-    const protocolNameById = protocols.reduce<Map<string, string>>(
+    const protocolNameById = protocols.reduce<Record<string, string>>(
       (acc, { id, metadata }) => {
-        return metadata.protocolName != null
-          ? { ...acc, [id]: metadata.protocolName }
-          : acc
+        if (metadata?.protocolName != null) {
+          acc[id] = metadata.protocolName
+        }
+        return acc
       },
-      new Map()
+      {}
     )
+
     return runs.reduce<Record<string, string>>((acc, run) => {
       const protocolName =
-        run.protocolId != null ? protocolNameById.get(run.protocolId) : null
+        run.protocolId != null ? protocolNameById[run.protocolId] : null
       if (run.logPeriodId != null && protocolName != null) {
         acc[run.logPeriodId] = protocolName
       }


### PR DESCRIPTION
# Overview

Adds loading skeleton on both ODD and Desktop Audit Logs sections of file manager, since this query is noticeably slower than other fetches.

https://github.com/user-attachments/assets/a8dcfdb6-023d-4126-adfb-a86025865605


https://github.com/user-attachments/assets/057fea5d-a405-4ea4-81e2-027bd45cf88f


## Test Plan and Hands on Testing

- in file manager section of a CRS-enabled robot's settings (on both desktop and ODD), navigate to file manager > audit logs
- verify that loading Skeleton renders until the log period summaries data is returned 

## Changelog

- add logic to render Skeleton while log period summaries query is loading

## Review requests

see test plan

## Risk assessment

low