### PR TITLE
fix(api): replace enums in livedata with strings

### DIFF
--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -90,9 +90,9 @@ class HeaterShaker(mod_abc.AbstractModule):
         if not simulating:
             poll_interval_seconds = poll_interval_seconds or POLL_PERIOD
 
-            async def _init_driver() -> tuple[
-                AbstractHeaterShakerDriver, Mapping[str, str]
-            ]:
+            async def _init_driver() -> (
+                tuple[AbstractHeaterShakerDriver, Mapping[str, str]]
+            ):
                 d = await HeaterShakerDriver.create(port=port, loop=hw_control_loop)
                 try:
                     info = await d.get_device_info()
@@ -246,9 +246,9 @@ class HeaterShaker(mod_abc.AbstractModule):
     @property
     def live_data(self) -> LiveData:
         data: HeaterShakerData = {
-            "temperatureStatus": self.temperature_status,
-            "speedStatus": self.speed_status,
-            "labwareLatchStatus": self.labware_latch_status,
+            "temperatureStatus": self.temperature_status.value,
+            "speedStatus": self.speed_status.value,
+            "labwareLatchStatus": self.labware_latch_status.value,
             "currentTemp": self.temperature,
             "targetTemp": self.target_temperature,
             "currentSpeed": self.speed,

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -90,9 +90,9 @@ class HeaterShaker(mod_abc.AbstractModule):
         if not simulating:
             poll_interval_seconds = poll_interval_seconds or POLL_PERIOD
 
-            async def _init_driver() -> (
-                tuple[AbstractHeaterShakerDriver, Mapping[str, str]]
-            ):
+            async def _init_driver() -> tuple[
+                AbstractHeaterShakerDriver, Mapping[str, str]
+            ]:
                 d = await HeaterShakerDriver.create(port=port, loop=hw_control_loop)
                 try:
                     info = await d.get_device_info()

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -218,7 +218,7 @@ class MagDeck(mod_abc.AbstractModule):
             "height": self.current_height,
         }
         return {
-            "status": self.status,
+            "status": self.status.value,
             "data": data,
         }
 

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -233,7 +233,7 @@ class TempDeck(mod_abc.AbstractModule):
             "targetTemp": self.target,
         }
         return {
-            "status": self.status,
+            "status": self.status.value,
             "data": data,
         }
 

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -627,10 +627,10 @@ class Thermocycler(mod_abc.AbstractModule):
     @property
     def live_data(self) -> types.LiveData:
         data: types.ThermocyclerData = {
-            "lid": self.lid_status,
+            "lid": self.lid_status.value,
             "lidTarget": self.lid_target,
             "lidTemp": self.lid_temp,
-            "lidTempStatus": self.lid_temp_status,
+            "lidTempStatus": self.lid_temp_status.value,
             "currentTemp": self.temperature,
             "targetTemp": self.target,
             "holdTime": self.hold_time,
@@ -641,7 +641,7 @@ class Thermocycler(mod_abc.AbstractModule):
             "totalStepCount": self.total_step_count,
         }
         return {
-            "status": self.status,
+            "status": self.status.value,
             "data": data,
         }
 

--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -419,7 +419,7 @@ class VacuumModule(mod_abc.AbstractModule):
             "currentPower": self._reader.pump_state.current_pwm,
             "targetPower": self._reader.get_target_power(),
             "ventStatus": self._reader.vacuum_state.vent_state.formatted,
-            "modeType": self._reader.operation_mode,
+            "modeType": self._reader.operation_mode.value,
         }
         return {"status": self.status.value, "data": data}
 

--- a/api/tests/opentrons/hardware_control/modules/__init__.py
+++ b/api/tests/opentrons/hardware_control/modules/__init__.py
@@ -1,0 +1,16 @@
+from opentrons.hardware_control.modules.mod_abc import AbstractModule
+
+
+def require_live_data_real_string(module: AbstractModule) -> None:
+    assert type(module.live_data["status"]) is str
+    data = module.live_data["data"]
+    assert data is not None
+    for k, v in data.items():
+        assert v is None or type(v) in (
+            str,
+            float,
+            int,
+            bool,
+        ), (
+            f"module {type(module)} live data key {k} has value {v} of type {type(v)}, must be POD"
+        )

--- a/api/tests/opentrons/hardware_control/modules/test_hc_flexstacker.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_flexstacker.py
@@ -12,6 +12,7 @@ from opentrons_shared_data.errors.exceptions import (
     FlexStackerShuttleNotEmptyError,
 )
 
+from . import require_live_data_real_string
 from opentrons.drivers.flex_stacker.simulator import SimulatingDriver
 from opentrons.drivers.flex_stacker.types import (
     Direction,
@@ -125,6 +126,7 @@ async def test_sim_state(subject: modules.FlexStacker) -> None:
     assert status["serial"] == "dummySerialFS"
     assert status["model"] == "a1"
     assert status["version"] == "stacker-fw"
+    require_live_data_real_string(subject)
 
 
 async def test_set_run_hold_current(

--- a/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
@@ -4,6 +4,7 @@ from typing import Any, AsyncGenerator
 import pytest
 from decoy import Decoy
 
+from . import require_live_data_real_string
 from opentrons.drivers.asyncio.communication.errors import ErrorResponse, UnhandledGcode
 from opentrons.drivers.heater_shaker.simulator import SimulatingDriver
 from opentrons.drivers.rpi_drivers.types import USBPort
@@ -172,6 +173,7 @@ async def test_initial_live_data(simulating_module: modules.HeaterShaker) -> Non
         },
         "status": "idle",
     }
