### PR TITLE
refactor(shared-data, api, hardware-testing): Bump VM commands

### DIFF
--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -1868,19 +1868,19 @@ class VacuumModuleContext(ModuleContext):
     Moving labware to or from the Vacuum Module is blocked while the pump is running
     or while the system is still under vacuum. To move labware, stop the pump, then open the vent, and wait for the pressure to return to atmospheric (0 mbar).
 
-    *New in version 2.30*
+    *New in version 2.31*
     """
 
     _core: VacuumModuleCore
 
     @property
-    @requires_version(2, 30)
+    @requires_version(2, 31)
     def serial_number(self) -> str:
         """Get the module's unique hardware serial number."""
         return self._core.get_serial_number()
 
     @property
-    @requires_version(2, 30)
+    @requires_version(2, 31)
     def max_gauge_pressure_mbar(self) -> int:
         """The maximum (deepest) vacuum pressure supported by the module (-800 mbar).
 
@@ -1889,7 +1889,7 @@ class VacuumModuleContext(ModuleContext):
         return self._core.get_max_gauge_pressure_mbar()
 
     @property
-    @requires_version(2, 30)
+    @requires_version(2, 31)
     def min_gauge_pressure_mbar(self) -> int:
         """The minimum vacuum pressure supported by the module (0 mbar, or atmospheric pressure).
 
@@ -1898,7 +1898,7 @@ class VacuumModuleContext(ModuleContext):
         return self._core.get_min_gauge_pressure_mbar()
 
     @property
-    @requires_version(2, 30)
+    @requires_version(2, 31)
     def manifold_dock(self) -> ModuleFixtureLocation:
         """Deck location for the Vacuum Module manifold dock / staging area.
 
@@ -1914,7 +1914,7 @@ class VacuumModuleContext(ModuleContext):
         area_name = f"{self.model}Dock{base_slot[0]}4"
         return ModuleFixtureLocation(addressable_area_name=area_name)
 
-    @requires_version(2, 30)
+    @requires_version(2, 31)
     def load_adapter_to_dock(
         self,
         name: str,
@@ -1957,7 +1957,7 @@ class VacuumModuleContext(ModuleContext):
 
         return adapter
 
-    @requires_version(2, 30)
+    @requires_version(2, 31)
     def move_to_dock(
         self,
         labware: Labware,
@@ -1994,7 +1994,7 @@ class VacuumModuleContext(ModuleContext):
             drop_offset=_drop_offset,
         )
 
-    @requires_version(2, 30)
+    @requires_version(2, 31)
     @publish(command=cmds.vacuum_module_start_set_vacuum_pressure)
     def start_set_vacuum_pressure(
         self,
@@ -2033,7 +2033,7 @@ class VacuumModuleContext(ModuleContext):
 
         return Task(api_version=self._api_version, core=task)
 
-    @requires_version(2, 30)
+    @requires_version(2, 31)
     @publish(command=cmds.vacuum_module_start_set_vacuum_power)
     def start_set_vacuum_power(
         self,
@@ -2072,7 +2072,7 @@ class VacuumModuleContext(ModuleContext):
 
         return Task(api_version=self._api_version, core=task)
 
-    @requires_version(2, 30)
+    @requires_version(2, 31)
     @publish(command=cmds.vacuum_module_stop_vacuum)
     def stop_vacuum_pump(self) -> None:
         """Stop the vacuum pump and disable active pressure and power control.
@@ -2081,7 +2081,7 @@ class VacuumModuleContext(ModuleContext):
         """
         self._core.stop_vacuum()
 
-    @requires_version(2, 30)
+    @requires_version(2, 31)
     @publish(command=cmds.vacuum_module_start_execute_profile)
     def start_execute_profile(
         self,
@@ -2135,7 +2135,7 @@ class VacuumModuleContext(ModuleContext):
         )
         return Task(api_version=self._api_version, core=task)
 
-    @requires_version(2, 30)
+    @requires_version(2, 31)
     @publish(command=cmds.vacuum_module_open_vent)
     def open_vent(self, equalize_timeout_s: Optional[int] = None) -> None:
         """Open the vent valve to bring the system to atmospheric pressure (0 mbar).
@@ -2147,7 +2147,7 @@ class VacuumModuleContext(ModuleContext):
         """
         self._core.open_vent(equalize_timeout_s=equalize_timeout_s)
 
-    @requires_version(2, 30)
+    @requires_version(2, 31)
     @publish(command=cmds.vacuum_module_close_vent)
     def close_vent(self) -> None:
         """Close the vent so the system can hold vacuum.

