### PR TITLE
fix(protocol-designer): fix vacuum ModuleLabel

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/ModuleLabel.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/ModuleLabel.tsx
@@ -22,7 +22,7 @@ import type {
 } from '@opentrons/shared-data'
 
 const CENTER_SLOT_WIDTH = 160
-const CETNER_SLOT_HEIGHT = 106
+const CENTER_SLOT_HEIGHT = 106
 const VACUUM_OFFSET_X = -19
 const VACUUM_OFFSET_Y = -10
 
@@ -99,7 +99,7 @@ export const ModuleLabel = (props: ModuleLabelProps): JSX.Element => {
         x={position[0] + VACUUM_OFFSET_X}
         y={position[1] - labelContainerHeight + VACUUM_OFFSET_Y}
         width={CENTER_SLOT_WIDTH}
-        height={CETNER_SLOT_HEIGHT}
+        height={CENTER_SLOT_HEIGHT}
         showModuleIcon={showModuleIcon}
       />
     )

--- a/protocol-designer/src/pages/Designer/DeckSetup/ModuleLabel.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/ModuleLabel.tsx
@@ -9,6 +9,7 @@ import {
   HEATERSHAKER_MODULE_TYPE,
   OT2_STANDARD_DECKID,
   TEMPERATURE_MODULE_TYPE,
+  VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
 import { getRobotType } from '../../../file-data/selectors'
@@ -19,6 +20,11 @@ import type {
   DeckSlotId,
   ModuleModel,
 } from '@opentrons/shared-data'
+
+const CENTER_SLOT_WIDTH = 160
+const CETNER_SLOT_HEIGHT = 106
+const VACUUM_OFFSET_X = -19
+const VACUUM_OFFSET_Y = -10
 
 interface ModuleLabelProps {
   showModuleIcon: boolean
@@ -71,6 +77,33 @@ export const ModuleLabel = (props: ModuleLabelProps): JSX.Element => {
     def?.moduleType === HEATERSHAKER_MODULE_TYPE && orientation === 'right' // shift depending on side of deck
       ? 7 // TODO(ND: 12/18/2024): investigate further why the module definition does not contain sufficient info to find this offset
       : 0
+
+  // This is incredibly unideal, but we need to special case the main vacuum module area, since there are
+  // no dimensions living on the module definition that point to the area's dimensions and origin.
+  // For the vacuum main area, we fall back to an arbitrary footprint that miimics a center slot's x and y,
+  // and manually alignt the label set to the corner of the cutout.
+  if (def?.moduleType === VACUUM_MODULE_TYPE) {
+    return (
+      <DeckLabelSet
+        ref={labelContainerRef}
+        deckLabels={[
+          ...labwareInfos,
+          {
+            text: labelName ?? def?.displayName,
+            isSelected,
+            isLast,
+            moduleModel: def?.model,
+            isZoomed: isZoomed,
+          },
+        ]}
+        x={position[0] + VACUUM_OFFSET_X}
+        y={position[1] - labelContainerHeight + VACUUM_OFFSET_Y}
+        width={CENTER_SLOT_WIDTH}
+        height={CETNER_SLOT_HEIGHT}
+        showModuleIcon={showModuleIcon}
+      />
+    )
+  }
 
   return (
     <DeckLabelSet


### PR DESCRIPTION
# Overview
Manually size and position ModuleLabel for main vacuum area. Unfortunately, this requires manual dimensions and positions, since there is no canonical set of values from the vacuum module definition or elsewhere that points to those specified in designs.

Closes RQA-5865

<img width="1719" height="903" alt="Screenshot 2026-08-13 at 10 25 00 AM" src="https://github.com/user-attachments/assets/67c7ae1d-178b-4186-bdc1-71df232f40bb" />

## Test Plan and Hands on Testing

- create or import a vacuum module protocol
- in starting deck, click the main vacuum module area and edit or add labware
- verify that the blue module label position and footprint matches designs

## Changelog

- add constants and render manual vacuum module label

## Review requests

see test plan

## Risk assessment

low