### PR TITLE
fix(api,protocol-designer): Don't allow modules to be placed adjacent to the vacuum module.

### DIFF
--- a/api/src/opentrons/motion_planning/deck_conflict.py
+++ b/api/src/opentrons/motion_planning/deck_conflict.py
@@ -15,6 +15,7 @@ from opentrons.motion_planning.adjacent_slots_getters import (
     get_adjacent_slots,
     get_adjacent_staging_slot,
     get_east_west_slots,
+    get_north_south_slots,
     get_south_slot,
 )
 from opentrons.protocols.api_support.constants import OPENTRONS_NAMESPACE
@@ -430,6 +431,31 @@ def _create_flex_restrictions(  # noqa: C901
                 source_location=location,
             )
         )
+    elif isinstance(item, VacuumModule):
+        if isinstance(location, StagingSlotName):
+            raise DeckConflictError(
+                "Cannot have a module loaded on a staging area slot."
+            )
+        # The vacuum module occupies its own slot. Labware on the module is
+        # tracked as part of the module, not as a separate slot item.
+        restrictions.append(
+            _NothingAllowed(
+                location=location,
+                source_item=item,
+                source_location=location,
+            )
+        )
+        # Gripper paddles collide with the vacuum collar when they open on a
+        # module in a north/south neighboring standard slot (A3 → B3, D3 → C3).
+        # Staging slots are not a gripper collision risk.
+        for blocked_location in _flex_slots_blocked_by_vacuum_module(location):
+            restrictions.append(
+                _NoModule(
+                    location=blocked_location,
+                    source_item=item,
+                    source_location=location,
+                )
+            )
     elif location in _flex_slots_allowing_stacker():
         restrictions.append(
             _NothingButStackerAllowed(
@@ -509,6 +535,24 @@ def _flex_slots_allowing_stacker() -> Set[DeckSlotName]:
         DeckSlotName.SLOT_C3,
         DeckSlotName.SLOT_D3,
     }
+
+
+def _flex_slots_blocked_by_vacuum_module(
+    vacuum_module_location: DeckSlotName,
+) -> List[DeckSlotName]:
+    """Standard slots that cannot hold a module when a vacuum module occupies this slot.
+
+    The gripper paddles collide with the vacuum collar when they open on a
+    module in a north/south neighboring standard slot:
+    - vacuum module on A3 → no modules on B3
+    - vacuum module on D3 (future) → no modules on C3
+
+    Staging slots are not included; they are not a gripper collision risk.
+    """
+    return [
+        DeckSlotName.from_primitive(neighbor_int).to_ot3_equivalent()
+        for neighbor_int in get_north_south_slots(vacuum_module_location.as_int())
+    ]
 
 
 def _is_ot2_fixed_trash(item: DeckItem) -> bool:

--- a/api/src/opentrons/protocol_engine/commands/load_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/load_labware.py
@@ -192,6 +192,10 @@ class LoadLabwareImplementation(
             )
 
         elif self._is_loading_to_module(params.location, ModuleModel.VACUUM_MODULE_V1):
+            if isinstance(verified_location, ModuleLocation):
+                self._state_view.labware.raise_if_labware_incompatible_with_vacuum_module(
+                    loaded_labware.definition
+                )
             self._state_view.labware.raise_if_labware_incompatible_with_vacuum_module_dock(
                 verified_location, loaded_labware.definition
             )

--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -377,6 +377,10 @@ class MoveLabwareImplementation(AbstractCommandImpl[MoveLabwareParams, _ExecuteR
                 self._state_view.labware.raise_if_labware_incompatible_with_plate_reader(
                     current_labware_definition
                 )
+            if module is not None and module.model == ModuleModel.VACUUM_MODULE_V1:
+                self._state_view.labware.raise_if_labware_incompatible_with_vacuum_module(
+                    current_labware_definition
+                )
 
         # Allow propagation of ModuleNotLoadedError.
         new_offset_id = self._equipment.find_applicable_labware_offset_id(

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1164,12 +1164,14 @@ class LabwareView:
     def raise_if_labware_incompatible_with_vacuum_module(
         self,
         labware_definition: LabwareDefinition,
-    ) -> None:
+    ) -> bool:
         """Raise if a filter plate is placed directly on the vacuum module.
 
         Filter plates must sit on a collar, spacer, or receiver plate. Some
         of them have their wells extend below the skirt and will not seat on
         the module surface.
+
+        Returns True if it does not raise.
         """
         if labware_validation.validate_definition_is_filter_plate(labware_definition):
             raise errors.LabwareIsNotAllowedInLocationError(
@@ -1177,6 +1179,7 @@ class LabwareView:
                 " onto the vacuum module. Filter plates must sit on a manifold"
                 " collar, spacer, or receiver plate."
             )
+        return True
 
     def raise_if_labware_incompatible_with_vacuum_module_dock(
         self,

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1161,6 +1161,23 @@ class LabwareView:
             )
         return True
 
+    def raise_if_labware_incompatible_with_vacuum_module(
+        self,
+        labware_definition: LabwareDefinition,
+    ) -> None:
+        """Raise if a filter plate is placed directly on the vacuum module.
+
+        Filter plates must sit on a collar, spacer, or receiver plate. Some
+        of them have their wells extend below the skirt and will not seat on
+        the module surface.
+        """
+        if labware_validation.validate_definition_is_filter_plate(labware_definition):
+            raise errors.LabwareIsNotAllowedInLocationError(
+                f"Cannot place '{labware_definition.parameters.loadName}' directly"
+                " onto the vacuum module. Filter plates must sit on a manifold"
+                " collar, spacer, or receiver plate."
+            )
+
     def raise_if_labware_incompatible_with_vacuum_module_dock(
         self,
         location: LabwareLocation,

--- a/api/tests/opentrons/motion_planning/test_deck_conflict.py
+++ b/api/tests/opentrons/motion_planning/test_deck_conflict.py
@@ -1,7 +1,7 @@
 """Tests for opentrons.protocols.geometry.deck_conflict."""
 
 from contextlib import nullcontext
-from typing import ContextManager
+from typing import ContextManager, Union
 
 import pytest
 
@@ -682,5 +682,115 @@ def test_allow_labware_in_stacker_quote_slot_unquote(
         existing_items={deck_slot_name: labware},
         new_item=stacker,
         new_location=deck_slot_name,
+        robot_type="OT-3 Standard",
+    )
+
+
+@pytest.mark.parametrize(
+    ("vacuum_module_location", "blocked_location"),
+    [
+        (DeckSlotName.SLOT_A3, DeckSlotName.SLOT_B3),
+        (DeckSlotName.SLOT_D3, DeckSlotName.SLOT_C3),
+    ],
+)
+def test_no_modules_adjacent_to_vacuum_module(
+    vacuum_module_location: DeckSlotName,
+    blocked_location: DeckSlotName,
+) -> None:
+    """A vacuum module should block modules on the neighboring standard slot.
+
+    Gripper paddles collide with the vacuum collar when they open on a module
+    in that neighboring slot (A3 → B3, D3 → C3).
+    """
+    vacuum_module = deck_conflict.VacuumModule(
+        highest_z_including_labware=123, name_for_errors="some_vacuum_module"
+    )
+    other_module = deck_conflict.MagneticBlockModule(
+        highest_z_including_labware=123, name_for_errors="some_other_module"
+    )
+
+    with pytest.raises(
+        deck_conflict.DeckConflictError,
+        match=(
+            f"some_vacuum_module in slot {vacuum_module_location}"
+            f" prevents some_other_module from using slot {blocked_location}"
+        ),
+    ):
+        deck_conflict.check(
+            existing_items={vacuum_module_location: vacuum_module},
+            new_location=blocked_location,
+            new_item=other_module,
+            robot_type="OT-3 Standard",
+        )
+
+    with pytest.raises(
+        deck_conflict.DeckConflictError,
+        match=(
+            f"some_other_module in slot {blocked_location}"
+            f" prevents some_vacuum_module from using slot {vacuum_module_location}"
+        ),
+    ):
+        deck_conflict.check(
+            existing_items={blocked_location: other_module},
+            new_location=vacuum_module_location,
+            new_item=vacuum_module,
+            robot_type="OT-3 Standard",
+        )
+
+
+@pytest.mark.parametrize(
+    ("vacuum_module_location", "allowed_location"),
+    [
+        (DeckSlotName.SLOT_A3, DeckSlotName.SLOT_C3),
+        (DeckSlotName.SLOT_A3, DeckSlotName.SLOT_B2),
+        (DeckSlotName.SLOT_A3, StagingSlotName.SLOT_B4),
+        (DeckSlotName.SLOT_D3, DeckSlotName.SLOT_B3),
+        (DeckSlotName.SLOT_D3, DeckSlotName.SLOT_C2),
+        (DeckSlotName.SLOT_D3, StagingSlotName.SLOT_C4),
+    ],
+)
+def test_unrelated_slots_allowed_next_to_vacuum_module(
+    vacuum_module_location: DeckSlotName,
+    allowed_location: Union[DeckSlotName, StagingSlotName],
+) -> None:
+    """A vacuum module should not block modules outside the neighboring standard slot.
+
+    Staging slots are allowed; they are not a gripper collision risk.
+    """
+    vacuum_module = deck_conflict.VacuumModule(
+        highest_z_including_labware=123, name_for_errors="some_vacuum_module"
+    )
+    other_module = deck_conflict.MagneticBlockModule(
+        highest_z_including_labware=123, name_for_errors="some_other_module"
+    )
+    deck_conflict.check(
+        existing_items={vacuum_module_location: vacuum_module},
+        new_location=allowed_location,
+        new_item=other_module,
+        robot_type="OT-3 Standard",
+    )
+
+
+def test_labware_allowed_adjacent_to_vacuum_module() -> None:
+    """Labware (not modules) should still be allowed on the neighboring slot."""
+    vacuum_module = deck_conflict.VacuumModule(
+        highest_z_including_labware=123, name_for_errors="some_vacuum_module"
+    )
+    labware = deck_conflict.Labware(
+        uri=LabwareUri("some_labware_uri"),
+        highest_z=123,
+        is_fixed_trash=False,
+        name_for_errors="some_labware",
+    )
+    deck_conflict.check(
+        existing_items={DeckSlotName.SLOT_A3: vacuum_module},
+        new_location=DeckSlotName.SLOT_B3,
+        new_item=labware,
+        robot_type="OT-3 Standard",
+    )
+    deck_conflict.check(
+        existing_items={DeckSlotName.SLOT_B3: labware},
+        new_location=DeckSlotName.SLOT_A3,
+        new_item=vacuum_module,
         robot_type="OT-3 Standard",
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
@@ -40,6 +40,7 @@ from opentrons.protocol_engine.types.location import (
     OnCutoutFixtureLocationSequenceComponent,
     OnModuleLocationSequenceComponent,
 )
+from opentrons.protocol_engine.types.module import LoadedModule, ModuleModel
 from opentrons.types import DeckSlotName
 
 
@@ -711,6 +712,76 @@ async def test_load_black_plate_contained_inside_collar_on_same_vacuum_module(
         result.public.locationSequence[0], OnModuleLocationSequenceComponent
     )
     assert result.public.locationSequence[0].moduleId == "module-id"
+
+
+async def test_load_filter_plate_directly_on_vacuum_module_raises(
+    decoy: Decoy,
+    well_plate_def: LabwareDefinition,
+    equipment: EquipmentHandler,
+    state_view: StateView,
+) -> None:
+    """It should reject a filter plate loaded directly onto the vacuum module."""
+    subject = LoadLabwareImplementation(equipment=equipment, state_view=state_view)
+    module_location = ModuleLocation(moduleId="module-id")
+
+    data = LoadLabwareParams(
+        location=module_location,
+        loadName="empore_96_wellplate_1200ul_c18_filter",
+        namespace="opentrons",
+        version=1,
+        displayName=None,
+    )
+
+    decoy.when(
+        await equipment.load_definition_for_details(
+            load_name="empore_96_wellplate_1200ul_c18_filter",
+            namespace="opentrons",
+            version=1,
+        )
+    ).then_return((well_plate_def, "opentrons/empore_96_wellplate_1200ul_c18_filter/1"))
+
+    decoy.when(
+        state_view.geometry.ensure_location_not_occupied(
+            module_location, None, well_plate_def
+        )
+    ).then_return(module_location)
+
+    decoy.when(
+        await equipment._load_labware_from_def_and_uri(
+            well_plate_def,
+            "opentrons/empore_96_wellplate_1200ul_c18_filter/1",
+            module_location,
+            None,
+            None,
+        )
+    ).then_return(
+        LoadedLabwareData(
+            labware_id="filter-id", definition=well_plate_def, offsetId=None
+        )
+    )
+
+    decoy.when(state_view.modules.get("module-id")).then_return(
+        LoadedModule.model_construct(
+            id="module-id",
+            model=ModuleModel.VACUUM_MODULE_V1,
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
+            serialNumber="serial",
+        )
+    )
+
+    decoy.when(
+        state_view.labware.raise_if_labware_incompatible_with_vacuum_module(
+            well_plate_def
+        )
+    ).then_raise(
+        LabwareIsNotAllowedInLocationError(
+            "Cannot place 'empore_96_wellplate_1200ul_c18_filter' directly"
+            " onto the vacuum module."
+        )
+    )
+
+    with pytest.raises(LabwareIsNotAllowedInLocationError, match="directly onto"):
+        await subject.execute(data)
 
 
 async def test_load_filter_plate_contained_inside_collar_on_vacuum_module(

--- a/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
@@ -1224,6 +1224,63 @@ async def test_vacuum_module_dock_incompatibility_raises(
         await subject.execute(data)
 
 
+async def test_move_filter_plate_directly_on_vacuum_module_raises(
+    decoy: Decoy,
+    subject: MoveLabwareImplementation,
+    state_view: StateView,
+) -> None:
+    """It should reject moving a filter plate directly onto the vacuum module."""
+    new_location = ModuleLocation(moduleId="vacuum-module-id")
+    data = MoveLabwareParams(
+        labwareId="filter-plate-id",
+        newLocation=new_location,
+        strategy=LabwareMovementStrategy.MANUAL_MOVE_WITHOUT_PAUSE,
+    )
+
+    decoy.when(state_view.labware.get("filter-plate-id")).then_return(
+        LoadedLabware(
+            id="filter-plate-id",
+            loadName="empore_96_wellplate_1200ul_c18_filter",
+            definitionUri="opentrons/empore_96_wellplate_1200ul_c18_filter/1",
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_C1),
+            offsetId=None,
+        )
+    )
+    lw_def = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+        namespace="opentrons",
+        parameters=Parameters2.model_construct(  # type: ignore[call-arg]
+            isMovableAdapter=False,
+            loadName="empore_96_wellplate_1200ul_c18_filter",
+            quirks=["filterPlate"],
+        ),
+    )
+    decoy.when(state_view.labware.get_definition("filter-plate-id")).then_return(lw_def)
+    decoy.when(
+        state_view.geometry.ensure_location_not_occupied(new_location, None, lw_def)
+    ).then_return(new_location)
+    decoy.when(state_view.modules.get("vacuum-module-id")).then_return(
+        LoadedModule.model_construct(
+            id="vacuum-module-id",
+            model=ModuleModel.VACUUM_MODULE_V1,
+            location=DeckSlotLocation(slotName=DeckSlotName("A3")),
+            serialNumber="serial",
+        )
+    )
+    decoy.when(
+        state_view.labware.raise_if_labware_incompatible_with_vacuum_module(lw_def)
+    ).then_raise(
+        errors.LabwareIsNotAllowedInLocationError(
+            "Cannot place 'empore_96_wellplate_1200ul_c18_filter' directly"
+            " onto the vacuum module."
+        )
+    )
+
+    with pytest.raises(
+        errors.LabwareIsNotAllowedInLocationError, match="directly onto"
+    ):
+        await subject.execute(data)
+
+
 @pytest.mark.parametrize(
     "strategy",
     [

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
@@ -2083,6 +2083,37 @@ def test_get_stacker_labware_overlap_offset_uses_default_when_no_match() -> None
     assert result == OverlapOffset(x=10, y=20, z=30)
 
 
+@pytest.mark.parametrize(
+    "quirks,should_raise",
+    [
+        (["filterPlate"], True),
+        (["filterPlate", "noLabwarePositionCheck"], True),
+        (None, False),
+        ([], False),
+    ],
+)
+def test_raise_if_labware_incompatible_with_vacuum_module(
+    quirks: list[str] | None, should_raise: bool
+) -> None:
+    """Filter plates cannot sit directly on the vacuum module."""
+    subject = get_labware_view()
+    definition = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+        parameters=Parameters2.model_construct(  # type: ignore[call-arg]
+            loadName="some_filter_plate",
+            quirks=quirks,
+        ),
+    )
+
+    if should_raise:
+        with pytest.raises(
+            errors.LabwareIsNotAllowedInLocationError,
+            match="directly onto the vacuum module",
+        ):
+            subject.raise_if_labware_incompatible_with_vacuum_module(definition)
+    else:
+        subject.raise_if_labware_incompatible_with_vacuum_module(definition)
+
+
 def test_get_grip_force(
     flex_50uL_tiprack: LabwareDefinition,
     reservoir_def: LabwareDefinition,

--- a/protocol-designer/src/assets/localization/en/shared.json
+++ b/protocol-designer/src/assets/localization/en/shared.json
@@ -131,6 +131,8 @@
   "swap_view": "Swap view",
   "temperaturemoduletype": "Temperature Module",
   "thermocycler_blocked": "The Thermocycler needs slots A1 and B1. Slot A1 is occupied.",
+  "vacuum_module_adjacent": "A Vacuum Module is adjacent to this slot. Modules cannot be placed next to a Vacuum Module.",
+  "vacuum_module_adjacent_to": "A module is adjacent to this slot. The Vacuum Module cannot be placed next to a module.",
   "thermocyclermoduletype": "Thermocycler Module",
   "tip_position_aspirate_delay_mmFromBottom": "Edit aspirate delay position",
   "tip_position_aspirate_touchTip_mmFromTop": "Edit aspirate touch tip position",

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
@@ -35,12 +35,17 @@ import {
   THERMOCYCLER_MODULE_CUTOUTS,
   THERMOCYCLER_MODULE_V2,
   TRASH_BIN_ADAPTER_FIXTURE,
+  VACUUM_MODULE_V1,
   WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
 import { getSlotInLocationStack, uuid } from '@opentrons/step-generation'
 
 import { editDeckConfiguration } from '/protocol-designer/step-forms/actions'
 import { getInitialDeckSetup } from '/protocol-designer/step-forms/selectors'
+import {
+  isCutoutBlockedByExistingVacuumModule,
+  wouldVacuumModuleBlockExistingModule,
+} from '/protocol-designer/utils/vacuumModuleSlotRestrictions'
 
 import { mapFixtureIdToFixtureName } from '../FlexHardware/util'
 import { useKitchen } from '../Kitchen/useKitchen'
@@ -146,13 +151,19 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
       ]
       setAllFixtureOptions(options)
       const moduleOptions = [
-        ...getModuleOptions(cutoutId, addressableAreaId, deckDef, fixtures),
+        ...getModuleOptions(
+          cutoutId,
+          addressableAreaId,
+          deckDef,
+          fixtures,
+          modules
+        ),
       ]
       setAllModuleOptions(moduleOptions)
     },
     // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [cutoutId, addressableAreaId, existingCutoutFixtureId]
+    [cutoutId, addressableAreaId, existingCutoutFixtureId, modules]
   )
 
   const modalProps: ModalProps = {
@@ -171,6 +182,7 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
     deckDefinition: deckDef,
     addressableAreaId,
     fixtures,
+    modules,
   })
 
   let nextStageOptions = null
@@ -262,6 +274,23 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
         ))
     ) {
       return t('thermocycler_blocked') as string
+    }
+    const addedModuleModels = addedCutoutConfigs.map(cutoutConfig =>
+      getModuleModelFromFixtureId(
+        cutoutConfig.cutoutFixtureId as CutoutFixtureId
+      )
+    )
+    if (
+      addedModuleModels.includes(VACUUM_MODULE_V1) &&
+      wouldVacuumModuleBlockExistingModule(cutoutId, modules)
+    ) {
+      return t('vacuum_module_adjacent_to') as string
+    }
+    if (
+      addedModuleModels.some(model => model != null) &&
+      isCutoutBlockedByExistingVacuumModule(addressableAreaId, modules)
+    ) {
+      return t('vacuum_module_adjacent') as string
     }
     return null
   }

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/AddFixtureModal.test.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/AddFixtureModal.test.tsx
@@ -182,4 +182,50 @@ describe('AddFixtureModal', () => {
       ])
     )
   })
