### PR TITLE
fix(app, odd): remove double lpc /searches queries

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/__tests__/useLPCLabwareInfo.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/__tests__/useLPCLabwareInfo.test.ts
@@ -30,7 +30,9 @@ describe('useLPCLabwareInfo', () => {
   const PROTOCOL_DATA = { commands: [] } as any
   const LABWARE_DEFS = [{ uri: 'labware-1' }] as any
   const MOCK_LW_LOCATION_COMBOS = [{ definitionUri: 'labware-uri-1' }] as any
-  const MOCK_SEARCH_PARAMS = { definitionUris: ['labware-uri-1'] } as any
+  const MOCK_SEARCH_PARAMS = {
+    filters: [{ definitionUri: 'labware-uri-1' }],
+  } as any
   const MOCK_STORED_OFFSETS = [{ id: 'offset-1' }] as any
   const MOCK_LEGACY_OFFSETS = [{ id: 'legacy-offset-1' }] as any
   const MOCK_LABWARE_INFO = { areOffsetsApplied: true } as any

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/index.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/index.ts
@@ -83,7 +83,7 @@ function useFlexLPCLabwareInfo({
       enabled:
         runStatus === RUN_STATUS_IDLE &&
         robotType === FLEX_ROBOT_TYPE &&
-        searchLwOffsetsParams.filters.length > 0,
+        searchLwOffsetsParams?.filters?.length > 0,
       refetchInterval: REFETCH_OFFSET_SEARCH_MS,
     }
   )

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/index.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/index.ts
@@ -80,7 +80,10 @@ function useFlexLPCLabwareInfo({
   const { data: lwOffsetsData } = useNotifySearchLabwareOffsets(
     searchLwOffsetsParams,
     {
-      enabled: runStatus === RUN_STATUS_IDLE && robotType === FLEX_ROBOT_TYPE,
+      enabled:
+        runStatus === RUN_STATUS_IDLE &&
+        robotType === FLEX_ROBOT_TYPE &&
+        searchLwOffsetsParams.filters.length > 0,
       refetchInterval: REFETCH_OFFSET_SEARCH_MS,
     }
   )


### PR DESCRIPTION
# Overview

LPC setup was querying `/labwareOffsets/searches` before the filters for the query loaded, thus doing a whole server roundtrip asking for useless data. This prevents that. This query was fairly expensive on the server side so hopefully this will contribute to some speedup in creating runs.

## Test Plan and Hands on Testing

During initial run setup, you should no longer see a network request to `/searches` with `filters: []`

## Risk assessment

Low