### PR TITLE
fix(protocol-designer): fix camera step summary style

### DIFF
--- a/protocol-designer/src/components/organisms/StepSummary/index.tsx
+++ b/protocol-designer/src/components/organisms/StepSummary/index.tsx
@@ -183,7 +183,9 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
     }
     case 'camera': {
       stepSummaryContent = (
-        <StyledTrans i18nKey={'protocol_steps:camera.capture_image'} />
+        <StyledText desktopStyle="bodyDefaultRegular">
+          {t('protocol_steps:camera.capture_image')}{' '}
+        </StyledText>
       )
       break
     }


### PR DESCRIPTION
# Overview

Update camera step summary text to correct style (desktop -> 'bodyDefaultRegular')

Closes RQA-5871

## Test Plan and Hands on Testing

- create and hover a camera step in PD
- verify that step summary text is `bodyDefaultRegular`

## Changelog

fix camera styled text implementation to match designs

## Review requests

see test plan

## Risk assessment

very low!