### PR TITLE
fix(app): dismiss robot update UI when CRS login is cancelled

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
@@ -73,10 +73,6 @@ export function RobotUpdateProgressModal({
   const [showFileSelect, setShowFileSelect] = useState<boolean>(false)
   const installFromFileRef = useRef<HTMLInputElement>(null)
 
-  const completeRobotUpdateHandler = (): void => {
-    if (closeUpdateBuildroot != null) closeUpdateBuildroot()
-  }
-
   const { updateStep, progressPercent } = useRobotUpdateInfo(robotName, session)
 
   let { error } = session || { error: null }
@@ -87,7 +83,6 @@ export function RobotUpdateProgressModal({
 
   useStatusBarAnimation(error != null)
   useCleanupRobotUpdateSessionOnDismount()
-  useDismissIfSessionCleared(session, closeUpdateBuildroot)
 
   const handleFileSelect: ChangeEventHandler<HTMLInputElement> = event => {
     const { files } = event.target
@@ -328,17 +323,6 @@ function useCleanupRobotUpdateSessionOnDismount(): void {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )
-}
-
-function useDismissIfSessionCleared(
-  session: RobotUpdateSession | null,
-  closeUpdateBuildroot?: () => void
-): void {
-  useEffect(() => {
-    if (session == null) {
-      closeUpdateBuildroot?.()
-    }
-  }, [session, closeUpdateBuildroot])
 }
 
 function useGetModalText(

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
@@ -60,13 +60,13 @@ const HIDDEN_CSS = css`
 interface RobotUpdateProgressModalProps {
   robotName: string
   session: RobotUpdateSession | null
-  closeUpdateBuildroot?: () => void
+  closeRobotUpdate: () => void
 }
 
 export function RobotUpdateProgressModal({
   robotName,
   session,
-  closeUpdateBuildroot,
+  closeRobotUpdate,
 }: RobotUpdateProgressModalProps): JSX.Element {
   const dispatch = useDispatch()
   const { t } = useTranslation('device_settings')
@@ -87,6 +87,7 @@ export function RobotUpdateProgressModal({
 
   useStatusBarAnimation(error != null)
   useCleanupRobotUpdateSessionOnDismount()
+  useDismissIfSessionCleared(session, closeUpdateBuildroot)
 
   const handleFileSelect: ChangeEventHandler<HTMLInputElement> = event => {
     const { files } = event.target
@@ -123,14 +124,12 @@ export function RobotUpdateProgressModal({
       textAlign="center"
       onClose={
         hasRobotCompletedInit || error || letUserExitUpdate
-          ? completeRobotUpdateHandler
+          ? closeRobotUpdate
           : undefined
       }
       footer={
         hasRobotCompletedInit || error ? (
-          <RobotUpdateProgressFooter
-            closeUpdateBuildroot={completeRobotUpdateHandler}
-          />
+          <RobotUpdateProgressFooter closeRobotUpdate={closeRobotUpdate} />
         ) : null
       }
     >
@@ -175,11 +174,11 @@ export function RobotUpdateProgressModal({
 }
 
 interface RobotUpdateProgressFooterProps {
-  closeUpdateBuildroot?: () => void
+  closeRobotUpdate: () => void
 }
 
 function RobotUpdateProgressFooter({
-  closeUpdateBuildroot,
+  closeRobotUpdate,
 }: RobotUpdateProgressFooterProps): JSX.Element {
   const { t } = useTranslation('device_settings')
 
@@ -190,7 +189,7 @@ function RobotUpdateProgressFooter({
       padding={`${SPACING.spacing16} 0`}
     >
       <NewPrimaryBtn
-        onClick={closeUpdateBuildroot}
+        onClick={closeRobotUpdate}
         marginRight={SPACING.spacing12}
         css={FOOTER_BUTTON_STYLE}
       >
@@ -329,6 +328,17 @@ function useCleanupRobotUpdateSessionOnDismount(): void {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )
+}
+
+function useDismissIfSessionCleared(
+  session: RobotUpdateSession | null,
+  closeUpdateBuildroot?: () => void
+): void {
+  useEffect(() => {
+    if (session == null) {
+      closeUpdateBuildroot?.()
+    }
+  }, [session, closeUpdateBuildroot])
 }
 
 function useGetModalText(

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/__tests__/RobotUpdateProgressModal.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/__tests__/RobotUpdateProgressModal.test.tsx
@@ -57,7 +57,7 @@ describe('DownloadUpdateModal', () => {
     props = {
       robotName: 'testRobot',
       session: mockRobotUpdateSession,
-      closeUpdateBuildroot: vi.fn(),
+      closeRobotUpdate: vi.fn(),
     }
     vi.mocked(useCreateLiveCommandMutation).mockReturnValue({
       createLiveCommand: mockCreateLiveCommand,
@@ -108,6 +108,12 @@ describe('DownloadUpdateModal', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
+  it('closes when the update session is cleared after login or documentation cancel', () => {
+    props = { ...props, session: null }
+    render(props)
+    expect(props.closeUpdateBuildroot).toHaveBeenCalled()
+  })
+
   it('renders the correct text when finalizing the robot update with no close button', () => {
     vi.mocked(useRobotUpdateInfo).mockReturnValue({
       updateStep: 'restart',
@@ -141,7 +147,7 @@ describe('DownloadUpdateModal', () => {
     expect(exitButton).toBeInTheDocument()
     expect(mockCreateLiveCommand).toHaveBeenCalled()
     fireEvent.click(exitButton)
-    expect(props.closeUpdateBuildroot).toHaveBeenCalled()
+    expect(props.closeRobotUpdate).toHaveBeenCalled()
   })
 
   it('renders an error modal and exit button if an error occurs', () => {
@@ -162,7 +168,7 @@ describe('DownloadUpdateModal', () => {
 
     expect(screen.getByText('test error')).toBeInTheDocument()
     fireEvent.click(exitButton)
-    expect(props.closeUpdateBuildroot).toHaveBeenCalled()
+    expect(props.closeRobotUpdate).toHaveBeenCalled()
 
     expect(useCreateLiveCommandMutation).toBeCalledWith(
       ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/__tests__/RobotUpdateProgressModal.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/__tests__/RobotUpdateProgressModal.test.tsx
@@ -108,12 +108,6 @@ describe('DownloadUpdateModal', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
-  it('closes when the update session is cleared after login or documentation cancel', () => {
-    props = { ...props, session: null }
-    render(props)
-    expect(props.closeUpdateBuildroot).toHaveBeenCalled()
-  })
-
   it('renders the correct text when finalizing the robot update with no close button', () => {
     vi.mocked(useRobotUpdateInfo).mockReturnValue({
       updateStep: 'restart',

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/index.tsx
@@ -38,6 +38,13 @@ const UpdateBuildroot = NiceModal.create(
       hasSeenSessionOnce.current = true
     }
 
+    // Dismiss so the progress modal cannot stay up with no close control.
+    useEffect(() => {
+      if (hasSeenSessionOnce.current && session == null) {
+        modal.remove()
+      }
+    }, [session, modal])
+
     useEffect(
       () => {
         if (robotName.current) {
@@ -61,16 +68,18 @@ const UpdateBuildroot = NiceModal.create(
       [robotName, close]
     )
 
-    if (hasSeenSessionOnce.current) {
+    if (hasSeenSessionOnce.current && session != null) {
       return (
         <ApiHostProvider robotName={robotName.current}>
           <RobotUpdateProgressModal
             robotName={robotName.current}
             session={session}
-            closeUpdateBuildroot={modal.remove}
+            closeRobotUpdate={modal.remove}
           />
         </ApiHostProvider>
       )
+    } else if (hasSeenSessionOnce.current) {
+      return null
     } else if (robot != null && robot.status !== UNREACHABLE) {
       return (
         <ViewUpdateModal

--- a/app/src/organisms/UpdateRobotSoftware/__tests__/UpdateRobotSoftware.test.tsx
+++ b/app/src/organisms/UpdateRobotSoftware/__tests__/UpdateRobotSoftware.test.tsx
@@ -78,13 +78,15 @@ const mockSession = {
 
 const mockAfterError = vi.fn()
 const mockBeforeCommitting = vi.fn()
+const mockAfterCancel = vi.fn()
 
-const render = () => {
+const render = (afterCancel: () => void = mockAfterCancel) => {
   return renderWithProviders(
     <UpdateRobotSoftware.UpdateRobotSoftware
       localRobot={mockRobot}
       afterError={mockAfterError}
       beforeCommittingSuccessfulUpdate={mockBeforeCommitting}
+      afterCancel={afterCancel}
     />,
     {
       i18nInstance: i18n,
@@ -96,6 +98,9 @@ const render = () => {
 describe('UpdateRobotSoftware', () => {
   beforeEach(() => {
     mockStartUpdate.mockClear()
+    mockAfterError.mockClear()
+    mockBeforeCommitting.mockClear()
+    mockAfterCancel.mockClear()
     vi.mocked(CompleteUpdateSoftware).mockReturnValue(
       <div>mock CompleteUpdateSoftware</div>
     )
@@ -179,5 +184,33 @@ describe('UpdateRobotSoftware', () => {
     vi.mocked(getRobotUpdateSession).mockReturnValue(mockInstallingSession)
     render()
     screen.getByText('mock UpdateSoftware')
+  })
+
+  it('should call afterCancel when the session is cleared', () => {
+    vi.mocked(getRobotUpdateSession).mockReturnValue(mockSession)
+    const [{ rerender }, store] = render(mockAfterCancel)
+    expect(mockAfterCancel).not.toHaveBeenCalled()
+
+    vi.mocked(getRobotUpdateSession).mockReturnValue(null)
+    vi.mocked(store.getState).mockReturnValue({
+      ...MOCK_STATE,
+      nonce: 1,
+    } as any)
+    rerender(
+      <UpdateRobotSoftware.UpdateRobotSoftware
+        localRobot={mockRobot}
+        afterError={mockAfterError}
+        beforeCommittingSuccessfulUpdate={mockBeforeCommitting}
+        afterCancel={mockAfterCancel}
+      />
+    )
+    expect(mockAfterCancel).toHaveBeenCalled()
+  })
+
+  it('should not call afterCancel before a session exists', () => {
+    vi.mocked(getRobotUpdateSession).mockReturnValue(null)
+    render(mockAfterCancel)
+    expect(mockAfterError).not.toHaveBeenCalled()
+    expect(mockAfterCancel).not.toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/UpdateRobotSoftware/index.tsx
+++ b/app/src/organisms/UpdateRobotSoftware/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { CompleteUpdateSoftware } from '/app/organisms/UpdateRobotSoftware/CompleteUpdateSoftware'
@@ -28,12 +28,18 @@ interface UpdateRobotSoftwareProps {
   localRobot: ViewableRobot
   afterError: (errorMessage: string) => void
   beforeCommittingSuccessfulUpdate?: () => void
+  afterCancel: () => void
 }
 
 export function UpdateRobotSoftware(
   props: UpdateRobotSoftwareProps
 ): JSX.Element {
-  const { localRobot, afterError, beforeCommittingSuccessfulUpdate } = props
+  const {
+    localRobot,
+    afterError,
+    beforeCommittingSuccessfulUpdate,
+    afterCancel,
+  } = props
   const robotName = localRobot?.name != null ? localRobot.name : 'no name'
   const dispatch = useDispatch<Dispatch>()
   const { startUpdate } = useRobotUpdateContext()
@@ -48,6 +54,14 @@ export function UpdateRobotSoftware(
     error: null,
   }
   const [isDownloading, setIsDownloading] = useState<boolean>(false)
+  const afterCancelRef = useRef(afterCancel)
+  afterCancelRef.current = afterCancel
+  const hadSessionRef = useRef(session != null)
+  const didCancelRef = useRef(false)
+
+  if (session != null) {
+    hadSessionRef.current = true
+  }
 
   useEffect(() => {
     // check isDownloading to avoid dispatching again
@@ -57,6 +71,13 @@ export function UpdateRobotSoftware(
       startUpdate(robotName)
     }
   }, [dispatch, startUpdate, robotName, isDownloading])
+
+  useEffect(() => {
+    if (session == null && hadSessionRef.current && !didCancelRef.current) {
+      didCancelRef.current = true
+      afterCancelRef.current()
+    }
+  }, [session])
 
   // Display Error screen
   if (sessionError != null) {

--- a/app/src/pages/ODD/UpdateRobot/UpdateRobot.tsx
+++ b/app/src/pages/ODD/UpdateRobot/UpdateRobot.tsx
@@ -74,6 +74,10 @@ export function UpdateRobot(): JSX.Element {
         <UpdateRobotSoftware
           localRobot={localRobot}
           afterError={setErrorString}
+          afterCancel={() => {
+            dispatch(clearRobotUpdateSession())
+            navigate(-1)
+          }}
         />
       )}
     </Flex>

--- a/app/src/pages/ODD/UpdateRobot/UpdateRobotDuringOnboarding.tsx
+++ b/app/src/pages/ODD/UpdateRobot/UpdateRobotDuringOnboarding.tsx
@@ -116,6 +116,10 @@ export function UpdateRobotDuringOnboarding(): JSX.Element {
         <UpdateRobotSoftware
           localRobot={localRobot}
           afterError={setErrorString}
+          afterCancel={() => {
+            dispatch(clearRobotUpdateSession())
+            navigate('/emergency-stop')
+          }}
           beforeCommittingSuccessfulUpdate={handleSuccessfulUpdate}
         />
       )}

--- a/app/src/pages/ODD/UpdateRobot/__tests__/UpdateRobotDuringOnboarding.test.tsx
+++ b/app/src/pages/ODD/UpdateRobot/__tests__/UpdateRobotDuringOnboarding.test.tsx
@@ -13,7 +13,6 @@ import type { RobotUpdateSession } from '/app/redux/robot-update/types'
 import type { State } from '/app/redux/types'
 
 const mockStartUpdate = vi.hoisted(() => vi.fn())
-const mockNavigate = vi.hoisted(() => vi.fn())
 
 vi.mock('/app/redux/discovery')
 vi.mock('/app/redux/robot-update')

--- a/app/src/pages/ODD/UpdateRobot/__tests__/UpdateRobotDuringOnboarding.test.tsx
+++ b/app/src/pages/ODD/UpdateRobot/__tests__/UpdateRobotDuringOnboarding.test.tsx
@@ -13,6 +13,7 @@ import type { RobotUpdateSession } from '/app/redux/robot-update/types'
 import type { State } from '/app/redux/types'
 
 const mockStartUpdate = vi.hoisted(() => vi.fn())
+const mockNavigate = vi.hoisted(() => vi.fn())
 
 vi.mock('/app/redux/discovery')
 vi.mock('/app/redux/robot-update')

--- a/app/src/resources/robot-update/useRobotUpdateOrchestrator/runRobotUpdateFlow.ts
+++ b/app/src/resources/robot-update/useRobotUpdateOrchestrator/runRobotUpdateFlow.ts
@@ -262,6 +262,7 @@ function reportFlowError(dispatch: Dispatch, error: unknown): void {
       )
       return
     }
+    // base case, the user backed out.
     dispatch(clearRobotUpdateSession())
     return
   }


### PR DESCRIPTION
Closes [RQA-5892](https://opentrons.atlassian.net/browse/RQA-5892)

# Overview

Fixes an issue in which cancelling CRS login (or documentation) during a Flex software update could leave the “Installing update…” UI stuck with no way to exit. On the desktop app, the update progress modal closes when the update session is cleared. On the ODD, the update screen exits (back to the previous page, or onboarding continues without updating).

### Current behavior

https://github.com/user-attachments/assets/f85599e9-949b-45fd-a88a-12445c40ee88

### Fixed behavior

https://github.com/user-attachments/assets/5d17cedc-5851-4817-b908-e41de7a36655

## Test Plan and Hands on Testing

- [x] See video for desktop flows.
- [x] Validated flows are escapable after dismissing the login modal on the ODD.
- [x] Completing login still proceeds through the update as before. Verified on a [special build](https://github.com/Opentrons/opentrons/actions/runs/32049229019) based on alpha.1.

## Changelog

- Dismissing the CRS login modal during a robot update correctly dismisses the update modal.

## Risk assessment

- lowish, behavior is easy to verify. it does touch the update flow, though.


[RQA-5892]: https://opentrons.atlassian.net/browse/RQA-5892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