### PR TITLE
fix(robot-server): clear maintenance run before MQTT refetch request

### DIFF
--- a/robot-server/robot_server/maintenance_runs/maintenance_run_data_manager.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_data_manager.py
@@ -197,8 +197,9 @@ class MaintenanceRunDataManager:
             RunNotFoundError: The given run identifier was not found.
         """
         if run_id == self._run_orchestrator_store.current_run_id:
-            self._maintenance_runs_publisher.stop_publishing_for_maintenance_run()
+            # Ensure maintenance run is cleared before stop publishing to eliminate race condition
             await self._run_orchestrator_store.clear()
+            self._maintenance_runs_publisher.stop_publishing_for_maintenance_run()
 
             if camera_settings is not None:
                 # Restart the live stream for the external run when the maintenance run has ended.

--- a/robot-server/robot_server/maintenance_runs/maintenance_run_data_manager.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_data_manager.py
@@ -197,7 +197,6 @@ class MaintenanceRunDataManager:
             RunNotFoundError: The given run identifier was not found.
         """
         if run_id == self._run_orchestrator_store.current_run_id:
-            # Ensure maintenance run is cleared before stop publishing to eliminate race condition
             await self._run_orchestrator_store.clear()
             self._maintenance_runs_publisher.stop_publishing_for_maintenance_run()
 


### PR DESCRIPTION
# Overview

On maintenance run delete, publish the MQTT current_run refetch advise only after the run is cleared, so clients don’t refetch a still-live run. Fixes sticky ODD “robot is busy” takeover after desktop ends LPC/calibration. Closes RQA-5815.

## Test Plan and Hands on Testing

- Tested this on QA1 with logging. Prior to this change the ODD would refetch status and find 200, as the run had not been cleared yet. Leading it to think the run was still going, and on manual terminate, deletes a stale run. With the fix, the server only publishes the refetch advise after the run is cleared, so the ODD fetches that the run is done, and exits the terminate window.
- Confirmed the fix works on FourBot, no logging however.

## Changelog

Reordered await run clear to be before stop publishing run hooks.

## Review requests

- Could this be an issue anywhere else you know of? I checked other places where we tear down run hooks, and everything looked good.
- Any knock on effects of awaiting the teardown?

## Risk assessment

- Low, reordering is very unlikely to have negative consequences as we only moved things before an await, not after.