+    require_live_data_real_string(simulating_module)
 
 
 async def test_updated_live_data(simulating_module: modules.HeaterShaker) -> None:
@@ -192,6 +194,7 @@ async def test_updated_live_data(simulating_module: modules.HeaterShaker) -> Non
         },
         "status": "running",
     }
+    require_live_data_real_string(simulating_module)
 
 
 async def test_deactivated_updated_live_data(
@@ -214,6 +217,7 @@ async def test_deactivated_updated_live_data(
         },
         "status": "running",
     }
+    require_live_data_real_string(simulating_module)
     await simulating_module.deactivate()
     assert simulating_module.live_data == {
         "data": {
@@ -228,6 +232,7 @@ async def test_deactivated_updated_live_data(
         },
         "status": "idle",
     }
+    require_live_data_real_string(simulating_module)
 
 
 async def fake_get_rpm(*args: Any, **kwargs: Any) -> RPM:

--- a/api/tests/opentrons/hardware_control/modules/test_hc_magdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_magdeck.py
@@ -3,6 +3,7 @@ from typing import AsyncGenerator
 
 import pytest
 
+from . import require_live_data_real_string
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.hardware_control import ExecutionManager, modules
 from opentrons.hardware_control.modules.magdeck import MagDeck
@@ -59,7 +60,7 @@ async def test_sim_data(subject: modules.MagDeck) -> None:
     assert subject.device_info["model"] == "mag_deck_v1.1"
     assert subject.device_info["version"] == "dummyVersionMD"
     assert subject.live_data["status"] == subject.status
-    assert "data" in subject.live_data
+    require_live_data_real_string(subject)
 
 
 async def test_sim_state_update(subject: modules.MagDeck) -> None:

--- a/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
@@ -4,6 +4,7 @@ from typing import AsyncGenerator
 import pytest
 from decoy import Decoy, matchers
 
+from . import require_live_data_real_string
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.hardware_control import ExecutionManager, modules
 from opentrons.hardware_control.modules.tempdeck import (
@@ -68,6 +69,7 @@ async def test_sim_state(subject: modules.AbstractModule) -> None:
     assert modules.ModuleDataValidator.is_temperature_module_data(live_data)
     assert live_data["currentTemp"] == subject.temperature
     assert live_data["targetTemp"] == subject.target
+    require_live_data_real_string(subject)
     status = subject.device_info
     assert status["serial"] == "dummySerialTD"
     # return v1 if sim_model is not passed

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -5,6 +5,7 @@ import mock
 import pytest
 from decoy import Decoy
 
+from . import require_live_data_real_string
 from opentrons.drivers.asyncio.communication.errors import ErrorResponse, UnhandledGcode
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.thermocycler import SimulatingDriver
@@ -155,6 +156,7 @@ async def test_sim_state(subject: modules.Thermocycler) -> None:
     assert subject.live_data["status"] == subject.status
     live_data = subject.live_data["data"]
     assert modules.ModuleDataValidator.is_thermocycler_data(live_data)
+    require_live_data_real_string(subject)
     assert live_data["currentTemp"] == subject.temperature
     assert live_data["targetTemp"] == subject.target
     status = subject.device_info
@@ -535,6 +537,7 @@ async def test_sync_error_response_to_poller(
         await subject_mocked_driver.set_temperature(20)
     assert subject_mocked_driver.live_data["status"] == "error"
     assert subject_mocked_driver.status == modules.TemperatureStatus.ERROR
+    require_live_data_real_string(subject_mocked_driver)
 
 
 async def test_async_error_response_to_poller(

--- a/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
@@ -10,6 +10,7 @@ from opentrons_shared_data.errors.exceptions import (
     VacuumModuleWasteFullError,
 )
 
+from . import require_live_data_real_string
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.vacuum_module.errors import (
     PressureNotReached,
@@ -276,6 +277,7 @@ async def test_live_data_includes_target_power_after_set_pump_state(
     assert live_data["targetPower"] == 65.0
     assert live_data["modeType"] == VacuumOperationMode.POWER
     assert live_data["ventStatus"] == VentStatus.CLOSED
+    require_live_data_real_string(subject)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Live data swears up and down it only has native data types (int, float, bool, None, str) but actually a bunch of those strings were our magic StrEnum, which require serialization. If they're sent on their own they'll get properly serialized because we have serialization for them, but if they're nested in other types, not so much.

Since these are supposed to be plain old strings, just scan through and make them that way, and add a little test helper to make sure they stay that way.

Closes RQA-5913

## testing
- [x] put it on a flex that has a heater shaker and look at the heater shaker.
- ~[ ] ditto magdeck~ dont care on flex
- [x] ditto tempdeck
- [x] ditto tc
- [x] ditto vacuum