### PR TITLE
feat(app): Reboot the robot after enabling Compliance Ready Software

### DIFF
--- a/app/src/assets/localization/en/access_control.json
+++ b/app/src/assets/localization/en/access_control.json
@@ -52,6 +52,7 @@
   "setup_wizard_permanent_message": "Once activated, all user actions will require a successful login. This cannot be undone.",
   "setup_wizard_recovery_account_details_description": "Record recovery account details in a safe location in case you forget your password and are locked out of the robot system.",
   "setup_wizard_recovery_account_details_title": "Recovery account details",
+  "setup_wizard_restarting_robot": "Restarting robot",
   "setup_wizard_service_pin_field_label": "Service PIN",
   "setup_wizard_service_pin_incorrect": "Incorrect service PIN",
   "setup_wizard_service_pin_internal_error": "Internal error while validating the service PIN",

--- a/app/src/organisms/Desktop/EnableCRSWizard/enablecrswizard.module.css
+++ b/app/src/organisms/Desktop/EnableCRSWizard/enablecrswizard.module.css
@@ -77,3 +77,18 @@
   height: 2.5rem;
   color: var(--yellow-50);
 }
+
+.loading_content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-24);
+}
+
+.loading_spinner {
+  width: 5.125rem;
+  height: 5.125rem;
+  color: var(--grey-60);
+}