--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -1,6 +1,6 @@
 from .types import APIVersion
 
-MAX_SUPPORTED_VERSION = APIVersion(2, 30)
+MAX_SUPPORTED_VERSION = APIVersion(2, 31)
 """The maximum supported protocol API version in this release."""
 
 MIN_SUPPORTED_VERSION = APIVersion(2, 0)

--- a/api/tests/opentrons/protocol_api/test_vacuum_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_vacuum_module_context.py
@@ -83,7 +83,7 @@ def subject(
 
 
 @pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 30))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 31))
 )
 def test_get_serial_number(
     decoy: Decoy, mock_core: VacuumModuleCore, subject: VacuumModuleContext
@@ -95,7 +95,7 @@ def test_get_serial_number(
 
 
 @pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 30))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 31))
 )
 def test_vacuum_module_manifold_dock_property(
     subject: VacuumModuleContext,
@@ -106,7 +106,7 @@ def test_vacuum_module_manifold_dock_property(
 
 
 @pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 30))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 31))
 )
 def test_vacuum_module_load_adapter_to_dock(
     decoy: Decoy,
@@ -157,7 +157,7 @@ def test_vacuum_module_load_adapter_to_dock(
 
 
 @pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 30))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 31))
 )
 def test_vacuum_module_move_to_dock(
     decoy: Decoy,
@@ -168,7 +168,7 @@ def test_vacuum_module_move_to_dock(
     """It should move labware to the manifold dock."""
     mock_labware = Labware(
         core=mock_labware_core,
-        api_version=APIVersion(2, 30),
+        api_version=APIVersion(2, 31),
         protocol_core=mock_protocol_core,
         core_map=decoy.mock(cls=LoadedCoreMap),
     )
@@ -188,7 +188,7 @@ def test_vacuum_module_move_to_dock(
 
 
 @pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 30))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 31))
 )
 def test_vacuum_module_move_to_dock_with_options(
     decoy: Decoy,
@@ -199,7 +199,7 @@ def test_vacuum_module_move_to_dock_with_options(
     """It should pass through use_gripper and offsets correctly."""
     mock_labware = Labware(
         core=mock_labware_core,
-        api_version=APIVersion(2, 30),
+        api_version=APIVersion(2, 31),
         protocol_core=mock_protocol_core,
         core_map=decoy.mock(cls=LoadedCoreMap),
     )
@@ -227,7 +227,7 @@ def test_vacuum_module_move_to_dock_with_options(
 
 
 @pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 30))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 31))
 )
 def test_vacuum_module_start_set_vacuum_pressure(
     decoy: Decoy,
@@ -262,7 +262,7 @@ def test_vacuum_module_start_set_vacuum_pressure(
 
 
 @pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 30))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 31))
 )
 def test_vacuum_module_start_set_vacuum_power(
     decoy: Decoy,
@@ -297,7 +297,7 @@ def test_vacuum_module_start_set_vacuum_power(
 
 
 @pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 30))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 31))
 )
 def test_vacuum_module_stop_vacuum(
     decoy: Decoy,
@@ -311,7 +311,7 @@ def test_vacuum_module_stop_vacuum(
 
 
 @pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 30))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 31))
 )
 def test_vacuum_module_start_execute_profile(
     decoy: Decoy,

--- a/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
+++ b/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
@@ -60,7 +60,7 @@ from opentrons import version
 import sys
 
 metadata = {"protocolName": "Gravimetric QC V3"}
-requirements = {"robotType": "Flex", "apiLevel": "2.30"}
+requirements = {"robotType": "Flex", "apiLevel": "2.31"}
 
 SCALE_SECONDS_TO_TRUE_STABILIZE = 60 * 3
 

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/high_temp_test/high_temp_vm_test.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/high_temp_test/high_temp_vm_test.py
@@ -8,7 +8,7 @@ from opentrons.protocol_api import ParameterContext
 from opentrons.drivers import vacuum_module  # type: ignore[import]
 
 metadata = {"protocolName": "VM 400mbar Stress Test-water pump impl"}
-requirements = {"robotType": "Flex", "apiLevel": "2.30"}
+requirements = {"robotType": "Flex", "apiLevel": "2.31"}
 
 Ard_idVendor = 9025
 Ard_idProduct = 66

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/protocol_api_demo/vacuum_module_api_demo.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/protocol_api_demo/vacuum_module_api_demo.py
@@ -13,7 +13,7 @@ metadata = {
 }
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.30",
+    "apiLevel": "2.31",
 }
 
 
