### PR TITLE
fix(api): quiet expected module serial errors

### DIFF
--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -5,6 +5,10 @@ import logging
 import os
 from typing import AsyncIterator, Literal, Type
 
+from serial.serialutil import (  # type: ignore[import-untyped]
+    SerialException as PySerialSerialException,
+)
+
 from .async_serial import AsyncSerial
 from .errors import (
     AlarmResponse,
@@ -720,17 +724,6 @@ class AsyncResponseSerialConnection(SerialConnection):
             ackless_responses.append(str_response)
         return ackless_responses
 
-    @staticmethod
-    def _is_retryable_send_error(error: BaseException) -> bool:
-        """Return whether a send failure should be retried.
-
-        Device-reported failures (error/alarm responses, including async module
-        errors such as ``async ERR401:...``) are permanent or one-shot. Retrying
-        them can consume the only notification and leave higher layers thinking
-        the command succeeded.
-        """
-        return not isinstance(error, FailedCommand)
-
     async def _send_data_multiack(
         self, data: str, retries: int, acks: int
     ) -> list[str]:
@@ -773,13 +766,36 @@ class AsyncResponseSerialConnection(SerialConnection):
                 responses = await self._send_one_retry(data, acks)
                 if responses:
                     return responses
-            except Exception as error:
+            except FailedCommand as error:
+                # Device-reported failures (error/alarm responses, including async module
+                # errors such as ``async ERR401:...``) are permanent or one-shot. Retrying
+                # them can consume the only notification and leave higher layers thinking
+                # the command succeeded. Also they are expected responses, dont log the
+                # error as a traceback.
+                log.info("Device reported an error during send: %s", error)
+                raise
+            except PySerialSerialException as error:
+                # Unplug / I/O errors are expected while a module is disappearing.
+                # Retry without a traceback; the poller already logs the final failure.
+                if retry < retries and not self._closed_on_purpose:
+                    log.warning(
+                        "%s: send failed (%s); retrying %s/%s",
+                        self._name,
+                        error,
+                        retry,
+                        retries,
+                    )
+                else:
+                    log.warning(
+                        "%s: send failed after %s retries: %s",
+                        self._name,
+                        retries,
+                        error,
+                    )
+                    raise
+            except Exception:
                 log.exception("Got an error during send")
-                if (
-                    retry < retries
-                    and not self._closed_on_purpose
-                    and self._is_retryable_send_error(error)
-                ):
+                if retry < retries and not self._closed_on_purpose:
                     pass
                 else:
                     log.warning(f"Already used {retry} {retries} and raising error")

--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -969,7 +969,11 @@ class FlexStackerReader(Reader):
         self._refresh_state = True
 
     def on_error(self, exception: Exception) -> None:
-        self._driver.reset_serial_buffers()
+        try:
+            self._driver.reset_serial_buffers()
+        except Exception:
+            # Port is often already gone on unplug; still record the poll error.
+            log.debug("Could not reset serial buffers after poll error", exc_info=True)
         self._set_error(exception)
 
     def _set_error(self, exception: Optional[Exception]) -> None:

--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -940,7 +940,11 @@ class VacuumModuleReader(Reader):
         self._refresh_state = True
 
     def on_error(self, exception: Exception) -> None:
-        self._driver.reset_serial_buffers()
+        try:
+            self._driver.reset_serial_buffers()
+        except Exception:
+            # Port is often already gone on unplug; still record the poll error.
+            log.debug("Could not reset serial buffers after poll error", exc_info=True)
         self._set_error(exception)
 
     def _set_error(self, exception: Optional[Exception]) -> None:

--- a/api/src/opentrons/hardware_control/poller.py
+++ b/api/src/opentrons/hardware_control/poller.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import errno
 import logging
 from abc import ABC, abstractmethod
 from typing import AsyncGenerator, List, Optional
@@ -10,10 +11,28 @@ from serial.serialutil import (  # type: ignore[import-untyped]
 
 from opentrons_shared_data.errors.exceptions import ModuleCommunicationError
 
-from opentrons.drivers.asyncio.communication.errors import SerialException
+from opentrons.drivers.asyncio.communication.errors import (
+    FailedCommand,
+    SerialException,
+)
 from opentrons.hardware_control.modules.errors import AbsorbanceReaderDisconnectedError
 
 log = logging.getLogger(__name__)
+
+_EXPECTED_DISCONNECT_ERRNOS = {errno.EIO, errno.ENODEV, errno.ENXIO}
+
+
+def _is_expected_disconnect_io_error(exc: BaseException) -> bool:
+    """Return whether ``exc`` is a typical unplug / vanished-port I/O error."""
+    if isinstance(exc, PySerialSerialException):
+        return True
+    if isinstance(exc, OSError) and exc.errno in _EXPECTED_DISCONNECT_ERRNOS:
+        return True
+    try:
+        import termios
+    except ImportError:
+        return False
+    return isinstance(exc, termios.error)
 
 
 class Reader(ABC):
@@ -115,8 +134,14 @@ class Poller:
     def _error_callback(self, exc: Exception) -> None:
         try:
             self._reader.on_error(exc)
-        except Exception:
-            log.exception("Exception in reader callback")
+        except Exception as callback_error:
+            if _is_expected_disconnect_io_error(callback_error):
+                log.warning(
+                    "Reader cleanup failed after serial disconnect: %s",
+                    callback_error,
+                )
+            else:
+                log.exception("Exception in reader callback")
 
     def _complete_all(
         self, exc: Exception | None, previous: List["asyncio.Future[None]"]
@@ -138,8 +163,12 @@ class Poller:
         except AbsorbanceReaderDisconnectedError as e:
             self._error_callback(e)
             self._complete_all(e, previous_waiters)
+        except FailedCommand as se:
+            log.info("Module reported an error during poll: %s", se)
+            self._error_callback(se)
+            self._complete_all(se, previous_waiters)
         except (SerialException, PySerialSerialException) as se:
-            log.error(f"Polling gcode error: {se}")
+            log.warning("Polling failed: %s", se)
             self._error_callback(se)
             self._complete_all(se, previous_waiters)
         except Exception as e:

--- a/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
@@ -5,6 +5,7 @@ import mock
 import pytest
 from _pytest.fixtures import SubRequest
 from mock import AsyncMock, call
+from serial.serialutil import SerialException as PySerialSerialException
 
 from opentrons.drivers.asyncio.communication.async_serial import AsyncSerial
 from opentrons.drivers.asyncio.communication.errors import (
@@ -434,6 +435,50 @@ async def test_send_data_does_not_retry_async_error(
     mock_serial_port.write.assert_awaited_once_with(data=data.encode())
     # Combined async + command frame is fully consumed in a single read.
     assert mock_serial_port.read_until.await_count == 1
+
+
+async def test_send_data_does_not_log_traceback_for_async_error(
+    mock_serial_port: AsyncMock,
+    async_subject: AsyncResponseSerialConnection,
+    ack: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Device-reported async errors are valid responses, not unexpected send failures."""
+    data = "M121 "
+    async_line = "async ERR400:vacuum:target pressure not reached"
+    combined_response = f"{async_line}\nM121 T:0.0 C:-4.7 V:1 {ack}".encode()
+    mock_serial_port.read_until.side_effect = [combined_response]
+
+    with caplog.at_level("DEBUG"):
+        with pytest.raises(ErrorResponse, match="ERR400"):
+            await async_subject._send_data_multiack(data=data, retries=2, acks=1)
+
+    assert "Got an error during send" not in caplog.text
+    assert "Already used" not in caplog.text
+    assert "Traceback" not in caplog.text
+    assert "Device reported an error during send" in caplog.text
+
+
+async def test_send_data_does_not_log_traceback_for_serial_io_error(
+    mock_serial_port: AsyncMock,
+    async_subject: AsyncResponseSerialConnection,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unplug I/O errors should retry without a traceback on every attempt."""
+    mock_serial_port.write.side_effect = PySerialSerialException(
+        "write failed: [Errno 5] Input/output error"
+    )
+
+    with caplog.at_level("DEBUG"):
+        with pytest.raises(PySerialSerialException, match="write failed"):
+            await async_subject._send_data_multiack(data="M121 ", retries=2, acks=1)
+
+    assert mock_serial_port.write.await_count == 3
+    assert "Got an error during send" not in caplog.text
+    assert "Traceback" not in caplog.text
+    assert "retrying 0/2" in caplog.text
+    assert "retrying 1/2" in caplog.text
+    assert "send failed after 2 retries" in caplog.text
 
 
 async def test_send_data_still_retries_missing_response(

--- a/api/tests/opentrons/hardware_control/test_poller.py
+++ b/api/tests/opentrons/hardware_control/test_poller.py
@@ -3,6 +3,7 @@ from typing import AsyncGenerator
 
 import pytest
 from decoy import Decoy, matchers
+from serial.serialutil import SerialException as PySerialSerialException
 
 from opentrons.hardware_control.poller import Poller, Reader
 
@@ -133,6 +134,29 @@ async def test_poller_start_error(
         mock_reader.on_error(matchers.ErrorMatching(RuntimeError, match="oh no")),
         times=1,
     )
+
+
+async def test_poller_disconnect_io_does_not_log_callback_traceback(
+    decoy: Decoy,
+    mock_reader: Reader,
+    subject: Poller,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unplug I/O during poll/cleanup should not dump a traceback."""
+    io_error = PySerialSerialException("write failed: [Errno 5] Input/output error")
+    decoy.when(await mock_reader.read()).then_raise(io_error)  # type: ignore[func-returns-value]
+    decoy.when(
+        mock_reader.on_error(matchers.ErrorMatching(PySerialSerialException))
+    ).then_raise(io_error)
+
+    with caplog.at_level("DEBUG"):
+        with pytest.raises(PySerialSerialException, match="write failed"):
+            await subject.start()
+
+    assert "Exception in reader callback" not in caplog.text
+    assert "Traceback" not in caplog.text
+    assert "Polling failed" in caplog.text
+    assert "Reader cleanup failed after serial disconnect" in caplog.text
 
 
 async def test_poller_wait_next_poll_error(


### PR DESCRIPTION
# Overview

Module serial logs treat a lot of expected traffic as a crash. A valid vacuum async error (`ERR400`/`ERR401`) dumps a send traceback, and unplugging a module dumps the same I/O traceback on every retry, plus another one when we try to flush buffers on a dead port.

This keeps retries as they are. Device-reported errors and unplug I/O just log a one-liner. Vacuum and Flex Stacker `on_error` still try to reset serial buffers, but a gone port no longer blows up the poller callback.

Async errors now look like this, instead of a giant traceback mess
```
Aug 18 14:44:36 FLXA1020240829003 opentrons-api-serial[1234099]: /dev/ot_module_vacuummodule0: Write -> b'M121 \n'
Aug 18 14:44:36 FLXA1020240829003 uvicorn[1234099]:  - "GET /health HTTP/1.1" 200
Aug 18 14:44:36 FLXA1020240829003 opentrons-api-serial[1234099]: /dev/ot_module_vacuummodule0: Read <- b'async ERR400:vacuum:target pressure not reached\nM121 T:0.0 C:-304.5 A:706.4 B:708.4 H:1012.9 E:0 D:0 V:0 OK\n'
Aug 18 14:44:36 FLXA1020240829003 opentrons-api-serial[1234099]: Device reported an error during send: /dev/ot_module_vacuummodule0: 'Received error response 'async ERR400:vacuum:target pressure not reached'
Aug 18 14:44:36 FLXA1020240829003 opentrons-api[1234099]: Module reported an error during poll: /dev/ot_module_vacuummodule0: 'Received error response 'async ERR400:vacuum:target pressure not reached'
Aug 18 14:44:36 FLXA1020240829003 opentrons-api[1234099]: Forwarding module event HardwareEventType.ASYNCHRONOUS_MODULE_ERROR for vacuumModuleV1 VM1020260616001 at /dev/ot_module_vacuummodule0
```

Serial retries and module disconnects now look like this, instead of a giant traceback mess
```
Aug 18 15:08:11 FLXA1020240829003 opentrons-api-serial[1244525]: /dev/ot_module_vacuummodule0: Write -> b'M121 \n'
Aug 18 15:08:11 FLXA1020240829003 opentrons-api-serial[1244525]: /dev/ot_module_vacuummodule0: send failed (write failed: [Errno 5] Input/output error); retrying 0/2
Aug 18 15:08:11 FLXA1020240829003 opentrons-api-serial[1244525]: /dev/ot_module_vacuummodule0: retry number 0/2
Aug 18 15:08:11 FLXA1020240829003 opentrons-api-serial[1244525]: /dev/ot_module_vacuummodule0: Write -> b'M121 \n'
Aug 18 15:08:11 FLXA1020240829003 opentrons-api-serial[1244525]: /dev/ot_module_vacuummodule0: send failed (write failed: [Errno 5] Input/output error); retrying 1/2
Aug 18 15:08:11 FLXA1020240829003 opentrons-api-serial[1244525]: /dev/ot_module_vacuummodule0: retry number 1/2
Aug 18 15:08:11 FLXA1020240829003 opentrons-api-serial[1244525]: /dev/ot_module_vacuummodule0: Write -> b'M121 \n'
Aug 18 15:08:11 FLXA1020240829003 python3[1244525]: Error GENERAL_ERROR is inappropriate for a RoboticsControlError exception
Aug 18 15:08:11 FLXA1020240829003 opentrons-api-serial[1244525]: /dev/ot_module_vacuummodule0: send failed after 2 retries: write failed: [Errno 5] Input/output error
Aug 18 15:08:11 FLXA1020240829003 opentrons-api[1244525]: Polling failed: write failed: [Errno 5] Input/output error
Aug 18 15:08:11 FLXA1020240829003 opentrons-api[1244525]: Forwarding module event HardwareEventType.ASYNCHRONOUS_MODULE_ERROR for vacuumModuleV1 VM1020260616001 at /dev/ot_module_vacuummodule0
```

## Test Plan and Hands on Testing

- On a Flex: inject/recover a real vacuum `ERR400` — no send traceback, recovery still enters
- Unplug a vacuum module mid-poll — three retry warnings, no send/cleanup traceback, `MODULE_DISCONNECTED` still fires

## Changelog

- Device-reported serial errors (`FailedCommand`) log at info, no traceback, and are not retried
- Unplug I/O (`SerialException`) still retries, but each attempt is a warning line
- Poller treats serial I/O as a warning; cleanup failures after disconnect are warnings
- Vacuum and Flex Stacker ignore buffer-reset failures when the port is already gone

## Review requests

- Is info/warning the right level for these, or should the retry lines be debug?

## Risk assessment

Low. Logging and cleanup only. Send/retry behavior is unchanged except we no longer `log.exception` on expected failures. Covers all modules that share the serial send path, not just vacuum.