### PR TITLE
fix(components): fix slider thumb

### DIFF
--- a/components/src/atoms/Slider/slider.module.css
+++ b/components/src/atoms/Slider/slider.module.css
@@ -52,6 +52,6 @@
   appearance: none;
   background-color: var(--blue-50);
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='4' height='24'><rect width='4' height='24' rx='2' fill='white' fill-opacity='0.5'/></svg>");
-  background-repeat: no-repeat;
   background-position: center;
+  background-repeat: no-repeat;
 }

--- a/components/src/atoms/Slider/slider.module.css
+++ b/components/src/atoms/Slider/slider.module.css
@@ -31,7 +31,7 @@
   background: linear-gradient(
     to right,
     var(--blue-50) 0%,
-    var(--blue-50) var(--value-percent),
+    var(--blue-50) calc(var(--value-percent)),
     var(--slider-unfilled, var(--blue-20)) var(--value-percent),
     var(--slider-unfilled, var(--blue-20)) 100%
   );
@@ -46,9 +46,12 @@
 .slider::-webkit-slider-thumb {
   width: 12px;
   height: 32px;
-  border: 4px solid var(--blue-50);
+  border: none;
   border-radius: 4px;
   margin-top: -16px; /* Center thumb on the 0-height track */
   appearance: none;
-  background: var(--blue-30);
+  background-color: var(--blue-50);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='4' height='24'><rect width='4' height='24' rx='2' fill='white' fill-opacity='0.5'/></svg>");
+  background-repeat: no-repeat;
+  background-position: center;
 }

--- a/components/src/atoms/Slider/slider.module.css
+++ b/components/src/atoms/Slider/slider.module.css
@@ -31,7 +31,7 @@
   background: linear-gradient(
     to right,
     var(--blue-50) 0%,
-    var(--blue-50) calc(var(--value-percent)),
+    var(--blue-50) var(--value-percent),
     var(--slider-unfilled, var(--blue-20)) var(--value-percent),
     var(--slider-unfilled, var(--blue-20)) 100%
   );


### PR DESCRIPTION
# Overview

Fixes slider thumb such that it is 2 nested shapes with independent radii and colors.
<img width="976" height="165" alt="Screenshot 2026-08-13 at 11 31 37 AM" src="https://github.com/user-attachments/assets/06ba2fd0-7e28-4689-ad20-1135d321fc41" />

Closes RQA-5868

## Test Plan and Hands on Testing

- open and inspect slider component on storybook, or inspect slider component in PD vacuum power settings field

## Changelog

- fix thumb style on `Slider` component CSS module

## Review requests

see test plan

## Risk assessment

low