### PR TITLE
fix(app): Remove all onblur overrides that were causing inputs to steal focus from each other

### DIFF
--- a/app/src/organisms/ODD/NetworkSettings/WifiPasswordInput.tsx
+++ b/app/src/organisms/ODD/NetworkSettings/WifiPasswordInput.tsx
@@ -26,10 +26,6 @@ export function WifiPasswordInput({
   const [showPassword, setShowPassword] = useState<boolean>(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const isUnboxingFlowOngoing = useIsUnboxingFlowOngoing()
-  const handleBlur = (): void => {
-    if (inputRef.current != null) inputRef.current?.focus()
-  }
-
   const mainWrapperClasses = clsx(
     styles.main_wrapper,
     !isUnboxingFlowOngoing && styles.main_wrapper_with_top_margin
@@ -55,7 +51,6 @@ export function WifiPasswordInput({
                 aria-label="wifi_password"
                 value={password}
                 type={showPassword ? 'text' : 'password'}
-                onBlur={handleBlur}
                 ref={inputRef}
                 autoFocus
                 onChange={e => {

--- a/app/src/organisms/ODD/NetworkSettings/WifiSsidInput.tsx
+++ b/app/src/organisms/ODD/NetworkSettings/WifiSsidInput.tsx
@@ -56,9 +56,6 @@ export function WifiSsidInput({
           }}
           type="text"
           error={errorMessage}
-          onBlur={e => {
-            e.target.focus()
-          }}
         />
       </Flex>
       <Flex width="100%" position={POSITION_FIXED} left="0" bottom="0">

--- a/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
@@ -51,10 +51,7 @@ export function LoginFieldInput<
       value={field.value ?? ''}
       name={field.name}
       id={field.name}
-      onBlur={e => {
-        field.onBlur()
-        e.target.focus()
-      }}
+      onBlur={field.onBlur}
       onChange={(e: ChangeEvent<HTMLInputElement>) => {
         field.onChange(e.target.value)
         onClearError?.()

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ChooseNumber.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ChooseNumber.tsx
@@ -125,9 +125,6 @@ export function ChooseNumber({
                 : `${parameter.min.toFixed(1)}-${parameter.max.toFixed(1)}`
             }
             error={error}
-            onBlur={e => {
-              e.target.focus()
-            }}
             onChange={e => {
               const inputValue = e.target.value
               handleInputChange(inputValue)

--- a/app/src/organisms/ODD/QuickTransferFlow/NameQuickTransfer.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/NameQuickTransfer.tsx
@@ -69,9 +69,6 @@ export function NameQuickTransfer(props: NameQuickTransferProps): JSX.Element {
             type="text"
             value={name}
             textAlign={TYPOGRAPHY.textAlignCenter}
-            onBlur={e => {
-              e.target.focus()
-            }}
             onChange={e => {
               setName(e.target.value as string)
             }}

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/AirGap.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/AirGap.tsx
@@ -208,9 +208,6 @@ export function AirGap(props: AirGapProps): JSX.Element {
               value={volume}
               label={t('air_gap_volume_µL')}
               error={volumeError}
-              onBlur={e => {
-                e.target.focus()
-              }}
               onChange={e => {
                 setVolume(Number(e.target.value))
               }}

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/BlowOut.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/BlowOut.tsx
@@ -401,9 +401,6 @@ export function BlowOut(props: BlowOutProps): JSX.Element {
               value={String(speed ?? '')}
               label={t('blow_out_speed')}
               error={speedError}
-              onBlur={e => {
-                e.target.focus()
-              }}
               onChange={e => {
                 handleFlowRateChange(e.target.value as string)
               }}

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Condition.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Condition.tsx
@@ -190,9 +190,6 @@ export function Condition(props: DelayProps): JSX.Element {
               value={conditionVolume}
               label={t('condition_volume')}
               error={volumeError}
-              onBlur={e => {
-                e.target.focus()
-              }}
               onChange={e => {
                 setConditionVolume(Number(e.target.value))
               }}

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Delay.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Delay.tsx
@@ -199,9 +199,6 @@ export function Delay(props: DelayProps): JSX.Element {
               value={delayDuration}
               error={durationError}
               label={t('delay_duration_s')}
-              onBlur={e => {
-                e.target.focus()
-              }}
               onChange={e => {
                 setDelayDuration(Number(e.target.value))
               }}

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/DisposalVolume.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/DisposalVolume.tsx
@@ -246,9 +246,6 @@ export function DisposalVolume(props: DisposalVolumeProps): JSX.Element {
               type="text"
               value={String(volume ?? '')}
               label={t('disposal_volume_µL')}
-              onBlur={e => {
-                e.target.focus()
-              }}
               onChange={e => {
                 handleVolumeChange(e.target.value as string)
               }}
@@ -321,9 +318,6 @@ export function DisposalVolume(props: DisposalVolumeProps): JSX.Element {
               value={String(flowRate ?? '')}
               label={t('blowout_flow_rate_µL')}
               error={flowRateError}
-              onBlur={e => {
-                e.target.focus()
-              }}
               onChange={e => {
                 handleFlowRateChange(e.target.value as string)
               }}

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/FlowRate.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/FlowRate.tsx
@@ -159,9 +159,6 @@ export function FlowRateEntry(props: FlowRateEntryProps): JSX.Element {
             value={flowRate}
             label={textEntryCopy}
             error={error}
-            onBlur={e => {
-              e.target.focus()
-            }}
             onChange={e => {
               handleFlowRateChange(e.target.value as string)
             }}

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Mix.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Mix.tsx
@@ -224,9 +224,6 @@ export function Mix(props: MixProps): JSX.Element {
               value={mixVolume}
               label={t('mix_volume_µL')}
               error={volumeError}
-              onBlur={e => {
-                e.target.focus()
-              }}
               onChange={e => {
                 setMixVolume(Number(e.target.value))
               }}
@@ -271,9 +268,6 @@ export function Mix(props: MixProps): JSX.Element {
               value={mixReps}
               error={repititionError}
               label={t('mix_repetitions')}
-              onBlur={e => {
-                e.target.focus()
-              }}
               onChange={e => {
                 setMixReps(Number(e.target.value))
               }}

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/PipettePath.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/PipettePath.tsx
@@ -208,9 +208,6 @@ export function PipettePath(props: PipettePathProps): JSX.Element {
               value={disposalVolume}
               label={t('disposal_volume_µL')}
               error={volumeError}
-              onBlur={e => {
-                e.target.focus()
-              }}
               onChange={e => {
                 setDisposalVolume(Number(e.target.value))
               }}

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/PushOut.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/PushOut.tsx
@@ -181,9 +181,6 @@ export function PushOut(props: PushOutProps): JSX.Element {
               value={volume}
               error={volumeError}
               label={t('push_out_volume')}
-              onBlur={e => {
-                e.target.focus()
-              }}
               onChange={e => {
                 setVolume(Number(e.target.value))
               }}

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Retract.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Retract.tsx
@@ -286,9 +286,6 @@ function RetractSettingComponent({
             type="number"
             value={speed}
             label={t('speed')}
-            onBlur={e => {
-              e.target.focus()
-            }}
             onChange={e => {
               handleSpeedChange(e.target.value as string)
             }}
@@ -327,9 +324,6 @@ function RetractSettingComponent({
             type="number"
             value={delayDuration}
             label={t('delay_duration_s')}
-            onBlur={e => {
-              e.target.focus()
-            }}
             onChange={e => {
               handleDelayDurationChange(e.target.value as string)
             }}
@@ -372,9 +366,6 @@ function RetractSettingComponent({
             value={position}
             error={positionError}
             label={positionText}
-            onBlur={e => {
-              e.target.focus()
-            }}
             onChange={e => {
               handlePositionChange(e.target.value as string)
             }}

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Submerge.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Submerge.tsx
@@ -286,9 +286,6 @@ function SubmergeSettingComponent({
             type="number"
             value={speed}
             label={t('speed')}
-            onBlur={e => {
-              e.target.focus()
-            }}
             onChange={e => {
               handleSpeedChange(e.target.value as string)
             }}
@@ -327,9 +324,6 @@ function SubmergeSettingComponent({
             type="number"
             value={delayDuration}
             label={t('delay_duration_s')}
-            onBlur={e => {
-              e.target.focus()
-            }}
             onChange={e => {
               handleDelayDurationChange(e.target.value as string)
             }}
@@ -373,9 +367,6 @@ function SubmergeSettingComponent({
             value={position}
             error={positionError}
             label={positionText}
-            onBlur={e => {
-              e.target.focus()
-            }}
             onChange={e => {
               handlePositionChange(e.target.value as string)
             }}

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/TipPosition.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/TipPosition.tsx
@@ -135,9 +135,6 @@ export function TipPositionEntry(props: TipPositionEntryProps): JSX.Element {
             value={tipPosition}
             label={textEntryCopy}
             error={error}
-            onBlur={e => {
-              e.target.focus()
-            }}
             onChange={e => {
               setTipPosition(Number(e.target.value))
             }}

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/TouchTip.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/TouchTip.tsx
@@ -239,9 +239,6 @@ export function TouchTip(props: TouchTipProps): JSX.Element {
               type="text"
               value={String(speed ?? '')}
               label={t('speed')}
-              onBlur={e => {
-                e.target.focus()
-              }}
               onChange={e => {
                 handleSpeedChange(e.target.value as string)
               }}
@@ -286,9 +283,6 @@ export function TouchTip(props: TouchTipProps): JSX.Element {
               value={String(position ?? '')}
               label={t('touch_tip_position_mm')}
               error={positionError}
-              onBlur={e => {
-                e.target.focus()
-              }}
               onChange={e => {
                 setPosition(e.target.value as string)
               }}

--- a/app/src/organisms/ODD/QuickTransferFlow/VolumeEntry.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/VolumeEntry.tsx
@@ -121,9 +121,6 @@ export function VolumeEntry(props: VolumeEntryProps): JSX.Element {
             value={volume}
             label={textEntryCopy}
             error={error}
-            onBlur={e => {
-              e.target.focus()
-            }}
             onChange={e => {
               handleVolumeChange(e.target.value as string)
             }}

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/AirGap.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/AirGap.test.tsx
@@ -104,7 +104,6 @@ describe('AirGap', () => {
         error: null,
         type: 'number',
         value: null,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -139,7 +138,6 @@ describe('AirGap', () => {
         error: 'Value must be between 0 to 195',
         type: 'number',
         value: 200,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -171,7 +169,6 @@ describe('AirGap', () => {
         error: null,
         type: 'number',
         value: 0,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -201,7 +198,6 @@ describe('AirGap', () => {
         error: null,
         type: 'number',
         value: 0,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -229,7 +225,6 @@ describe('AirGap', () => {
         error: null,
         type: 'number',
         value: 0,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -270,7 +265,6 @@ describe('AirGap', () => {
         error: null,
         type: 'number',
         value: 4,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -298,7 +292,6 @@ describe('AirGap', () => {
         error: null,
         type: 'number',
         value: 16,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/Delay.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/Delay.test.tsx
@@ -110,7 +110,6 @@ describe('Delay', () => {
         error: null,
         type: 'number',
         value: null,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -144,7 +143,6 @@ describe('Delay', () => {
         error: 'Value must be between 0.1 to 9999999999',
         type: 'number',
         value: 0,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -193,7 +191,6 @@ describe('Delay', () => {
         error: null,
         type: 'number',
         value: 15,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -222,7 +219,6 @@ describe('Delay', () => {
         error: null,
         type: 'number',
         value: 20,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/FlowRate.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/FlowRate.test.tsx
@@ -117,7 +117,6 @@ describe('FlowRate', () => {
         error: null,
         type: 'text',
         value: '35',
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -141,7 +140,6 @@ describe('FlowRate', () => {
         error: null,
         type: 'text',
         value: '62',
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -161,7 +159,6 @@ describe('FlowRate', () => {
         error: null,
         type: 'text',
         value: '',
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/Mix.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/Mix.test.tsx
@@ -110,7 +110,6 @@ describe('Mix', () => {
         error: null,
         type: 'number',
         value: null,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -144,7 +143,6 @@ describe('Mix', () => {
         error: 'Value must be between 1 to 200',
         type: 'number',
         value: 0,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -173,7 +171,6 @@ describe('Mix', () => {
         error: 'Value must be between 1 to 999',
         type: 'number',
         value: 0,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -223,7 +220,6 @@ describe('Mix', () => {
         error: null,
         type: 'number',
         value: 15,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -236,7 +232,6 @@ describe('Mix', () => {
         error: null,
         type: 'number',
         value: 55,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -266,7 +261,6 @@ describe('Mix', () => {
         error: null,
         type: 'number',
         value: 18,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -279,7 +273,6 @@ describe('Mix', () => {
         error: null,
         type: 'number',
         value: 2,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/PipettePath.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/PipettePath.test.tsx
@@ -184,7 +184,6 @@ describe('PipettePath', () => {
         error: null,
         type: 'number',
         value: 20,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -218,7 +217,6 @@ describe('PipettePath', () => {
         error: 'Value must be between 1 to 160',
         type: 'number',
         value: 201,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/TipPosition.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/TipPosition.test.tsx
@@ -98,7 +98,6 @@ describe('TipPosition', () => {
         error: null,
         type: 'text',
         value: 10,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -122,7 +121,6 @@ describe('TipPosition', () => {
         error: null,
         type: 'text',
         value: 75,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -142,7 +140,6 @@ describe('TipPosition', () => {
         error: 'Value must be between 1 to 52',
         type: 'text',
         value: 0,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -168,7 +165,6 @@ describe('TipPosition', () => {
         error: 'Value must be between 1 to 202',
         type: 'text',
         value: 0,
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/TouchTip.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/TouchTip.test.tsx
@@ -121,7 +121,6 @@ describe('TouchTip', () => {
         error: null,
         type: 'text',
         value: '',
-        onBlur: expect.any(Function),
       }),
       {}
     )
@@ -160,7 +159,6 @@ describe('TouchTip', () => {
         error: 'Value must be between -25 to 0',
         type: 'text',
         value: '-98',
-        onBlur: expect.any(Function),
       }),
       {}
     )
@@ -190,7 +188,6 @@ describe('TouchTip', () => {
         error: 'Value must be between -100 to 0',
         type: 'text',
         value: '1',
-        onBlur: expect.any(Function),
       }),
       {}
     )
@@ -237,7 +234,6 @@ describe('TouchTip', () => {
         error: null,
         type: 'text',
         value: '-25',
-        onBlur: expect.any(Function),
       }),
       {}
     )
@@ -265,7 +261,6 @@ describe('TouchTip', () => {
         error: null,
         type: 'text',
         value: '-8',
-        onBlur: expect.any(Function),
       }),
       {}
     )

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/VolumeEntry.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/VolumeEntry.test.tsx
@@ -79,7 +79,6 @@ describe('VolumeEntry', () => {
         error: null,
         type: 'text',
         value: '',
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -104,7 +103,6 @@ describe('VolumeEntry', () => {
         error: null,
         type: 'text',
         value: '',
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -129,7 +127,6 @@ describe('VolumeEntry', () => {
         error: null,
         type: 'text',
         value: '',
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}
@@ -172,7 +169,6 @@ describe('VolumeEntry', () => {
         error: 'Value must be between 5 to 50',
         type: 'text',
         value: '90',
-        onBlur: expect.any(Function),
         onChange: expect.any(Function),
       },
       {}


### PR DESCRIPTION
## Overview

This closes EXEC-2948. Other PRs have already done bits and pieces of this. This PR does the remainder.

## Details

Basically all of the input fields on the on-device display were doing this:

```typescript
onBlur={e => {
  e.target.focus()
}}
```

Whenever they were about to lose focus, they would grab it right back, thereby preventing focus from ever moving to anything else.

This used to be OK, but it interacts badly with our new UIs for logging in and entering documentation, because we implemented them as overlays. If there is a field hoarding focus for itself, and then the login overlay appears on top of it, it will prevent the user from entering their username and password into the login overlay.

Our solution is to stop overriding `onBlur`, and let focus move around according to the browser's default behavior. This causes other problems (EXEC-2890), but we can deal with those separately.

## Test Plan and Hands on Testing

* [x] Follow the steps to reproduce in EXEC-2948.

## Changelog

* Remove all `onBlur` overrides that were preventing focus from leaving an input element.

## Review requests

Agreed in principle?

## Risk assessment

High. This affects a lot of pages, and it reveals other latent problems, like EXEC-2890. 