+
+  it('does not offer modules on B3 when a vacuum module is on A3', () => {
+    const updatedProps = {
+      ...props,
+      cutoutId: 'cutoutB3' as CutoutId,
+      addressableAreaId: 'B3' as AddressableAreaName,
+      modules: {
+        vacuum: {
+          id: 'vacuum',
+          cutoutId: 'cutoutA3' as CutoutId,
+          model: 'vacuumModuleV1' as const,
+          type: 'vacuumModuleType' as const,
+          slot: 'A3',
+          moduleState: {} as any,
+          pythonName: 'vacuumModule',
+        },
+      },
+    }
+    render(updatedProps)
+    screen.getByText('Add to Slot B3')
+    expect(screen.queryByText('Modules')).not.toBeInTheDocument()
+  })
+
+  it('does not offer the vacuum module on A3 when B3 already has a module', () => {
+    const updatedProps = {
+      ...props,
+      cutoutId: 'cutoutA3' as CutoutId,
+      addressableAreaId: 'A3' as AddressableAreaName,
+      modules: {
+        hs: {
+          id: 'hs',
+          cutoutId: 'cutoutB3' as CutoutId,
+          model: 'heaterShakerModuleV1' as const,
+          type: 'heaterShakerModuleType' as const,
+          slot: 'B3',
+          moduleState: {} as any,
+          pythonName: 'heaterShaker',
+        },
+      },
+    }
+    render(updatedProps)
+    screen.getByText('Modules')
+    fireEvent.click(screen.getAllByText('Select options')[1])
+    expect(screen.queryByText('Vacuum Module GEN1')).not.toBeInTheDocument()
+    screen.getByText('Temperature Module GEN2')
+  })
 })

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/utils.test.ts
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/utils.test.ts
@@ -1,20 +1,24 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  FLEX_ROBOT_TYPE,
   FLEX_STACKER_V1_FIXTURE,
   FLEX_STACKER_WITH_MAG_BLOCK_FIXTURE,
   FLEX_STACKER_WITH_WASTE_CHUTE_ADAPTER_NO_COVER_FIXTURE,
