### PR TITLE
fix(protocol-designer, step-generation): fix vac collar movement logic and rendering

### DIFF
--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -186,3 +186,6 @@ export const VACUUM_MODULE_SLOT = 'A3'
 
 export const VACUUM_MODULE_TYPE_WITH_LABWARE: 'vacuumModuleTypeWithLabware' =
   'vacuumModuleTypeWithLabware'
+
+export const VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_X: number = -11.5
+export const VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_Y: number = -12

--- a/protocol-designer/src/pages/Designer/DeckSetup/VacuumDockLabwareRenders.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/VacuumDockLabwareRenders.tsx
@@ -1,6 +1,10 @@
 import { VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA } from '@opentrons/shared-data'
 
 import { LabwareOnDeck } from '/protocol-designer/components/organisms'
+import {
+  VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_X,
+  VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_Y,
+} from '/protocol-designer/constants'
 
 import { HighlightLabware } from '../HighlightLabware'
 import { LabwareControls } from './Overlays'
@@ -86,7 +90,11 @@ export function VacuumDockLabwareRenders(
       })}
       <HighlightLabware
         labwareOnDeck={topLabware}
-        position={[x, y, 0]}
+        position={[
+          x + VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_X,
+          y + VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_Y,
+          0,
+        ]}
         isZoomed={selectedZoomInSlot != null}
       />
       <LabwareControls
