### PR TITLE
fix(robot-server): clearing a run in pyro returns actual data for commands and other run result properties

### DIFF
--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -414,9 +414,6 @@ class RunOrchestratorStore:
             RunConflictError: The current run orchestrator is not idle, so it cannot
                 be cleared.
         """
-        if feature_flags.protocol_subprocess_enabled():
-            return await self.clear_pyro()
-
         if self.run_coordinator.get_is_okay_to_clear():
             await self.run_coordinator.finish(
                 drop_tips_after_run=False,
@@ -431,6 +428,9 @@ class RunOrchestratorStore:
         run_time_parameters = self.run_coordinator.get_run_time_parameters()
         command_annotations = self.run_coordinator.get_all_command_annotations()
         preconditions = self.run_coordinator.get_preconditions()
+
+        if feature_flags.protocol_subprocess_enabled():
+            self._run_process_pyro_provider.set_active_process_as_used()
 
         if self._run_coordinator is not None:
             self._run_coordinator.clear_command_history()
@@ -475,31 +475,6 @@ class RunOrchestratorStore:
         self._run_coordinator = run_process
         self._initialize_stored_engine_state()
         return summary
-
-    async def clear_pyro(self) -> RunResult:
-        """End the pyro protocol subprocess and remove the pyro proxy from the nameserver."""
-        if self.run_coordinator.get_is_okay_to_clear():
-            await self.run_coordinator.finish(
-                drop_tips_after_run=False,
-                set_run_status=False,
-                post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
-            )
-        else:
-            raise RunConflictError("Current run is not idle or stopped.")
-
-        run_data = self.run_coordinator.get_state_summary()
-
-        self._run_process_pyro_provider.set_active_process_as_used()
-
-        self._run_coordinator = None
-
-        return RunResult(
-            state_summary=run_data,
-            commands=[],
-            parameters=[],
-            command_annotations=[],
-            command_preconditions=None,
-        )
 
     # todo(mm, 2024-11-15): Are all of these pass-through methods helpful?
     # Can we delete them and make callers just call .run_orchestrator.play(), etc.?


### PR DESCRIPTION
# Overview

Addresses EXEC-2938

This PR fixes an issue where when in Pyro subprocess mode, clearing a run would return empty-stub information for `commands`, `parameters`, `command_annotations`, and `command_preconditions`, and additionally would not call `clear_command_history`.

This was noticed when testing downloading the log period for a CRS enabled Flex. It was found that the run commands would be empty in the generated run log, and upon further investigation the run commands endpoint was also empty. It turns out stub data we put in the method was never actually replaced with the real data, and this was unnoticed until now.

To fix this, the `clear_pyro` method was removed and the one pyro related thing it did differently is now the thing gated behind the feature flag.


## Test Plan and Hands on Testing

Tested on a robot to ensure the run ends cleanly and commands are there as we expect.

## Changelog

- refactor away `clear_pyro` so that all the correct data and actions from before occur

## Review requests

## Risk assessment

Low, fixes a pretty bad bug that was deleting information about a run. All the types that weren't being returned before are being serialized, and if there are issues there then they will appear now, but cursory testing doesn't reveal any problems and this fixes the main issue