### PR TITLE
fix(protocol-designer): fix sentry init function to align with redux state

### DIFF
--- a/protocol-designer/src/analytics/actions.ts
+++ b/protocol-designer/src/analytics/actions.ts
@@ -1,4 +1,5 @@
 import { OLDEST_MIGRATEABLE_VERSION } from '../load-file/migration'
+import { setSentryTracking } from '../resources/sentry'
 import { setMixpanelTracking } from './mixpanel'
 
 import type { AnalyticsEvent } from './mixpanel'
@@ -10,11 +11,8 @@ export interface SetOptIn {
 
 const _setOptIn = (payload: SetOptIn['payload']): SetOptIn => {
   // side effects
-  if (payload) {
-    setMixpanelTracking(true)
-  } else {
-    setMixpanelTracking(false)
-  }
+  setMixpanelTracking(payload.hasOptedIn)
+  setSentryTracking(payload.hasOptedIn)
 
   return {
     type: 'SET_OPT_IN',

--- a/protocol-designer/src/resources/sentry.ts
+++ b/protocol-designer/src/resources/sentry.ts
@@ -1,6 +1,7 @@
 import {
   browserTracingIntegration,
   captureConsoleIntegration,
+  close,
   init,
   replayIntegration,
 } from '@sentry/react'
@@ -33,8 +34,7 @@ const resolveSentryEnvironment = ():
   return 'development'
 }
 
-export const initializeSentry = (state: BaseState): void => {
-  const optedIn = getHasOptedIn(state)?.hasOptedIn ?? false
+const startSentry = (): void => {
   if (isSentryInitialized) {
     console.warn('Sentry is already initialized')
     return
@@ -44,51 +44,74 @@ export const initializeSentry = (state: BaseState): void => {
     console.warn('Sentry DSN not found - Sentry is not initialized')
     return
   }
-  if (optedIn) {
-    try {
-      init({
-        dsn: sentryDsn,
-        environment: resolveSentryEnvironment(),
-        release: sentryRelease,
-        integrations: [
-          captureConsoleIntegration({ levels: ['assert'] }),
-          replayIntegration(),
-          browserTracingIntegration(),
-        ],
-        attachStacktrace: true, // include stack traces in captureConsoleIntegration
-        tracesSampleRate: 1.0,
-        tracePropagationTargets: [
-          'localhost',
-          /^https:\/\/designer\.opentrons\.com/,
-        ],
-        replaysSessionSampleRate: 0.0, // No Session Replay
-        replaysOnErrorSampleRate: 0.0, // No Session Replay
-        ignoreErrors: [
-          // Ignore the fetch since PD doesn't use fetch
-          /Failed to fetch/i,
-          // Most likely triggered by MS Defender trying to run PD. Nothing we can do but ignore it:
-          // https://github.com/getsentry/sentry-javascript/issues/3440
-          'Non-Error promise rejection captured with value: Object Not Found Matching Id:',
-        ],
-        beforeBreadcrumb(breadcrumb, hint) {
-          if (
-            // Sentry records breadcrumbs for HTTP requests we issue, but the Mixpanel
-            // request is huge and not useful:
-            breadcrumb.data?.url?.includes('/api.mixpanel.com/track') ||
-            // We console.debug() every time we send an event to Mixpanel, ignore it too:
-            (breadcrumb.category === 'console' && breadcrumb.level === 'debug')
-          ) {
-            return null
-          }
-          return breadcrumb
-        },
-      })
-      isSentryInitialized = true
-      console.log('Sentry.init done')
-    } catch (error) {
-      console.error('Error initializing Sentry:', error)
+
+  try {
+    const client = init({
+      dsn: sentryDsn,
+      environment: resolveSentryEnvironment(),
+      release: sentryRelease,
+      integrations: [
+        captureConsoleIntegration({ levels: ['assert'] }),
+        replayIntegration(),
+        browserTracingIntegration(),
+      ],
+      attachStacktrace: true, // include stack traces in captureConsoleIntegration
+      tracesSampleRate: 1.0,
+      tracePropagationTargets: [
+        /^https:\/\/designer\.opentrons\.com(?::443)?(?:\/|$)/,
+        /^https?:\/\/localhost(?::\d+)?(?:\/|$)/,
+      ],
+      replaysSessionSampleRate: 0.0, // No Session Replay
+      replaysOnErrorSampleRate: 0.0, // No Session Replay
+      ignoreErrors: [
+        // Ignore the fetch since PD doesn't use fetch
+        /Failed to fetch/i,
+        // Most likely triggered by MS Defender trying to run PD. Nothing we can do but ignore it:
+        // https://github.com/getsentry/sentry-javascript/issues/3440
+        'Non-Error promise rejection captured with value: Object Not Found Matching Id:',
+      ],
+      beforeBreadcrumb(breadcrumb, hint) {
+        if (
+          // Sentry records breadcrumbs for HTTP requests we issue, but the Mixpanel
+          // request is huge and not useful:
+          breadcrumb.data?.url?.includes('/api.mixpanel.com/track') ||
+          // We console.debug() every time we send an event to Mixpanel, ignore it too:
+          (breadcrumb.category === 'console' && breadcrumb.level === 'debug')
+        ) {
+          return null
+        }
+        return breadcrumb
+      },
+    })
+
+    if (client == null) {
+      console.warn('Sentry.init did not create a client')
+      return
     }
-  } else {
-    console.debug('User has opted out of Sentry; stopping Sentry')
+
+    isSentryInitialized = true
+    console.log('Sentry.init done')
+  } catch (error) {
+    console.error('Error initializing Sentry:', error)
   }
+}
+
+export const setSentryTracking = (optedIn: boolean): void => {
+  if (optedIn) {
+    startSentry()
+    return
+  }
+
+  if (isSentryInitialized) {
+    isSentryInitialized = false
+    void close().catch(error => {
+      console.error('Error stopping Sentry:', error)
+    })
+  }
+  console.debug('User has opted out of Sentry; Sentry is stopped')
+}
+
+export const initializeSentry = (state: BaseState): void => {
+  const optedIn = getHasOptedIn(state)?.hasOptedIn ?? false
+  setSentryTracking(optedIn)
 }

--- a/protocol-designer/src/resources/sentry.ts
+++ b/protocol-designer/src/resources/sentry.ts
@@ -15,11 +15,21 @@ let isSentryInitialized = false
 
 // Production DSN is shared by production and staging so sourcemaps live in one project.
 // Development can still fall back to the dev DSN if it is configured locally.
-const sentryDsn = _OT_PD_SENTRY_DSN_ ?? _OT_PD_SENTRY_DEV_DSN_
+const sentryDsn =
+  typeof _OT_PD_SENTRY_DSN_ !== 'undefined'
+    ? _OT_PD_SENTRY_DSN_
+    : typeof _OT_PD_SENTRY_DEV_DSN_ !== 'undefined'
+      ? _OT_PD_SENTRY_DEV_DSN_
+      : undefined
 
 // Sentry release is normally the app version, but local builds can override it
 // (e.g. `local-dev`) so locally uploaded sourcemaps resolve against local events.
-const sentryRelease = _OT_PD_SENTRY_RELEASE_ ?? _OT_PD_VERSION_
+const sentryRelease =
+  typeof _OT_PD_SENTRY_RELEASE_ !== 'undefined'
+    ? _OT_PD_SENTRY_RELEASE_
+    : typeof _OT_PD_VERSION_ !== 'undefined'
+      ? _OT_PD_VERSION_
+      : undefined
 
 const resolveSentryEnvironment = ():
   'production' | 'staging' | 'development' => {


### PR DESCRIPTION
# Overview
fix sentry init function to align with redux state (while working on Sentry for OAI, noticed that the current implementation would have an issue)

closes AUTH-3193

## Test Plan and Hands on Testing
- none

## Changelog
- update sentry.ts to make opt-out works as expected
- use the value from state instead of passing boolean

## Review requests


## Risk assessment
mid