@@ -21,7 +21,7 @@ requirements = {
 
 # --------------------Vacuum Module API --------------------
 
-apiLevel: 2.30
+apiLevel: 2.31
 
 1.
     vm_mod.close_vent()

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/protocol_api_demo/vacuum_module_science_demo_protocol.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/protocol_api_demo/vacuum_module_science_demo_protocol.py
@@ -13,7 +13,7 @@ metadata = {
 }
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.30",
+    "apiLevel": "2.31",
 }
 
 

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/protocol_api_demo/vacuum_module_still_under_vacuum_test.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/protocol_api_demo/vacuum_module_still_under_vacuum_test.py
@@ -30,7 +30,7 @@ metadata = {
 }
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.30",
+    "apiLevel": "2.31",
 }
 
 

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/slas_2026_demo/slas_2026_demo.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/slas_2026_demo/slas_2026_demo.py
@@ -15,7 +15,7 @@ metadata = {
 }
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.30",
+    "apiLevel": "2.31",
 }
 
 

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_async_error_test.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_async_error_test.py
@@ -45,7 +45,7 @@ metadata = {
 }
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.30",
+    "apiLevel": "2.31",
 }
 
 _PRESET_GCODE: dict[str, str] = {

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_equalize_move_labware_test.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_equalize_move_labware_test.py
@@ -46,7 +46,7 @@ metadata = {
 }
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.30",
+    "apiLevel": "2.31",
 }
 
 # Mild vacuum + short holds keep QC / sim runs fast.

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_labware_verification_protocol.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_labware_verification_protocol.py
@@ -18,7 +18,7 @@ metadata = {
 }
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.30",
+    "apiLevel": "2.31",
 }
 
 COLLAR_CHOICES: List[ParameterChoice] = [

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_qc_protocol.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_qc_protocol.py
@@ -18,7 +18,7 @@ metadata = {
 }
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.30",
+    "apiLevel": "2.31",
 }
 
 PIPETTE_CHOICES: List[ParameterChoice] = [

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_still_under_vacuum_test.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_still_under_vacuum_test.py
@@ -30,7 +30,7 @@ metadata = {
 }
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.30",
+    "apiLevel": "2.31",
 }
 
 

--- a/shared-data/command/schemas/18.json
+++ b/shared-data/command/schemas/18.json
@@ -1131,6 +1131,54 @@
       "title": "CloseLabwareLatchParams",
       "type": "object"
     },