--- a/app/src/organisms/Desktop/EnableCRSWizard/index.tsx
+++ b/app/src/organisms/Desktop/EnableCRSWizard/index.tsx
@@ -598,62 +598,75 @@ function RecoveryAccountDetailsPage({
       width={WIZARD_MODAL_WIDTH}
       header={header}
       footer={
-        <div className={styles.footer}>
-          <SecondaryButton
-            // Unlike other pages, the "next" button is destructive here,
-            // so autofocus the "Back" button instead.
-            autoFocus
-            onClick={onBack}
-          >
-            {t('shared:back')}
-          </SecondaryButton>
-          <PrimaryButton
-            disabled={isLoading}
-            onClick={() => {
-              void handleCompleteSetup()
-            }}
-          >
-            {t('setup_wizard_complete_setup')}
-          </PrimaryButton>
-        </div>
+        isLoading ? null : (
+          <div className={styles.footer}>
+            <SecondaryButton
+              // Unlike other pages, the "next" button is destructive here,
+              // so autofocus the "Back" button instead.
+              autoFocus
+              onClick={onBack}
+            >
+              {t('shared:back')}
+            </SecondaryButton>
+            <PrimaryButton
+              onClick={() => {
+                void handleCompleteSetup()
+              }}
+            >
+              {t('setup_wizard_complete_setup')}
+            </PrimaryButton>
+          </div>
+        )
       }
     >
       <div className={styles.content}>
-        <div className={styles.recovery_content}>
-          <Icon name="error" className={styles.recovery_icon} />
-          <div className={styles.recovery_text}>
-            <StyledText desktopStyle="headingSmallBold">
-              {t('setup_wizard_recovery_account_details_title')}
-            </StyledText>
-            <StyledText desktopStyle="bodyDefaultRegular">
-              {t('setup_wizard_recovery_account_details_description')}
+        {isLoading ? (
+          <div className={styles.loading_content}>
+            <Icon name="ot-spinner" spin className={styles.loading_spinner} />
+            <StyledText
+              desktopStyle="headingSmallSemiBold"
+              className={styles.loading_text}
+            >
+              {t('setup_wizard_restarting_robot')}
             </StyledText>
           </div>
-          {submissionError != null ? (
-            <InlineNotification
-              type="error"
-              heading={t('setup_wizard_submission_error')}
-            />
-          ) : null}
-          <div className={styles.recovery_list}>
-            <div className={styles.detail_row}>
-              <StyledText desktopStyle="bodyDefaultSemiBold">
-                {t('username')}
+        ) : (
+          <div className={styles.recovery_content}>
+            <Icon name="error" className={styles.recovery_icon} />
+            <div className={styles.recovery_text}>
+              <StyledText desktopStyle="headingSmallBold">
+                {t('setup_wizard_recovery_account_details_title')}
               </StyledText>
               <StyledText desktopStyle="bodyDefaultRegular">
-                {RECOVERY_ACCOUNT_USERNAME}
+                {t('setup_wizard_recovery_account_details_description')}
               </StyledText>
             </div>
-            <div className={styles.detail_row}>
-              <StyledText desktopStyle="bodyDefaultSemiBold">
-                {t('login_form_password_field')}
-              </StyledText>
-              <StyledText desktopStyle="bodyDefaultRegular">
-                {recoveryAccountPassword}
-              </StyledText>
+            {submissionError != null ? (
+              <InlineNotification
+                type="error"
+                heading={t('setup_wizard_submission_error')}
+              />
+            ) : null}
+            <div className={styles.recovery_list}>
+              <div className={styles.detail_row}>
+                <StyledText desktopStyle="bodyDefaultSemiBold">
+                  {t('username')}
+                </StyledText>
+                <StyledText desktopStyle="bodyDefaultRegular">
+                  {RECOVERY_ACCOUNT_USERNAME}
+                </StyledText>
+              </div>
+              <div className={styles.detail_row}>
+                <StyledText desktopStyle="bodyDefaultSemiBold">
+                  {t('login_form_password_field')}
+                </StyledText>
+                <StyledText desktopStyle="bodyDefaultRegular">
+                  {recoveryAccountPassword}
+                </StyledText>
+              </div>
             </div>
           </div>
-        </div>
+        )}
       </div>
     </ModalShell>
   )

--- a/app/src/organisms/Desktop/EnableCRSWizard/useEnableCRSMutation.ts
+++ b/app/src/organisms/Desktop/EnableCRSWizard/useEnableCRSMutation.ts
@@ -1,16 +1,28 @@
 /* eslint-disable opentrons/no-direct-mutating */
 
 import { useMutation, useQueryClient } from 'react-query'
+import { useDispatch, useStore } from 'react-redux'
 
 import {
   createUser,
   deleteUser,
+  getOAuth2Token,
+  OAUTH2_CLIENT_ID,
   patchAccessControlEnabled,
+  restart,
 } from '@opentrons/api-client'
 import {
   accessControlEnabledQueryKey,
   useHost,
 } from '@opentrons/react-api-client'
+
+import { useRobot } from '/app/redux-resources/robots'
+import {
+  beginRobotRestartTracking,
+  RESTART_SUCCEEDED_STATUS,
+} from '/app/redux/robot-admin'
+import { type State } from '/app/redux/types'
+import { waitForStoreCondition } from '/app/redux/waitForStoreCondition'
 
 import type { UseMutationResult } from 'react-query'
 import type { CreateUserRequest } from '@opentrons/api-client'
@@ -27,9 +39,12 @@ interface AccountCreationParams {
   fullName: string
 }
 
+const USER_NOTE =
+  'Automatically done by the system as part of first-time setup of Compliance Ready Software.'
+
 /**
- * Create an admin account, a service account, a recovery account,
- * and finally flip the switch to enable Compliance Ready Software.
+ * Create initial accounts, flip the switch to enable Compliance Ready Software,
+ * and restart the robot.
  *
  * We do this all in one batch at the end of the wizard to reduce the chances of it
  * getting interrupted and leaving the robot in a half-set-up state. Though it's still
@@ -41,12 +56,18 @@ export function useEnableCRSMutation(): UseMutationResult<
   EnableCRSParams
 > {
   const hostConfig = useHost()
+  const robotName = hostConfig?.robotName
   const queryClient = useQueryClient()
+  const dispatch = useDispatch()
+  const store = useStore<State>()
+
+  const bootIdBeforeRestart =
+    useRobot(hostConfig?.robotName ?? null)?.serverHealth?.bootId ?? null
 
   const enableCRS = async (params: EnableCRSParams): Promise<void> => {
-    if (hostConfig == null) {
+    if (hostConfig == null || robotName == null) {
       throw Error(
-        "hostConfig is null, couldn't enable CRS. Robot disconnected?"
+        "hostConfig or robotName is null, couldn't enable CRS. Robot disconnected?"
       )
     }
 
@@ -80,17 +101,49 @@ export function useEnableCRSMutation(): UseMutationResult<
       await createUser(hostConfig, { data: userToCreate })
     }
 
-    const response = await patchAccessControlEnabled(hostConfig, {
+    await patchAccessControlEnabled(hostConfig, {
       data: { accessControlEnabled: true },
     })
-    queryClient.setQueryData(
-      accessControlEnabledQueryKey(hostConfig),
-      response.data
+
+    // Now that accessControlEnabled is true, anything we do needs to be authorized.
+    // Authenticate as one of the accounts we just created.
+    const tokenResponse = await getOAuth2Token(hostConfig, {
+      client_id: OAUTH2_CLIENT_ID,
+      grant_type: 'password',
+      username: params.adminAccount.username,
+      password: params.adminAccount.password,
+    })
+    const hostConfigWithAccessToken: typeof hostConfig = {
+      ...hostConfig,
+      token: tokenResponse.data.access_token,
+    }
+
+    // Send the restart request, start tracking the restart progress through Redux,
+    // and wait for the robot to come back online.
+    //
+    // Note: We can't use the useRestartRobotMutation hook because it captures its
+    // HostConfig at the time the hook is called (when the component is rendered),
+    // whereas we modify our HostConfig midway through this whole procedure when we
+    // log in as the new admin account.
+    await restart(hostConfigWithAccessToken, USER_NOTE)
+    for (const action of beginRobotRestartTracking(
+      robotName,
+      bootIdBeforeRestart
+    )) {
+      dispatch(action)
+    }
+    await waitForStoreCondition(
+      store,
+      state => state.robotAdmin[robotName]?.restart?.status ?? null,
+      status => status === RESTART_SUCCEEDED_STATUS
     )
 
-    // The designs also call for a robot restart here.
-    // The backend doesn't actually need that, at the time of writing,
-    // so it's left out for now.
+    // Make sure we fetch the new access control status (enabled) and that UI reflects
+    // it before we return. At the time of writing, this doesn't matter because the
+    // robot's restart makes everything reload anyway, so this is just future-proofing.
+    await queryClient.invalidateQueries(
+      accessControlEnabledQueryKey(hostConfig)
+    )
   }
 
   // We're using just a plain react-query useMutation() here instead of


### PR DESCRIPTION
## Overview

This closes EXEC-2867.

## Changelog

In the first-time setup flow for Compliance Ready Software:

1. Create the initial accounts (as before)
2. Enable Compliance Ready Software (as before)

Then:

3. Log in as one of the users we just created. (Because CRS is enabled now, and so everything needs to be authenticated.)
4. Send a reboot request.
5. Wait for the reboot to complete.
6. Exit the wizard.

And show a loading indicator while all of this is going on.

## Test Plan and Hands on Testing

Tested on a real robot:

* [x] It reboots
* [x] It shows the loading indicator
* [x] It recognizes when the reboot has completed

## Review requests

Fundamental questions:

* Agreed with the basic approach? Of logging in as one of the newly-created accounts, and using its credentials to send the restart request?

Implementation questions:

* Is there a cleaner way to do the "wait for reboot to complete" thing? I'm copying this from some preexisting code.
  * It would be nice if we could have a shared `useMutation()` like `useRebootAndWait()`. I tried that, but I had some trouble with getting it to capture the most up-to-date `hostConfig`. This code is unusual in that we need to set `hostConfig.token` *midway through* the volley of requests. 

## Risk assessment

Medium. This bounces between React, React Query, and Redux, and so it's difficult to meaningfully cover with our usual automated tests, which are mock-heavy.