+  getDeckDefFromRobotType,
   MAGNETIC_BLOCK_V1_FIXTURE,
   STAGING_AREA_RIGHT_SLOT_FIXTURE,
   STAGING_AREA_SLOT_WITH_WASTE_CHUTE_RIGHT_ADAPTER_NO_COVER_FIXTURE,
   TEMPERATURE_MODULE_V2_FIXTURE,
   TRASH_BIN_ADAPTER_FIXTURE,
+  VACUUM_MODULE_V1,
   WASTE_CHUTE_RIGHT_ADAPTER_NO_COVER_FIXTURE,
 } from '@opentrons/shared-data'
 
-import { mergeToComboFixtures } from '../utils'
+import { getModuleOptions, mergeToComboFixtures } from '../utils'
 
 import type { CutoutConfigMap, DeckConfiguration } from '@opentrons/shared-data'
+import type { FormModules } from '/protocol-designer/step-forms'
 
 describe('mergeToComboFixtures', () => {
   it('should return empty arrays when no configs provided', () => {
@@ -213,5 +217,77 @@ describe('mergeToComboFixtures', () => {
     expect(result.remainingAdditionalEquipmentConfig).toEqual(
       additionalEquipmentConfig
     )
+  })
+})
+
+describe('getModuleOptions vacuum module gripper collisions', () => {
+  const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
+  const vacuumOnA3: FormModules = {
+    1: {
+      model: VACUUM_MODULE_V1,
+      type: 'vacuumModuleType',
+      slot: 'A3',
+      cutoutFixtureId: VACUUM_MODULE_V1,
+      cutoutId: 'cutoutA3',
+    },
+  }
+  const heaterShakerOnB3: FormModules = {
+    1: {
+      model: 'heaterShakerModuleV1',
+      type: 'heaterShakerModuleType',
+      slot: 'B3',
+      cutoutFixtureId: 'heaterShakerModuleV1',
+      cutoutId: 'cutoutB3',
+    },
+  }
+
+  it('offers no modules on B3 when a vacuum module is on A3', () => {
+    expect(getModuleOptions('cutoutB3', 'B3', deckDef, {}, vacuumOnA3)).toEqual(
+      []
+    )
+  })
+
+  it('still offers modules on C3 when a vacuum module is on A3', () => {
+    expect(
+      getModuleOptions('cutoutC3', 'C3', deckDef, {}, vacuumOnA3).length
+    ).toBeGreaterThan(0)
+  })
+
+  it('does not change staging slot B4 module options when a vacuum module is on A3', () => {
+    const stagingOnB3 = {
+      staging: {
+        name: 'stagingArea' as const,
+        cutoutId: 'cutoutB3' as const,
+        cutoutFixtureId: 'stagingAreaRightSlot' as const,
+      },
+    }
+    expect(
+      getModuleOptions('cutoutB3', 'B4', deckDef, stagingOnB3, vacuumOnA3)
+    ).toEqual(getModuleOptions('cutoutB3', 'B4', deckDef, stagingOnB3, {}))
+  })
+
+  it('does not offer the vacuum module on A3 when B3 already has a module', () => {
+    const options = getModuleOptions(
+      'cutoutA3',
+      'A3',
+      deckDef,
+      {},
+      heaterShakerOnB3
+    )
+    expect(
+      options.some(option =>
+        option.some(config => config.cutoutFixtureId === VACUUM_MODULE_V1)
+      )
+    ).toBe(false)
+    expect(options.length).toBeGreaterThan(0)
+  })
+
+  it('offers the vacuum module on A3 when the neighboring slot is empty', () => {
+    const options = getModuleOptions('cutoutA3', 'A3', deckDef, {}, {})
+    expect(
+      options.some(option =>
+        option.some(config => config.cutoutFixtureId === VACUUM_MODULE_V1)
+      )
+    ).toBe(true)
   })
 })

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/utils.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/utils.tsx
@@ -9,6 +9,7 @@ import {
   getComboFixtureFromFixtureIds,
   getDeckDefFromRobotType,
   getMainAAForAFixture,
+  getModuleModelFromFixtureId,
   getNewConfigForDeckConfig,
   getReplacementFixtureForFixtureRemoval,
   getWasteChuteOptions,
@@ -22,11 +23,16 @@ import {
   THERMOCYCLER_V2_FRONT_FIXTURE,
   THERMOCYCLER_V2_REAR_FIXTURE,
   TRASH_BIN_ADAPTER_FIXTURE,
+  VACUUM_MODULE_V1,
   WASTE_CHUTE_ADDRESSABLE_AREAS,
 } from '@opentrons/shared-data'
 
 import { FLEX_MODULE_MODELS } from '/protocol-designer/pages/Designer/DeckSetup/constants'
 import { editDeckConfiguration } from '/protocol-designer/step-forms/actions'
+import {
+  isCutoutBlockedByExistingVacuumModule,
+  wouldVacuumModuleBlockExistingModule,
+} from '/protocol-designer/utils/vacuumModuleSlotRestrictions'
 
 import { AddFixtureModal } from './AddFixtureModal'
 
@@ -337,11 +343,38 @@ export const getModuleFixtures = (
     .filter((config): config is CutoutConfigMap[] => config !== null)
 }
 
+const filterVacuumModuleGripperCollisions = (
+  availableOptions: CutoutConfigMap[][],
+  cutoutId: CutoutId,
+  addressableAreaId: AddressableAreaNamesWithFakes,
+  modules?: FormModules | InitialDeckStateModules
+): CutoutConfigMap[][] => {
+  if (modules == null) {
+    return availableOptions
+  }
+  if (isCutoutBlockedByExistingVacuumModule(addressableAreaId, modules)) {
+    return []
+  }
+  if (!wouldVacuumModuleBlockExistingModule(cutoutId, modules)) {
+    return availableOptions
+  }
+  return availableOptions.filter(
+    option =>
+      !option.some(
+        config =>
+          getModuleModelFromFixtureId(
+            config.cutoutFixtureId as CutoutFixtureId
+          ) === VACUUM_MODULE_V1
+      )
+  )
+}
+
 export const getModules = (
   cutoutId: CutoutId,
   addressableAreaId: AddressableAreaNamesWithFakes,
   deckDef: DeckDefinition,
-  fixtures: Fixtures
+  fixtures: Fixtures,
+  modules?: FormModules | InitialDeckStateModules
 ): CutoutConfigMap[][] => {
   const availableOptions: CutoutConfigMap[][] = []
 
@@ -357,12 +390,17 @@ export const getModules = (
     )
 
   if (isStagingAreaInSlot4) {
-    return getModuleFixtures(
+    return filterVacuumModuleGripperCollisions(
+      getModuleFixtures(
+        cutoutId,
+        MAGNETIC_BLOCK_V1,
+        addressableAreaId,
+        deckDef,
+        fixtures
+      ),
       cutoutId,
-      MAGNETIC_BLOCK_V1,
       addressableAreaId,
-      deckDef,
-      fixtures
+      modules
     )
   }
 
@@ -380,16 +418,22 @@ export const getModules = (
     availableOptions.push(...moduleOptions)
   })
 
-  return availableOptions
+  return filterVacuumModuleGripperCollisions(
+    availableOptions,
+    cutoutId,
+    addressableAreaId,
+    modules
+  )
 }
 
 export const getModuleOptions = (
   cutoutId: CutoutId,
   addressableAreaId: AddressableAreaNamesWithFakes,
   deckDef: DeckDefinition,
-  fixtures: Fixtures
+  fixtures: Fixtures,
+  modules?: FormModules | InitialDeckStateModules
 ): CutoutConfigMap[][] => {
-  return getModules(cutoutId, addressableAreaId, deckDef, fixtures)
+  return getModules(cutoutId, addressableAreaId, deckDef, fixtures, modules)
 }
 
 interface AvailableOptionsProps {
@@ -399,6 +443,7 @@ interface AvailableOptionsProps {
   addressableAreaId: AddressableAreaNamesWithFakes
   fixtures: Fixtures
   existingCutoutFixtureId?: CutoutFixtureIdsWithFakes
+  modules?: FormModules | InitialDeckStateModules
 }
 export const getAvailableOptions = (
   props: AvailableOptionsProps
@@ -410,6 +455,7 @@ export const getAvailableOptions = (
     addressableAreaId,
     deckDefinition,
     fixtures,
+    modules,
   } = props
 
   let availableOptions: CutoutConfigMap[][] = []
@@ -426,7 +472,8 @@ export const getAvailableOptions = (
       cutoutId,
       addressableAreaId,
       deckDefinition,
-      fixtures
+      fixtures,
+      modules
     )
   }
   if (optionStage === 'wasteChuteOptions') {

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
@@ -335,6 +335,15 @@ export function SelectLabwareModal(
         return !isFilterPlate
       }
 
+      // spacer on the module: still allow filter plates (they sit on the spacer)
+      if (
+        moduleType === VACUUM_MODULE_TYPE &&
+        mainModuleTopIsSpacer &&
+        (parameters.quirks ?? []).includes('filterPlate')
+      ) {
+        return false
+      }
+
       // for main vacuum module area with existing labware, filter explicitly
       // (skip when only a bare spacer is present — treat like an empty module)
       if (

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
@@ -190,6 +190,13 @@ export function LabwareLocationField(
   // explicit compatibleParentLabware / stackingOffsetWithLabware
   const isMovingLabwareFilterPlate =
     movingLabwareDef?.parameters.quirks?.includes('filterPlate') ?? false
+  // filter plates cannot sit directly on the vacuum module
+  if (isMovingLabwareFilterPlate) {
+    unoccupiedLabwareLocationsOptions =
+      unoccupiedLabwareLocationsOptions.filter(
+        ({ value }) => moduleEntities[value]?.type !== VACUUM_MODULE_TYPE
+      )
+  }
   if (movingLabwareDef != null && !isMovingLabwareFilterPlate) {
     unoccupiedLabwareLocationsOptions =
       unoccupiedLabwareLocationsOptions.filter(({ value }) => {

--- a/protocol-designer/src/utils/__tests__/labwareModuleCompatibility.test.ts
+++ b/protocol-designer/src/utils/__tests__/labwareModuleCompatibility.test.ts
@@ -1,12 +1,40 @@
 import { describe, expect, it } from 'vitest'
 
+import { VACUUM_MODULE_TYPE } from '@opentrons/shared-data'
 import { fixture_96_plate } from '@opentrons/shared-data/labware/fixtures/2'
 
-import { getLabwareIsCustom } from '../labwareModuleCompatibility'
+import {
+  getLabwareCompatibleWithModule,
+  getLabwareIsCustom,
+} from '../labwareModuleCompatibility'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 
 describe('labwareModuleCompatibility', () => {
+  describe('getLabwareCompatibleWithModule', () => {
+    const wellPlate = fixture_96_plate as LabwareDefinition2
+    const filterPlate = {
+      ...wellPlate,
+      parameters: {
+        ...wellPlate.parameters,
+        loadName: 'empore_96_wellplate_1200ul_c18_filter',
+        quirks: ['filterPlate', 'noLabwarePositionCheck'],
+      },
+    } as LabwareDefinition2
+
+    it('does not allow filter plates directly on the vacuum module', () => {
+      expect(
+        getLabwareCompatibleWithModule(filterPlate, VACUUM_MODULE_TYPE)
+      ).toBe(false)
+    })
+
+    it('still allows regular well plates on the vacuum module', () => {
+      expect(
+        getLabwareCompatibleWithModule(wellPlate, VACUUM_MODULE_TYPE)
+      ).toBe(true)
+    })
+  })
+
   describe('getLabwareIsCustom', () => {
     const labwareOnDeck = {
       labwareDefURI: 'fixture/fixture_96_plate',

--- a/protocol-designer/src/utils/__tests__/vacuumModuleSlotRestrictions.test.ts
+++ b/protocol-designer/src/utils/__tests__/vacuumModuleSlotRestrictions.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  doesVacuumModuleBlockModuleSlot,
+  getSlotsBlockedForModulesByVacuumModule,
+  getStandardColumn3Slot,
+  isCutoutBlockedByExistingVacuumModule,
+  wouldVacuumModuleBlockExistingModule,
+} from '../vacuumModuleSlotRestrictions'
+
+import type { ModuleLocationForVacuumRestriction } from '../vacuumModuleSlotRestrictions'
+
+const vacuumOnA3: Record<string, ModuleLocationForVacuumRestriction> = {
+  vm: {
+    slot: 'A3',
+    cutoutId: 'cutoutA3',
+    type: 'vacuumModuleType',
+    model: 'vacuumModuleV1',
+  },
+}
+
+const heaterShakerOnB3: Record<string, ModuleLocationForVacuumRestriction> = {
+  hs: {
+    slot: 'B3',
+    cutoutId: 'cutoutB3',
+    type: 'heaterShakerModuleType',
+    model: 'heaterShakerModuleV1',
+  },
+}
+
+const stackerOnB4: Record<string, ModuleLocationForVacuumRestriction> = {
+  stacker: {
+    slot: 'B4',
+    cutoutId: 'cutoutB3',
+    type: 'flexStackerModuleType',
+    model: 'flexStackerModuleV1',
+  },
+}
+
+describe('getStandardColumn3Slot', () => {
+  it('extracts column-3 slots from cutouts and addressable areas', () => {
+    expect(getStandardColumn3Slot('A3')).toBe('A3')
+    expect(getStandardColumn3Slot('cutoutB3')).toBe('B3')
+    expect(getStandardColumn3Slot('cutoutD3')).toBe('D3')
+    expect(getStandardColumn3Slot('temperatureModuleV2B3')).toBe('B3')
+  })
+
+  it('returns null for staging slots and other locations', () => {
+    expect(getStandardColumn3Slot('C4')).toBe(null)
+    expect(getStandardColumn3Slot('B4')).toBe(null)
+    expect(getStandardColumn3Slot('A1')).toBe(null)
+    expect(getStandardColumn3Slot(null)).toBe(null)
+  })
+})
+
+describe('getSlotsBlockedForModulesByVacuumModule', () => {
+  it('blocks the inboard neighbor standard slot when the vacuum module is on A3', () => {
+    expect(getSlotsBlockedForModulesByVacuumModule('A3')).toEqual(['B3'])
+    expect(getSlotsBlockedForModulesByVacuumModule('cutoutA3')).toEqual(['B3'])
+  })
+
+  it('blocks the inboard neighbor standard slot when the vacuum module is on D3', () => {
+    expect(getSlotsBlockedForModulesByVacuumModule('D3')).toEqual(['C3'])
+    expect(getSlotsBlockedForModulesByVacuumModule('cutoutD3')).toEqual(['C3'])
+  })
+
+  it('returns no blocked slots for unsupported vacuum module locations', () => {
+    expect(getSlotsBlockedForModulesByVacuumModule('A1')).toEqual([])
+  })
+})
+
+describe('doesVacuumModuleBlockModuleSlot', () => {
+  it('blocks the neighboring standard slot', () => {
+    expect(doesVacuumModuleBlockModuleSlot('A3', 'B3')).toBe(true)
+    expect(doesVacuumModuleBlockModuleSlot('A3', 'cutoutB3')).toBe(true)
+    expect(doesVacuumModuleBlockModuleSlot('D3', 'C3')).toBe(true)
+  })
+
+  it('does not block staging slots or unrelated slots', () => {
+    expect(doesVacuumModuleBlockModuleSlot('A3', 'B4')).toBe(false)
+    expect(doesVacuumModuleBlockModuleSlot('D3', 'C4')).toBe(false)
+    expect(doesVacuumModuleBlockModuleSlot('A3', 'C3')).toBe(false)
+    expect(doesVacuumModuleBlockModuleSlot('A3', 'A2')).toBe(false)
+    expect(doesVacuumModuleBlockModuleSlot('D3', 'B3')).toBe(false)
+  })
+})
+
+describe('existing-module checks', () => {
+  it('blocks B3 when a vacuum module is already on A3', () => {
+    expect(isCutoutBlockedByExistingVacuumModule('cutoutB3', vacuumOnA3)).toBe(
+      true
+    )
+    expect(isCutoutBlockedByExistingVacuumModule('cutoutC3', vacuumOnA3)).toBe(
+      false
+    )
+  })
+
+  it('does not block staging slot B4 when a vacuum module is on A3', () => {
+    expect(isCutoutBlockedByExistingVacuumModule('B4', vacuumOnA3)).toBe(false)
+  })
+
+  it('blocks adding a vacuum module to A3 when B3 already has a module', () => {
+    expect(
+      wouldVacuumModuleBlockExistingModule('cutoutA3', heaterShakerOnB3)
+    ).toBe(true)
+    expect(wouldVacuumModuleBlockExistingModule('cutoutA3', stackerOnB4)).toBe(
+      false
+    )
+    expect(wouldVacuumModuleBlockExistingModule('cutoutA3', {})).toBe(false)
+  })
+
+  it('blocks adding a vacuum module to D3 when C3 already has a module', () => {
+    expect(
+      wouldVacuumModuleBlockExistingModule('cutoutD3', {
+        mag: {
+          slot: 'C3',
+          cutoutId: 'cutoutC3',
+          type: 'magneticBlockType',
+          model: 'magneticBlockV1',
+        },
+      })
+    ).toBe(true)
+  })
+})

--- a/protocol-designer/src/utils/labwareModuleCompatibility.ts
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.ts
@@ -148,6 +148,10 @@ const _getLabwareCompatibleWithVacuumModule = (
   def: LabwareDefinition2,
   isDock: boolean = false
 ): boolean => {
+  // Filter plates cannot sit on the bare module or dock;
+  if ((def.parameters.quirks ?? []).includes('filterPlate')) {
+    return false
+  }
   if (isDock) {
     return (
       COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE[
@@ -160,9 +164,7 @@ const _getLabwareCompatibleWithVacuumModule = (
   return (
     COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE[VACUUM_MODULE_TYPE].includes(
       def.parameters.loadName
-    ) ||
-    def.metadata.displayCategory === 'wellPlate' ||
-    (def.parameters.quirks ?? []).includes('filterPlate')
+    ) || def.metadata.displayCategory === 'wellPlate'
   )
 }
 

--- a/protocol-designer/src/utils/vacuumModuleSlotRestrictions.ts
+++ b/protocol-designer/src/utils/vacuumModuleSlotRestrictions.ts
@@ -1,0 +1,113 @@
+import { VACUUM_MODULE_TYPE, VACUUM_MODULE_V1 } from '@opentrons/shared-data'
+
+import type { CutoutId } from '@opentrons/shared-data'
+
+const FLEX_ROWS = ['A', 'B', 'C', 'D'] as const
+const STANDARD_COLUMN = '3'
+
+export interface ModuleLocationForVacuumRestriction {
+  slot: string
+  cutoutId?: CutoutId | string | null
+  type?: string
+  model?: string
+}
+
+/**
+ * Extract a Flex column-3 standard slot (A3/B3/C3/D3) from a slot, cutout,
+ * or addressable area. Staging slots (A4–D4) return null — they are not a
+ * gripper collision risk next to a vacuum module.
+ */
+export function getStandardColumn3Slot(
+  slotOrCutout: string | null | undefined
+): string | null {
+  if (slotOrCutout == null) {
+    return null
+  }
+  const match = /([ABCD])3/.exec(slotOrCutout)
+  if (match == null) {
+    return null
+  }
+  return `${match[1]}${STANDARD_COLUMN}`
+}
+
+/**
+ * Standard slots that cannot hold a module when a vacuum module occupies
+ * `vacuumModuleSlot`.
+ *
+ * The gripper paddles collide with the vacuum collar when they open on a
+ * module in the neighboring inboard standard slot:
+ * - vacuum module on A3 → no modules on B3
+ * - vacuum module on D3 (future) → no modules on C3
+ *
+ * Staging slots are not included.
+ */
+export function getSlotsBlockedForModulesByVacuumModule(
+  vacuumModuleSlot: string
+): string[] {
+  const standardSlot = getStandardColumn3Slot(vacuumModuleSlot)
+  if (standardSlot == null) {
+    return []
+  }
+  const row = standardSlot[0] as (typeof FLEX_ROWS)[number]
+  const rowIndex = FLEX_ROWS.indexOf(row)
+  if (rowIndex < 0) {
+    return []
+  }
+  // Mid-deck is between B and C. Move one row toward the center.
+  const neighborRowIndex = rowIndex <= 1 ? rowIndex + 1 : rowIndex - 1
+  const neighborRow = FLEX_ROWS[neighborRowIndex]
+  return [`${neighborRow}${STANDARD_COLUMN}`]
+}
+
+export function doesVacuumModuleBlockModuleSlot(
+  vacuumModuleSlot: string,
+  candidateSlot: string
+): boolean {
+  const candidateStandard = getStandardColumn3Slot(candidateSlot)
+  if (candidateStandard == null) {
+    return false
+  }
+  return getSlotsBlockedForModulesByVacuumModule(vacuumModuleSlot).includes(
+    candidateStandard
+  )
+}
+
+function getModuleLocationKey(
+  module: ModuleLocationForVacuumRestriction
+): string {
+  // Prefer the module's slot so a stacker/mag block on a staging slot (B4)
+  // is not treated as occupying the neighboring standard slot (B3).
+  return module.slot
+}
+
+export function getVacuumModuleLocations(
+  modules: Record<string, ModuleLocationForVacuumRestriction>
+): string[] {
+  return Object.values(modules)
+    .filter(
+      module =>
+        module.type === VACUUM_MODULE_TYPE || module.model === VACUUM_MODULE_V1
+    )
+    .map(module => getModuleLocationKey(module))
+}
+
+export function isCutoutBlockedByExistingVacuumModule(
+  cutoutId: CutoutId | string,
+  modules: Record<string, ModuleLocationForVacuumRestriction>
+): boolean {
+  return getVacuumModuleLocations(modules).some(vacuumModuleSlot =>
+    doesVacuumModuleBlockModuleSlot(vacuumModuleSlot, cutoutId)
+  )
+}
+
+export function wouldVacuumModuleBlockExistingModule(
+  vacuumModuleCutoutId: CutoutId | string,
+  modules: Record<string, ModuleLocationForVacuumRestriction>
+): boolean {
+  return Object.values(modules).some(module =>
+    doesVacuumModuleBlockModuleSlot(
+      vacuumModuleCutoutId,
+      getModuleLocationKey(module)
+    )
+  )
+}


### PR DESCRIPTION
# Overview

The gripper paddles can hit the vacuum module collar when attempting to access labware on a module in an adjacent slot, so let's prevent the placement of modules so we don't run into this. Right now, the vacuum module can be placed on A3, so let's prevent module placements on B3. In the future, we might also want to allow the vacuum module on D3, so let's generalize to adjacent slots. Also, let's not allow filter plates to be placed directly on the vacuum module; let's update PD and the API to prevent module and filter plate placement.

Closes: [RQA-5903](https://opentrons.atlassian.net/browse/RQA-5903)

## Test Plan and Hands on Testing

- [x] Make sure you cant place a module on B3 if a vacuum module is on A3 on PD or Protocol API
- [x] Make sure you can still place the Flex Stacker on a staging slow (column 4)

## Changelog

- Add deck placement restrictions modules around the vacuum module to PD and Protocol API

## Review requests
## Risk assessment


[RQA-5903]: https://opentrons.atlassian.net/browse/RQA-5903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