### PR TITLE
feat(protocol-visualization): activate step details button in playback controls

### DIFF
--- a/protocol-visualization/src/molecules/PlayBackControls/index.tsx
+++ b/protocol-visualization/src/molecules/PlayBackControls/index.tsx
@@ -25,7 +25,8 @@ interface PlayBackControlsProps {
   setSelectedCommand: Dispatch<SetStateAction<string | null>>
   milliSecondsPerFrame: number
   setMilliSecondsPerFrame: Dispatch<SetStateAction<number>>
-  onClickStepDetail?: () => void
+  showStepDetails: boolean
+  onClickStepDetails: Dispatch<SetStateAction<boolean>>
 }
 
 export function PlayBackControls(props: PlayBackControlsProps): ReactNode {
@@ -38,7 +39,8 @@ export function PlayBackControls(props: PlayBackControlsProps): ReactNode {
     setSelectedCommand,
     milliSecondsPerFrame,
     setMilliSecondsPerFrame,
-    // onClickStepDetail,
+    showStepDetails,
+    onClickStepDetails,
   } = props
 
   const { t } = useTranslation('protocol_visualization')
@@ -144,7 +146,9 @@ export function PlayBackControls(props: PlayBackControlsProps): ReactNode {
       <div className={styles.controls_right}>
         <button
           type="button"
-          onClick={() => {}}
+          onClick={() => {
+            onClickStepDetails(!showStepDetails)
+          }}
           className={styles.icon_button}
           aria-label={t('step_details')}
         >

--- a/protocol-visualization/src/organisms/VisualizerContainer/index.tsx
+++ b/protocol-visualization/src/organisms/VisualizerContainer/index.tsx
@@ -51,6 +51,7 @@ export function ProtocolVisualization(
   const [isDragging, setIsDragging] = useState<boolean>(false)
 
   const [selectedCommandId, setSelectedCommand] = useState<string | null>(null)
+  const [showStepDetails, setShowStepDetails] = useState<boolean>(true)
 
   // for resizable columns
   const [leftWidth, setLeftWidth] = useState<number>(INITIAL_WIDTH_PX)
@@ -305,10 +306,8 @@ export function ProtocolVisualization(
             setSelectedCommand={setSelectedCommand}
             milliSecondsPerFrame={milliSecondsPerFrame}
             setMilliSecondsPerFrame={setMilliSecondsPerFrame}
-            // 将来のサイドバー制御をバインド可能
-            onClickStepDetail={() => {
-              console.log('Toggle sidebar action')
-            }}
+            showStepDetails={showStepDetails}
+            onClickStepDetails={setShowStepDetails}
           />
         </div>
         {/* Gutter between center & right */}
@@ -323,7 +322,7 @@ export function ProtocolVisualization(
           className={styles.right_column}
           style={{ width: `${rightWidth}px` }}
         >
-          {selectedRunTimeCommand != null ? (
+          {selectedRunTimeCommand != null && showStepDetails ? (
             <StepDetailContainer
               commands={commands}
               robotState={robotState}


### PR DESCRIPTION
# Overview
activate step details button in playback controls

https://opentrons.slack.com/files/U036EGBKY76/F0BPPBYNA76/stepdetailsbutton.mov

closes AUTH-3174

## Test Plan and Hands on Testing


## Changelog
- add useState to show/hide the step details col

## Review requests


## Risk assessment
low
