### PR TITLE
fix(protocol-designer): remove trash requirement in Hardware page

### DIFF
--- a/protocol-designer/src/pages/Hardware/index.tsx
+++ b/protocol-designer/src/pages/Hardware/index.tsx
@@ -18,9 +18,7 @@ import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { NAV_BAR_HEIGHT_REM } from '../../components/atoms'
 import { FlexHardware, Ot2Modules } from '../../components/organisms'
-import { useKitchen } from '../../components/organisms/Kitchen/useKitchen'
 import { getFileMetadata, getRobotType } from '../../file-data/selectors'
-import { getAdditionalEquipmentEntities } from '../../step-forms/selectors'
 
 export function Hardware(): JSX.Element {
   const { t } = useTranslation([
@@ -31,14 +29,7 @@ export function Hardware(): JSX.Element {
   ])
   const fileMetadata = useSelector(getFileMetadata)
   const navigate = useNavigate()
-  const { makeSnackbar } = useKitchen()
   const robotType = useSelector(getRobotType)
-  const additionalEquipmentEntities = useSelector(
-    getAdditionalEquipmentEntities
-  )
-  const hasTrash = Object.values(additionalEquipmentEntities).some(
-    ae => ae.name === 'trashBin' || ae.name === 'wasteChute'
-  )
 
   const protocolName =
     fileMetadata.protocolName != null && fileMetadata.protocolName !== ''
@@ -85,11 +76,7 @@ export function Hardware(): JSX.Element {
           </StyledText>
           <PrimaryButton
             onClick={() => {
-              if (hasTrash) {
-                navigate('/overview')
-              } else {
-                makeSnackbar(t('starting_deck_state:trash_required') as string)
-              }
+              navigate('/overview')
             }}
           >
             {t('shared:save')}


### PR DESCRIPTION
# Overview

We no longer require a trash fixture to be loaded for a valid protocol. This PR removes that requirement from a missed place, in the Hardware component, mounted when clicking "Edit" on the hardware section of the protocol overview page.

Closes RQA-5864

## Test Plan and Hands on Testing

[asdf.py](https://github.com/user-attachments/files/31031646/asdf.1.py)

- create or import a protocol without a trash fixture
- from hardware section of protocols overview page, click "edit"
- click "Save" on hardware configurator, and verify that you are successfully kicked back to the overview page without a snackbar rendering

## Changelog

- remove trash requirement and cruft from `Hardware` page component

## Review requests

see test plan

## Risk assessment

low