### PR TITLE
fix(step-generation): robust check for collar movement safety to main manifold

### DIFF
--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -107,6 +107,10 @@ export function getIsVacuumSpacer(def: LabwareDefinition2): boolean {
   return VACUUM_SPACER_LOAD_NAMES.includes(def.parameters.loadName)
 }
 
+const getIsVacuumCollar = (def: LabwareDefinition2): boolean => {
+  return (def.parameters.quirks ?? []).includes('vacuumModuleDock')
+}
+
 type trashOrLabware = 'wasteChute' | 'trashBin' | 'labware' | null
 
 export const getCutoutIdByAddressableArea = (
@@ -1106,6 +1110,11 @@ export const getIsLabwareCompatibleWithStack = (
     const isLidRole = allowedRoles.includes('lid')
 
     const isVacuumSpacer = getIsVacuumSpacer(topLabwareEntity.def)
+    const isOccupiedByCollar = stack.some(
+      entityId =>
+        entityId in labwareEntities &&
+        getIsVacuumCollar(labwareEntities[entityId].def)
+    )
     const movingLabwareIsCollar =
       movingLabwareEntity.def.parameters.quirks?.includes('vacuumModuleDock') ??
       false
@@ -1121,7 +1130,7 @@ export const getIsLabwareCompatibleWithStack = (
           false
         )) ||
       // vacuum spacer: same rules as the main module area — only collars and filter plates
-      (isVacuumSpacer && movingLabwareIsCollar) ||
+      (!isOccupiedByCollar && movingLabwareIsCollar) ||
       // any labware can go onto an adapter that provides a stacking default (spacers excluded above)
       ((topLabwareEntity.def.parameters.quirks?.includes(
         'providesStackingDefault'


### PR DESCRIPTION
# Overview

Provides more robust safety check for moving a collar to the main vacuum module manifold area. Rather than simply checking the top labware of the stack on the manifold, we need to check whether any element of the stack is a collar. If not, the move is safe (some combination of spacer, collection plate, and filter plate).

Closes RQA-5817

## Test Plan and Hands on Testing
[vac_test_collar_to_manifold.py](https://github.com/user-attachments/files/30994230/vac_test_collar_to_manifold.py)

- create or upload a protocol that loads a spacer + collection plate on the main vacuum area, and a collar (and optionally filter plate) on the dock
- create a move step to move the collar back to the main vacuum area (A3)
- verify that no timeline error surfaces

## Changelog

- check full stack of manifold-located labware to determine safety of moving a collar back to the manifold
- add utility for getting whether a labware is a vacuum collar

## Review requests

- see test plan

## Risk assessment

lowish