### PR TITLE
fix(app): enable login button and show error states

### DIFF
--- a/app/src/assets/localization/en/access_control.json
+++ b/app/src/assets/localization/en/access_control.json
@@ -32,6 +32,8 @@
   "on_device_login_confirm_password": "Confirm password",
   "on_device_login_new_password": "New password",
   "on_device_login_password_mismatch": "Passwords do not match.",
+  "on_device_login_password_required": "Password required",
+  "on_device_login_username_required": "Username required",
   "set_new_password_error_session_expired": "Your session has expired. Log in again to set a new password.",
   "set_new_password_error_update_failed": "Failed to update password. Try again.",
   "set_new_password_success": "Password reset for {{username}}",

--- a/app/src/organisms/Desktop/LoginModal/__tests__/LoginModal.test.tsx
+++ b/app/src/organisms/Desktop/LoginModal/__tests__/LoginModal.test.tsx
@@ -90,6 +90,12 @@ function mockLoginFailure(message: string): void {
   }))
 }
 
+function mockLoginAccountLocked(): void {
+  mockLoginFailure(
+    'Account locked. Please contact an administrator to unlock your account.'
+  )
+}
+
 function mockLoginSSLError(): void {
   const sslError = {
     isAxiosError: true,
@@ -183,6 +189,30 @@ describe('LoginModal', () => {
     screen.getByLabelText('Username')
     screen.getByLabelText('Password')
     screen.getByRole('button', { name: 'Forgot password?' })
+    expect(screen.getByRole('button', { name: 'Log in' })).toBeEnabled()
+  })
+
+  it('shows required field errors when log in is clicked with empty fields', () => {
+    renderAndOpenLoginModal()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Log in' }))
+
+    screen.getByText('Username required')
+    screen.getByText('Password required')
+    expect(submitPassword).not.toHaveBeenCalled()
+  })
+
+  it('shows a password required error when username is filled', () => {
+    renderAndOpenLoginModal()
+
+    fireEvent.change(screen.getByLabelText('Username'), {
+      target: { value: 'alice' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Log in' }))
+
+    screen.getByText('Password required')
+    expect(screen.queryByText('Username required')).toBeNull()
+    expect(submitPassword).not.toHaveBeenCalled()
   })
 
   it('shows forgot password content and returns to login on back', () => {
@@ -242,6 +272,24 @@ describe('LoginModal', () => {
 
     screen.getByText('Test error message')
     screen.getByText('Compliance Ready Software Login')
+  })
+
+  it('shows an account locked error when the account is locked', () => {
+    mockLoginAccountLocked()
+
+    renderAndOpenLoginModal()
+
+    fireEvent.change(screen.getByLabelText('Username'), {
+      target: { value: 'alice' },
+    })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'secret-password' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Log in' }))
+
+    screen.getByText(
+      'Account locked. Please contact an administrator to unlock your account.'
+    )
   })
 
   it('shows password expired view when login requires a new password', () => {

--- a/app/src/organisms/Desktop/LoginModal/index.tsx
+++ b/app/src/organisms/Desktop/LoginModal/index.tsx
@@ -37,6 +37,8 @@ import type { ComponentProps, Dispatch, SetStateAction } from 'react'
 interface LoginFormState {
   username: string
   logInPassword: string
+  usernameRequiredError: string | null
+  passwordRequiredError: string | null
   error: string | null
 }
 
@@ -60,6 +62,8 @@ type LoginModalScreen =
 const INITIAL_LOGIN_FORM: LoginFormState = {
   username: '',
   logInPassword: '',
+  usernameRequiredError: null,
+  passwordRequiredError: null,
   error: null,
 }
 
@@ -179,6 +183,8 @@ function LoginModalImpl(props: LoginModalImplProps): JSX.Element {
           formData: {
             username: successfulUsername,
             logInPassword: '',
+            usernameRequiredError: null,
+            passwordRequiredError: null,
             error: null,
           },
         })
@@ -192,7 +198,31 @@ function LoginModalImpl(props: LoginModalImplProps): JSX.Element {
     event.preventDefault()
     if (screen.kind !== 'login') return
     const { username, logInPassword } = screen.formData
-    submitPassword(username, logInPassword)
+    const trimmedUsername = username.trim()
+    const trimmedPassword = logInPassword.trim()
+    const usernameRequiredError =
+      trimmedUsername === ''
+        ? (t('access_control:on_device_login_username_required') as string)
+        : null
+    const passwordRequiredError =
+      trimmedPassword === ''
+        ? (t('access_control:on_device_login_password_required') as string)
+        : null
+
+    if (usernameRequiredError != null || passwordRequiredError != null) {
+      updateLoginFormData(setScreen, {
+        usernameRequiredError,
+        passwordRequiredError,
+        error: null,
+      })
+      return
+    }
+
+    updateLoginFormData(setScreen, {
+      usernameRequiredError: null,
+      passwordRequiredError: null,
+    })
+    submitPassword(trimmedUsername, trimmedPassword)
   }
 
   const validateConfirmPasswordMatch = (
@@ -213,16 +243,11 @@ function LoginModalImpl(props: LoginModalImplProps): JSX.Element {
   const footer = (() => {
     switch (screen.kind) {
       case 'login': {
-        const { username, logInPassword } = screen.formData
-        const isLoginDisabled =
-          username === '' || logInPassword === '' || isAuthLoading
         return (
           <PrimaryButton
             type="submit"
             form={loginFormId}
-            // todo(mm, 2026-06-02): Instead of outright disabling the submit button
-            // when any fields are missing, we should show errors on those fields.
-            disabled={isLoginDisabled}
+            disabled={isAuthLoading}
           >
             {t('access_control:log_in_link')}
           </PrimaryButton>
@@ -289,11 +314,15 @@ function LoginModalImpl(props: LoginModalImplProps): JSX.Element {
               formData={screen.formData}
               onSubmit={handleLoginSubmit}
               onUsernameChange={value => {
-                updateLoginFormData(setScreen, { username: value, error: null })
+                updateLoginFormData(setScreen, {
+                  username: value,
+                  usernameRequiredError: null,
+                })
               }}
               onLogInPasswordChange={value => {
                 updateLoginFormData(setScreen, {
                   logInPassword: value,
+                  passwordRequiredError: null,
                   error: null,
                 })
               }}
@@ -395,6 +424,7 @@ function LoginView(props: LoginViewProps): JSX.Element {
           title={t('access_control:login_form_username_field')}
           type="text"
           value={formData.username}
+          error={formData.usernameRequiredError ?? undefined}
           onChange={event => {
             onUsernameChange(event.target.value)
           }}
@@ -404,7 +434,9 @@ function LoginView(props: LoginViewProps): JSX.Element {
           title={t('access_control:login_form_password_field')}
           type="password"
           value={formData.logInPassword}
-          error={formData.error ?? undefined}
+          error={
+            formData.passwordRequiredError ?? formData.error ?? undefined
+          }
           onChange={event => {
             onLogInPasswordChange(event.target.value)
           }}

--- a/app/src/organisms/Desktop/LoginModal/index.tsx
+++ b/app/src/organisms/Desktop/LoginModal/index.tsx
@@ -434,9 +434,7 @@ function LoginView(props: LoginViewProps): JSX.Element {
           title={t('access_control:login_form_password_field')}
           type="password"
           value={formData.logInPassword}
-          error={
-            formData.passwordRequiredError ?? formData.error ?? undefined
-          }
+          error={formData.passwordRequiredError ?? formData.error ?? undefined}
           onChange={event => {
             onLogInPasswordChange(event.target.value)
           }}

--- a/app/src/resources/auth/hooks/__tests__/getOAuth2LoginErrorMessage.test.ts
+++ b/app/src/resources/auth/hooks/__tests__/getOAuth2LoginErrorMessage.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getOAuth2LoginErrorMessage } from '../getOAuth2LoginErrorMessage'
 
-const t = vi.fn((key: string, options?: { attemptsRemaining?: number }) => {
+const mockT = vi.fn((key: string, options?: { attemptsRemaining?: number }) => {
   if (key === 'login_error_incorrect_with_attempts_remaining') {
     return `incorrect (${options?.attemptsRemaining} remaining)`
   }
@@ -20,52 +20,48 @@ function axiosError(data: Record<string, unknown>): unknown {
   }
 }
 
+function getMessage(data: Record<string, unknown>): string {
+  return getOAuth2LoginErrorMessage(axiosError(data), mockT as any)
+}
+
 describe('getOAuth2LoginErrorMessage', () => {
+  beforeEach(() => {
+    mockT.mockClear()
+  })
+
   it('returns the locked message when the account is locked by an admin', () => {
-    const message = getOAuth2LoginErrorMessage(
-      axiosError({
+    expect(
+      getMessage({
         error: 'invalid_grant',
         opentrons_account_locked: true,
-      }),
-      t
-    )
-
-    expect(message).toBe('login_error_locked')
+      })
+    ).toBe('login_error_locked')
   })
 
   it('returns the locked message when login attempts are exhausted', () => {
-    const message = getOAuth2LoginErrorMessage(
-      axiosError({
+    expect(
+      getMessage({
         error: 'invalid_grant',
         opentrons_login_attempts_remaining: 0,
         opentrons_account_locked: true,
-      }),
-      t
-    )
-
-    expect(message).toBe('login_error_locked')
+      })
+    ).toBe('login_error_locked')
   })
 
   it('returns the attempts remaining message for a failed login', () => {
-    const message = getOAuth2LoginErrorMessage(
-      axiosError({
+    expect(
+      getMessage({
         error: 'invalid_grant',
         opentrons_login_attempts_remaining: 2,
-      }),
-      t
-    )
-
-    expect(message).toBe('incorrect (2 remaining)')
+      })
+    ).toBe('incorrect (2 remaining)')
   })
 
   it('returns the generic incorrect message when no lockout metadata is present', () => {
-    const message = getOAuth2LoginErrorMessage(
-      axiosError({
+    expect(
+      getMessage({
         error: 'invalid_grant',
-      }),
-      t
-    )
-
-    expect(message).toBe('login_error_incorrect')
+      })
+    ).toBe('login_error_incorrect')
   })
 })

--- a/app/src/resources/auth/hooks/__tests__/getOAuth2LoginErrorMessage.test.ts
+++ b/app/src/resources/auth/hooks/__tests__/getOAuth2LoginErrorMessage.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { getOAuth2LoginErrorMessage } from '../getOAuth2LoginErrorMessage'
+
+const t = vi.fn((key: string, options?: { attemptsRemaining?: number }) => {
+  if (key === 'login_error_incorrect_with_attempts_remaining') {
+    return `incorrect (${options?.attemptsRemaining} remaining)`
+  }
+  return key
+})
+
+function axiosError(data: Record<string, unknown>): unknown {
+  return {
+    isAxiosError: true,
+    message: 'Request failed',
+    response: {
+      status: 400,
+      data,
+    },
+  }
+}
+
+describe('getOAuth2LoginErrorMessage', () => {
+  it('returns the locked message when the account is locked by an admin', () => {
+    const message = getOAuth2LoginErrorMessage(
+      axiosError({
+        error: 'invalid_grant',
+        opentrons_account_locked: true,
+      }),
+      t
+    )
+
+    expect(message).toBe('login_error_locked')
+  })
+
+  it('returns the locked message when login attempts are exhausted', () => {
+    const message = getOAuth2LoginErrorMessage(
+      axiosError({
+        error: 'invalid_grant',
+        opentrons_login_attempts_remaining: 0,
+        opentrons_account_locked: true,
+      }),
+      t
+    )
+
+    expect(message).toBe('login_error_locked')
+  })
+
+  it('returns the attempts remaining message for a failed login', () => {
+    const message = getOAuth2LoginErrorMessage(
+      axiosError({
+        error: 'invalid_grant',
+        opentrons_login_attempts_remaining: 2,
+      }),
+      t
+    )
+
+    expect(message).toBe('incorrect (2 remaining)')
+  })
+
+  it('returns the generic incorrect message when no lockout metadata is present', () => {
+    const message = getOAuth2LoginErrorMessage(
+      axiosError({
+        error: 'invalid_grant',
+      }),
+      t
+    )
+
+    expect(message).toBe('login_error_incorrect')
+  })
+})

--- a/app/src/resources/auth/hooks/getOAuth2LoginErrorMessage.ts
+++ b/app/src/resources/auth/hooks/getOAuth2LoginErrorMessage.ts
@@ -5,7 +5,7 @@ import type { TFunction } from 'i18next'
 /**
  * Shape of an error response from `POST /auth/oauth2/token`: the standard
  * RFC 6749 § 5.2 fields plus the opentrons-specific
- * `opentrons_login_attempts_remaining` and `opentrons_account_locked` fields.
+ * `opentrons_login_attempts_remaining` field returned when the lockout limit is configured. `opentrons_account_locked` field returned when the account is locked by an admin.
  */
 interface OAuth2TokenErrorResponse {
   error?: string

--- a/app/src/resources/auth/hooks/getOAuth2LoginErrorMessage.ts
+++ b/app/src/resources/auth/hooks/getOAuth2LoginErrorMessage.ts
@@ -5,13 +5,13 @@ import type { TFunction } from 'i18next'
 /**
  * Shape of an error response from `POST /auth/oauth2/token`: the standard
  * RFC 6749 § 5.2 fields plus the opentrons-specific
- * `opentrons_login_attempts_remaining` field returned when the lockout limit
- * is configured.
+ * `opentrons_login_attempts_remaining` and `opentrons_account_locked` fields.
  */
 interface OAuth2TokenErrorResponse {
   error?: string
   error_description?: string
   opentrons_login_attempts_remaining?: number
+  opentrons_account_locked?: boolean
 }
 
 export function getOAuth2LoginErrorMessage(
@@ -22,15 +22,14 @@ export function getOAuth2LoginErrorMessage(
     const data = error.response?.data as OAuth2TokenErrorResponse | undefined
     const oauth2ErrorCode = data?.error
     const attemptsRemaining = data?.opentrons_login_attempts_remaining
+    const accountLocked = data?.opentrons_account_locked === true
     if (oauth2ErrorCode === 'invalid_grant') {
-      if (typeof attemptsRemaining === 'number') {
-        if (attemptsRemaining === 0) {
-          return t('login_error_locked')
-        } else {
-          return t('login_error_incorrect_with_attempts_remaining', {
-            attemptsRemaining,
-          })
-        }
+      if (accountLocked || attemptsRemaining === 0) {
+        return t('login_error_locked')
+      } else if (typeof attemptsRemaining === 'number') {
+        return t('login_error_incorrect_with_attempts_remaining', {
+          attemptsRemaining,
+        })
       } else {
         return t('login_error_incorrect')
       }

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -310,7 +310,9 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
             self.__send_audit_log(
                 "login failed", f"user {username} failed to login: account is locked"
             )
-            raise _CustomInvalidCredentialsError(login_attempts_remaining=None)
+            raise _CustomInvalidCredentialsError(
+                login_attempts_remaining=None, account_locked=True
+            )
 
         password_is_correct = password_hash.verify(password, user.hashed_password)
 
@@ -337,7 +339,9 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
             self.__send_audit_log(
                 "login failed", f"user {username} failed to login: {reason}"
             )
-            raise _CustomInvalidCredentialsError(attempts_remaining)
+            raise _CustomInvalidCredentialsError(
+                attempts_remaining, account_locked=is_currently_locked
+            )
 
         # If the credentials pass the gauntlet above, it's a successful login.
         self.__user_store.clear_failed_logins(username)
@@ -488,14 +492,18 @@ class _CustomInvalidCredentialsError(oauthlib.oauth2.InvalidGrantError):
     this way, but you gotta do what you gotta do.
     """
 
-    def __init__(self, login_attempts_remaining: int | None) -> None:
+    def __init__(
+        self, login_attempts_remaining: int | None, *, account_locked: bool = False
+    ) -> None:
         """Construct the error.
 
         Params:
             login_attempts_remaining: How many login attempts the user has left
                 before their account is locked, or `None` to omit that information.
+            account_locked: Whether the account is locked and requires admin unlock.
         """
         self.__login_attempts_remaining = login_attempts_remaining
+        self.__account_locked = account_locked
         super().__init__(
             description="Invalid credentials given.",  # Match oauthlib's default description.
             uri=None,
@@ -513,6 +521,8 @@ class _CustomInvalidCredentialsError(oauthlib.oauth2.InvalidGrantError):
             result["opentrons_login_attempts_remaining"] = (
                 self.__login_attempts_remaining
             )
+        if self.__account_locked:
+            result["opentrons_account_locked"] = True
         return json.dumps(result)
 
 

--- a/auth-server/tests/integration/test_failed_login_lockout.tavern.yaml
+++ b/auth-server/tests/integration/test_failed_login_lockout.tavern.yaml
@@ -80,6 +80,7 @@ stages:
         error: invalid_grant
         error_description: Invalid credentials given.
         opentrons_login_attempts_remaining: 0
+        opentrons_account_locked: true
 
   - name: Correct credentials, but rejected because of the lockout
     request:
@@ -96,6 +97,7 @@ stages:
         error: invalid_grant
         error_description: Invalid credentials given.
         opentrons_login_attempts_remaining: 0
+        opentrons_account_locked: true
 
   - name: Incorrect credentials rejected with exactly the same response (to prevent fishing for them)
     request:


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/EXEC-2714.
enable login button and show errors for username req, password req. 
added logic for account locked (admin locked)

## Test Plan and Hands on Testing


https://github.com/user-attachments/assets/7588520c-e10c-4b47-8637-93cbb8ac96f4

https://github.com/user-attachments/assets/f637a6c7-e192-4aaa-bef3-9dd3f7e31672


## Changelog

- added opentrons_account_locked to tken response. 
- added error states for account locked and login error states. 

## Risk assessment

low. 
