### PR TITLE
fix(protocol-designer): fix focus state rendering in vacuum profile input fields

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/vacuumprofile.module.css
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/vacuumprofile.module.css
@@ -91,7 +91,6 @@
 
 .presaved_vacuum_step_form_row {
   display: flex;
-  overflow: hidden;
   min-width: 0;
   flex-direction: row;
   align-items: flex-start;
@@ -137,7 +136,7 @@
 }
 
 .flex_fill {
-  overflow: hidden;
+  display: flex;
   min-width: 0;
   flex: 1;
 }


### PR DESCRIPTION
# Overview

Fix CSS module styles for vacuum profile, such that focused input fields render correctly.

Closes RQA-5869

## Test Plan and Hands on Testing

- create or import a vacuum PD protocol
- create or open a vacuum profile step, and open the profile modal
- click or tab to focus input fields, and verify that the border is not clipped

#### Before 

<img width="230" height="154" alt="Screenshot 2026-08-13 at 3 04 46 PM" src="https://github.com/user-attachments/assets/d7042361-c350-4c3c-a1b3-4129ad993be8" />

#### After
<img width="250" height="196" alt="Screenshot 2026-08-13 at 3 04 19 PM" src="https://github.com/user-attachments/assets/99818ec2-3386-4f7d-a5f2-d1ce072ad2d7" />


## Changelog

fix CSS module for vacuum profile

## Review requests

see test plan

## Risk assessment

low