### PR TITLE
refactor(app): change download audit log text

### DIFF
--- a/app/src/assets/localization/en/access_control.json
+++ b/app/src/assets/localization/en/access_control.json
@@ -14,6 +14,7 @@
   "documentation_required": "Documentation Required",
   "download_audit_logs": "Download audit logs",
   "download_audit_logs_description": "Once a protocol run is complete, audit logs must be downloaded locally before continuing.",
+  "download_now": "Download now",
   "forgot_password_heading": "Forgot password?",
   "forgot_password_link": "Forgot password?",
   "forgot_password_subheading": "Log in to an admin account to reset the password for your account.",

--- a/app/src/assets/localization/en/access_control.json
+++ b/app/src/assets/localization/en/access_control.json
@@ -13,7 +13,7 @@
   "desktop_password_expired_subheading": "Create a new password to use",
   "documentation_required": "Documentation Required",
   "download_audit_logs": "Download audit logs",
-  "download_audit_logs_description": "Audit logs are not saved to the robot and must be downloaded locally before continuing. Once this session ends, the data cannot be recovered.",
+  "download_audit_logs_description": "Once a protocol run is complete, audit logs must be downloaded locally before continuing.",
   "forgot_password_heading": "Forgot password?",
   "forgot_password_link": "Forgot password?",
   "forgot_password_subheading": "Log in to an admin account to reset the password for your account.",

--- a/app/src/organisms/Desktop/DownloadAuditLogsModal/__tests__/DownloadAuditLogsModal.test.tsx
+++ b/app/src/organisms/Desktop/DownloadAuditLogsModal/__tests__/DownloadAuditLogsModal.test.tsx
@@ -31,7 +31,8 @@ describe('DownloadAuditLogsModal', () => {
 
   it('renders the warning title, description, and download button', () => {
     render(props)
-    expect(screen.getAllByText('Download audit logs')).toHaveLength(2)
+    expect(screen.getAllByText('Download audit logs')).toHaveLength(1)
+    expect(screen.getAllByText('Download now')).toHaveLength(1)
     screen.getByText(
       'Once a protocol run is complete, audit logs must be downloaded locally before continuing.'
     )
@@ -39,7 +40,7 @@ describe('DownloadAuditLogsModal', () => {
 
   it('calls onDownload when the download button is clicked', () => {
     render(props)
-    screen.getByRole('button', { name: 'Download audit logs' }).click()
+    screen.getByRole('button', { name: 'Download now' }).click()
     expect(props.onDownload).toHaveBeenCalled()
   })
 

--- a/app/src/organisms/Desktop/DownloadAuditLogsModal/__tests__/DownloadAuditLogsModal.test.tsx
+++ b/app/src/organisms/Desktop/DownloadAuditLogsModal/__tests__/DownloadAuditLogsModal.test.tsx
@@ -33,7 +33,7 @@ describe('DownloadAuditLogsModal', () => {
     render(props)
     expect(screen.getAllByText('Download audit logs')).toHaveLength(2)
     screen.getByText(
-      'Audit logs are not saved to the robot and must be downloaded locally before continuing. Once this session ends, the data cannot be recovered.'
+      'Once a protocol run is complete, audit logs must be downloaded locally before continuing.'
     )
   })
 

--- a/app/src/organisms/Desktop/DownloadAuditLogsModal/index.tsx
+++ b/app/src/organisms/Desktop/DownloadAuditLogsModal/index.tsx
@@ -46,7 +46,7 @@ export function DownloadAuditLogsModal({
                 aria-hidden
                 spin={isLoading}
               />
-              {t('download_audit_logs')}
+              {t('download_now')}
             </span>
           </PrimaryButton>
         </div>


### PR DESCRIPTION
This makes it a little clearer that things aren't getting deleted without your say-so.

Closes RQA-5900
