### PR TITLE
feat(step-generation): update PAPI version emitted by step generation Python protocols

### DIFF
--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -52,7 +52,7 @@ import type {
   WasteChuteEntities,
 } from '../types'
 
-export const PAPI_VERSION = '2.30' // oldest version that we need from api/src/opentrons/protocols/api_support/definitions.py, might not be the actual latest version
+export const PAPI_VERSION = '2.31' // oldest version that we need from api/src/opentrons/protocols/api_support/definitions.py, might not be the actual latest version
 export const PD_APPLICATION_VERSION = '9.0.1' // latest PD version to insert into DESIGNER_APPLICATION blob
 
 export function pythonImports(): string {


### PR DESCRIPTION
# Overview

Bump PAPI version from 2.30 -> 2.31

## Test Plan and Hands on Testing

- import or create a PD protocol, and export
- inspect requirements dict, and verify API level is 2.31

## Changelog

- update PAPI version in step-generation

## Review requests


see test plan
## Risk assessment

low