### PR TITLE
fix(protocol-designer): fix presaved profile step styling

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumStep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumStep.tsx
@@ -118,7 +118,7 @@ export function PresavedVacuumStep(
           />
         )}
         <div className={styles.presaved_content}>
-          <Flex flexDirection={DIRECTION_COLUMN} gap={SPACING.spacing8}>
+          <div className={styles.presaved_fields}>
             <div className={styles.presaved_vacuum_step_form_row}>
               <div className={styles.flex_fill}>
                 <InputField
@@ -199,7 +199,7 @@ export function PresavedVacuumStep(
                 updateField('ventAfter', !ventAfter)
               }}
             />
-          </Flex>
+          </div>
         </div>
       </div>
     </ListItem>
@@ -217,22 +217,27 @@ function StepEndingHoldField(props: {
     : t('vacuum.previous_state.vent.closed')
 
   return (
-    <ListButton
-      type="noActive"
-      padding={SPACING.spacing12}
-      width="100%"
-      justifyContent="space-between"
-      onClick={onChange}
-      backgroundColor={COLORS.white}
-      alignItems="center"
-    >
-      <StyledText desktopStyle="bodyDefaultRegular">
-        {t('vacuum.controls.ending_hold_vent.label')}
+    <div className={styles.presaved_vacuum_step_hold}>
+      <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
+        {t('vacuum.controls.ending_hold_vent.title')}
       </StyledText>
-      <div className={styles.ending_hold_toggle_row}>
-        <StyledText desktopStyle="bodyDefaultRegular">{label}</StyledText>
-        <ToggleButton label={label} toggledOn={toggledOn} />
-      </div>
-    </ListButton>
+      <ListButton
+        type="noActive"
+        padding={SPACING.spacing12}
+        width="100%"
+        justifyContent="space-between"
+        onClick={onChange}
+        backgroundColor={COLORS.white}
+        alignItems="center"
+      >
+        <StyledText desktopStyle="bodyDefaultRegular">
+          {t('vacuum.controls.ending_hold_vent.label')}
+        </StyledText>
+        <div className={styles.ending_hold_toggle_row}>
+          <StyledText desktopStyle="bodyDefaultRegular">{label}</StyledText>
+          <ToggleButton label={label} toggledOn={toggledOn} />
+        </div>
+      </ListButton>
+    </div>
   )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumStep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumStep.tsx
@@ -3,8 +3,6 @@ import { useTranslation } from 'react-i18next'
 
 import {
   COLORS,
-  DIRECTION_COLUMN,
-  Flex,
   Icon,
   InputField,
   ListButton,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/vacuumprofile.module.css
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/vacuumprofile.module.css
@@ -76,6 +76,12 @@
   background-color: var(--grey-40);
 }
 
+.presaved_fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-16);
+}
+
 .presaved_vacuum_step_content {
   display: flex;
   width: 100%;
@@ -90,6 +96,12 @@
   flex-direction: row;
   align-items: flex-start;
   gap: var(--spacing-12);
+}
+
+.presaved_vacuum_step_hold {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-8);
 }
 
 .cycle_steps_list {


### PR DESCRIPTION
# Overview

Add title and fix gap for ending hold vent list button.

Closes RQA-5870

## Test Plan and Hands on Testing

- create a vacuum step profile and open modal
- create a new presaved step and verify that spacing and text above ending hold vent list button matches designs ("Ending hold" title, 16px spacing)
<img width="759" height="621" alt="Screenshot 2026-08-13 at 2 13 57 PM" src="https://github.com/user-attachments/assets/3b1b1f4e-d6e1-4bce-b854-6f8410d60430" />

## Changelog

- fix style for presaved step

## Review requests

see test plan

## Risk assessment

⬇️ 