### PR TITLE
fix(components): remove own style from ResizableContainer

### DIFF
--- a/components/src/molecules/ResizableContainer/index.tsx
+++ b/components/src/molecules/ResizableContainer/index.tsx
@@ -18,6 +18,10 @@ export interface ResizableContainerProps {
   edge: 'left' | 'right'
   // the default width of the container
   defaultWidth?: number
+  // for custom styling
+  className?: string
+  // for inline styling
+  style?: CSSProperties
 }
 
 export const ResizableContainer: React.FC<ResizableContainerProps> = (
@@ -30,6 +34,8 @@ export const ResizableContainer: React.FC<ResizableContainerProps> = (
     maxWidth,
     edge,
     defaultWidth,
+    className,
+    style: customStyle,
   } = props
   const [width, setWidth] = useState<number | null>(defaultWidth ?? null)
   const [isResizing, setIsResizing] = useState(false)
@@ -87,12 +93,18 @@ export const ResizableContainer: React.FC<ResizableContainerProps> = (
     document.body.style.userSelect = ''
   }
 
-  const style: CSSProperties = width !== null ? { width: `${width}px` } : {}
+  const containerStyle: CSSProperties = {
+    ...customStyle,
+    ...(width !== null ? { width: `${width}px` } : {}),
+  }
 
   return (
-    <div ref={containerRef} className={styles.container} style={style}>
+    <div
+      ref={containerRef}
+      className={clsx(styles.container, className)}
+      style={containerStyle}
+    >
       {children}
-
       {/* handle part */}
       <div
         role="separator"

--- a/components/src/molecules/ResizableContainer/resizablecontainer.module.css
+++ b/components/src/molecules/ResizableContainer/resizablecontainer.module.css
@@ -3,7 +3,6 @@
   min-width: 0;
   height: 100%;
   box-sizing: border-box;
-  padding: var(--spacing-12);
 }
 
 .handle {


### PR DESCRIPTION


# Overview
remove own style from ResizableContainer to have flexibility

## Test Plan and Hands on Testing
none

## Changelog
- remove padding and add className and style (for inline styling)

## Review requests


## Risk assessment
low