### PR TITLE
refactor(robot-server, api): Ensure RunOrchestratorStore and descendant orchestrators are asynchronous

### DIFF
--- a/api/src/opentrons/protocol_engine/create_protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/create_protocol_engine.py
@@ -221,7 +221,7 @@ async def _protocol_engine(
         else CameraProvider(),
     )
     try:
-        orchestrator.play(deck_configuration)
+        await orchestrator.play(deck_configuration)
         yield protocol_engine
     finally:
         await orchestrator.finish(

--- a/api/src/opentrons/protocol_runner/run_coordinator.py
+++ b/api/src/opentrons/protocol_runner/run_coordinator.py
@@ -44,6 +44,7 @@ from opentrons.protocol_engine.types.execution import PostRunHardwareState
 from opentrons.protocol_reader.protocol_source import ProtocolSource
 from opentrons.protocol_runner.protocol_runner import RunResult
 from opentrons.types import NozzleMapInterface
+from robot_server.runs.error_recovery_models import ErrorRecoveryRule
 
 
 class NoProtocolRunAvailable(RuntimeError):

--- a/api/src/opentrons/protocol_runner/run_coordinator.py
+++ b/api/src/opentrons/protocol_runner/run_coordinator.py
@@ -75,7 +75,7 @@ class AbstractRunCoordinator(ABC):
         ...
 
     @abstractmethod
-    def play(self, deck_configuration: Optional[DeckConfigurationType] = None) -> None:
+    async def play(self, deck_configuration: Optional[DeckConfigurationType] = None) -> None:
         """Start or resume the run."""
         ...
 
@@ -90,7 +90,7 @@ class AbstractRunCoordinator(ABC):
         ...
 
     @abstractmethod
-    def pause(self) -> None:
+    async def pause(self) -> None:
         """Pause the run."""
         ...
 
@@ -100,7 +100,7 @@ class AbstractRunCoordinator(ABC):
         ...
 
     @abstractmethod
-    def resume_from_recovery(self, reconcile_false_positive: bool) -> None:
+    async def resume_from_recovery(self, reconcile_false_positive: bool) -> None:
         """Resume the run from recovery."""
         ...
 
@@ -116,22 +116,22 @@ class AbstractRunCoordinator(ABC):
         ...
 
     @abstractmethod
-    def get_state_summary(self) -> StateSummary:
+    async def get_state_summary(self) -> StateSummary:
         """Get protocol run data."""
         ...
 
     @abstractmethod
-    def get_preconditions(self) -> CommandPreconditions:
+    async def get_preconditions(self) -> CommandPreconditions:
         """Get the preconditions of a protocol run."""
         ...
 
     @abstractmethod
-    def get_loaded_labware_definitions(self) -> List[LabwareDefinition]:
+    async def get_loaded_labware_definitions(self) -> List[LabwareDefinition]:
         """Get loaded labware definitions."""
         ...
 
     @abstractmethod
-    def get_run_time_parameters(self) -> List[RunTimeParameter]:
+    async def get_run_time_parameters(self) -> List[RunTimeParameter]:
         """Get the list of run time parameters defined in the protocol, if any.
 
         This returns a list of all run time parameters with their validated definitions
@@ -149,32 +149,32 @@ class AbstractRunCoordinator(ABC):
         ...
 
     @abstractmethod
-    def get_all_command_annotations(self) -> List[CommandAnnotation]:
+    async def get_all_command_annotations(self) -> List[CommandAnnotation]:
         """Get the list of command annotations defined in the protocol, if any."""
         ...
 
     @abstractmethod
-    def get_total_command_annotations_count(self) -> int:
+    async def get_total_command_annotations_count(self) -> int:
         """Get the total number of command annotations defined in the protocol, if any."""
         ...
 
     @abstractmethod
-    def get_command_annotation(self, annotation_id: str) -> CommandAnnotation:
+    async def get_command_annotation(self, annotation_id: str) -> CommandAnnotation:
         """Get the command annotation by ID."""
         ...
 
     @abstractmethod
-    def get_current_command(self) -> Optional[CommandPointer]:
+    async def get_current_command(self) -> Optional[CommandPointer]:
         """Get the "current" command, if any."""
         ...
 
     @abstractmethod
-    def get_most_recently_finalized_command(self) -> Optional[CommandPointer]:
+    async def get_most_recently_finalized_command(self) -> Optional[CommandPointer]:
         """Get the most recently finalized command, if any."""
         ...
 
     @abstractmethod
-    def get_command_slice(
+    async def get_command_slice(
         self, cursor: Optional[int], length: int, include_fixit_commands: bool
     ) -> CommandSlice:
         """Get a slice of run commands.
@@ -187,14 +187,14 @@ class AbstractRunCoordinator(ABC):
         ...
 
     @abstractmethod
-    def get_command_annotations_slice(
+    async def get_command_annotations_slice(
         self, cursor: int, length: int
     ) -> CommandAnnotationsSlice:
         """Get a slice of command annotations in the run."""
         ...
 
     @abstractmethod
-    def get_command_error_slice(
+    async def get_command_error_slice(
         self,
         cursor: int,
         length: int,
@@ -210,66 +210,66 @@ class AbstractRunCoordinator(ABC):
         ...
 
     @abstractmethod
-    def get_command_recovery_target(self) -> Optional[CommandPointer]:
+    async def get_command_recovery_target(self) -> Optional[CommandPointer]:
         """Get the current error recovery target."""
         ...
 
     @abstractmethod
-    def get_command(self, command_id: str) -> Command:
+    async def get_command(self, command_id: str) -> Command:
         """Get a run's command by ID."""
         ...
 
     @abstractmethod
-    def get_all_commands(self) -> List[Command]:
+    async def get_all_commands(self) -> List[Command]:
         """Get all run commands."""
         ...
 
     @abstractmethod
-    def get_command_errors(self) -> List[ErrorOccurrence]:
+    async def get_command_errors(self) -> List[ErrorOccurrence]:
         """Get all run command errors."""
         ...
 
     @abstractmethod
-    def get_run_status(self) -> EngineStatus:
+    async def get_run_status(self) -> EngineStatus:
         """Get the current execution status of the engine."""
         ...
 
     @abstractmethod
-    def get_is_run_terminal(self) -> bool:
+    async def get_is_run_terminal(self) -> bool:
         """Get whether engine is in a terminal state."""
         ...
 
     @abstractmethod
-    def get_camera_capture_image_settings(
+    async def get_camera_capture_image_settings(
         self,
     ) -> Dict[str, Any]:
         """Get camera capture image settings."""
         ...
 
     @abstractmethod
-    def run_has_started(self) -> bool:
+    async def run_has_started(self) -> bool:
         """Get whether the run has started."""
         ...
 
     @abstractmethod
-    def run_has_stopped(self) -> bool:
+    async def run_has_stopped(self) -> bool:
         """Get whether the run has stopped."""
         ...
 
     @abstractmethod
-    def add_labware_offset(
+    async def add_labware_offset(
         self, request: LabwareOffsetCreate | LegacyLabwareOffsetCreate
     ) -> LabwareOffset:
         """Add a new labware offset to state."""
         ...
 
     @abstractmethod
-    def add_labware_definition(self, definition: LabwareDefinition) -> LabwareUri:
+    async def add_labware_definition(self, definition: LabwareDefinition) -> LabwareUri:
         """Add a new labware definition to state."""
         ...
 
     @abstractmethod
-    def add_camera_enablement_settings(
+    async def add_camera_enablement_settings(
         self,
         enablement_settings: CameraSettings,
     ) -> CameraSettings:
@@ -277,7 +277,7 @@ class AbstractRunCoordinator(ABC):
         ...
 
     @abstractmethod
-    def add_camera_capture_image_settings(
+    async def add_camera_capture_image_settings(
         self,
         camera_id: Optional[str] = None,
         resolution: Optional[Tuple[int, int]] = None,
@@ -302,7 +302,7 @@ class AbstractRunCoordinator(ABC):
         ...
 
     @abstractmethod
-    def estop(self) -> None:
+    async def estop(self) -> None:
         """Handle an E-stop event from the hardware API."""
         ...
 
@@ -351,7 +351,7 @@ class AbstractRunCoordinator(ABC):
         ...
 
     @abstractmethod
-    def get_is_okay_to_clear(self) -> bool:
+    async def get_is_okay_to_clear(self) -> bool:
         """Get whether the engine is stopped or sitting idly, so it could be removed."""
         ...
 
@@ -371,21 +371,30 @@ class AbstractRunCoordinator(ABC):
         ...
 
     @abstractmethod
-    def get_nozzle_maps(self) -> Mapping[str, NozzleMapInterface]:
+    async def get_nozzle_maps(self) -> Mapping[str, NozzleMapInterface]:
         """Get current nozzle maps keyed by pipette id."""
         ...
 
     @abstractmethod
-    def get_tip_attached(self) -> Dict[str, bool]:
+    async def get_tip_attached(self) -> Dict[str, bool]:
         """Get current tip state keyed by pipette id."""
         ...
 
     @abstractmethod
-    def get_flex_stacker_substate(self) -> Mapping[str, FlexStackerSubState]:
+    async def set_error_recovery_policy(
+            self,
+            error_recovery_rules: List[ErrorRecoveryRule],
+            error_recovery_is_enabled: bool,
+    ) -> None:
+        """Create error recovery policy for the run."""
+        ...
+
+    @abstractmethod
+    async def get_flex_stacker_substate(self) -> Mapping[str, FlexStackerSubState]:
         """Get current (if any) Flex Stacker Substates keyed by module id."""
         ...
 
     @abstractmethod
-    def clear_command_history(self) -> None:
+    async def clear_command_history(self) -> None:
         """Force cleanup of command history."""
         ...

--- a/api/src/opentrons/protocol_runner/run_coordinator.py
+++ b/api/src/opentrons/protocol_runner/run_coordinator.py
@@ -44,7 +44,6 @@ from opentrons.protocol_engine.types.execution import PostRunHardwareState
 from opentrons.protocol_reader.protocol_source import ProtocolSource
 from opentrons.protocol_runner.protocol_runner import RunResult
 from opentrons.types import NozzleMapInterface
-from robot_server.runs.error_recovery_models import ErrorRecoveryRule
 
 
 class NoProtocolRunAvailable(RuntimeError):
@@ -76,7 +75,9 @@ class AbstractRunCoordinator(ABC):
         ...
 
     @abstractmethod
-    async def play(self, deck_configuration: Optional[DeckConfigurationType] = None) -> None:
+    async def play(
+        self, deck_configuration: Optional[DeckConfigurationType] = None
+    ) -> None:
         """Start or resume the run."""
         ...
 
@@ -379,15 +380,6 @@ class AbstractRunCoordinator(ABC):
     @abstractmethod
     async def get_tip_attached(self) -> Dict[str, bool]:
         """Get current tip state keyed by pipette id."""
-        ...
-
-    @abstractmethod
-    async def set_error_recovery_policy(
-            self,
-            error_recovery_rules: List[ErrorRecoveryRule],
-            error_recovery_is_enabled: bool,
-    ) -> None:
-        """Create error recovery policy for the run."""
         ...
 
     @abstractmethod

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -167,7 +167,9 @@ class RunOrchestrator(AbstractRunCoordinator):
             camera_provider=camera_provider,
         )
 
-    async def play(self, deck_configuration: Optional[DeckConfigurationType] = None) -> None:
+    async def play(
+        self, deck_configuration: Optional[DeckConfigurationType] = None
+    ) -> None:
         """Start or resume the run."""
         # todo(mm, 2024-07-09): The deck configuration is set at the same time here for
         # historical reasons. It's unsafe to change the deck configuration mid-run

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -167,7 +167,7 @@ class RunOrchestrator(AbstractRunCoordinator):
             camera_provider=camera_provider,
         )
 
-    def play(self, deck_configuration: Optional[DeckConfigurationType] = None) -> None:
+    async def play(self, deck_configuration: Optional[DeckConfigurationType] = None) -> None:
         """Start or resume the run."""
         # todo(mm, 2024-07-09): The deck configuration is set at the same time here for
         # historical reasons. It's unsafe to change the deck configuration mid-run
@@ -195,13 +195,13 @@ class RunOrchestrator(AbstractRunCoordinator):
         else:
             return await self._setup_runner.run(deck_configuration=deck_configuration)
 
-    def pause(self) -> None:
+    async def pause(self) -> None:
         """Pause the run."""
         self._protocol_engine.request_pause()
 
     async def stop(self) -> None:
         """Stop the run."""
-        if self.run_has_started():
+        if await self.run_has_started():
             await self._protocol_engine.request_stop()
         else:
             await self.finish(
@@ -210,7 +210,7 @@ class RunOrchestrator(AbstractRunCoordinator):
                 post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
             )
 
-    def resume_from_recovery(self, reconcile_false_positive: bool) -> None:
+    async def resume_from_recovery(self, reconcile_false_positive: bool) -> None:
         """Resume the run from recovery."""
         self._protocol_engine.resume_from_recovery(reconcile_false_positive)
 
@@ -229,19 +229,19 @@ class RunOrchestrator(AbstractRunCoordinator):
             post_run_hardware_state=post_run_hardware_state,
         )
 
-    def get_state_summary(self) -> StateSummary:
+    async def get_state_summary(self) -> StateSummary:
         """Get protocol run data."""
         return self._protocol_engine.state_view.get_summary()
 
-    def get_preconditions(self) -> CommandPreconditions:
+    async def get_preconditions(self) -> CommandPreconditions:
         """Get the preconditions of a protocol run."""
         return self._protocol_engine.state_view.preconditions.get_precondition()
 
-    def get_loaded_labware_definitions(self) -> List[LabwareDefinition]:
+    async def get_loaded_labware_definitions(self) -> List[LabwareDefinition]:
         """Get loaded labware definitions."""
         return self._protocol_engine.state_view.labware.get_loaded_labware_definitions()
 
-    def get_run_time_parameters(self) -> List[RunTimeParameter]:
+    async def get_run_time_parameters(self) -> List[RunTimeParameter]:
         """Get the list of run time parameters defined in the protocol, if any.
 
         This returns a list of all run time parameters with their validated definitions
@@ -262,27 +262,27 @@ class RunOrchestrator(AbstractRunCoordinator):
             else self._protocol_runner.run_time_parameters
         )
 
-    def get_all_command_annotations(self) -> List[CommandAnnotation]:
+    async def get_all_command_annotations(self) -> List[CommandAnnotation]:
         """Get the list of command annotations defined in the protocol, if any."""
         return self._protocol_engine.state_view.commands.get_all_command_annotations()
 
-    def get_total_command_annotations_count(self) -> int:
+    async def get_total_command_annotations_count(self) -> int:
         """Get the total number of command annotations defined in the protocol, if any."""
         return len(
             self._protocol_engine.state_view.commands.get_all_command_annotations()
         )
 
-    def get_command_annotation(self, annotation_id: str) -> CommandAnnotation:
+    async def get_command_annotation(self, annotation_id: str) -> CommandAnnotation:
         """Get the command annotation by ID."""
         return self._protocol_engine.state_view.commands.get_command_annotation(
             annotation_id
         )
 
-    def get_current_command(self) -> Optional[CommandPointer]:
+    async def get_current_command(self) -> Optional[CommandPointer]:
         """Get the "current" command, if any."""
         return self._protocol_engine.state_view.commands.get_current()
 
-    def get_most_recently_finalized_command(self) -> Optional[CommandPointer]:
+    async def get_most_recently_finalized_command(self) -> Optional[CommandPointer]:
         """Get the most recently finalized command, if any."""
         most_recently_finalized_command = self._protocol_engine.state_view.commands.get_most_recently_finalized_command()
         return (
@@ -296,7 +296,7 @@ class RunOrchestrator(AbstractRunCoordinator):
             else None
         )
 
-    def get_command_slice(
+    async def get_command_slice(
         self, cursor: Optional[int], length: int, include_fixit_commands: bool
     ) -> CommandSlice:
         """Get a slice of run commands.
@@ -310,7 +310,7 @@ class RunOrchestrator(AbstractRunCoordinator):
             cursor=cursor, length=length, include_fixit_commands=include_fixit_commands
         )
 
-    def get_command_annotations_slice(
+    async def get_command_annotations_slice(
         self, cursor: int, length: int
     ) -> CommandAnnotationsSlice:
         """Get a slice of command annotations in the run."""
@@ -318,7 +318,7 @@ class RunOrchestrator(AbstractRunCoordinator):
             cursor=cursor, length=length
         )
 
-    def get_command_error_slice(
+    async def get_command_error_slice(
         self,
         cursor: int,
         length: int,
@@ -335,31 +335,31 @@ class RunOrchestrator(AbstractRunCoordinator):
             cursor=cursor, length=length
         )
 
-    def get_command_recovery_target(self) -> Optional[CommandPointer]:
+    async def get_command_recovery_target(self) -> Optional[CommandPointer]:
         """Get the current error recovery target."""
         return self._protocol_engine.state_view.commands.get_recovery_target()
 
-    def get_command(self, command_id: str) -> Command:
+    async def get_command(self, command_id: str) -> Command:
         """Get a run's command by ID."""
         return self._protocol_engine.state_view.commands.get(command_id=command_id)
 
-    def get_all_commands(self) -> List[Command]:
+    async def get_all_commands(self) -> List[Command]:
         """Get all run commands."""
         return self._protocol_engine.state_view.commands.get_all()
 
-    def get_command_errors(self) -> List[ErrorOccurrence]:
+    async def get_command_errors(self) -> List[ErrorOccurrence]:
         """Get all run command errors."""
         return self._protocol_engine.state_view.commands.get_all_errors()
 
-    def get_run_status(self) -> EngineStatus:
+    async def get_run_status(self) -> EngineStatus:
         """Get the current execution status of the engine."""
         return self._protocol_engine.state_view.commands.get_status()
 
-    def get_is_run_terminal(self) -> bool:
+    async def get_is_run_terminal(self) -> bool:
         """Get whether engine is in a terminal state."""
         return self._protocol_engine.state_view.commands.get_is_terminal()
 
-    def get_camera_capture_image_settings(
+    async def get_camera_capture_image_settings(
         self,
     ) -> Dict[str, Any]:
         """Get camera capture image settings."""
@@ -373,32 +373,32 @@ class RunOrchestrator(AbstractRunCoordinator):
             "saturation": self._protocol_engine.state_view.camera.get_saturation(),
         }
 
-    def run_has_started(self) -> bool:
+    async def run_has_started(self) -> bool:
         """Get whether the run has started."""
         return self._protocol_engine.state_view.commands.has_been_played()
 
-    def run_has_stopped(self) -> bool:
+    async def run_has_stopped(self) -> bool:
         """Get whether the run has stopped."""
         return self._protocol_engine.state_view.commands.get_is_stopped()
 
-    def add_labware_offset(
+    async def add_labware_offset(
         self, request: LabwareOffsetCreate | LegacyLabwareOffsetCreate
     ) -> LabwareOffset:
         """Add a new labware offset to state."""
         return self._protocol_engine.add_labware_offset(request)
 
-    def add_labware_definition(self, definition: LabwareDefinition) -> LabwareUri:
+    async def add_labware_definition(self, definition: LabwareDefinition) -> LabwareUri:
         """Add a new labware definition to state."""
         return self._protocol_engine.add_labware_definition(definition)
 
-    def add_camera_enablement_settings(
+    async def add_camera_enablement_settings(
         self,
         enablement_settings: CameraSettings,
     ) -> CameraSettings:
         """Add new camera enablement settings."""
         return self._protocol_engine.add_camera_enablement_settings(enablement_settings)
 
-    def add_camera_capture_image_settings(
+    async def add_camera_capture_image_settings(
         self,
         camera_id: Optional[str] = None,
         resolution: Optional[Tuple[int, int]] = None,
@@ -430,7 +430,7 @@ class RunOrchestrator(AbstractRunCoordinator):
                 await self._protocol_engine.wait_for_command(added_command.id)
         return added_command
 
-    def estop(self) -> None:
+    async def estop(self) -> None:
         """Handle an E-stop event from the hardware API."""
         return self._protocol_engine.estop()
 
@@ -496,7 +496,7 @@ class RunOrchestrator(AbstractRunCoordinator):
                 run_time_param_paths=run_time_param_paths,
             )
 
-    def get_is_okay_to_clear(self) -> bool:
+    async def get_is_okay_to_clear(self) -> bool:
         """Get whether the engine is stopped or sitting idly, so it could be removed."""
         return self._protocol_engine.state_view.commands.get_is_okay_to_clear()
 
@@ -512,11 +512,11 @@ class RunOrchestrator(AbstractRunCoordinator):
         """Get engine deck type."""
         return self._protocol_engine.state_view.config.deck_type
 
-    def get_nozzle_maps(self) -> Mapping[str, NozzleMapInterface]:
+    async def get_nozzle_maps(self) -> Mapping[str, NozzleMapInterface]:
         """Get current nozzle maps keyed by pipette id."""
         return self._protocol_engine.state_view.pipettes.get_nozzle_configurations()
 
-    def get_tip_attached(self) -> Dict[str, bool]:
+    async def get_tip_attached(self) -> Dict[str, bool]:
         """Get current tip state keyed by pipette id."""
 
         def has_tip_attached(pipette_id: str) -> bool:
@@ -531,11 +531,11 @@ class RunOrchestrator(AbstractRunCoordinator):
         )
         return {pipette_id: has_tip_attached(pipette_id) for pipette_id in pipette_ids}
 
-    def set_error_recovery_policy(self, policy: ErrorRecoveryPolicy) -> None:
+    async def set_error_recovery_policy(self, policy: ErrorRecoveryPolicy) -> None:
         """Create error recovery policy for the run."""
         self._protocol_engine.set_error_recovery_policy(policy)
 
-    def get_flex_stacker_substate(self) -> Mapping[str, FlexStackerSubState]:
+    async def get_flex_stacker_substate(self) -> Mapping[str, FlexStackerSubState]:
         """Get current (if any) Flex Stacker Substates keyed by module id."""
         modules = self._protocol_engine.state_view.modules.get_all()
         stackers: Dict[str, FlexStackerSubState] = {}
@@ -574,6 +574,6 @@ class RunOrchestrator(AbstractRunCoordinator):
         else:
             raise UnknownProtocolParseMode()
 
-    def clear_command_history(self) -> None:
+    async def clear_command_history(self) -> None:
         """Force cleanup of command history."""
         self._protocol_engine.clear_command_history()

--- a/api/tests/opentrons/protocol_runner/test_run_orchestrator.py
+++ b/api/tests/opentrons/protocol_runner/test_run_orchestrator.py
@@ -246,22 +246,22 @@ async def test_run_calls_protocol_live_runner(
     decoy.verify(await mock_protocol_live_runner.run(deck_configuration=[]))
 
 
-def test_get_run_time_parameters_returns_an_empty_list_no_protocol(
+async def test_get_run_time_parameters_returns_an_empty_list_no_protocol(
     live_protocol_subject: RunOrchestrator,
 ) -> None:
     """Should return an empty list in case the protocol runner is not initialized."""
-    result = live_protocol_subject.get_run_time_parameters()
+    result = await live_protocol_subject.get_run_time_parameters()
     assert result == []
 
 
-def test_get_run_time_parameters_returns_an_empty_list_json_runner(
+async def test_get_run_time_parameters_returns_an_empty_list_json_runner(
     decoy: Decoy,
     mock_protocol_json_runner: JsonRunner,
     json_protocol_subject: RunOrchestrator,
 ) -> None:
     """Should return an empty list in case the protocol runner is a json runner."""
     decoy.when(mock_protocol_json_runner.run_time_parameters).then_return([])
-    result = json_protocol_subject.get_run_time_parameters()
+    result = await json_protocol_subject.get_run_time_parameters()
     assert result == []
 
 
@@ -302,13 +302,13 @@ async def test_add_command_and_wait_for_interval(
     )
 
 
-def test_estop(
+async def test_estop(
     decoy: Decoy,
     live_protocol_subject: RunOrchestrator,
     mock_protocol_engine: ProtocolEngine,
 ) -> None:
     """Verify an estop call."""
-    live_protocol_subject.estop()
+    await live_protocol_subject.estop()
     decoy.verify(mock_protocol_engine.estop())
 
 
@@ -463,7 +463,7 @@ def test_get_run_id_raises(
         orchestrator.run_id
 
 
-def test_get_is_okay_to_clear(
+async def test_get_is_okay_to_clear(
     decoy: Decoy,
     mock_protocol_engine: ProtocolEngine,
     live_protocol_subject: RunOrchestrator,
@@ -472,14 +472,14 @@ def test_get_is_okay_to_clear(
     decoy.when(
         mock_protocol_engine.state_view.commands.get_is_okay_to_clear()
     ).then_return(True)
-    result = live_protocol_subject.get_is_okay_to_clear()
+    result = await live_protocol_subject.get_is_okay_to_clear()
 
     assert result is True
 
     decoy.when(
         mock_protocol_engine.state_view.commands.get_is_okay_to_clear()
     ).then_return(False)
-    result = live_protocol_subject.get_is_okay_to_clear()
+    result = await live_protocol_subject.get_is_okay_to_clear()
 
     assert result is False
 
@@ -549,14 +549,14 @@ async def test_command_generator(
         index = index + 1
 
 
-def test_create_error_recovery_policy(
+async def test_create_error_recovery_policy(
     decoy: Decoy,
     mock_protocol_engine: ProtocolEngine,
     live_protocol_subject: RunOrchestrator,
 ) -> None:
     """Should call PE set_error_recovery_policy."""
     policy = decoy.mock(cls=ErrorRecoveryPolicy)
-    live_protocol_subject.set_error_recovery_policy(policy)
+    await live_protocol_subject.set_error_recovery_policy(policy)
     decoy.verify(mock_protocol_engine.set_error_recovery_policy(policy))
 
 

--- a/robot-server/robot_server/commands/router.py
+++ b/robot-server/robot_server/commands/router.py
@@ -111,7 +111,7 @@ async def create_command(
         command=command_create, wait_until_complete=waitUntilComplete, timeout=timeout
     )
 
-    response_data = cast(StatelessCommand, orchestrator.get_command(command.id))
+    response_data = cast(StatelessCommand, await orchestrator.get_command(command.id))
 
     return await PydanticResponse.create(
         content=SimpleBody.model_construct(data=response_data),
@@ -160,7 +160,7 @@ async def get_commands_list(
         cursor: Cursor index for the collection response.
         pageLength: Maximum number of items to return.
     """
-    cmd_slice = orchestrator.get_command_slice(
+    cmd_slice = await orchestrator.get_command_slice(
         cursor=cursor, length=pageLength, include_fixit_commands=True
     )
     commands = cast(List[StatelessCommand], cmd_slice.commands)
@@ -197,7 +197,7 @@ async def get_command(
         orchestrator: Run orchestrator with commands.
     """
     try:
-        command = orchestrator.get_command(commandId)
+        command = await orchestrator.get_command(commandId)
 
     except CommandDoesNotExistError as e:
         raise CommandNotFound.from_exc(e).as_error(status.HTTP_404_NOT_FOUND) from e

--- a/robot-server/robot_server/data_files/router.py
+++ b/robot-server/robot_server/data_files/router.py
@@ -444,7 +444,7 @@ async def get_data_files_by_run_id(
         run_data_manager: Current and historical run data management.
     """
     try:
-        run_data_manager.get(runId)
+        await run_data_manager.get(runId)
     except RunNotFoundError as e:
         raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND) from e
 
@@ -595,7 +595,7 @@ async def delete_run_images(
         data_file_publisher: The data file MQTT event publisher.
     """
     try:
-        run_data_manager.get(runId)
+        await run_data_manager.get(runId)
     except RunNotFoundError as e:
         raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND) from e
 

--- a/robot-server/robot_server/maintenance_runs/maintenance_run_data_manager.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_data_manager.py
@@ -154,7 +154,7 @@ class MaintenanceRunDataManager:
 
         return maintenance_run_data
 
-    def get(self, run_id: str) -> MaintenanceRun:
+    async def get(self, run_id: str) -> MaintenanceRun:
         """Get a maintenance run resource.
 
         Args:
@@ -170,7 +170,7 @@ class MaintenanceRunDataManager:
         if current_id != run_id:
             raise MaintenanceRunNotFoundError(run_id=run_id)
         created_at = self._run_orchestrator_store.current_run_created_at
-        state_summary = self._get_state_summary(run_id=run_id)
+        state_summary = await self._get_state_summary(run_id=run_id)
 
         return _build_run(
             run_id=run_id,
@@ -212,7 +212,7 @@ class MaintenanceRunDataManager:
         else:
             raise MaintenanceRunNotFoundError(run_id=run_id)
 
-    def get_commands_slice(
+    async def get_commands_slice(
         self,
         run_id: str,
         cursor: Optional[int],
@@ -230,12 +230,12 @@ class MaintenanceRunDataManager:
         """
         if run_id != self._run_orchestrator_store.current_run_id:
             raise MaintenanceRunNotFoundError(run_id=run_id)
-        the_slice = self._run_orchestrator_store.get_command_slice(
+        the_slice = await self._run_orchestrator_store.get_command_slice(
             cursor=cursor, length=length
         )
         return the_slice
 
-    def get_current_command(self, run_id: str) -> Optional[CommandPointer]:
+    async def get_current_command(self, run_id: str) -> Optional[CommandPointer]:
         """Get the "current" command, if any.
 
         See `ProtocolEngine.state_view.commands.get_current()` for the definition
@@ -245,14 +245,16 @@ class MaintenanceRunDataManager:
             run_id: ID of the run.
         """
         if self._run_orchestrator_store.current_run_id == run_id:
-            return self._run_orchestrator_store.get_current_command()
+            return await self._run_orchestrator_store.get_current_command()
         else:
             # todo(mm, 2024-05-20):
             # For historical runs to behave consistently with the current run,
             # this should be the most recently completed command, not `None`.
             return None
 
-    def get_recovery_target_command(self, run_id: str) -> Optional[CommandPointer]:
+    async def get_recovery_target_command(
+        self, run_id: str
+    ) -> Optional[CommandPointer]:
         """Get the current error recovery target.
 
         See `ProtocolEngine.state_view.commands.get_recovery_target()`.
@@ -261,12 +263,12 @@ class MaintenanceRunDataManager:
             run_id: ID of the run.
         """
         if self._run_orchestrator_store.current_run_id == run_id:
-            return self._run_orchestrator_store.get_command_recovery_target()
+            return await self._run_orchestrator_store.get_command_recovery_target()
         else:
             # Historical runs can't have any ongoing error recovery.
             return None
 
-    def get_command(self, run_id: str, command_id: str) -> Command:
+    async def get_command(self, run_id: str, command_id: str) -> Command:
         """Get a run's command by ID.
 
         Args:
@@ -279,7 +281,7 @@ class MaintenanceRunDataManager:
         """
         if run_id != self._run_orchestrator_store.current_run_id:
             raise MaintenanceRunNotFoundError(run_id=run_id)
-        return self._run_orchestrator_store.get_command(command_id=command_id)
+        return await self._run_orchestrator_store.get_command(command_id=command_id)
 
-    def _get_state_summary(self, run_id: str) -> Optional[StateSummary]:
-        return self._run_orchestrator_store.get_state_summary()
+    async def _get_state_summary(self, run_id: str) -> Optional[StateSummary]:
+        return await self._run_orchestrator_store.get_state_summary()

--- a/robot-server/robot_server/maintenance_runs/maintenance_run_orchestrator_store.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_orchestrator_store.py
@@ -69,7 +69,7 @@ async def handle_estop_event(
                 return
             # todo(mm, 2024-04-17): This estop teardown sequencing belongs in the
             # runner layer.
-            maintenance_run_orchestraotr_store.run_orchestrator.estop()
+            await maintenance_run_orchestraotr_store.run_orchestrator.estop()
             await maintenance_run_orchestraotr_store.run_orchestrator.finish(
                 error=EStopActivatedError()
             )
@@ -207,11 +207,11 @@ class MaintenanceRunOrchestratorStore:
         )
 
         for offset in labware_offsets:
-            self._run_orchestrator.add_labware_offset(offset)
+            await self._run_orchestrator.add_labware_offset(offset)
 
         self._created_at = created_at
 
-        return self._run_orchestrator.get_state_summary()
+        return await self._run_orchestrator.get_state_summary()
 
     async def clear(self) -> RunResult:
         """Remove the ProtocolEngine.
@@ -220,7 +220,7 @@ class MaintenanceRunOrchestratorStore:
             RunConflictError: The current run orchestrator is not idle, so
             it cannot be cleared.
         """
-        if self.run_orchestrator.get_is_okay_to_clear():
+        if await self.run_orchestrator.get_is_okay_to_clear():
             await self.run_orchestrator.finish(
                 drop_tips_after_run=False,
                 set_run_status=False,
@@ -229,9 +229,9 @@ class MaintenanceRunOrchestratorStore:
         else:
             raise RunConflictError("Current run is not idle or stopped.")
 
-        run_data = self.run_orchestrator.get_state_summary()
-        commands = self.run_orchestrator.get_all_commands()
-        preconditions = self.run_orchestrator.get_preconditions()
+        run_data = await self.run_orchestrator.get_state_summary()
+        commands = await self.run_orchestrator.get_all_commands()
+        preconditions = await self.run_orchestrator.get_preconditions()
         self._run_orchestrator = None
         self._created_at = None
 
@@ -243,7 +243,7 @@ class MaintenanceRunOrchestratorStore:
             command_preconditions=preconditions,
         )
 
-    def get_command_slice(
+    async def get_command_slice(
         self,
         cursor: Optional[int],
         length: int,
@@ -254,25 +254,25 @@ class MaintenanceRunOrchestratorStore:
             cursor: Requested index of first command in the returned slice.
             length: Length of slice to return.
         """
-        return self.run_orchestrator.get_command_slice(
+        return await self.run_orchestrator.get_command_slice(
             cursor=cursor, length=length, include_fixit_commands=False
         )
 
-    def get_current_command(self) -> Optional[CommandPointer]:
+    async def get_current_command(self) -> Optional[CommandPointer]:
         """Get the "current" command, if any."""
-        return self.run_orchestrator.get_current_command()
+        return await self.run_orchestrator.get_current_command()
 
-    def get_command_recovery_target(self) -> Optional[CommandPointer]:
+    async def get_command_recovery_target(self) -> Optional[CommandPointer]:
         """Get the current error recovery target."""
-        return self.run_orchestrator.get_command_recovery_target()
+        return await self.run_orchestrator.get_command_recovery_target()
 
-    def get_command(self, command_id: str) -> Command:
+    async def get_command(self, command_id: str) -> Command:
         """Get a run's command by ID."""
-        return self.run_orchestrator.get_command(command_id=command_id)
+        return await self.run_orchestrator.get_command(command_id=command_id)
 
-    def get_state_summary(self) -> StateSummary:
+    async def get_state_summary(self) -> StateSummary:
         """Get protocol run data."""
-        return self.run_orchestrator.get_state_summary()
+        return await self.run_orchestrator.get_state_summary()
 
     async def add_command_and_wait_for_interval(
         self,
@@ -285,15 +285,15 @@ class MaintenanceRunOrchestratorStore:
             command=request, wait_until_complete=wait_until_complete, timeout=timeout
         )
 
-    def add_labware_offset(
+    async def add_labware_offset(
         self, request: LegacyLabwareOffsetCreate | LabwareOffsetCreate
     ) -> LabwareOffset:
         """Add a new labware offset to state."""
-        return self.run_orchestrator.add_labware_offset(request)
+        return await self.run_orchestrator.add_labware_offset(request)
 
-    def add_labware_definition(self, definition: LabwareDefinition) -> LabwareUri:
+    async def add_labware_definition(self, definition: LabwareDefinition) -> LabwareUri:
         """Add a new labware definition to state."""
-        return self.run_orchestrator.add_labware_definition(definition)
+        return await self.run_orchestrator.add_labware_definition(definition)
 
     async def handle_proxy_estop_event(
         self,
@@ -313,7 +313,7 @@ class MaintenanceRunOrchestratorStore:
                     return
                 # todo(mm, 2024-04-17): This estop teardown sequencing belongs in the
                 # runner layer.
-                self.run_orchestrator.estop()
+                await self.run_orchestrator.estop()
                 await self.run_orchestrator.finish(error=EStopActivatedError())
         except Exception:
             # This is a background task kicked off by a hardware event,

--- a/robot-server/robot_server/maintenance_runs/router/base_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/base_router.py
@@ -126,7 +126,7 @@ async def get_run_data_from_url(
         run_data_manager: Current and historical run data management.
     """
     try:
-        run_data = run_data_manager.get(runId)
+        run_data = await run_data_manager.get(runId)
     except MaintenanceRunNotFoundError as e:
         raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
 
@@ -235,7 +235,7 @@ async def get_current_run(
             detail="No maintenance run currently running."
         ).as_error(status.HTTP_404_NOT_FOUND)
 
-    data = run_data_manager.get(current_run_id)
+    data = await run_data_manager.get(current_run_id)
     links = AllRunsLinks(
         current=ResourceLink.model_construct(href=f"/maintenance_runs/{current_run_id}")
     )
@@ -304,7 +304,7 @@ async def remove_run(
         camera_settings = None
         if run_data_manager.current_run_id is not None:
             # Import the camera settings from an external run if one exists
-            state_summary = run_data_manager._get_good_state_summary(
+            state_summary = await run_data_manager._get_good_state_summary(
                 run_data_manager.current_run_id
             )
             if (

--- a/robot-server/robot_server/maintenance_runs/router/commands_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/commands_router.py
@@ -208,7 +208,7 @@ async def create_run_command(
     except pe_errors.SetupCommandNotAllowedError as e:
         raise CommandNotAllowed.from_exc(e).as_error(status.HTTP_409_CONFLICT)
 
-    response_data = run_orchestrator_store.get_command(command.id)
+    response_data = await run_orchestrator_store.get_command(command.id)
 
     return await PydanticResponse.create(
         content=SimpleBody.model_construct(data=response_data),
@@ -266,7 +266,7 @@ async def get_run_commands(
         run_data_manager: Run data retrieval interface.
     """
     try:
-        command_slice = run_data_manager.get_commands_slice(
+        command_slice = await run_data_manager.get_commands_slice(
             run_id=runId,
             cursor=cursor,
             length=pageLength,
@@ -274,8 +274,10 @@ async def get_run_commands(
     except MaintenanceRunNotFoundError as e:
         raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND) from e
 
-    current_command = run_data_manager.get_current_command(run_id=runId)
-    recovery_target_command = run_data_manager.get_recovery_target_command(run_id=runId)
+    current_command = await run_data_manager.get_current_command(run_id=runId)
+    recovery_target_command = await run_data_manager.get_recovery_target_command(
+        run_id=runId
+    )
 
     data = [
         RunCommandSummary.model_construct(
@@ -340,7 +342,7 @@ async def get_run_command(
         run_data_manager: Run data retrieval.
     """
     try:
-        command = run_data_manager.get_command(run_id=runId, command_id=commandId)
+        command = await run_data_manager.get_command(run_id=runId, command_id=commandId)
     except MaintenanceRunNotFoundError as e:
         raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND) from e
     except CommandDoesNotExistError as e:

--- a/robot-server/robot_server/maintenance_runs/router/labware_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/labware_router.py
@@ -84,7 +84,7 @@ async def add_labware_offset(
 
     added_offsets: list[LabwareOffset] = []
     for offset_to_add in offsets_to_add:
-        added_offset = run_orchestrator_store.add_labware_offset(offset_to_add)
+        added_offset = await run_orchestrator_store.add_labware_offset(offset_to_add)
         added_offsets.append(added_offset)
         log.info(f'Added labware offset "{added_offset.id}" to run "{run.id}".')
 
@@ -134,7 +134,7 @@ async def add_labware_definition(
         run_orchestrator_store: Engine storage interface.
         run: Run response data by ID from URL; ensures 404 if run not found.
     """
-    uri = run_orchestrator_store.add_labware_definition(request_body.data)
+    uri = await run_orchestrator_store.add_labware_definition(request_body.data)
     log.info(f'Added labware definition "{uri}" to run "{run.id}".')
 
     return PydanticResponse(

--- a/robot-server/robot_server/protocols/analyses_manager.py
+++ b/robot-server/robot_server/protocols/analyses_manager.py
@@ -73,19 +73,22 @@ class AnalysesManager:
             )
         except Exception as error:
             internal_error = em.map_unexpected_error(error)
-            await self._analysis_store.save_initialization_failed_analysis(
-                protocol_id=protocol_resource.protocol_id,
-                analysis_id=analysis_id,
-                robot_type=protocol_resource.source.robot_type,
-                run_time_parameters=await analyzer.get_verified_run_time_parameters(),
-                errors=[
-                    ErrorOccurrence.from_failed(
-                        id="internal-error",
-                        createdAt=datetime_helper.utc_now(),
-                        error=internal_error,
-                    )
-                ],
-            )
+            try:
+                await self._analysis_store.save_initialization_failed_analysis(
+                    protocol_id=protocol_resource.protocol_id,
+                    analysis_id=analysis_id,
+                    robot_type=protocol_resource.source.robot_type,
+                    run_time_parameters=await analyzer.get_verified_run_time_parameters(),
+                    errors=[
+                        ErrorOccurrence.from_failed(
+                            id="internal-error",
+                            createdAt=datetime_helper.utc_now(),
+                            error=internal_error,
+                        )
+                    ],
+                )
+            finally:
+                await analyzer.clean_up()
             raise FailedToInitializeAnalyzer() from error
         return analyzer
 

--- a/robot-server/robot_server/protocols/analyses_manager.py
+++ b/robot-server/robot_server/protocols/analyses_manager.py
@@ -77,7 +77,7 @@ class AnalysesManager:
                 protocol_id=protocol_resource.protocol_id,
                 analysis_id=analysis_id,
                 robot_type=protocol_resource.source.robot_type,
-                run_time_parameters=analyzer.get_verified_run_time_parameters(),
+                run_time_parameters=await analyzer.get_verified_run_time_parameters(),
                 errors=[
                     ErrorOccurrence.from_failed(
                         id="internal-error",
@@ -95,7 +95,7 @@ class AnalysesManager:
         analyzer: protocol_analyzer.ProtocolAnalyzer,
     ) -> AnalysisSummary:
         """Start an analysis of the given protocol resource with verified run time parameters."""
-        run_time_parameters = analyzer.get_verified_run_time_parameters()
+        run_time_parameters = await analyzer.get_verified_run_time_parameters()
         self._analysis_store.add_pending(
             protocol_id=analyzer.protocol_resource.protocol_id,
             analysis_id=analysis_id,

--- a/robot-server/robot_server/protocols/protocol_analyzer.py
+++ b/robot-server/robot_server/protocols/protocol_analyzer.py
@@ -92,35 +92,38 @@ class ProtocolAnalyzer:
         assert self._protocol_resource is not None
         assert self._coordinator is not None
         try:
-            result = await self._coordinator.run(
-                deck_configuration=[],
-            )
-        except BaseException as error:
-            await self.update_to_failed_analysis(
+            try:
+                result = await self._coordinator.run(
+                    deck_configuration=[],
+                )
+            except BaseException as error:
+                await self.update_to_failed_analysis(
+                    analysis_id=analysis_id,
+                    protocol_robot_type=self._protocol_resource.source.robot_type,
+                    error=error,
+                    run_time_parameters=await self._coordinator.get_run_time_parameters(),
+                )
+                return
+
+            log.info(f'Completed analysis "{analysis_id}".')
+
+            await self._analysis_store.update(
                 analysis_id=analysis_id,
-                protocol_robot_type=self._protocol_resource.source.robot_type,
-                error=error,
-                run_time_parameters=await self._coordinator.get_run_time_parameters(),
+                robot_type=self._protocol_resource.source.robot_type,
+                run_time_parameters=result.parameters,
+                commands=result.commands,
+                labware=result.state_summary.labware,
+                modules=result.state_summary.modules,
+                pipettes=result.state_summary.pipettes,
+                errors=result.state_summary.errors,
+                liquids=result.state_summary.liquids,
+                liquidClasses=result.state_summary.liquidClasses,
+                command_annotations=result.command_annotations,
+                command_preconditions=result.command_preconditions,
+                labware_offsets=result.state_summary.labwareOffsets,
             )
-            return
-
-        log.info(f'Completed analysis "{analysis_id}".')
-
-        await self._analysis_store.update(
-            analysis_id=analysis_id,
-            robot_type=self._protocol_resource.source.robot_type,
-            run_time_parameters=result.parameters,
-            commands=result.commands,
-            labware=result.state_summary.labware,
-            modules=result.state_summary.modules,
-            pipettes=result.state_summary.pipettes,
-            errors=result.state_summary.errors,
-            liquids=result.state_summary.liquids,
-            liquidClasses=result.state_summary.liquidClasses,
-            command_annotations=result.command_annotations,
-            command_preconditions=result.command_preconditions,
-            labware_offsets=result.state_summary.labwareOffsets,
-        )
+        finally:
+            await self.clean_up()
 
     async def update_to_failed_analysis(
         self,
@@ -154,7 +157,7 @@ class ProtocolAnalyzer:
             labware_offsets=[],
         )
 
-    async def __aexit__(self) -> None:
+    async def clean_up(self) -> None:
         """Stop the simulating run orchestrator.
 
         Once the analyzer is no longer in use- either because analysis completed
@@ -174,6 +177,7 @@ class ProtocolAnalyzer:
                     "Analyzer is no longer in use but orchestrator is busy. "
                     "Cannot stop the orchestrator currently."
                 )
+            self._coordinator = None
 
 
 def create_protocol_analyzer(

--- a/robot-server/robot_server/protocols/protocol_analyzer.py
+++ b/robot-server/robot_server/protocols/protocol_analyzer.py
@@ -49,10 +49,10 @@ class ProtocolAnalyzer:
         """Return the protocol resource."""
         return self._protocol_resource
 
-    def get_verified_run_time_parameters(self) -> List[RunTimeParameter]:
+    async def get_verified_run_time_parameters(self) -> List[RunTimeParameter]:
         """Get the validated RTPs with values set by the client."""
         assert self._coordinator is not None
-        return self._coordinator.get_run_time_parameters()
+        return await self._coordinator.get_run_time_parameters()
 
     async def load_orchestrator(
         self,
@@ -101,7 +101,7 @@ class ProtocolAnalyzer:
                 analysis_id=analysis_id,
                 protocol_robot_type=self._protocol_resource.source.robot_type,
                 error=error,
-                run_time_parameters=self._coordinator.get_run_time_parameters(),
+                run_time_parameters=await self._coordinator.get_run_time_parameters(),
             )
             return
 
@@ -163,7 +163,10 @@ class ProtocolAnalyzer:
         are stopped timely and do not block server shutdown.
         """
         if self._coordinator is not None:
-            if self._coordinator.get_is_okay_to_clear():
+            okay_to_clear = asyncio.run_coroutine_threadsafe(
+                self._coordinator.get_is_okay_to_clear(), asyncio.get_running_loop()
+            ).result()
+            if okay_to_clear:
                 asyncio.run_coroutine_threadsafe(
                     self._coordinator.stop(), asyncio.get_running_loop()
                 )

--- a/robot-server/robot_server/protocols/protocol_analyzer.py
+++ b/robot-server/robot_server/protocols/protocol_analyzer.py
@@ -155,7 +155,7 @@ class ProtocolAnalyzer:
             labware_offsets=[],
         )
 
-    def __del__(self) -> None:
+    async def __aexit__(self) -> None:
         """Stop the simulating run orchestrator.
 
         Once the analyzer is no longer in use- either because analysis completed
@@ -163,13 +163,9 @@ class ProtocolAnalyzer:
         are stopped timely and do not block server shutdown.
         """
         if self._coordinator is not None:
-            okay_to_clear = asyncio.run_coroutine_threadsafe(
-                self._coordinator.get_is_okay_to_clear(), asyncio.get_running_loop()
-            ).result()
+            okay_to_clear = await self._coordinator.get_is_okay_to_clear()
             if okay_to_clear:
-                asyncio.run_coroutine_threadsafe(
-                    self._coordinator.stop(), asyncio.get_running_loop()
-                )
+                await self._coordinator.stop()
                 if feature_flags.protocol_subprocess_enabled():
                     self._run_process_pyro_provider.set_active_process_as_used(
                         simulator=True

--- a/robot-server/robot_server/protocols/protocol_analyzer.py
+++ b/robot-server/robot_server/protocols/protocol_analyzer.py
@@ -1,6 +1,5 @@
 """Protocol analysis module."""
 
-import asyncio
 import logging
 from typing import List, Optional, Union
 

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -563,6 +563,8 @@ async def _start_new_analysis_if_necessary(
                     analyzer=analyzer,
                 )
             )
+        else:
+            await analyzer.clean_up()
 
     return analyses, started_new_analysis
 

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -550,7 +550,7 @@ async def _start_new_analysis_if_necessary(
             # The most recent analysis was done using different RTP values
             not await analysis_store.matching_rtp_values_in_analysis(
                 last_analysis_summary=analyses[-1],
-                new_parameters=analyzer.get_verified_run_time_parameters(),
+                new_parameters=await analyzer.get_verified_run_time_parameters(),
             )
         ):
             log.info(

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -223,7 +223,10 @@ async def get_is_okay_to_create_maintenance_run(
         orchestrator = run_orchestrator_store.run_coordinator
     except NoRunCoordinator:
         return True
-    return not orchestrator.run_has_started() or orchestrator.get_is_run_terminal()
+    return (
+        not await orchestrator.run_has_started()
+        or await orchestrator.get_is_run_terminal()
+    )
 
 
 async def get_run_data_manager(

--- a/robot-server/robot_server/runs/light_control_task.py
+++ b/robot-server/robot_server/runs/light_control_task.py
@@ -143,13 +143,13 @@ class LightController:
                 )
             )
 
-    def _get_current_engine_status(self) -> Optional[EngineStatus]:
+    async def _get_current_engine_status(self) -> Optional[EngineStatus]:
         """Get the `status` value from the engine's active run engine."""
         if self._run_orchestrator_store is None:
             return None
         current_id = self._run_orchestrator_store.current_run_id
         if current_id is not None:
-            return self._run_orchestrator_store.get_status()
+            return await self._run_orchestrator_store.get_status()
 
         return None
 
@@ -162,12 +162,12 @@ class LightController:
             and status.update_state is UpdateState.updating
         ]
 
-    def get_current_status(self) -> Status:
+    async def get_current_status(self) -> Status:
         """Get the overall status of the system for light purposes."""
         return Status(
             active_updates=self._get_active_updates(),
             estop_status=self._hardware_state_store.get_estop_state(),
-            engine_status=self._get_current_engine_status(),
+            engine_status=await self._get_current_engine_status(),
         )
 
 
@@ -176,10 +176,10 @@ async def run_light_task(driver: LightController) -> None:
 
     This is intended to be run as a background task once the EngineStore has been created.
     """
-    prev_status = driver.get_current_status()
+    prev_status = await driver.get_current_status()
     await driver.update(prev_status=None, new_status=prev_status)
     while True:
         await asyncio.sleep(0.1)
-        new_status = driver.get_current_status()
+        new_status = await driver.get_current_status()
         await driver.update(prev_status=prev_status, new_status=new_status)
         prev_status = new_status

--- a/robot-server/robot_server/runs/router/actions_router.py
+++ b/robot-server/robot_server/runs/router/actions_router.py
@@ -160,7 +160,7 @@ async def create_run_action(
         if action_type == RunActionType.PLAY:
             deck_configuration = await deck_configuration_store.get_deck_configuration()
 
-        action = run_controller.create_action(
+        action = await run_controller.create_action(
             action_id=action_id,
             action_type=action_type,
             created_at=created_at,

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -232,7 +232,7 @@ async def get_run_data_from_url(
         run_data_manager: Current and historical run data management.
     """
     try:
-        run_data = run_data_manager.get(runId)
+        run_data = await run_data_manager.get(runId)
     except RunNotFoundError as e:
         raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
 
@@ -426,7 +426,7 @@ async def get_runs(
         pageLength: Maximum number of items to return.
         run_data_manager: Current and historical run data management.
     """
-    data = run_data_manager.get_all(length=pageLength)
+    data = await run_data_manager.get_all(length=pageLength)
     current_run_id = run_data_manager.current_run_id
     meta = MultiBodyMeta(cursor=0, totalLength=len(data))
     links = AllRunsLinks(
@@ -585,7 +585,7 @@ async def update_run(  # noqa: C901
         if request_body.data.signedBy is not None:
             # Depending on settings, updating `current` may require `signedBy`
             # to have already been set, so we need to process `signedBy` first.
-            run_data = run_data_manager.set_signed_by(
+            run_data = await run_data_manager.set_signed_by(
                 run_id=runId, signed_by=request_body.data.signedBy
             )
         if request_body.data.current is not None:
@@ -601,7 +601,7 @@ async def update_run(  # noqa: C901
                 staging_dir = create_download_staging_dir(persistence_directory_root)
                 staging_path = Path(staging_dir.name)
 
-                run_log_entry = collect_run_log(
+                run_log_entry = await collect_run_log(
                     run_id=runId,
                     run=run_store.get(runId),
                     run_data_manager=run_data_manager,
@@ -615,7 +615,7 @@ async def update_run(  # noqa: C901
                 staging_dir.cleanup()
 
         if run_data is None:
-            run_data = run_data_manager.get(runId)
+            run_data = await run_data_manager.get(runId)
     except RunConflictError as e:
         raise RunNotIdle(detail=str(e)).as_error(status.HTTP_409_CONFLICT) from e
     except RunNotCurrentError as e:
@@ -683,14 +683,14 @@ async def get_run_commands_error(
         run_data_manager: Run data retrieval interface.
     """
     try:
-        all_errors_count = run_data_manager.get_command_errors_count(run_id=runId)
+        all_errors_count = await run_data_manager.get_command_errors_count(run_id=runId)
 
         if cursor is None:
             cursor = max(all_errors_count - 1, 0)
             cursor = max(cursor - pageLength + 1, 0)
             cursor = min(cursor, all_errors_count)
 
-        command_error_slice = run_data_manager.get_command_error_slice(
+        command_error_slice = await run_data_manager.get_command_error_slice(
             run_id=runId,
             cursor=cursor,
             length=pageLength,
@@ -741,7 +741,7 @@ async def get_current_state(  # noqa: C901
         robot_type: The type of robot.
     """
     try:
-        run = run_data_manager.get(run_id=runId)
+        run = await run_data_manager.get(run_id=runId)
     except RunNotCurrentError as e:
         raise RunStopped(detail=str(e)).as_error(status.HTTP_409_CONFLICT)
 
@@ -773,7 +773,7 @@ async def get_current_state(  # noqa: C901
         ]
 
         command = (
-            run_data_manager.get_command(runId, current_command.command_id)
+            await run_data_manager.get_command(runId, current_command.command_id)
             if current_command
             else None
         )

--- a/robot-server/robot_server/runs/router/camera_router.py
+++ b/robot-server/robot_server/runs/router/camera_router.py
@@ -116,7 +116,7 @@ async def add_camera_settings(
         ),
     )
 
-    response_data = run_orchestrator_store.add_camera_enablement_settings(
+    response_data = await run_orchestrator_store.add_camera_enablement_settings(
         camera_settings
     )
     log.info(f'Added unique camera settings "{request_body.data}" to run "{run.id}".')
@@ -193,7 +193,7 @@ async def add_camera_capture_image_settings(
             status.HTTP_409_CONFLICT
         )
 
-    run_orchestrator_store.add_camera_capture_image_settings(
+    await run_orchestrator_store.add_camera_capture_image_settings(
         capture_image_settings=request_body.data
     )
     log.info(
@@ -233,7 +233,7 @@ async def get_camera_capture_image_settings(
         robot_type: Used to validate robot type for live stream service.
         camera_provider: Access to the camera settings and related services.
     """
-    result = run_orchestrator_store.get_camera_capture_image_settings(
+    result = await run_orchestrator_store.get_camera_capture_image_settings(
         camera_id=cameraId
     )
 

--- a/robot-server/robot_server/runs/router/command_annotations_router.py
+++ b/robot-server/robot_server/runs/router/command_annotations_router.py
@@ -84,7 +84,7 @@ async def get_command_annotations_list(
     """
     try:
         total_command_annotations_count = (
-            run_data_manager.get_total_command_annotations_count(
+            await run_data_manager.get_total_command_annotations_count(
                 run_id=runId,
             )
         )
@@ -93,7 +93,7 @@ async def get_command_annotations_list(
             cursor = max(cursor - pageLength + 1, 0)
             cursor = min(cursor, total_command_annotations_count)
 
-        annotations_slice = run_data_manager.get_command_annotations_slice(
+        annotations_slice = await run_data_manager.get_command_annotations_slice(
             run_id=runId, cursor=cursor, length=pageLength
         )
     except RunNotFoundError as e:
@@ -138,7 +138,7 @@ async def get_command_annotation(
         commandAnnotationId: Unique command annotation identifier.
     """
     try:
-        annotation = run_data_manager.get_command_annotation(
+        annotation = await run_data_manager.get_command_annotation(
             run_id=runId, annotation_id=commandAnnotationId
         )
     except RunNotFoundError as e:

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -244,7 +244,7 @@ async def create_run_command(
     except pe_errors.CommandNotAllowedError as e:
         raise CommandNotAllowed.from_exc(e).as_error(status.HTTP_400_BAD_REQUEST)
 
-    response_data = run_orchestrator_store.get_command(command.id)
+    response_data = await run_orchestrator_store.get_command(command.id)
 
     return await PydanticResponse.create(
         content=SimpleBody.model_construct(data=response_data),
@@ -310,7 +310,7 @@ async def get_run_commands(
             " If `false`, only return safe commands.
     """
     try:
-        command_slice = run_data_manager.get_commands_slice(
+        command_slice = await run_data_manager.get_commands_slice(
             run_id=runId,
             cursor=cursor,
             length=pageLength,
@@ -320,7 +320,9 @@ async def get_run_commands(
         raise RunNotFound.from_exc(e).as_error(status.HTTP_404_NOT_FOUND) from e
 
     current_command = run_data_manager.get_current_command(run_id=runId)
-    recovery_target_command = run_data_manager.get_recovery_target_command(run_id=runId)
+    recovery_target_command = await run_data_manager.get_recovery_target_command(
+        run_id=runId
+    )
 
     data = [
         RunCommandSummary.model_construct(
@@ -402,7 +404,7 @@ async def get_run_commands_as_pre_serialized_list(
             " If `false`, only return safe commands.
     """
     try:
-        commands = run_data_manager.get_all_commands_as_preserialized_list(
+        commands = await run_data_manager.get_all_commands_as_preserialized_list(
             run_id=runId, include_fixit_commands=includeFixitCommands
         )
     except RunNotFoundError as e:
@@ -446,7 +448,7 @@ async def get_run_command(
         run_data_manager: Run data retrieval.
     """
     try:
-        command = run_data_manager.get_command(run_id=runId, command_id=commandId)
+        command = await run_data_manager.get_command(run_id=runId, command_id=commandId)
     except RunNotFoundError as e:
         raise RunNotFound.from_exc(e).as_error(status.HTTP_404_NOT_FOUND) from e
     except CommandNotFoundError as e:

--- a/robot-server/robot_server/runs/router/error_recovery_policy_router.py
+++ b/robot-server/robot_server/runs/router/error_recovery_policy_router.py
@@ -58,7 +58,7 @@ async def put_error_recovery_policy(
     """
     rules = request_body.data.policyRules
     try:
-        run_data_manager.set_error_recovery_rules(run_id=runId, rules=rules)
+        await run_data_manager.set_error_recovery_rules(run_id=runId, rules=rules)
     except RunNotCurrentError as e:
         raise RunStopped(detail=str(e)).as_error(status.HTTP_409_CONFLICT) from e
 

--- a/robot-server/robot_server/runs/router/file_download_router.py
+++ b/robot-server/robot_server/runs/router/file_download_router.py
@@ -141,7 +141,7 @@ async def download_run_files(
     staging_path = Path(staging_dir.name)
 
     try:
-        zip_entries = _collect_run_download_entries(
+        zip_entries = await _collect_run_download_entries(
             run_id=runId,
             run=run,
             run_data_manager=run_data_manager,
@@ -186,7 +186,7 @@ def _append_if_present(zip_entries: List[ZipEntry], entry: Optional[ZipEntry]) -
         zip_entries.append(entry)
 
 
-def _collect_run_download_entries(
+async def _collect_run_download_entries(
     *,
     run_id: str,
     run: Union[RunResource, BadRunResource],
@@ -222,7 +222,7 @@ def _collect_run_download_entries(
     if csv_input:
         _append_if_present(
             zip_entries,
-            collect_rtp_csv(
+            await collect_rtp_csv(
                 run_id=run_id,
                 run_data_manager=run_data_manager,
                 data_files_store=data_files_store,
@@ -231,7 +231,7 @@ def _collect_run_download_entries(
     if run_log:
         _append_if_present(
             zip_entries,
-            collect_run_log(
+            await collect_run_log(
                 run_id=run_id,
                 run=run,
                 run_data_manager=run_data_manager,
@@ -242,7 +242,7 @@ def _collect_run_download_entries(
     if labware_offsets:
         _append_if_present(
             zip_entries,
-            collect_labware_offsets(
+            await collect_labware_offsets(
                 run_id=run_id,
                 run=run,
                 run_data_manager=run_data_manager,

--- a/robot-server/robot_server/runs/router/labware_router.py
+++ b/robot-server/robot_server/runs/router/labware_router.py
@@ -86,7 +86,7 @@ async def add_labware_offset(
 
     added_offsets: list[LabwareOffset] = []
     for offset_to_add in offsets_to_add:
-        added_offset = run_orchestrator_store.add_labware_offset(offset_to_add)
+        added_offset = await run_orchestrator_store.add_labware_offset(offset_to_add)
         added_offsets.append(added_offset)
         log.info(f'Added labware offset "{added_offset.id}" to run "{run.id}".')
 
@@ -138,7 +138,7 @@ async def add_labware_definition(
             status.HTTP_409_CONFLICT
         )
 
-    uri = run_orchestrator_store.add_labware_definition(request_body.data)
+    uri = await run_orchestrator_store.add_labware_definition(request_body.data)
     log.info(f'Added labware definition "{uri}" to run "{run.id}".')
 
     return PydanticResponse(
@@ -177,7 +177,7 @@ async def get_run_loaded_labware_definitions(
         run_data_manager: Current and historical run data management.
     """
     try:
-        labware_definitions = run_data_manager.get_run_loaded_labware_definitions(
+        labware_definitions = await run_data_manager.get_run_loaded_labware_definitions(
             run_id=runId
         )
     except RunNotCurrentError as e:

--- a/robot-server/robot_server/runs/run_controller.py
+++ b/robot-server/robot_server/runs/run_controller.py
@@ -42,7 +42,7 @@ class RunController:
         self._runs_publisher = runs_publisher
         self._maintenance_runs_publisher = maintenance_runs_publisher
 
-    def create_action(
+    async def create_action(
         self,
         action_id: str,
         action_type: RunActionType,
@@ -70,9 +70,9 @@ class RunController:
 
         try:
             if action_type == RunActionType.PLAY:
-                if self._run_orchestrator_store.run_was_started():
+                if await self._run_orchestrator_store.run_was_started():
                     log.info(f'Resuming run "{self._run_id}".')
-                    self._run_orchestrator_store.play()
+                    await self._run_orchestrator_store.play()
                 else:
                     log.info(f'Starting run "{self._run_id}".')
                     # TODO(mc, 2022-05-13): run_orchestrator_store.runner.run could raise
@@ -88,7 +88,7 @@ class RunController:
 
             elif action_type == RunActionType.PAUSE:
                 log.info(f'Pausing run "{self._run_id}".')
-                self._run_orchestrator_store.pause()
+                await self._run_orchestrator_store.pause()
 
             elif action_type == RunActionType.STOP:
                 log.info(f'Stopping run "{self._run_id}".')
@@ -96,7 +96,7 @@ class RunController:
 
             elif action_type == RunActionType.RESUME_FROM_RECOVERY:
                 log.info(f'Resuming run "{self._run_id}" from error recovery mode.')
-                self._run_orchestrator_store.resume_from_recovery(
+                await self._run_orchestrator_store.resume_from_recovery(
                     reconcile_false_positive=False
                 )
 
@@ -108,7 +108,7 @@ class RunController:
                     f'Resuming run "{self._run_id}" from error recovery mode,'
                     f" assuming false-positive."
                 )
-                self._run_orchestrator_store.resume_from_recovery(
+                await self._run_orchestrator_store.resume_from_recovery(
                     reconcile_false_positive=True
                 )
 

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -307,12 +307,14 @@ class RunDataManager:
             protocol_id=protocol.protocol_id if protocol is not None else None,
             log_period_id=log_period_id,
         )
-        run_time_parameters = self._run_orchestrator_store.get_run_time_parameters()
+        run_time_parameters = (
+            await self._run_orchestrator_store.get_run_time_parameters()
+        )
         self._run_store.insert_csv_rtp(
             run_id=run_id, run_time_parameters=run_time_parameters
         )
 
-        self._runs_publisher.start_publishing_for_run(
+        await self._runs_publisher.start_publishing_for_run(
             get_current_command=self.get_current_command,
             get_recovery_target_command=self.get_recovery_target_command,
             get_state_summary=self._get_good_state_summary,
@@ -325,7 +327,7 @@ class RunDataManager:
             await camera_provider.get_camera_settings(),
             state_summary.cameraSettings,
         )
-        self._run_orchestrator_store.add_camera_capture_image_settings(
+        await self._run_orchestrator_store.add_camera_capture_image_settings(
             capture_image_settings=self._camera_setting_store.get_camera_capture_image_settings()
         )
 
@@ -336,7 +338,7 @@ class RunDataManager:
             run_time_parameters=run_time_parameters,
         )
 
-    def get(self, run_id: str) -> Union[Run, BadRun]:
+    async def get(self, run_id: str) -> Union[Run, BadRun]:
         """Get a run resource.
 
         This method will pull from the current run or the historical runs,
@@ -352,13 +354,13 @@ class RunDataManager:
             RunNotFoundError: The given run identifier does not exist.
         """
         run_resource = self._run_store.get(run_id=run_id)
-        state_summary = self._get_state_summary(run_id=run_id)
-        parameters = self._get_run_time_parameters(run_id=run_id)
+        state_summary = await self._get_state_summary(run_id=run_id)
+        parameters = await self._get_run_time_parameters(run_id=run_id)
         current = run_id == self._run_orchestrator_store.current_run_id
 
         return _build_run(run_resource, state_summary, current, parameters)
 
-    def get_run_loaded_labware_definitions(
+    async def get_run_loaded_labware_definitions(
         self, run_id: str
     ) -> List[LabwareDefinition]:
         """Get a run's load labware definitions.
@@ -382,9 +384,9 @@ class RunDataManager:
                 f"Cannot get load labware definitions of {run_id} because it is not the current run."
             )
 
-        return self._run_orchestrator_store.get_loaded_labware_definitions()
+        return await self._run_orchestrator_store.get_loaded_labware_definitions()
 
-    def get_all(self, length: Optional[int]) -> List[Union[Run, BadRun]]:
+    async def get_all(self, length: Optional[int]) -> List[Union[Run, BadRun]]:
         """Get current and stored run resources.
 
         Results are ordered from oldest to newest.
@@ -395,10 +397,12 @@ class RunDataManager:
         return [
             _build_run(
                 run_resource=run_resource,
-                state_summary=self._get_state_summary(run_resource.run_id),
+                state_summary=await self._get_state_summary(run_resource.run_id),
                 current=run_resource.run_id
                 == self._run_orchestrator_store.current_run_id,
-                run_time_parameters=self._get_run_time_parameters(run_resource.run_id),
+                run_time_parameters=await self._get_run_time_parameters(
+                    run_resource.run_id
+                ),
             )
             for run_resource in self._run_store.get_all(length)
         ]
@@ -477,7 +481,7 @@ class RunDataManager:
             run_time_parameters=run_result.parameters,
         )
 
-    def set_signed_by(self, run_id: str, signed_by: str) -> Union[Run, BadRun]:
+    async def set_signed_by(self, run_id: str, signed_by: str) -> Union[Run, BadRun]:
         """Record that a human has reviewed the current completed run.
 
         Args:
@@ -496,16 +500,16 @@ class RunDataManager:
                 f"Cannot sign {run_id} because it is not the current run."
             )
 
-        if not self._run_orchestrator_store.get_is_run_terminal():
+        if not await self._run_orchestrator_store.get_is_run_terminal():
             raise RunNotCompleteError(
                 f"Cannot sign {run_id} because it has not completed."
             )
 
         self._run_store.set_signed_by(run_id=run_id, signed_by=signed_by)
         self._runs_publisher.publish_runs_advise_refetch(run_id)
-        return self.get(run_id=run_id)
+        return await self.get(run_id=run_id)
 
-    def get_commands_slice(
+    async def get_commands_slice(
         self,
         run_id: str,
         cursor: Optional[int],
@@ -524,7 +528,7 @@ class RunDataManager:
             RunNotFoundError: The given run identifier was not found in the database.
         """
         if run_id == self._run_orchestrator_store.current_run_id:
-            return self._run_orchestrator_store.get_command_slice(
+            return await self._run_orchestrator_store.get_command_slice(
                 cursor=cursor,
                 length=length,
                 include_fixit_commands=include_fixit_commands,
@@ -535,7 +539,7 @@ class RunDataManager:
             run_id=run_id, cursor=cursor, length=length, include_fixit_commands=True
         )
 
-    def get_command_error_slice(
+    async def get_command_error_slice(
         self, run_id: str, cursor: int, length: int
     ) -> CommandErrorSlice:
         """Get a slice of run commands errors.
@@ -549,7 +553,7 @@ class RunDataManager:
             RunNotCurrentError: The given run identifier is not the current run.
         """
         if run_id == self._run_orchestrator_store.current_run_id:
-            return self._run_orchestrator_store.get_command_error_slice(
+            return await self._run_orchestrator_store.get_command_error_slice(
                 cursor=cursor, length=length
             )
         return self._run_store.get_commands_errors_slice(
@@ -583,7 +587,9 @@ class RunDataManager:
         else:
             return self._get_historical_run_last_command(run_id=run_id)
 
-    def get_recovery_target_command(self, run_id: str) -> Optional[CommandPointer]:
+    async def get_recovery_target_command(
+        self, run_id: str
+    ) -> Optional[CommandPointer]:
         """Get the current error recovery target.
 
         See `ProtocolEngine.state_view.commands.get_recovery_target()`.
@@ -592,12 +598,12 @@ class RunDataManager:
             run_id: ID of the run.
         """
         if self._run_orchestrator_store.current_run_id == run_id:
-            return self._run_orchestrator_store.get_command_recovery_target()
+            return await self._run_orchestrator_store.get_command_recovery_target()
         else:
             # Historical runs can't have any ongoing error recovery.
             return None
 
-    def get_command(self, run_id: str, command_id: str) -> Command:
+    async def get_command(self, run_id: str, command_id: str) -> Command:
         """Get a run's command by ID.
 
         Args:
@@ -609,23 +615,25 @@ class RunDataManager:
             CommandNotFoundError: The given command identifier was not found.
         """
         if self._run_orchestrator_store.current_run_id == run_id:
-            return self._run_orchestrator_store.get_command(command_id=command_id)
+            return await self._run_orchestrator_store.get_command(command_id=command_id)
 
         return self._run_store.get_command(run_id=run_id, command_id=command_id)
 
-    def get_command_errors_count(self, run_id: str) -> int:
+    async def get_command_errors_count(self, run_id: str) -> int:
         """Get all command errors."""
         if run_id == self._run_orchestrator_store.current_run_id:
-            return len(self._run_orchestrator_store.get_command_errors())
+            return len(await self._run_orchestrator_store.get_command_errors())
         return self._run_store.get_command_errors_count(run_id)
 
-    def get_total_command_annotations_count(self, run_id: str) -> int:
+    async def get_total_command_annotations_count(self, run_id: str) -> int:
         """Get the total number of command annotations in the specified run."""
         if run_id == self._run_orchestrator_store.current_run_id:
-            return self._run_orchestrator_store.get_total_command_annotations_count()
+            return (
+                await self._run_orchestrator_store.get_total_command_annotations_count()
+            )
         return self._run_store.get_total_command_annotations_count(run_id)
 
-    def get_command_annotations_slice(
+    async def get_command_annotations_slice(
         self, run_id: str, cursor: int, length: int
     ) -> CommandAnnotationsSlice:
         """Get a slice of the run's commands annotations.
@@ -636,19 +644,21 @@ class RunDataManager:
             length: Length of slice to return.
         """
         if run_id == self._run_orchestrator_store.current_run_id:
-            return self._run_orchestrator_store.get_command_annotations_slice(
+            return await self._run_orchestrator_store.get_command_annotations_slice(
                 cursor=cursor, length=length
             )
         return self._run_store.get_command_annotations_slice(
             run_id=run_id, cursor=cursor, length=length
         )
 
-    def get_command_annotation(
+    async def get_command_annotation(
         self, run_id: str, annotation_id: str
     ) -> CommandAnnotation:
         """Get a run's command annotation by ID."""
         if run_id == self._run_orchestrator_store.current_run_id:
-            return self._run_orchestrator_store.get_command_annotation(annotation_id)
+            return await self._run_orchestrator_store.get_command_annotation(
+                annotation_id
+            )
         return self._run_store.get_command_annotation(run_id, annotation_id)
 
     def get_nozzle_maps(self, run_id: str) -> Mapping[str, NozzleMapInterface]:
@@ -674,13 +684,13 @@ class RunDataManager:
 
         raise RunNotCurrentError()
 
-    def get_all_commands_as_preserialized_list(
+    async def get_all_commands_as_preserialized_list(
         self, run_id: str, include_fixit_commands: bool
     ) -> List[str]:
         """Get all commands of a run in a serialized json list."""
         if (
             run_id == self._run_orchestrator_store.current_run_id
-            and not self._run_orchestrator_store.get_is_run_terminal()
+            and not await self._run_orchestrator_store.get_is_run_terminal()
         ):
             raise PreSerializedCommandsNotAvailableError(
                 "Pre-serialized commands are only available after a run has ended."
@@ -689,7 +699,7 @@ class RunDataManager:
             run_id, include_fixit_commands
         )
 
-    def set_error_recovery_rules(
+    async def set_error_recovery_rules(
         self, run_id: str, rules: List[ErrorRecoveryRule]
     ) -> None:
         """Set the run's error recovery policy, in robot-server terms.
@@ -706,7 +716,7 @@ class RunDataManager:
         mapped_policy = error_recovery_mapping.create_error_recovery_policy_from_rules(
             self._current_run_error_recovery_rules, is_enabled
         )
-        self._run_orchestrator_store.set_error_recovery_policy(
+        await self._run_orchestrator_store.set_error_recovery_policy(
             policy=mapped_policy,
             error_recovery_rules=self._current_run_error_recovery_rules,
             error_recovery_is_enabled=is_enabled,
@@ -735,19 +745,21 @@ class RunDataManager:
                     f"Run {run_id} must be signed off before this action."
                 )
 
-    def _get_state_summary(self, run_id: str) -> Union[StateSummary, BadStateSummary]:
+    async def _get_state_summary(
+        self, run_id: str
+    ) -> Union[StateSummary, BadStateSummary]:
         if run_id == self._run_orchestrator_store.current_run_id:
-            return self._run_orchestrator_store.get_state_summary()
+            return await self._run_orchestrator_store.get_state_summary()
         else:
             return self._run_store.get_state_summary(run_id=run_id)
 
-    def _get_good_state_summary(self, run_id: str) -> Optional[StateSummary]:
-        summary = self._get_state_summary(run_id)
+    async def _get_good_state_summary(self, run_id: str) -> Optional[StateSummary]:
+        summary = await self._get_state_summary(run_id)
         return summary if isinstance(summary, StateSummary) else None
 
-    def _get_run_time_parameters(self, run_id: str) -> List[RunTimeParameter]:
+    async def _get_run_time_parameters(self, run_id: str) -> List[RunTimeParameter]:
         if run_id == self._run_orchestrator_store.current_run_id:
-            return self._run_orchestrator_store.get_run_time_parameters()
+            return await self._run_orchestrator_store.get_run_time_parameters()
         else:
             return self._run_store.get_run_time_parameters(run_id=run_id)
 

--- a/robot-server/robot_server/runs/run_download_utils.py
+++ b/robot-server/robot_server/runs/run_download_utils.py
@@ -34,14 +34,14 @@ def collect_protocol_file(
     return main_file, f"{name_stem}{main_file.suffix}"
 
 
-def collect_rtp_csv(
+async def collect_rtp_csv(
     run_id: str,
     run_data_manager: RunDataManager,
     data_files_store: DataFilesStore,
 ) -> Optional[Tuple[Path, str]]:
     """Return the CSV runtime parameter input file, or None if unavailable."""
     try:
-        run_record = run_data_manager.get(run_id)
+        run_record = await run_data_manager.get(run_id)
         for param in run_record.runTimeParameters:
             if param.type == "csv_file" and param.file is not None:
                 file_info = data_files_store.get(param.file.id)
@@ -53,7 +53,7 @@ def collect_rtp_csv(
         return None
 
 
-def collect_run_log(
+async def collect_run_log(
     run_id: str,
     run: Union[RunResource, BadRunResource],
     run_data_manager: RunDataManager,
@@ -62,14 +62,14 @@ def collect_run_log(
 ) -> Optional[Tuple[Path, str]]:
     """Build a run log JSON file in ``staging_dir``, or None if unavailable."""
     try:
-        run_record = run_data_manager.get(run_id)
-        length_probe = run_data_manager.get_commands_slice(
+        run_record = await run_data_manager.get(run_id)
+        length_probe = await run_data_manager.get_commands_slice(
             run_id=run_id,
             cursor=0,
             length=0,
             include_fixit_commands=True,
         )
-        command_slice = run_data_manager.get_commands_slice(
+        command_slice = await run_data_manager.get_commands_slice(
             run_id=run_id,
             cursor=0,
             length=length_probe.total_length,
@@ -113,7 +113,7 @@ def collect_run_log(
         return None
 
 
-def collect_labware_offsets(
+async def collect_labware_offsets(
     run_id: str,
     run: Union[RunResource, BadRunResource],
     run_data_manager: RunDataManager,
@@ -122,7 +122,7 @@ def collect_labware_offsets(
 ) -> Optional[Tuple[Path, str]]:
     """Build labware offsets JSON in ``staging_dir``, or None if unavailable."""
     try:
-        run_record = run_data_manager.get(run_id)
+        run_record = await run_data_manager.get(run_id)
         offsets_payload = [
             offset.model_dump(mode="json", by_alias=True)
             for offset in run_record.labwareOffsets

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -105,7 +105,7 @@ async def _do_handle_hardware_event(  # noqa: C901
             return
         # todo(mm, 2024-04-17): This estop teardown sequencing belongs in the
         # runner layer.
-        run_orchestrator_store.run_coordinator.estop()
+        await run_orchestrator_store.run_coordinator.estop()  # CASEY NOTE flag
         await run_orchestrator_store.run_coordinator.finish(error=EStopActivatedError())
     elif isinstance(event, AsynchronousModuleErrorNotification):
         if run_orchestrator_store.current_run_id is None:
@@ -204,6 +204,7 @@ class RunOrchestratorStore:
         self._run_coordinator: Optional[Union[RunOrchestrator, DirectedRunProcess]] = (
             None
         )
+        self._current_run_id: Optional[str] = None
         self._default_run_orchestrator: Optional[RunOrchestrator] = None
         self._run_process_pyro_provider = run_process_pyro_provider
         if not feature_flags.hardware_subprocess_enabled():
@@ -228,8 +229,8 @@ class RunOrchestratorStore:
     def current_run_id(self) -> Optional[str]:
         """Get the run identifier associated with the current run orchestrator."""
         return (
-            self.run_coordinator.run_id if self._run_coordinator is not None else None
-        )
+            self._current_run_id
+        )  # CASEY NOTE flag - this whole thing was changed out, no more remote request
 
     def default_run_orchestrator_door_watcher_callback_route_for_proxy(
         self, event: HardwareEvent
@@ -248,10 +249,10 @@ class RunOrchestratorStore:
         Raises:
             RunConflictError: if a run-specific run orchestrator is active.
         """
-        if (
+        if (  # CASEY NOTE flag all this must change
             self._run_coordinator is not None
-            and self.run_coordinator.run_has_started()
-            and not self.run_coordinator.run_has_stopped()
+            and await self.run_coordinator.run_has_started()
+            and not await self.run_coordinator.run_has_stopped()
         ):
             raise RunConflictError("A run is currently active")
 
@@ -284,14 +285,14 @@ class RunOrchestratorStore:
 
             # Initialize values for the default run orchestrator
             self._clear_stored_engine_state()
-            self._nozzle_maps = self._default_run_orchestrator.get_nozzle_maps()
-            self._tip_attached = self._default_run_orchestrator.get_tip_attached()
-            self._current_command = self._default_run_orchestrator.get_current_command()
-            self._most_recent_finalized_command = (
-                self._default_run_orchestrator.get_most_recently_finalized_command()
+            self._nozzle_maps = await self._default_run_orchestrator.get_nozzle_maps()
+            self._tip_attached = await self._default_run_orchestrator.get_tip_attached()
+            self._current_command = (
+                await self._default_run_orchestrator.get_current_command()
             )
+            self._most_recent_finalized_command = await self._default_run_orchestrator.get_most_recently_finalized_command()
             self._flex_stacker_substate = (
-                self._default_run_orchestrator.get_flex_stacker_substate()
+                await self._default_run_orchestrator.get_flex_stacker_substate()
             )
             return self._default_run_orchestrator
         return default_orchestrator
@@ -397,13 +398,16 @@ class RunOrchestratorStore:
             orchestrator.prepare()
 
         for offset in labware_offsets:
-            orchestrator.add_labware_offset(offset)
+            await orchestrator.add_labware_offset(offset)
 
-        summary = orchestrator.get_state_summary()
+        summary = await orchestrator.get_state_summary()
         self._clear_stored_engine_state()
         self._run_coordinator = orchestrator
+        self._current_run_id = run_id
 
-        self._initialize_stored_engine_state()
+        await (
+            self._initialize_stored_engine_state()
+        )  # CASEY NOTE flag - doesn't matter here but could be awaited if made async
 
         return summary
 
@@ -414,7 +418,9 @@ class RunOrchestratorStore:
             RunConflictError: The current run orchestrator is not idle, so it cannot
                 be cleared.
         """
-        if self.run_coordinator.get_is_okay_to_clear():
+        if (
+            await self.run_coordinator.get_is_okay_to_clear()
+        ):  # CASEY NOTE flag needs async?
             await self.run_coordinator.finish(
                 drop_tips_after_run=False,
                 set_run_status=False,
@@ -423,18 +429,31 @@ class RunOrchestratorStore:
         else:
             raise RunConflictError("Current run is not idle or stopped.")
 
-        run_data = self.run_coordinator.get_state_summary()
-        commands = self.run_coordinator.get_all_commands()
-        run_time_parameters = self.run_coordinator.get_run_time_parameters()
-        command_annotations = self.run_coordinator.get_all_command_annotations()
-        preconditions = self.run_coordinator.get_preconditions()
+        run_data = (
+            await self.run_coordinator.get_state_summary()
+        )  # CASEY NOTE flag needs async?
+        commands = (
+            await self.run_coordinator.get_all_commands()
+        )  # CASEY NOTE flag needs async?
+        run_time_parameters = (
+            await self.run_coordinator.get_run_time_parameters()
+        )  # CASEY NOTE flag needs async?
+        command_annotations = (
+            await self.run_coordinator.get_all_command_annotations()
+        )  # CASEY NOTE flag needs async?
+        preconditions = (
+            await self.run_coordinator.get_preconditions()
+        )  # CASEY NOTE flag needs async?
 
         if feature_flags.protocol_subprocess_enabled():
             self._run_process_pyro_provider.set_active_process_as_used()
 
         if self._run_coordinator is not None:
-            self._run_coordinator.clear_command_history()
+            await (
+                self._run_coordinator.clear_command_history()
+            )  # CASEY NOTE flag needs async?
             self._run_coordinator = None
+            self._current_run_id = None
 
         return RunResult(
             state_summary=run_data,
@@ -467,49 +486,64 @@ class RunOrchestratorStore:
             error_recovery_is_enabled=error_recovery_is_enabled,
             run_time_param_values=run_time_param_values,
             run_time_param_paths=run_time_param_paths,
-            proxy_of_callback_for_handling_door_events=run_process.register_hardware_door_event(),
+            proxy_of_callback_for_handling_door_events=await run_process.register_hardware_door_event(),  # CASEY NOTE flag - THESE MUST BE DONE! UH OH
         )
 
-        summary = run_process.get_state_summary()
+        summary = await run_process.get_state_summary()  # CASEY NOTE flag
         self._clear_stored_engine_state()
         self._run_coordinator = run_process
-        self._initialize_stored_engine_state()
+        self._current_run_id = run_id
+        await (
+            self._initialize_stored_engine_state()
+        )  # CASEY NOTE flag - matters here, make this async
         return summary
 
     # todo(mm, 2024-11-15): Are all of these pass-through methods helpful?
     # Can we delete them and make callers just call .run_orchestrator.play(), etc.?
 
-    def play(self, deck_configuration: Optional[DeckConfigurationType] = None) -> None:
+    async def play(
+        self, deck_configuration: Optional[DeckConfigurationType] = None
+    ) -> None:
         """Start or resume the run."""
-        self.run_coordinator.play(deck_configuration=deck_configuration)
+        await self.run_coordinator.play(
+            deck_configuration=deck_configuration
+        )  # CASEY NOTE flag - make this whole func async
 
     async def run(self, deck_configuration: DeckConfigurationType) -> RunResult:
         """Start the run."""
         return await self.run_coordinator.run(deck_configuration=deck_configuration)
 
-    def pause(self) -> None:
+    async def pause(self) -> None:
         """Pause the run."""
-        self.run_coordinator.pause()
+        await (
+            self.run_coordinator.pause()
+        )  # CASEY NOTE flag - make this whole func async
 
     async def stop(self) -> None:
         """Stop the run."""
         await self.run_coordinator.stop()
 
-    def resume_from_recovery(self, reconcile_false_positive: bool) -> None:
+    async def resume_from_recovery(self, reconcile_false_positive: bool) -> None:
         """Resume the run from recovery mode."""
-        self.run_coordinator.resume_from_recovery(reconcile_false_positive)
+        await self.run_coordinator.resume_from_recovery(
+            reconcile_false_positive
+        )  # CASEY NOTE flag - make this whole func async
 
     async def finish(self, error: Optional[Exception]) -> None:
         """Finish the run."""
         await self.run_coordinator.finish(error=error)
 
-    def get_state_summary(self) -> StateSummary:
+    async def get_state_summary(self) -> StateSummary:
         """Get protocol run data."""
-        return self.run_coordinator.get_state_summary()
+        return (
+            await self.run_coordinator.get_state_summary()
+        )  # CASEY NOTE flag - make this whole func async
 
-    def get_loaded_labware_definitions(self) -> List[LabwareDefinition]:
+    async def get_loaded_labware_definitions(self) -> List[LabwareDefinition]:
         """Get loaded labware definitions."""
-        return self.run_coordinator.get_loaded_labware_definitions()
+        return (
+            await self.run_coordinator.get_loaded_labware_definitions()
+        )  # CASEY NOTE flag - make this whole func async
 
     def get_nozzle_maps(self) -> Mapping[str, NozzleMapInterface]:
         """Get the current nozzle map keyed by pipette id."""
@@ -521,9 +555,11 @@ class RunOrchestratorStore:
         assert self._tip_attached is not None
         return self._tip_attached
 
-    def get_run_time_parameters(self) -> List[RunTimeParameter]:
+    async def get_run_time_parameters(self) -> List[RunTimeParameter]:
         """Parameter definitions defined by protocol, if any. Will always be empty before execution."""
-        return self.run_coordinator.get_run_time_parameters()
+        return (
+            await self.run_coordinator.get_run_time_parameters()
+        )  # CASEY NOTE flag - make this whole func async
 
     def get_flex_stacker_substate(self) -> Mapping[str, FlexStackerSubState]:
         """Get the current (if any) Flex Stacker Substates keyed by modile id."""
@@ -538,7 +574,7 @@ class RunOrchestratorStore:
         """Get the most recently finalized command, if any."""
         return self._most_recent_finalized_command
 
-    def get_command_slice(
+    async def get_command_slice(
         self, cursor: Optional[int], length: int, include_fixit_commands: bool
     ) -> CommandSlice:
         """Get a slice of run commands.
@@ -548,11 +584,11 @@ class RunOrchestratorStore:
             length: Length of slice to return.
             include_fixit_commands: Include fixit commands.
         """
-        return self.run_coordinator.get_command_slice(
+        return await self.run_coordinator.get_command_slice(  # CASEY NOTE flag - make this whole func async
             cursor=cursor, length=length, include_fixit_commands=include_fixit_commands
         )
 
-    def get_command_error_slice(
+    async def get_command_error_slice(
         self,
         cursor: int,
         length: int,
@@ -563,53 +599,69 @@ class RunOrchestratorStore:
             cursor: Requested index of first command error in the returned slice.
             length: Length of slice to return.
         """
-        return self.run_coordinator.get_command_error_slice(
+        return await self.run_coordinator.get_command_error_slice(  # CASEY NOTE flag - make this whole func async
             cursor=cursor, length=length
         )
 
-    def get_command_errors(self) -> list[ErrorOccurrence]:
+    async def get_command_errors(self) -> list[ErrorOccurrence]:
         """Get all command errors."""
-        return self.run_coordinator.get_command_errors()
+        return (
+            await self.run_coordinator.get_command_errors()
+        )  # CASEY NOTE flag - make this whole func async
 
-    def get_command_recovery_target(self) -> Optional[CommandPointer]:
+    async def get_command_recovery_target(self) -> Optional[CommandPointer]:
         """Get the current error recovery target."""
-        return self.run_coordinator.get_command_recovery_target()
+        return (
+            await self.run_coordinator.get_command_recovery_target()
+        )  # CASEY NOTE flag - make this whole func async
 
-    def get_command(self, command_id: str) -> Command:
+    async def get_command(self, command_id: str) -> Command:
         """Get a run's command by ID."""
-        return self.run_coordinator.get_command(command_id=command_id)
+        return await self.run_coordinator.get_command(
+            command_id=command_id
+        )  # CASEY NOTE flag - make this whole func async
 
-    def get_total_command_annotations_count(self) -> int:
+    async def get_total_command_annotations_count(self) -> int:
         """Get the total number of command annotations in the run."""
-        return self.run_coordinator.get_total_command_annotations_count()
+        return (
+            await self.run_coordinator.get_total_command_annotations_count()
+        )  # CASEY NOTE flag - make this whole func async
 
-    def get_command_annotations_slice(
+    async def get_command_annotations_slice(
         self,
         cursor: int,
         length: int,
     ) -> CommandAnnotationsSlice:
         """Get a slice of run commands."""
-        return self.run_coordinator.get_command_annotations_slice(
+        return await self.run_coordinator.get_command_annotations_slice(  # CASEY NOTE flag - make this whole func async
             cursor=cursor, length=length
         )
 
-    def get_command_annotation(self, annotation_id: str) -> CommandAnnotation:
+    async def get_command_annotation(self, annotation_id: str) -> CommandAnnotation:
         """Get the specified command annotation."""
-        return self.run_coordinator.get_command_annotation(annotation_id)
+        return await self.run_coordinator.get_command_annotation(
+            annotation_id
+        )  # CASEY NOTE flag - make this whole func async
 
-    def get_status(self) -> EngineStatus:
+    async def get_status(self) -> EngineStatus:
         """Get the current execution status of the run."""
-        return self.run_coordinator.get_run_status()
+        return (
+            await self.run_coordinator.get_run_status()
+        )  # CASEY NOTE flag - make this whole func async
 
-    def get_is_run_terminal(self) -> bool:
+    async def get_is_run_terminal(self) -> bool:
         """Get whether run is in a terminal state."""
-        return self.run_coordinator.get_is_run_terminal()
+        return (
+            await self.run_coordinator.get_is_run_terminal()
+        )  # CASEY NOTE flag - make this whole func async
 
-    def get_camera_capture_image_settings(
+    async def get_camera_capture_image_settings(
         self, camera_id: str
     ) -> CameraCaptureImageSettings:
         """Get camera capture image settings to state."""
-        settings = self.run_coordinator.get_camera_capture_image_settings()
+        settings = (
+            await self.run_coordinator.get_camera_capture_image_settings()
+        )  # CASEY NOTE flag - make this whole func async
 
         # todo(chb, 2026-01-12): Currently we only store one set of camera settings in the camera store at a time.
         # Storing multiple will mean updating get_camera_capture_image_settings() to return specific cameras.
@@ -627,31 +679,39 @@ class RunOrchestratorStore:
             saturation=settings["saturation"],
         )
 
-    def run_was_started(self) -> bool:
+    async def run_was_started(self) -> bool:
         """Get whether the run has started."""
-        return self.run_coordinator.run_has_started()
+        return (
+            await self.run_coordinator.run_has_started()
+        )  # CASEY NOTE flag - make this whole func async
 
-    def add_labware_offset(
+    async def add_labware_offset(
         self, request: LabwareOffsetCreate | LegacyLabwareOffsetCreate
     ) -> LabwareOffset:
         """Add a new labware offset to state."""
-        return self.run_coordinator.add_labware_offset(request)
+        return await self.run_coordinator.add_labware_offset(
+            request
+        )  # CASEY NOTE flag - make this whole func async
 
-    def add_labware_definition(self, definition: LabwareDefinition) -> LabwareUri:
+    async def add_labware_definition(self, definition: LabwareDefinition) -> LabwareUri:
         """Add a new labware definition to state."""
-        return self.run_coordinator.add_labware_definition(definition)
+        return await self.run_coordinator.add_labware_definition(
+            definition
+        )  # CASEY NOTE flag - make this whole func async
 
-    def set_error_recovery_policy(
+    async def set_error_recovery_policy(
         self,
         policy: error_recovery_policy.ErrorRecoveryPolicy,
         error_recovery_rules: List[ErrorRecoveryRule],
         error_recovery_is_enabled: bool,
     ) -> None:
         """Create run policy rules for error recovery."""
-        if isinstance(self.run_coordinator, RunOrchestrator):
-            self.run_coordinator.set_error_recovery_policy(policy)
+        if isinstance(
+            self.run_coordinator, RunOrchestrator
+        ):  # CASEY NOTE flag - make this whole func async
+            await self.run_coordinator.set_error_recovery_policy(policy)
         else:
-            self.run_coordinator.set_error_recovery_policy(
+            await self.run_coordinator.set_error_recovery_policy(
                 error_recovery_rules, error_recovery_is_enabled
             )
 
@@ -659,17 +719,19 @@ class RunOrchestratorStore:
         """Set the access control policy for the Run Orchestrator Store."""
         self._access_control_mode = access_control_mode
 
-    def add_camera_enablement_settings(
+    async def add_camera_enablement_settings(
         self, enablement_settings: CameraSettings
     ) -> CameraSettings:
         """Add new camera enablement settings to state."""
-        return self.run_coordinator.add_camera_enablement_settings(enablement_settings)
+        return await self.run_coordinator.add_camera_enablement_settings(
+            enablement_settings
+        )  # CASEY NOTE flag - make this whole func async
 
-    def add_camera_capture_image_settings(
+    async def add_camera_capture_image_settings(
         self, capture_image_settings: CameraCaptureImageSettings
     ) -> None:
         """Add new camera capture image settings to state."""
-        self.run_coordinator.add_camera_capture_image_settings(
+        await self.run_coordinator.add_camera_capture_image_settings(  # CASEY NOTE flag - make this whole func async
             camera_id=capture_image_settings.cameraId,
             resolution=capture_image_settings.resolution,
             zoom=capture_image_settings.zoom,
@@ -735,15 +797,19 @@ class RunOrchestratorStore:
             if isinstance(event, FlexStackerSubstateNotification):
                 self._flex_stacker_substate = event.stacker_substate_map
 
-    def _initialize_stored_engine_state(self) -> None:
+    async def _initialize_stored_engine_state(self) -> None:
         """Initialize the orchestrator store local engine state."""
-        self._nozzle_maps = self.run_coordinator.get_nozzle_maps()
-        self._tip_attached = self.run_coordinator.get_tip_attached()
-        self._current_command = self.run_coordinator.get_current_command()
+        self._nozzle_maps = (
+            await self.run_coordinator.get_nozzle_maps()
+        )  # CASEY NOTE flag - make this whole func async
+        self._tip_attached = await self.run_coordinator.get_tip_attached()
+        self._current_command = await self.run_coordinator.get_current_command()
         self._most_recent_finalized_command = (
-            self.run_coordinator.get_most_recently_finalized_command()
+            await self.run_coordinator.get_most_recently_finalized_command()
         )
-        self._flex_stacker_substate = self.run_coordinator.get_flex_stacker_substate()
+        self._flex_stacker_substate = (
+            await self.run_coordinator.get_flex_stacker_substate()
+        )
 
     def _clear_stored_engine_state(self) -> None:
         """Clear the stored engine state, called when creating a new run orchestrator so no state persists between runs."""

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -105,7 +105,7 @@ async def _do_handle_hardware_event(  # noqa: C901
             return
         # todo(mm, 2024-04-17): This estop teardown sequencing belongs in the
         # runner layer.
-        await run_orchestrator_store.run_coordinator.estop()  # CASEY NOTE flag
+        await run_orchestrator_store.run_coordinator.estop()
         await run_orchestrator_store.run_coordinator.finish(error=EStopActivatedError())
     elif isinstance(event, AsynchronousModuleErrorNotification):
         if run_orchestrator_store.current_run_id is None:
@@ -228,9 +228,7 @@ class RunOrchestratorStore:
     @property
     def current_run_id(self) -> Optional[str]:
         """Get the run identifier associated with the current run orchestrator."""
-        return (
-            self._current_run_id
-        )  # CASEY NOTE flag - this whole thing was changed out, no more remote request
+        return self._current_run_id
 
     def default_run_orchestrator_door_watcher_callback_route_for_proxy(
         self, event: HardwareEvent
@@ -249,7 +247,7 @@ class RunOrchestratorStore:
         Raises:
             RunConflictError: if a run-specific run orchestrator is active.
         """
-        if (  # CASEY NOTE flag all this must change
+        if (
             self._run_coordinator is not None
             and await self.run_coordinator.run_has_started()
             and not await self.run_coordinator.run_has_stopped()
@@ -405,9 +403,7 @@ class RunOrchestratorStore:
         self._run_coordinator = orchestrator
         self._current_run_id = run_id
 
-        await (
-            self._initialize_stored_engine_state()
-        )  # CASEY NOTE flag - doesn't matter here but could be awaited if made async
+        await self._initialize_stored_engine_state()
 
         return summary
 
@@ -418,9 +414,7 @@ class RunOrchestratorStore:
             RunConflictError: The current run orchestrator is not idle, so it cannot
                 be cleared.
         """
-        if (
-            await self.run_coordinator.get_is_okay_to_clear()
-        ):  # CASEY NOTE flag needs async?
+        if await self.run_coordinator.get_is_okay_to_clear():
             await self.run_coordinator.finish(
                 drop_tips_after_run=False,
                 set_run_status=False,
@@ -429,29 +423,17 @@ class RunOrchestratorStore:
         else:
             raise RunConflictError("Current run is not idle or stopped.")
 
-        run_data = (
-            await self.run_coordinator.get_state_summary()
-        )  # CASEY NOTE flag needs async?
-        commands = (
-            await self.run_coordinator.get_all_commands()
-        )  # CASEY NOTE flag needs async?
-        run_time_parameters = (
-            await self.run_coordinator.get_run_time_parameters()
-        )  # CASEY NOTE flag needs async?
-        command_annotations = (
-            await self.run_coordinator.get_all_command_annotations()
-        )  # CASEY NOTE flag needs async?
-        preconditions = (
-            await self.run_coordinator.get_preconditions()
-        )  # CASEY NOTE flag needs async?
+        run_data = await self.run_coordinator.get_state_summary()
+        commands = await self.run_coordinator.get_all_commands()
+        run_time_parameters = await self.run_coordinator.get_run_time_parameters()
+        command_annotations = await self.run_coordinator.get_all_command_annotations()
+        preconditions = await self.run_coordinator.get_preconditions()
 
         if feature_flags.protocol_subprocess_enabled():
             self._run_process_pyro_provider.set_active_process_as_used()
 
         if self._run_coordinator is not None:
-            await (
-                self._run_coordinator.clear_command_history()
-            )  # CASEY NOTE flag needs async?
+            await self._run_coordinator.clear_command_history()
             self._run_coordinator = None
             self._current_run_id = None
 
@@ -486,16 +468,14 @@ class RunOrchestratorStore:
             error_recovery_is_enabled=error_recovery_is_enabled,
             run_time_param_values=run_time_param_values,
             run_time_param_paths=run_time_param_paths,
-            proxy_of_callback_for_handling_door_events=await run_process.register_hardware_door_event(),  # CASEY NOTE flag - THESE MUST BE DONE! UH OH
+            proxy_of_callback_for_handling_door_events=await run_process.register_hardware_door_event(),
         )
 
-        summary = await run_process.get_state_summary()  # CASEY NOTE flag
+        summary = await run_process.get_state_summary()
         self._clear_stored_engine_state()
         self._run_coordinator = run_process
         self._current_run_id = run_id
-        await (
-            self._initialize_stored_engine_state()
-        )  # CASEY NOTE flag - matters here, make this async
+        await self._initialize_stored_engine_state()
         return summary
 
     # todo(mm, 2024-11-15): Are all of these pass-through methods helpful?
@@ -505,9 +485,7 @@ class RunOrchestratorStore:
         self, deck_configuration: Optional[DeckConfigurationType] = None
     ) -> None:
         """Start or resume the run."""
-        await self.run_coordinator.play(
-            deck_configuration=deck_configuration
-        )  # CASEY NOTE flag - make this whole func async
+        await self.run_coordinator.play(deck_configuration=deck_configuration)
 
     async def run(self, deck_configuration: DeckConfigurationType) -> RunResult:
         """Start the run."""
@@ -515,9 +493,7 @@ class RunOrchestratorStore:
 
     async def pause(self) -> None:
         """Pause the run."""
-        await (
-            self.run_coordinator.pause()
-        )  # CASEY NOTE flag - make this whole func async
+        await self.run_coordinator.pause()
 
     async def stop(self) -> None:
         """Stop the run."""
@@ -525,9 +501,7 @@ class RunOrchestratorStore:
 
     async def resume_from_recovery(self, reconcile_false_positive: bool) -> None:
         """Resume the run from recovery mode."""
-        await self.run_coordinator.resume_from_recovery(
-            reconcile_false_positive
-        )  # CASEY NOTE flag - make this whole func async
+        await self.run_coordinator.resume_from_recovery(reconcile_false_positive)
 
     async def finish(self, error: Optional[Exception]) -> None:
         """Finish the run."""
@@ -535,15 +509,11 @@ class RunOrchestratorStore:
 
     async def get_state_summary(self) -> StateSummary:
         """Get protocol run data."""
-        return (
-            await self.run_coordinator.get_state_summary()
-        )  # CASEY NOTE flag - make this whole func async
+        return await self.run_coordinator.get_state_summary()
 
     async def get_loaded_labware_definitions(self) -> List[LabwareDefinition]:
         """Get loaded labware definitions."""
-        return (
-            await self.run_coordinator.get_loaded_labware_definitions()
-        )  # CASEY NOTE flag - make this whole func async
+        return await self.run_coordinator.get_loaded_labware_definitions()
 
     def get_nozzle_maps(self) -> Mapping[str, NozzleMapInterface]:
         """Get the current nozzle map keyed by pipette id."""
@@ -557,9 +527,7 @@ class RunOrchestratorStore:
 
     async def get_run_time_parameters(self) -> List[RunTimeParameter]:
         """Parameter definitions defined by protocol, if any. Will always be empty before execution."""
-        return (
-            await self.run_coordinator.get_run_time_parameters()
-        )  # CASEY NOTE flag - make this whole func async
+        return await self.run_coordinator.get_run_time_parameters()
 
     def get_flex_stacker_substate(self) -> Mapping[str, FlexStackerSubState]:
         """Get the current (if any) Flex Stacker Substates keyed by modile id."""
@@ -584,7 +552,7 @@ class RunOrchestratorStore:
             length: Length of slice to return.
             include_fixit_commands: Include fixit commands.
         """
-        return await self.run_coordinator.get_command_slice(  # CASEY NOTE flag - make this whole func async
+        return await self.run_coordinator.get_command_slice(
             cursor=cursor, length=length, include_fixit_commands=include_fixit_commands
         )
 
@@ -599,33 +567,25 @@ class RunOrchestratorStore:
             cursor: Requested index of first command error in the returned slice.
             length: Length of slice to return.
         """
-        return await self.run_coordinator.get_command_error_slice(  # CASEY NOTE flag - make this whole func async
+        return await self.run_coordinator.get_command_error_slice(
             cursor=cursor, length=length
         )
 
     async def get_command_errors(self) -> list[ErrorOccurrence]:
         """Get all command errors."""
-        return (
-            await self.run_coordinator.get_command_errors()
-        )  # CASEY NOTE flag - make this whole func async
+        return await self.run_coordinator.get_command_errors()
 
     async def get_command_recovery_target(self) -> Optional[CommandPointer]:
         """Get the current error recovery target."""
-        return (
-            await self.run_coordinator.get_command_recovery_target()
-        )  # CASEY NOTE flag - make this whole func async
+        return await self.run_coordinator.get_command_recovery_target()
 
     async def get_command(self, command_id: str) -> Command:
         """Get a run's command by ID."""
-        return await self.run_coordinator.get_command(
-            command_id=command_id
-        )  # CASEY NOTE flag - make this whole func async
+        return await self.run_coordinator.get_command(command_id=command_id)
 
     async def get_total_command_annotations_count(self) -> int:
         """Get the total number of command annotations in the run."""
-        return (
-            await self.run_coordinator.get_total_command_annotations_count()
-        )  # CASEY NOTE flag - make this whole func async
+        return await self.run_coordinator.get_total_command_annotations_count()
 
     async def get_command_annotations_slice(
         self,
@@ -633,35 +593,27 @@ class RunOrchestratorStore:
         length: int,
     ) -> CommandAnnotationsSlice:
         """Get a slice of run commands."""
-        return await self.run_coordinator.get_command_annotations_slice(  # CASEY NOTE flag - make this whole func async
+        return await self.run_coordinator.get_command_annotations_slice(
             cursor=cursor, length=length
         )
 
     async def get_command_annotation(self, annotation_id: str) -> CommandAnnotation:
         """Get the specified command annotation."""
-        return await self.run_coordinator.get_command_annotation(
-            annotation_id
-        )  # CASEY NOTE flag - make this whole func async
+        return await self.run_coordinator.get_command_annotation(annotation_id)
 
     async def get_status(self) -> EngineStatus:
         """Get the current execution status of the run."""
-        return (
-            await self.run_coordinator.get_run_status()
-        )  # CASEY NOTE flag - make this whole func async
+        return await self.run_coordinator.get_run_status()
 
     async def get_is_run_terminal(self) -> bool:
         """Get whether run is in a terminal state."""
-        return (
-            await self.run_coordinator.get_is_run_terminal()
-        )  # CASEY NOTE flag - make this whole func async
+        return await self.run_coordinator.get_is_run_terminal()
 
     async def get_camera_capture_image_settings(
         self, camera_id: str
     ) -> CameraCaptureImageSettings:
         """Get camera capture image settings to state."""
-        settings = (
-            await self.run_coordinator.get_camera_capture_image_settings()
-        )  # CASEY NOTE flag - make this whole func async
+        settings = await self.run_coordinator.get_camera_capture_image_settings()
 
         # todo(chb, 2026-01-12): Currently we only store one set of camera settings in the camera store at a time.
         # Storing multiple will mean updating get_camera_capture_image_settings() to return specific cameras.
@@ -681,23 +633,17 @@ class RunOrchestratorStore:
 
     async def run_was_started(self) -> bool:
         """Get whether the run has started."""
-        return (
-            await self.run_coordinator.run_has_started()
-        )  # CASEY NOTE flag - make this whole func async
+        return await self.run_coordinator.run_has_started()
 
     async def add_labware_offset(
         self, request: LabwareOffsetCreate | LegacyLabwareOffsetCreate
     ) -> LabwareOffset:
         """Add a new labware offset to state."""
-        return await self.run_coordinator.add_labware_offset(
-            request
-        )  # CASEY NOTE flag - make this whole func async
+        return await self.run_coordinator.add_labware_offset(request)
 
     async def add_labware_definition(self, definition: LabwareDefinition) -> LabwareUri:
         """Add a new labware definition to state."""
-        return await self.run_coordinator.add_labware_definition(
-            definition
-        )  # CASEY NOTE flag - make this whole func async
+        return await self.run_coordinator.add_labware_definition(definition)
 
     async def set_error_recovery_policy(
         self,
@@ -706,9 +652,7 @@ class RunOrchestratorStore:
         error_recovery_is_enabled: bool,
     ) -> None:
         """Create run policy rules for error recovery."""
-        if isinstance(
-            self.run_coordinator, RunOrchestrator
-        ):  # CASEY NOTE flag - make this whole func async
+        if isinstance(self.run_coordinator, RunOrchestrator):
             await self.run_coordinator.set_error_recovery_policy(policy)
         else:
             await self.run_coordinator.set_error_recovery_policy(
@@ -725,13 +669,13 @@ class RunOrchestratorStore:
         """Add new camera enablement settings to state."""
         return await self.run_coordinator.add_camera_enablement_settings(
             enablement_settings
-        )  # CASEY NOTE flag - make this whole func async
+        )
 
     async def add_camera_capture_image_settings(
         self, capture_image_settings: CameraCaptureImageSettings
     ) -> None:
         """Add new camera capture image settings to state."""
-        await self.run_coordinator.add_camera_capture_image_settings(  # CASEY NOTE flag - make this whole func async
+        await self.run_coordinator.add_camera_capture_image_settings(
             camera_id=capture_image_settings.cameraId,
             resolution=capture_image_settings.resolution,
             zoom=capture_image_settings.zoom,
@@ -799,9 +743,7 @@ class RunOrchestratorStore:
 
     async def _initialize_stored_engine_state(self) -> None:
         """Initialize the orchestrator store local engine state."""
-        self._nozzle_maps = (
-            await self.run_coordinator.get_nozzle_maps()
-        )  # CASEY NOTE flag - make this whole func async
+        self._nozzle_maps = await self.run_coordinator.get_nozzle_maps()
         self._tip_attached = await self.run_coordinator.get_tip_attached()
         self._current_command = await self.run_coordinator.get_current_command()
         self._most_recent_finalized_command = (

--- a/robot-server/robot_server/runs/run_process.py
+++ b/robot-server/robot_server/runs/run_process.py
@@ -173,7 +173,7 @@ class DirectedRunProcess(AbstractRunCoordinator):
         log.info(f"Directed Run Process initialized with Run ID: {self._run_id}")
 
     @pyro_behavior(specialty_func=convert_result_to_proxy, apply_local=False)
-    def register_hardware_door_event(self) -> HardwareEventHandler:
+    async def register_hardware_door_event(self) -> HardwareEventHandler:
         """Create a callback for the door watcher on the hardware controller via the protocol engine.
 
         The returned callback is meant to run in the hardware API's thread.
@@ -282,7 +282,7 @@ class DirectedRunProcess(AbstractRunCoordinator):
             orchestrator.prepare()
 
         for offset in labware_offsets:
-            orchestrator.add_labware_offset(offset)
+            await orchestrator.add_labware_offset(offset)
 
         self._run_orchestrator = orchestrator
 
@@ -303,9 +303,11 @@ class DirectedRunProcess(AbstractRunCoordinator):
         assert self._run_orchestrator is not None
         return self._run_orchestrator
 
-    def play(self, deck_configuration: Optional[DeckConfigurationType] = None) -> None:
+    async def play(
+        self, deck_configuration: Optional[DeckConfigurationType] = None
+    ) -> None:
         """Start or resume the run."""
-        self._guaranteed_run_orchestrator.play(deck_configuration)
+        await self._guaranteed_run_orchestrator.play(deck_configuration)
 
     async def run(
         self,
@@ -318,17 +320,19 @@ class DirectedRunProcess(AbstractRunCoordinator):
             deck_configuration, protocol_source, run_time_param_values
         )
 
-    def pause(self) -> None:
+    async def pause(self) -> None:
         """Pause the run."""
-        self._guaranteed_run_orchestrator.pause()
+        await self._guaranteed_run_orchestrator.pause()
 
     async def stop(self) -> None:
         """Stop the run."""
         await self._guaranteed_run_orchestrator.stop()
 
-    def resume_from_recovery(self, reconcile_false_positive: bool) -> None:
+    async def resume_from_recovery(self, reconcile_false_positive: bool) -> None:
         """Resume the run from recovery."""
-        self._guaranteed_run_orchestrator.resume_from_recovery(reconcile_false_positive)
+        await self._guaranteed_run_orchestrator.resume_from_recovery(
+            reconcile_false_positive
+        )
 
     async def finish(
         self,
@@ -343,19 +347,19 @@ class DirectedRunProcess(AbstractRunCoordinator):
             error, drop_tips_after_run, set_run_status, post_run_hardware_state
         )
 
-    def get_state_summary(self) -> StateSummary:
+    async def get_state_summary(self) -> StateSummary:
         """Get protocol run data."""
-        return self._guaranteed_run_orchestrator.get_state_summary()
+        return await self._guaranteed_run_orchestrator.get_state_summary()
 
-    def get_preconditions(self) -> CommandPreconditions:
+    async def get_preconditions(self) -> CommandPreconditions:
         """Get the preconditions of a protocol run."""
-        return self._guaranteed_run_orchestrator.get_preconditions()
+        return await self._guaranteed_run_orchestrator.get_preconditions()
 
-    def get_loaded_labware_definitions(self) -> List[LabwareDefinition]:
+    async def get_loaded_labware_definitions(self) -> List[LabwareDefinition]:
         """Get loaded labware definitions."""
-        return self._guaranteed_run_orchestrator.get_loaded_labware_definitions()
+        return await self._guaranteed_run_orchestrator.get_loaded_labware_definitions()
 
-    def get_run_time_parameters(self) -> List[RunTimeParameter]:
+    async def get_run_time_parameters(self) -> List[RunTimeParameter]:
         """Get the list of run time parameters defined in the protocol, if any.
 
         This returns a list of all run time parameters with their validated definitions
@@ -370,29 +374,31 @@ class DirectedRunProcess(AbstractRunCoordinator):
         whose values were successfully set will have the client-requested values while
         the others will contain the default values.
         """
-        return self._guaranteed_run_orchestrator.get_run_time_parameters()
+        return await self._guaranteed_run_orchestrator.get_run_time_parameters()
 
-    def get_all_command_annotations(self) -> List[CommandAnnotation]:
+    async def get_all_command_annotations(self) -> List[CommandAnnotation]:
         """Get the list of command annotations defined in the protocol, if any."""
-        return self._guaranteed_run_orchestrator.get_all_command_annotations()
+        return await self._guaranteed_run_orchestrator.get_all_command_annotations()
 
-    def get_total_command_annotations_count(self) -> int:
+    async def get_total_command_annotations_count(self) -> int:
         """Get the total number of command annotations defined in the protocol, if any."""
-        return self._guaranteed_run_orchestrator.get_total_command_annotations_count()
+        return await self._guaranteed_run_orchestrator.get_total_command_annotations_count()
 
-    def get_command_annotation(self, annotation_id: str) -> CommandAnnotation:
+    async def get_command_annotation(self, annotation_id: str) -> CommandAnnotation:
         """Get the command annotation by ID."""
-        return self._guaranteed_run_orchestrator.get_command_annotation(annotation_id)
+        return await self._guaranteed_run_orchestrator.get_command_annotation(
+            annotation_id
+        )
 
-    def get_current_command(self) -> Optional[CommandPointer]:
+    async def get_current_command(self) -> Optional[CommandPointer]:
         """Get the "current" command, if any."""
-        return self._guaranteed_run_orchestrator.get_current_command()
+        return await self._guaranteed_run_orchestrator.get_current_command()
 
-    def get_most_recently_finalized_command(self) -> Optional[CommandPointer]:
+    async def get_most_recently_finalized_command(self) -> Optional[CommandPointer]:
         """Get the most recently finalized command, if any."""
-        return self._guaranteed_run_orchestrator.get_most_recently_finalized_command()
+        return await self._guaranteed_run_orchestrator.get_most_recently_finalized_command()
 
-    def get_command_slice(
+    async def get_command_slice(
         self, cursor: Optional[int], length: int, include_fixit_commands: bool
     ) -> CommandSlice:
         """Get a slice of run commands.
@@ -402,19 +408,19 @@ class DirectedRunProcess(AbstractRunCoordinator):
             length: Length of slice to return.
             include_fixit_commands: Get all command intents.
         """
-        return self._guaranteed_run_orchestrator.get_command_slice(
+        return await self._guaranteed_run_orchestrator.get_command_slice(
             cursor, length, include_fixit_commands
         )
 
-    def get_command_annotations_slice(
+    async def get_command_annotations_slice(
         self, cursor: int, length: int
     ) -> CommandAnnotationsSlice:
         """Get a slice of command annotations in the run."""
-        return self._guaranteed_run_orchestrator.get_command_annotations_slice(
+        return await self._guaranteed_run_orchestrator.get_command_annotations_slice(
             cursor, length
         )
 
-    def get_command_error_slice(
+    async def get_command_error_slice(
         self,
         cursor: int,
         length: int,
@@ -427,66 +433,72 @@ class DirectedRunProcess(AbstractRunCoordinator):
                 based on the last error occurrence.
             length: Length of slice to return.
         """
-        return self._guaranteed_run_orchestrator.get_command_error_slice(cursor, length)
+        return await self._guaranteed_run_orchestrator.get_command_error_slice(
+            cursor, length
+        )
 
-    def get_command_recovery_target(self) -> Optional[CommandPointer]:
+    async def get_command_recovery_target(self) -> Optional[CommandPointer]:
         """Get the current error recovery target."""
-        return self._guaranteed_run_orchestrator.get_command_recovery_target()
+        return await self._guaranteed_run_orchestrator.get_command_recovery_target()
 
-    def get_command(self, command_id: str) -> Command:
+    async def get_command(self, command_id: str) -> Command:
         """Get a run's command by ID."""
-        return self._guaranteed_run_orchestrator.get_command(command_id)
+        return await self._guaranteed_run_orchestrator.get_command(command_id)
 
-    def get_all_commands(self) -> List[Command]:
+    async def get_all_commands(self) -> List[Command]:
         """Get all run commands."""
-        return self._guaranteed_run_orchestrator.get_all_commands()
+        return await self._guaranteed_run_orchestrator.get_all_commands()
 
-    def get_command_errors(self) -> List[ErrorOccurrence]:
+    async def get_command_errors(self) -> List[ErrorOccurrence]:
         """Get all run command errors."""
-        return self._guaranteed_run_orchestrator.get_command_errors()
+        return await self._guaranteed_run_orchestrator.get_command_errors()
 
-    def get_run_status(self) -> EngineStatus:
+    async def get_run_status(self) -> EngineStatus:
         """Get the current execution status of the engine."""
-        return self._guaranteed_run_orchestrator.get_run_status()
+        return await self._guaranteed_run_orchestrator.get_run_status()
 
-    def get_is_run_terminal(self) -> bool:
+    async def get_is_run_terminal(self) -> bool:
         """Get whether engine is in a terminal state."""
-        return self._guaranteed_run_orchestrator.get_is_run_terminal()
+        return await self._guaranteed_run_orchestrator.get_is_run_terminal()
 
-    def get_camera_capture_image_settings(
+    async def get_camera_capture_image_settings(
         self,
     ) -> Dict[str, Any]:
         """Get camera capture image settings."""
-        return self._guaranteed_run_orchestrator.get_camera_capture_image_settings()
+        return (
+            await self._guaranteed_run_orchestrator.get_camera_capture_image_settings()
+        )
 
-    def run_has_started(self) -> bool:
+    async def run_has_started(self) -> bool:
         """Get whether the run has started."""
-        return self._guaranteed_run_orchestrator.run_has_started()
+        return await self._guaranteed_run_orchestrator.run_has_started()
 
-    def run_has_stopped(self) -> bool:
+    async def run_has_stopped(self) -> bool:
         """Get whether the run has stopped."""
-        return self._guaranteed_run_orchestrator.run_has_stopped()
+        return await self._guaranteed_run_orchestrator.run_has_stopped()
 
-    def add_labware_offset(
+    async def add_labware_offset(
         self, request: LabwareOffsetCreate | LegacyLabwareOffsetCreate
     ) -> LabwareOffset:
         """Add a new labware offset to state."""
-        return self._guaranteed_run_orchestrator.add_labware_offset(request)
+        return await self._guaranteed_run_orchestrator.add_labware_offset(request)
 
-    def add_labware_definition(self, definition: LabwareDefinition) -> LabwareUri:
+    async def add_labware_definition(self, definition: LabwareDefinition) -> LabwareUri:
         """Add a new labware definition to state."""
-        return self._guaranteed_run_orchestrator.add_labware_definition(definition)
+        return await self._guaranteed_run_orchestrator.add_labware_definition(
+            definition
+        )
 
-    def add_camera_enablement_settings(
+    async def add_camera_enablement_settings(
         self,
         enablement_settings: CameraSettings,
     ) -> CameraSettings:
         """Add new camera enablement settings."""
-        return self._guaranteed_run_orchestrator.add_camera_enablement_settings(
+        return await self._guaranteed_run_orchestrator.add_camera_enablement_settings(
             enablement_settings
         )
 
-    def add_camera_capture_image_settings(
+    async def add_camera_capture_image_settings(
         self,
         camera_id: Optional[str] = None,
         resolution: Optional[Tuple[int, int]] = None,
@@ -497,7 +509,7 @@ class DirectedRunProcess(AbstractRunCoordinator):
         saturation: Optional[float] = None,
     ) -> None:
         """Add new camera capture image settings."""
-        self._guaranteed_run_orchestrator.add_camera_capture_image_settings(
+        await self._guaranteed_run_orchestrator.add_camera_capture_image_settings(
             camera_id, resolution, zoom, pan, contrast, brightness, saturation
         )
 
@@ -515,9 +527,9 @@ class DirectedRunProcess(AbstractRunCoordinator):
             )
         )
 
-    def estop(self) -> None:
+    async def estop(self) -> None:
         """Handle an E-stop event from the hardware API."""
-        self._guaranteed_run_orchestrator.estop()
+        await self._guaranteed_run_orchestrator.estop()
 
     async def asynchronous_module_error(
         self,
@@ -566,9 +578,9 @@ class DirectedRunProcess(AbstractRunCoordinator):
             protocol_source, run_time_param_values, run_time_param_paths, parse_mode
         )
 
-    def get_is_okay_to_clear(self) -> bool:
+    async def get_is_okay_to_clear(self) -> bool:
         """Get whether the engine is stopped or sitting idly, so it could be removed."""
-        return self._guaranteed_run_orchestrator.get_is_okay_to_clear()
+        return await self._guaranteed_run_orchestrator.get_is_okay_to_clear()
 
     def prepare(self) -> None:
         """Prepare live runner for a run."""
@@ -583,16 +595,16 @@ class DirectedRunProcess(AbstractRunCoordinator):
         return self._deck_type
 
     @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)
-    def get_nozzle_maps(self) -> Mapping[str, NozzleMap]:
+    async def get_nozzle_maps(self) -> Mapping[str, NozzleMap]:
         """Get current nozzle maps keyed by pipette id."""
         # NOTE: For the sake of Pyro compatibility this method returns NozzleMap, a serializable type
-        return self._guaranteed_run_orchestrator.get_nozzle_maps()  # type: ignore
+        return await self._guaranteed_run_orchestrator.get_nozzle_maps()  # type: ignore
 
-    def get_tip_attached(self) -> Dict[str, bool]:
+    async def get_tip_attached(self) -> Dict[str, bool]:
         """Get current tip state keyed by pipette id."""
-        return self._guaranteed_run_orchestrator.get_tip_attached()
+        return await self._guaranteed_run_orchestrator.get_tip_attached()
 
-    def set_error_recovery_policy(
+    async def set_error_recovery_policy(
         self,
         error_recovery_rules: List[ErrorRecoveryRule],
         error_recovery_is_enabled: bool,
@@ -601,13 +613,13 @@ class DirectedRunProcess(AbstractRunCoordinator):
         policy = create_error_recovery_policy_from_rules(
             error_recovery_rules, error_recovery_is_enabled
         )
-        self._guaranteed_run_orchestrator.set_error_recovery_policy(policy)
+        await self._guaranteed_run_orchestrator.set_error_recovery_policy(policy)
 
     @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)
-    def get_flex_stacker_substate(self) -> Mapping[str, FlexStackerSubState]:
+    async def get_flex_stacker_substate(self) -> Mapping[str, FlexStackerSubState]:
         """Get current (if any) Flex Stacker Substates keyed by module id."""
-        return self._guaranteed_run_orchestrator.get_flex_stacker_substate()
+        return await self._guaranteed_run_orchestrator.get_flex_stacker_substate()
 
-    def clear_command_history(self) -> None:
+    async def clear_command_history(self) -> None:
         """Force cleanup of command history."""
-        self._guaranteed_run_orchestrator.clear_command_history()
+        await self._guaranteed_run_orchestrator.clear_command_history()

--- a/robot-server/robot_server/service/legacy/routers/camera.py
+++ b/robot-server/robot_server/service/legacy/routers/camera.py
@@ -100,6 +100,11 @@ async def post_camera(
         camera_settings_store.get_error_recovery_camera_enabled()
     )
 
+    run_data = (
+        await run_data_manager.get(run_data_manager.current_run_id)
+        if run_data_manager.current_run_id is not None
+        else None
+    )
     if camera.robot_supports_livestream(robot_type):
         stream_settings = _get_stream_settings()
         if (
@@ -109,7 +114,8 @@ async def post_camera(
                 run_data_manager.current_run_id is not None
                 and (
                     True
-                    if run_data_manager.get(run_data_manager.current_run_id).status
+                    if run_data is not None
+                    and run_data.status
                     not in [
                         EngineStatus.IDLE,
                         EngineStatus.STOPPED,
@@ -262,8 +268,14 @@ async def post_camera_preview_image(
     """
     Return a preview image based on the provided capture image settings.
     """
+    run_data = (
+        await run_data_manager.get(run_data_manager.current_run_id)
+        if run_data_manager.current_run_id is not None
+        else None
+    )
     if run_data_manager.current_run_id is not None and (
-        run_data_manager.get(run_data_manager.current_run_id).status
+        run_data is not None
+        and run_data.status
         not in [EngineStatus.STOPPED, EngineStatus.FAILED, EngineStatus.SUCCEEDED]
     ):
         raise HTTPException(
@@ -469,6 +481,11 @@ async def post_live_stream_settings(
     camera_enabled = camera_settings_store.get_camera_enabled()
     live_stream_enabled = camera_settings_store.get_live_stream_enabled()
 
+    run_data = (
+        await run_data_manager.get(run_data_manager.current_run_id)
+        if run_data_manager.current_run_id is not None
+        else None
+    )
     if (
         camera_enabled
         and live_stream_enabled
@@ -476,7 +493,8 @@ async def post_live_stream_settings(
             run_data_manager.current_run_id is not None
             and (
                 True
-                if run_data_manager.get(run_data_manager.current_run_id).status
+                if run_data is not None
+                and run_data.status
                 not in [
                     EngineStatus.IDLE,
                     EngineStatus.STOPPED,

--- a/robot-server/robot_server/service/notifications/publishers/maintenance_runs_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/maintenance_runs_publisher.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Annotated, Callable, Optional
+from typing import Annotated, Any, Callable, Coroutine, Optional
 
 from fastapi import Depends
 
@@ -21,7 +21,7 @@ class _RunHooks:
     """Generated during a protocol run. Utilized by MaintenanceRunsPublisher."""
 
     run_id: str
-    get_state_summary: Callable[[str], Optional[StateSummary]]
+    get_state_summary: Callable[[str], Coroutine[Any, Any, Optional[StateSummary]]]
 
 
 @dataclass
@@ -50,7 +50,7 @@ class MaintenanceRunsPublisher:
     async def start_publishing_for_maintenance_run(
         self,
         run_id: str,
-        get_state_summary: Callable[[str], Optional[StateSummary]],
+        get_state_summary: Callable[[str], Coroutine[Any, Any, Optional[StateSummary]]],
     ) -> None:
         """Initialize RunsPublisher with necessary information derived from the current run.
 
@@ -87,7 +87,7 @@ class MaintenanceRunsPublisher:
     async def _handle_engine_status_change(self) -> None:
         """Publish a refetch flag if the engine status has changed."""
         if self._run_hooks is not None and self._engine_state_slice is not None:
-            new_state_summary = self._run_hooks.get_state_summary(
+            new_state_summary = await self._run_hooks.get_state_summary(
                 self._run_hooks.run_id
             )
 

--- a/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Annotated, Callable, Optional
+from typing import Annotated, Any, Callable, Coroutine, Optional
 
 from fastapi import Depends
 
@@ -21,8 +21,10 @@ class _RunHooks:
 
     run_id: str
     get_current_command: Callable[[str], Optional[CommandPointer]]
-    get_recovery_target_command: Callable[[str], Optional[CommandPointer]]
-    get_state_summary: Callable[[str], Optional[StateSummary]]
+    get_recovery_target_command: Callable[
+        [str], Coroutine[Any, Any, Optional[CommandPointer]]
+    ]
+    get_state_summary: Callable[[str], Coroutine[Any, Any, Optional[StateSummary]]]
 
 
 @dataclass
@@ -57,12 +59,14 @@ class RunsPublisher:
         )
 
     # TODO(jh, 08-01-25): Free run_hooks and engine_state_slice during run cleanup for more predictable protocol engine GC.
-    def start_publishing_for_run(
+    async def start_publishing_for_run(
         self,
         run_id: str,
         get_current_command: Callable[[str], Optional[CommandPointer]],
-        get_recovery_target_command: Callable[[str], Optional[CommandPointer]],
-        get_state_summary: Callable[[str], Optional[StateSummary]],
+        get_recovery_target_command: Callable[
+            [str], Coroutine[Any, Any, Optional[CommandPointer]]
+        ],
+        get_state_summary: Callable[[str], Coroutine[Any, Any, Optional[StateSummary]]],
     ) -> None:
         """Initialize RunsPublisher with necessary information derived from the current run.
 
@@ -137,8 +141,10 @@ class RunsPublisher:
 
     async def _handle_recovery_target_command_change(self) -> None:
         if self._run_hooks is not None and self._engine_state_slice is not None:
-            new_recovery_target_command = self._run_hooks.get_recovery_target_command(
-                self._run_hooks.run_id
+            new_recovery_target_command = (
+                await self._run_hooks.get_recovery_target_command(
+                    self._run_hooks.run_id
+                )
             )
             if (
                 self._engine_state_slice.recovery_target_command
@@ -152,7 +158,7 @@ class RunsPublisher:
     async def _handle_relevant_engine_change(self) -> None:
         """Publish a refetch flag if relevant engine changes occur."""
         if self._run_hooks is not None and self._engine_state_slice is not None:
-            new_state_summary = self._run_hooks.get_state_summary(
+            new_state_summary = await self._run_hooks.get_state_summary(
                 self._run_hooks.run_id
             )
 

--- a/robot-server/tests/commands/test_router.py
+++ b/robot-server/tests/commands/test_router.py
@@ -45,8 +45,12 @@ async def test_create_command(
         result=None,
     )
 
-    def _stub_queued_command_state(*_a: object, **_k: object) -> pe_commands.Command:
-        decoy.when(run_orchestrator.get_command("abc123")).then_return(queued_command)
+    async def _stub_queued_command_state(
+        *_a: object, **_k: object
+    ) -> pe_commands.Command:
+        decoy.when(await run_orchestrator.get_command("abc123")).then_return(
+            queued_command
+        )
         return queued_command
 
     decoy.when(
@@ -99,7 +103,9 @@ async def test_create_command_wait_for_complete(
         )
     ).then_return(completed_command)
 
-    decoy.when(run_orchestrator.get_command("abc123")).then_return(completed_command)
+    decoy.when(await run_orchestrator.get_command("abc123")).then_return(
+        completed_command
+    )
 
     result = await create_command(
         RequestModel(data=command_create),
@@ -132,7 +138,7 @@ async def test_get_commands_list(
         params=pe_commands.HomeParams(),
     )
 
-    decoy.when(run_orchestrator.get_current_command()).then_return(
+    decoy.when(await run_orchestrator.get_current_command()).then_return(
         CommandPointer(
             command_id="abc123",
             command_key="command-key-1",
@@ -141,7 +147,7 @@ async def test_get_commands_list(
         )
     )
     decoy.when(
-        run_orchestrator.get_command_slice(
+        await run_orchestrator.get_command_slice(
             cursor=1337, length=42, include_fixit_commands=True
         )
     ).then_return(
@@ -172,7 +178,7 @@ async def test_get_command(
         params=pe_commands.HomeParams(),
     )
 
-    decoy.when(run_orchestrator.get_command("abc123")).then_return(command_1)
+    decoy.when(await run_orchestrator.get_command("abc123")).then_return(command_1)
 
     result = await get_command(commandId="abc123", orchestrator=run_orchestrator)
 
@@ -185,7 +191,7 @@ async def test_get_command_not_found(
     run_orchestrator: RunOrchestrator,
 ) -> None:
     """It should raise a 404 if command is not found."""
-    decoy.when(run_orchestrator.get_command("abc123")).then_raise(
+    decoy.when(await run_orchestrator.get_command("abc123")).then_raise(
         CommandDoesNotExistError("oh no")
     )
 

--- a/robot-server/tests/data_files/test_router.py
+++ b/robot-server/tests/data_files/test_router.py
@@ -662,7 +662,9 @@ async def test_delete_run_images(
     data_file_publisher: DataFilePublisher,
 ) -> None:
     """It should delete all images for a run."""
-    decoy.when(run_data_manager.get("run-id")).then_return(decoy.mock(name="run_data"))
+    decoy.when(await run_data_manager.get("run-id")).then_return(
+        decoy.mock(name="run_data")
+    )
     decoy.when(run_data_manager.current_run_id).then_return(None)
 
     result = await delete_run_images(
@@ -686,7 +688,7 @@ async def test_delete_run_images_run_not_found(
     data_file_publisher: DataFilePublisher,
 ) -> None:
     """It should raise an error if the run doesn't exist."""
-    decoy.when(run_data_manager.get("run-id")).then_raise(
+    decoy.when(await run_data_manager.get("run-id")).then_raise(
         RunNotFoundError(run_id="run-id")
     )
 
@@ -927,7 +929,9 @@ async def test_get_data_files_by_run_id(
     expected_length: int,
 ) -> None:
     """It should return metadata for all data files associated with a run."""
-    decoy.when(run_data_manager.get("run-id")).then_return(decoy.mock(name="run_data"))
+    decoy.when(await run_data_manager.get("run-id")).then_return(
+        decoy.mock(name="run_data")
+    )
 
     decoy.when(data_files_store.get_data_files_by_run_id("run-id")).then_return(
         DataFilesByRunInfo(
@@ -960,7 +964,7 @@ async def test_get_data_files_by_run_id_run_not_found(
     run_data_manager: RunDataManager,
 ) -> None:
     """It should raise an error if the run doesn't exist."""
-    decoy.when(run_data_manager.get("run-id")).then_raise(
+    decoy.when(await run_data_manager.get("run-id")).then_raise(
         RunNotFoundError(run_id="run-id")
     )
 

--- a/robot-server/tests/maintenance_runs/router/test_base_router.py
+++ b/robot-server/tests/maintenance_runs/router/test_base_router.py
@@ -179,7 +179,7 @@ async def test_get_run_data_from_url(
         hasEverEnteredErrorRecovery=False,
     )
 
-    decoy.when(mock_maintenance_run_data_manager.get("run-id")).then_return(
+    decoy.when(await mock_maintenance_run_data_manager.get("run-id")).then_return(
         expected_response
     )
 
@@ -259,9 +259,9 @@ async def test_get_current_run(
     decoy.when(mock_maintenance_run_data_manager.current_run_id).then_return(
         "current-run-id"
     )
-    decoy.when(mock_maintenance_run_data_manager.get("current-run-id")).then_return(
-        current_run_data
-    )
+    decoy.when(
+        await mock_maintenance_run_data_manager.get("current-run-id")
+    ).then_return(current_run_data)
 
     result = await get_current_run(run_data_manager=mock_maintenance_run_data_manager)
 
@@ -320,7 +320,7 @@ async def test_delete_run_by_id_with_external_run(
     """It should pass in external camera settings if an external run exists when deleting a maintenance run."""
     assert mock_run_data_manager.current_run_id is not None
     decoy.when(
-        mock_run_data_manager._get_good_state_summary(
+        await mock_run_data_manager._get_good_state_summary(
             mock_run_data_manager.current_run_id
         )
     ).then_return(

--- a/robot-server/tests/maintenance_runs/router/test_commands_router.py
+++ b/robot-server/tests/maintenance_runs/router/test_commands_router.py
@@ -112,7 +112,7 @@ async def test_create_run_command(
     ).then_return(command_once_added)
 
     decoy.when(
-        mock_maintenance_run_orchestrator_store.get_command("command-id")
+        await mock_maintenance_run_orchestrator_store.get_command("command-id")
     ).then_return(command_once_added)
 
     result = await create_run_command(
@@ -158,7 +158,7 @@ async def test_create_run_command_blocking_completion(
     ).then_return(command_once_completed)
 
     decoy.when(
-        mock_maintenance_run_orchestrator_store.get_command("command-id")
+        await mock_maintenance_run_orchestrator_store.get_command("command-id")
     ).then_return(command_once_completed)
 
     result = await create_run_command(
@@ -230,7 +230,7 @@ async def test_create_run_command_door_open_allows_when_opted_out(
     ).then_return(command_once_added)
 
     decoy.when(
-        mock_maintenance_run_orchestrator_store.get_command("command-id")
+        await mock_maintenance_run_orchestrator_store.get_command("command-id")
     ).then_return(command_once_added)
 
     result = await create_run_command(
@@ -271,7 +271,7 @@ async def test_get_run_commands(
     )
 
     decoy.when(
-        mock_maintenance_run_data_manager.get_current_command("run-id")
+        await mock_maintenance_run_data_manager.get_current_command("run-id")
     ).then_return(
         CommandPointer(
             command_id="current-command-id",
@@ -281,7 +281,7 @@ async def test_get_run_commands(
         )
     )
     decoy.when(
-        mock_maintenance_run_data_manager.get_recovery_target_command("run-id")
+        await mock_maintenance_run_data_manager.get_recovery_target_command("run-id")
     ).then_return(
         CommandPointer(
             command_id="recovery-target-command-id",
@@ -292,7 +292,7 @@ async def test_get_run_commands(
     )
 
     decoy.when(
-        mock_maintenance_run_data_manager.get_commands_slice(
+        await mock_maintenance_run_data_manager.get_commands_slice(
             run_id="run-id",
             cursor=None,
             length=42,
@@ -358,10 +358,10 @@ async def test_get_run_commands_empty(
 ) -> None:
     """It should return an empty commands list if no commands."""
     decoy.when(
-        mock_maintenance_run_data_manager.get_current_command("run-id")
+        await mock_maintenance_run_data_manager.get_current_command("run-id")
     ).then_return(None)
     decoy.when(
-        mock_maintenance_run_data_manager.get_commands_slice(
+        await mock_maintenance_run_data_manager.get_commands_slice(
             run_id="run-id", cursor=21, length=42
         )
     ).then_return(CommandSlice(commands=[], cursor=0, total_length=0))
@@ -387,7 +387,7 @@ async def test_get_run_commands_not_found(
     not_found_error = MaintenanceRunNotFoundError("oh no")
 
     decoy.when(
-        mock_maintenance_run_data_manager.get_commands_slice(
+        await mock_maintenance_run_data_manager.get_commands_slice(
             run_id="run-id", cursor=21, length=42
         )
     ).then_raise(not_found_error)
@@ -420,7 +420,7 @@ async def test_get_run_command_by_id(
     )
 
     decoy.when(
-        mock_maintenance_run_data_manager.get_command("run-id", "command-id")
+        await mock_maintenance_run_data_manager.get_command("run-id", "command-id")
     ).then_return(command)
 
     result = await get_run_command(
@@ -447,7 +447,7 @@ async def test_get_run_command_missing(
 ) -> None:
     """It should 404 if you attempt to get a non-existent command."""
     decoy.when(
-        mock_maintenance_run_data_manager.get_command(
+        await mock_maintenance_run_data_manager.get_command(
             run_id="run-id", command_id="command-id"
         )
     ).then_raise(exception)

--- a/robot-server/tests/maintenance_runs/router/test_labware_router.py
+++ b/robot-server/tests/maintenance_runs/router/test_labware_router.py
@@ -87,12 +87,12 @@ async def test_add_labware_offsets(
     )
 
     decoy.when(
-        mock_maintenance_run_orchestrator_store.add_labware_offset(
+        await mock_maintenance_run_orchestrator_store.add_labware_offset(
             labware_offset_request_1
         )
     ).then_return(labware_offset_1)
     decoy.when(
-        mock_maintenance_run_orchestrator_store.add_labware_offset(
+        await mock_maintenance_run_orchestrator_store.add_labware_offset(
             labware_offset_request_2
         )
     ).then_return(labware_offset_2)
@@ -134,7 +134,7 @@ async def test_add_labware_definition(
     uri = pe_types.LabwareUri("some/definition/uri")
 
     decoy.when(
-        mock_maintenance_run_orchestrator_store.add_labware_definition(
+        await mock_maintenance_run_orchestrator_store.add_labware_definition(
             labware_definition
         )
     ).then_return(uri)

--- a/robot-server/tests/maintenance_runs/test_engine_store.py
+++ b/robot-server/tests/maintenance_runs/test_engine_store.py
@@ -194,7 +194,7 @@ async def test_estop_callback(
     decoy.when(run_orchestrator_store.current_run_id).then_return(None)
     await handle_estop_event(run_orchestrator_store, disengage_event)
     decoy.verify(
-        run_orchestrator_store.run_orchestrator.estop(),
+        await run_orchestrator_store.run_orchestrator.estop(),
         ignore_extra_args=True,
         times=0,
     )
@@ -207,7 +207,7 @@ async def test_estop_callback(
     decoy.when(run_orchestrator_store.current_run_id).then_return("fake-run-id")
     await handle_estop_event(run_orchestrator_store, engage_event)
     decoy.verify(
-        run_orchestrator_store.run_orchestrator.estop(),
+        await run_orchestrator_store.run_orchestrator.estop(),
         await run_orchestrator_store.run_orchestrator.finish(
             error=matchers.IsA(EStopActivatedError)
         ),

--- a/robot-server/tests/maintenance_runs/test_engine_store.py
+++ b/robot-server/tests/maintenance_runs/test_engine_store.py
@@ -155,7 +155,7 @@ async def test_clear_engine_not_stopped_or_idle(
         created_at=datetime(2023, 6, 1),
         notify_publishers=mock_notify_publishers,
     )
-    subject.run_orchestrator.play()
+    await subject.run_orchestrator.play()
 
     with pytest.raises(RunConflictError):
         await subject.clear()

--- a/robot-server/tests/maintenance_runs/test_run_data_manager.py
+++ b/robot-server/tests/maintenance_runs/test_run_data_manager.py
@@ -305,14 +305,14 @@ async def test_get_current_run(
     decoy.when(mock_maintenance_run_orchestrator_store.current_run_id).then_return(
         run_id
     )
-    decoy.when(mock_maintenance_run_orchestrator_store.get_state_summary()).then_return(
-        engine_state_summary
-    )
+    decoy.when(
+        await mock_maintenance_run_orchestrator_store.get_state_summary()
+    ).then_return(engine_state_summary)
     decoy.when(
         mock_maintenance_run_orchestrator_store.current_run_created_at
     ).then_return(datetime(2023, 1, 1))
 
-    result = subject.get(run_id=run_id)
+    result = await subject.get(run_id=run_id)
 
     assert result == MaintenanceRun(
         current=True,
@@ -348,7 +348,7 @@ async def test_get_run_not_current(
         "not-current-id"
     )
     with pytest.raises(MaintenanceRunNotFoundError):
-        subject.get(run_id=run_id)
+        await subject.get(run_id=run_id)
 
 
 async def test_delete_current_run(
@@ -375,7 +375,7 @@ async def test_delete_current_run(
     )
 
 
-def test_get_commands_slice_current_run(
+async def test_get_commands_slice_current_run(
     decoy: Decoy,
     subject: MaintenanceRunDataManager,
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
@@ -403,9 +403,9 @@ def test_get_commands_slice_current_run(
         "run-id"
     )
     decoy.when(
-        mock_maintenance_run_orchestrator_store.get_command_slice(1, 2)
+        await mock_maintenance_run_orchestrator_store.get_command_slice(1, 2)
     ).then_return(expected_command_slice)
 
-    result = subject.get_commands_slice("run-id", 1, 2)
+    result = await subject.get_commands_slice("run-id", 1, 2)
 
     assert expected_command_slice == result

--- a/robot-server/tests/protocols/test_analyses_manager.py
+++ b/robot-server/tests/protocols/test_analyses_manager.py
@@ -169,7 +169,7 @@ async def test_raises_error_and_saves_result_if_initialization_errors(
             run_time_param_paths={},
         )
     ).then_raise(raised_exception)
-    decoy.when(analyzer.get_verified_run_time_parameters()).then_return([])
+    decoy.when(await analyzer.get_verified_run_time_parameters()).then_return([])
     decoy.when(em.map_unexpected_error(error=raised_exception)).then_return(
         enumerated_error
     )
@@ -225,7 +225,7 @@ async def test_start_analysis(
     )
     analyzer = decoy.mock(cls=protocol_analyzer.ProtocolAnalyzer)
     decoy.when(analyzer.protocol_resource).then_return(protocol_resource)
-    decoy.when(analyzer.get_verified_run_time_parameters()).then_return(
+    decoy.when(await analyzer.get_verified_run_time_parameters()).then_return(
         [bool_parameter]
     )
     analysis_summary_result = await subject.start_analysis(

--- a/robot-server/tests/protocols/test_analyses_manager.py
+++ b/robot-server/tests/protocols/test_analyses_manager.py
@@ -193,7 +193,8 @@ async def test_raises_error_and_saves_result_if_initialization_errors(
                     error=enumerated_error,
                 )
             ],
-        )
+        ),
+        await analyzer.clean_up(),
     )
 
 

--- a/robot-server/tests/protocols/test_protocol_analyzer.py
+++ b/robot-server/tests/protocols/test_protocol_analyzer.py
@@ -347,7 +347,7 @@ async def test_analyze_updates_pending_on_error(
             deck_configuration=[],
         )
     ).then_raise(raised_exception)
-    decoy.when(orchestrator.get_run_time_parameters()).then_return([])
+    decoy.when(await orchestrator.get_run_time_parameters()).then_return([])
     decoy.when(em.map_unexpected_error(error=raised_exception)).then_return(
         enumerated_error
     )

--- a/robot-server/tests/protocols/test_protocol_analyzer.py
+++ b/robot-server/tests/protocols/test_protocol_analyzer.py
@@ -265,6 +265,7 @@ async def test_analyze(
             command_preconditions=command_preconditions,
         )
     )
+    decoy.when(await orchestrator.get_is_okay_to_clear()).then_return(True)
 
     await subject.analyze(
         analysis_id="analysis-id",
@@ -355,6 +356,7 @@ async def test_analyze_updates_pending_on_error(
     decoy.when(datetime_helper.utc_now()).then_return(
         datetime(year=2023, month=3, day=3)
     )
+    decoy.when(await orchestrator.get_is_okay_to_clear()).then_return(True)
     await subject.load_orchestrator(
         run_time_param_values={"rtp_var": 123}, run_time_param_paths={}
     )

--- a/robot-server/tests/protocols/test_protocols_router.py
+++ b/robot-server/tests/protocols/test_protocols_router.py
@@ -1234,6 +1234,7 @@ async def test_create_existing_protocol_with_same_run_time_params(
         key="dummy-key-222",
     )
     assert result.status_code == 200
+    decoy.verify(await analyzer.clean_up())
 
 
 async def test_create_existing_protocol_with_pending_analysis_raises(
@@ -1824,6 +1825,7 @@ async def test_create_protocol_analyses_with_same_rtp_values(
     )
     assert result.content.data == analysis_summaries
     assert result.status_code == 200
+    decoy.verify(await analyzer.clean_up())
 
 
 async def test_update_protocol_analyses_with_new_rtp_values(

--- a/robot-server/tests/protocols/test_protocols_router.py
+++ b/robot-server/tests/protocols/test_protocols_router.py
@@ -501,7 +501,7 @@ async def test_create_existing_protocol(
             run_time_param_paths={},
         )
     ).then_return(analyzer)
-    decoy.when(analyzer.get_verified_run_time_parameters()).then_return([])
+    decoy.when(await analyzer.get_verified_run_time_parameters()).then_return([])
     decoy.when(
         await analysis_store.matching_rtp_values_in_analysis(
             last_analysis_summary=completed_analysis, new_parameters=[]
@@ -626,7 +626,7 @@ async def test_create_protocol(
             run_time_param_paths={},
         )
     ).then_return(analyzer)
-    decoy.when(analyzer.get_verified_run_time_parameters()).then_return([])
+    decoy.when(await analyzer.get_verified_run_time_parameters()).then_return([])
     decoy.when(
         await analyses_manager.start_analysis(
             analysis_id="analysis-id",
@@ -1049,7 +1049,7 @@ async def test_create_existing_protocol_with_different_run_time_params(
             },
         )
     ).then_return(analyzer)
-    decoy.when(analyzer.get_verified_run_time_parameters()).then_return(
+    decoy.when(await analyzer.get_verified_run_time_parameters()).then_return(
         [run_time_parameter]
     )
     decoy.when(
@@ -1189,7 +1189,7 @@ async def test_create_existing_protocol_with_same_run_time_params(
             run_time_param_paths={},
         )
     ).then_return(analyzer)
-    decoy.when(analyzer.get_verified_run_time_parameters()).then_return(
+    decoy.when(await analyzer.get_verified_run_time_parameters()).then_return(
         [run_time_parameter]
     )
     decoy.when(
@@ -1323,7 +1323,7 @@ async def test_create_existing_protocol_with_pending_analysis_raises(
             run_time_param_paths={},
         )
     ).then_return(analyzer)
-    decoy.when(analyzer.get_verified_run_time_parameters()).then_return(
+    decoy.when(await analyzer.get_verified_run_time_parameters()).then_return(
         [run_time_parameter]
     )
     decoy.when(
@@ -1800,7 +1800,7 @@ async def test_create_protocol_analyses_with_same_rtp_values(
             run_time_param_paths={},
         )
     ).then_return(analyzer)
-    decoy.when(analyzer.get_verified_run_time_parameters()).then_return(
+    decoy.when(await analyzer.get_verified_run_time_parameters()).then_return(
         [run_time_parameter]
     )
     decoy.when(
@@ -1912,7 +1912,7 @@ async def test_update_protocol_analyses_with_new_rtp_values(
             run_time_param_paths=rtp_files,
         )
     ).then_return(analyzer)
-    decoy.when(analyzer.get_verified_run_time_parameters()).then_return(
+    decoy.when(await analyzer.get_verified_run_time_parameters()).then_return(
         [run_time_parameter, csv_parameter]
     )
     decoy.when(

--- a/robot-server/tests/runs/router/test_actions_router.py
+++ b/robot-server/tests/runs/router/test_actions_router.py
@@ -64,7 +64,7 @@ async def test_create_run_action(
     ).then_return([])
     decoy.when(mock_maintenance_run_orchestrator_store.current_run_id).then_return(None)
     decoy.when(
-        mock_run_controller.create_action(
+        await mock_run_controller.create_action(
             action_id=action_id,
             action_type=action_type,
             created_at=created_at,
@@ -117,7 +117,7 @@ async def test_play_action_clears_maintenance_run(
         "some-id"
     )
     decoy.when(
-        mock_run_controller.create_action(
+        await mock_run_controller.create_action(
             action_id=action_id,
             action_type=action_type,
             created_at=created_at,
@@ -175,7 +175,7 @@ async def test_create_play_action_not_allowed(
     ).then_return([])
     decoy.when(mock_maintenance_run_orchestrator_store.current_run_id).then_return(None)
     decoy.when(
-        mock_run_controller.create_action(
+        await mock_run_controller.create_action(
             action_id=action_id,
             action_type=action_type,
             created_at=created_at,

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -703,7 +703,7 @@ async def test_get_run_data_from_url(
         hasEverEnteredErrorRecovery=False,
     )
 
-    decoy.when(mock_run_data_manager.get("run-id")).then_return(expected_response)
+    decoy.when(await mock_run_data_manager.get("run-id")).then_return(expected_response)
 
     result = await get_run_data_from_url(
         runId="run-id",
@@ -720,7 +720,9 @@ async def test_get_run_with_missing_id(
     """It should 404 if the run ID does not exist."""
     not_found_error = RunNotFoundError(run_id="run-id")
 
-    decoy.when(mock_run_data_manager.get(run_id="run-id")).then_raise(not_found_error)
+    decoy.when(await mock_run_data_manager.get(run_id="run-id")).then_raise(
+        not_found_error
+    )
 
     with pytest.raises(ApiError) as exc_info:
         await get_run_data_from_url(
@@ -764,7 +766,7 @@ async def test_get_runs_empty(
     mock_run_data_manager: RunDataManager,
 ) -> None:
     """It should return an empty collection response when no runs exist."""
-    decoy.when(mock_run_data_manager.get_all(length=20)).then_return([])
+    decoy.when(await mock_run_data_manager.get_all(length=20)).then_return([])
     decoy.when(mock_run_data_manager.current_run_id).then_return(None)
 
     result = await get_runs(run_data_manager=mock_run_data_manager, pageLength=20)
@@ -821,7 +823,9 @@ async def test_get_runs_not_empty(
         hasEverEnteredErrorRecovery=False,
     )
 
-    decoy.when(mock_run_data_manager.get_all(20)).then_return([response_1, response_2])
+    decoy.when(await mock_run_data_manager.get_all(20)).then_return(
+        [response_1, response_2]
+    )
     decoy.when(mock_run_data_manager.current_run_id).then_return("unique-id-2")
 
     result = await get_runs(run_data_manager=mock_run_data_manager, pageLength=20)
@@ -994,7 +998,7 @@ async def test_update_current_none_noop(
         hasEverEnteredErrorRecovery=False,
     )
 
-    decoy.when(mock_run_data_manager.get("run-id")).then_return(expected_response)
+    decoy.when(await mock_run_data_manager.get("run-id")).then_return(expected_response)
 
     result = await update_run(
         runId="run-id",
@@ -1043,7 +1047,9 @@ async def test_update_run_signed_by_and_uncurrent(
     uncurrent_response = signed_response.model_copy(update={"current": False})
 
     decoy.when(
-        mock_run_data_manager.set_signed_by(run_id="run-id", signed_by="Alice Example")
+        await mock_run_data_manager.set_signed_by(
+            run_id="run-id", signed_by="Alice Example"
+        )
     ).then_return(signed_response)
     decoy.when(
         await mock_run_data_manager.uncurrent("run-id", access_control_status=False)
@@ -1080,7 +1086,9 @@ async def test_update_run_not_complete(
 ) -> None:
     """It should 409 if signing a run that has not completed."""
     decoy.when(
-        mock_run_data_manager.set_signed_by(run_id="run-id", signed_by="Alice Example")
+        await mock_run_data_manager.set_signed_by(
+            run_id="run-id", signed_by="Alice Example"
+        )
     ).then_raise(RunNotCompleteError("oh no"))
 
     with pytest.raises(ApiError) as exc_info:
@@ -1286,7 +1294,9 @@ async def test_update_run_signed_by(
     )
 
     decoy.when(
-        mock_run_data_manager.set_signed_by(run_id="run-id", signed_by="Alice Example")
+        await mock_run_data_manager.set_signed_by(
+            run_id="run-id", signed_by="Alice Example"
+        )
     ).then_return(expected_response)
 
     result = await update_run(
@@ -1310,14 +1320,16 @@ async def test_get_run_commands_errors(
 ) -> None:
     """It should return a list of all commands errors in a run."""
     decoy.when(
-        mock_run_data_manager.get_command_error_slice(
+        await mock_run_data_manager.get_command_error_slice(
             run_id="run-id",
             cursor=0,
             length=42,
         )
     ).then_raise(RunNotCurrentError("oh no!"))
 
-    decoy.when(mock_run_data_manager.get_command_errors_count("run-id")).then_return(1)
+    decoy.when(
+        await mock_run_data_manager.get_command_errors_count("run-id")
+    ).then_return(1)
 
     with pytest.raises(ApiError):
         result = await get_run_commands_error(
@@ -1339,14 +1351,16 @@ async def test_get_run_commands_errors_raises_no_run(
         createdAt=datetime(year=2024, month=4, day=4),
         detail="Things are not looking good.",
     )
-    decoy.when(mock_run_data_manager.get_command_errors_count("run-id")).then_return(1)
+    decoy.when(
+        await mock_run_data_manager.get_command_errors_count("run-id")
+    ).then_return(1)
 
     command_error_slice = CommandErrorSlice(
         cursor=1, total_length=3, commands_errors=[error]
     )
 
     decoy.when(
-        mock_run_data_manager.get_command_error_slice(
+        await mock_run_data_manager.get_command_error_slice(
             run_id="run-id",
             cursor=0,
             length=42,
@@ -1383,14 +1397,16 @@ async def test_get_run_commands_errors_default_cursor(
     expected_cursor_result: int,
 ) -> None:
     """It should return a list of all commands errors in a run."""
-    decoy.when(mock_run_data_manager.get_command_errors_count("run-id")).then_return(1)
+    decoy.when(
+        await mock_run_data_manager.get_command_errors_count("run-id")
+    ).then_return(1)
 
     command_error_slice = CommandErrorSlice(
         cursor=expected_cursor_result, total_length=3, commands_errors=error_list
     )
 
     decoy.when(
-        mock_run_data_manager.get_command_error_slice(
+        await mock_run_data_manager.get_command_error_slice(
             run_id="run-id",
             cursor=0,
             length=42,
@@ -1526,7 +1542,7 @@ async def test_get_current_state_run_not_current(
     """It should raise RunStopped when the run is not current."""
     run_id = "non-current-run-id"
 
-    decoy.when(mock_run_data_manager.get(run_id=run_id)).then_raise(
+    decoy.when(await mock_run_data_manager.get(run_id=run_id)).then_raise(
         RunNotCurrentError("Run is not current")
     )
 

--- a/robot-server/tests/runs/router/test_camera_router.py
+++ b/robot-server/tests/runs/router/test_camera_router.py
@@ -77,14 +77,16 @@ async def test_camera_settings(
     )
 
     decoy.verify(
-        mock_run_orchestrator_store.add_camera_capture_image_settings(image_settings)
+        await mock_run_orchestrator_store.add_camera_capture_image_settings(
+            image_settings
+        )
     )
 
     assert result.content.data == image_settings
     assert result.status_code == 201
 
     decoy.when(
-        mock_run_orchestrator_store.get_camera_capture_image_settings(
+        await mock_run_orchestrator_store.get_camera_capture_image_settings(
             "ot_system_camera"
         )
     ).then_return(image_settings)

--- a/robot-server/tests/runs/router/test_command_annotations_router.py
+++ b/robot-server/tests/runs/router/test_command_annotations_router.py
@@ -49,7 +49,7 @@ async def test_get_command_annotations_slice(
         total_length=400,
     )
     decoy.when(
-        mock_run_data_manager.get_command_annotations_slice(
+        await mock_run_data_manager.get_command_annotations_slice(
             run_id="run-id", cursor=1, length=4
         )
     ).then_return(expected_annotations)
@@ -114,10 +114,10 @@ async def test_get_command_annotations_slice_uses_default_values(
         total_length=456,
     )
     decoy.when(
-        mock_run_data_manager.get_total_command_annotations_count("run-id")
+        await mock_run_data_manager.get_total_command_annotations_count("run-id")
     ).then_return(total_annotations_in_run)
     decoy.when(
-        mock_run_data_manager.get_command_annotations_slice(
+        await mock_run_data_manager.get_command_annotations_slice(
             run_id="run-id",
             cursor=expected_cursor,
             length=expected_page_length,
@@ -150,10 +150,10 @@ async def test_get_command_annotations_slice_cursor_calculation_non_default_page
         total_length=456,
     )
     decoy.when(
-        mock_run_data_manager.get_total_command_annotations_count("run-id")
+        await mock_run_data_manager.get_total_command_annotations_count("run-id")
     ).then_return(total_annotations_in_run)
     decoy.when(
-        mock_run_data_manager.get_command_annotations_slice(
+        await mock_run_data_manager.get_command_annotations_slice(
             run_id="run-id",
             cursor=expected_cursor,
             length=page_length,
@@ -180,7 +180,7 @@ async def test_get_command_annotations_slice_with_non_default_cursor(
         total_length=456,
     )
     decoy.when(
-        mock_run_data_manager.get_command_annotations_slice(
+        await mock_run_data_manager.get_command_annotations_slice(
             run_id="run-id",
             cursor=100,
             length=4,
@@ -208,7 +208,7 @@ async def test_get_specified_command_annotation(
         params={},
     )
     decoy.when(
-        mock_run_data_manager.get_command_annotation("run-id", "annotation-id")
+        await mock_run_data_manager.get_command_annotation("run-id", "annotation-id")
     ).then_return(expected_annotation)
     result = await get_command_annotation(
         runId="run-id",
@@ -234,7 +234,7 @@ async def test_get_command_annotation_raises_errors(
 ) -> None:
     """It should 404 if you attempt to get a non-existent command annotation."""
     decoy.when(
-        mock_run_data_manager.get_command_annotation("run-id", "annotation-id")
+        await mock_run_data_manager.get_command_annotation("run-id", "annotation-id")
     ).then_raise(exception)
 
     with pytest.raises(ApiError) as exc_info:

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -112,10 +112,12 @@ async def test_create_run_command(
         params=pe_commands.WaitForResumeParams(message="Hello"),
     )
 
-    def _stub_queued_command_state(*_a: object, **_k: object) -> pe_commands.Command:
-        decoy.when(mock_run_orchestrator_store.get_command("command-id")).then_return(
-            command_once_added
-        )
+    async def _stub_queued_command_state(
+        *_a: object, **_k: object
+    ) -> pe_commands.Command:
+        decoy.when(
+            await mock_run_orchestrator_store.get_command("command-id")
+        ).then_return(command_once_added)
         return command_once_added
 
     decoy.when(
@@ -201,7 +203,7 @@ async def test_create_run_command_blocking_completion(
         )
     ).then_return(command_once_completed)
 
-    decoy.when(mock_run_orchestrator_store.get_command("command-id")).then_return(
+    decoy.when(await mock_run_orchestrator_store.get_command("command-id")).then_return(
         command_once_completed
     )
 
@@ -338,7 +340,9 @@ async def test_get_run_commands(
             index=101,
         )
     )
-    decoy.when(mock_run_data_manager.get_recovery_target_command("run-id")).then_return(
+    decoy.when(
+        await mock_run_data_manager.get_recovery_target_command("run-id")
+    ).then_return(
         CommandPointer(
             command_id="recovery-target-command-id",
             command_key="recovery-target-command-key",
@@ -347,7 +351,7 @@ async def test_get_run_commands(
         )
     )
     decoy.when(
-        mock_run_data_manager.get_commands_slice(
+        await mock_run_data_manager.get_commands_slice(
             run_id="run-id", cursor=None, length=42, include_fixit_commands=True
         )
     ).then_return(CommandSlice(commands=[command], cursor=1, total_length=3))
@@ -414,7 +418,7 @@ async def test_get_run_commands_empty(
     """It should return an empty commands list if no commands."""
     decoy.when(mock_run_data_manager.get_current_command("run-id")).then_return(None)
     decoy.when(
-        mock_run_data_manager.get_commands_slice(
+        await mock_run_data_manager.get_commands_slice(
             run_id="run-id", cursor=21, length=42, include_fixit_commands=True
         )
     ).then_return(CommandSlice(commands=[], cursor=0, total_length=0))
@@ -441,7 +445,7 @@ async def test_get_run_commands_not_found(
     not_found_error = RunNotFoundError("oh no")
 
     decoy.when(
-        mock_run_data_manager.get_commands_slice(
+        await mock_run_data_manager.get_commands_slice(
             run_id="run-id", cursor=21, length=42, include_fixit_commands=True
         )
     ).then_raise(not_found_error)
@@ -471,9 +475,9 @@ async def test_get_run_command_by_id(
         params=pe_commands.MoveToWellParams(pipetteId="a", labwareId="b", wellName="c"),
     )
 
-    decoy.when(mock_run_data_manager.get_command("run-id", "command-id")).then_return(
-        command
-    )
+    decoy.when(
+        await mock_run_data_manager.get_command("run-id", "command-id")
+    ).then_return(command)
 
     result = await get_run_command(
         runId="run-id",
@@ -499,7 +503,9 @@ async def test_get_run_command_missing(
 ) -> None:
     """It should 404 if you attempt to get a non-existent command."""
     decoy.when(
-        mock_run_data_manager.get_command(run_id="run-id", command_id="command-id")
+        await mock_run_data_manager.get_command(
+            run_id="run-id", command_id="command-id"
+        )
     ).then_raise(exception)
 
     with pytest.raises(ApiError) as exc_info:

--- a/robot-server/tests/runs/router/test_error_recovery_policy_router.py
+++ b/robot-server/tests/runs/router/test_error_recovery_policy_router.py
@@ -23,7 +23,7 @@ async def test_put(decoy: Decoy, mock_run_data_manager: RunDataManager) -> None:
         run_data_manager=mock_run_data_manager,
     )
     decoy.verify(
-        mock_run_data_manager.set_error_recovery_rules(
+        await mock_run_data_manager.set_error_recovery_rules(
             run_id="run-id", rules=policies.policyRules
         )
     )
@@ -35,7 +35,7 @@ async def test_put_raises_not_active_run(
     """It should raise that the run is not current."""
     policies = decoy.mock(cls=er_models.ErrorRecoveryPolicy)
     decoy.when(
-        mock_run_data_manager.set_error_recovery_rules(  # type: ignore[func-returns-value]
+        await mock_run_data_manager.set_error_recovery_rules(  # type: ignore[func-returns-value]
             run_id="run-id", rules=policies.policyRules
         )
     ).then_raise(RunNotCurrentError())

--- a/robot-server/tests/runs/router/test_file_download_router.py
+++ b/robot-server/tests/runs/router/test_file_download_router.py
@@ -72,7 +72,7 @@ async def _read_and_cleanup_zip(result: FileResponse) -> zipfile.ZipFile:
     return zipfile.ZipFile(io.BytesIO(zip_bytes))
 
 
-def _stub_run_record_for_download(
+async def _stub_run_record_for_download(
     decoy: Decoy,
     run_data_manager: RunDataManager,
     *,
@@ -86,13 +86,13 @@ def _stub_run_record_for_download(
     )
     decoy.when(mock_run_record.labwareOffsets).then_return(labware_offsets or [])
     decoy.when(mock_run_record.runTimeParameters).then_return(run_time_parameters or [])
-    decoy.when(run_data_manager.get(run_id)).then_return(mock_run_record)
+    decoy.when(await run_data_manager.get(run_id)).then_return(mock_run_record)
 
     command = _make_home_command()
     empty_slice = CommandSlice(commands=[], cursor=0, total_length=1)
     full_slice = CommandSlice(commands=[command], cursor=0, total_length=1)
     decoy.when(
-        run_data_manager.get_commands_slice(
+        await run_data_manager.get_commands_slice(
             run_id=run_id,
             cursor=0,
             length=0,
@@ -100,7 +100,7 @@ def _stub_run_record_for_download(
         )
     ).then_return(empty_slice)
     decoy.when(
-        run_data_manager.get_commands_slice(
+        await run_data_manager.get_commands_slice(
             run_id=run_id,
             cursor=0,
             length=1,
@@ -235,7 +235,7 @@ async def test_download_run_files_with_images_protocol_run_log_and_offsets(
             stored=True,
         )
     )
-    _stub_run_record_for_download(
+    await _stub_run_record_for_download(
         decoy,
         mock_run_data_manager,
         labware_offsets=[labware_offset],
@@ -459,7 +459,9 @@ async def test_download_run_files_skips_missing_run_log_and_offsets_silently(
         datetime(2024, 6, 20, 10, 30, 15, tzinfo=timezone.utc)
     )
     decoy.when(mock_run_store.get("run-id")).then_return(mock_run)
-    decoy.when(mock_run_data_manager.get("run-id")).then_raise(RuntimeError("boom"))
+    decoy.when(await mock_run_data_manager.get("run-id")).then_raise(
+        RuntimeError("boom")
+    )
 
     result = await download_run_files(
         runId="run-id",
@@ -560,7 +562,9 @@ async def test_download_run_files_requested_but_missing_returns_204(
         )
     ).then_return(DataFileWithCommandsInfoSlice(file_info=[], total_length=0))
     _stub_empty_output_files(decoy, data_files_store)
-    decoy.when(mock_run_data_manager.get("run-id")).then_raise(RuntimeError("skip"))
+    decoy.when(await mock_run_data_manager.get("run-id")).then_raise(
+        RuntimeError("skip")
+    )
 
     result = await download_run_files(
         runId="run-id",

--- a/robot-server/tests/runs/router/test_labware_router.py
+++ b/robot-server/tests/runs/router/test_labware_router.py
@@ -91,10 +91,10 @@ async def test_add_labware_offsets(
     )
 
     decoy.when(
-        mock_run_orchestrator_store.add_labware_offset(labware_offset_request_1)
+        await mock_run_orchestrator_store.add_labware_offset(labware_offset_request_1)
     ).then_return(labware_offset_1)
     decoy.when(
-        mock_run_orchestrator_store.add_labware_offset(labware_offset_request_2)
+        await mock_run_orchestrator_store.add_labware_offset(labware_offset_request_2)
     ).then_return(labware_offset_2)
 
     result = await add_labware_offset(
@@ -159,7 +159,7 @@ async def test_add_labware_definition(
     uri = pe_types.LabwareUri("some/definition/uri")
 
     decoy.when(
-        mock_run_orchestrator_store.add_labware_definition(labware_definition)
+        await mock_run_orchestrator_store.add_labware_definition(labware_definition)
     ).then_return(uri)
 
     result = await add_labware_definition(
@@ -197,7 +197,7 @@ async def test_get_run_labware_definition(
 ) -> None:
     """It should wrap the run's labware defintion in a response."""
     decoy.when(
-        mock_run_data_manager.get_run_loaded_labware_definitions(run_id="run-id")
+        await mock_run_data_manager.get_run_loaded_labware_definitions(run_id="run-id")
     ).then_return(
         [
             SD_LabwareDefinition2.model_construct(namespace="test_1"),  # type: ignore[call-arg]

--- a/robot-server/tests/runs/test_light_control_task.py
+++ b/robot-server/tests/runs/test_light_control_task.py
@@ -72,7 +72,7 @@ async def test_get_current_status_ot2(
     decoy.when(run_orchestrator_store.current_run_id).then_return(
         "fake_id" if active else None
     )
-    decoy.when(run_orchestrator_store.get_status()).then_return(status)
+    decoy.when(await run_orchestrator_store.get_status()).then_return(status)
     decoy.when(hardware_api.get_estop_state()).then_return(estop)
     subject._hardware_state_store.update_hardware_status_callback(
         event=EstopStateNotification()
@@ -84,7 +84,7 @@ async def test_get_current_status_ot2(
         engine_status=status if active else None,
     )
 
-    assert subject.get_current_status() == expected
+    assert await subject.get_current_status() == expected
 
 
 @pytest.mark.parametrize(
@@ -126,7 +126,8 @@ async def test_get_current_status(
         event=SubsystemConnectionNotification()
     )
 
-    result = subject.get_current_status().active_updates
+    current_status = await subject.get_current_status()
+    result = current_status.active_updates
     assert len(result) == len(active_updates)
     for subsystem in result:
         assert subsystem in active_updates
@@ -220,17 +221,19 @@ async def test_provide_run_orchestrator_store(
     )
     decoy.when(hardware_api.get_estop_state()).then_return(EstopState.DISENGAGED)
     hardware_store.update_hardware_status_callback(event=EstopStateNotification())
-    assert subject.get_current_status() == Status(
+    assert await subject.get_current_status() == Status(
         active_updates=[],
         estop_status=EstopState.DISENGAGED,
         engine_status=None,
     )
 
     decoy.when(run_orchestrator_store.current_run_id).then_return("fake_id")
-    decoy.when(run_orchestrator_store.get_status()).then_return(EngineStatus.RUNNING)
+    decoy.when(await run_orchestrator_store.get_status()).then_return(
+        EngineStatus.RUNNING
+    )
 
     subject.update_run_orchestrator_store(run_orchestrator_store=run_orchestrator_store)
-    assert subject.get_current_status() == Status(
+    assert await subject.get_current_status() == Status(
         active_updates=[],
         estop_status=EstopState.DISENGAGED,
         engine_status=EngineStatus.RUNNING,

--- a/robot-server/tests/runs/test_run_controller.py
+++ b/robot-server/tests/runs/test_run_controller.py
@@ -288,7 +288,7 @@ async def test_create_pause_action(
     )
 
     decoy.verify(mock_run_store.insert_action(run_id, result), times=1)
-    decoy.verify(mock_run_orchestrator_store.pause(), times=1)
+    decoy.verify(await mock_run_orchestrator_store.pause(), times=1)
 
 
 async def test_create_stop_action(
@@ -341,7 +341,9 @@ async def test_create_resume_from_recovery_action(
 
     decoy.verify(mock_run_store.insert_action(run_id, result), times=1)
     decoy.verify(
-        mock_run_orchestrator_store.resume_from_recovery(reconcile_false_positive=False)
+        await mock_run_orchestrator_store.resume_from_recovery(
+            reconcile_false_positive=False
+        )
     )
 
 

--- a/robot-server/tests/runs/test_run_controller.py
+++ b/robot-server/tests/runs/test_run_controller.py
@@ -159,9 +159,9 @@ async def test_create_play_action_to_resume(
     subject: RunController,
 ) -> None:
     """It should resume a run."""
-    decoy.when(mock_run_orchestrator_store.run_was_started()).then_return(True)
+    decoy.when(await mock_run_orchestrator_store.run_was_started()).then_return(True)
 
-    result = subject.create_action(
+    result = await subject.create_action(
         action_id="some-action-id",
         action_type=RunActionType.PLAY,
         created_at=datetime(year=2021, month=1, day=1),
@@ -175,7 +175,7 @@ async def test_create_play_action_to_resume(
     )
 
     decoy.verify(mock_run_store.insert_action(run_id, result), times=1)
-    decoy.verify(mock_run_orchestrator_store.play(), times=1)
+    decoy.verify(await mock_run_orchestrator_store.play(), times=1)
     decoy.verify(await mock_run_orchestrator_store.run(deck_configuration=[]), times=0)
 
 
@@ -195,9 +195,9 @@ async def test_create_play_action_to_start(
     subject: RunController,
 ) -> None:
     """It should start a run."""
-    decoy.when(mock_run_orchestrator_store.run_was_started()).then_return(False)
+    decoy.when(await mock_run_orchestrator_store.run_was_started()).then_return(False)
 
-    result = subject.create_action(
+    result = await subject.create_action(
         action_id="some-action-id",
         action_type=RunActionType.PLAY,
         created_at=datetime(year=2021, month=1, day=1),
@@ -266,7 +266,7 @@ async def test_create_play_action_to_start(
     )
 
 
-def test_create_pause_action(
+async def test_create_pause_action(
     decoy: Decoy,
     mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
@@ -274,7 +274,7 @@ def test_create_pause_action(
     subject: RunController,
 ) -> None:
     """It should resume a run."""
-    result = subject.create_action(
+    result = await subject.create_action(
         action_id="some-action-id",
         action_type=RunActionType.PAUSE,
         created_at=datetime(year=2021, month=1, day=1),
@@ -291,7 +291,7 @@ def test_create_pause_action(
     decoy.verify(mock_run_orchestrator_store.pause(), times=1)
 
 
-def test_create_stop_action(
+async def test_create_stop_action(
     decoy: Decoy,
     mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
@@ -300,7 +300,7 @@ def test_create_stop_action(
     subject: RunController,
 ) -> None:
     """It should resume a run."""
-    result = subject.create_action(
+    result = await subject.create_action(
         action_id="some-action-id",
         action_type=RunActionType.STOP,
         created_at=datetime(year=2021, month=1, day=1),
@@ -317,7 +317,7 @@ def test_create_stop_action(
     decoy.verify(mock_task_runner.run(mock_run_orchestrator_store.stop), times=1)
 
 
-def test_create_resume_from_recovery_action(
+async def test_create_resume_from_recovery_action(
     decoy: Decoy,
     mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
@@ -326,7 +326,7 @@ def test_create_resume_from_recovery_action(
     subject: RunController,
 ) -> None:
     """It should call `resume_from_recovery()` on the underlying engine store."""
-    result = subject.create_action(
+    result = await subject.create_action(
         action_id="some-action-id",
         action_type=RunActionType.RESUME_FROM_RECOVERY,
         created_at=datetime(year=2021, month=1, day=1),
@@ -364,12 +364,12 @@ async def test_action_not_allowed(
     exception: Exception,
 ) -> None:
     """It should raise a RunActionNotAllowedError if a play/pause action is rejected."""
-    decoy.when(mock_run_orchestrator_store.run_was_started()).then_return(True)
-    decoy.when(mock_run_orchestrator_store.play()).then_raise(exception)  # type: ignore[func-returns-value]
-    decoy.when(mock_run_orchestrator_store.pause()).then_raise(exception)  # type: ignore[func-returns-value]
+    decoy.when(await mock_run_orchestrator_store.run_was_started()).then_return(True)
+    decoy.when(await mock_run_orchestrator_store.play()).then_raise(exception)  # type: ignore[func-returns-value]
+    decoy.when(await mock_run_orchestrator_store.pause()).then_raise(exception)  # type: ignore[func-returns-value]
 
     with pytest.raises(RunActionNotAllowedError, match="oh no"):
-        subject.create_action(
+        await subject.create_action(
             action_id="whatever",
             action_type=action_type,
             created_at=datetime(year=2021, month=1, day=1),

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -335,7 +335,9 @@ async def test_create(
         )
     ).then_return(engine_state_summary)
 
-    decoy.when(mock_run_orchestrator_store.get_run_time_parameters()).then_return([])
+    decoy.when(await mock_run_orchestrator_store.get_run_time_parameters()).then_return(
+        []
+    )
 
     decoy.when(
         mock_run_store.insert(
@@ -350,7 +352,7 @@ async def test_create(
         displayName="foo", variableName="bar", default=True, value=False
     )
     file_parameter = CSVParameter(displayName="my_file", variableName="file-id")
-    decoy.when(mock_run_orchestrator_store.get_run_time_parameters()).then_return(
+    decoy.when(await mock_run_orchestrator_store.get_run_time_parameters()).then_return(
         [bool_parameter, file_parameter]
     )
 
@@ -500,14 +502,14 @@ async def test_get_current_run(
 
     decoy.when(mock_run_store.get(run_id=run_id)).then_return(run_resource)
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return(run_id)
-    decoy.when(mock_run_orchestrator_store.get_state_summary()).then_return(
+    decoy.when(await mock_run_orchestrator_store.get_state_summary()).then_return(
         engine_state_summary
     )
-    decoy.when(mock_run_orchestrator_store.get_run_time_parameters()).then_return(
+    decoy.when(await mock_run_orchestrator_store.get_run_time_parameters()).then_return(
         run_time_parameters
     )
 
-    result = subject.get(run_id=run_id)
+    result = await subject.get(run_id=run_id)
 
     assert result == Run(
         current=True,
@@ -553,7 +555,7 @@ async def test_get_historical_run(
     )
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return("some other id")
 
-    result = subject.get(run_id=run_id)
+    result = await subject.get(run_id=run_id)
 
     assert result == Run(
         current=False,
@@ -599,7 +601,7 @@ async def test_get_historical_run_no_data(
     )
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return("some other id")
 
-    result = subject.get(run_id=run_id)
+    result = await subject.get(run_id=run_id)
 
     assert result == BadRun(
         dataError=run_error,
@@ -700,10 +702,10 @@ async def test_get_all_runs(
     )
 
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return("current-run")
-    decoy.when(mock_run_orchestrator_store.get_state_summary()).then_return(
+    decoy.when(await mock_run_orchestrator_store.get_state_summary()).then_return(
         current_run_data
     )
-    decoy.when(mock_run_orchestrator_store.get_run_time_parameters()).then_return(
+    decoy.when(await mock_run_orchestrator_store.get_run_time_parameters()).then_return(
         current_run_time_parameters
     )
     decoy.when(mock_run_store.get_state_summary("historical-run")).then_return(
@@ -716,7 +718,7 @@ async def test_get_all_runs(
         [historical_run_resource, current_run_resource]
     )
 
-    result = subject.get_all(length=20)
+    result = await subject.get_all(length=20)
 
     assert result == [
         Run(
@@ -1269,7 +1271,7 @@ async def test_create_replacement_signoff_enforcement(
         )
 
 
-def test_get_commands_slice_from_db(
+async def test_get_commands_slice_from_db(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_store: RunStore,
@@ -1296,14 +1298,14 @@ def test_get_commands_slice_from_db(
             run_id="run_id", cursor=1, length=2, include_fixit_commands=True
         )
     ).then_return(expected_command_slice)
-    result = subject.get_commands_slice(
+    result = await subject.get_commands_slice(
         run_id="run_id", cursor=1, length=2, include_fixit_commands=True
     )
 
     assert expected_command_slice == result
 
 
-def test_get_commands_slice_current_run(
+async def test_get_commands_slice_current_run(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_orchestrator_store: RunOrchestratorStore,
@@ -1325,16 +1327,18 @@ def test_get_commands_slice_current_run(
         commands=expected_commands_result, cursor=1, total_length=3
     )
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return("run-id")
-    decoy.when(mock_run_orchestrator_store.get_command_slice(1, 2, True)).then_return(
-        expected_command_slice
-    )
+    decoy.when(
+        await mock_run_orchestrator_store.get_command_slice(1, 2, True)
+    ).then_return(expected_command_slice)
 
-    result = subject.get_commands_slice("run-id", 1, 2, include_fixit_commands=True)
+    result = await subject.get_commands_slice(
+        "run-id", 1, 2, include_fixit_commands=True
+    )
 
     assert expected_command_slice == result
 
 
-def test_get_commands_errors_slice_historical_run(
+async def test_get_commands_errors_slice_historical_run(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_orchestrator_store: RunOrchestratorStore,
@@ -1353,12 +1357,12 @@ def test_get_commands_errors_slice_historical_run(
         command_error_slice
     )
 
-    result = subject.get_command_error_slice("run-id", 1, 2)
+    result = await subject.get_command_error_slice("run-id", 1, 2)
 
     assert command_error_slice == result
 
 
-def test_get_commands_errors_slice_current_run(
+async def test_get_commands_errors_slice_current_run(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_orchestrator_store: RunOrchestratorStore,
@@ -1374,16 +1378,16 @@ def test_get_commands_errors_slice_current_run(
     )
 
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return("run-id")
-    decoy.when(mock_run_orchestrator_store.get_command_error_slice(1, 2)).then_return(
-        command_error_slice
-    )
+    decoy.when(
+        await mock_run_orchestrator_store.get_command_error_slice(1, 2)
+    ).then_return(command_error_slice)
 
-    result = subject.get_command_error_slice("run-id", 1, 2)
+    result = await subject.get_command_error_slice("run-id", 1, 2)
 
     assert command_error_slice == result
 
 
-def test_get_commands_slice_from_db_run_not_found(
+async def test_get_commands_slice_from_db_run_not_found(
     decoy: Decoy, subject: RunDataManager, mock_run_store: RunStore
 ) -> None:
     """Should get a sliced command list from run store."""
@@ -1393,7 +1397,7 @@ def test_get_commands_slice_from_db_run_not_found(
         )
     ).then_raise(RunNotFoundError(run_id="run-id"))
     with pytest.raises(RunNotFoundError):
-        subject.get_commands_slice(
+        await subject.get_commands_slice(
             run_id="run-id", cursor=1, length=2, include_fixit_commands=True
         )
 
@@ -1527,7 +1531,7 @@ def test_get_last_completed_command_not_current_run(
     assert result == expected_last_command
 
 
-def test_get_command_from_engine(
+async def test_get_command_from_engine(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_store: RunStore,
@@ -1536,15 +1540,15 @@ def test_get_command_from_engine(
 ) -> None:
     """Should get command by id from engine store."""
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return("run-id")
-    decoy.when(mock_run_orchestrator_store.get_command("command-id")).then_return(
+    decoy.when(await mock_run_orchestrator_store.get_command("command-id")).then_return(
         run_command
     )
-    result = subject.get_command("run-id", "command-id")
+    result = await subject.get_command("run-id", "command-id")
 
     assert result == run_command
 
 
-def test_get_command_from_db(
+async def test_get_command_from_db(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_store: RunStore,
@@ -1556,12 +1560,12 @@ def test_get_command_from_db(
     decoy.when(
         mock_run_store.get_command(run_id="run-id", command_id="command-id")
     ).then_return(run_command)
-    result = subject.get_command("run-id", "command-id")
+    result = await subject.get_command("run-id", "command-id")
 
     assert result == run_command
 
 
-def test_get_command_from_db_run_not_found(
+async def test_get_command_from_db_run_not_found(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_store: RunStore,
@@ -1575,10 +1579,10 @@ def test_get_command_from_db_run_not_found(
     ).then_raise(RunNotFoundError("run-id"))
 
     with pytest.raises(RunNotFoundError):
-        subject.get_command("run-id", "command-id")
+        await subject.get_command("run-id", "command-id")
 
 
-def test_get_command_from_db_command_not_found(
+async def test_get_command_from_db_command_not_found(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_store: RunStore,
@@ -1592,10 +1596,10 @@ def test_get_command_from_db_command_not_found(
     ).then_raise(CommandNotFoundError(command_id="command-id"))
 
     with pytest.raises(CommandNotFoundError):
-        subject.get_command("run-id", "command-id")
+        await subject.get_command("run-id", "command-id")
 
 
-def test_get_all_commands_as_preserialized_list(
+async def test_get_all_commands_as_preserialized_list(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_store: RunStore,
@@ -1606,13 +1610,13 @@ def test_get_all_commands_as_preserialized_list(
     decoy.when(
         mock_run_store.get_all_commands_as_preserialized_list("run-id", True)
     ).then_return(['{"id": command-1}', '{"id": command-2}'])
-    assert subject.get_all_commands_as_preserialized_list("run-id", True) == [
+    assert await subject.get_all_commands_as_preserialized_list("run-id", True) == [
         '{"id": command-1}',
         '{"id": command-2}',
     ]
 
 
-def test_get_all_commands_as_preserialized_list_errors_for_active_runs(
+async def test_get_all_commands_as_preserialized_list_errors_for_active_runs(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_store: RunStore,
@@ -1620,12 +1624,14 @@ def test_get_all_commands_as_preserialized_list_errors_for_active_runs(
 ) -> None:
     """It should raise an error when fetching pre-serialized commands list while run is active."""
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return("current-run-id")
-    decoy.when(mock_run_orchestrator_store.get_is_run_terminal()).then_return(False)
+    decoy.when(await mock_run_orchestrator_store.get_is_run_terminal()).then_return(
+        False
+    )
     with pytest.raises(PreSerializedCommandsNotAvailableError):
-        subject.get_all_commands_as_preserialized_list("current-run-id", True)
+        await subject.get_all_commands_as_preserialized_list("current-run-id", True)
 
 
-def test_get_command_annotations_slice_current_run(
+async def test_get_command_annotations_slice_current_run(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_orchestrator_store: RunOrchestratorStore,
@@ -1645,15 +1651,17 @@ def test_get_command_annotations_slice_current_run(
     )
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return("current-run-id")
     decoy.when(
-        mock_run_orchestrator_store.get_command_annotations_slice(cursor=1, length=10)
+        await mock_run_orchestrator_store.get_command_annotations_slice(
+            cursor=1, length=10
+        )
     ).then_return(annotations_slice)
-    result = subject.get_command_annotations_slice(
+    result = await subject.get_command_annotations_slice(
         run_id="current-run-id", cursor=1, length=10
     )
     assert result == annotations_slice
 
 
-def test_get_command_annotation_from_current_run(
+async def test_get_command_annotation_from_current_run(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_orchestrator_store: RunOrchestratorStore,
@@ -1667,13 +1675,13 @@ def test_get_command_annotation_from_current_run(
     )
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return("run-id")
     decoy.when(
-        mock_run_orchestrator_store.get_command_annotation("annotation-id")
+        await mock_run_orchestrator_store.get_command_annotation("annotation-id")
     ).then_return(cmd_annotation)
-    result = subject.get_command_annotation("run-id", "annotation-id")
+    result = await subject.get_command_annotation("run-id", "annotation-id")
     assert result == cmd_annotation
 
 
-def test_get_command_annotations_slice_from_db(
+async def test_get_command_annotations_slice_from_db(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_orchestrator_store: RunOrchestratorStore,
@@ -1699,13 +1707,13 @@ def test_get_command_annotations_slice_from_db(
             run_id="not-current-id", cursor=1, length=10
         )
     ).then_return(annotations_slice)
-    result = subject.get_command_annotations_slice(
+    result = await subject.get_command_annotations_slice(
         run_id="not-current-id", cursor=1, length=10
     )
     assert result == annotations_slice
 
 
-def test_get_command_annotation_from_db(
+async def test_get_command_annotation_from_db(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_orchestrator_store: RunOrchestratorStore,
@@ -1725,7 +1733,7 @@ def test_get_command_annotation_from_db(
             run_id="not-current-run-id", command_annotation_id="annotation-id"
         )
     ).then_return(cmd_annotation)
-    result = subject.get_command_annotation("not-current-run-id", "annotation-id")
+    result = await subject.get_command_annotation("not-current-run-id", "annotation-id")
     assert result == cmd_annotation
 
 
@@ -1739,7 +1747,7 @@ async def test_get_current_run_labware_definition(
     """It should get the current run labware definition from the engine."""
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return("run-id")
     decoy.when(
-        mock_run_orchestrator_store.get_loaded_labware_definitions()
+        await mock_run_orchestrator_store.get_loaded_labware_definitions()
     ).then_return(
         [
             LabwareDefinition2.model_construct(namespace="test_1"),  # type: ignore[call-arg]
@@ -1747,7 +1755,7 @@ async def test_get_current_run_labware_definition(
         ]
     )
 
-    result = subject.get_run_loaded_labware_definitions(run_id="run-id")
+    result = await subject.get_run_loaded_labware_definitions(run_id="run-id")
 
     assert result == [
         LabwareDefinition2.model_construct(namespace="test_1"),  # type: ignore[call-arg]
@@ -1765,7 +1773,7 @@ async def test_set_error_recovery_rules_raises_run_not_current(
         "not-current-run-id"
     )
     with pytest.raises(RunNotCurrentError):
-        subject.set_error_recovery_rules(
+        await subject.set_error_recovery_rules(
             run_id="run-id", rules=decoy.mock(cls=List[ErrorRecoveryRule])
         )
 
@@ -1789,11 +1797,11 @@ async def test_set_error_recovery_rules_translates_and_calls_orchestrator(
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return(
         sentinel.current_run_id
     )
-    subject.set_error_recovery_rules(
+    await subject.set_error_recovery_rules(
         run_id=sentinel.current_run_id, rules=sentinel.input_rules
     )
     decoy.verify(
-        mock_run_orchestrator_store.set_error_recovery_policy(
+        await mock_run_orchestrator_store.set_error_recovery_policy(
             sentinel.expected_output, sentinel.input_rules, sentinel.is_enabled
         )
     )
@@ -1813,7 +1821,7 @@ async def test_get_error_recovery_rules(
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return(
         sentinel.current_run_id
     )
-    subject.set_error_recovery_rules(
+    await subject.set_error_recovery_rules(
         run_id=sentinel.current_run_id, rules=sentinel.input_rules
     )
     assert (

--- a/robot-server/tests/runs/test_run_orchestrator_store.py
+++ b/robot-server/tests/runs/test_run_orchestrator_store.py
@@ -499,7 +499,7 @@ async def test_estop_callback(
     await handle_hardware_event(run_orchestrator_store, disengage_event)
     assert run_orchestrator_store.run_coordinator is not None
     decoy.verify(
-        run_orchestrator_store.run_coordinator.estop(),
+        await run_orchestrator_store.run_coordinator.estop(),
         ignore_extra_args=True,
         times=0,
     )
@@ -513,7 +513,7 @@ async def test_estop_callback(
     await handle_hardware_event(run_orchestrator_store, engage_event)
     assert run_orchestrator_store._run_coordinator is not None
     decoy.verify(
-        run_orchestrator_store.run_coordinator.estop(),
+        await run_orchestrator_store.run_coordinator.estop(),
         await run_orchestrator_store.run_coordinator.finish(
             error=matchers.IsA(EStopActivatedError)
         ),

--- a/robot-server/tests/runs/test_run_orchestrator_store.py
+++ b/robot-server/tests/runs/test_run_orchestrator_store.py
@@ -331,7 +331,7 @@ async def test_clear_engine_not_stopped_or_idle(
         notify_publishers=mock_notify_publishers,
     )
     assert subject._run_coordinator is not None
-    subject._run_coordinator.play(deck_configuration=[])
+    await subject._run_coordinator.play(deck_configuration=[])
     with pytest.raises(RunConflictError):
         await subject.clear()
 
@@ -448,7 +448,7 @@ async def test_get_default_orchestrator_conflict(
         camera_provider=CameraProvider(),
         notify_publishers=mock_notify_publishers,
     )
-    subject.play()
+    await subject.play()
 
     with pytest.raises(RunConflictError):
         await subject.get_default_orchestrator()

--- a/robot-server/tests/runs/test_run_process.py
+++ b/robot-server/tests/runs/test_run_process.py
@@ -271,7 +271,7 @@ async def test_run_process_create(
         protocol=None,
         run_time_param_values=None,
         run_time_param_paths=None,
-        proxy_of_callback_for_handling_door_events=run_process.register_hardware_door_event(),
+        proxy_of_callback_for_handling_door_events=await run_process.register_hardware_door_event(),
     )
 
     await run_process.finish()

--- a/robot-server/tests/service/notifications/publishers/test_runs_publisher.py
+++ b/robot-server/tests/service/notifications/publishers/test_runs_publisher.py
@@ -22,6 +22,16 @@ def make_command_pointer(command_id: str) -> CommandPointer:
     )
 
 
+async def make_async_command_pointer(command_id: str) -> CommandPointer:
+    """Create a dummy CommandPointer."""
+    return CommandPointer(
+        command_id=command_id,
+        command_key="1",
+        index=0,
+        created_at=datetime(year=2021, month=1, day=1),
+    )
+
+
 @pytest.fixture
 def notification_client() -> Mock:
     """Mocked notification client."""
@@ -53,7 +63,7 @@ async def test_initialize(
     get_recovery_target_command = AsyncMock()
     get_state_summary = AsyncMock()
 
-    runs_publisher.start_publishing_for_run(
+    await runs_publisher.start_publishing_for_run(
         run_id, get_current_command, get_recovery_target_command, get_state_summary
     )
 
@@ -83,7 +93,7 @@ async def test_clean_up_current_run(
     runs_publisher: RunsPublisher, notification_client: Mock
 ) -> None:
     """It should publish to appropriate topics at the end of a run."""
-    runs_publisher.start_publishing_for_run(
+    await runs_publisher.start_publishing_for_run(
         "1234", AsyncMock(), AsyncMock(), AsyncMock()
     )
 
@@ -108,7 +118,7 @@ async def test_handle_current_command_change(
     runs_publisher: RunsPublisher, notification_client: Mock
 ) -> None:
     """It should handle command changes appropriately."""
-    runs_publisher.start_publishing_for_run(
+    await runs_publisher.start_publishing_for_run(
         run_id="1234",
         get_current_command=lambda _: make_command_pointer("command1"),
         get_recovery_target_command=AsyncMock(),
@@ -143,10 +153,10 @@ async def test_handle_recovery_target_command_change(
     runs_publisher: RunsPublisher, notification_client: Mock
 ) -> None:
     """It should handle command changes appropriately."""
-    runs_publisher.start_publishing_for_run(
+    await runs_publisher.start_publishing_for_run(
         run_id="1234",
         get_current_command=AsyncMock(),
-        get_recovery_target_command=lambda _: make_command_pointer("command1"),
+        get_recovery_target_command=lambda _: make_async_command_pointer("command1"),
         get_state_summary=AsyncMock(),
     )
 
@@ -164,7 +174,7 @@ async def test_handle_recovery_target_command_change(
     assert notification_client.publish_advise_refetch.call_count == 2
 
     runs_publisher._run_hooks.get_recovery_target_command = (
-        lambda _: make_command_pointer("command2")
+        lambda _: make_async_command_pointer("command2")
     )
 
     await runs_publisher._handle_recovery_target_command_change()
@@ -178,7 +188,7 @@ async def test_handle_relevant_engine_change(
     runs_publisher: RunsPublisher, notification_client: Mock
 ) -> None:
     """It should handle relevant engine changes appropriately."""
-    runs_publisher.start_publishing_for_run(
+    await runs_publisher.start_publishing_for_run(
         run_id="1234",
         get_current_command=lambda _: make_command_pointer("command1"),
         get_recovery_target_command=AsyncMock(),
@@ -217,7 +227,7 @@ async def test_handle_labware_offset_count_change(
     runs_publisher: RunsPublisher, notification_client: Mock
 ) -> None:
     """It should handle labware offset count changes appropriately."""
-    runs_publisher.start_publishing_for_run(
+    await runs_publisher.start_publishing_for_run(
         run_id="1234",
         get_current_command=lambda _: make_command_pointer("command1"),
         get_recovery_target_command=AsyncMock(),
@@ -258,7 +268,7 @@ async def test_publish_pre_serialized_commannds_notif(
     runs_publisher: RunsPublisher, notification_client: Mock
 ) -> None:
     """It should send out a notification for pre serialized commands."""
-    runs_publisher.start_publishing_for_run(
+    await runs_publisher.start_publishing_for_run(
         run_id="1234",
         get_current_command=lambda _: make_command_pointer("command1"),
         get_recovery_target_command=AsyncMock(),

--- a/robot-server/tests/service/notifications/publishers/test_runs_publisher.py
+++ b/robot-server/tests/service/notifications/publishers/test_runs_publisher.py
@@ -201,7 +201,7 @@ async def test_handle_relevant_engine_change(
     assert runs_publisher._engine_state_slice
 
     runs_publisher._run_hooks.run_id = "1234"
-    runs_publisher._run_hooks.get_state_summary = MagicMock(
+    runs_publisher._run_hooks.get_state_summary = AsyncMock(
         return_value=MagicMock(status=EngineStatus.IDLE, labwareOffsets=[])
     )
     runs_publisher._engine_state_slice.state_summary_status = EngineStatus.IDLE
@@ -241,7 +241,7 @@ async def test_handle_labware_offset_count_change(
 
     initial_offsets = ["offset1", "offset2"]
     runs_publisher._run_hooks.run_id = "1234"
-    runs_publisher._run_hooks.get_state_summary = MagicMock(
+    runs_publisher._run_hooks.get_state_summary = AsyncMock(
         return_value=MagicMock(status=EngineStatus.IDLE, labwareOffsets=initial_offsets)
     )
     runs_publisher._engine_state_slice.state_summary_status = EngineStatus.IDLE


### PR DESCRIPTION
# Overview
Covers (at least partially): RQA-5562 RQA-5732 RQA-5837 RQA-5729 RQA-5731

When we implemented subprocess mode we introduced extra steps for remote calling in all of our blocking calls to the RunOrchestratorStore. This PR seeks to refactor the surfaces of the RunOrchestratorStore that touch a `run_coordinator` to be entirely **async**.

A `run_coordinator` can either be a RunOrchestrator created by the robot-server, or a DirectedRunProcess which lives in a separate linux process communicated to via Pyro5. Because of this, both styles have been refactored to be async where they interact with the RunOrchestratorStore.

## Test Plan and Hands on Testing
- [x] Update all unit tests to reflect new async interface
- [x] Add temporary debug logs to Pyro client interface and ensure that no calls that go through RunOrchestratorStore execute in the main thread

Test on robot and ensure the following work **both in and out of** subprocess mode:
- [x] Protocol upload
- [x] Protocol analysis
- [x] Protocol run
- [x] Error recovery
- [x] Pipette attach/detach/calibration
- [x] Module setup and calibration
--
- [x] ALL worked with subprocess mode **ON**
- [x] ALL worked with subprocess mode **OFF**

Retest all in CRS mode:
- [x] Did the above work in CRS as well?
- [x] Did the above work OUT of CRS mode?

## Changelog
- Refactored the entire RunOrchestratorStore to be async
- Replaced ProtocolAnalyzer `__del__` method with an explicitly called async `clean_up` method


## Review requests
A refactor this large comes with some risks, does anything in here raise a big red flag?

## Risk assessment
Medium-High: This refactors the interface through which all run behavior is initiated and controlled. Scary!