### PR TITLE
fix(protocol-designer): filter out non-pipettable labware in liquid handling steps

### DIFF
--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -7,6 +7,7 @@ import {
   FLEX_STACKER_MODULE_TYPE,
   getAllDefinitions,
   getIsLid,
+  getIsPipettableLabware,
   getIsTiprack,
   getPositionFromSlotId,
   MOVABLE_TRASH_ADDRESSABLE_AREAS,
@@ -409,6 +410,10 @@ export const useLabwareDropdownOptions = (
         isOffDeck &&
         (type === 'labware' || (type === 'moveLabware' && useGripper))
 
+      // if pipetting, ensure the labware is pipettable (not an adapter)
+      const isPipetteInaccessible =
+        type === 'labware' && !getIsPipettableLabware(labwareEntity.def)
+
       //  TODO: refactor this to be easier to read
       const shouldExclude =
         isInaccessible ||
@@ -421,7 +426,8 @@ export const useLabwareDropdownOptions = (
           !isTopOfStack &&
           !isMovableAdapter &&
           !isLabwareLidCombo) ||
-        (type === 'labware' && !isTopOfStack)
+        (type === 'labware' && !isTopOfStack) ||
+        isPipetteInaccessible
       if (shouldExclude) {
         return acc
       }


### PR DESCRIPTION
# Overview

As noticed in the case of an empty vacuum collar, we should not allow pipetting to or from non-pipettable labware in the `LabwareField` copmonent's options.

Closes RQA-5888

## Test Plan and Hands on Testing

- import protocol attached to ticket
- create a mix or transfer step
- verify that the empty vacuum collar does not populate in the source/destination/mix labware dropdown

## Changelog

- add check for pipettable labware in `useLabwareDropdownOptions`

## Review requests

see test plan

## Risk assessment

low