### PR TITLE
fix(app): During first-time setup of CRS, delete users before creating them

### DIFF
--- a/app/src/organisms/Desktop/EnableCRSWizard/useEnableCRSMutation.ts
+++ b/app/src/organisms/Desktop/EnableCRSWizard/useEnableCRSMutation.ts
@@ -72,8 +72,8 @@ export function useEnableCRSMutation(): UseMutationResult<
     ]
     for (const userToCreate of usersToCreate) {
       // If the user already exists, try deleting it to make room for our new one.
-      // This should never happen in normal production use, but it might happen in dev--
-      // users might be left over from prior testing.
+      // This might happen if a prior attempt to enable CRS was interrupted.
+      // It can also happen in dev, if users were left over from prior testing.
       try {
         await deleteUser(hostConfig, userToCreate.username)
       } catch {}

--- a/app/src/organisms/Desktop/EnableCRSWizard/useEnableCRSMutation.ts
+++ b/app/src/organisms/Desktop/EnableCRSWizard/useEnableCRSMutation.ts
@@ -4,7 +4,6 @@ import { useMutation, useQueryClient } from 'react-query'
 
 import {
   createUser,
-  CreateUserRequest,
   deleteUser,
   patchAccessControlEnabled,
 } from '@opentrons/api-client'
@@ -14,6 +13,7 @@ import {
 } from '@opentrons/react-api-client'
 
 import type { UseMutationResult } from 'react-query'
+import type { CreateUserRequest } from '@opentrons/api-client'
 
 export interface EnableCRSParams {
   adminAccount: AccountCreationParams

--- a/app/src/organisms/Desktop/EnableCRSWizard/useEnableCRSMutation.ts
+++ b/app/src/organisms/Desktop/EnableCRSWizard/useEnableCRSMutation.ts
@@ -2,7 +2,12 @@
 
 import { useMutation, useQueryClient } from 'react-query'
 
-import { createUser, patchAccessControlEnabled } from '@opentrons/api-client'
+import {
+  createUser,
+  CreateUserRequest,
+  deleteUser,
+  patchAccessControlEnabled,
+} from '@opentrons/api-client'
 import {
   accessControlEnabledQueryKey,
   useHost,
@@ -45,34 +50,35 @@ export function useEnableCRSMutation(): UseMutationResult<
       )
     }
 
-    // todo(mm, 2026-07-20): If the wizard was previously interrupted, these requests
-    // will fail because the users already exist. We might want to clear preexisting
-    // users beforehand.
-
-    await createUser(hostConfig, {
-      data: {
+    const usersToCreate: Array<CreateUserRequest['data']> = [
+      {
         accountType: 'admin',
         username: params.adminAccount.username,
         password: params.adminAccount.password,
         fullName: params.adminAccount.fullName,
       },
-    })
-    await createUser(hostConfig, {
-      data: {
+      {
         accountType: 'admin',
         username: params.recoveryAccount.username,
         password: params.recoveryAccount.password,
         fullName: params.recoveryAccount.fullName,
       },
-    })
-    await createUser(hostConfig, {
-      data: {
+      {
         accountType: 'service',
         username: params.serviceAccount.username,
         password: params.serviceAccount.password,
         fullName: params.serviceAccount.fullName,
       },
-    })
+    ]
+    for (const userToCreate of usersToCreate) {
+      // If the user already exists, try deleting it to make room for our new one.
+      // This should never happen in normal production use, but it might happen in dev--
+      // users might be left over from prior testing.
+      try {
+        await deleteUser(hostConfig, userToCreate.username)
+      } catch {}
+      await createUser(hostConfig, { data: userToCreate })
+    }
 
     const response = await patchAccessControlEnabled(hostConfig, {
       data: { accessControlEnabled: true },


### PR DESCRIPTION
## Overview

This closes RQA-5874.

For various reasons, in testing, sometimes a robot can have users on it even though CRS is disabled. If that happens, enabling CRS through the desktop app will fail: it will try to create users that already exist.

The same problem can also theoretically happen in production, if the first CRS setup was interrupted.

This works around it by deleting the old users to make room for the new ones.

## Test Plan and Hands on Testing

Tested on a local dev server.

## Review requests

Does this seem like a good enough solution?

## Risk assessment

Low.

This will "dangerously" destroy preexisting user data. However, none of this can run if CRS is already enabled. So I think the only preexisting user data that this might destroy is worthless cruft, anyway.