### PR TITLE
fix(app,odd): seed queries from mutation responses

### DIFF
--- a/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol.ts
+++ b/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol.ts
@@ -1,9 +1,7 @@
 import { useTranslation } from 'react-i18next'
-import { useQueryClient } from 'react-query'
 import { useSelector } from 'react-redux'
 
 import {
-  getQueryKey,
   useCreateProtocolMutation,
   useCreateRunMutation,
   useHost,
@@ -45,7 +43,6 @@ export function useCreateRunFromProtocol(
   const contextHost = useHost()
   const host =
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
-  const queryClient = useQueryClient()
   const { t } = useTranslation('shared')
 
   const customLabwareFiles = useSelector((state: State) =>
@@ -68,19 +65,6 @@ export function useCreateRunFromProtocol(
     documentationState,
     {
       ...options,
-      onSuccess: (...args) => {
-        const [response] = args
-        queryClient.setQueryData(
-          getQueryKey(host, 'runs', response.data.id, 'details'),
-          response
-        )
-        queryClient
-          .invalidateQueries(getQueryKey(host, 'runs', 'details'))
-          .catch((e: Error) => {
-            console.error(`error invalidating runs query: ${e.message}`)
-          })
-        options.onSuccess?.(...args)
-      },
       onError: (error, variables, context) => {
         clearDocreport()
         options.onError?.(error, variables, context)

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ProtocolSetupParameters.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ProtocolSetupParameters.tsx
@@ -1,6 +1,5 @@
 import { Fragment, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useQueryClient } from 'react-query'
 import { useNavigate } from 'react-router-dom'
 
 import {
@@ -10,7 +9,6 @@ import {
   SPACING,
 } from '@opentrons/components'
 import {
-  getQueryKey,
   isDocumentedMutationError,
   useCreateProtocolAnalysisMutation,
   useCreateRunMutation,
@@ -62,7 +60,6 @@ export function ProtocolSetupParameters({
   const { t } = useTranslation('protocol_setup')
   const navigate = useNavigate()
   const host = useHost()
-  const queryClient = useQueryClient()
   const [chooseValueScreen, setChooseValueScreen] =
     useState<ChoiceParameter | null>(null)
   const [showNumericalInputScreen, setShowNumericalInputScreen] =
@@ -189,17 +186,6 @@ export function ProtocolSetupParameters({
   const { createRun, isLoading: isRunLoading } = useCreateRunMutation(
     documentationState,
     {
-      onSuccess: data => {
-        queryClient.setQueryData(
-          getQueryKey(host, 'runs', data.data.id, 'details'),
-          data
-        )
-        queryClient
-          .invalidateQueries(getQueryKey(host, 'runs', 'details'))
-          .catch((e: Error) => {
-            console.error(`could not invalidate runs cache: ${e.message}`)
-          })
-      },
       onError: error => {
         if (isDocumentedMutationError(error)) {
           setStartSetup(false)

--- a/app/src/organisms/ODD/QuickTransferFlow/SummaryAndSettings.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SummaryAndSettings.tsx
@@ -1,6 +1,5 @@
 import { useReducer, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useQueryClient } from 'react-query'
 import { useNavigate } from 'react-router-dom'
 
 import {
@@ -13,7 +12,6 @@ import {
   Tabs,
 } from '@opentrons/components'
 import {
-  getQueryKey,
   useCreateProtocolMutation,
   useCreateRunMutation,
   useHost,
@@ -55,7 +53,6 @@ export function SummaryAndSettings(
   const { exitButtonProps, state: wizardFlowState, analyticsStartTime } = props
   const navigate = useNavigate()
   const { trackEventWithRobotSerial } = useTrackEventWithRobotSerial()
-  const queryClient = useQueryClient()
   const host = useHost()
   const { t } = useTranslation(['quick_transfer', 'shared'])
   const [showSaveOrRunModal, setShowSaveOrRunModal] = useState<boolean>(false)
@@ -82,15 +79,6 @@ export function SummaryAndSettings(
     documentationState,
     {
       onSuccess: data => {
-        queryClient.setQueryData(
-          getQueryKey(host, 'runs', data.data.id, 'details'),
-          data
-        )
-        queryClient
-          .invalidateQueries(getQueryKey(host, 'runs', 'details'))
-          .catch((e: Error) => {
-            console.error(`error invalidating runs query: ${e.message}`)
-          })
         navigate(`/runs/${data.data.id}/setup`)
       },
     },

--- a/app/src/pages/ODD/ProtocolDetails/index.tsx
+++ b/app/src/pages/ODD/ProtocolDetails/index.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useQueryClient } from 'react-query'
 import { useDispatch, useSelector } from 'react-redux'
 import { useNavigate, useParams } from 'react-router-dom'
 import last from 'lodash/last'
@@ -27,7 +26,6 @@ import {
   TYPOGRAPHY,
 } from '@opentrons/components'
 import {
-  getQueryKey,
   isDocumentedMutationError,
   useCreateRunMutation,
   useDeleteProtocolMutation,
@@ -327,7 +325,6 @@ export function ProtocolDetails(): JSX.Element | null {
   const host = useHost()
   const { makeSnackbar } = useToaster()
   const [showParameters, setShowParameters] = useState<boolean>(false)
-  const queryClient = useQueryClient()
   const [currentOption, setCurrentOption] = useState<TabOption>(
     protocolSectionTabOptions[0]
   )
@@ -354,19 +351,7 @@ export function ProtocolDetails(): JSX.Element | null {
   const { deleteProtocol } = useDeleteProtocolMutation(deleteDocumentationState)
   const { deleteRun } = useDeleteRunMutation(deleteDocumentationState)
   const documentationState = useDocumentationState()
-  const { createRun } = useCreateRunMutation(documentationState, {
-    onSuccess: data => {
-      queryClient.setQueryData(
-        getQueryKey(host, 'runs', data.data.id, 'details'),
-        data
-      )
-      queryClient
-        .invalidateQueries(getQueryKey(host, 'runs', 'details'))
-        .catch((e: Error) => {
-          console.error(`could not invalidate runs cache: ${e.message}`)
-        })
-    },
-  })
+  const { createRun } = useCreateRunMutation(documentationState)
 
   const isRobotOutOfStorage = useIsRobotOutOfStorage()
   const [showRobotOutOfStorageModal, setShowRobotOutOfStorageModal] =

--- a/app/src/pages/ODD/QuickTransferDetails/index.tsx
+++ b/app/src/pages/ODD/QuickTransferDetails/index.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useQueryClient } from 'react-query'
 import { useDispatch, useSelector } from 'react-redux'
 import { useNavigate, useParams } from 'react-router-dom'
 
@@ -25,9 +24,7 @@ import {
   TYPOGRAPHY,
 } from '@opentrons/components'
 import {
-  getQueryKey,
   useCreateRunMutation,
-  useHost,
   useProtocolQuery,
 } from '@opentrons/react-api-client'
 
@@ -308,9 +305,7 @@ export function QuickTransferDetails(): JSX.Element | null {
   )
 
   const dispatch = useDispatch<Dispatch>()
-  const host = useHost()
   const { makeSnackbar } = useToaster()
-  const queryClient = useQueryClient()
   const [currentOption, setCurrentOption] = useState<TabOption>(
     transferSectionTabOptions[0]
   )
@@ -328,19 +323,7 @@ export function QuickTransferDetails(): JSX.Element | null {
   const pinned = pinnedTransferIds.includes(transferId)
   const documentationState = useDocumentationState()
 
-  const { createRun } = useCreateRunMutation(documentationState, {
-    onSuccess: data => {
-      queryClient.setQueryData(
-        getQueryKey(host, 'runs', data.data.id, 'details'),
-        data
-      )
-      queryClient
-        .invalidateQueries(getQueryKey(host, 'runs', 'details'))
-        .catch((e: Error) => {
-          console.error(`could not invalidate runs cache: ${e.message}`)
-        })
-    },
-  })
+  const { createRun } = useCreateRunMutation(documentationState)
 
   const handlePinClick = (): void => {
     if (!pinned) {

--- a/app/src/resources/runs/useCloneRun.ts
+++ b/app/src/resources/runs/useCloneRun.ts
@@ -41,20 +41,11 @@ export function useCloneRun(
     documentationState,
     {
       onSuccess: response => {
-        queryClient.setQueryData(
-          getQueryKey(host, 'runs', response.data.id, 'details'),
-          response
-        )
-
-        const invalidateRuns = queryClient.invalidateQueries(
-          getQueryKey(host, 'runs', 'details')
-        )
-        const invalidateProtocols = queryClient.invalidateQueries(
-          getQueryKey(host, 'protocols', protocolKey)
-        )
-        Promise.all([invalidateRuns, invalidateProtocols]).catch((e: Error) => {
-          console.error(`error invalidating runs query: ${e.message}`)
-        })
+        queryClient
+          .invalidateQueries(getQueryKey(host, 'protocols', protocolKey))
+          .catch((e: Error) => {
+            console.error(`error invalidating protocol query: ${e.message}`)
+          })
         // The onSuccess callback is not awaited until query invalidation, because currently, in every instance this
         // onSuccessCallback is utilized, we only use it for navigating. We may need to revisit this.
         onSuccessCallback?.(response)

--- a/react-api-client/src/accessControl/usePatchRobotServerAccessControlSettingsMutation.ts
+++ b/react-api-client/src/accessControl/usePatchRobotServerAccessControlSettingsMutation.ts
@@ -58,13 +58,10 @@ export function usePatchRobotServerAccessControlSettingsMutation(
     }: DocumentedMutationParameters<PatchRobotServerAccessControlSettingsRequest>) =>
       patchRobotServerAccessControlSettings(host!, body, userNotes)
         .then(response => {
-          queryClient
-            .invalidateQueries(getQueryKey(host, 'accessControl', 'settings'))
-            .catch((e: Error) => {
-              console.error(
-                `error invalidating robot server access control settings query: ${e.message}`
-              )
-            })
+          queryClient.setQueryData(
+            getQueryKey(host, 'accessControl', 'settings'),
+            response.data
+          )
           return response.data
         })
         .catch((e: AxiosError) => {

--- a/react-api-client/src/audit/settings/useAuditSettingsMutation.ts
+++ b/react-api-client/src/audit/settings/useAuditSettingsMutation.ts
@@ -56,15 +56,10 @@ export function useAuditSettingsMutation(
     }: DocumentedMutationParameters<PatchAuditSettingsRequest>) =>
       patchAuditSettings(host!, body, userNotes)
         .then(response => {
-          queryClient
-            .invalidateQueries(
-              getQueryKey(host, 'audit', 'external', 'settings')
-            )
-            .catch((e: Error) => {
-              console.error(
-                `error invalidating audit settings query: ${e.message}`
-              )
-            })
+          queryClient.setQueryData(
+            getQueryKey(host, 'audit', 'external', 'settings'),
+            response.data
+          )
           return response.data
         })
         .catch((e: AxiosError) => {

--- a/react-api-client/src/auth/settings/useAuthSettingsMutation.ts
+++ b/react-api-client/src/auth/settings/useAuthSettingsMutation.ts
@@ -56,13 +56,10 @@ export function useAuthSettingsMutation(
     }: DocumentedMutationParameters<PatchAuthSettingsRequest>) =>
       patchAuthSettings(host!, body, userNotes)
         .then(response => {
-          queryClient
-            .invalidateQueries(getQueryKey(host, 'auth', 'settings'))
-            .catch((e: Error) => {
-              console.error(
-                `error invalidating auth settings query: ${e.message}`
-              )
-            })
+          queryClient.setQueryData(
+            getQueryKey(host, 'auth', 'settings'),
+            response.data
+          )
           return response.data
         })
         .catch((e: AxiosError) => {

--- a/react-api-client/src/dataFiles/useDeleteRunImages.ts
+++ b/react-api-client/src/dataFiles/useDeleteRunImages.ts
@@ -40,7 +40,11 @@ export function useDeleteRunImages(
     ['delete_run_images'],
     ({ variables: runId, userNotes }: DocumentedMutationParameters<string>) =>
       deleteRunImages(host!, runId, userNotes).then(response => {
-        queryClient.invalidateQueries(getQueryKey(host, 'dataFiles', runId))
+        queryClient
+          .invalidateQueries(getQueryKey(host, 'dataFiles', runId))
+          .catch((e: Error) => {
+            console.error(`error invalidating data files query: ${e.message}`)
+          })
         return response.data
       }),
     options

--- a/react-api-client/src/dataFiles/useImageFileQuery.ts
+++ b/react-api-client/src/dataFiles/useImageFileQuery.ts
@@ -18,7 +18,7 @@ export function useImageFileQuery(
   }
 
   const query = useQuery<ImageFilesDataResponse>(
-    getQueryKey(host, '/dataFiles/', runId, '/images'),
+    getQueryKey(host, 'dataFiles', runId, 'images'),
     () => getImageFiles(host!, runId).then(response => response.data),
     allOptions
   )

--- a/react-api-client/src/dataFiles/useUploadCsvFileMutation.ts
+++ b/react-api-client/src/dataFiles/useUploadCsvFileMutation.ts
@@ -65,12 +65,12 @@ export function useUploadCsvFileMutation(
           .invalidateQueries(getQueryKey(host, 'dataFiles'))
           .then(() =>
             queryClient.setQueryData(
-              getQueryKey(host, 'dataFiles'),
+              getQueryKey(host, 'dataFiles', response.data.data.id),
               response.data
             )
           )
           .catch((e: Error) => {
-            throw e
+            console.error(`error invalidating data files query: ${e.message}`)
           })
         return response.data
       }),

--- a/react-api-client/src/deck_configuration/useUpdateDeckConfigurationMutation.ts
+++ b/react-api-client/src/deck_configuration/useUpdateDeckConfigurationMutation.ts
@@ -50,12 +50,13 @@ export function useUpdateDeckConfigurationMutation(
     getQueryKey(host, 'deck_configuration'),
     ({ variables: deckConfig, userNotes }) =>
       updateDeckConfiguration(host!, deckConfig, userNotes).then(response => {
-        queryClient
-          .invalidateQueries(getQueryKey(host, 'deck_configuration'))
-          .catch((e: Error) => {
-            throw e
-          })
-        return response.data?.data?.cutoutFixtures ?? []
+        const updatedDeckConfiguration =
+          response.data?.data?.cutoutFixtures ?? []
+        queryClient.setQueryData(
+          getQueryKey(host, 'deck_configuration'),
+          updatedDeckConfiguration
+        )
+        return updatedDeckConfiguration
       }),
     options
   )

--- a/react-api-client/src/labwareOffsets/useSearchLabwareOffsets.ts
+++ b/react-api-client/src/labwareOffsets/useSearchLabwareOffsets.ts
@@ -17,7 +17,7 @@ export function useSearchLabwareOffsets(
 ): UseQueryResult<SearchLabwareOffsetsResponse, AxiosError> {
   const host = useHost()
   const query = useQuery<SearchLabwareOffsetsResponse, AxiosError>(
-    getQueryKey(host, 'searchLabwareOffsets', data),
+    getQueryKey(host, 'labwareOffsets', data),
     () =>
       searchLabwareOffsets(host!, data)
         .then(response => response.data)

--- a/react-api-client/src/maintenance_runs/useCreateMaintenanceRunMutation.ts
+++ b/react-api-client/src/maintenance_runs/useCreateMaintenanceRunMutation.ts
@@ -57,7 +57,22 @@ export function useCreateMaintenanceRunMutation(
     actionsToDocument,
     ({ variables: createMaintenanceRunData, userNotes }) =>
       createMaintenanceRun(host!, createMaintenanceRunData, userNotes)
-        .then(response => response.data)
+        .then(response => {
+          queryClient.setQueryData(
+            getQueryKey(host, 'maintenance_runs', 'current_run'),
+            response.data
+          )
+          queryClient.setQueryData(
+            getQueryKey(
+              host,
+              'maintenance_runs',
+              response.data.data.id,
+              'details'
+            ),
+            response.data
+          )
+          return response.data
+        })
         .catch(e => {
           queryClient.invalidateQueries(
             getQueryKey(host, 'robot/control/estopStatus')

--- a/react-api-client/src/protocols/useAllCsvFilesQuery.ts
+++ b/react-api-client/src/protocols/useAllCsvFilesQuery.ts
@@ -18,7 +18,7 @@ export function useAllCsvFilesQuery(
   }
 
   const query = useQuery<UploadedCsvFilesResponse>(
-    getQueryKey(host, `protocols/${protocolId}/dataFiles`),
+    getQueryKey(host, 'protocols', protocolId, 'dataFiles'),
     () => getCsvFiles(host!, protocolId).then(response => response.data),
     allOptions
   )

--- a/react-api-client/src/robot/useSetLightsMutation.ts
+++ b/react-api-client/src/robot/useSetLightsMutation.ts
@@ -1,3 +1,5 @@
+import { useQueryClient } from 'react-query'
+
 import { setLights } from '@opentrons/api-client'
 
 import { useDocumentedMutation } from '../accessControl'
@@ -34,13 +36,17 @@ export function useSetLightsMutation(
   const contextHost = useHost()
   const host =
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
+  const queryClient = useQueryClient()
   const mutation = useDocumentedMutation<Lights, AxiosError, SetLightsData>(
     documentationState,
     ['set_lights'],
     getQueryKey(host, 'robot', 'lights'),
     ({ variables: setLightsData, userNotes }) =>
       setLights(host!, setLightsData, userNotes)
-        .then(response => response.data)
+        .then(response => {
+          queryClient.setQueryData(getQueryKey(host, 'lights'), response.data)
+          return response.data
+        })
         .catch(e => {
           throw e
         }),

--- a/react-api-client/src/runs/useCreateLiveCommandMutation.ts
+++ b/react-api-client/src/runs/useCreateLiveCommandMutation.ts
@@ -4,7 +4,8 @@ import { useQueryClient } from 'react-query'
 import { createLiveCommand } from '@opentrons/api-client'
 
 import { useDocumentedMutation } from '../accessControl'
-import { getQueryKey, useHost } from '../api'
+import { useHost } from '../api'
+import { modulesQueryKey } from '../modules'
 
 import type {
   UseMutateAsyncFunction,
@@ -66,9 +67,11 @@ export function useCreateLiveCommandMutation(
         userNotes
       ).then(response => {
         queryClient
-          .invalidateQueries(getQueryKey(host, 'commands'))
+          .invalidateQueries(modulesQueryKey(host))
           .catch((e: Error) => {
-            console.error(`error invalidating commands query: ${e.message}`)
+            console.error(
+              `error invalidating live commands query: ${e.message}`
+            )
           })
         addActionToDocument?.(response.data.data)
         return response.data

--- a/react-api-client/src/runs/useCreateRunMutation.ts
+++ b/react-api-client/src/runs/useCreateRunMutation.ts
@@ -1,3 +1,5 @@
+import { useQueryClient } from 'react-query'
+
 import { createRun } from '@opentrons/api-client'
 
 import { useDocumentedMutation } from '../accessControl'
@@ -39,6 +41,7 @@ export function useCreateRunMutation(
   const contextHost = useHost()
   const host =
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
+  const queryClient = useQueryClient()
   const mutation = useDocumentedMutation<Run, AxiosError, CreateRunData>(
     documentationState,
     [...(actionsToDocument ?? []), 'create_run'],
@@ -48,7 +51,18 @@ export function useCreateRunMutation(
       userNotes,
     }: DocumentedMutationParameters<CreateRunData>) =>
       createRun(host!, createRunData, userNotes)
-        .then(response => response.data)
+        .then(response => {
+          queryClient.setQueryData(
+            getQueryKey(host, 'runs', response.data.data.id, 'details'),
+            response.data
+          )
+          queryClient
+            .invalidateQueries(getQueryKey(host, 'runs', 'details'))
+            .catch((e: Error) => {
+              console.error(`error invalidating runs query: ${e.message}`)
+            })
+          return response.data
+        })
         .catch(e => {
           throw e
         }),

--- a/react-api-client/src/runs/useRunActionMutations.ts
+++ b/react-api-client/src/runs/useRunActionMutations.ts
@@ -55,18 +55,30 @@ export function useRunActionMutations(
     }
   )
 
-  const { stopRun, isLoading: isStopRunActionLoading } =
-    useStopRunMutation(documentationState)
+  const { stopRun, isLoading: isStopRunActionLoading } = useStopRunMutation(
+    documentationState,
+    [],
+    {
+      onSuccess,
+    }
+  )
 
   const {
     resumeRunFromRecovery,
     isLoading: isResumeRunFromRecoveryActionLoading,
-  } = useResumeRunFromRecoveryMutation(documentationState)
+  } = useResumeRunFromRecoveryMutation(documentationState, {
+    onSuccess,
+  })
 
   const {
     resumeRunFromRecoveryAssumingFalsePositive,
     isLoading: isResumeRunFromRecoveryAssumingFalsePositiveActionLoading,
-  } = useResumeRunFromRecoveryAssumingFalsePositiveMutation(documentationState)
+  } = useResumeRunFromRecoveryAssumingFalsePositiveMutation(
+    documentationState,
+    {
+      onSuccess,
+    }
+  )
 
   return {
     playRun: () => {

--- a/react-api-client/src/subsystems/useCurrentAllSubsystemUpdatesQuery.ts
+++ b/react-api-client/src/subsystems/useCurrentAllSubsystemUpdatesQuery.ts
@@ -13,13 +13,13 @@ export function useCurrentAllSubsystemUpdatesQuery<TError = Error>(
   const host = useHost()
   const queryClient = useQueryClient()
   const query = useQuery<CurrentSubsystemUpdates, TError>(
-    getQueryKey(host, '/subsystems/updates/current'),
+    getQueryKey(host, 'subsystems', 'updates', 'current'),
     () => getCurrentAllSubsystemUpdates(host!).then(response => response.data),
     {
       enabled: host !== null,
       onError: () => {
         queryClient.setQueryData(
-          getQueryKey(host, '/subsystems/updates/current'),
+          getQueryKey(host, 'subsystems', 'updates', 'current'),
           undefined
         )
       },

--- a/react-api-client/src/subsystems/useCurrentSubsystemUpdateQuery.ts
+++ b/react-api-client/src/subsystems/useCurrentSubsystemUpdateQuery.ts
@@ -17,7 +17,7 @@ export function useCurrentSubsystemUpdateQuery<TError = Error>(
   const host = useHost()
   const queryClient = useQueryClient()
   const query = useQuery<SubsystemUpdateProgressData, TError>(
-    getQueryKey(host, '/subsystems/updates/current', subsystem),
+    getQueryKey(host, 'subsystems', 'updates', 'current', subsystem),
     () =>
       getCurrentSubsystemUpdate(host!, subsystem as Subsystem).then(
         response => response.data
@@ -26,7 +26,7 @@ export function useCurrentSubsystemUpdateQuery<TError = Error>(
       enabled: host !== null,
       onError: () => {
         queryClient.setQueryData(
-          getQueryKey(host, '/subsystems/updates/current', subsystem),
+          getQueryKey(host, 'subsystems', 'updates', 'current', subsystem),
           undefined
         )
       },

--- a/react-api-client/src/subsystems/useSubsystemUpdateQuery.ts
+++ b/react-api-client/src/subsystems/useSubsystemUpdateQuery.ts
@@ -13,7 +13,7 @@ export function useSubsystemUpdateQuery<TError = Error>(
 ): UseQueryResult<SubsystemUpdateProgressData, TError> {
   const host = useHost()
   const query = useQuery<SubsystemUpdateProgressData, TError>(
-    getQueryKey(host, 'subsystems/updates/all/', updateId),
+    getQueryKey(host, 'subsystems', 'updates', 'all', updateId),
     () => getSubsystemUpdate(host!, updateId!).then(response => response.data),
     {
       ...options,

--- a/react-api-client/src/subsystems/useUpdateSubsystemMutation.ts
+++ b/react-api-client/src/subsystems/useUpdateSubsystemMutation.ts
@@ -50,12 +50,29 @@ export function useUpdateSubsystemMutation(
     ['update_subsystem'],
     ({ variables: subsystem, userNotes }) =>
       updateSubsystem(host!, subsystem, userNotes).then(response => {
-        queryClient.removeQueries(getQueryKey(host, 'subsystems/updates'))
+        queryClient.setQueryData(
+          getQueryKey(
+            host,
+            'subsystems',
+            'updates',
+            'all',
+            response.data.data.id
+          ),
+          response.data
+        )
+        queryClient.setQueryData(
+          getQueryKey(host, 'subsystems', 'updates', 'current', subsystem),
+          response.data
+        )
         queryClient
-          .invalidateQueries(getQueryKey(host, 'subsystems/updates'))
+          .invalidateQueries(
+            getQueryKey(host, 'subsystems', 'updates', 'current'),
+            { exact: true }
+          )
           .catch((e: Error) => {
             console.error(`error invalidating subsystems query: ${e.message}`)
           })
+
         return response.data
       }),
     options

--- a/react-api-client/src/system/usePutSystemTimeMutation.ts
+++ b/react-api-client/src/system/usePutSystemTimeMutation.ts
@@ -1,7 +1,10 @@
+import { useQueryClient } from 'react-query'
+
 import { putSystemTime } from '@opentrons/api-client'
 
 import { useDocumentedMutation } from '../accessControl'
 import { useHost } from '../api'
+import { systemTimeQueryKey } from './useSystemTimeQuery'
 
 import type { AxiosError } from 'axios'
 import type {
@@ -35,6 +38,7 @@ export function usePutSystemTimeMutation(
   const contextHost = useHost()
   const host =
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
+  const queryClient = useQueryClient()
 
   const mutation = useDocumentedMutation<
     SystemTimeResponse,
@@ -47,9 +51,10 @@ export function usePutSystemTimeMutation(
       variables: systemTime,
       userNotes,
     }: DocumentedMutationParameters<string>) =>
-      putSystemTime(host!, systemTime, userNotes).then(
-        response => response.data
-      ),
+      putSystemTime(host!, systemTime, userNotes).then(response => {
+        queryClient.setQueryData(systemTimeQueryKey(host), response.data)
+        return response.data
+      }),
     options
   )
 


### PR DESCRIPTION
# Overview

This PR seeds several queries using responses from mutations. Rather than just broadly invalidating queries we can rely on mutation responses to provide useful data that when seeded can prevent unnecessary network requests.

Newly seeded queries include:
- access Control settings
- audit server settings
- auth server settings
- uploading CSV files
- deck configuration
- creating maintenance runs
- refactors creating runs to seed from the mutation directly 
- turning off/on lights
- updating system firmware
- updating system time

In addition, while auditing query invalidation I found a few incorrect keys, inefficient invalidates, and other weirdness. Those fixes include:
- incorrect query keys in `useImageFileQuery`
- unused query key in `useSearchLabwareOffsets`
- weirdly formatted query keys in `useAllCSVFilesQuery`
- incorrect query key in `useCreateLiveCommandMutation`
- stop and resume run not invalidating queries
- weirdly formatted query keys in `useCurrentSubsystemUpdateQuery`

## Test Plan and Hands on Testing

Changing access control, audit, and auth server settings should work correctly. Uploading CSVs for protocols should work correctly. Changing deck configuration, creating maintenance runs and protocol runs should work correctly. Turning off and on the lights should work correctly.  Updating pipette and module firmware should work correctly. 

## Review requests

I know this is in the weeds but we're trying to cut down to truly the minimum number of network requests. I did my best to maintain specific usecases of `invalidateQueries` but if there was anywhere you notice we were doing something weird on purpose that I removed, let me know.

## Risk assessment

Medium, query seeding shouldn't change anything functional, but its possible some of these invalidates were doing something fairly important that I'm missing the nuance of. 