### PR TITLE
fix(api): fixes for robot context

### DIFF
--- a/api/src/opentrons/hardware_control/motion_utilities.py
+++ b/api/src/opentrons/hardware_control/motion_utilities.py
@@ -65,6 +65,7 @@ def offset_for_mount(
         OT3Mount.LEFT: left_mount_offset,
         OT3Mount.RIGHT: right_mount_offset,
         OT3Mount.GRIPPER: cast(Point, gripper_mount_offset),
+        Mount.EXTENSION: cast(Point, gripper_mount_offset),
     }
     return offsets[primary_mount]
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1438,7 +1438,6 @@ class OT3API(
         for axis, position_value in position.items():
             if axis not in absolute_positions:
                 absolute_positions[axis] = position_value
-        # breakpoint()
         await self._move(
             target_position=absolute_positions,
             speed=speed,

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1438,7 +1438,7 @@ class OT3API(
         for axis, position_value in position.items():
             if axis not in absolute_positions:
                 absolute_positions[axis] = position_value
-
+        # breakpoint()
         await self._move(
             target_position=absolute_positions,
             speed=speed,

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1419,11 +1419,11 @@ class OT3API(
         for axis in [Axis.Z_L, Axis.Z_R, Axis.Z_G]:
             if axis in position:
                 have_z = True
-                if Axis.Z_L:
+                if axis == Axis.Z_L:
                     carriage_effectors_offset = (
                         self._robot_calibration.left_mount_offset
                     )
-                elif Axis.Z_R:
+                elif axis == Axis.Z_R:
                     carriage_effectors_offset = (
                         self._robot_calibration.right_mount_offset
                     )
@@ -2582,7 +2582,7 @@ class OT3API(
         mount: Union[top_types.Mount, OT3Mount],
         cp_override: Optional[CriticalPoint] = None,
     ) -> top_types.Point:
-        if mount == OT3Mount.GRIPPER:
+        if mount == OT3Mount.GRIPPER or mount == top_types.Mount.EXTENSION:
             return self._gripper_handler.get_critical_point(cp_override)
         else:
             return self._pipette_handler.critical_point_for(

--- a/api/src/opentrons/protocol_engine/execution/gantry_mover.py
+++ b/api/src/opentrons/protocol_engine/execution/gantry_mover.py
@@ -41,6 +41,9 @@ _MOTOR_AXIS_TO_HARDWARE_MOUNT: Dict[MotorAxis, Mount] = {
     MotorAxis.LEFT_Z: Mount.LEFT,
     MotorAxis.RIGHT_Z: Mount.RIGHT,
     MotorAxis.EXTENSION_Z: Mount.EXTENSION,
+    MotorAxis.RIGHT_PLUNGER: Mount.RIGHT,
+    MotorAxis.LEFT_PLUNGER: Mount.LEFT,
+    MotorAxis.EXTENSION_JAW: Mount.EXTENSION,
 }
 
 _HARDWARE_MOUNT_MOTOR_AXIS_TO: Dict[Mount, MotorAxis] = {

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -2819,3 +2819,30 @@ async def test_get_motor_usage_data(
 
     api_result = await ot3_hardware.get_motor_usage_data()
     assert api_result == lifetime_data
+
+
+@pytest.mark.parametrize(
+    "mount",
+    [
+        Mount.LEFT,
+        Mount.RIGHT,
+        Mount.EXTENSION,
+        OT3Mount.LEFT,
+        OT3Mount.RIGHT,
+        OT3Mount.GRIPPER,
+    ],
+)
+async def test_critical_point_for(
+    ot3_hardware: ThreadManager[OT3API],
+    mock_instrument_handlers: Tuple[Mock, Mock],
+    mount: Union[Mount, OT3Mount],
+    decoy: Decoy,
+) -> None:
+    """Ensure that the correct instrument handler is called for each possible mount."""
+    mock_gripper, mock_pipette = mock_instrument_handlers
+
+    _ = ot3_hardware.critical_point_for(mount)
+    if mount in [Mount.EXTENSION, OT3Mount.GRIPPER]:
+        decoy.verify(mock_gripper.get_critical_point(None))
+    else:
+        decoy.verify(mock_pipette.critical_point_for(OT3Mount.from_mount(mount)))

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import types
+from datetime import datetime
 from math import copysign, isclose
 from typing import (
     Any,
@@ -101,6 +102,7 @@ from opentrons.hardware_control.modules import (
 )
 from opentrons.hardware_control.motion_utilities import target_position_from_plunger
 from opentrons.hardware_control.ot3api import OT3API
+from opentrons.hardware_control.robot_calibration import DeckCalibration
 from opentrons.hardware_control.types import (
     Axis,
     CriticalPoint,
@@ -366,6 +368,17 @@ async def mock_instrument_handlers(
         ) as mock_pipette_handler,
     ):
         yield mock_gripper_handler, mock_pipette_handler
+
+
+@pytest.fixture
+def fake_deck_calibration() -> DeckCalibration:
+    inrange_matrix = [[1.0, 0, 0], [0.0, 1, 0], [0.0, 0, 1]]
+    return DeckCalibration(
+        attitude=inrange_matrix,
+        last_modified=datetime.now(),
+        source=SourceType.user,
+        status=CalibrationStatus(),
+    )
 
 
 @pytest.fixture
@@ -2080,19 +2093,17 @@ async def test_move_to_plunger_bottom(
 
 @pytest.mark.parametrize(
     "input_position, expected_move_pos",
-    [
-        ({Axis.X: 13}, {Axis.X: 13, Axis.Y: 493.8, Axis.Z_L: 253.475}),
+    [  
+        ({Axis.X: 13}, {Axis.X: 13, Axis.Y: 493.8}),
         (
             {Axis.X: 13, Axis.Y: 14, Axis.Z_R: 15},
-            {Axis.X: 13, Axis.Y: 14, Axis.Z_R: -240.675},
+            {Axis.X: 13, Axis.Y: 14},
         ),
         (
             {Axis.Z_R: 15, Axis.Z_L: 16},
             {
                 Axis.X: 477.2,
                 Axis.Y: 493.8,
-                Axis.Z_L: -239.675,
-                Axis.Z_R: -240.675,
             },
         ),
     ],
@@ -2101,12 +2112,38 @@ async def test_move_axes(
     ot3_hardware: ThreadManager[OT3API],
     mock_move: AsyncMock,
     mock_check_motor: Mock,
+    fake_deck_calibration: DeckCalibration,
     input_position: Dict[Axis, float],
     expected_move_pos: OrderedDict[Axis, float],
 ) -> None:
+    mount_axes = [Axis.Z_L, Axis.Z_R, Axis.Z_G]
+    dummy_mount_offsets = {
+        Axis.Z_L: Point(z=50),
+        Axis.Z_R: Point(z=150),
+        Axis.Z_G: Point(z=100),
+    }
+    current_position = ot3_hardware._current_position
+    ot3_hardware._robot_calibration.right_mount_offset = dummy_mount_offsets[Axis.Z_R]
+    ot3_hardware._robot_calibration.left_mount_offset = dummy_mount_offsets[Axis.Z_L]
+    ot3_hardware._robot_calibration.gripper_mount_offset = dummy_mount_offsets[Axis.Z_G]
+    # make sure we test against the robot calibration directly
+    expected_mount_offsets = {
+        Axis.Z_L: ot3_hardware._robot_calibration.left_mount_offset,
+        Axis.Z_R: ot3_hardware._robot_calibration.right_mount_offset,
+        Axis.Z_G: ot3_hardware._robot_calibration.gripper_mount_offset,
+    }
+
+    # ensure that calibration offsets get applied properly for each mount
+    for axis in input_position:
+        if axis in mount_axes:
+            expected_move_pos[axis] = (
+                input_position[axis] - expected_mount_offsets[axis].z
+            )
+    if all([mount_ax not in input_position for mount_ax in mount_axes]):
+        expected_move_pos[Axis.Z_L] = current_position[Axis.Z_L]
+
     await ot3_hardware.move_axes(position=input_position)
     mock_check_motor.return_value = True
-
     mock_move.assert_called_once_with(
         target_position=expected_move_pos, speed=None, expect_stalls=False
     )

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -2093,7 +2093,7 @@ async def test_move_to_plunger_bottom(
 
 @pytest.mark.parametrize(
     "input_position, expected_move_pos",
-    [  
+    [
         ({Axis.X: 13}, {Axis.X: 13, Axis.Y: 493.8}),
         (
             {Axis.X: 13, Axis.Y: 14, Axis.Z_R: 15},

--- a/api/tests/opentrons/protocol_engine/execution/test_gantry_mover.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_gantry_mover.py
@@ -718,3 +718,32 @@ async def test_virtual_move_axes(
     """It should simulate moving a set of axis by a certain distance."""
     pos = await virtual_subject.move_axes(axis_map, critical_point, 100, relative_move)
     assert pos == expected_position
+
+
+@pytest.mark.parametrize(
+    ("input_axis", "expected_mount"),
+    [
+        (MotorAxis.LEFT_Z, Mount.LEFT),
+        (MotorAxis.RIGHT_Z, Mount.RIGHT),
+        (MotorAxis.EXTENSION_Z, Mount.EXTENSION),
+        (MotorAxis.RIGHT_PLUNGER, Mount.RIGHT),
+        (MotorAxis.LEFT_PLUNGER, Mount.LEFT),
+        (MotorAxis.EXTENSION_JAW, Mount.EXTENSION),
+    ],
+)
+def test_pick_mount_from_axis_map(
+    hardware_subject: HardwareGantryMover,
+    virtual_subject: VirtualGantryMover,
+    input_axis: MotorAxis,
+    expected_mount: Mount,
+) -> None:
+    """Make sure pick_mount_from_axis_map returns the expected mount."""
+    fake_position = 19.0
+    virtual_mount = virtual_subject.pick_mount_from_axis_map(
+        {input_axis: fake_position}
+    )
+    hardware_mount = hardware_subject.pick_mount_from_axis_map(
+        {input_axis: fake_position}
+    )
+
+    assert virtual_mount == hardware_mount == expected_mount

--- a/api/tests/opentrons/protocol_engine/execution/test_gantry_mover.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_gantry_mover.py
@@ -518,6 +518,14 @@ async def test_home_z(
             OrderedDict({HardwareAxis.Q: 10.0}),
             {HardwareAxis.Q: 10.0},
         ],
+        [
+            {MotorAxis.EXTENSION_Z: 10.0},
+            None,
+            False,
+            Mount.EXTENSION,
+            OrderedDict({HardwareAxis.Z_G: 9.0}),
+            {HardwareAxis.Z_G: 10.0},
+        ],
     ],
 )
 @pytest.mark.ot3_only


### PR DESCRIPTION
## Overview
There were a couple places where we weren’t properly adding critical points or comparing axes/mounts thoroughly. These changes enable at least `RobotContext::move_axes_relative`