### PR TITLE
fix(app): Capitalize the "Save" button

### DIFF
--- a/app/src/assets/localization/en/shared.json
+++ b/app/src/assets/localization/en/shared.json
@@ -73,7 +73,7 @@
   "robot_is_busy_no_protocol_run_allowed": "This robot is busy and can’t run this protocol right now. <robotLink>Go to Robot</robotLink>",
   "robot_is_reachable_but_not_responding": "This robot's API server is not responding correctly to requests at IP address {{hostname}}",
   "robot_was_seen_but_is_unreachable": "This robot has been seen recently, but is currently not reachable at IP address {{hostname}}",
-  "save": "save",
+  "save": "Save",
   "shutdown": "shutdown",
   "slot": "Slot {{slot}}",
   "something_went_wrong": "something went wrong",

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/__tests__/PersonalAccountSettings.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/__tests__/PersonalAccountSettings.test.tsx
@@ -128,12 +128,12 @@ describe('PersonalAccountSettings', () => {
     openEditForm()
     expect(screen.getByDisplayValue('alice')).toBeInTheDocument()
     expect(screen.getByDisplayValue('Alice Example')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'save' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Cancel' })[1]!)
     expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
     expect(
-      screen.queryByRole('button', { name: 'save' })
+      screen.queryByRole('button', { name: 'Save' })
     ).not.toBeInTheDocument()
   })
 
@@ -202,7 +202,7 @@ describe('PersonalAccountSettings', () => {
     fireEvent.change(screen.getByDisplayValue('Alice Example'), {
       target: { value: 'Alice Updated' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
 
     await waitFor(() => {
       expect(mockUpdateSelf).toHaveBeenCalledOnce()
@@ -216,7 +216,7 @@ describe('PersonalAccountSettings', () => {
     })
     expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
     expect(
-      screen.queryByRole('button', { name: 'save' })
+      screen.queryByRole('button', { name: 'Save' })
     ).not.toBeInTheDocument()
   })
 
@@ -251,7 +251,7 @@ describe('PersonalAccountSettings', () => {
       renderComponent()
       openEditForm()
       applyChange()
-      fireEvent.click(screen.getByRole('button', { name: 'save' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
 
       await waitFor(() => {
         expect(mockUpdateSelf).toHaveBeenCalledWith({ data: expectedData })
@@ -266,12 +266,12 @@ describe('PersonalAccountSettings', () => {
     fireEvent.change(screen.getByDisplayValue('alice'), {
       target: { value: 'alice2' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
 
     await waitFor(() => {
       screen.getByText('Unable to save account settings. Try again.')
     })
-    expect(screen.getByRole('button', { name: 'save' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
   })
 
   it('shows a username error when updateSelf returns username already exists', async () => {
@@ -281,14 +281,14 @@ describe('PersonalAccountSettings', () => {
     fireEvent.change(screen.getByDisplayValue('alice'), {
       target: { value: 'bob' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
 
     await waitFor(() => {
       screen.getByText(
         'This username is already taken. Choose a different username.'
       )
     })
-    expect(screen.getByRole('button', { name: 'save' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
     expect(
       screen.queryByText('Unable to save account settings. Try again.')
     ).not.toBeInTheDocument()

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/__tests__/PersonalAccountSettingsEditForm.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/__tests__/PersonalAccountSettingsEditForm.test.tsx
@@ -41,7 +41,7 @@ describe('PersonalAccountSettingsEditForm', () => {
     render(props)
     expect(screen.getByDisplayValue('alice')).toBeInTheDocument()
     expect(screen.getByDisplayValue('Alice Example')).toBeInTheDocument()
-    const saveButton = screen.getByRole('button', { name: 'save' })
+    const saveButton = screen.getByRole('button', { name: 'Save' })
     expect(saveButton).toBeDisabled()
     fireEvent.click(saveButton)
     expect(props.onCancel).not.toHaveBeenCalled()
@@ -53,7 +53,7 @@ describe('PersonalAccountSettingsEditForm', () => {
     fireEvent.change(screen.getByDisplayValue('alice'), {
       target: { value: 'alice2' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
     await waitFor(() => {
       expect(props.onSave).toHaveBeenCalledWith({
         data: { username: 'alice2' },
@@ -66,7 +66,7 @@ describe('PersonalAccountSettingsEditForm', () => {
     fireEvent.change(screen.getByDisplayValue('Alice Example'), {
       target: { value: 'Alice Updated' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
     await waitFor(() => {
       expect(props.onSave).toHaveBeenCalledWith({
         data: { fullName: 'Alice Updated' },
@@ -79,7 +79,7 @@ describe('PersonalAccountSettingsEditForm', () => {
     fireEvent.change(screen.getByDisplayValue('alice'), {
       target: { value: '   ' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
     await waitFor(() => {
       expect(props.onSave).not.toHaveBeenCalled()
     })
@@ -90,7 +90,7 @@ describe('PersonalAccountSettingsEditForm', () => {
     fireEvent.change(screen.getByDisplayValue('alice'), {
       target: { value: '' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
 
     await waitFor(() => {
       expect(screen.getByText('Username is required.')).toBeInTheDocument()
@@ -110,14 +110,14 @@ describe('PersonalAccountSettingsEditForm', () => {
     await waitFor(() => {
       screen.getByText('Passwords do not match')
     })
-    fireEvent.click(screen.getByRole('button', { name: 'save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
     expect(props.onSave).not.toHaveBeenCalled()
     const [passwordInput, confirmPasswordInput] = getPasswordInputs(container)
     fireEvent.change(passwordInput, { target: { value: 'new-password' } })
     fireEvent.change(confirmPasswordInput, {
       target: { value: 'new-password' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
     await waitFor(() => {
       expect(props.onSave).toHaveBeenCalledWith({
         data: { password: 'new-password' },
@@ -139,7 +139,7 @@ describe('PersonalAccountSettingsEditForm', () => {
     fireEvent.change(screen.getByDisplayValue('alice'), {
       target: { value: 'alice2' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
 
     await waitFor(() => {
       screen.getByText('Unable to save account settings. Try again.')

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/FlowRate.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/FlowRate.tsx
@@ -44,7 +44,7 @@ interface FlowRateEntryProps {
 
 export function FlowRateEntry(props: FlowRateEntryProps): JSX.Element {
   const { onBack, state, dispatch, kind } = props
-  const { i18n, t } = useTranslation(['quick_transfer', 'shared'])
+  const { t } = useTranslation(['quick_transfer', 'shared'])
   const { trackEventWithRobotSerial } = useTrackEventWithRobotSerial()
 
   const initialFlowRate =
@@ -131,7 +131,7 @@ export function FlowRateEntry(props: FlowRateEntryProps): JSX.Element {
     <Flex position={POSITION_FIXED} backgroundColor={COLORS.white} width="100%">
       <ChildNavigation
         header={headerCopy}
-        buttonText={i18n.format(t('shared:save'), 'capitalize')}
+        buttonText={t('shared:save')}
         onClickBack={onBack}
         onClickButton={handleClickSave}
         top={SPACING.spacing8}

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/PreWetTip.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/PreWetTip.tsx
@@ -13,7 +13,6 @@ import {
 } from '@opentrons/components'
 
 import { getTopPortalEl } from '/app/App/portal'
-import { i18n } from '/app/i18n'
 import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 import { useTrackEventWithRobotSerial } from '/app/redux-resources/analytics'
 import { ANALYTICS_QUICK_TRANSFER_SETTING_SAVED } from '/app/redux/analytics'
@@ -80,7 +79,7 @@ export function PreWetTip(props: PreWetTipProps): JSX.Element {
     <Flex position={POSITION_FIXED} backgroundColor={COLORS.white} width="100%">
       <ChildNavigation
         header={t('pre_wet_tip_before_aspirating')}
-        buttonText={i18n.format(t('shared:save'), 'capitalize')}
+        buttonText={t('shared:save')}
         onClickBack={handleClickBackOrExit}
         onClickButton={handleClickSave}
         top={SPACING.spacing8}

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/TipPosition.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/TipPosition.tsx
@@ -36,7 +36,7 @@ interface TipPositionEntryProps {
 
 export function TipPositionEntry(props: TipPositionEntryProps): JSX.Element {
   const { onBack, state, dispatch, kind } = props
-  const { i18n, t } = useTranslation(['quick_transfer', 'shared'])
+  const { t } = useTranslation(['quick_transfer', 'shared'])
   const { trackEventWithRobotSerial } = useTrackEventWithRobotSerial()
   const keyboardRef = useRef(null)
 
@@ -107,7 +107,7 @@ export function TipPositionEntry(props: TipPositionEntryProps): JSX.Element {
             ? t('aspirate_tip_position')
             : t('dispense_tip_position')
         }
-        buttonText={i18n.format(t('shared:save'), 'capitalize')}
+        buttonText={t('shared:save')}
         onClickBack={onBack}
         onClickButton={handleClickSave}
         top={SPACING.spacing8}

--- a/app/src/pages/ODD/DeckConfiguration/index.tsx
+++ b/app/src/pages/ODD/DeckConfiguration/index.tsx
@@ -81,7 +81,7 @@ export function DeckConfigurationEditor(): JSX.Element {
       >
         <ChildNavigation
           header={t('devices_landing:deck_configuration')}
-          buttonText={i18n.format(t('shared:save'), 'capitalize')}
+          buttonText={t('shared:save')}
           onClickButton={handleClickConfirm}
           secondaryButtonProps={secondaryButtonProps}
         />


### PR DESCRIPTION
## Overview

The save button in the "Edit user" modal was "save" instead of "Save". Per [our current practices](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/6195773488/Internationalization+guide), this fixes it by changing the underlying i18n strings.

A few places were already fixing this another way, via `i18n.capitalize()`. That's unnecessary now, so it's removed for simplicity.

## Test Plan and Hands on Testing

* [ ] "save" is now "Save" in the "Edit user" modal.

## Review requests

None.

## Risk assessment

Low.