### PR TITLE
fix(app): Disable the Jupyter button with a tooltip when ACM is enabled

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -287,6 +287,7 @@
   "jupyter_notebook": "Jupyter Notebook",
   "jupyter_notebook_description": "Open the Jupyter Notebook running on this robot in the web browser. This is an experimental feature.",
   "jupyter_notebook_link": "Learn more about using Jupyter notebook",
+  "jupyter_notebook_unavailable_when_crs_enabled": "Jupyter Notebook is not available when Compliance Ready Software is enabled.",
   "last_calibrated": "Last calibrated: {{date}}",
   "last_calibrated_label": "Last Calibrated",
   "launch_jupyter_notebook": "Launch Jupyter Notebook",

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/OpenJupyterControl.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/OpenJupyterControl.tsx
@@ -7,8 +7,11 @@ import {
   JUSTIFY_SPACE_BETWEEN,
   LegacyStyledText,
   SPACING,
+  Tooltip,
   TYPOGRAPHY,
+  useHoverTooltip,
 } from '@opentrons/components'
+import { useAccessControlEnabledQuery } from '@opentrons/react-api-client'
 
 import { TertiaryButton } from '/app/atoms/buttons'
 import { ExternalLink } from '/app/atoms/Link/ExternalLink'
@@ -31,6 +34,11 @@ export function OpenJupyterControl({
   const { t } = useTranslation('device_settings')
   const targetURL = `http://${robotIp}:48888`
   const trackEvent = useTrackEvent()
+  const [buttonPropsForTooltip, tooltipProps] = useHoverTooltip()
+  const accessControlEnabledQuery = useAccessControlEnabledQuery()
+  const isAccessControlEnabled =
+    accessControlEnabledQuery.data?.data.accessControlEnabled ?? false
+  const isDisabled = isEstopNotDisengaged || isAccessControlEnabled
 
   const handleClick = (): void => {
     trackEvent(EVENT_JUPYTER_OPEN)
@@ -54,12 +62,18 @@ export function OpenJupyterControl({
         </ExternalLink>
       </Box>
       <TertiaryButton
-        disabled={isEstopNotDisengaged}
+        {...buttonPropsForTooltip}
+        disabled={isDisabled}
         onClick={handleClick}
         marginLeft={SPACING.spacing32}
       >
         {t('launch_jupyter_notebook')}
       </TertiaryButton>
+      {isAccessControlEnabled ? (
+        <Tooltip tooltipProps={tooltipProps}>
+          {t('jupyter_notebook_unavailable_when_crs_enabled')}
+        </Tooltip>
+      ) : null}
     </Flex>
   )
 }

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/OpenJupyterControl.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/OpenJupyterControl.test.tsx
@@ -1,8 +1,10 @@
 import { MemoryRouter } from 'react-router-dom'
 import { fireEvent, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import '@testing-library/jest-dom/vitest'
+
+import { useAccessControlEnabledQuery } from '@opentrons/react-api-client'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
@@ -13,6 +15,15 @@ import { OpenJupyterControl } from '../OpenJupyterControl'
 import type { ComponentProps } from 'react'
 
 vi.mock('/app/redux/analytics')
+vi.mock('@opentrons/react-api-client')
+
+const mockAccessControlEnabledQuery = (
+  value: Partial<ReturnType<typeof useAccessControlEnabledQuery>>
+): void => {
+  vi.mocked(useAccessControlEnabledQuery).mockReturnValue(
+    value as ReturnType<typeof useAccessControlEnabledQuery>
+  )
+}
 
 const mockIpAddress = '1.1.1.1'
 const mockLink = `http://${mockIpAddress}:48888`
@@ -39,6 +50,15 @@ describe('RobotSettings OpenJupyterControl', () => {
       isEstopNotDisengaged: false,
     }
     vi.mocked(useTrackEvent).mockReturnValue(trackEvent)
+    mockAccessControlEnabledQuery({
+      data: { data: { accessControlEnabled: false } },
+      isLoading: false,
+      isSuccess: true,
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
   })
 
   it('should render title, description and button', () => {
@@ -82,5 +102,17 @@ describe('RobotSettings OpenJupyterControl', () => {
       name: 'Launch Jupyter Notebook',
     })
     expect(button).toBeDisabled()
+  })
+
+  it('should disable the button when access control is enabled', () => {
+    mockAccessControlEnabledQuery({
+      data: { data: { accessControlEnabled: true } },
+      isLoading: false,
+      isSuccess: true,
+    })
+    render(props)
+    expect(
+      screen.getByRole('button', { name: 'Launch Jupyter Notebook' })
+    ).toBeDisabled()
   })
 })


### PR DESCRIPTION
## Overview

This closes RQA-5876. When Compliance Ready Software is enabled, disable the Jupyter Notebook button with an explanatory tooltip.

I'm using a tooltip instead of hiding the button entirely in order to prevent layout shift when the "is CRS enabled" query loads, and also just because it seems easier to troubleshoot. The "update from file" button does something similar.

## Test Plan and Hands on Testing

<img width="895" height="221" alt="Screenshot 2026-08-14 at 10 34 28 AM" src="https://github.com/user-attachments/assets/dd8a6d24-9fe5-4547-b297-924686ec141d" />

## Review requests

* Agreed with disabling it and showing a tooltip instead of hiding the button entirely?
* Does the UX copy seem good?

## Risk assessment

Low.
