### PR TITLE
fix(shared-data, api): update vacuum module seating and labware gripper defs

### DIFF
--- a/api/src/opentrons/protocol_engine/state/labware_origin_math/stackup_origin_to_labware_origin.py
+++ b/api/src/opentrons/protocol_engine/state/labware_origin_math/stackup_origin_to_labware_origin.py
@@ -1008,16 +1008,8 @@ def _get_child_labware_overlap_with_parent_labware(
         else child_labware.legacyStackingOffsetWithLabware.get(parent_labware_name)
     )
 
-    # The parent labware does not exist in the child mapping, use the childs `default` value
-    if overlap is None:
-        overlap = (
-            child_labware.stackingOffsetWithLabware.get("default")
-            if isinstance(child_labware, LabwareDefinition2)
-            else child_labware.legacyStackingOffsetWithLabware.get("default")
-        )
-
-    # The child mapping does not have a default, use the `default` from the parent
-    # IF the parent has the `providesStackingDefault` quirk.
+    # The parent labware does not exist in the child mapping, use the `default`
+    # from the parent if the parent has the `providesStackingDefault` quirk.
     if overlap is None:
         if isinstance(parent_labware, LabwareDefinition2):
             if (
@@ -1027,6 +1019,15 @@ def _get_child_labware_overlap_with_parent_labware(
                 overlap = parent_labware.stackingOffsetWithLabware.get("default")
         else:
             overlap = parent_labware.legacyStackingOffsetWithLabware.get("default")
+
+    # The parent does not have a `providesStackingDefault` quirk or explicit
+    # mapping, use the `default` from the parent.
+    if overlap is None:
+        overlap = (
+            child_labware.stackingOffsetWithLabware.get("default")
+            if isinstance(child_labware, LabwareDefinition2)
+            else child_labware.legacyStackingOffsetWithLabware.get("default")
+        )
 
     if overlap is None:
         if isinstance(child_labware, LabwareDefinition3):

--- a/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
@@ -1098,7 +1098,7 @@ def test_v3_child_on_v2_parent_labware() -> None:
         deck_definition=deck_def,
     )
 
-    expected_total = Point(x=175, y=760, z=1855)
+    expected_total = Point(x=300, y=985, z=1530)
 
     assert result_non_topmost == expected_total
 

--- a/shared-data/deck/definitions/5/ot3_standard.json
+++ b/shared-data/deck/definitions/5/ot3_standard.json
@@ -979,7 +979,7 @@
       {
         "id": "vacuumModuleV1A3",
         "areaType": "vacuumModule",
-        "offsetFromCutoutFixture": [0, 0, 19.0],
+        "offsetFromCutoutFixture": [0.4, 0, 18.75],
         "boundingBox": {
           "xDimension": 128.0,
           "yDimension": 86.0,

--- a/shared-data/js/helpers/__tests__/positionMath.test.ts
+++ b/shared-data/js/helpers/__tests__/positionMath.test.ts
@@ -124,7 +124,7 @@ describe('getPositionFromSlotId()', () => {
   it('returns coordinates for vacuum module main addressable area', () => {
     expect(
       getPositionFromSlotId('vacuumModuleV1A3', OT3_DECK_DEF)
-    ).toStrictEqual([328, 321, 19])
+    ).toStrictEqual([328.4, 321, 18.75])
   })
 })
 

--- a/shared-data/labware/definitions/2/millipore_24_wellplate_800ul/1.json
+++ b/shared-data/labware/definitions/2/millipore_24_wellplate_800ul/1.json
@@ -289,6 +289,8 @@
     "y": 0,
     "z": 0
   },
+  "gripForce": 15,
+  "gripHeightFromLabwareBottom": 15.79,
   "stackingOffsetWithLabware": {
     "default": {
       "x": 0,

--- a/shared-data/labware/definitions/2/millipore_384_wellplate_100ul_filter/1.json
+++ b/shared-data/labware/definitions/2/millipore_384_wellplate_100ul_filter/1.json
@@ -4700,6 +4700,8 @@
     "y": 0,
     "z": 0
   },
+  "gripForce": 15,
+  "gripHeightFromLabwareBottom": 11.85,
   "stackingOffsetWithLabware": {
     "default": {
       "x": 0,

--- a/shared-data/labware/definitions/2/millipore_96_wellplate_300ul_filter/1.json
+++ b/shared-data/labware/definitions/2/millipore_96_wellplate_300ul_filter/1.json
@@ -26,6 +26,8 @@
     "y": 0,
     "z": 0
   },
+  "gripForce": 15,
+  "gripHeightFromLabwareBottom": 9.72,
   "dimensions": {
     "xDimension": 124.03,
     "yDimension": 81.91,

--- a/shared-data/labware/definitions/2/millipore_96_wellplate_300ul_hts_filter/1.json
+++ b/shared-data/labware/definitions/2/millipore_96_wellplate_300ul_hts_filter/1.json
@@ -1019,6 +1019,8 @@
     "y": 0,
     "z": 0
   },
+  "gripForce": 15,
+  "gripHeightFromLabwareBottom": 11.95,
   "stackingOffsetWithLabware": {
     "default": {
       "x": 0,

--- a/shared-data/labware/definitions/2/millipore_96_wellplate_300ul_pcr_filter/1.json
+++ b/shared-data/labware/definitions/2/millipore_96_wellplate_300ul_pcr_filter/1.json
@@ -1016,6 +1016,8 @@
     "y": 0,
     "z": 0
   },
+  "gripForce": 15,
+  "gripHeightFromLabwareBottom": 11.9,
   "stackingOffsetWithLabware": {
     "default": {
       "x": 0,

--- a/shared-data/labware/definitions/2/millipore_96_wellplate_400ul/1.json
+++ b/shared-data/labware/definitions/2/millipore_96_wellplate_400ul/1.json
@@ -1015,6 +1015,8 @@
     "y": 0,
     "z": 0
   },
+  "gripForce": 15,
+  "gripHeightFromLabwareBottom": 14.52,
   "stackingOffsetWithLabware": {
     "default": {
       "x": 0,

--- a/shared-data/labware/definitions/2/millipore_96_wellplate_500ul_solvinet_filter/1.json
+++ b/shared-data/labware/definitions/2/millipore_96_wellplate_500ul_solvinet_filter/1.json
@@ -29,6 +29,8 @@
     "y": 0,
     "z": 0
   },
+  "gripForce": 15,
+  "gripHeightFromLabwareBottom": 11.91,
   "dimensions": {
     "xDimension": 127.8,
     "yDimension": 85.49,

--- a/shared-data/labware/definitions/2/millipore_96_wellplate_500ul_ultracel_filter/1.json
+++ b/shared-data/labware/definitions/2/millipore_96_wellplate_500ul_ultracel_filter/1.json
@@ -26,6 +26,8 @@
     "y": 0,
     "z": 0
   },
+  "gripForce": 15,
+  "gripHeightFromLabwareBottom": 11.95,
   "dimensions": {
     "xDimension": 127.75,
     "yDimension": 85.49,

--- a/shared-data/labware/definitions/2/opentrons_vacuum_manifold_collar_short/1.json
+++ b/shared-data/labware/definitions/2/opentrons_vacuum_manifold_collar_short/1.json
@@ -56,7 +56,7 @@
     "default": {
       "x": 0,
       "y": 0,
-      "z": 2
+      "z": 3.5
     }
   },
   "stackingOffsetWithModule": {

--- a/shared-data/labware/definitions/2/opentrons_vacuum_manifold_collar_tall/1.json
+++ b/shared-data/labware/definitions/2/opentrons_vacuum_manifold_collar_tall/1.json
@@ -56,7 +56,7 @@
     "default": {
       "x": 0,
       "y": 0,
-      "z": 2
+      "z": 3.5
     }
   },
   "stackingOffsetWithModule": {

--- a/shared-data/labware/definitions/2/thermoscientificnunc_96_wellplate_1000ul_filter/1.json
+++ b/shared-data/labware/definitions/2/thermoscientificnunc_96_wellplate_1000ul_filter/1.json
@@ -1112,6 +1112,8 @@
     "y": 0,
     "z": 0
   },
+  "gripForce": 15,
+  "gripHeightFromLabwareBottom": 29.1,
   "stackingOffsetWithLabware": {
     "default": {
       "x": 0,

--- a/shared-data/module/definitions/3/vacuumModuleV1.json
+++ b/shared-data/module/definitions/3/vacuumModuleV1.json
@@ -3,13 +3,13 @@
   "moduleType": "vacuumModuleType",
   "model": "vacuumModuleV1",
   "labwareOffset": {
-    "x": 0,
+    "x": 0.4,
     "y": 0,
-    "z": 19
+    "z": 18.75
   },
   "features": {},
   "dimensions": {
-    "bareOverallHeight": 37,
+    "bareOverallHeight": 36.5,
     "overLabwareHeight": 0,
     "xDimension": 143,
     "yDimension": 101.5,
@@ -28,7 +28,7 @@
       "frontRightTop": {
         "x": 143,
         "y": 101.5,
-        "z": 37
+        "z": 36.5
       }
     }
   },
@@ -52,7 +52,7 @@
       "dropOffset": {
         "x": 0,
         "y": 0,
-        "z": 2
+        "z": 1
       }
     }
   },


### PR DESCRIPTION
# Overview

Correct the vacuum module seating geometry based on hardware measurements and the gripper/stacking definitions needed to place filter and collection plates on it. The new `providesStackingDefault ` changes are strictly additive and keep the same behavior unless you use the new properties.

Closes: [RQA-5832](https://opentrons.atlassian.net/browse/RQA-5832) [RQA-5739](https://opentrons.atlassian.net/browse/RQA-5739)

## Test Plan and Hands on Testing

- [x] Run the following protocol and make sure that the plates are being pickup / dropped off properly and that there is no wide offset on the z

[vm_hold_offset_verify.py](https://github.com/user-attachments/files/31153327/vm_hold_offset_verify.py)


## Changelog

- Adjust vacuumModuleV1.json, ot3_standard.json addressable area based on new measurements.
- Add `gripForce: 15` and `gripHeightFromLabwareBottom = zDimension - 2.5` from missing VM labware.
- Adjust Collar stacking default z from 2 → 3.5 to match new measurements.
- `providesStackingDefault` parent overlap is used before the child's default

## Review requests

- Confirm parent-default-before-child-default makes sense

## Risk assessment

Medium. The overlap lookup change can retarget any stack where a child `default` previously overrode a parent `providesStackingDefault`.

[RQA-5832]: https://opentrons.atlassian.net/browse/RQA-5832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-5739]: https://opentrons.atlassian.net/browse/RQA-5739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