+    "CloseVentCreate": {
+      "description": "A request to close the vent.",
+      "properties": {
+        "commandAnnotationIds": {
+          "description": "A list of command annotation IDs (if any) that apply to this command.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Commandannotationids",
+          "type": "array"
+        },
+        "commandType": {
+          "const": "vacuumModule/closeVent",
+          "default": "vacuumModule/closeVent",
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CloseVentParams"
+        }
+      },
+      "required": ["params"],
+      "title": "CloseVentCreate",
+      "type": "object"
+    },
+    "CloseVentParams": {
+      "description": "Input parameters to close the vent.",
+      "properties": {
+        "moduleId": {
+          "description": "Unique ID of the vacuum module.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "CloseVentParams",
+      "type": "object"
+    },
     "ColumnNozzleLayoutConfiguration": {
       "description": "Information required for nozzle configurations of type ROW and COLUMN.",
       "properties": {
@@ -4706,6 +4754,60 @@
       "title": "OpenLabwareLatchParams",
       "type": "object"
     },
+    "OpenVentCreate": {
+      "description": "A request to open the vent.",
+      "properties": {
+        "commandAnnotationIds": {
+          "description": "A list of command annotation IDs (if any) that apply to this command.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Commandannotationids",
+          "type": "array"
+        },
+        "commandType": {
+          "const": "vacuumModule/openVent",
+          "default": "vacuumModule/openVent",
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/OpenVentParams"
+        }
+      },
+      "required": ["params"],
+      "title": "OpenVentCreate",
+      "type": "object"
+    },
+    "OpenVentParams": {
+      "description": "Input parameters to open the vent.",
+      "properties": {
+        "equalizeTimeout": {
+          "default": null,
+          "description": "Time in seconds to wait for pressure equalization after opening the vent. Does not wait if None.",
+          "title": "Equalizetimeout",
+          "type": "integer"
+        },
+        "moduleId": {
+          "description": "Unique ID of the vacuum module.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "OpenVentParams",
+      "type": "object"
+    },
     "PickUpTipCreate": {
       "description": "Pick up tip command creation request model.",
       "properties": {
@@ -6524,11 +6626,342 @@
       "title": "StartRunExtendedProfileParams",
       "type": "object"
     },
+    "StartRunProfileCreate": {
+      "description": "A request to run a vacuum module profile.",
+      "properties": {
+        "commandAnnotationIds": {
+          "description": "A list of command annotation IDs (if any) that apply to this command.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Commandannotationids",
+          "type": "array"
+        },
+        "commandType": {
+          "const": "vacuumModule/startRunProfile",
+          "default": "vacuumModule/startRunProfile",
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/StartRunProfileParams"
+        }
+      },
+      "required": ["params"],
+      "title": "StartRunProfileCreate",
+      "type": "object"
+    },
+    "StartRunProfileParams": {
+      "description": "Input parameters to run a vacuum profile.",
+      "properties": {
+        "equalizeTimeout": {
+          "default": null,
+          "description": "Time in seconds to wait for pressure equalization after the profile completes if ventAfter is True. Does not wait if None.",
+          "title": "Equalizetimeout",
+          "type": "integer"
+        },
+        "moduleId": {
+          "description": "Unique ID of the vacuum module.",
+          "title": "Moduleid",
+          "type": "string"
+        },
+        "profile": {
+          "description": "List of Vacuum Module profile steps.",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/VacuumModuleProfilePowerStep"
+              },
+              {
+                "$ref": "#/$defs/VacuumModuleProfilePressureStep"
+              },
+              {
+                "$ref": "#/$defs/VacuumModuleProfileCycle"
+              }
+            ]
+          },
+          "title": "Profile",
+          "type": "array"
+        },
+        "taskId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The id of the profile task",
+          "title": "Taskid"
+        },
+        "ventAfter": {
+          "default": false,
+          "description": "Whether to open the vent after the profile is complete.",
+          "title": "Ventafter",
+          "type": "boolean"
+        }
+      },
+      "required": ["moduleId", "profile"],
+      "title": "StartRunProfileParams",
+      "type": "object"
+    },
+    "StartSetVacuumPowerCreate": {
+      "description": "A request to set the vacuum pump power.",
+      "properties": {
+        "commandAnnotationIds": {
+          "description": "A list of command annotation IDs (if any) that apply to this command.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Commandannotationids",
+          "type": "array"
+        },
+        "commandType": {
+          "const": "vacuumModule/startSetVacuumPower",
+          "default": "vacuumModule/startSetVacuumPower",
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/StartSetVacuumPowerParams"
+        }
+      },
+      "required": ["params"],
+      "title": "StartSetVacuumPowerCreate",
+      "type": "object"
+    },
+    "StartSetVacuumPowerParams": {
+      "description": "Input parameters to start the vacuum pump.",
+      "properties": {
+        "duration": {
+          "default": null,
+          "description": "Duration in sec. to hold target power for after it is reached.",
+          "title": "Duration",
+          "type": "integer"
+        },
+        "equalizeTimeout": {
+          "default": null,
+          "description": "Time in seconds to wait for pressure equalization after opening the vent. Does not wait if None.",
+          "title": "Equalizetimeout",
+          "type": "integer"
+        },
+        "moduleId": {
+          "description": "Unique ID of the vacuum module.",
+          "title": "Moduleid",
+          "type": "string"
+        },
+        "percentPower": {
+          "description": "Desired duty cycle of the vacuum pump as a percentage between 1 and 100%.",
+          "title": "Percentpower",
+          "type": "integer"
+        },
+        "rate": {
+          "default": null,
+          "description": "Target rate of power change in mbar/sec",
+          "title": "Rate",
+          "type": "number"
+        },
+        "taskId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The id of the task",
+          "title": "Taskid"
+        },
+        "timeout": {
+          "default": null,
+          "description": "Specify timeframe in seconds that target power must be reached in before a timeout error occurs.",
+          "title": "Timeout",
+          "type": "integer"
+        },
+        "ventAfter": {
+          "default": true,
+          "description": "Whether the system should open the vent after the target power is held for the duration.",
+          "title": "Ventafter",
+          "type": "boolean"
+        }
+      },
+      "required": ["moduleId", "percentPower"],
+      "title": "StartSetVacuumPowerParams",
+      "type": "object"
+    },
+    "StartSetVacuumPressureCreate": {
+      "description": "A request to start the vacuum pump.",
+      "properties": {
+        "commandAnnotationIds": {
+          "description": "A list of command annotation IDs (if any) that apply to this command.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Commandannotationids",
+          "type": "array"
+        },
+        "commandType": {
+          "const": "vacuumModule/startSetVacuumPressure",
+          "default": "vacuumModule/startSetVacuumPressure",
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/StartSetVacuumPressureParams"
+        }
+      },
+      "required": ["params"],
+      "title": "StartSetVacuumPressureCreate",
+      "type": "object"
+    },
+    "StartSetVacuumPressureParams": {
+      "description": "Input parameters to set the internal vacuum pressure.",
+      "properties": {
+        "duration": {
+          "default": null,
+          "description": "Duration in sec. to hold target pressure for after it is reached.",
+          "title": "Duration",
+          "type": "integer"
+        },
+        "equalizeTimeout": {
+          "default": null,
+          "description": "Time in seconds to wait for pressure equalization after opening the vent. Does not wait if None.",
+          "title": "Equalizetimeout",
+          "type": "integer"
+        },
+        "gaugePressure": {
+          "description": "Target gauge pressure in mBar.",
+          "title": "Gaugepressure",
+          "type": "number"
+        },
+        "moduleId": {
+          "description": "Unique ID of the vacuum module.",
+          "title": "Moduleid",
+          "type": "string"
+        },
+        "rate": {
+          "default": null,
+          "description": "Target rate of pressure change in mbar/sec",
+          "title": "Rate",
+          "type": "number"
+        },
+        "taskId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The id of the task",
+          "title": "Taskid"
+        },
+        "timeout": {
+          "default": null,
+          "description": "Specify timeframe in seconds that pressure must be reached in before a timeout error occurs.",
+          "title": "Timeout",
+          "type": "integer"
+        },
+        "ventAfter": {
+          "default": true,
+          "description": "Whether the system should open the vent after the target pressure is held for the duration.",
+          "title": "Ventafter",
+          "type": "boolean"
+        }
+      },
+      "required": ["moduleId", "gaugePressure"],
+      "title": "StartSetVacuumPressureParams",
+      "type": "object"
+    },
     "StatusBarAnimation": {
       "description": "Status Bar animation options.",
       "enum": ["idle", "confirm", "updating", "disco", "off"],
       "title": "StatusBarAnimation",
       "type": "string"
+    },
+    "StopVacuumCreate": {
+      "description": "A request to stop the vacuum pump.",
+      "properties": {
+        "commandAnnotationIds": {
+          "description": "A list of command annotation IDs (if any) that apply to this command.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Commandannotationids",
+          "type": "array"
+        },
+        "commandType": {
+          "const": "vacuumModule/stopVacuum",
+          "default": "vacuumModule/stopVacuum",
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/StopVacuumParams"
+        }
+      },
+      "required": ["params"],
+      "title": "StopVacuumCreate",
+      "type": "object"
+    },
+    "StopVacuumParams": {
+      "description": "Input parameters to stop the vacuum pump.",
+      "properties": {
+        "moduleId": {
+          "description": "Unique ID of the vacuum module.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "StopVacuumParams",
+      "type": "object"
     },
     "StoreCreate": {
       "description": "A request to execute a Flex Stacker store command.",
@@ -7422,6 +7855,121 @@
       "title": "UpdatePositionEstimatorsParams",
       "type": "object"
     },
+    "VacuumModuleProfileCycle": {
+      "description": "Input parameters for a vacuum module cycle.",
+      "properties": {
+        "repetitions": {
+          "title": "Repetitions",
+          "type": "integer"
+        },
+        "steps": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/VacuumModuleProfilePowerStep"
+              },
+              {
+                "$ref": "#/$defs/VacuumModuleProfilePressureStep"
+              }
+            ]
+          },
+          "title": "Steps",
+          "type": "array"
+        },
+        "ventAfter": {
+          "default": null,
+          "title": "Ventafter",
+          "type": "boolean"
+        }
+      },
+      "required": ["steps", "repetitions"],
+      "title": "VacuumModuleProfileCycle",
+      "type": "object"
+    },
+    "VacuumModuleProfilePowerStep": {
+      "description": "Input parameters for a vacuum module Power Step.",
+      "properties": {
+        "enablePump": {
+          "title": "Enablepump",
+          "type": "boolean"
+        },
+        "holdTimeMinutes": {
+          "default": null,
+          "title": "Holdtimeminutes",
+          "type": "integer"
+        },
+        "holdTimeSeconds": {
+          "default": null,
+          "title": "Holdtimeseconds",
+          "type": "integer"
+        },
+        "percentPower": {
+          "default": null,
+          "title": "Percentpower",
+          "type": "integer"
+        },
+        "rampRate": {
+          "default": null,
+          "title": "Ramprate",
+          "type": "number"
+        },
+        "timeoutSeconds": {
+          "default": null,
+          "title": "Timeoutseconds",
+          "type": "integer"
+        },
+        "ventAfter": {
+          "default": null,
+          "title": "Ventafter",
+          "type": "boolean"
+        }
+      },
+      "required": ["enablePump"],
+      "title": "VacuumModuleProfilePowerStep",
+      "type": "object"
+    },
+    "VacuumModuleProfilePressureStep": {
+      "description": "Input parameters for a vacuum module Pressure Step.",
+      "properties": {
+        "enablePump": {
+          "title": "Enablepump",
+          "type": "boolean"
+        },
+        "gaugePressureMbar": {
+          "default": null,
+          "title": "Gaugepressurembar",
+          "type": "integer"
+        },
+        "holdTimeMinutes": {
+          "default": null,
+          "title": "Holdtimeminutes",
+          "type": "integer"
+        },
+        "holdTimeSeconds": {
+          "default": null,
+          "title": "Holdtimeseconds",
+          "type": "integer"
+        },
+        "rampRate": {
+          "default": null,
+          "title": "Ramprate",
+          "type": "number"
+        },
+        "timeoutSeconds": {
+          "default": null,
+          "title": "Timeoutseconds",
+          "type": "integer"
+        },
+        "ventAfter": {
+          "default": null,
+          "title": "Ventafter",
+          "type": "boolean"
+        }
+      },
+      "required": ["enablePump"],
+      "title": "VacuumModuleProfilePressureStep",
+      "type": "object"
+    },
     "Vec3f": {
       "description": "A 3D vector of floats.",
       "properties": {
@@ -8209,7 +8757,7 @@
       "type": "object"
     }
   },
