### PR TITLE
fix(protocol-visualization): fix z-index value for ModelessModal

### DIFF
--- a/protocol-visualization/src/organisms/WellTooltip/welltooltip.module.css
+++ b/protocol-visualization/src/organisms/WellTooltip/welltooltip.module.css
@@ -1,6 +1,6 @@
 .popper_content {
   position: fixed;
-  z-index: 2;
+  z-index: 1001;
   width: max-content;
   padding: var(--spacing-8);
   border-radius: var(--border-radius-8);


### PR DESCRIPTION


# Overview

z-index value will be modified after phase-1 because ModelessModal uses `1000`

<img width="331" height="311" alt="Screenshot 2026-08-12 at 6 17 01 PM" src="https://github.com/user-attachments/assets/88703687-33da-4ea2-8221-06693ee56a2a" />


closes ATUH-3186


## Test Plan and Hands on Testing
none

## Changelog
- update Welltooltip z-index

## Review requests


## Risk assessment
low
