### PR TITLE
fix(protocol-designer): coerce A4-loaded VM into A3

### DIFF
--- a/protocol-designer/src/components/organisms/FlexHardware/util.ts
+++ b/protocol-designer/src/components/organisms/FlexHardware/util.ts
@@ -18,6 +18,7 @@ import {
   THERMOCYCLER_MODULE_TYPE,
   THERMOCYCLER_V2_REAR_FIXTURE,
   TRASH_BIN_ADAPTER_FIXTURE,
+  VACUUM_MODULE_V1,
   WASTE_CHUTE_FIXTURES,
 } from '@opentrons/shared-data'
 
@@ -539,7 +540,11 @@ const handleCreateModule = (ctx: ModuleEntry): void => {
     return
   }
 
-  const slot = getSlotDisplayNameFromAAWithFakes(value.addressableAreaId)
+  let slot: string = getSlotDisplayNameFromAAWithFakes(value.addressableAreaId)
+  // hard code override for Vacuum slot since we allow UI selection in A3 OR A4
+  if (model === VACUUM_MODULE_V1) {
+    slot = 'A3'
+  }
   dispatch(createModule({ slot, model, type }))
 }
 

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
@@ -35,6 +35,7 @@ import {
   THERMOCYCLER_MODULE_CUTOUTS,
   THERMOCYCLER_MODULE_V2,
   TRASH_BIN_ADAPTER_FIXTURE,
+  VACUUM_MODULE_V1,
   WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
 import { getSlotInLocationStack, uuid } from '@opentrons/step-generation'
@@ -313,6 +314,24 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
       .map(cf => cf.id)
       .includes(newModule.cutoutFixtureId as CutoutFixtureId)
 
+    const isVacuumModule = getCutoutFixturesForModuleModel(
+      VACUUM_MODULE_V1,
+      deckDef
+    )
+      .map(cf => cf.id)
+      .includes(newModule.cutoutFixtureId as CutoutFixtureId)
+
+    let slot: string = getSlotDisplayNameFromAAWithFakes(
+      newModule.addressableAreaId as AddressableAreaName
+    )
+    if (isThermocyclerModule) {
+      slot = 'B1'
+    }
+    if (isVacuumModule) {
+      slot = 'A3'
+    }
+    console.log({ isVacuumModule, slot })
+
     const updatedModules: FormModules = {
       ...filteredModules,
       ...(matchedModule != null &&
@@ -323,11 +342,7 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
       [uuid()]: {
         model: moduleModel,
         type: getModuleType(moduleModel as ModuleModel),
-        slot: isThermocyclerModule
-          ? 'B1'
-          : getSlotDisplayNameFromAAWithFakes(
-              newModule.addressableAreaId as AddressableAreaName
-            ),
+        slot,
         cutoutFixtureId: newModule.cutoutFixtureId as FlexModuleCutoutFixtureId,
         cutoutId: isThermocyclerModule ? 'cutoutB1' : newModule.cutoutId,
       },


### PR DESCRIPTION
# Overview

Special cases vacuum module "loaded" in A4, forcing the actual addition of the module to be loaded into slot A3 given the current PD architecture with respect to loading modules in slots.

Closes RQA-5857

## Test Plan and Hands on Testing

### onboarding
- create a flex protocol and load a vacuum module from clicking the A4 addressable area
- continue to deck setup and verify that the module renders correctly in A3+A4

### protocol editor
- delete the afore-added VM in the protocol editor > deck hardware view
- re-add the VM from A4, navigate back to starting deck state, and again verify that the module renders correctly in A3 + A4

## Changelog

- special case vacuum module addition from A4 (gross, but need to special case given the fact that this is not a combo fixture, and product/design require addition from A3 OR A4)

## Review requests

see test plan

## Risk assessment

Low