-  "$id": "opentronsCommandSchemaV17",
+  "$id": "opentronsCommandSchemaV18",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "discriminator": {
     "mapping": {
@@ -8316,6 +8864,12 @@
       "unsafe/ungripLabware": "#/$defs/UnsafeUngripLabwareCreate",
       "unsafe/updatePositionEstimators": "#/$defs/UpdatePositionEstimatorsCreate",
       "unsealPipetteFromTip": "#/$defs/UnsealPipetteFromTipCreate",
+      "vacuumModule/closeVent": "#/$defs/CloseVentCreate",
+      "vacuumModule/openVent": "#/$defs/OpenVentCreate",
+      "vacuumModule/startRunProfile": "#/$defs/StartRunProfileCreate",
+      "vacuumModule/startSetVacuumPower": "#/$defs/StartSetVacuumPowerCreate",
+      "vacuumModule/startSetVacuumPressure": "#/$defs/StartSetVacuumPressureCreate",
+      "vacuumModule/stopVacuum": "#/$defs/StopVacuumCreate",
       "verifyTipPresence": "#/$defs/VerifyTipPresenceCreate",
       "waitForDuration": "#/$defs/WaitForDurationCreate",
       "waitForResume": "#/$defs/WaitForResumeCreate",
@@ -8584,6 +9138,24 @@
     },
     {
       "$ref": "#/$defs/EmptyCreate"
+    },
+    {
+      "$ref": "#/$defs/StopVacuumCreate"
+    },
+    {
+      "$ref": "#/$defs/StartSetVacuumPressureCreate"
+    },
+    {
+      "$ref": "#/$defs/StartSetVacuumPowerCreate"
+    },
+    {
+      "$ref": "#/$defs/OpenVentCreate"
+    },
+    {
+      "$ref": "#/$defs/CloseVentCreate"
+    },
+    {
+      "$ref": "#/$defs/StartRunProfileCreate"
     },
     {
       "$ref": "#/$defs/CalibrateGripperCreate"


### PR DESCRIPTION
# Overview

Because the VM will ship in a version proceeding 10.0.0, and 10.0.0 will contain PAPI additions and modifications, we should bump all the VM related commands to 2.31, the subsequent PAPI version.

## Test Plan and Hands on Testing

- Sufficiently covered by CI.

## Changelog

- Bumped VM PAPI commands to v2.31.

## Risk assessment

- low, only risk is if we forget to bump a VM command
