### PR TITLE
fix(odd, app): speed up run creation by pruning extraneous queries

### DIFF
--- a/app/src/App/ODDTopLevelRedirects/hooks/useCurrentRunRoute.ts
+++ b/app/src/App/ODDTopLevelRedirects/hooks/useCurrentRunRoute.ts
@@ -21,7 +21,7 @@ export function useCurrentRunRoute(currentRunId: string): string | null {
   const hasRunStarted = runRecord?.data.startedAt != null
   const runStatus = runRecord?.data.status
 
-  if (isFetching) {
+  if (isFetching || runRecord?.data.id !== currentRunId) {
     return null
   } else if (
     runStatus === RUN_STATUS_SUCCEEDED ||

--- a/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol.ts
+++ b/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol.ts
@@ -69,8 +69,13 @@ export function useCreateRunFromProtocol(
     {
       ...options,
       onSuccess: (...args) => {
+        const [response] = args
+        queryClient.setQueryData(
+          getQueryKey(host, 'runs', response.data.id, 'details'),
+          response
+        )
         queryClient
-          .invalidateQueries(getQueryKey(host, 'runs'))
+          .invalidateQueries(getQueryKey(host, 'runs', 'details'))
           .catch((e: Error) => {
             console.error(`error invalidating runs query: ${e.message}`)
           })

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/index.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/index.ts
@@ -108,7 +108,7 @@ function useOT2LPCLabwareInfo({
   robotType,
 }: UseLPCLabwareInfoProps): Pick<UseLPCLabwareInfoResult, 'legacyOffsets'> {
   const { data: runRecord } = useNotifyRunQuery(runId ?? null, {
-    enabled: robotType === OT2_ROBOT_TYPE,
+    enabled: robotType === OT2_ROBOT_TYPE && runId != null,
   })
   const legacyOffsets = runRecord?.data?.labwareOffsets ?? []
 

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ProtocolSetupParameters.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ProtocolSetupParameters.tsx
@@ -190,8 +190,12 @@ export function ProtocolSetupParameters({
     documentationState,
     {
       onSuccess: data => {
+        queryClient.setQueryData(
+          getQueryKey(host, 'runs', data.data.id, 'details'),
+          data
+        )
         queryClient
-          .invalidateQueries(getQueryKey(host, 'runs'))
+          .invalidateQueries(getQueryKey(host, 'runs', 'details'))
           .catch((e: Error) => {
             console.error(`could not invalidate runs cache: ${e.message}`)
           })

--- a/app/src/organisms/ODD/QuickTransferFlow/SummaryAndSettings.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SummaryAndSettings.tsx
@@ -82,8 +82,12 @@ export function SummaryAndSettings(
     documentationState,
     {
       onSuccess: data => {
+        queryClient.setQueryData(
+          getQueryKey(host, 'runs', data.data.id, 'details'),
+          data
+        )
         queryClient
-          .invalidateQueries(getQueryKey(host, 'runs'))
+          .invalidateQueries(getQueryKey(host, 'runs', 'details'))
           .catch((e: Error) => {
             console.error(`error invalidating runs query: ${e.message}`)
           })

--- a/app/src/pages/ODD/ProtocolDetails/index.tsx
+++ b/app/src/pages/ODD/ProtocolDetails/index.tsx
@@ -356,8 +356,12 @@ export function ProtocolDetails(): JSX.Element | null {
   const documentationState = useDocumentationState()
   const { createRun } = useCreateRunMutation(documentationState, {
     onSuccess: data => {
+      queryClient.setQueryData(
+        getQueryKey(host, 'runs', data.data.id, 'details'),
+        data
+      )
       queryClient
-        .invalidateQueries(getQueryKey(host, 'runs'))
+        .invalidateQueries(getQueryKey(host, 'runs', 'details'))
         .catch((e: Error) => {
           console.error(`could not invalidate runs cache: ${e.message}`)
         })

--- a/app/src/pages/ODD/QuickTransferDetails/index.tsx
+++ b/app/src/pages/ODD/QuickTransferDetails/index.tsx
@@ -330,8 +330,12 @@ export function QuickTransferDetails(): JSX.Element | null {
 
   const { createRun } = useCreateRunMutation(documentationState, {
     onSuccess: data => {
+      queryClient.setQueryData(
+        getQueryKey(host, 'runs', data.data.id, 'details'),
+        data
+      )
       queryClient
-        .invalidateQueries(getQueryKey(host, 'runs'))
+        .invalidateQueries(getQueryKey(host, 'runs', 'details'))
         .catch((e: Error) => {
           console.error(`could not invalidate runs cache: ${e.message}`)
         })

--- a/app/src/resources/runs/useCloneRun.ts
+++ b/app/src/resources/runs/useCloneRun.ts
@@ -41,8 +41,13 @@ export function useCloneRun(
     documentationState,
     {
       onSuccess: response => {
+        queryClient.setQueryData(
+          getQueryKey(host, 'runs', response.data.id, 'details'),
+          response
+        )
+
         const invalidateRuns = queryClient.invalidateQueries(
-          getQueryKey(host, 'runs')
+          getQueryKey(host, 'runs', 'details')
         )
         const invalidateProtocols = queryClient.invalidateQueries(
           getQueryKey(host, 'protocols', protocolKey)

--- a/app/src/resources/runs/useNotifyRunQuery.ts
+++ b/app/src/resources/runs/useNotifyRunQuery.ts
@@ -23,7 +23,9 @@ export function useNotifyRunQuery<TError = Error>(
   const httpQueryResult = useRunQuery(runId, queryOptionsNotify, hostOverride)
 
   useEffect(() => {
-    if (shouldRefetch && runId != null && runId !== 'null') {
+    // Route params can turn a missing id into the literal string "null" (e.g. `/runs/${null}` → `/runs/null`). Treat that like no id.
+    const isValidRunId = runId != null && runId !== 'null'
+    if (shouldRefetch && isValidRunId) {
       void httpQueryResult.refetch()
     }
 

--- a/app/src/resources/runs/useNotifyRunQuery.ts
+++ b/app/src/resources/runs/useNotifyRunQuery.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 import { useRunQuery } from '@opentrons/react-api-client'
 
 import { useNotifyDataReady } from '../useNotifyDataReady'
@@ -20,9 +22,14 @@ export function useNotifyRunQuery<TError = Error>(
 
   const httpQueryResult = useRunQuery(runId, queryOptionsNotify, hostOverride)
 
-  if (shouldRefetch && runId != null) {
-    void httpQueryResult.refetch()
-  }
+  useEffect(() => {
+    if (shouldRefetch && runId != null && runId !== 'null') {
+      void httpQueryResult.refetch()
+    }
+
+    // refetch is stable, the result object is not
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldRefetch, runId])
 
   return httpQueryResult
 }

--- a/react-api-client/src/runs/useRunQuery.ts
+++ b/react-api-client/src/runs/useRunQuery.ts
@@ -22,8 +22,12 @@ export function useRunQuery<TError = Error>(
     getQueryKey(host, 'runs', runId, 'details'),
     () => getRun(host!, runId!).then(response => response.data),
     {
-      enabled: host !== null && runId != null && options.enabled !== false,
       ...options,
+      enabled:
+        host !== null &&
+        runId != null &&
+        runId !== 'null' &&
+        options.enabled !== false,
     }
   )
 

--- a/react-api-client/src/runs/useRunQuery.ts
+++ b/react-api-client/src/runs/useRunQuery.ts
@@ -18,16 +18,14 @@ export function useRunQuery<TError = Error>(
   const host =
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
   const queryClient = useQueryClient()
+  // Route params can turn a missing id into the literal string "null" (e.g. `/runs/${null}` → `/runs/null`). Treat that like no id.
+  const isValidRunId = runId != null && runId !== 'null'
   const query = useQuery<Run, TError>(
     getQueryKey(host, 'runs', runId, 'details'),
     () => getRun(host!, runId!).then(response => response.data),
     {
       ...options,
-      enabled:
-        host !== null &&
-        runId != null &&
-        runId !== 'null' &&
-        options.enabled !== false,
+      enabled: host !== null && isValidRunId && options.enabled !== false,
     }
   )
 


### PR DESCRIPTION
# Overview

This PR attempts to speed up run creation by pruning some strange extraneous queries I was seeing being sent from the frontend while a new run was loading.

### /runs/null
We we're calling `refetch()` in `useNotifyRunQuery` during render, but ReactQuery only updates the query key with a `useEffect`. So briefly during run creation, `useNotifyRunQuery` would see a new runId and go to refetch the query immediately, but ReactQuery hadn't actually updated the key yet, so the refetch would hit `/runs/null` and do a whole server round trip with useless data. Moving the refetch into the useEffect gives ReactQuery the time to load the correct key. 

In the process of tracking this down, I found a few weird edge cases where /runs/null could theoretically be hit, so I patched those out as well 

### /runs/{previous run id}
When the POST request creating the run returned, we were invalidating every query that hit _any_ `/runs` endpoint, i.e. including `/runs/{id}`. This invalidated queries for still mounted components that just happened to have stale references to the previous run, and triggered a refetch for data about a run that nothing in the ODD actually cared about. I updated the create run response to only invalidate calls to `/runs` exactly. In addition, since the response carried all the info for the new run anyways, I also had it seed the `/run/{new run id}` query as well.

Its anecdotal, but I'm seeing a pretty major speedup in loading times for creating new runs since adding these changes.

## Test Plan and Hands on Testing

Creating runs from the ODD and desktop should work normally. Tracking responses in the network tab, you should no longer see queries for stale run Ids or for `/runs/null`

## Review requests

There are more places in the codebase that I could improve with these patterns - moving notify refetches into useEffects, and seeding queries with mutation responses - if you all approve of the methods I'm using here. Let me know!

## Risk assessment

Medium. I'm in the weeds here, there could be something I missed, particularly with the query invalidation.