@@ -95,7 +103,11 @@ export function VacuumDockLabwareRenders(
         setHover={setHover}
         setShowMenuListForId={setShowMenuListForId}
         hover={hover}
-        slotPosition={[x, y, 0]}
+        slotPosition={[
+          x + VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_X,
+          y + VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_Y,
+          0,
+        ]}
         setHoveredLabware={setHoveredLabware}
         setDraggedLabware={setDraggedLabware}
         swapBlocked={false}
@@ -105,7 +117,11 @@ export function VacuumDockLabwareRenders(
       />
       <ActiveLabwareControls
         itemId={VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA}
-        slotPosition={[x, y, 0]}
+        slotPosition={[
+          x + VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_X,
+          y + VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_Y,
+          0,
+        ]}
         hover={hover}
         setHover={setHover}
         slotBoundingBox={labwareInterfaceBoundingBox}

--- a/protocol-designer/src/pages/Designer/DeckSetup/VacuumDockLabwareRenders.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/VacuumDockLabwareRenders.tsx
@@ -11,7 +11,7 @@ import { LabwareControls } from './Overlays'
 import { ActiveLabwareControls } from './Overlays/ActiveLabwareControls'
 
 import type { Dispatch, SetStateAction } from 'react'
-import type { DeckSlotId } from '@opentrons/shared-data'
+import type { CoordinateTuple, DeckSlotId } from '@opentrons/shared-data'
 import type {
   LabwareOnDeck as LabwareOnDeckType,
   ModuleOnDeck,
@@ -73,6 +73,12 @@ export function VacuumDockLabwareRenders(
     zDimension: 0,
   }
 
+  const dockPositionWithOffset: CoordinateTuple = [
+    x + VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_X,
+    y + VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_Y,
+    0,
+  ]
+
   return (
     <>
       {/* Render all labware in the stack (bottom to top) */}
@@ -90,11 +96,7 @@ export function VacuumDockLabwareRenders(
       })}
       <HighlightLabware
         labwareOnDeck={topLabware}
-        position={[
-          x + VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_X,
-          y + VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_Y,
-          0,
-        ]}
+        position={dockPositionWithOffset}
         isZoomed={selectedZoomInSlot != null}
       />
       <LabwareControls
@@ -103,11 +105,7 @@ export function VacuumDockLabwareRenders(
         setHover={setHover}
         setShowMenuListForId={setShowMenuListForId}
         hover={hover}
-        slotPosition={[
-          x + VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_X,
-          y + VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_Y,
-          0,
-        ]}
+        slotPosition={dockPositionWithOffset}
         setHoveredLabware={setHoveredLabware}
         setDraggedLabware={setDraggedLabware}
         swapBlocked={false}
@@ -117,11 +115,7 @@ export function VacuumDockLabwareRenders(
       />
       <ActiveLabwareControls
         itemId={VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA}
-        slotPosition={[
-          x + VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_X,
-          y + VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_Y,
-          0,
-        ]}
+        slotPosition={dockPositionWithOffset}
         hover={hover}
         setHover={setHover}
         slotBoundingBox={labwareInterfaceBoundingBox}

--- a/protocol-designer/src/pages/Designer/LabwareLabel.tsx
+++ b/protocol-designer/src/pages/Designer/LabwareLabel.tsx
@@ -3,9 +3,15 @@ import { useSelector } from 'react-redux'
 
 import { DeckLabelSet } from '@opentrons/components'
 
+import {
+  VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_X,
+  VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_Y,
+} from '/protocol-designer/constants'
+
 import { selectors } from '../../labware-ingred/selectors'
 import { START_TERMINAL_ITEM_ID } from '../../steplist'
 import { getSelectedTerminalItemId } from '../../ui/steps'
+import { getIsVacuumCollar } from './DeckSetup/utils'
 
 import type { DeckLabelProps } from '@opentrons/components'
 import type {
@@ -68,6 +74,13 @@ export const LabwareLabel = (props: LabwareLabelProps): JSX.Element => {
     labwareDef.parameters.loadName === 'opentrons_flex_deck_riser' &&
     nestedLabwareInfo.length === 0
 
+  const isVacuumCollar = getIsVacuumCollar(labwareDef)
+  const [vacuumCollarAdjustmentX, vacuumCollarAdjustmentY] = isVacuumCollar
+    ? [
+        VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_X,
+        VACUUM_COLLAR_OFFSET_MM_FROM_CORNER_Y,
+      ]
+    : [0, 0]
   return (
     <DeckLabelSet
       ref={labelContainerRef}
@@ -75,9 +88,15 @@ export const LabwareLabel = (props: LabwareLabelProps): JSX.Element => {
       x={
         position[0] +
         labwareDef.cornerOffsetFromSlot.x -
-        (showDeckRiserAdjustments ? DECK_RISER_ADJUSTED_X : 0)
+        (showDeckRiserAdjustments ? DECK_RISER_ADJUSTED_X : 0) +
+        vacuumCollarAdjustmentX
       }
-      y={position[1] + labwareDef.cornerOffsetFromSlot.y - labelContainerHeight}
+      y={
+        position[1] +
+        labwareDef.cornerOffsetFromSlot.y -
+        labelContainerHeight +
+        vacuumCollarAdjustmentY
+      }
       width={labwareDef.dimensions.xDimension}
       height={
         labwareDef.dimensions.yDimension -

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
@@ -7,6 +7,7 @@ import {
   FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS,
   getIsDeckSlotCompatible,
   getIsLid,
+  getIsTiprack,
   getModuleDisplayName,
   OT2_SINGLE_SLOT_ADDRESSABLE_AREAS,
   VACUUM_MODULE_TYPE,
@@ -14,6 +15,7 @@ import {
 } from '@opentrons/shared-data'
 import {
   getFullStackFromLabwares,
+  getIsVacuumSpacer,
   getSlotInLocationStack,
   VACUUM_DOCK_ADDRESSABLE_AREA,
   VACUUM_DOCK_LOCATION,
@@ -37,6 +39,7 @@ import {
   getUnoccupiedLabwareLocationOptions,
 } from '/protocol-designer/top-selectors/labware-locations'
 import { hoverSelection } from '/protocol-designer/ui/steps/actions/actions'
+import { getIsAdapter } from '/protocol-designer/utils'
 
 import { getSortedAddressableArea } from './utils'
 
@@ -188,6 +191,9 @@ export function LabwareLocationField(
   // compatible— filter plates can go anywhere, adapters with
   // providesStackingDefault accept any labware, otherwise fall back to
   // explicit compatibleParentLabware / stackingOffsetWithLabware
+  const isTiprack = movingLabwareDef != null && getIsTiprack(movingLabwareDef)
+  const isAdapter =
+    movingLabwareDef != null && getIsAdapter(labware, labwareEntities)
   const isMovingLabwareFilterPlate =
     movingLabwareDef?.parameters.quirks?.includes('filterPlate') ?? false
   if (movingLabwareDef != null && !isMovingLabwareFilterPlate) {
@@ -197,7 +203,11 @@ export function LabwareLocationField(
         if (destDef?.parameters.isMovableAdapter !== true) {
           return true
         }
-        if (destDef.parameters.quirks?.includes('providesStackingDefault')) {
+        if (
+          destDef.parameters.quirks?.includes('providesStackingDefault') &&
+          !isTiprack &&
+          !isAdapter
+        ) {
           return true
         }
         const destLoadName = destDef.parameters.loadName
@@ -212,6 +222,8 @@ export function LabwareLocationField(
     labwareEntities[labware]?.def.parameters.quirks?.includes(
       'vacuumModuleDock'
     ) ?? false
+  const isLabwareVacuumSpacer =
+    movingLabwareDef != null && getIsVacuumSpacer(movingLabwareDef)
 
   // only vacuumModuleDock-quirk labware can be moved to the vacuum dock
   if (!isLabwareVacuumDockCompatible) {
@@ -219,7 +231,12 @@ export function LabwareLocationField(
       unoccupiedLabwareLocationsOptions.filter(
         ({ value }) => value !== VACUUM_DOCK_ADDRESSABLE_AREA
       )
-  } else if (isLabwareVacuumDockCompatible && robotState != null) {
+  }
+
+  if (
+    (isLabwareVacuumDockCompatible || isLabwareVacuumSpacer) &&
+    robotState != null
+  ) {
     const vacuumModuleEntry = Object.entries(moduleEntities).find(
       ([, entity]) => entity.type === VACUUM_MODULE_TYPE
     )
@@ -240,8 +257,9 @@ export function LabwareLocationField(
       })
 
       // offer the vacuum module as a destination when it has no collar yet
-      // (empty module is valid — collar can sit directly on the module)
-      // forMoveLabware will build the full stack including any existing module labware
+      // (empty/exposed module is valid — a collar or a vacuum spacer can sit
+      // directly on the module) forMoveLabware will build the full stack
+      // including any existing module labware
       if (vacuumModuleHasNoCollar) {
         const isVacuumModuleAlreadyIncluded =
           unoccupiedLabwareLocationsOptions.some(
@@ -259,13 +277,17 @@ export function LabwareLocationField(
         }
       }
 
-      // collar can only go to the vacuum dock or the vacuum module main area (when eligible)
-      unoccupiedLabwareLocationsOptions =
-        unoccupiedLabwareLocationsOptions.filter(
-          ({ value }) =>
-            value === VACUUM_DOCK_ADDRESSABLE_AREA ||
-            (vacuumModuleHasNoCollar && value === vacuumModuleId)
-        )
+      // collar can only go to the vacuum dock or the vacuum module main area
+      // (when eligible); a vacuum spacer isn't restricted this way — it just
+      // gains the empty main area as an extra option above
+      if (isLabwareVacuumDockCompatible) {
+        unoccupiedLabwareLocationsOptions =
+          unoccupiedLabwareLocationsOptions.filter(
+            ({ value }) =>
+              value === VACUUM_DOCK_ADDRESSABLE_AREA ||
+              (vacuumModuleHasNoCollar && value === vacuumModuleId)
+          )
+      }
     }
   }
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/utils.ts
@@ -3,7 +3,12 @@ import {
   FLEX_ROBOT_TYPE,
   OT2_SINGLE_SLOT_ADDRESSABLE_AREAS,
 } from '@opentrons/shared-data'
-import { getSlotInLocationStack } from '@opentrons/step-generation'
+import {
+  getSlotInLocationStack,
+  VACUUM_DOCK_ADDRESSABLE_AREA,
+} from '@opentrons/step-generation'
+
+import { VACUUM_DOCK_DISPLAY_LOCATION } from '/protocol-designer/constants'
 
 import type { DropdownOption } from '@opentrons/components'
 import type { AddressableAreaName, RobotType } from '@opentrons/shared-data'
@@ -26,7 +31,13 @@ export const getSortedAddressableArea = (
         return modulesState[value].slot
       }
       if (labwareState?.[value]?.stack != null) {
-        return getSlotInLocationStack(labwareState[value]?.stack)
+        const slotInLocationStack = getSlotInLocationStack(
+          labwareState[value]?.stack
+        )
+        // explicit check for vacuum dock
+        return slotInLocationStack === VACUUM_DOCK_ADDRESSABLE_AREA
+          ? VACUUM_DOCK_DISPLAY_LOCATION
+          : slotInLocationStack
       }
       // value is a slot or OFFDECK
       return value

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -7,6 +7,7 @@ import {
   FLEX_STACKER_MODULE_TYPE,
   getAllDefinitions,
   getIsLid,
+  getIsPipettableLabware,
   getIsTiprack,
   getPositionFromSlotId,
   MOVABLE_TRASH_ADDRESSABLE_AREAS,
@@ -23,6 +24,7 @@ import {
   getIsSlotAVacuumDock,
   getIsVacuumSpacer,
   getSlotInLocationStack,
+  VACUUM_DOCK_ADDRESSABLE_AREA,
 } from '@opentrons/step-generation'
 
 import {
@@ -37,8 +39,10 @@ import { getLabwareNicknamesById } from '../../ui/labware/selectors'
 import {
   getAllLabwareIdsOfCertainURIOnStack,
   getFullStackFromLabwaresOnDeck,
+  getIsAdapter,
   getStagingAreaAddressableAreas,
 } from '../../utils'
+import { getIsVacuumCollar } from './DeckSetup/utils'
 
 import type { DropdownOption } from '@opentrons/components'
 import type {
@@ -409,6 +413,24 @@ export const useLabwareDropdownOptions = (
         isOffDeck &&
         (type === 'labware' || (type === 'moveLabware' && useGripper))
 
+      const lwIndex = fullStackFromLabwares.findIndex(
+        element => element === labwareId
+      )
+      const elementsAboveLw = fullStackFromLabwares.slice(0, lwIndex)
+      const isAdapterAbove = elementsAboveLw.some(element =>
+        getIsAdapter(element, labwareEntities)
+      )
+      const isOnlyCollarAboveAndIsPipettable =
+        elementsAboveLw.length === 1 &&
+        elementsAboveLw[0] in labwareEntities &&
+        getIsVacuumCollar(labwareEntities[elementsAboveLw[0]].def) &&
+        getIsPipettableLabware(def)
+      const isAccessibleFromTop =
+        isTopOfStack || isOnlyCollarAboveAndIsPipettable
+
+      const isPipettingToNonPipettableLabware =
+        type === 'labware' && !getIsPipettableLabware(def)
+
       //  TODO: refactor this to be easier to read
       const shouldExclude =
         isInaccessible ||
@@ -421,7 +443,9 @@ export const useLabwareDropdownOptions = (
           !isTopOfStack &&
           !isMovableAdapter &&
           !isLabwareLidCombo) ||
-        (type === 'labware' && !isTopOfStack)
+        (type === 'labware' && !isAccessibleFromTop) ||
+        (type === 'moveLabware' && isAdapterAbove) ||
+        isPipettingToNonPipettableLabware
       if (shouldExclude) {
         return acc
       }
@@ -488,6 +512,7 @@ export const getUnoccupiedStackOptions = (args: {
       const destIsVacuumSpacer = getIsVacuumSpacer(labwareOnDeckDef)
       const movingLabwareIsCollar =
         def.parameters.quirks?.includes('vacuumModuleDock') ?? false
+      const isVacuumDock = slot === VACUUM_DOCK_ADDRESSABLE_AREA
 
       const isCompatible =
         // filter plates can go on any non-lid, non-tiprack, non-filter-plate labware
@@ -537,7 +562,7 @@ export const getUnoccupiedStackOptions = (args: {
                   })
                 : displayName,
             value: labwareId,
-            deckLabel: slot,
+            deckLabel: isVacuumDock ? VACUUM_DOCK_DISPLAY_LOCATION : slot,
           },
         ]
       }

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -22,9 +22,11 @@ import {
 import {
   COLUMN_4_SLOTS,
   getAllLargestStacks,
+  getModuleLocationSlot,
   getProvidedAddressableAreasExposed,
   getSlotInLocationStack,
   getTopLocationInStack,
+  VACUUM_DOCK_LOCATION,
 } from '@opentrons/step-generation'
 
 import { OFFDECK, VACUUM_DOCK_DISPLAY_LOCATION } from '../../constants'
@@ -210,6 +212,12 @@ export const getUnoccupiedLabwareLocationOptions: Selector<Option[] | null> =
               getTopLocationInStack(stack) !== labwareId
           )
           const adapterSlot = getSlotInLocationStack(labwareOnDeck.stack)
+          // an adapter parked on the vacuum dock still has the vacuum module's id
+          // in its stack, but it isn't sitting on the module's own registered slot
+          // (getUnoccupiedStackOptions already offers it as a destination correctly,
+          // so skip it here rather than mislabeling it with the module's A3 slot)
+          const isOnVacuumDock =
+            labwareOnDeck.stack.includes(VACUUM_DOCK_LOCATION)
           const modIdWithAdapter = Object.keys(modules).find(modId =>
             labwareOnDeck.stack.includes(modId)
           )
@@ -217,15 +225,17 @@ export const getUnoccupiedLabwareLocationOptions: Selector<Option[] | null> =
             labwareEntities[labwareId].def.metadata.displayName
           const modSlot =
             modIdWithAdapter != null ? modules[modIdWithAdapter].slot : null
+          const transformedModSlot =
+            modSlot != null ? getModuleLocationSlot(modSlot) : null
           const isAdapter = getIsAdapter(labwareId, labwareEntities)
           const moduleUnderAdapter =
             modIdWithAdapter != null
               ? getModuleDisplayName(moduleEntities[modIdWithAdapter].model)
               : 'unknown module'
-          const moduleSlotInfo = modSlot ?? 'unknown slot'
+          const moduleSlotInfo = transformedModSlot ?? 'unknown slot'
           const adapterSlotInfo = adapterSlot ?? 'unknown adapter'
 
-          return isAdapter && !hasLabwareAboveAdapter
+          return isAdapter && !hasLabwareAboveAdapter && !isOnVacuumDock
             ? [
                 ...acc,
                 {

--- a/protocol-designer/src/ui/modules/__tests__/utils.test.ts
+++ b/protocol-designer/src/ui/modules/__tests__/utils.test.ts
@@ -11,6 +11,7 @@ import {
   TC_MODULE_LOCATION_OT3,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
+  VACUUM_MODULE_LOCATION,
   VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
@@ -29,13 +30,17 @@ describe('getModuleDisplayLocation', () => {
     const result = getModuleDisplayLocation(moduleOnDeck, FLEX_ROBOT_TYPE)
     expect(result).toEqual(TC_MODULE_LOCATION_OT3)
   })
+  it('returns the correct display location for a vacuum module on Flex', () => {
+    const moduleOnDeck = { type: VACUUM_MODULE_TYPE } as ModuleOnDeck
+    const result = getModuleDisplayLocation(moduleOnDeck, FLEX_ROBOT_TYPE)
+    expect(result).toEqual(VACUUM_MODULE_LOCATION)
+  })
   ;[
     MAGNETIC_MODULE_TYPE,
     TEMPERATURE_MODULE_TYPE,
     HEATERSHAKER_MODULE_TYPE,
     ABSORBANCE_READER_TYPE,
     FLEX_STACKER_MODULE_TYPE,
-    VACUUM_MODULE_TYPE,
   ].forEach(type => {
     it(`returns the slot for ${type}`, () => {
       const moduleOnDeck = {

--- a/protocol-designer/src/ui/modules/utils.ts
+++ b/protocol-designer/src/ui/modules/utils.ts
@@ -13,6 +13,7 @@ import {
   TC_MODULE_LOCATION_OT3,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
+  VACUUM_MODULE_LOCATION,
   VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
@@ -91,6 +92,9 @@ export const getModuleDisplayLocation = (
     return robotType === FLEX_ROBOT_TYPE
       ? TC_MODULE_LOCATION_OT3
       : TC_MODULE_LOCATION_OT2
+  }
+  if (type === VACUUM_MODULE_TYPE) {
+    return VACUUM_MODULE_LOCATION
   }
   return slot
 }

--- a/step-generation/src/constants.ts
+++ b/step-generation/src/constants.ts
@@ -193,3 +193,5 @@ export const VACUUM_SPACER_LOAD_NAMES: string[] = [
   'opentrons_vacuum_manifold_spacer_short',
   'opentrons_vacuum_manifold_spacer_tall',
 ]
+
+export const VACUUM_DOCK_DISPLAY_LOCATION: 'A4' = 'A4'

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -52,6 +52,7 @@ import {
   HOPPER_FAKE_LOCATIONS,
   HOPPER_STACKER_LOCATION,
   STAGING_AREA_SLOTS,
+  VACUUM_DOCK_DISPLAY_LOCATION,
   VACUUM_DOCK_LOCATION,
   VACUUM_SPACER_LOAD_NAMES,
   ZERO_OFFSET,
@@ -915,6 +916,13 @@ export const getSlotInLocationStack = (
       return slot
     }
   }
+}
+
+export const getModuleLocationSlot = (moduleSlot: string): string => {
+  if (moduleSlot === VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA) {
+    return VACUUM_DOCK_DISPLAY_LOCATION
+  }
+  return moduleSlot
 }
 
 export const getTopLocationInStack = (stack?: string[]): string => {


### PR DESCRIPTION
# Overview

Fixes a variety of bugs pertaining to vacuum collar and spacer movement and deck rendering alignment.

Closes RQA-5881
Closes RQA-5882
Closes RQA-5887
Closes RQA-5888
Closes RQA-5891
Closes RQA-5899
Closes RQA-5901

## Test Plan and Hands on Testing

#### Collar highlight and hover (RQA-5881)

- create or import a protocol with a vacuum collar
- hover the collar in starting deck state and verify that the hover shadow aligns to the collar
- create a step that highlights the collar, like a move labware step with collar selected
- verify that the highlight aligns to the collar

| Before | After |
|--------|--------|
| <img width="157" height="158" alt="Screenshot 2026-08-18 at 11 55 40 AM" src="https://github.com/user-attachments/assets/8fdea2ca-4e61-418f-88ee-8d6b0f86829c" /> | <img width="155" height="178" alt="Screenshot 2026-08-18 at 11 54 18 AM" src="https://github.com/user-attachments/assets/ceb70a03-491e-49e8-bcbb-542c792dfdd6" /> |
| <img width="153" height="132" alt="Screenshot 2026-08-18 at 11 56 05 AM" src="https://github.com/user-attachments/assets/85fd8599-8b23-4379-89a8-d68b8d50a836" /> | <img width="156" height="144" alt="Screenshot 2026-08-18 at 11 54 55 AM" src="https://github.com/user-attachments/assets/943809e2-6ca7-4a6e-94e9-bae8bd88953b" /> | 

#### Vacuum dock display location
- create a move step with the new location as the vacuum collar
- verify that the display location is "A4" and is correctly sorted in the dropdown options

| Before | After |
|--------|--------|
| <img width="345" height="453" alt="Screenshot 2026-08-18 at 11 58 08 AM" src="https://github.com/user-attachments/assets/bb32ab0e-1518-4279-b7c4-6613367411a4" /> | <img width="343" height="395" alt="Screenshot 2026-08-18 at 12 00 14 PM" src="https://github.com/user-attachments/assets/78971189-b78e-41cf-944b-d2592d3d2f1e" /> |

#### Vacuum collar and spacer movement
- create or import a protocol with a spacer on the main module area and collar on the dock
- verify that you can move the spacer off the module onto an open deck slot
- verify that you cannot move the spacer onto the collar 
- verify that you cannot move any tiprack onto the collar 

#### Pipetting to a plate through a collar
- create or import a protocol with a plate beneath a collar on main module area, and no plate on top of the collar
- create a transfer or mix step
- verify that the collar itself is _not_ available as a pipetting labware option
- verify that the plate directly accessible through the collar is available as a pipetting labware option

## Changelog

- allow pipetting through a collar to its most direct parent if that parent is a pipettable labware and there is no other labware on top of the collar (in accordance with PAPI restrictions)
- update logic for moving spacers and collars around the deck, and block moving tipracks and spacers on top of collars
- disallow pipetting to non-pipettable labware (like adapters)
- fix module location label and dock location label

## Review requests

see test plan

## Risk assessment

lowish. lots of changes here, but all are scoped to wholly new vacuum module interactions