### PR TITLE
fix(protocol-designer): render vacuum module dock label

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/ModuleLabel.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/ModuleLabel.tsx
@@ -25,6 +25,7 @@ const CENTER_SLOT_WIDTH = 160
 const CENTER_SLOT_HEIGHT = 106
 const VACUUM_OFFSET_X = -19
 const VACUUM_OFFSET_Y = -10
+const VACUUM_DOCK_OFFSET_X = 7
 
 interface ModuleLabelProps {
   showModuleIcon: boolean
@@ -37,6 +38,7 @@ interface ModuleLabelProps {
   isZoomed?: boolean
   labwareInfos?: DeckLabelProps[]
   labelName?: string
+  isVacuumDock?: boolean
 }
 export const ModuleLabel = (props: ModuleLabelProps): JSX.Element => {
   const {
@@ -50,6 +52,7 @@ export const ModuleLabel = (props: ModuleLabelProps): JSX.Element => {
     labelName,
     slot,
     showModuleIcon = false,
+    isVacuumDock = false,
   } = props
   const robotType = useSelector(getRobotType)
   const labelContainerRef = useRef<HTMLDivElement>(null)
@@ -96,7 +99,11 @@ export const ModuleLabel = (props: ModuleLabelProps): JSX.Element => {
             isZoomed: isZoomed,
           },
         ]}
-        x={position[0] + VACUUM_OFFSET_X}
+        x={
+          position[0] +
+          VACUUM_OFFSET_X +
+          (isVacuumDock ? VACUUM_DOCK_OFFSET_X : 0)
+        }
         y={position[1] - labelContainerHeight + VACUUM_OFFSET_Y}
         width={CENTER_SLOT_WIDTH}
         height={CENTER_SLOT_HEIGHT}

--- a/protocol-designer/src/pages/Designer/DeckSetup/SelectedItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SelectedItems.tsx
@@ -7,8 +7,12 @@ import {
   getModuleDef,
   getModuleType,
   inferModuleOrientationFromXCoordinate,
+  VACUUM_MODULE_V1,
 } from '@opentrons/shared-data'
-import { getSlotInLocationStack } from '@opentrons/step-generation'
+import {
+  getSlotInLocationStack,
+  VACUUM_DOCK_ADDRESSABLE_AREA,
+} from '@opentrons/step-generation'
 
 import { getCustomLabwareDefsByURI } from '../../../labware-defs/selectors'
 import { selectors } from '../../../labware-ingred/selectors'
@@ -107,6 +111,12 @@ export const SelectedItems = (props: SelectedItemsProps): JSX.Element => {
     (selectedAdapterDefURI ? 1 : 0) +
     (selectedTopLabware?.labwareDefURI ? 1 : 0)
 
+  const isVacuumDock = selectedSlot.slot === VACUUM_DOCK_ADDRESSABLE_AREA
+
+  const transformedModuleModel = isVacuumDock
+    ? VACUUM_MODULE_V1
+    : selectedModuleModel
+
   return (
     <>
       {selectedFixture != null && selectedSlot.cutout != null ? (
@@ -117,7 +127,7 @@ export const SelectedItems = (props: SelectedItemsProps): JSX.Element => {
           deckDef={deckDef}
         />
       ) : null}
-      {selectedModuleModel != null &&
+      {transformedModuleModel != null &&
       slotPosition != null &&
       orientation != null ? (
         <>
@@ -131,17 +141,18 @@ export const SelectedItems = (props: SelectedItemsProps): JSX.Element => {
           available for labware on the stacker. so we don't want to re-render the stacker
           in the hopper slot
           */}
-          {isSlotAHopper ? null : (
+          {isSlotAHopper || isVacuumDock ? null : (
             <Module
-              key={`${selectedModuleModel}_${selectedSlot.slot}_selected`}
+              key={`${transformedModuleModel}_${selectedSlot.slot}_selected`}
               x={slotPosition[0]}
               y={slotPosition[1]}
-              def={getModuleDef(selectedModuleModel)}
+              def={getModuleDef(transformedModuleModel)}
               orientation={orientation}
               targetDeckId={null}
               targetSlotId={null}
               childrenPositioningMode={
-                getModuleType(selectedModuleModel) === FLEX_STACKER_MODULE_TYPE
+                getModuleType(transformedModuleModel) ===
+                FLEX_STACKER_MODULE_TYPE
                   ? 'passThrough'
                   : 'offsetToSlot'
               }
@@ -149,15 +160,15 @@ export const SelectedItems = (props: SelectedItemsProps): JSX.Element => {
               <SelectedModuleLabwareRender
                 topLabwareOnDeck={matchingSelectedTopLabwareOnDeck}
                 adapterDef={selectedAdapterDef}
-                moduleModel={selectedModuleModel}
+                moduleModel={transformedModuleModel}
                 lidOnDeck={matchingSelectedLidOnDeck}
               />
             </Module>
           )}
-          {selectedModuleModel != null ? (
+          {transformedModuleModel != null ? (
             <ModuleLabel
               isLast={selectedAdapterDefURI == null}
-              moduleModel={selectedModuleModel}
+              moduleModel={transformedModuleModel}
               position={slotPosition}
               orientation={orientation}
               isSelected={true}
@@ -166,6 +177,7 @@ export const SelectedItems = (props: SelectedItemsProps): JSX.Element => {
               showModuleIcon={
                 selectedTopLabware.amount > 1 || lengthOfStack > 1
               }
+              isVacuumDock={isVacuumDock}
             />
           ) : null}
         </>
@@ -174,7 +186,7 @@ export const SelectedItems = (props: SelectedItemsProps): JSX.Element => {
         showModuleIcon={selectedTopLabware.amount > 1 || lengthOfStack > 1}
         labwareDef={selectedTopLabwareDef ?? selectedAdapterDef}
         slotPosition={slotPosition}
-        moduleModel={selectedModuleModel ?? null}
+        moduleModel={transformedModuleModel}
         nestedLabwareInfo={
           selectedAdapterDef != null && selectedTopLabwareDef != null
             ? [

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -111,14 +111,7 @@ const _getAdjustedSlot = (
   }
   return slot
 }
-const _getOffsetFromSlot = (
-  slot: DeckSlot,
-  isSlotAVacuumDock: boolean,
-  isSlotAHopper: boolean
-): number => {
-  if (isSlotAVacuumDock) {
-    return VACUUM_DOCK_LABWARE_X_OFFSET
-  }
+const _getOffsetFromSlot = (slot: DeckSlot, isSlotAHopper: boolean): number => {
   if (isSlotAHopper) {
     return HOPPER_LABWARE_X_OFFSET
   }
@@ -152,7 +145,7 @@ export const getSlotInformation = (
       ? getPositionFromSlotId(
           adjustedSlot,
           deckDef,
-          _getOffsetFromSlot(slot, isSlotAVacuumDock, isSlotAHopper)
+          _getOffsetFromSlot(slot, isSlotAHopper)
         )
       : null
   const createdModuleForSlot = Object.values(deckSetupModules).find(

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -28,7 +28,6 @@ import {
 import {
   HOPPER_LABWARE_X_OFFSET,
   VACUUM_DOCK_DISPLAY_LOCATION,
-  VACUUM_DOCK_LABWARE_X_OFFSET,
 } from '/protocol-designer/constants'
 
 import { getRobotType } from '../../file-data/selectors'


### PR DESCRIPTION
# Overview

Special cases vacuum module dock label in ModuleLabel and SelectedItems. Also, fixes utility that inadvertently set the vacuum module position far to the right.

Closes RQA-5867

## Test Plan and Hands on Testing

#### starting deck state
- click to add labware to the vacuum module dock
- verify that the module label renders correctly
<img width="631" height="535" alt="Screenshot 2026-08-14 at 11 16 38 AM" src="https://github.com/user-attachments/assets/1e31cbcc-c39d-4ce6-827c-e9ddc5345279" />

#### move step
- create a move labware step such that the destination is the vacuum dock
- verify that the module label renders correctly
<img width="486" height="238" alt="Screenshot 2026-08-14 at 11 28 58 AM" src="https://github.com/user-attachments/assets/b2710afc-e4b7-45b8-aa1c-2cfef1edcc33" />

## Changelog

- special case vacuum dock rendering in `SelectedItems` > `ModuleLabel`
- fix up positioning utility for dock rendering

## Review requests

see test plan

## Risk assessment

low 