### PR TITLE
fix(app): Preserve the caret position when using the show/hide password button

### DIFF
--- a/app/src/molecules/PasswordVisibilityToggle/__tests__/PasswordVisibilityToggle.test.tsx
+++ b/app/src/molecules/PasswordVisibilityToggle/__tests__/PasswordVisibilityToggle.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom/vitest'
 
 import { fireEvent, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
@@ -39,6 +40,25 @@ describe('PasswordVisibilityToggle', () => {
   it('calls onToggle when the button is pressed', () => {
     render(props)
     fireEvent.click(screen.getByRole('button', { name: 'Show' }))
+    expect(props.onToggle).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not steal focus from an adjacent password input when clicked', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <>
+        <input aria-label="password" defaultValue="secret" />
+        <PasswordVisibilityToggle {...props} />
+      </>,
+      { i18nInstance: i18n }
+    )
+    const input = screen.getByLabelText('password')
+    input.focus()
+    expect(input).toHaveFocus()
+
+    await user.click(screen.getByRole('button', { name: 'Show' }))
+
+    expect(input).toHaveFocus()
     expect(props.onToggle).toHaveBeenCalledTimes(1)
   })
 

--- a/app/src/molecules/PasswordVisibilityToggle/index.tsx
+++ b/app/src/molecules/PasswordVisibilityToggle/index.tsx
@@ -7,15 +7,12 @@ import styles from './passwordvisibilitytoggle.module.css'
 interface PasswordVisibilityToggleProps {
   /** Whether the password is currently visible (i.e. input type="text"). */
   isVisible: boolean
-  /** Called when the user taps the toggle. The caller owns visibility state and
-   * is responsible for refocusing the input if needed. */
+  /** Called when the user taps the toggle. */
   onToggle: () => void
 }
 
 /**
- * Touch-screen "Show / Hide" button rendered next to a password input on the
- * ODD. Used by `OnDeviceLogin` and `SetWifiCred` to keep the eye-icon control
- * outside the input field itself.
+ * On-device display "Show / Hide" button rendered next to a password input.
  */
 export function PasswordVisibilityToggle({
   isVisible,
@@ -23,7 +20,16 @@ export function PasswordVisibilityToggle({
 }: PasswordVisibilityToggleProps): JSX.Element {
   const { t } = useTranslation('device_settings')
   return (
-    <button type="button" onClick={onToggle} className={styles.toggle_button}>
+    <button
+      type="button"
+      onMouseDown={e => {
+        // This prevents focus from moving from the password field to this toggle button,
+        // but lets the click event go through.
+        e.preventDefault()
+      }}
+      onClick={onToggle}
+      className={styles.toggle_button}
+    >
       <Icon name={isVisible ? 'eye-slash' : 'eye'} size="3rem" />
       <StyledText oddStyle="bodyTextSemiBold">
         {isVisible ? t('hide') : t('show')}

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/PasswordInputField.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/PasswordInputField.tsx
@@ -38,6 +38,11 @@ export function PasswordInputField({
           type="button"
           className={styles.password_visibility_button}
           aria-label={t('toggle_password_visibility')}
+          onMouseDown={e => {
+            // This prevents focus from moving from the password field to this toggle button,
+            // but lets the click event go through.
+            e.preventDefault()
+          }}
           onClick={() => {
             setShowPassword(current => !current)
           }}

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/__tests__/PasswordInputField.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/__tests__/PasswordInputField.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom/vitest'
 
 import { fireEvent, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
@@ -47,6 +48,21 @@ describe('PasswordInputField', () => {
     const input = screen.getByDisplayValue('secret')
     expect(input).toHaveAttribute('type', 'text')
     expect(input).toHaveValue('secret')
+  })
+
+  it('keeps focus on the password input when the visibility toggle is clicked', async () => {
+    const user = userEvent.setup()
+    render({ ...props, value: 'secret' })
+    const input = screen.getByDisplayValue('secret')
+    input.focus()
+    expect(input).toHaveFocus()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Toggle password visibility' })
+    )
+
+    expect(input).toHaveFocus()
+    expect(input).toHaveAttribute('type', 'text')
   })
 
   it('calls onChange when the value changes', () => {

--- a/app/src/organisms/ODD/NetworkSettings/WifiPasswordInput.tsx
+++ b/app/src/organisms/ODD/NetworkSettings/WifiPasswordInput.tsx
@@ -62,7 +62,6 @@ export function WifiPasswordInput({
               isVisible={showPassword}
               onToggle={() => {
                 setShowPassword(currentState => !currentState)
-                inputRef?.current?.focus()
               }}
             />
           </div>

--- a/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
@@ -36,11 +36,6 @@ export function LoginFieldInput<
   const isPasswordHidden = isPasswordField && !showPassword
   const inputType: 'text' | 'password' = isPasswordHidden ? 'password' : 'text'
 
-  const togglePasswordVisibility = (): void => {
-    setShowPassword(current => !current)
-    inputRef.current?.focus()
-  }
-
   const inputField = (
     <TouchInputField
       ref={setRefs(inputRef, field.ref)}
@@ -66,7 +61,9 @@ export function LoginFieldInput<
       <div className={styles.password_field_input}>{inputField}</div>
       <PasswordVisibilityToggle
         isVisible={showPassword}
-        onToggle={togglePasswordVisibility}
+        onToggle={() => {
+          setShowPassword(current => !current)
+        }}
       />
     </div>
   )

--- a/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
@@ -62,7 +62,7 @@ export function LoginFieldInput<
       <PasswordVisibilityToggle
         isVisible={showPassword}
         onToggle={() => {
-          setShowPassword(current => !current)
+          setShowPassword(prev=> !prev)
         }}
       />
     </div>

--- a/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
@@ -62,7 +62,7 @@ export function LoginFieldInput<
       <PasswordVisibilityToggle
         isVisible={showPassword}
         onToggle={() => {
-          setShowPassword(prev=> !prev)
+          setShowPassword(prev => !prev)
         }}
       />
     </div>


### PR DESCRIPTION
## Overview

This closes RQA-5894.

## Test Plan and Hands on Testing

In:

* [x] The ODD's Wi-Fi password entry screen
* [x] The ODD's login screen
* [x] The desktop app's login modal

If you:

* [x] Enter some text, leave the cursor at the end, and toggle the button
* [x] Enter some text, tap to move the cursor somewhere in the middle, and toggle the button

Then the cursor retains its position.

## Details

Background context: when the user clicks the visibility toggle, we want keyboard focus to remain in the input field, so they can keep typing their password without interruption. Normally, the browser would move focus to the button.

Historically, we've done this by _refocusing_ the input field. I think the problem with that approach is that there's a brief moment when the input is unfocused, so the browser loses track of where the caret should be, so we get bugs like RQA-5894.

My new approach here is to prevent focus from moving off of the input in the first place. It turns out that we can do this by calling `e.preventDefault()` on the `mouseDown` event (*not* the `click` event!). It prevents the focus from moving, but it lets the `click` event proceed as normal, which is exactly what we want.

## Review requests

Does this approach seem good?

## Risk assessment

Low.
