### PR TITLE
fix(api): recover waitForTasks when a background vacuum task fails

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/background_task_recovery.py
+++ b/api/src/opentrons/protocol_engine/commands/background_task_recovery.py
@@ -5,16 +5,18 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Sequence
 
 from ..types import FinishedTask
-from .command import CommandIntent
 
 if TYPE_CHECKING:
-    from ..execution import EquipmentHandler, MovementHandler, TaskHandler
+    from ..commands.command_unions import (
+        Command,
+        CommandCreate,
+        CommandDefinedErrorData,
+    )
     from ..execution.associated_command_recovery_resolver import (
         AssociatedCommandRecoveryResolver,
     )
     from ..resources import ModelUtils
     from ..state.state import StateView
-    from .command_unions import Command, CommandDefinedErrorData
 
 
 def running_wait_for_tasks_covers_task(state_view: StateView, task_id: str) -> bool:
@@ -65,59 +67,78 @@ def defined_error_from_failed_tasks(
     return mapped
 
 
-async def restart_originating_background_tasks(
+def expand_wait_for_tasks_fixit(
+    task_ids: Sequence[str],
+    state_view: StateView,
+    resolvers: Sequence[AssociatedCommandRecoveryResolver],
+    model_utils: ModelUtils,
+) -> tuple[list[CommandCreate], list[str]] | None:
+    """Queue-time expansion for a waitForTasks fixit.
+
+    When the wait is retrying recoverable background failures, return new
+    originating command requests plus rewritten ``task_ids``. The caller must
+    queue those requests first so the new start_* commands run before wait.
+
+    Returns None when the wait should be queued unchanged.
+    """
+    failed_task_ids = state_view.tasks.get_failed_tasks(list(task_ids))
+    if not failed_task_ids:
+        return None
+    if (
+        defined_error_from_failed_tasks(
+            failed_task_ids, state_view, resolvers, model_utils
+        )
+        is None
+    ):
+        return None
+
+    origin_to_new_task: dict[str, str] = {}
+    creates: list[CommandCreate] = []
+    for task_id in failed_task_ids:
+        origin_id = state_view.tasks.get_originating_command_id(task_id)
+        if origin_id is None:
+            return None
+        if origin_id in origin_to_new_task:
+            continue
+        command = state_view.commands.get(origin_id)
+        new_task_id = model_utils.generate_id()
+        create = _create_retry(command, new_task_id, resolvers)
+        if create is None:
+            return None
+        origin_to_new_task[origin_id] = new_task_id
+        creates.append(create)
+
+    rewritten_task_ids = [
+        _rewritten_task_id(task_id, failed_task_ids, state_view, origin_to_new_task)
+        for task_id in task_ids
+    ]
+    return creates, rewritten_task_ids
+
+
+def _create_retry(
+    command: Command,
+    task_id: str,
+    resolvers: Sequence[AssociatedCommandRecoveryResolver],
+) -> CommandCreate | None:
+    for resolver in resolvers:
+        create = resolver.create_retry(command, task_id=task_id)
+        if create is not None:
+            return create
+    return None
+
+
+def _rewritten_task_id(
+    task_id: str,
     failed_task_ids: Sequence[str],
     state_view: StateView,
-    resolvers: Sequence[AssociatedCommandRecoveryResolver],
-    task_handler: TaskHandler,
-    equipment: EquipmentHandler | None,
-    movement: MovementHandler | None,
-    model_utils: ModelUtils,
-) -> list[str]:
-    """Ask resolvers to re-run each unique originating command.
-
-    Returns new task ids, or an empty list if any origin cannot be restarted.
-    """
-    origins = _background_commands_to_restart(failed_task_ids, state_view)
-    new_task_ids: list[str] = []
-    for command in origins:
-        restarted_task_id = await _restart_command(
-            command,
-            resolvers,
-            state_view=state_view,
-            task_handler=task_handler,
-            equipment=equipment,
-            movement=movement,
-            model_utils=model_utils,
-        )
-        if restarted_task_id is None:
-            return []
-        new_task_ids.append(restarted_task_id)
-    return new_task_ids
-
-
-async def _restart_command(
-    command: Command,
-    resolvers: Sequence[AssociatedCommandRecoveryResolver],
-    *,
-    state_view: StateView,
-    task_handler: TaskHandler,
-    equipment: EquipmentHandler | None,
-    movement: MovementHandler | None,
-    model_utils: ModelUtils,
-) -> str | None:
-    for resolver in resolvers:
-        if not resolver.is_associated_command(command):
-            continue
-        return await resolver.restart(
-            command,
-            state_view=state_view,
-            task_handler=task_handler,
-            equipment=equipment,
-            movement=movement,
-            model_utils=model_utils,
-        )
-    return None
+    origin_to_new_task: dict[str, str],
+) -> str:
+    if task_id not in failed_task_ids:
+        return task_id
+    origin_id = state_view.tasks.get_originating_command_id(task_id)
+    if origin_id is None:
+        return task_id
+    return origin_to_new_task.get(origin_id, task_id)
 
 
 def _running_wait_for_tasks(state_view: StateView) -> Command | None:
@@ -164,66 +185,14 @@ def _map_failed_task(
     for resolver in resolvers:
         if not resolver.can_handle_error(finished.error):
             continue
-        # Prefer the background command, but still map if a retry attributed the
-        # new task to waitForTasks. The error itself is what recovery needs.
-        command_for_mapping = originating_command
         if not resolver.is_associated_command(originating_command):
-            fallback_id = _associated_origin_for_error(
-                originating_command, state_view, resolver
-            )
-            if fallback_id is not None:
-                command_for_mapping = state_view.commands.get(fallback_id)
+            continue
         mapped = resolver.to_defined_error_data(
             error=finished.error,
-            command=command_for_mapping,
+            command=originating_command,
             state_view=state_view,
             model_utils=model_utils,
         )
         if mapped is not None:
             return mapped
     return None
-
-
-def _associated_origin_for_error(
-    originating_command: Command,
-    state_view: StateView,
-    resolver: AssociatedCommandRecoveryResolver,
-) -> str | None:
-    """If origin is waitForTasks, recover the background command it was waiting on."""
-    for command in _background_commands_to_restart(
-        _waited_task_ids(originating_command), state_view
-    ):
-        if resolver.is_associated_command(command):
-            return command.id
-    return None
-
-
-def _background_commands_to_restart(
-    failed_task_ids: Sequence[str], state_view: StateView
-) -> list[Command]:
-    """Walk from failed tasks to unique background commands.
-
-    A waitForTasks fixit creates new tasks attributed to itself. Those must
-    still restart the original background task implementations, not waitForTasks.
-    """
-    seen_origin_ids: set[str] = set()
-    commands: list[Command] = []
-    pending = list(failed_task_ids)
-    while pending:
-        task_id = pending.pop()
-        origin_id = state_view.tasks.get_originating_command_id(task_id)
-        if origin_id is None or origin_id in seen_origin_ids:
-            continue
-        seen_origin_ids.add(origin_id)
-        command = state_view.commands.get(origin_id)
-        if getattr(command, "commandType", None) == "waitForTasks":
-            pending.extend(_waited_task_ids(command))
-            continue
-        commands.append(command)
-    return commands
-
-
-def is_fixit_wait_for_tasks(state_view: StateView) -> bool:
-    """Return whether the running command is a waitForTasks fixit retry."""
-    running_command = _running_wait_for_tasks(state_view)
-    return running_command is not None and running_command.intent == CommandIntent.FIXIT

--- a/api/src/opentrons/protocol_engine/commands/background_task_recovery.py
+++ b/api/src/opentrons/protocol_engine/commands/background_task_recovery.py
@@ -1,0 +1,229 @@
+"""Recovery helpers for background tasks waited on by waitForTasks."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Sequence
+
+from ..types import FinishedTask
+from .command import CommandIntent
+
+if TYPE_CHECKING:
+    from ..execution import EquipmentHandler, MovementHandler, TaskHandler
+    from ..execution.associated_command_recovery_resolver import (
+        AssociatedCommandRecoveryResolver,
+    )
+    from ..resources import ModelUtils
+    from ..state.state import StateView
+    from .command_unions import Command, CommandDefinedErrorData
+
+
+def running_wait_for_tasks_covers_task(state_view: StateView, task_id: str) -> bool:
+    """Return whether the running command is a waitForTasks that includes ``task_id``."""
+    running_command = _running_wait_for_tasks(state_view)
+    if running_command is None:
+        return False
+    return task_id in _waited_task_ids(running_command)
+
+
+def running_wait_for_tasks_covers_command(
+    state_view: StateView, command_id: str
+) -> bool:
+    """Return whether a running waitForTasks can still observe a failure of ``command_id``.
+
+    Wait owns recovery only while it can still fail: the originating task is
+    still running, or has already failed.
+    """
+    running_command = _running_wait_for_tasks(state_view)
+    if running_command is None:
+        return False
+    return any(
+        state_view.tasks.get_originating_command_id(task_id) == command_id
+        and _wait_can_observe_task_failure(state_view, task_id)
+        for task_id in _waited_task_ids(running_command)
+    )
+
+
+def defined_error_from_failed_tasks(
+    failed_task_ids: Sequence[str],
+    state_view: StateView,
+    resolvers: Sequence[AssociatedCommandRecoveryResolver],
+    model_utils: ModelUtils,
+) -> CommandDefinedErrorData | None:
+    """Map failed waited-on tasks to defined error data via recovery resolvers.
+
+    Returns the first mapped error when every failed task is handled by some
+    resolver. Returns None if any failure is unhandled so waitForTasks can
+    raise TaskFailedError.
+    """
+    mapped: CommandDefinedErrorData | None = None
+    for task_id in failed_task_ids:
+        this_mapped = _map_failed_task(task_id, state_view, resolvers, model_utils)
+        if this_mapped is None:
+            return None
+        if mapped is None:
+            mapped = this_mapped
+    return mapped
+
+
+async def restart_originating_background_tasks(
+    failed_task_ids: Sequence[str],
+    state_view: StateView,
+    resolvers: Sequence[AssociatedCommandRecoveryResolver],
+    task_handler: TaskHandler,
+    equipment: EquipmentHandler | None,
+    movement: MovementHandler | None,
+    model_utils: ModelUtils,
+) -> list[str]:
+    """Ask resolvers to re-run each unique originating command.
+
+    Returns new task ids, or an empty list if any origin cannot be restarted.
+    """
+    origins = _background_commands_to_restart(failed_task_ids, state_view)
+    new_task_ids: list[str] = []
+    for command in origins:
+        restarted_task_id = await _restart_command(
+            command,
+            resolvers,
+            state_view=state_view,
+            task_handler=task_handler,
+            equipment=equipment,
+            movement=movement,
+            model_utils=model_utils,
+        )
+        if restarted_task_id is None:
+            return []
+        new_task_ids.append(restarted_task_id)
+    return new_task_ids
+
+
+async def _restart_command(
+    command: Command,
+    resolvers: Sequence[AssociatedCommandRecoveryResolver],
+    *,
+    state_view: StateView,
+    task_handler: TaskHandler,
+    equipment: EquipmentHandler | None,
+    movement: MovementHandler | None,
+    model_utils: ModelUtils,
+) -> str | None:
+    for resolver in resolvers:
+        if not resolver.is_associated_command(command):
+            continue
+        return await resolver.restart(
+            command,
+            state_view=state_view,
+            task_handler=task_handler,
+            equipment=equipment,
+            movement=movement,
+            model_utils=model_utils,
+        )
+    return None
+
+
+def _running_wait_for_tasks(state_view: StateView) -> Command | None:
+    running_command_id = state_view.commands.get_running_command_id()
+    if running_command_id is None:
+        return None
+    running_command = state_view.commands.get(running_command_id)
+    if running_command.commandType != "waitForTasks":
+        return None
+    return running_command
+
+
+def _waited_task_ids(command: Command) -> list[str]:
+    task_ids = getattr(command.params, "task_ids", None)
+    if not isinstance(task_ids, list):
+        return []
+    return [task_id for task_id in task_ids if isinstance(task_id, str)]
+
+
+def _wait_can_observe_task_failure(state_view: StateView, task_id: str) -> bool:
+    """Return whether waitForTasks will still see a failure for ``task_id``."""
+    try:
+        task = state_view.tasks.get(task_id)
+    except Exception:
+        return False
+    if isinstance(task, FinishedTask):
+        return task.error is not None
+    return True
+
+
+def _map_failed_task(
+    task_id: str,
+    state_view: StateView,
+    resolvers: Sequence[AssociatedCommandRecoveryResolver],
+    model_utils: ModelUtils,
+) -> CommandDefinedErrorData | None:
+    finished = state_view.tasks.get_finished(task_id)
+    if finished.error is None:
+        return None
+    origin_id = state_view.tasks.get_originating_command_id(task_id)
+    if origin_id is None:
+        return None
+    originating_command = state_view.commands.get(origin_id)
+    for resolver in resolvers:
+        if not resolver.can_handle_error(finished.error):
+            continue
+        # Prefer the background command, but still map if a retry attributed the
+        # new task to waitForTasks. The error itself is what recovery needs.
+        command_for_mapping = originating_command
+        if not resolver.is_associated_command(originating_command):
+            fallback_id = _associated_origin_for_error(
+                originating_command, state_view, resolver
+            )
+            if fallback_id is not None:
+                command_for_mapping = state_view.commands.get(fallback_id)
+        mapped = resolver.to_defined_error_data(
+            error=finished.error,
+            command=command_for_mapping,
+            state_view=state_view,
+            model_utils=model_utils,
+        )
+        if mapped is not None:
+            return mapped
+    return None
+
+
+def _associated_origin_for_error(
+    originating_command: Command,
+    state_view: StateView,
+    resolver: AssociatedCommandRecoveryResolver,
+) -> str | None:
+    """If origin is waitForTasks, recover the background command it was waiting on."""
+    for command in _background_commands_to_restart(
+        _waited_task_ids(originating_command), state_view
+    ):
+        if resolver.is_associated_command(command):
+            return command.id
+    return None
+
+
+def _background_commands_to_restart(
+    failed_task_ids: Sequence[str], state_view: StateView
+) -> list[Command]:
+    """Walk from failed tasks to unique background commands.
+
+    A waitForTasks fixit creates new tasks attributed to itself. Those must
+    still restart the original background task implementations, not waitForTasks.
+    """
+    seen_origin_ids: set[str] = set()
+    commands: list[Command] = []
+    pending = list(failed_task_ids)
+    while pending:
+        task_id = pending.pop()
+        origin_id = state_view.tasks.get_originating_command_id(task_id)
+        if origin_id is None or origin_id in seen_origin_ids:
+            continue
+        seen_origin_ids.add(origin_id)
+        command = state_view.commands.get(origin_id)
+        if getattr(command, "commandType", None) == "waitForTasks":
+            pending.extend(_waited_task_ids(command))
+            continue
+        commands.append(command)
+    return commands
+
+
+def is_fixit_wait_for_tasks(state_view: StateView) -> bool:
+    """Return whether the running command is a waitForTasks fixit retry."""
+    running_command = _running_wait_for_tasks(state_view)
+    return running_command is not None and running_command.intent == CommandIntent.FIXIT

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/recovery.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/recovery.py
@@ -7,6 +7,9 @@ from typing import TYPE_CHECKING, get_args
 from opentrons_shared_data.errors.exceptions import EnumeratedError
 
 from ...errors import ErrorOccurrence
+from ...execution.associated_command_recovery_resolver import (
+    reexecute_background_start_command,
+)
 from ...state import update_types
 from ...types import LoadedModule, ModuleModel
 from .common import (
@@ -14,9 +17,15 @@ from .common import (
     defined_error_data_from_task_error,
     is_recoverable_module_error,
 )
-from .start_run_profile import StartRunProfileCommandType
-from .start_set_vacuum_power import StartSetVacuumPowerCommandType
-from .start_set_vacuum_pressure import StartSetVacuumPressureCommandType
+from .start_run_profile import StartRunProfileCommandType, StartRunProfileImpl
+from .start_set_vacuum_power import (
+    StartSetVacuumPowerCommandType,
+    StartSetVacuumPowerImpl,
+)
+from .start_set_vacuum_pressure import (
+    StartSetVacuumPressureCommandType,
+    StartSetVacuumPressureImpl,
+)
 
 VACUUM_BACKGROUND_COMMAND_TYPES: frozenset[str] = frozenset(
     {
@@ -29,8 +38,17 @@ VACUUM_BACKGROUND_COMMAND_TYPES: frozenset[str] = frozenset(
 if TYPE_CHECKING:
     from ...commands import Command
     from ...commands.command_unions import CommandDefinedErrorData
+    from ...execution import EquipmentHandler, MovementHandler, TaskHandler
     from ...resources import ModelUtils
     from ...state.state import StateView
+
+
+def _vacuum_start_impl_cls(command_type: str) -> type | None:
+    return {
+        get_args(StartSetVacuumPressureCommandType)[0]: StartSetVacuumPressureImpl,
+        get_args(StartSetVacuumPowerCommandType)[0]: StartSetVacuumPowerImpl,
+        get_args(StartRunProfileCommandType)[0]: StartRunProfileImpl,
+    }.get(command_type)
 
 
 class VacuumModuleAssociatedCommandRecoveryResolver:
@@ -90,6 +108,27 @@ class VacuumModuleAssociatedCommandRecoveryResolver:
             error,
             model_utils,
             state_update_if_false_positive=state_update_if_false_positive,
+        )
+
+    async def restart(
+        self,
+        command: Command,
+        *,
+        state_view: StateView,
+        task_handler: TaskHandler,
+        equipment: EquipmentHandler | None,
+        movement: MovementHandler | None,
+        model_utils: ModelUtils,
+    ) -> str | None:
+        """Re-run a vacuum start_* implementation and return the new task id."""
+        return await reexecute_background_start_command(
+            _vacuum_start_impl_cls(command.commandType),
+            command,
+            state_view=state_view,
+            task_handler=task_handler,
+            equipment=equipment,
+            movement=movement,
+            model_utils=model_utils,
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/recovery.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/recovery.py
@@ -7,24 +7,28 @@ from typing import TYPE_CHECKING, get_args
 from opentrons_shared_data.errors.exceptions import EnumeratedError
 
 from ...errors import ErrorOccurrence
-from ...execution.associated_command_recovery_resolver import (
-    reexecute_background_start_command,
-)
 from ...state import update_types
 from ...types import LoadedModule, ModuleModel
+from ..command import CommandIntent
 from .common import (
     defined_error_data_from_enumerated_error,
     defined_error_data_from_task_error,
     is_recoverable_module_error,
 )
-from .start_run_profile import StartRunProfileCommandType, StartRunProfileImpl
+from .start_run_profile import (
+    StartRunProfile,
+    StartRunProfileCommandType,
+    StartRunProfileCreate,
+)
 from .start_set_vacuum_power import (
+    StartSetVacuumPower,
     StartSetVacuumPowerCommandType,
-    StartSetVacuumPowerImpl,
+    StartSetVacuumPowerCreate,
 )
 from .start_set_vacuum_pressure import (
+    StartSetVacuumPressure,
     StartSetVacuumPressureCommandType,
-    StartSetVacuumPressureImpl,
+    StartSetVacuumPressureCreate,
 )
 
 VACUUM_BACKGROUND_COMMAND_TYPES: frozenset[str] = frozenset(
@@ -37,18 +41,28 @@ VACUUM_BACKGROUND_COMMAND_TYPES: frozenset[str] = frozenset(
 
 if TYPE_CHECKING:
     from ...commands import Command
-    from ...commands.command_unions import CommandDefinedErrorData
-    from ...execution import EquipmentHandler, MovementHandler, TaskHandler
+    from ...commands.command_unions import CommandCreate, CommandDefinedErrorData
     from ...resources import ModelUtils
     from ...state.state import StateView
 
 
-def _vacuum_start_impl_cls(command_type: str) -> type | None:
-    return {
-        get_args(StartSetVacuumPressureCommandType)[0]: StartSetVacuumPressureImpl,
-        get_args(StartSetVacuumPowerCommandType)[0]: StartSetVacuumPowerImpl,
-        get_args(StartRunProfileCommandType)[0]: StartRunProfileImpl,
-    }.get(command_type)
+def _vacuum_start_create(command: Command, task_id: str) -> CommandCreate | None:
+    if isinstance(command, StartSetVacuumPressure):
+        return StartSetVacuumPressureCreate(
+            params=command.params.model_copy(update={"taskId": task_id}),
+            intent=CommandIntent.FIXIT,
+        )
+    if isinstance(command, StartSetVacuumPower):
+        return StartSetVacuumPowerCreate(
+            params=command.params.model_copy(update={"taskId": task_id}),
+            intent=CommandIntent.FIXIT,
+        )
+    if isinstance(command, StartRunProfile):
+        return StartRunProfileCreate(
+            params=command.params.model_copy(update={"taskId": task_id}),
+            intent=CommandIntent.FIXIT,
+        )
+    return None
 
 
 class VacuumModuleAssociatedCommandRecoveryResolver:
@@ -110,26 +124,9 @@ class VacuumModuleAssociatedCommandRecoveryResolver:
             state_update_if_false_positive=state_update_if_false_positive,
         )
 
-    async def restart(
-        self,
-        command: Command,
-        *,
-        state_view: StateView,
-        task_handler: TaskHandler,
-        equipment: EquipmentHandler | None,
-        movement: MovementHandler | None,
-        model_utils: ModelUtils,
-    ) -> str | None:
-        """Re-run a vacuum start_* implementation and return the new task id."""
-        return await reexecute_background_start_command(
-            _vacuum_start_impl_cls(command.commandType),
-            command,
-            state_view=state_view,
-            task_handler=task_handler,
-            equipment=equipment,
-            movement=movement,
-            model_utils=model_utils,
-        )
+    def create_retry(self, command: Command, *, task_id: str) -> CommandCreate | None:
+        """Return a new vacuum start_* request that creates ``task_id``."""
+        return _vacuum_start_create(command, task_id)
 
 
 def _vacuum_false_positive_state_update(

--- a/api/src/opentrons/protocol_engine/commands/wait_for_tasks.py
+++ b/api/src/opentrons/protocol_engine/commands/wait_for_tasks.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING, Optional, Sequence, Type, Union
 
 from pydantic import BaseModel, Field
 from typing_extensions import Literal
@@ -10,11 +10,31 @@ from typing_extensions import Literal
 from ..errors import ErrorOccurrence
 from ..errors.error_occurrence import ProtocolCommandFailedError
 from ..errors.exceptions import TaskFailedError
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..resources import ModelUtils
+from .background_task_recovery import (
+    defined_error_from_failed_tasks,
+    is_fixit_wait_for_tasks,
+    restart_originating_background_tasks,
+)
+from .command import (
+    AbstractCommandImpl,
+    BaseCommand,
+    BaseCommandCreate,
+    SuccessData,
+)
 
 if TYPE_CHECKING:
-    from ..execution import RunControlHandler, TaskHandler
+    from ..execution import (
+        EquipmentHandler,
+        MovementHandler,
+        RunControlHandler,
+        TaskHandler,
+    )
+    from ..execution.associated_command_recovery_resolver import (
+        AssociatedCommandRecoveryResolver,
+    )
     from ..state.state import StateView
+    from .command_unions import CommandDefinedErrorData
 
 
 WaitForTasksCommandType = Literal["waitForTasks"]
@@ -38,8 +58,14 @@ class WaitForTasksResult(BaseModel):
     )
 
 
+_ExecuteReturn = Union[
+    SuccessData[WaitForTasksResult],
+    "CommandDefinedErrorData",
+]
+
+
 class WaitForTasksImplementation(
-    AbstractCommandImpl[WaitForTasksParams, SuccessData[WaitForTasksResult]]
+    AbstractCommandImpl[WaitForTasksParams, _ExecuteReturn]
 ):
     """WaitForTasks command implementation."""
 
@@ -48,42 +74,91 @@ class WaitForTasksImplementation(
         task_handler: TaskHandler,
         run_control: RunControlHandler,
         state_view: StateView,
-        **kwargs: object,
+        equipment: EquipmentHandler | None = None,
+        movement: MovementHandler | None = None,
+        model_utils: ModelUtils | None = None,
+        resolvers: Sequence[AssociatedCommandRecoveryResolver] | None = None,
+        **_unused_dependencies: object,
     ) -> None:
         self._task_handler = task_handler
         self._run_control = run_control
         self._state_view = state_view
+        self._equipment = equipment
+        self._movement = movement
+        self._model_utils = model_utils or ModelUtils()
+        self._resolvers = resolvers
 
-    async def execute(
-        self, params: WaitForTasksParams
-    ) -> SuccessData[WaitForTasksResult]:
-        """Checks for existance of task id and then asynchronously waits for the valid, specified tasks to finish."""
-        # Raises the exception if we don't have a valid task id.
+    async def execute(self, params: WaitForTasksParams) -> _ExecuteReturn:
+        """Wait for tasks. Recoverable background failures become defined errors."""
         for task_id in params.task_ids:
             _ = self._state_view.tasks.get(task_id)
 
-        await self._run_control.wait_for_tasks(params.task_ids)
+        waited_task_ids = list(params.task_ids)
+        if is_fixit_wait_for_tasks(self._state_view):
+            failed_already = self._state_view.tasks.get_failed_tasks(params.task_ids)
+            if (
+                failed_already
+                and defined_error_from_failed_tasks(
+                    failed_already,
+                    self._state_view,
+                    self._get_resolvers(),
+                    self._model_utils,
+                )
+                is not None
+            ):
+                restarted = await restart_originating_background_tasks(
+                    failed_already,
+                    self._state_view,
+                    self._get_resolvers(),
+                    self._task_handler,
+                    self._equipment,
+                    self._movement,
+                    self._model_utils,
+                )
+                if restarted:
+                    waited_task_ids = restarted
 
-        failed_tasks = self._state_view.tasks.get_failed_tasks(params.task_ids)
-        if (
-            failed_tasks
-            and not self._state_view.failed_task_failures_absorbed_by_active_recovery(
-                params.task_ids
-            )
+        await self._run_control.wait_for_tasks(waited_task_ids)
+
+        failed_tasks = self._state_view.tasks.get_failed_tasks(waited_task_ids)
+        if not failed_tasks:
+            return SuccessData(public=WaitForTasksResult(task_ids=params.task_ids))
+
+        # Fail-before-wait race only: start_* already owns recovery, so do not
+        # raise a second error. Mixed or uncovered failures still fail the wait.
+        if self._state_view.failed_task_failures_absorbed_by_active_recovery(
+            waited_task_ids
         ):
-            raise TaskFailedError(
-                message=f"{len(failed_tasks)} tasks failed.",
-                details={"failed_task_ids": failed_tasks},
-                wrapping=[
-                    ProtocolCommandFailedError(
-                        original_error=self._state_view.tasks.get_finished(
-                            task_id
-                        ).error
-                    )
-                    for task_id in failed_tasks
-                ],
+            return SuccessData(public=WaitForTasksResult(task_ids=params.task_ids))
+
+        defined_error = defined_error_from_failed_tasks(
+            failed_tasks,
+            self._state_view,
+            self._get_resolvers(),
+            self._model_utils,
+        )
+        if defined_error is not None:
+            return defined_error
+
+        raise TaskFailedError(
+            message=f"{len(failed_tasks)} tasks failed.",
+            details={"failed_task_ids": failed_tasks},
+            wrapping=[
+                ProtocolCommandFailedError(
+                    original_error=self._state_view.tasks.get_finished(task_id).error
+                )
+                for task_id in failed_tasks
+            ],
+        )
+
+    def _get_resolvers(self) -> Sequence[AssociatedCommandRecoveryResolver]:
+        if self._resolvers is None:
+            from ..execution.associated_command_error_recovery import (
+                default_associated_command_recovery_resolvers,
             )
-        return SuccessData(public=WaitForTasksResult(task_ids=params.task_ids))
+
+            self._resolvers = default_associated_command_recovery_resolvers()
+        return self._resolvers
 
 
 class WaitForTasks(

--- a/api/src/opentrons/protocol_engine/commands/wait_for_tasks.py
+++ b/api/src/opentrons/protocol_engine/commands/wait_for_tasks.py
@@ -11,11 +11,7 @@ from ..errors import ErrorOccurrence
 from ..errors.error_occurrence import ProtocolCommandFailedError
 from ..errors.exceptions import TaskFailedError
 from ..resources import ModelUtils
-from .background_task_recovery import (
-    defined_error_from_failed_tasks,
-    is_fixit_wait_for_tasks,
-    restart_originating_background_tasks,
-)
+from .background_task_recovery import defined_error_from_failed_tasks
 from .command import (
     AbstractCommandImpl,
     BaseCommand,
@@ -24,12 +20,7 @@ from .command import (
 )
 
 if TYPE_CHECKING:
-    from ..execution import (
-        EquipmentHandler,
-        MovementHandler,
-        RunControlHandler,
-        TaskHandler,
-    )
+    from ..execution import RunControlHandler, TaskHandler
     from ..execution.associated_command_recovery_resolver import (
         AssociatedCommandRecoveryResolver,
     )
@@ -74,8 +65,6 @@ class WaitForTasksImplementation(
         task_handler: TaskHandler,
         run_control: RunControlHandler,
         state_view: StateView,
-        equipment: EquipmentHandler | None = None,
-        movement: MovementHandler | None = None,
         model_utils: ModelUtils | None = None,
         resolvers: Sequence[AssociatedCommandRecoveryResolver] | None = None,
         **_unused_dependencies: object,
@@ -83,8 +72,6 @@ class WaitForTasksImplementation(
         self._task_handler = task_handler
         self._run_control = run_control
         self._state_view = state_view
-        self._equipment = equipment
-        self._movement = movement
         self._model_utils = model_utils or ModelUtils()
         self._resolvers = resolvers
 
@@ -93,41 +80,16 @@ class WaitForTasksImplementation(
         for task_id in params.task_ids:
             _ = self._state_view.tasks.get(task_id)
 
-        waited_task_ids = list(params.task_ids)
-        if is_fixit_wait_for_tasks(self._state_view):
-            failed_already = self._state_view.tasks.get_failed_tasks(params.task_ids)
-            if (
-                failed_already
-                and defined_error_from_failed_tasks(
-                    failed_already,
-                    self._state_view,
-                    self._get_resolvers(),
-                    self._model_utils,
-                )
-                is not None
-            ):
-                restarted = await restart_originating_background_tasks(
-                    failed_already,
-                    self._state_view,
-                    self._get_resolvers(),
-                    self._task_handler,
-                    self._equipment,
-                    self._movement,
-                    self._model_utils,
-                )
-                if restarted:
-                    waited_task_ids = restarted
+        await self._run_control.wait_for_tasks(params.task_ids)
 
-        await self._run_control.wait_for_tasks(waited_task_ids)
-
-        failed_tasks = self._state_view.tasks.get_failed_tasks(waited_task_ids)
+        failed_tasks = self._state_view.tasks.get_failed_tasks(params.task_ids)
         if not failed_tasks:
             return SuccessData(public=WaitForTasksResult(task_ids=params.task_ids))
 
         # Fail-before-wait race only: start_* already owns recovery, so do not
         # raise a second error. Mixed or uncovered failures still fail the wait.
         if self._state_view.failed_task_failures_absorbed_by_active_recovery(
-            waited_task_ids
+            params.task_ids
         ):
             return SuccessData(public=WaitForTasksResult(task_ids=params.task_ids))
 

--- a/api/src/opentrons/protocol_engine/execution/associated_command_error_recovery.py
+++ b/api/src/opentrons/protocol_engine/execution/associated_command_error_recovery.py
@@ -10,6 +10,10 @@ from opentrons_shared_data.errors.exceptions import EnumeratedError
 from ..actions import Action, FinishTaskAction
 from ..actions.action_handler import ActionHandler
 from ..commands import CommandStatus
+from ..commands.background_task_recovery import (
+    running_wait_for_tasks_covers_command,
+    running_wait_for_tasks_covers_task,
+)
 from ..commands.vacuum_module.recovery import (
     VacuumModuleAssociatedCommandRecoveryResolver,
 )
@@ -77,6 +81,9 @@ class AssociatedCommandErrorRecoveryOrchestrator(ActionHandler):
             )
             if command_id is None:
                 continue
+            if running_wait_for_tasks_covers_command(self._state_store, command_id):
+                # waitForTasks is the recoverable command; do not fail the start_*.
+                return True
             if self._try_fail_associated_command(
                 resolver=resolver,
                 command_id=command_id,
@@ -90,6 +97,8 @@ class AssociatedCommandErrorRecoveryOrchestrator(ActionHandler):
     ) -> None:
         command_id = self._state_store.tasks.get_originating_command_id(task_id)
         if command_id is None:
+            return
+        if running_wait_for_tasks_covers_task(self._state_store, task_id):
             return
 
         for resolver in self._resolvers:

--- a/api/src/opentrons/protocol_engine/execution/associated_command_recovery_resolver.py
+++ b/api/src/opentrons/protocol_engine/execution/associated_command_recovery_resolver.py
@@ -2,22 +2,19 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Protocol
 
 from opentrons_shared_data.errors.exceptions import EnumeratedError
 
 from ..commands import Command
-from ..commands.command import SuccessData
 from ..commands.command_unions import CommandDefinedErrorData
 from ..errors import ErrorOccurrence
 from ..types import ModuleModel
 
 if TYPE_CHECKING:
+    from ..commands.command_unions import CommandCreate
     from ..resources import ModelUtils
     from ..state.state import StateView
-    from .equipment import EquipmentHandler
-    from .movement import MovementHandler
-    from .task_handler import TaskHandler
 
 
 class AssociatedCommandRecoveryResolver(Protocol):
@@ -50,49 +47,11 @@ class AssociatedCommandRecoveryResolver(Protocol):
         """Map the error to defined command error data for the associated command."""
         ...
 
-    async def restart(
-        self,
-        command: Command,
-        *,
-        state_view: StateView,
-        task_handler: TaskHandler,
-        equipment: EquipmentHandler | None,
-        movement: MovementHandler | None,
-        model_utils: ModelUtils,
-    ) -> str | None:
-        """Re-run ``command`` and return the new background task id, if any."""
+    def create_retry(self, command: Command, *, task_id: str) -> CommandCreate | None:
+        """Return a new originating command request for a waitForTasks fixit.
+
+        The request must use ``task_id`` so the following waitForTasks can wait
+        on the new background task. Return None if this resolver does not own
+        ``command``.
+        """
         ...
-
-
-async def reexecute_background_start_command(
-    impl_cls: type | None,
-    command: Command,
-    *,
-    state_view: StateView,
-    task_handler: TaskHandler,
-    equipment: EquipmentHandler | None,
-    movement: MovementHandler | None,
-    model_utils: ModelUtils,
-) -> str | None:
-    """Construct ``impl_cls``, re-run ``command.params``, and return the new task id."""
-    if impl_cls is None or equipment is None or movement is None:
-        return None
-    impl = impl_cls(
-        state_view=state_view,
-        task_handler=task_handler,
-        equipment=equipment,
-        movement=movement,
-        model_utils=model_utils,
-    )
-    result = await impl.execute(_params_for_restart(command))
-    if not isinstance(result, SuccessData):
-        return None
-    task_id = getattr(result.public, "taskId", None)
-    return task_id if isinstance(task_id, str) else None
-
-
-def _params_for_restart(command: Command) -> Any:
-    params = command.params
-    if getattr(params, "taskId", None) is None:
-        return params
-    return params.model_copy(update={"taskId": None})

--- a/api/src/opentrons/protocol_engine/execution/associated_command_recovery_resolver.py
+++ b/api/src/opentrons/protocol_engine/execution/associated_command_recovery_resolver.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from opentrons_shared_data.errors.exceptions import EnumeratedError
 
 from ..commands import Command
+from ..commands.command import SuccessData
 from ..commands.command_unions import CommandDefinedErrorData
 from ..errors import ErrorOccurrence
 from ..types import ModuleModel
@@ -14,6 +15,9 @@ from ..types import ModuleModel
 if TYPE_CHECKING:
     from ..resources import ModelUtils
     from ..state.state import StateView
+    from .equipment import EquipmentHandler
+    from .movement import MovementHandler
+    from .task_handler import TaskHandler
 
 
 class AssociatedCommandRecoveryResolver(Protocol):
@@ -45,3 +49,50 @@ class AssociatedCommandRecoveryResolver(Protocol):
     ) -> CommandDefinedErrorData | None:
         """Map the error to defined command error data for the associated command."""
         ...
+
+    async def restart(
+        self,
+        command: Command,
+        *,
+        state_view: StateView,
+        task_handler: TaskHandler,
+        equipment: EquipmentHandler | None,
+        movement: MovementHandler | None,
+        model_utils: ModelUtils,
+    ) -> str | None:
+        """Re-run ``command`` and return the new background task id, if any."""
+        ...
+
+
+async def reexecute_background_start_command(
+    impl_cls: type | None,
+    command: Command,
+    *,
+    state_view: StateView,
+    task_handler: TaskHandler,
+    equipment: EquipmentHandler | None,
+    movement: MovementHandler | None,
+    model_utils: ModelUtils,
+) -> str | None:
+    """Construct ``impl_cls``, re-run ``command.params``, and return the new task id."""
+    if impl_cls is None or equipment is None or movement is None:
+        return None
+    impl = impl_cls(
+        state_view=state_view,
+        task_handler=task_handler,
+        equipment=equipment,
+        movement=movement,
+        model_utils=model_utils,
+    )
+    result = await impl.execute(_params_for_restart(command))
+    if not isinstance(result, SuccessData):
+        return None
+    task_id = getattr(result.public, "taskId", None)
+    return task_id if isinstance(task_id, str) else None
+
+
+def _params_for_restart(command: Command) -> Any:
+    params = command.params
+    if getattr(params, "taskId", None) is None:
+        return params
+    return params.model_copy(update={"taskId": None})

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -248,6 +248,8 @@ class ProtocolEngine:
                 "failed command id should be supplied with a FIXIT command."
             )
 
+        request = self._expand_wait_for_tasks_fixit(request, failed_command_id)
+
         command_id = self._model_utils.generate_id()
         if request.intent in (
             commands.CommandIntent.SETUP,
@@ -271,6 +273,45 @@ class ProtocolEngine:
         )
         self._action_dispatcher.dispatch(action)
         return self._state_store.commands.get(command_id)
+
+    def _expand_wait_for_tasks_fixit(
+        self,
+        request: commands.CommandCreate,
+        failed_command_id: Optional[str],
+    ) -> commands.CommandCreate:
+        """Queue new originating start_* commands before a waitForTasks fixit.
+
+        App Retry re-posts the failed wait with the old task ids. Those tasks
+        already failed, so we dispatch new start_* commands (new ids) and point
+        the wait at the new task ids. The start_* commands are queued first so
+        the worker runs them before wait.
+        """
+        if not isinstance(request, commands.WaitForTasksCreate):
+            return request
+        if request.intent != commands.CommandIntent.FIXIT:
+            return request
+
+        from .commands.background_task_recovery import expand_wait_for_tasks_fixit
+        from .execution.associated_command_error_recovery import (
+            default_associated_command_recovery_resolvers,
+        )
+
+        expansion = expand_wait_for_tasks_fixit(
+            request.params.task_ids,
+            self.state_view,
+            default_associated_command_recovery_resolvers(),
+            self._model_utils,
+        )
+        if expansion is None:
+            return request
+
+        creates, rewritten_task_ids = expansion
+        for create in creates:
+            self.add_command(create, failed_command_id=failed_command_id)
+        rewritten_params = request.params.model_copy(
+            update={"task_ids": rewritten_task_ids}
+        )
+        return request.model_copy(update={"params": rewritten_params})
 
     async def wait_for_command(self, command_id: str) -> None:
         """Wait for a command to be completed.

--- a/api/src/opentrons/protocol_engine/state/state.py
+++ b/api/src/opentrons/protocol_engine/state/state.py
@@ -180,9 +180,11 @@ class StateView(HasState[State]):
     ) -> bool:
         """Return whether every failed waited-on task is covered by active recovery.
 
-        A failed task is covered when the engine is awaiting recovery and the task's
-        originating command is the current recovery target. This lets ``waitForTasks``
-        succeed after associated-command recovery without masking unrelated failures.
+        Used only for the fail-before-wait race: ``start_*`` already entered
+        recovery, and ``waitForTasks`` must not raise a second error. A failed
+        task is covered when the engine is awaiting recovery and the task's
+        originating command is the current recovery target. Unrelated failures
+        are not absorbed.
         """
         failed_task_ids = self._tasks.get_failed_tasks(task_ids)
         if not failed_task_ids:

--- a/api/tests/opentrons/protocol_engine/commands/test_background_task_recovery.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_background_task_recovery.py
@@ -1,0 +1,232 @@
+"""Tests for waitForTasks background-task recovery helpers."""
+
+from datetime import datetime
+
+from decoy import Decoy
+
+from opentrons.protocol_engine.commands.background_task_recovery import (
+    expand_wait_for_tasks_fixit,
+)
+from opentrons.protocol_engine.commands.command import CommandIntent, CommandStatus
+from opentrons.protocol_engine.commands.vacuum_module.recovery import (
+    VacuumModuleAssociatedCommandRecoveryResolver,
+)
+from opentrons.protocol_engine.commands.vacuum_module.start_set_vacuum_pressure import (
+    StartSetVacuumPressure,
+    StartSetVacuumPressureCreate,
+    StartSetVacuumPressureParams,
+    StartSetVacuumPressureResult,
+)
+from opentrons.protocol_engine.errors import ErrorOccurrence
+from opentrons.protocol_engine.resources import ModelUtils
+from opentrons.protocol_engine.state.module_substates.vacuum_module_substate import (
+    VacuumModuleId,
+    VacuumModuleSubState,
+)
+from opentrons.protocol_engine.state.state import StateView
+from opentrons.protocol_engine.types.tasks import FinishedTask
+
+
+def _start_pressure_command(
+    timestamp: datetime,
+    command_id: str = "start-command-id",
+    task_id: str = "task-1",
+) -> StartSetVacuumPressure:
+    return StartSetVacuumPressure.model_construct(
+        id=command_id,
+        key=f"{command_id}-key",
+        createdAt=timestamp,
+        commandType="vacuumModule/startSetVacuumPressure",
+        status=CommandStatus.SUCCEEDED,
+        params=StartSetVacuumPressureParams(
+            moduleId="vacuum-module-id",
+            gaugePressure=-800.0,
+            duration=30,
+            timeout=10,
+            ventAfter=True,
+        ),
+        result=StartSetVacuumPressureResult(taskId=task_id),
+    )
+
+
+def _vacuum_pressure_error(
+    timestamp: datetime, error_id: str = "error"
+) -> ErrorOccurrence:
+    return ErrorOccurrence(
+        id=error_id,
+        createdAt=timestamp,
+        errorType="VacuumModulePressureNotReachedError",
+        errorCode="3040",
+        detail="Vacuum Module Target Pressure Not Reached",
+        errorInfo={"mode": "pressure", "target": -800.0, "current": -4.0},
+    )
+
+
+def _stub_failed_vacuum_task(
+    decoy: Decoy,
+    state_view: StateView,
+    *,
+    task_id: str,
+    origin_id: str,
+    command: StartSetVacuumPressure,
+    timestamp: datetime,
+) -> None:
+    decoy.when(state_view.tasks.get_finished(task_id)).then_return(
+        FinishedTask(
+            id=task_id,
+            createdAt=timestamp,
+            finishedAt=timestamp,
+            error=_vacuum_pressure_error(timestamp, f"{task_id}-error"),
+        )
+    )
+    decoy.when(state_view.tasks.get_originating_command_id(task_id)).then_return(
+        origin_id
+    )
+    decoy.when(state_view.commands.get(origin_id)).then_return(command)
+    decoy.when(
+        state_view.modules.get_vacuum_module_substate("vacuum-module-id")
+    ).then_return(
+        VacuumModuleSubState(
+            module_id=VacuumModuleId("vacuum-module-id"),
+            pump_engaged=True,
+        )
+    )
+
+
+def test_expand_wait_for_tasks_fixit_returns_none_when_no_failed_tasks(
+    decoy: Decoy,
+    state_view: StateView,
+    model_utils: ModelUtils,
+) -> None:
+    """A wait with no failed tasks should be queued unchanged."""
+    decoy.when(state_view.tasks.get_failed_tasks(["task-1"])).then_return([])
+
+    result = expand_wait_for_tasks_fixit(
+        ["task-1"],
+        state_view,
+        [VacuumModuleAssociatedCommandRecoveryResolver()],
+        model_utils,
+    )
+
+    assert result is None
+
+
+def test_expand_wait_for_tasks_fixit_returns_none_for_unrecoverable_failure(
+    decoy: Decoy,
+    state_view: StateView,
+    model_utils: ModelUtils,
+) -> None:
+    """Unrecoverable waited failures should not dispatch a new start_*."""
+    timestamp = datetime.now()
+    decoy.when(state_view.tasks.get_failed_tasks(["task-1"])).then_return(["task-1"])
+    decoy.when(state_view.tasks.get_finished("task-1")).then_return(
+        FinishedTask(
+            id="task-1",
+            createdAt=timestamp,
+            finishedAt=timestamp,
+            error=ErrorOccurrence(
+                id="error",
+                createdAt=timestamp,
+                errorType="TaskFailedError",
+                detail="detail",
+            ),
+        )
+    )
+    decoy.when(state_view.tasks.get_originating_command_id("task-1")).then_return(
+        "start-command-id"
+    )
+    decoy.when(state_view.commands.get("start-command-id")).then_return(
+        _start_pressure_command(timestamp)
+    )
+
+    result = expand_wait_for_tasks_fixit(
+        ["task-1"],
+        state_view,
+        [VacuumModuleAssociatedCommandRecoveryResolver()],
+        model_utils,
+    )
+
+    assert result is None
+
+
+def test_expand_wait_for_tasks_fixit_builds_new_start_and_rewrites_failed_ids(
+    decoy: Decoy,
+    state_view: StateView,
+    model_utils: ModelUtils,
+) -> None:
+    """Recoverable failures should become a new start_* plus rewritten wait ids."""
+    timestamp = datetime.now()
+    start_command = _start_pressure_command(timestamp)
+    decoy.when(state_view.tasks.get_failed_tasks(["task-1", "ok-task"])).then_return(
+        ["task-1"]
+    )
+    _stub_failed_vacuum_task(
+        decoy,
+        state_view,
+        task_id="task-1",
+        origin_id="start-command-id",
+        command=start_command,
+        timestamp=timestamp,
+    )
+    decoy.when(model_utils.generate_id()).then_return("new-task")
+    decoy.when(model_utils.get_timestamp()).then_return(timestamp)
+
+    result = expand_wait_for_tasks_fixit(
+        ["task-1", "ok-task"],
+        state_view,
+        [VacuumModuleAssociatedCommandRecoveryResolver()],
+        model_utils,
+    )
+
+    assert result is not None
+    creates, rewritten = result
+    assert len(creates) == 1
+    assert isinstance(creates[0], StartSetVacuumPressureCreate)
+    assert creates[0].intent == CommandIntent.FIXIT
+    assert creates[0].params.taskId == "new-task"
+    assert creates[0].params.moduleId == "vacuum-module-id"
+    assert creates[0].params.gaugePressure == -800.0
+    assert rewritten == ["new-task", "ok-task"]
+
+
+def test_expand_wait_for_tasks_fixit_dedupes_shared_origin(
+    decoy: Decoy,
+    state_view: StateView,
+    model_utils: ModelUtils,
+) -> None:
+    """Two failed tasks from the same start_* should dispatch one new command."""
+    timestamp = datetime.now()
+    start_command = _start_pressure_command(timestamp)
+    decoy.when(state_view.tasks.get_failed_tasks(["task-1", "task-2"])).then_return(
+        ["task-1", "task-2"]
+    )
+    _stub_failed_vacuum_task(
+        decoy,
+        state_view,
+        task_id="task-1",
+        origin_id="start-command-id",
+        command=start_command,
+        timestamp=timestamp,
+    )
+    _stub_failed_vacuum_task(
+        decoy,
+        state_view,
+        task_id="task-2",
+        origin_id="start-command-id",
+        command=start_command,
+        timestamp=timestamp,
+    )
+    decoy.when(model_utils.generate_id()).then_return("new-task")
+    decoy.when(model_utils.get_timestamp()).then_return(timestamp)
+
+    result = expand_wait_for_tasks_fixit(
+        ["task-1", "task-2"],
+        state_view,
+        [VacuumModuleAssociatedCommandRecoveryResolver()],
+        model_utils,
+    )
+
+    assert result is not None
+    creates, rewritten = result
+    assert len(creates) == 1
+    assert rewritten == ["new-task", "new-task"]

--- a/api/tests/opentrons/protocol_engine/commands/test_wait_for_tasks.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_wait_for_tasks.py
@@ -1,21 +1,52 @@
 """Test wait for tasks."""
 
 from datetime import datetime
+from types import SimpleNamespace
+from typing import cast
 
 import pytest
 from decoy import Decoy, matchers
+from pydantic import BaseModel
 
+from opentrons.hardware_control.modules.types import VacuumOperationMode
 from opentrons.protocol_engine.actions import ActionDispatcher
-from opentrons.protocol_engine.commands.command import SuccessData
+from opentrons.protocol_engine.commands.command import (
+    CommandIntent,
+    CommandStatus,
+    DefinedErrorData,
+    SuccessData,
+)
+from opentrons.protocol_engine.commands.command_unions import Command
+from opentrons.protocol_engine.commands.vacuum_module.common import (
+    VacuumPressureNotReachedError,
+)
+from opentrons.protocol_engine.commands.vacuum_module.recovery import (
+    VacuumModuleAssociatedCommandRecoveryResolver,
+)
+from opentrons.protocol_engine.commands.vacuum_module.start_set_vacuum_pressure import (
+    StartSetVacuumPressure,
+    StartSetVacuumPressureParams,
+    StartSetVacuumPressureResult,
+)
 from opentrons.protocol_engine.commands.wait_for_tasks import (
+    WaitForTasks,
     WaitForTasksImplementation,
     WaitForTasksParams,
     WaitForTasksResult,
 )
 from opentrons.protocol_engine.errors import ErrorOccurrence
 from opentrons.protocol_engine.errors.exceptions import TaskFailedError
-from opentrons.protocol_engine.execution import RunControlHandler
+from opentrons.protocol_engine.execution import (
+    EquipmentHandler,
+    MovementHandler,
+    RunControlHandler,
+)
 from opentrons.protocol_engine.execution.task_handler import TaskHandler
+from opentrons.protocol_engine.resources import ModelUtils
+from opentrons.protocol_engine.state.module_substates.vacuum_module_substate import (
+    VacuumModuleId,
+    VacuumModuleSubState,
+)
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.types.tasks import FinishedTask, Task
 
@@ -39,6 +70,7 @@ async def test_wait_for_tasks_implementation_no_error(
     task_ids = ["task1", "task2"]
     data = WaitForTasksParams(task_ids=task_ids)
 
+    decoy.when(state_view.commands.get_running_command_id()).then_return(None)
     decoy.when(state_view.tasks.get_failed_tasks(task_ids)).then_return([])
     result = await subject.execute(data)
     for task in task_ids:
@@ -68,6 +100,7 @@ async def test_wait_for_tasks_implementation_with_error(
     task_ids = ["task1", "task2"]
     data = WaitForTasksParams(task_ids=task_ids)
     created_timestamp = datetime.now()
+    decoy.when(state_view.commands.get_running_command_id()).then_return(None)
     decoy.when(state_view.tasks.get_failed_tasks(task_ids)).then_return([task_ids[0]])
     decoy.when(
         state_view.failed_task_failures_absorbed_by_active_recovery(task_ids)
@@ -114,6 +147,7 @@ async def test_wait_for_tasks_succeeds_when_recovery_active_with_no_failed_tasks
     task_ids = ["task1"]
     data = WaitForTasksParams(task_ids=task_ids)
 
+    decoy.when(state_view.commands.get_running_command_id()).then_return(None)
     decoy.when(state_view.tasks.get_failed_tasks(task_ids)).then_return([])
     fake_task = decoy.mock(cls=Task)
     decoy.when(state_view.tasks.get(task_ids[0])).then_return(fake_task)
@@ -139,6 +173,7 @@ async def test_wait_for_tasks_succeeds_when_recoverable_failure_absorbed(
     task_ids = ["task1"]
     data = WaitForTasksParams(task_ids=task_ids)
 
+    decoy.when(state_view.commands.get_running_command_id()).then_return(None)
     decoy.when(state_view.tasks.get_failed_tasks(task_ids)).then_return(task_ids)
     decoy.when(
         state_view.failed_task_failures_absorbed_by_active_recovery(task_ids)
@@ -168,6 +203,7 @@ async def test_wait_for_tasks_raises_when_recovery_active_but_uncovered_failure(
     data = WaitForTasksParams(task_ids=task_ids)
     created_timestamp = datetime.now()
 
+    decoy.when(state_view.commands.get_running_command_id()).then_return(None)
     decoy.when(state_view.tasks.get_failed_tasks(task_ids)).then_return(task_ids)
     decoy.when(
         state_view.failed_task_failures_absorbed_by_active_recovery(task_ids)
@@ -194,3 +230,493 @@ async def test_wait_for_tasks_raises_when_recovery_active_but_uncovered_failure(
 
     assert exc_info.value.message == "2 tasks failed."
     decoy.verify(await run_control.wait_for_tasks(task_ids))
+
+
+def _start_pressure_command(
+    timestamp: datetime,
+    command_id: str = "start-command-id",
+    task_id: str = "task1",
+) -> StartSetVacuumPressure:
+    return StartSetVacuumPressure.model_construct(
+        id=command_id,
+        key=f"{command_id}-key",
+        createdAt=timestamp,
+        commandType="vacuumModule/startSetVacuumPressure",
+        status=CommandStatus.SUCCEEDED,
+        params=StartSetVacuumPressureParams(
+            moduleId="vacuum-module-id",
+            gaugePressure=-800.0,
+            duration=30,
+            timeout=10,
+            ventAfter=True,
+        ),
+        result=StartSetVacuumPressureResult(taskId=task_id),
+    )
+
+
+def _vacuum_pressure_error(
+    timestamp: datetime, error_id: str = "error"
+) -> ErrorOccurrence:
+    return ErrorOccurrence(
+        id=error_id,
+        createdAt=timestamp,
+        errorType="VacuumModulePressureNotReachedError",
+        errorCode="3040",
+        detail="Vacuum Module Target Pressure Not Reached",
+        errorInfo={"mode": "pressure", "target": -800.0, "current": -4.0},
+    )
+
+
+def _unrecoverable_task_error(
+    timestamp: datetime, error_id: str = "error"
+) -> ErrorOccurrence:
+    return ErrorOccurrence(
+        id=error_id,
+        createdAt=timestamp,
+        errorType="TaskFailedError",
+        detail="detail",
+    )
+
+
+async def test_wait_for_tasks_returns_defined_error_via_resolver(
+    decoy: Decoy,
+    run_control: RunControlHandler,
+    real_task_handler: TaskHandler,
+    state_view: StateView,
+) -> None:
+    """Resolver-handled task failures should become defined waitForTasks errors."""
+    subject = WaitForTasksImplementation(
+        run_control=run_control,
+        task_handler=real_task_handler,
+        state_view=state_view,
+        model_utils=ModelUtils(),
+        resolvers=[VacuumModuleAssociatedCommandRecoveryResolver()],
+    )
+    task_ids = ["task1"]
+    data = WaitForTasksParams(task_ids=task_ids)
+    created_timestamp = datetime.now()
+    decoy.when(state_view.commands.get_running_command_id()).then_return(None)
+    decoy.when(state_view.tasks.get_failed_tasks(task_ids)).then_return(task_ids)
+    decoy.when(
+        state_view.failed_task_failures_absorbed_by_active_recovery(task_ids)
+    ).then_return(False)
+    decoy.when(state_view.tasks.get(task_ids[0])).then_return(decoy.mock(cls=Task))
+    decoy.when(state_view.tasks.get_finished(task_ids[0])).then_return(
+        FinishedTask(
+            id=task_ids[0],
+            createdAt=matchers.Anything(),
+            finishedAt=matchers.Anything(),
+            error=_vacuum_pressure_error(created_timestamp),
+        )
+    )
+    decoy.when(state_view.tasks.get_originating_command_id("task1")).then_return(
+        "start-command-id"
+    )
+    decoy.when(state_view.commands.get("start-command-id")).then_return(
+        _start_pressure_command(created_timestamp)
+    )
+    decoy.when(
+        state_view.modules.get_vacuum_module_substate("vacuum-module-id")
+    ).then_return(
+        VacuumModuleSubState(
+            module_id=VacuumModuleId("vacuum-module-id"),
+            pump_engaged=True,
+        )
+    )
+
+    result = await subject.execute(data)
+
+    assert isinstance(result, DefinedErrorData)
+    assert isinstance(result.public, VacuumPressureNotReachedError)
+    decoy.verify(await run_control.wait_for_tasks(task_ids))
+
+
+async def test_wait_for_tasks_returns_first_defined_error_when_all_recoverable(
+    decoy: Decoy,
+    run_control: RunControlHandler,
+    real_task_handler: TaskHandler,
+    state_view: StateView,
+) -> None:
+    """Every recoverable failure should still fail waitForTasks as defined."""
+    subject = WaitForTasksImplementation(
+        run_control=run_control,
+        task_handler=real_task_handler,
+        state_view=state_view,
+        model_utils=ModelUtils(),
+        resolvers=[VacuumModuleAssociatedCommandRecoveryResolver()],
+    )
+    task_ids = ["task1", "task2"]
+    data = WaitForTasksParams(task_ids=task_ids)
+    created_timestamp = datetime.now()
+    decoy.when(state_view.commands.get_running_command_id()).then_return(None)
+    decoy.when(state_view.tasks.get_failed_tasks(task_ids)).then_return(task_ids)
+    decoy.when(
+        state_view.failed_task_failures_absorbed_by_active_recovery(task_ids)
+    ).then_return(False)
+    decoy.when(
+        state_view.modules.get_vacuum_module_substate("vacuum-module-id")
+    ).then_return(
+        VacuumModuleSubState(
+            module_id=VacuumModuleId("vacuum-module-id"),
+            pump_engaged=True,
+        )
+    )
+    for index, task_id in enumerate(task_ids, start=1):
+        origin_id = f"start-command-{index}"
+        decoy.when(state_view.tasks.get(task_id)).then_return(decoy.mock(cls=Task))
+        decoy.when(state_view.tasks.get_finished(task_id)).then_return(
+            FinishedTask(
+                id=task_id,
+                createdAt=matchers.Anything(),
+                finishedAt=matchers.Anything(),
+                error=_vacuum_pressure_error(created_timestamp, f"{task_id}-error"),
+            )
+        )
+        decoy.when(state_view.tasks.get_originating_command_id(task_id)).then_return(
+            origin_id
+        )
+        decoy.when(state_view.commands.get(origin_id)).then_return(
+            _start_pressure_command(
+                created_timestamp, command_id=origin_id, task_id=task_id
+            )
+        )
+
+    result = await subject.execute(data)
+
+    assert isinstance(result, DefinedErrorData)
+    assert isinstance(result.public, VacuumPressureNotReachedError)
+    decoy.verify(await run_control.wait_for_tasks(task_ids))
+
+
+async def test_wait_for_tasks_raises_when_recoverable_and_unrecoverable_mixed(
+    decoy: Decoy,
+    run_control: RunControlHandler,
+    real_task_handler: TaskHandler,
+    state_view: StateView,
+) -> None:
+    """A mixed recoverable and unrecoverable wait should cancel the protocol."""
+    subject = WaitForTasksImplementation(
+        run_control=run_control,
+        task_handler=real_task_handler,
+        state_view=state_view,
+        model_utils=ModelUtils(),
+        resolvers=[VacuumModuleAssociatedCommandRecoveryResolver()],
+    )
+    task_ids = ["task1", "task2"]
+    data = WaitForTasksParams(task_ids=task_ids)
+    created_timestamp = datetime.now()
+    decoy.when(state_view.commands.get_running_command_id()).then_return(None)
+    decoy.when(state_view.tasks.get_failed_tasks(task_ids)).then_return(task_ids)
+    decoy.when(
+        state_view.failed_task_failures_absorbed_by_active_recovery(task_ids)
+    ).then_return(False)
+    decoy.when(state_view.tasks.get(task_ids[0])).then_return(decoy.mock(cls=Task))
+    decoy.when(state_view.tasks.get(task_ids[1])).then_return(decoy.mock(cls=Task))
+    decoy.when(state_view.tasks.get_finished(task_ids[0])).then_return(
+        FinishedTask(
+            id=task_ids[0],
+            createdAt=matchers.Anything(),
+            finishedAt=matchers.Anything(),
+            error=_vacuum_pressure_error(created_timestamp, "task1-error"),
+        )
+    )
+    decoy.when(state_view.tasks.get_finished(task_ids[1])).then_return(
+        FinishedTask(
+            id=task_ids[1],
+            createdAt=matchers.Anything(),
+            finishedAt=matchers.Anything(),
+            error=_unrecoverable_task_error(created_timestamp, "task2-error"),
+        )
+    )
+    decoy.when(state_view.tasks.get_originating_command_id("task1")).then_return(
+        "start-command-id"
+    )
+    decoy.when(state_view.commands.get("start-command-id")).then_return(
+        _start_pressure_command(created_timestamp)
+    )
+    decoy.when(
+        state_view.modules.get_vacuum_module_substate("vacuum-module-id")
+    ).then_return(
+        VacuumModuleSubState(
+            module_id=VacuumModuleId("vacuum-module-id"),
+            pump_engaged=True,
+        )
+    )
+
+    with pytest.raises(TaskFailedError) as exc_info:
+        await subject.execute(data)
+
+    assert exc_info.value.message == "2 tasks failed."
+    decoy.verify(await run_control.wait_for_tasks(task_ids))
+
+
+class _FakeStartResult(BaseModel):
+    taskId: str = "restarted-task"
+
+
+class _FakeStartImpl:
+    def __init__(self, **kwargs: object) -> None:
+        pass
+
+    async def execute(self, params: object) -> SuccessData[_FakeStartResult]:
+        return SuccessData(public=_FakeStartResult())
+
+
+class _AlwaysMapsResolver:
+    """Resolver that treats every task failure as recoverable."""
+
+    def can_handle_error(self, error: object) -> bool:
+        return True
+
+    def is_associated_command(self, command: object) -> bool:
+        return True
+
+    def get_command_id_for_async_notification(
+        self,
+        module_model: object,
+        module_serial: str | None,
+        state_view: object,
+    ) -> str | None:
+        return None
+
+    def to_defined_error_data(
+        self, *args: object, **kwargs: object
+    ) -> DefinedErrorData[VacuumPressureNotReachedError]:
+        return DefinedErrorData(
+            public=VacuumPressureNotReachedError(
+                id="mapped",
+                createdAt=datetime.now(),
+                errorInfo={
+                    "mode": VacuumOperationMode.PRESSURE,
+                    "target": 0.0,
+                    "current": 0.0,
+                },
+            )
+        )
+
+    async def restart(self, command: object, **kwargs: object) -> str | None:
+        impl_cls = getattr(command, "_ImplementationCls", None)
+        if impl_cls is None:
+            return None
+        result = await impl_cls().execute(getattr(command, "params", None))
+        public = getattr(result, "public", None)
+        task_id = getattr(public, "taskId", None)
+        return task_id if isinstance(task_id, str) else None
+
+
+async def test_wait_for_tasks_fixit_reexecutes_originating_command(
+    decoy: Decoy,
+    run_control: RunControlHandler,
+    real_task_handler: TaskHandler,
+    state_view: StateView,
+) -> None:
+    """A waitForTasks fixit should re-run the originating command implementation."""
+    originating_command = SimpleNamespace(
+        commandType="vacuumModule/startSetVacuumPressure",
+        params=SimpleNamespace(),
+        _ImplementationCls=_FakeStartImpl,
+    )
+    subject = WaitForTasksImplementation(
+        run_control=run_control,
+        task_handler=real_task_handler,
+        state_view=state_view,
+        equipment=decoy.mock(cls=EquipmentHandler),
+        movement=decoy.mock(cls=MovementHandler),
+        model_utils=ModelUtils(),
+        resolvers=[_AlwaysMapsResolver()],
+    )
+    original_task_ids = ["task1"]
+    data = WaitForTasksParams(task_ids=original_task_ids)
+    created_timestamp = datetime.now()
+    wait_command = WaitForTasks.model_construct(
+        id="wait-fixit-id",
+        key="wait-fixit-key",
+        createdAt=created_timestamp,
+        commandType="waitForTasks",
+        status=CommandStatus.RUNNING,
+        intent=CommandIntent.FIXIT,
+        params=data,
+    )
+    task_error = ErrorOccurrence(
+        id="error",
+        createdAt=created_timestamp,
+        errorType="VacuumModulePressureNotReachedError",
+        errorCode="3040",
+        detail="Vacuum Module Target Pressure Not Reached",
+        errorInfo={"mode": "pressure", "target": -800.0, "current": -4.0},
+    )
+    decoy.when(state_view.commands.get_running_command_id()).then_return(
+        "wait-fixit-id"
+    )
+    decoy.when(state_view.commands.get("wait-fixit-id")).then_return(wait_command)
+    decoy.when(state_view.tasks.get(original_task_ids[0])).then_return(
+        decoy.mock(cls=Task)
+    )
+    decoy.when(state_view.tasks.get_failed_tasks(original_task_ids)).then_return(
+        original_task_ids
+    )
+    decoy.when(state_view.tasks.get_failed_tasks(["restarted-task"])).then_return([])
+    decoy.when(state_view.tasks.get_finished(original_task_ids[0])).then_return(
+        FinishedTask(
+            id=original_task_ids[0],
+            createdAt=created_timestamp,
+            finishedAt=created_timestamp,
+            error=task_error,
+        )
+    )
+    decoy.when(state_view.tasks.get_originating_command_id("task1")).then_return(
+        "start-command-id"
+    )
+    decoy.when(state_view.commands.get("start-command-id")).then_return(
+        cast(Command, originating_command)
+    )
+
+    result = await subject.execute(data)
+
+    assert result == SuccessData(public=WaitForTasksResult(task_ids=original_task_ids))
+    decoy.verify(await run_control.wait_for_tasks(["restarted-task"]))
+
+
+async def test_wait_for_tasks_maps_defined_error_when_retried_task_origin_is_wait(
+    decoy: Decoy,
+    run_control: RunControlHandler,
+    real_task_handler: TaskHandler,
+    state_view: StateView,
+) -> None:
+    """A task created by a waitForTasks retry must still map to a defined error."""
+    subject = WaitForTasksImplementation(
+        run_control=run_control,
+        task_handler=real_task_handler,
+        state_view=state_view,
+        model_utils=ModelUtils(),
+        resolvers=[VacuumModuleAssociatedCommandRecoveryResolver()],
+    )
+    created_timestamp = datetime.now()
+    restarted_task_id = "restarted-task"
+    data = WaitForTasksParams(task_ids=[restarted_task_id])
+    wait_command = WaitForTasks.model_construct(
+        id="wait-fixit-id",
+        key="wait-fixit-key",
+        createdAt=created_timestamp,
+        commandType="waitForTasks",
+        status=CommandStatus.SUCCEEDED,
+        params=WaitForTasksParams(task_ids=["task1"]),
+    )
+    decoy.when(state_view.commands.get_running_command_id()).then_return(None)
+    decoy.when(state_view.tasks.get_failed_tasks([restarted_task_id])).then_return(
+        [restarted_task_id]
+    )
+    decoy.when(
+        state_view.failed_task_failures_absorbed_by_active_recovery([restarted_task_id])
+    ).then_return(False)
+    decoy.when(state_view.tasks.get(restarted_task_id)).then_return(
+        decoy.mock(cls=Task)
+    )
+    decoy.when(state_view.tasks.get_finished(restarted_task_id)).then_return(
+        FinishedTask(
+            id=restarted_task_id,
+            createdAt=matchers.Anything(),
+            finishedAt=matchers.Anything(),
+            error=_vacuum_pressure_error(created_timestamp),
+        )
+    )
+    decoy.when(
+        state_view.tasks.get_originating_command_id(restarted_task_id)
+    ).then_return("wait-fixit-id")
+    decoy.when(state_view.commands.get("wait-fixit-id")).then_return(wait_command)
+    decoy.when(state_view.tasks.get_originating_command_id("task1")).then_return(
+        "start-command-id"
+    )
+    decoy.when(state_view.commands.get("start-command-id")).then_return(
+        _start_pressure_command(created_timestamp)
+    )
+    decoy.when(
+        state_view.modules.get_vacuum_module_substate("vacuum-module-id")
+    ).then_return(
+        VacuumModuleSubState(
+            module_id=VacuumModuleId("vacuum-module-id"),
+            pump_engaged=True,
+        )
+    )
+
+    result = await subject.execute(data)
+
+    assert isinstance(result, DefinedErrorData)
+    assert isinstance(result.public, VacuumPressureNotReachedError)
+    decoy.verify(await run_control.wait_for_tasks([restarted_task_id]))
+
+
+async def test_wait_for_tasks_fixit_restarts_start_when_failed_task_origin_is_wait(
+    decoy: Decoy,
+    run_control: RunControlHandler,
+    real_task_handler: TaskHandler,
+    state_view: StateView,
+) -> None:
+    """A second retry must still re-run start_*, not waitForTasks."""
+    originating_command = SimpleNamespace(
+        id="start-command-id",
+        commandType="vacuumModule/startSetVacuumPressure",
+        params=SimpleNamespace(),
+        _ImplementationCls=_FakeStartImpl,
+    )
+    subject = WaitForTasksImplementation(
+        run_control=run_control,
+        task_handler=real_task_handler,
+        state_view=state_view,
+        equipment=decoy.mock(cls=EquipmentHandler),
+        movement=decoy.mock(cls=MovementHandler),
+        model_utils=ModelUtils(),
+        resolvers=[_AlwaysMapsResolver()],
+    )
+    created_timestamp = datetime.now()
+    previous_wait = WaitForTasks.model_construct(
+        id="previous-wait-id",
+        key="previous-wait-key",
+        createdAt=created_timestamp,
+        commandType="waitForTasks",
+        status=CommandStatus.FAILED,
+        params=WaitForTasksParams(task_ids=["task1"]),
+    )
+    retry_task_ids = ["retry-task"]
+    data = WaitForTasksParams(task_ids=retry_task_ids)
+    wait_command = WaitForTasks.model_construct(
+        id="wait-fixit-id",
+        key="wait-fixit-key",
+        createdAt=created_timestamp,
+        commandType="waitForTasks",
+        status=CommandStatus.RUNNING,
+        intent=CommandIntent.FIXIT,
+        params=data,
+    )
+    decoy.when(state_view.commands.get_running_command_id()).then_return(
+        "wait-fixit-id"
+    )
+    decoy.when(state_view.commands.get("wait-fixit-id")).then_return(wait_command)
+    decoy.when(state_view.commands.get("previous-wait-id")).then_return(previous_wait)
+    decoy.when(state_view.tasks.get("retry-task")).then_return(decoy.mock(cls=Task))
+    decoy.when(state_view.tasks.get_failed_tasks(retry_task_ids)).then_return(
+        retry_task_ids
+    )
+    decoy.when(state_view.tasks.get_failed_tasks(["restarted-task"])).then_return([])
+    decoy.when(state_view.tasks.get_finished("retry-task")).then_return(
+        FinishedTask(
+            id="retry-task",
+            createdAt=created_timestamp,
+            finishedAt=created_timestamp,
+            error=_vacuum_pressure_error(created_timestamp),
+        )
+    )
+    decoy.when(state_view.tasks.get_originating_command_id("retry-task")).then_return(
+        "previous-wait-id"
+    )
+    decoy.when(state_view.tasks.get_originating_command_id("task1")).then_return(
+        "start-command-id"
+    )
+    decoy.when(state_view.commands.get("start-command-id")).then_return(
+        cast(Command, originating_command)
+    )
+
+    result = await subject.execute(data)
+
+    assert result == SuccessData(public=WaitForTasksResult(task_ids=retry_task_ids))
+    decoy.verify(await run_control.wait_for_tasks(["restarted-task"]))

--- a/api/tests/opentrons/protocol_engine/commands/test_wait_for_tasks.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_wait_for_tasks.py
@@ -1,22 +1,16 @@
 """Test wait for tasks."""
 
 from datetime import datetime
-from types import SimpleNamespace
-from typing import cast
 
 import pytest
 from decoy import Decoy, matchers
-from pydantic import BaseModel
 
-from opentrons.hardware_control.modules.types import VacuumOperationMode
 from opentrons.protocol_engine.actions import ActionDispatcher
 from opentrons.protocol_engine.commands.command import (
-    CommandIntent,
     CommandStatus,
     DefinedErrorData,
     SuccessData,
 )
-from opentrons.protocol_engine.commands.command_unions import Command
 from opentrons.protocol_engine.commands.vacuum_module.common import (
     VacuumPressureNotReachedError,
 )
@@ -29,18 +23,13 @@ from opentrons.protocol_engine.commands.vacuum_module.start_set_vacuum_pressure 
     StartSetVacuumPressureResult,
 )
 from opentrons.protocol_engine.commands.wait_for_tasks import (
-    WaitForTasks,
     WaitForTasksImplementation,
     WaitForTasksParams,
     WaitForTasksResult,
 )
 from opentrons.protocol_engine.errors import ErrorOccurrence
 from opentrons.protocol_engine.errors.exceptions import TaskFailedError
-from opentrons.protocol_engine.execution import (
-    EquipmentHandler,
-    MovementHandler,
-    RunControlHandler,
-)
+from opentrons.protocol_engine.execution import RunControlHandler
 from opentrons.protocol_engine.execution.task_handler import TaskHandler
 from opentrons.protocol_engine.resources import ModelUtils
 from opentrons.protocol_engine.state.module_substates.vacuum_module_substate import (
@@ -448,275 +437,3 @@ async def test_wait_for_tasks_raises_when_recoverable_and_unrecoverable_mixed(
 
     assert exc_info.value.message == "2 tasks failed."
     decoy.verify(await run_control.wait_for_tasks(task_ids))
-
-
-class _FakeStartResult(BaseModel):
-    taskId: str = "restarted-task"
-
-
-class _FakeStartImpl:
-    def __init__(self, **kwargs: object) -> None:
-        pass
-
-    async def execute(self, params: object) -> SuccessData[_FakeStartResult]:
-        return SuccessData(public=_FakeStartResult())
-
-
-class _AlwaysMapsResolver:
-    """Resolver that treats every task failure as recoverable."""
-
-    def can_handle_error(self, error: object) -> bool:
-        return True
-
-    def is_associated_command(self, command: object) -> bool:
-        return True
-
-    def get_command_id_for_async_notification(
-        self,
-        module_model: object,
-        module_serial: str | None,
-        state_view: object,
-    ) -> str | None:
-        return None
-
-    def to_defined_error_data(
-        self, *args: object, **kwargs: object
-    ) -> DefinedErrorData[VacuumPressureNotReachedError]:
-        return DefinedErrorData(
-            public=VacuumPressureNotReachedError(
-                id="mapped",
-                createdAt=datetime.now(),
-                errorInfo={
-                    "mode": VacuumOperationMode.PRESSURE,
-                    "target": 0.0,
-                    "current": 0.0,
-                },
-            )
-        )
-
-    async def restart(self, command: object, **kwargs: object) -> str | None:
-        impl_cls = getattr(command, "_ImplementationCls", None)
-        if impl_cls is None:
-            return None
-        result = await impl_cls().execute(getattr(command, "params", None))
-        public = getattr(result, "public", None)
-        task_id = getattr(public, "taskId", None)
-        return task_id if isinstance(task_id, str) else None
-
-
-async def test_wait_for_tasks_fixit_reexecutes_originating_command(
-    decoy: Decoy,
-    run_control: RunControlHandler,
-    real_task_handler: TaskHandler,
-    state_view: StateView,
-) -> None:
-    """A waitForTasks fixit should re-run the originating command implementation."""
-    originating_command = SimpleNamespace(
-        commandType="vacuumModule/startSetVacuumPressure",
-        params=SimpleNamespace(),
-        _ImplementationCls=_FakeStartImpl,
-    )
-    subject = WaitForTasksImplementation(
-        run_control=run_control,
-        task_handler=real_task_handler,
-        state_view=state_view,
-        equipment=decoy.mock(cls=EquipmentHandler),
-        movement=decoy.mock(cls=MovementHandler),
-        model_utils=ModelUtils(),
-        resolvers=[_AlwaysMapsResolver()],
-    )
-    original_task_ids = ["task1"]
-    data = WaitForTasksParams(task_ids=original_task_ids)
-    created_timestamp = datetime.now()
-    wait_command = WaitForTasks.model_construct(
-        id="wait-fixit-id",
-        key="wait-fixit-key",
-        createdAt=created_timestamp,
-        commandType="waitForTasks",
-        status=CommandStatus.RUNNING,
-        intent=CommandIntent.FIXIT,
-        params=data,
-    )
-    task_error = ErrorOccurrence(
-        id="error",
-        createdAt=created_timestamp,
-        errorType="VacuumModulePressureNotReachedError",
-        errorCode="3040",
-        detail="Vacuum Module Target Pressure Not Reached",
-        errorInfo={"mode": "pressure", "target": -800.0, "current": -4.0},
-    )
-    decoy.when(state_view.commands.get_running_command_id()).then_return(
-        "wait-fixit-id"
-    )
-    decoy.when(state_view.commands.get("wait-fixit-id")).then_return(wait_command)
-    decoy.when(state_view.tasks.get(original_task_ids[0])).then_return(
-        decoy.mock(cls=Task)
-    )
-    decoy.when(state_view.tasks.get_failed_tasks(original_task_ids)).then_return(
-        original_task_ids
-    )
-    decoy.when(state_view.tasks.get_failed_tasks(["restarted-task"])).then_return([])
-    decoy.when(state_view.tasks.get_finished(original_task_ids[0])).then_return(
-        FinishedTask(
-            id=original_task_ids[0],
-            createdAt=created_timestamp,
-            finishedAt=created_timestamp,
-            error=task_error,
-        )
-    )
-    decoy.when(state_view.tasks.get_originating_command_id("task1")).then_return(
-        "start-command-id"
-    )
-    decoy.when(state_view.commands.get("start-command-id")).then_return(
-        cast(Command, originating_command)
-    )
-
-    result = await subject.execute(data)
-
-    assert result == SuccessData(public=WaitForTasksResult(task_ids=original_task_ids))
-    decoy.verify(await run_control.wait_for_tasks(["restarted-task"]))
-
-
-async def test_wait_for_tasks_maps_defined_error_when_retried_task_origin_is_wait(
-    decoy: Decoy,
-    run_control: RunControlHandler,
-    real_task_handler: TaskHandler,
-    state_view: StateView,
-) -> None:
-    """A task created by a waitForTasks retry must still map to a defined error."""
-    subject = WaitForTasksImplementation(
-        run_control=run_control,
-        task_handler=real_task_handler,
-        state_view=state_view,
-        model_utils=ModelUtils(),
-        resolvers=[VacuumModuleAssociatedCommandRecoveryResolver()],
-    )
-    created_timestamp = datetime.now()
-    restarted_task_id = "restarted-task"
-    data = WaitForTasksParams(task_ids=[restarted_task_id])
-    wait_command = WaitForTasks.model_construct(
-        id="wait-fixit-id",
-        key="wait-fixit-key",
-        createdAt=created_timestamp,
-        commandType="waitForTasks",
-        status=CommandStatus.SUCCEEDED,
-        params=WaitForTasksParams(task_ids=["task1"]),
-    )
-    decoy.when(state_view.commands.get_running_command_id()).then_return(None)
-    decoy.when(state_view.tasks.get_failed_tasks([restarted_task_id])).then_return(
-        [restarted_task_id]
-    )
-    decoy.when(
-        state_view.failed_task_failures_absorbed_by_active_recovery([restarted_task_id])
-    ).then_return(False)
-    decoy.when(state_view.tasks.get(restarted_task_id)).then_return(
-        decoy.mock(cls=Task)
-    )
-    decoy.when(state_view.tasks.get_finished(restarted_task_id)).then_return(
-        FinishedTask(
-            id=restarted_task_id,
-            createdAt=matchers.Anything(),
-            finishedAt=matchers.Anything(),
-            error=_vacuum_pressure_error(created_timestamp),
-        )
-    )
-    decoy.when(
-        state_view.tasks.get_originating_command_id(restarted_task_id)
-    ).then_return("wait-fixit-id")
-    decoy.when(state_view.commands.get("wait-fixit-id")).then_return(wait_command)
-    decoy.when(state_view.tasks.get_originating_command_id("task1")).then_return(
-        "start-command-id"
-    )
-    decoy.when(state_view.commands.get("start-command-id")).then_return(
-        _start_pressure_command(created_timestamp)
-    )
-    decoy.when(
-        state_view.modules.get_vacuum_module_substate("vacuum-module-id")
-    ).then_return(
-        VacuumModuleSubState(
-            module_id=VacuumModuleId("vacuum-module-id"),
-            pump_engaged=True,
-        )
-    )
-
-    result = await subject.execute(data)
-
-    assert isinstance(result, DefinedErrorData)
-    assert isinstance(result.public, VacuumPressureNotReachedError)
-    decoy.verify(await run_control.wait_for_tasks([restarted_task_id]))
-
-
-async def test_wait_for_tasks_fixit_restarts_start_when_failed_task_origin_is_wait(
-    decoy: Decoy,
-    run_control: RunControlHandler,
-    real_task_handler: TaskHandler,
-    state_view: StateView,
-) -> None:
-    """A second retry must still re-run start_*, not waitForTasks."""
-    originating_command = SimpleNamespace(
-        id="start-command-id",
-        commandType="vacuumModule/startSetVacuumPressure",
-        params=SimpleNamespace(),
-        _ImplementationCls=_FakeStartImpl,
-    )
-    subject = WaitForTasksImplementation(
-        run_control=run_control,
-        task_handler=real_task_handler,
-        state_view=state_view,
-        equipment=decoy.mock(cls=EquipmentHandler),
-        movement=decoy.mock(cls=MovementHandler),
-        model_utils=ModelUtils(),
-        resolvers=[_AlwaysMapsResolver()],
-    )
-    created_timestamp = datetime.now()
-    previous_wait = WaitForTasks.model_construct(
-        id="previous-wait-id",
-        key="previous-wait-key",
-        createdAt=created_timestamp,
-        commandType="waitForTasks",
-        status=CommandStatus.FAILED,
-        params=WaitForTasksParams(task_ids=["task1"]),
-    )
-    retry_task_ids = ["retry-task"]
-    data = WaitForTasksParams(task_ids=retry_task_ids)
-    wait_command = WaitForTasks.model_construct(
-        id="wait-fixit-id",
-        key="wait-fixit-key",
-        createdAt=created_timestamp,
-        commandType="waitForTasks",
-        status=CommandStatus.RUNNING,
-        intent=CommandIntent.FIXIT,
-        params=data,
-    )
-    decoy.when(state_view.commands.get_running_command_id()).then_return(
-        "wait-fixit-id"
-    )
-    decoy.when(state_view.commands.get("wait-fixit-id")).then_return(wait_command)
-    decoy.when(state_view.commands.get("previous-wait-id")).then_return(previous_wait)
-    decoy.when(state_view.tasks.get("retry-task")).then_return(decoy.mock(cls=Task))
-    decoy.when(state_view.tasks.get_failed_tasks(retry_task_ids)).then_return(
-        retry_task_ids
-    )
-    decoy.when(state_view.tasks.get_failed_tasks(["restarted-task"])).then_return([])
-    decoy.when(state_view.tasks.get_finished("retry-task")).then_return(
-        FinishedTask(
-            id="retry-task",
-            createdAt=created_timestamp,
-            finishedAt=created_timestamp,
-            error=_vacuum_pressure_error(created_timestamp),
-        )
-    )
-    decoy.when(state_view.tasks.get_originating_command_id("retry-task")).then_return(
-        "previous-wait-id"
-    )
-    decoy.when(state_view.tasks.get_originating_command_id("task1")).then_return(
-        "start-command-id"
-    )
-    decoy.when(state_view.commands.get("start-command-id")).then_return(
-        cast(Command, originating_command)
-    )
-
-    result = await subject.execute(data)
-
-    assert result == SuccessData(public=WaitForTasksResult(task_ids=retry_task_ids))
-    decoy.verify(await run_control.wait_for_tasks(["restarted-task"]))

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_recovery.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_recovery.py
@@ -1,13 +1,12 @@
 """Tests for vacuum module associated-command recovery resolver."""
 
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock, patch
 
 from decoy import Decoy
 
 from opentrons_shared_data.errors.exceptions import VacuumModuleWasteFullError
 
-from opentrons.protocol_engine.commands.command import CommandStatus, SuccessData
+from opentrons.protocol_engine.commands.command import CommandIntent, CommandStatus
 from opentrons.protocol_engine.commands.vacuum_module.common import (
     VACUUM_WASTE_CONTAINER_FULL_ERROR_CODE,
     VacuumModuleCarboyFullError,
@@ -17,6 +16,7 @@ from opentrons.protocol_engine.commands.vacuum_module.recovery import (
 )
 from opentrons.protocol_engine.commands.vacuum_module.start_set_vacuum_pressure import (
     StartSetVacuumPressure,
+    StartSetVacuumPressureCreate,
     StartSetVacuumPressureParams,
     StartSetVacuumPressureResult,
 )
@@ -25,11 +25,6 @@ from opentrons.protocol_engine.commands.wait_for_tasks import (
     WaitForTasksParams,
 )
 from opentrons.protocol_engine.errors import ErrorOccurrence
-from opentrons.protocol_engine.execution import (
-    EquipmentHandler,
-    MovementHandler,
-    TaskHandler,
-)
 from opentrons.protocol_engine.resources import ModelUtils
 from opentrons.protocol_engine.state.module_substates.vacuum_module_substate import (
     VacuumModuleId,
@@ -156,35 +151,22 @@ def _start_pressure_command(timestamp: datetime) -> StartSetVacuumPressure:
     )
 
 
-async def test_restart_runs_start_pressure_impl(decoy: Decoy) -> None:
-    """It should re-run the public start pressure impl and clear taskId."""
+def test_create_retry_builds_new_start_pressure_request() -> None:
+    """It should copy start_* params onto a new fixit request with a new task id."""
     subject = VacuumModuleAssociatedCommandRecoveryResolver()
     command = _start_pressure_command(datetime.now())
-    impl = MagicMock()
-    impl.execute = AsyncMock(
-        return_value=SuccessData(public=StartSetVacuumPressureResult(taskId="new-task"))
-    )
 
-    with patch(
-        "opentrons.protocol_engine.commands.vacuum_module.recovery.StartSetVacuumPressureImpl",
-        return_value=impl,
-    ):
-        task_id = await subject.restart(
-            command,
-            state_view=decoy.mock(cls=StateView),
-            task_handler=decoy.mock(cls=TaskHandler),
-            equipment=decoy.mock(cls=EquipmentHandler),
-            movement=decoy.mock(cls=MovementHandler),
-            model_utils=ModelUtils(),
-        )
+    create = subject.create_retry(command, task_id="new-task")
 
-    assert task_id == "new-task"
-    executed_params = impl.execute.await_args.args[0]
-    assert executed_params.taskId is None
+    assert isinstance(create, StartSetVacuumPressureCreate)
+    assert create.intent == CommandIntent.FIXIT
+    assert create.params.moduleId == "vacuum-module-id"
+    assert create.params.gaugePressure == -50.0
+    assert create.params.taskId == "new-task"
 
 
-async def test_restart_returns_none_for_unassociated_command(decoy: Decoy) -> None:
-    """It should not restart commands that are not vacuum start_* commands."""
+def test_create_retry_returns_none_for_unassociated_command() -> None:
+    """It should not build a retry request for non-vacuum start_* commands."""
     subject = VacuumModuleAssociatedCommandRecoveryResolver()
     command = WaitForTasks.model_construct(
         id="wait-id",
@@ -195,13 +177,4 @@ async def test_restart_returns_none_for_unassociated_command(decoy: Decoy) -> No
         params=WaitForTasksParams(task_ids=["task-1"]),
     )
 
-    task_id = await subject.restart(
-        command,
-        state_view=decoy.mock(cls=StateView),
-        task_handler=decoy.mock(cls=TaskHandler),
-        equipment=decoy.mock(cls=EquipmentHandler),
-        movement=decoy.mock(cls=MovementHandler),
-        model_utils=ModelUtils(),
-    )
-
-    assert task_id is None
+    assert subject.create_retry(command, task_id="new-task") is None

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_recovery.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_recovery.py
@@ -1,12 +1,13 @@
 """Tests for vacuum module associated-command recovery resolver."""
 
 from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from decoy import Decoy
 
 from opentrons_shared_data.errors.exceptions import VacuumModuleWasteFullError
 
-from opentrons.protocol_engine.commands.command import CommandStatus
+from opentrons.protocol_engine.commands.command import CommandStatus, SuccessData
 from opentrons.protocol_engine.commands.vacuum_module.common import (
     VACUUM_WASTE_CONTAINER_FULL_ERROR_CODE,
     VacuumModuleCarboyFullError,
@@ -19,7 +20,16 @@ from opentrons.protocol_engine.commands.vacuum_module.start_set_vacuum_pressure 
     StartSetVacuumPressureParams,
     StartSetVacuumPressureResult,
 )
+from opentrons.protocol_engine.commands.wait_for_tasks import (
+    WaitForTasks,
+    WaitForTasksParams,
+)
 from opentrons.protocol_engine.errors import ErrorOccurrence
+from opentrons.protocol_engine.execution import (
+    EquipmentHandler,
+    MovementHandler,
+    TaskHandler,
+)
 from opentrons.protocol_engine.resources import ModelUtils
 from opentrons.protocol_engine.state.module_substates.vacuum_module_substate import (
     VacuumModuleId,
@@ -127,3 +137,71 @@ def test_to_defined_error_data_maps_carboy_full(
     assert result is not None
     assert isinstance(result.public, VacuumModuleCarboyFullError)
     assert result.public.errorType == "vacuumCarboyFull"
+
+
+def _start_pressure_command(timestamp: datetime) -> StartSetVacuumPressure:
+    return StartSetVacuumPressure.model_construct(
+        id="start-command-id",
+        key="start-command-key",
+        createdAt=timestamp,
+        commandType="vacuumModule/startSetVacuumPressure",
+        status=CommandStatus.SUCCEEDED,
+        params=StartSetVacuumPressureParams.model_construct(
+            moduleId="vacuum-module-id",
+            gaugePressure=-50.0,
+            ventAfter=True,
+            taskId="old-task",
+        ),
+        result=StartSetVacuumPressureResult(taskId="old-task"),
+    )
+
+
+async def test_restart_runs_start_pressure_impl(decoy: Decoy) -> None:
+    """It should re-run the public start pressure impl and clear taskId."""
+    subject = VacuumModuleAssociatedCommandRecoveryResolver()
+    command = _start_pressure_command(datetime.now())
+    impl = MagicMock()
+    impl.execute = AsyncMock(
+        return_value=SuccessData(public=StartSetVacuumPressureResult(taskId="new-task"))
+    )
+
+    with patch(
+        "opentrons.protocol_engine.commands.vacuum_module.recovery.StartSetVacuumPressureImpl",
+        return_value=impl,
+    ):
+        task_id = await subject.restart(
+            command,
+            state_view=decoy.mock(cls=StateView),
+            task_handler=decoy.mock(cls=TaskHandler),
+            equipment=decoy.mock(cls=EquipmentHandler),
+            movement=decoy.mock(cls=MovementHandler),
+            model_utils=ModelUtils(),
+        )
+
+    assert task_id == "new-task"
+    executed_params = impl.execute.await_args.args[0]
+    assert executed_params.taskId is None
+
+
+async def test_restart_returns_none_for_unassociated_command(decoy: Decoy) -> None:
+    """It should not restart commands that are not vacuum start_* commands."""
+    subject = VacuumModuleAssociatedCommandRecoveryResolver()
+    command = WaitForTasks.model_construct(
+        id="wait-id",
+        key="wait-key",
+        createdAt=datetime.now(),
+        commandType="waitForTasks",
+        status=CommandStatus.FAILED,
+        params=WaitForTasksParams(task_ids=["task-1"]),
+    )
+
+    task_id = await subject.restart(
+        command,
+        state_view=decoy.mock(cls=StateView),
+        task_handler=decoy.mock(cls=TaskHandler),
+        equipment=decoy.mock(cls=EquipmentHandler),
+        movement=decoy.mock(cls=MovementHandler),
+        model_utils=ModelUtils(),
+    )
+
+    assert task_id is None

--- a/api/tests/opentrons/protocol_engine/execution/test_associated_command_error_recovery.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_associated_command_error_recovery.py
@@ -21,6 +21,11 @@ from opentrons.protocol_engine.commands.vacuum_module.start_set_vacuum_pressure 
     StartSetVacuumPressureParams,
     StartSetVacuumPressureResult,
 )
+from opentrons.protocol_engine.commands.wait_for_tasks import (
+    WaitForTasks,
+    WaitForTasksParams,
+    WaitForTasksResult,
+)
 from opentrons.protocol_engine.error_recovery_policy import (
     ErrorRecoveryType,
     never_recover,
@@ -36,6 +41,7 @@ from opentrons.protocol_engine.state.module_substates.vacuum_module_substate imp
 )
 from opentrons.protocol_engine.state.state import StateStore
 from opentrons.protocol_engine.types import LoadedModule, ModuleModel
+from opentrons.protocol_engine.types.tasks import FinishedTask
 
 
 @pytest.fixture
@@ -108,6 +114,7 @@ def test_finish_task_dispatches_fail_for_associated_start_command(
     decoy.when(model_utils.generate_id()).then_return("defined-error-id")
     decoy.when(state_store.commands.get_is_awaiting_recovery()).then_return(False)
     decoy.when(state_store.commands.get_is_terminal()).then_return(False)
+    decoy.when(state_store.commands.get_running_command_id()).then_return(None)
     decoy.when(state_store.commands.get("start-command-id")).then_return(start_command)
     decoy.when(state_store.commands.get_error_recovery_policy()).then_return(
         lambda config, failed_command, defined_error_data: (
@@ -168,6 +175,7 @@ def test_try_recover_from_module_error_uses_resolver(
     decoy.when(model_utils.generate_id()).then_return("defined-error-id")
     decoy.when(state_store.commands.get_is_awaiting_recovery()).then_return(False)
     decoy.when(state_store.commands.get_is_terminal()).then_return(False)
+    decoy.when(state_store.commands.get_running_command_id()).then_return(None)
     decoy.when(state_store.commands.get("start-command-id")).then_return(start_command)
     decoy.when(state_store.commands.get_error_recovery_policy()).then_return(
         lambda config, failed_command, defined_error_data: (
@@ -231,6 +239,7 @@ def test_orchestrator_skips_unhandled_errors(
 ) -> None:
     """It should ignore task failures that no resolver handles."""
     timestamp = datetime.now()
+    decoy.when(state_store.commands.get_running_command_id()).then_return(None)
     decoy.when(state_store.tasks.get_originating_command_id("task-1")).then_return(
         "start-command-id"
     )
@@ -266,6 +275,7 @@ def test_try_recover_from_module_error_returns_false_for_non_recoverable_policy(
     decoy.when(model_utils.generate_id()).then_return("defined-error-id")
     decoy.when(state_store.commands.get_is_awaiting_recovery()).then_return(False)
     decoy.when(state_store.commands.get_is_terminal()).then_return(False)
+    decoy.when(state_store.commands.get_running_command_id()).then_return(None)
     decoy.when(state_store.commands.get("start-command-id")).then_return(start_command)
     decoy.when(state_store.commands.get_error_recovery_policy()).then_return(
         never_recover
@@ -304,3 +314,181 @@ def test_try_recover_from_module_error_returns_false_for_non_recoverable_policy(
 
     assert recovered is False
     decoy.verify(action_dispatcher.dispatch(matchers.Anything()), times=0)
+
+
+def _wait_for_tasks_command(timestamp: datetime) -> WaitForTasks:
+    return WaitForTasks.model_construct(
+        id="wait-command-id",
+        key="wait-command-key",
+        createdAt=timestamp,
+        commandType="waitForTasks",
+        status=CommandStatus.RUNNING,
+        params=WaitForTasksParams(task_ids=["task-1"]),
+        result=WaitForTasksResult(task_ids=["task-1"]),
+    )
+
+
+def test_finish_task_skips_start_command_when_wait_for_tasks_is_running(
+    decoy: Decoy,
+    subject: AssociatedCommandErrorRecoveryOrchestrator,
+    state_store: StateStore,
+    action_dispatcher: ActionDispatcher,
+) -> None:
+    """A running waitForTasks should own recovery instead of the start command."""
+    timestamp = datetime.now()
+    decoy.when(state_store.tasks.get_originating_command_id("task-1")).then_return(
+        "start-command-id"
+    )
+    decoy.when(state_store.commands.get_running_command_id()).then_return(
+        "wait-command-id"
+    )
+    decoy.when(state_store.commands.get("wait-command-id")).then_return(
+        _wait_for_tasks_command(timestamp)
+    )
+
+    subject.handle_action(
+        FinishTaskAction(
+            task_id="task-1",
+            finished_at=timestamp,
+            error=ErrorOccurrence(
+                id="task-error-id",
+                createdAt=timestamp,
+                errorType="VacuumModuleWasteFullError",
+                errorCode="3041",
+                detail="Vacuum Module Waste Container Full",
+            ),
+        )
+    )
+
+    decoy.verify(action_dispatcher.dispatch(matchers.Anything()), times=0)
+
+
+def test_try_recover_from_module_error_defers_to_running_wait_for_tasks(
+    decoy: Decoy,
+    subject: AssociatedCommandErrorRecoveryOrchestrator,
+    state_store: StateStore,
+    action_dispatcher: ActionDispatcher,
+) -> None:
+    """Late async errors should not fail start_* while waitForTasks is running."""
+    timestamp = datetime.now()
+    decoy.when(
+        state_store.modules.get_has_module_probably_matching_hardware_details(
+            ModuleModel.VACUUM_MODULE_V1, "VM123"
+        )
+    ).then_return(True)
+    decoy.when(state_store.modules.get_all()).then_return(
+        [
+            LoadedModule.model_construct(
+                id="vacuum-module-id",
+                model=ModuleModel.VACUUM_MODULE_V1,
+                serialNumber="VM123",
+            )
+        ]
+    )
+    decoy.when(
+        state_store.tasks.get_last_background_command_id("vacuum-module-id")
+    ).then_return("start-command-id")
+    decoy.when(state_store.commands.get_running_command_id()).then_return(
+        "wait-command-id"
+    )
+    decoy.when(state_store.commands.get("wait-command-id")).then_return(
+        _wait_for_tasks_command(timestamp)
+    )
+    decoy.when(state_store.tasks.get_originating_command_id("task-1")).then_return(
+        "start-command-id"
+    )
+
+    recovered = subject.try_recover_from_module_error(
+        module_model=ModuleModel.VACUUM_MODULE_V1,
+        module_serial="VM123",
+        error=VacuumModuleWasteFullError("VM123", "pressure", 0.0, 0.0),
+    )
+
+    assert recovered is True
+    decoy.verify(action_dispatcher.dispatch(matchers.Anything()), times=0)
+
+
+def test_try_recover_from_module_error_recovers_start_after_waited_task_succeeded(
+    decoy: Decoy,
+    subject: AssociatedCommandErrorRecoveryOrchestrator,
+    state_store: StateStore,
+    action_dispatcher: ActionDispatcher,
+    model_utils: ModelUtils,
+) -> None:
+    """Late async after a succeeded waited task is start_* recovery, not swallowed."""
+    timestamp = datetime.now()
+    start_command = _start_command(timestamp)
+    decoy.when(model_utils.get_timestamp()).then_return(timestamp)
+    decoy.when(model_utils.generate_id()).then_return("defined-error-id")
+    decoy.when(state_store.commands.get_is_awaiting_recovery()).then_return(False)
+    decoy.when(state_store.commands.get_is_terminal()).then_return(False)
+    decoy.when(state_store.commands.get_running_command_id()).then_return(
+        "wait-command-id"
+    )
+    decoy.when(state_store.commands.get("wait-command-id")).then_return(
+        _wait_for_tasks_command(timestamp)
+    )
+    decoy.when(state_store.commands.get("start-command-id")).then_return(start_command)
+    decoy.when(state_store.commands.get_error_recovery_policy()).then_return(
+        lambda config, failed_command, defined_error_data: (
+            ErrorRecoveryType.WAIT_FOR_RECOVERY
+        )
+    )
+    decoy.when(
+        state_store.modules.get_has_module_probably_matching_hardware_details(
+            ModuleModel.VACUUM_MODULE_V1, "VM123"
+        )
+    ).then_return(True)
+    decoy.when(state_store.modules.get_all()).then_return(
+        [
+            LoadedModule.model_construct(
+                id="vacuum-module-id",
+                model=ModuleModel.VACUUM_MODULE_V1,
+                serialNumber="VM123",
+            )
+        ]
+    )
+    decoy.when(
+        state_store.tasks.get_last_background_command_id("vacuum-module-id")
+    ).then_return("start-command-id")
+    decoy.when(state_store.tasks.get_originating_command_id("task-1")).then_return(
+        "start-command-id"
+    )
+    decoy.when(state_store.tasks.get("task-1")).then_return(
+        FinishedTask(
+            id="task-1",
+            createdAt=timestamp,
+            finishedAt=timestamp,
+            error=None,
+        )
+    )
+    decoy.when(
+        state_store.modules.get_vacuum_module_substate("vacuum-module-id")
+    ).then_return(
+        VacuumModuleSubState(
+            module_id=VacuumModuleId("vacuum-module-id"),
+            pump_engaged=False,
+        )
+    )
+
+    recovered = subject.try_recover_from_module_error(
+        module_model=ModuleModel.VACUUM_MODULE_V1,
+        module_serial="VM123",
+        error=VacuumModuleWasteFullError("VM123", "pressure", 0.0, 0.0),
+    )
+
+    assert recovered is True
+    decoy.verify(
+        action_dispatcher.dispatch(
+            BeginAwaitingRecoveryAction(
+                command_id="start-command-id",
+                command=start_command,
+                error_id="defined-error-id",
+                failed_at=timestamp,
+                error=matchers.Anything(),
+                notes=matchers.Anything(),
+                type=ErrorRecoveryType.WAIT_FOR_RECOVERY,
+            )
+        ),
+        times=1,
+    )

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -366,6 +366,137 @@ def test_add_fixit_command(
     assert result == queued
 
 
+def test_add_wait_for_tasks_fixit_queues_originating_command_first(
+    decoy: Decoy,
+    state_store: StateStore,
+    action_dispatcher: ActionDispatcher,
+    model_utils: ModelUtils,
+    subject: ProtocolEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A waitForTasks fixit should queue a new start_* before the rewritten wait."""
+    created_at = datetime(year=2021, month=1, day=1)
+    robot_type: RobotType = "OT-3 Standard"
+    wait_request = commands.WaitForTasksCreate(
+        params=commands.WaitForTasksParams(task_ids=["old-task"]),
+        intent=commands.CommandIntent.FIXIT,
+    )
+    start_create = commands.vacuum_module.StartSetVacuumPressureCreate(
+        params=commands.vacuum_module.StartSetVacuumPressureParams(
+            moduleId="vacuum-module-id",
+            gaugePressure=-800.0,
+            taskId="new-task",
+        ),
+        intent=commands.CommandIntent.FIXIT,
+    )
+    rewritten_wait = wait_request.model_copy(
+        update={"params": commands.WaitForTasksParams(task_ids=["new-task"])}
+    )
+    queued_start = commands.vacuum_module.StartSetVacuumPressure(
+        id="start-command-id",
+        key="start-command-key",
+        status=commands.CommandStatus.QUEUED,
+        createdAt=created_at,
+        params=start_create.params,
+        intent=commands.CommandIntent.FIXIT,
+    )
+    queued_wait = commands.WaitForTasks(
+        id="wait-command-id",
+        key="wait-command-key",
+        status=commands.CommandStatus.QUEUED,
+        createdAt=created_at,
+        params=rewritten_wait.params,
+        intent=commands.CommandIntent.FIXIT,
+    )
+
+    monkeypatch.setattr(
+        "opentrons.protocol_engine.commands.background_task_recovery.expand_wait_for_tasks_fixit",
+        lambda *args, **kwargs: ([start_create], ["new-task"]),
+    )
+
+    decoy.when(state_store.config).then_return(
+        Config(robot_type=robot_type, deck_type=DeckType.OT3_STANDARD)
+    )
+    decoy.when(
+        slot_standardization.standardize_command(wait_request, robot_type)
+    ).then_return(wait_request)
+    decoy.when(
+        slot_standardization.standardize_command(start_create, robot_type)
+    ).then_return(start_create)
+
+    ids = iter(["start-command-id", "wait-command-id"])
+    decoy.when(model_utils.generate_id()).then_do(lambda prefix="": next(ids))
+    decoy.when(model_utils.get_timestamp()).then_return(created_at)
+
+    def _stub_queued_start(*_a: object, **_k: object) -> None:
+        decoy.when(state_store.commands.get("start-command-id")).then_return(
+            queued_start
+        )
+
+    def _stub_queued_wait(*_a: object, **_k: object) -> None:
+        decoy.when(state_store.commands.get("wait-command-id")).then_return(queued_wait)
+
+    decoy.when(
+        state_store.commands.validate_action_allowed(
+            QueueCommandAction(
+                command_id="start-command-id",
+                created_at=created_at,
+                request=start_create,
+                request_hash=None,
+            )
+        )
+    ).then_return(
+        QueueCommandAction(
+            command_id="start-command-id",
+            created_at=created_at,
+            request=start_create,
+            request_hash=None,
+        )
+    )
+    decoy.when(
+        action_dispatcher.dispatch(  # type: ignore[func-returns-value]
+            QueueCommandAction(
+                command_id="start-command-id",
+                created_at=created_at,
+                request=start_create,
+                request_hash=None,
+            )
+        )
+    ).then_do(_stub_queued_start)
+
+    decoy.when(
+        state_store.commands.validate_action_allowed(
+            QueueCommandAction(
+                command_id="wait-command-id",
+                created_at=created_at,
+                request=rewritten_wait,
+                request_hash=None,
+            )
+        )
+    ).then_return(
+        QueueCommandAction(
+            command_id="wait-command-id",
+            created_at=created_at,
+            request=rewritten_wait,
+            request_hash=None,
+        )
+    )
+    decoy.when(
+        action_dispatcher.dispatch(  # type: ignore[func-returns-value]
+            QueueCommandAction(
+                command_id="wait-command-id",
+                created_at=created_at,
+                request=rewritten_wait,
+                request_hash=None,
+            )
+        )
+    ).then_do(_stub_queued_wait)
+
+    result = subject.add_command(wait_request)
+
+    assert result == queued_wait
+
+
 def test_add_fixit_command_raises(
     decoy: Decoy,
     state_store: StateStore,

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_async_error_test.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_async_error_test.py
@@ -51,6 +51,7 @@ requirements = {
 _PRESET_GCODE: dict[str, str] = {
     "waste_full": "async ERR401:waste container full",
     "pressure_not_reached": "async ERR400:pressure not reached",
+    "none": "",
 }
 
 _SCENARIO_CHOICES: list[ParameterChoice] = [
@@ -114,8 +115,9 @@ def add_parameters(parameters: ParameterContext) -> None:
         variable_name="async_error_preset",
         display_name="Async Error Preset",
         description="Recoverable vacuum async error to inject after starting vacuum.",
-        default="waste_full",
+        default="none",
         choices=[
+            {"display_name": "None", "value": "none"},
             {"display_name": "Waste container full (ERR401)", "value": "waste_full"},
             {
                 "display_name": "Pressure not reached (ERR400)",
@@ -143,8 +145,16 @@ def add_parameters(parameters: ParameterContext) -> None:
         display_name="Vacuum Hold (seconds)",
         variable_name="vacuum_hold_seconds",
         description="Hold duration for timed vacuum background tasks and profile steps.",
-        default=60,
+        default=30,
         minimum=10,
+        maximum=600,
+    )
+    parameters.add_int(
+        display_name="Vacuum Timeout (seconds)",
+        variable_name="vacuum_timeout_seconds",
+        description="Timeout before pressure is considered not reached, disabled if 0.",
+        default=0,
+        minimum=0,
         maximum=600,
     )
     parameters.add_int(
@@ -217,34 +227,37 @@ def _start_vacuum_task(
     target_pressure = ctx.params.target_pressure_mbar  # type: ignore[attr-defined]
     target_power = ctx.params.target_percent_power  # type: ignore[attr-defined]
     hold_seconds = ctx.params.vacuum_hold_seconds  # type: ignore[attr-defined]
+    timeout_seconds = ctx.params.vacuum_timeout_seconds or None  # type: ignore[attr-defined]
     profile_repetitions = ctx.params.profile_repetitions  # type: ignore[attr-defined]
 
     if selected_api == "start_set_vacuum_pressure":
         ctx.comment(
             f"Starting start_set_vacuum_pressure to {target_pressure} mbar "
-            f"for {hold_seconds}s (background task)."
+            f"for {hold_seconds}s timeout {timeout_seconds}s (background task)."
         )
         return vm_mod.start_set_vacuum_pressure(
             target_pressure,
-            hold_seconds,
+            duration_s=hold_seconds,
+            timeout_s=timeout_seconds,
             vent_after=False,
         )
 
     if selected_api == "start_set_vacuum_power":
         ctx.comment(
             f"Starting start_set_vacuum_power at {target_power}% "
-            f"for {hold_seconds}s (background task)."
+            f"for {hold_seconds}s timeout {timeout_seconds}s (background task)."
         )
         return vm_mod.start_set_vacuum_power(
             target_power,
-            hold_seconds,
+            duration_s=hold_seconds,
+            timeout_s=timeout_seconds,
             vent_after=False,
         )
 
     if selected_api == "start_execute_profile":
         ctx.comment(
             f"Starting start_execute_profile with one pressure step to "
-            f"{target_pressure} mbar for {hold_seconds}s, "
+            f"{target_pressure} mbar for {hold_seconds}s timeout {timeout_seconds}s, "
             f"{profile_repetitions} repetition(s) (background task)."
         )
         return vm_mod.start_execute_profile(
@@ -253,6 +266,7 @@ def _start_vacuum_task(
                     "enable_pump": True,
                     "gauge_pressure_mbar": target_pressure,
                     "hold_time_seconds": hold_seconds,
+                    "timeout_seconds": timeout_seconds,
                     "vent_after": False,
                 }
             ],
@@ -273,12 +287,13 @@ def _wait_for_injection(ctx: ProtocolContext, vacuum_api: str) -> None:
 
 def _inject_async_error(ctx: ProtocolContext, vm_mod: VacuumModuleContext) -> str:
     gcode_response = _resolve_gcode_response(ctx)
-    ctx.comment(f"Injecting async G-code response: {gcode_response!r}")
-    inject_async_gcode_response(vm_mod, gcode_response)
-    ctx.comment(
-        "Async error injected. Recoverable errors (ERR400/ERR401) should enter "
-        "associated-command recovery instead of stopping the run."
-    )
+    if gcode_response:
+        ctx.comment(f"Injecting async G-code response: {gcode_response!r}")
+        inject_async_gcode_response(vm_mod, gcode_response)
+        ctx.comment(
+            "Async error injected. Recoverable errors (ERR400/ERR401) should enter "
+            "associated-command recovery instead of stopping the run."
+        )
     return gcode_response
 
 

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -1382,7 +1382,7 @@ class VacuumModuleUnknownError(RoboticsControlError):
         )
 
 
-class VacuumModulePressureNotReachedError(RoboticsControlError):
+class VacuumModulePressureNotReachedError(RoboticsInteractionError):
     """An error indicating that the target pressure was not reached in the vacuum module."""
 
     def __init__(
@@ -1422,7 +1422,7 @@ class VacuumModulePressureNotReachedError(RoboticsControlError):
         )
 
 
-class VacuumModuleWasteFullError(RoboticsControlError):
+class VacuumModuleWasteFullError(RoboticsInteractionError):
     """An error indicating that the vacuum module waste container is full."""
 
     def __init__(

--- a/shared-data/python_tests/errors/test_exceptions.py
+++ b/shared-data/python_tests/errors/test_exceptions.py
@@ -6,6 +6,7 @@ import pytest
 
 from opentrons_shared_data.errors.exceptions import (
     PythonException,
+    RoboticsInteractionError,
     VacuumModulePressureNotReachedError,
     VacuumModuleUnknownError,
     VacuumModuleWasteFullError,
@@ -164,3 +165,21 @@ def test_vacuum_module_errors_round_trip_through_pickle(
     """Vacuum module errors should pickle and unpickle without losing data."""
     restored = pickle.loads(pickle.dumps(error))
     assert restored == error
+
+
+@pytest.mark.parametrize(
+    "error_cls",
+    [VacuumModulePressureNotReachedError, VacuumModuleWasteFullError],
+)
+def test_recoverable_vacuum_errors_are_robotics_interaction_errors(
+    error_cls: type[VacuumModulePressureNotReachedError]
+    | type[VacuumModuleWasteFullError],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """3040/3041 belong to robotics interaction, not robotics control."""
+    with caplog.at_level("ERROR"):
+        error = error_cls("VM123", "pressure", 0.0, 0.0)
+
+    assert isinstance(error, RoboticsInteractionError)
+    assert "inappropriate for a RoboticsControlError" not in caplog.text
+    assert "inappropriate for a RoboticsInteractionError" not in caplog.text


### PR DESCRIPTION
# Overview

Follow-up to associated-command recovery ([#21871](https://github.com/Opentrons/opentrons/pull/21871)). When a protocol is blocked on `waitForTasks` and a vacuum background task fails recoverably (3040/3041), recovery was attached to the already-succeeded `start_*` commands. `waitForTasks` then either raised an undefined `TaskFailedError` or absorbed the error so the protocol continued. App Retry re-posted those background commands, which raced the original task and failed the run.

If `waitForTasks` is waiting on the failed task, it is now the recoverable command. App Retry still just re-posts the failed wait. The engine expands that fixit: it queues a **new** `start_*` (new command id, new task id), then waits on that task. The original `start_*` stays succeeded. If nobody is waiting, associated-command recovery on `start_*` is unchanged.

Work towards: [RQA-5853](https://opentrons.atlassian.net/browse/RQA-5853)

## Test Plan and Hands on Testing

- Pressure-only: `waitForTasks` failed with the defined error 3040; fixit retry succeeded; run succeeded
- Pressure then power: same for pressure; then power wait succeeded; run succeeded

## Changelog

- `waitForTasks` maps recoverable background failures to defined errors and owns recovery while it is running
- A `waitForTasks` fixit queues a new originating `start_*` and waits on the new task id
- Associated-command recovery still attaches to background commands when no wait covers the task
- Mixed recoverable + unrecoverable waited failures still fail the run
- Vacuum 3040/3041 are `RoboticsInteractionError` (they were under the wrong parent)

## Review requests

- Does the wait-vs-`start_*` ownership split match what we want for 10.2?
- Expanding the wait fixit in `add_command` (API-only, no app change) feel right?

## Risk assessment

Low, unreleased

[EXEC-1861]: https://opentrons.atlassian.net/browse/EXEC-1861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RQA-5853]: https://opentrons.atlassian.net/browse/RQA-5853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
