### PR TITLE
fix(odd): change run loading screen

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -59,7 +59,7 @@
   "choose_enum": "Choose {{displayName}}",
   "cli_ssh": "Command Line Interface (SSH)",
   "closing": "Closing...",
-  "complete_setup_before_proceeding": "complete setup before continuing run",
+  "complete_setup_before_proceeding": "complete setup before starting the run",
   "configure": "Configure",
   "configured": "configured",
   "confirm_heater_shaker_module_modal_description": "Before the run begins, module should have both anchors fully extended for a firm attachment. The thermal adapter should be attached to the module. ",

--- a/app/src/atoms/Skeleton/index.tsx
+++ b/app/src/atoms/Skeleton/index.tsx
@@ -8,10 +8,10 @@ interface SkeletonProps {
   //  backgroundSize is the total width to add to every Skeleton in the component which controls the animation speed
   backgroundSize: string
   borderRadius?: string
-  fixedBackround?: boolean
+  fixedBackground?: boolean
 }
 export const Skeleton = (props: SkeletonProps): JSX.Element => {
-  const { width, height, backgroundSize, borderRadius, fixedBackround } = props
+  const { width, height, backgroundSize, borderRadius, fixedBackground } = props
   const SKELETON_STYLE = css`
     border-radius: ${borderRadius ?? BORDERS.borderRadius8};
     animation: shimmer 2s infinite linear;
@@ -25,7 +25,7 @@ export const Skeleton = (props: SkeletonProps): JSX.Element => {
     width: ${width};
     height: ${height};
     ${
-      fixedBackround &&
+      fixedBackground &&
       `
       background-attachment: fixed;
     `

--- a/app/src/atoms/Skeleton/index.tsx
+++ b/app/src/atoms/Skeleton/index.tsx
@@ -8,9 +8,10 @@ interface SkeletonProps {
   //  backgroundSize is the total width to add to every Skeleton in the component which controls the animation speed
   backgroundSize: string
   borderRadius?: string
+  fixedBackround?: boolean
 }
 export const Skeleton = (props: SkeletonProps): JSX.Element => {
-  const { width, height, backgroundSize, borderRadius } = props
+  const { width, height, backgroundSize, borderRadius, fixedBackround } = props
   const SKELETON_STYLE = css`
     border-radius: ${borderRadius ?? BORDERS.borderRadius8};
     animation: shimmer 2s infinite linear;
@@ -23,6 +24,12 @@ export const Skeleton = (props: SkeletonProps): JSX.Element => {
     background-size: ${backgroundSize};
     width: ${width};
     height: ${height};
+    ${
+      fixedBackround &&
+      `
+      background-attachment: fixed;
+    `
+    }
 
     @keyframes shimmer {
       0% {

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupSkeleton.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupSkeleton.tsx
@@ -1,4 +1,12 @@
-import { BORDERS } from '@opentrons/components'
+import {
+  BORDERS,
+  COLORS,
+  DIRECTION_COLUMN,
+  Flex,
+  JUSTIFY_SPACE_BETWEEN,
+  POSITION_ABSOLUTE,
+  SPACING,
+} from '@opentrons/components'
 
 import { Skeleton } from '/app/atoms/Skeleton'
 
@@ -16,6 +24,27 @@ export function ProtocolSetupTitleSkeleton(): JSX.Element {
         width="28rem"
         backgroundSize="99rem"
         borderRadius={BORDERS.borderRadius12}
+      />
+    </>
+  )
+}
+
+export function ProtocolSetupButtonsSkeleton(): JSX.Element {
+  return (
+    <>
+      <Skeleton
+        height="6.25rem"
+        width="6.25rem"
+        backgroundSize="99rem"
+        borderRadius={BORDERS.borderRadiusFull}
+        fixedBackround
+      />
+      <Skeleton
+        height="6.25rem"
+        width="6.25rem"
+        backgroundSize="99rem"
+        borderRadius={BORDERS.borderRadiusFull}
+        fixedBackround
       />
     </>
   )
@@ -40,5 +69,40 @@ export function ProtocolSetupStepSkeleton(): JSX.Element {
       <SetupSkeleton />
       <SetupSkeleton />
     </>
+  )
+}
+
+export function ProtocolSetupFullSkeleton(): JSX.Element {
+  return (
+    <Flex
+      position={POSITION_ABSOLUTE}
+      top="0"
+      left="0"
+      height="100vh"
+      width="100vw"
+      backgroundColor={COLORS.white}
+      flexDirection={DIRECTION_COLUMN}
+    >
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        padding={`${SPACING.spacing32} ${SPACING.spacing40} ${SPACING.spacing40}`}
+      >
+        <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
+          <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing2}>
+            <ProtocolSetupTitleSkeleton />
+          </Flex>
+          <Flex gridGap={SPACING.spacing16}>
+            <ProtocolSetupButtonsSkeleton />
+          </Flex>
+        </Flex>
+      </Flex>
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        gridGap={SPACING.spacing8}
+        paddingX={SPACING.spacing40}
+      >
+        <ProtocolSetupStepSkeleton />
+      </Flex>
+    </Flex>
   )
 }

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupSkeleton.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupSkeleton.tsx
@@ -37,14 +37,14 @@ export function ProtocolSetupButtonsSkeleton(): JSX.Element {
         width="6.25rem"
         backgroundSize="99rem"
         borderRadius={BORDERS.borderRadiusFull}
-        fixedBackround
+        fixedBackground
       />
       <Skeleton
         height="6.25rem"
         width="6.25rem"
         backgroundSize="99rem"
         borderRadius={BORDERS.borderRadiusFull}
-        fixedBackround
+        fixedBackground
       />
     </>
   )

--- a/app/src/organisms/ODD/ProtocolSetup/__tests__/ProtocolSetupSkeleton.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/__tests__/ProtocolSetupSkeleton.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
 import {
+  ProtocolSetupButtonsSkeleton,
   ProtocolSetupStepSkeleton,
   ProtocolSetupTitleSkeleton,
 } from '../ProtocolSetupSkeleton'
@@ -14,6 +15,18 @@ describe('ProtocolSetupSkeleton', () => {
 
     titleSkeletons.forEach(titleSkeleton => {
       expect(titleSkeleton).toHaveStyle('background-size: 99rem')
+    })
+  })
+
+  it('renders Skeletons to replace the close and play buttons', () => {
+    render(<ProtocolSetupButtonsSkeleton />)
+    const buttonSkeletons = screen.getAllByRole('status')
+    expect(buttonSkeletons.length).toBe(2)
+
+    buttonSkeletons.forEach(buttonSkeleton => {
+      expect(buttonSkeleton).toHaveStyle('background-size: 99rem')
+      expect(buttonSkeleton).toHaveStyle('height: 6.25rem')
+      expect(buttonSkeleton).toHaveStyle('width: 6.25rem')
     })
   })
 

--- a/app/src/organisms/ODD/RobotDashboard/RecentRunProtocolCard.tsx
+++ b/app/src/organisms/ODD/RobotDashboard/RecentRunProtocolCard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { formatDistance } from 'date-fns'
@@ -28,6 +29,7 @@ import {
   useProtocolQuery,
 } from '@opentrons/react-api-client'
 
+import { getTopPortalEl } from '/app/App/portal'
 import { ODD_FOCUS_VISIBLE } from '/app/atoms/buttons/constants'
 import { Skeleton } from '/app/atoms/Skeleton'
 import {
@@ -37,6 +39,7 @@ import {
 import { useCloneRun } from '/app/resources/runs'
 import { useMissingProtocolHardware } from '/app/transformations/commands'
 
+import { ProtocolSetupFullSkeleton } from '../ProtocolSetup'
 import { useRerunnableStatusText } from './hooks'
 
 import type { RunData, RunStatus } from '@opentrons/api-client'
@@ -107,7 +110,11 @@ export function ProtocolWithLastRun({
   const trackEvent = useTrackEvent()
   // TODO(BC, 08/29/23): reintroduce this analytics event when we refactor the hook to fetch data lazily (performance concern)
   // const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runData.id)
-  const { cloneRun } = useCloneRun(runData.id)
+  const { cloneRun, isCloning } = useCloneRun(runData.id, run => {
+    if (run.data.id != null) {
+      navigate(`/runs/${run.data.id}/setup`)
+    }
+  })
   const [showSpinner, setShowSpinner] = useState<boolean>(false)
 
   const protocolName =
@@ -159,9 +166,6 @@ export function ProtocolWithLastRun({
       navigate(`/protocols/${protocolId}`)
     } else {
       cloneRun()
-      // Navigate to a dummy setup skeleton until TopLevelRedirects routes to the proper setup page. Doing so prevents
-      // needing to manage complex UI state updates for protocol cards, overzealous dashboard rendering, and potential navigation pitfalls.
-      navigate('/runs/1234/setup')
       trackEvent({
         name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
         properties: { sourceLocation: 'RecentRunProtocolCard' },
@@ -191,6 +195,10 @@ export function ProtocolWithLastRun({
     } else {
       return ''
     }
+  }
+
+  if (isCloning) {
+    return createPortal(<ProtocolSetupFullSkeleton />, getTopPortalEl())
   }
 
   return isProtocolFetching || isLookingForHardware ? (

--- a/app/src/pages/ODD/ProtocolSetup/Buttons.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/Buttons.tsx
@@ -38,22 +38,17 @@ export function PlayButton({
   return (
     <Btn
       alignItems={ALIGN_CENTER}
-      backgroundColor={isEnabled ? COLORS.blue50 : COLORS.grey35}
+      backgroundColor={COLORS.blue50}
       borderRadius="6.25rem"
       display={DISPLAY_FLEX}
       height="6.25rem"
       justifyContent={JUSTIFY_CENTER}
       width="6.25rem"
-      disabled={disabled}
       onClick={onPlay}
       aria-label="play"
       css={playButtonStyle}
     >
-      <Icon
-        color={isEnabled ? COLORS.white : COLORS.grey50}
-        name="play"
-        size="2.5rem"
-      />
+      <Icon color={COLORS.white} name="play" size="2.5rem" />
     </Btn>
   )
 }

--- a/app/src/pages/ODD/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -37,6 +37,7 @@ import {
 import { useIsHeaterShakerInProtocol } from '/app/organisms/ModuleCard/hooks'
 import {
   getUnmatchedModulesForProtocol,
+  ProtocolSetupButtonsSkeleton,
   ProtocolSetupLabware,
   ProtocolSetupModulesAndDeck,
   ProtocolSetupOffsets,
@@ -165,6 +166,7 @@ const MockProtocolSetupLabware = vi.mocked(ProtocolSetupLabware)
 const MockProtocolSetupOffsets = vi.mocked(ProtocolSetupOffsets)
 const MockProtocolSetupCamera = vi.mocked(ProtocolSetupCamera)
 const MockProtocolSetupTitleSkeleton = vi.mocked(ProtocolSetupTitleSkeleton)
+const MockProtocolSetupButtonsSkeleton = vi.mocked(ProtocolSetupButtonsSkeleton)
 const MockProtocolSetupStepSkeleton = vi.mocked(ProtocolSetupStepSkeleton)
 const MockConfirmSetupStepsCompleteModal = vi.mocked(
   ConfirmSetupStepsCompleteModal
@@ -551,9 +553,10 @@ describe('ProtocolSetup', () => {
       data: null,
     } as any)
     MockProtocolSetupTitleSkeleton.mockReturnValue(<div>SKELETON</div>)
+    MockProtocolSetupButtonsSkeleton.mockReturnValue(<div>SKELETON</div>)
     MockProtocolSetupStepSkeleton.mockReturnValue(<div>SKELETON</div>)
     render(`/runs/${RUN_ID}/setup/`)
-    expect(screen.getAllByText('SKELETON').length).toBeGreaterThanOrEqual(2)
+    expect(screen.getAllByText('SKELETON').length).toBeGreaterThanOrEqual(3)
   })
 
   it('should render toast and make a button disabled when a robot door is open', async () => {

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -51,6 +51,7 @@ import { useIsHeaterShakerInProtocol } from '/app/organisms/ModuleCard/hooks'
 import {
   AnalysisFailedModal,
   getUnmatchedModulesForProtocol,
+  ProtocolSetupButtonsSkeleton,
   ProtocolSetupInstruments,
   ProtocolSetupLabware,
   ProtocolSetupModulesAndDeck,
@@ -183,7 +184,6 @@ function PrepareToRun({
     'shared',
     'deck_configuration',
   ])
-  const navigate = useNavigate()
   const { makeSnackbar } = useToaster()
   const { scrollRef, isScrolled } = useScrollPosition()
 
@@ -237,11 +237,6 @@ function PrepareToRun({
       setIsPollingForCompletedAnalysis(true)
     }
   }, [mostRecentAnalysis?.status])
-
-  const onConfirmCancelClose = (): void => {
-    setShowConfirmCancelModal(false)
-    navigate(-1)
-  }
 
   const protocolHasModules =
     mostRecentAnalysis?.modules != null &&
@@ -657,21 +652,22 @@ function PrepareToRun({
             )}
           </Flex>
           <Flex gridGap={SPACING.spacing16}>
-            <CloseButton
-              onClose={
-                !isLoading
-                  ? () => {
-                      setShowConfirmCancelModal(true)
-                    }
-                  : onConfirmCancelClose
-              }
-            />
-            <PlayButton
-              disabled={isLoading}
-              onPlay={!isLoading ? onPlay : undefined}
-              ready={!isLoading ? isReadyToRun : false}
-              isDoorOpen={doorStatus.isDoorOpen}
-            />
+            {!isLoading ? (
+              <>
+                <CloseButton
+                  onClose={() => {
+                    setShowConfirmCancelModal(true)
+                  }}
+                />
+                <PlayButton
+                  onPlay={onPlay}
+                  ready={isReadyToRun}
+                  isDoorOpen={doorStatus.isDoorOpen}
+                />
+              </>
+            ) : (
+              <ProtocolSetupButtonsSkeleton />
+            )}
           </Flex>
         </Flex>
       </Flex>

--- a/app/src/redux-resources/robots/hooks/useIsRobotBusy.ts
+++ b/app/src/redux-resources/robots/hooks/useIsRobotBusy.ts
@@ -21,7 +21,8 @@ export function useIsRobotBusy(
   const { poll } = options
   const queryOptions = poll ? { refetchInterval: ROBOT_STATUS_POLL_MS } : {}
   const robotHasCurrentRun =
-    useNotifyAllRunsQuery({}, queryOptions)?.data?.links?.current != null
+    useNotifyAllRunsQuery({ pageLength: 0 }, queryOptions)?.data?.links
+      ?.current != null
   const { data: maintenanceRunData } = useNotifyCurrentMaintenanceRun({
     refetchInterval: poll ? ROBOT_STATUS_POLL_MS : false,
   })

--- a/app/src/resources/runs/__tests__/useMostRecentRunId.test.tsx
+++ b/app/src/resources/runs/__tests__/useMostRecentRunId.test.tsx
@@ -14,7 +14,7 @@ describe('useMostRecentRunId hook', () => {
 
   it('should return the first run if any runs exist', async () => {
     when(vi.mocked(useNotifyAllRunsQuery))
-      .calledWith()
+      .calledWith({ pageLength: 1 })
       .thenReturn({ data: { data: [{ id: 'some_run_id' }] } } as any)
 
     const { result } = renderHook(useMostRecentRunId)
@@ -24,7 +24,7 @@ describe('useMostRecentRunId hook', () => {
 
   it('should return null if no runs exist', async () => {
     when(vi.mocked(useNotifyAllRunsQuery))
-      .calledWith()
+      .calledWith({ pageLength: 1 })
       .thenReturn({ data: { data: [] } } as any)
 
     const { result } = renderHook(useMostRecentRunId)
@@ -33,7 +33,7 @@ describe('useMostRecentRunId hook', () => {
   })
   it('should return null if no run data exists', async () => {
     when(vi.mocked(useNotifyAllRunsQuery))
-      .calledWith()
+      .calledWith({ pageLength: 1 })
       .thenReturn({ data: { data: null } } as any)
 
     const { result } = renderHook(useMostRecentRunId)

--- a/app/src/resources/runs/useMostRecentRunId.ts
+++ b/app/src/resources/runs/useMostRecentRunId.ts
@@ -3,7 +3,7 @@ import last from 'lodash/last'
 import { useNotifyAllRunsQuery } from './useNotifyAllRunsQuery'
 
 export function useMostRecentRunId(): string | null {
-  const { data: allRuns } = useNotifyAllRunsQuery()
+  const { data: allRuns } = useNotifyAllRunsQuery({ pageLength: 1 })
   return allRuns != null && allRuns.data?.length > 0
     ? (last(allRuns.data)?.id ?? null)
     : null


### PR DESCRIPTION
# Overview

https://github.com/user-attachments/assets/1e8e511b-6d35-4b99-a653-1e29781f9ae9

OK so - originally on the ODD, when you launched a run from one of those big colorful cards on the main page, it would immediately navigate you to, literally, '/runs/1234/setup'. This succeeded at its main goal of rendering a loading screen immediately, but it used the real setup page, and thus had a bad flaw of just hammering the backend with a bunch of requests asking "hey, whats the deal with this run 1234? Can I please get the LPC data for run 1234?". This wasn't really an issue until pyro mode changes meant that the more requests hitting the main robot server loop, the slower everything went. 

This changes things to instead render a loading skeleton immediately from the RecentRunProtocolCard while the clone run request is loading, and transitioning seamlessly to the correct run route once its accessible. This should prevent unnecessary server requests and hopefully speed up creating runs.

Additionally, after a conversation with Sue I took this opportunity to update the run loading screen - swapping out the functional buttons for skeletons so you can't dismiss the loading screen and have it pop up on you again later by surprise, and un-disabling the Play button as per the new design push for no disabled buttons. (A snack still fires if you try and play a run before its ready)

This PR also changes two queries to `/runs` that were asking for every single run when it only needed the most recent run, hopefully speeding up creating runs as well.

## Test Plan and Hands on Testing

1. Launch a run from a 'RecentRunsProtocolCard' on the ODD dashboard
2. A loading run skeleton should pop up immediately
3. After a while, the ODD should transition silently to the /runs/{runid}/setup page. This probably will still show a loading screen - if it does, the switch should not be visible to the user (except as maybe a flicker in the css animation)
4. The loading screen should transition immediately to the usual run setup screen.
5. On the run setup screen, the play button should be enabled, and pressing it should launch a snack if the run isn't all set up.

## Changelog

Users can no longer close out of a run loading screen until the run can be canceled - preventing an issue where the run setup screen would pop up by surprise.

Run setup screen play button is now always enabled, and shows a message to the user if pressed before setup is complete.

## Risk assessment

Medium - mostly design changes but still high traffic