### PR TITLE
fix(app): login loop in run again

### DIFF
--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns/HistoricalProtocolRunOverflowMenu.tsx
@@ -170,7 +170,6 @@ interface MenuDropdownProps extends HistoricalProtocolRunOverflowMenuProps {
 }
 function MenuDropdown(props: MenuDropdownProps): JSX.Element {
   const { t } = useTranslation('device_details')
-  const navigate = useNavigate()
 
   const {
     run,

--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns/HistoricalProtocolRunOverflowMenu.tsx
@@ -68,6 +68,7 @@ import { RobotOutOfStorageModal } from '../RobotOutOfStorageModal.tsx'
 import type { Dispatch, MouseEventHandler, SetStateAction } from 'react'
 import type { Run, RunData } from '@opentrons/api-client'
 import type { IconProps } from '@opentrons/components'
+import type { RunControls } from '/app/organisms/RunTimeControl'
 
 export interface HistoricalProtocolRunOverflowMenuProps {
   run: RunData
@@ -102,6 +103,12 @@ export function HistoricalProtocolRunOverflowMenu(
   const [showRobotOutOfStorageModal, setShowRobotOutOfStorageModal] =
     useState<boolean>(false)
   const navigate = useNavigate()
+  const onResetSuccess = (createRunResponse: Run): void => {
+    navigate(
+      `/devices/${robotName}/protocol-runs/${createRunResponse.data.id}/run-preview`
+    )
+  }
+  const runControls = useRunControls(run.id, onResetSuccess)
 
   return (
     <>
@@ -142,6 +149,7 @@ export function HistoricalProtocolRunOverflowMenu(
                 closeOverflowMenu={handleOverflowClick}
                 setShowRobotOutOfStorageModal={setShowRobotOutOfStorageModal}
                 setShowOverflowMenu={setShowOverflowMenu}
+                runControls={runControls}
               />
             </Box>
             {menuOverlay}
@@ -158,6 +166,7 @@ interface MenuDropdownProps extends HistoricalProtocolRunOverflowMenuProps {
   isDownloading: boolean
   setShowRobotOutOfStorageModal: Dispatch<SetStateAction<boolean>>
   setShowOverflowMenu: Dispatch<SetStateAction<boolean>>
+  runControls: RunControls
 }
 function MenuDropdown(props: MenuDropdownProps): JSX.Element {
   const { t } = useTranslation('device_details')
@@ -173,10 +182,11 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
     runHasImages,
     setShowRobotOutOfStorageModal,
     setShowOverflowMenu,
+    runControls,
   } = props
 
   const { id: runId } = run
-
+  const { reset, isResetRunLoading, isRunControlLoading } = runControls
   const isRobotOnWrongVersionOfSoftware =
     useIsRobotOnWrongVersionOfSoftware(robotName)
   const documentationState = useDocumentationState()
@@ -184,11 +194,7 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
     useDeleteRunImages(documentationState)
 
   const [targetProps, tooltipProps] = useHoverTooltip()
-  const onResetSuccess = (createRunResponse: Run): void => {
-    navigate(
-      `/devices/${robotName}/protocol-runs/${createRunResponse.data.id}/run-preview`
-    )
-  }
+
   const onDownloadClick: MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()
     e.stopPropagation()
@@ -197,10 +203,7 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
   }
   const trackEvent = useTrackEvent()
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
-  const { reset, isResetRunLoading, isRunControlLoading } = useRunControls(
-    runId,
-    onResetSuccess
-  )
+
   const { deleteRun, isLoading: isDeletingRun } =
     useDeleteRunMutation(documentationState)
   const robot = useRobot(robotName)


### PR DESCRIPTION
When you run again from the overflow menu in the run history page, you get a loop of login - reason - login. This is because the run overflow menu disappears when the login modal pops up, and the overflow menu component was what hosts the login mechanics, so the hooks that control them didn't get rendered anymore. By hoisting useRunControls to the outer component that is always "rendered" (though usually not visibly), the hook gets to keep its state and the problem is fixed.

Closes RQA-5916
