### PR TITLE
fix(app, odd): add useEffect to notify refetch logic

### DIFF
--- a/app/src/resources/camera/useNotifyCamera.ts
+++ b/app/src/resources/camera/useNotifyCamera.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 import { useCamera } from '@opentrons/react-api-client'
 
 import { useNotifyDataReady } from '../useNotifyDataReady'
@@ -16,9 +18,14 @@ export function useNotifyCamera(
 
   const httpQueryResult = useCamera(queryOptionsNotify)
 
-  if (shouldRefetch) {
-    void httpQueryResult.refetch()
-  }
+  useEffect(() => {
+    if (shouldRefetch) {
+      void httpQueryResult.refetch()
+    }
+
+    // refetch is stable, the result object is not
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldRefetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/client_data/audit/useClientDataLogDeletion.ts
+++ b/app/src/resources/client_data/audit/useClientDataLogDeletion.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import { useClientData, useUpdateClientData } from '@opentrons/react-api-client'
 
@@ -27,9 +27,14 @@ export function useClientDataLogDeletion(
     queryOptionsNotify
   )
 
-  if (shouldRefetch) {
-    void httpQueryResult.refetch()
-  }
+  useEffect(() => {
+    if (shouldRefetch) {
+      void httpQueryResult.refetch()
+    }
+
+    // refetch is stable, the result object is not
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldRefetch])
 
   const { data } = httpQueryResult
 

--- a/app/src/resources/client_data/encryptionKeys/useNotifyClientDataEncryptionKeys.ts
+++ b/app/src/resources/client_data/encryptionKeys/useNotifyClientDataEncryptionKeys.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 import { useClientData } from '@opentrons/react-api-client'
 
 import { useNotifyDataReady } from '../../useNotifyDataReady'
@@ -24,9 +26,14 @@ export function useNotifyClientDataEncryptionKeys(
     queryOptionsNotify
   )
 
-  if (shouldRefetch) {
-    void httpQueryResult.refetch()
-  }
+  useEffect(() => {
+    if (shouldRefetch) {
+      void httpQueryResult.refetch()
+    }
+
+    // refetch is stable, the result object is not
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldRefetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/client_data/lpc/useNotifyClientDataLPC.ts
+++ b/app/src/resources/client_data/lpc/useNotifyClientDataLPC.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 import { useClientData } from '@opentrons/react-api-client'
 
 import { useNotifyDataReady } from '../../useNotifyDataReady'
@@ -25,9 +27,14 @@ export function useNotifyClientDataLPC(
     queryOptionsNotify
   )
 
-  if (shouldRefetch) {
-    void httpQueryResult.refetch()
-  }
+  useEffect(() => {
+    if (shouldRefetch) {
+      void httpQueryResult.refetch()
+    }
+
+    // refetch is stable, the result object is not
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldRefetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/client_data/recovery/useNotifyClientDataRecovery.ts
+++ b/app/src/resources/client_data/recovery/useNotifyClientDataRecovery.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 import { useClientData } from '@opentrons/react-api-client'
 
 import { useNotifyDataReady } from '../../useNotifyDataReady'
@@ -24,9 +26,14 @@ export function useNotifyClientDataRecovery(
     queryOptionsNotify
   )
 
-  if (shouldRefetch) {
-    void httpQueryResult.refetch()
-  }
+  useEffect(() => {
+    if (shouldRefetch) {
+      void httpQueryResult.refetch()
+    }
+
+    // refetch is stable, the result object is not
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldRefetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/dataFiles/useNotifyImageFileQuery.ts
+++ b/app/src/resources/dataFiles/useNotifyImageFileQuery.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 import { useImageFileQuery } from '@opentrons/react-api-client'
 
 import { useNotifyDataReady } from '../useNotifyDataReady'
@@ -17,9 +19,14 @@ export function useNotifyImageFileQuery(
 
   const httpQueryResult = useImageFileQuery(runId, queryOptionsNotify)
 
-  if (shouldRefetch) {
-    void httpQueryResult.refetch()
-  }
+  useEffect(() => {
+    if (shouldRefetch) {
+      void httpQueryResult.refetch()
+    }
+
+    // refetch is stable, the result object is not
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldRefetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/deck_configuration/useNotifyDeckConfigurationQuery.ts
+++ b/app/src/resources/deck_configuration/useNotifyDeckConfigurationQuery.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 import { useDeckConfigurationQuery } from '@opentrons/react-api-client'
 
 import { useNotifyDataReady } from '../useNotifyDataReady'
@@ -16,9 +18,14 @@ export function useNotifyDeckConfigurationQuery(
 
   const httpQueryResult = useDeckConfigurationQuery(queryOptionsNotify)
 
-  if (shouldRefetch) {
-    void httpQueryResult.refetch()
-  }
+  useEffect(() => {
+    if (shouldRefetch) {
+      void httpQueryResult.refetch()
+    }
+
+    // refetch is stable, the result object is not
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldRefetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/labware_offsets/useNotifySearchLabwareOffsets.ts
+++ b/app/src/resources/labware_offsets/useNotifySearchLabwareOffsets.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 import { useSearchLabwareOffsets } from '@opentrons/react-api-client'
 
 import { useNotifyDataReady } from '../useNotifyDataReady'
@@ -24,9 +26,14 @@ export function useNotifySearchLabwareOffsets(
 
   const httpQueryResult = useSearchLabwareOffsets(request, queryOptionsNotify)
 
-  if (shouldRefetch) {
-    void httpQueryResult.refetch()
-  }
+  useEffect(() => {
+    if (shouldRefetch) {
+      void httpQueryResult.refetch()
+    }
+
+    // refetch is stable, the result object is not
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldRefetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/maintenance_runs/notifications/useNotifyCurrentMaintenanceRun.ts
+++ b/app/src/resources/maintenance_runs/notifications/useNotifyCurrentMaintenanceRun.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 import { useCurrentMaintenanceRun } from '@opentrons/react-api-client'
 
 import { useNotifyDataReady } from '../../useNotifyDataReady'
@@ -16,9 +18,14 @@ export function useNotifyCurrentMaintenanceRun(
 
   const httpQueryResult = useCurrentMaintenanceRun(queryOptionsNotify)
 
-  if (shouldRefetch) {
-    void httpQueryResult.refetch()
-  }
+  useEffect(() => {
+    if (shouldRefetch) {
+      void httpQueryResult.refetch()
+    }
+
+    // refetch is stable, the result object is not
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldRefetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/runs/__tests__/useNotifyRunQuery.test.tsx
+++ b/app/src/resources/runs/__tests__/useNotifyRunQuery.test.tsx
@@ -1,0 +1,108 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useRunQuery } from '@opentrons/react-api-client'
+
+import { useNotifyDataReady } from '/app/resources/useNotifyDataReady'
+
+import { useNotifyRunQuery } from '../useNotifyRunQuery'
+
+vi.mock('@opentrons/react-api-client')
+vi.mock('/app/resources/useNotifyDataReady')
+
+const MOCK_RUN_ID = 'run-123'
+const MOCK_OPTIONS = { staleTime: 5000 }
+
+describe('useNotifyRunQuery', () => {
+  const refetch = vi.fn()
+  const queryOptionsNotify = { ...MOCK_OPTIONS, refetchInterval: false }
+
+  beforeEach(() => {
+    vi.mocked(useNotifyDataReady).mockReturnValue({
+      shouldRefetch: false,
+      queryOptionsNotify,
+    } as any)
+    vi.mocked(useRunQuery).mockReturnValue({
+      refetch,
+    } as any)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should pass notify options through to useRunQuery', () => {
+    renderHook(() => useNotifyRunQuery(MOCK_RUN_ID, MOCK_OPTIONS))
+
+    expect(useNotifyDataReady).toHaveBeenCalledWith({
+      topic: `robot-server/runs/${MOCK_RUN_ID}`,
+      options: MOCK_OPTIONS,
+      hostOverride: undefined,
+    })
+    expect(useRunQuery).toHaveBeenCalledWith(
+      MOCK_RUN_ID,
+      queryOptionsNotify,
+      undefined
+    )
+  })
+
+  it('should refetch in an effect when shouldRefetch is true, not during render', () => {
+    vi.mocked(useNotifyDataReady).mockReturnValue({
+      shouldRefetch: true,
+      queryOptionsNotify,
+    } as any)
+    vi.mocked(useRunQuery).mockImplementation(() => {
+      // useRunQuery runs during render; refetch must not have been called yet.
+      expect(refetch).not.toHaveBeenCalled()
+      return { refetch } as any
+    })
+
+    renderHook(() => useNotifyRunQuery(MOCK_RUN_ID, MOCK_OPTIONS))
+
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not refetch when shouldRefetch is false', () => {
+    renderHook(() => useNotifyRunQuery(MOCK_RUN_ID, MOCK_OPTIONS))
+
+    expect(refetch).not.toHaveBeenCalled()
+  })
+
+  it('should not refetch when runId is null', () => {
+    vi.mocked(useNotifyDataReady).mockReturnValue({
+      shouldRefetch: true,
+      queryOptionsNotify,
+    } as any)
+
+    renderHook(() => useNotifyRunQuery(null, MOCK_OPTIONS))
+
+    expect(refetch).not.toHaveBeenCalled()
+  })
+
+  it('should not refetch when runId is the string "null"', () => {
+    vi.mocked(useNotifyDataReady).mockReturnValue({
+      shouldRefetch: true,
+      queryOptionsNotify,
+    } as any)
+
+    renderHook(() => useNotifyRunQuery('null', MOCK_OPTIONS))
+
+    expect(refetch).not.toHaveBeenCalled()
+  })
+
+  it('should refetch when shouldRefetch becomes true after a rerender', () => {
+    const { rerender } = renderHook(() =>
+      useNotifyRunQuery(MOCK_RUN_ID, MOCK_OPTIONS)
+    )
+
+    expect(refetch).not.toHaveBeenCalled()
+
+    vi.mocked(useNotifyDataReady).mockReturnValue({
+      shouldRefetch: true,
+      queryOptionsNotify,
+    } as any)
+    rerender()
+
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/src/resources/runs/useNotifyAllCommandsAsPreSerializedList.ts
+++ b/app/src/resources/runs/useNotifyAllCommandsAsPreSerializedList.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 import { useAllCommandsAsPreSerializedList } from '@opentrons/react-api-client'
 
 import { useNotifyDataReady } from '../useNotifyDataReady'
@@ -23,9 +25,14 @@ export function useNotifyAllCommandsAsPreSerializedList(
     queryOptionsNotify
   )
 
-  if (shouldRefetch) {
-    void httpQueryResult.refetch()
-  }
+  useEffect(() => {
+    if (shouldRefetch) {
+      void httpQueryResult.refetch()
+    }
+
+    // refetch is stable, the result object is not
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldRefetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/runs/useNotifyAllCommandsQuery.ts
+++ b/app/src/resources/runs/useNotifyAllCommandsQuery.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 import { useAllCommandsQuery } from '@opentrons/react-api-client'
 
 import { useNotifyDataReady } from '../useNotifyDataReady'
@@ -24,9 +26,14 @@ export function useNotifyAllCommandsQuery<TError = Error>(
 
   const httpQueryResult = useAllCommandsQuery(runId, params, queryOptionsNotify)
 
-  if (shouldRefetch) {
-    void httpQueryResult.refetch()
-  }
+  useEffect(() => {
+    if (shouldRefetch) {
+      void httpQueryResult.refetch()
+    }
+
+    // refetch is stable, the result object is not
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldRefetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/runs/useNotifyAllRunsQuery.ts
+++ b/app/src/resources/runs/useNotifyAllRunsQuery.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 import { useAllRunsQuery } from '@opentrons/react-api-client'
 
 import { useNotifyDataReady } from '../useNotifyDataReady'
@@ -31,9 +33,14 @@ export function useNotifyAllRunsQuery(
     hostOverride
   )
 
-  if (shouldRefetch) {
-    void httpQueryResult.refetch()
-  }
+  useEffect(() => {
+    if (shouldRefetch) {
+      void httpQueryResult.refetch()
+    }
+
+    // refetch is stable, the result object is not
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldRefetch])
 
   return httpQueryResult
 }


### PR DESCRIPTION
# Overview

Okay. So. ReactQuery bundles up queries by route to prevent multiple components from hitting the same route at the same time. When we call `useQuery` a bunch of times in different places were really creating subscriptions called 'observers' to the same core query behind the scenes. ReactQuery updates these observers with whatever data we call `useQuery` with, BUT, that update happens within a `useEffect` aka after render. In hooks using this MQTT notify pattern, we were calling `query.refetch()` DURING render, so in that first frame after creating or updating the call to `useQuery`, we were calling `.refetch()` on a stale version of the observer! This was causing weirdness like sending out a query for `GET /runs/null` during protocol setup, and likely other similarly quiet weird bugs. By moving the refetch to a `useEffect` we guarantee we'll always be referencing the most recent version of the observer. 

## Test Plan and Hands on Testing

Creating runs, deleting runs, canceling runs, completing runs, error recovery, LPC, log deletion, encryption keys, deck configuration, maintenance runs, and robot busy signals should all work normally. 

## Risk assessment

Uhhh. Hard to say. Its a very wide spread of behaviors but technically, this should only be delaying an async call by less than a frame. Should be fine.