### PR TITLE
fix(auth): keep user write scopes and gate requireAdminCreds at request time

### DIFF
--- a/auth-server/auth_server/authentication_checker.py
+++ b/auth-server/auth_server/authentication_checker.py
@@ -32,6 +32,7 @@ from server_utils.auth.resource_server.authentication_checker import (
     AuthServerAuthenticationChecker,
 )
 from server_utils.auth.resource_server.types import (
+    AdminCredsSettingsResponse,
     AuthSettingsResponse,
     TokenIntrospectionRequestFormData,
     TokenIntrospectionResponse,
@@ -75,6 +76,13 @@ class _SelfClient(Client):
         response_body = {"data": {"accessControlEnabled": access_control_enabled}}
         converted_response_body = AuthSettingsResponse.model_validate(response_body)
         return converted_response_body
+
+    @override
+    async def get_admin_creds_settings(self) -> AdminCredsSettingsResponse:
+        settings = self._settings_store.get_settings()
+        return AdminCredsSettingsResponse.model_validate(
+            {"data": settings.model_dump(mode="json")}
+        )
 
     @override
     async def introspect_token(self, token: str) -> TokenIntrospectionResponse:

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -438,19 +438,18 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
             )
             return False
 
-    def _live_scopes_for_username(self, username: str) -> set[Scope] | None:
-        """Return the user's current scopes, or None if the user no longer exists.
+    def _live_auth_for_username(self, username: str) -> tuple[set[Scope], str] | None:
+        """Return live scopes and account type, or None if the user no longer exists.
 
-        Token issuance snapshots scopes from account type plus the current
-        requireAdminCreds* settings. Resource servers authorize from introspection,
-        so we recompute here. Otherwise a settings change would leave old
-        permissions on already-issued tokens (RQA-5854).
+        Token issuance snapshots scopes. Resource servers authorize from
+        introspection, so we recompute scopes (password-reset restriction) and
+        account type here.
         """
         user = self.__user_store.get(username)
         if user is None:
             return None
         settings = self.__settings_store.get_settings()
-        return get_scope_set_of_user(
+        scopes = get_scope_set_of_user(
             user,
             settings,
             must_reset_password(
@@ -459,6 +458,7 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
                 settings.passwordResetTime,
             ),
         )
+        return scopes, user.account_type
 
     @override
     @pydantic.validate_call(config=_validate_call_config)
@@ -475,8 +475,9 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
             refresh_token, now=self.__get_now()
         )
         assert token is not None
-        live_scopes = self._live_scopes_for_username(token.username)
-        assert live_scopes is not None
+        live_auth = self._live_auth_for_username(token.username)
+        assert live_auth is not None
+        live_scopes, _account_type = live_auth
         return sorted(s.api_name for s in live_scopes)
 
     @override
@@ -497,17 +498,19 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         )
         if found_access_token is None:
             return None
-        live_scopes = self._live_scopes_for_username(found_access_token.username)
-        if live_scopes is None:
+        live_auth = self._live_auth_for_username(found_access_token.username)
+        if live_auth is None:
             return None
+        live_scopes, account_type = live_auth
         # Values defined by:
         # https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
-        # except ot_fullname, which is custom to us. if you add other custom fields,
-        # please prefix them with ot-.
+        # except ot_fullname and ot_account_type, which are custom to us. if you add
+        # other custom fields, please prefix them with ot-.
         return {
             "scope": serialize_scopes(live_scopes),
             "username": found_access_token.username,
             "ot_fullname": found_access_token.fullname,
+            "ot_account_type": account_type,
             # "active": True is set implicitly by oauthlib.
         }
 

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -438,21 +438,46 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
             )
             return False
 
+    def _live_scopes_for_username(self, username: str) -> set[Scope] | None:
+        """Return the user's current scopes, or None if the user no longer exists.
+
+        Token issuance snapshots scopes from account type plus the current
+        requireAdminCreds* settings. Resource servers authorize from introspection,
+        so we recompute here. Otherwise a settings change would leave old
+        permissions on already-issued tokens (RQA-5854).
+        """
+        user = self.__user_store.get(username)
+        if user is None:
+            return None
+        settings = self.__settings_store.get_settings()
+        return get_scope_set_of_user(
+            user,
+            settings,
+            must_reset_password(
+                user,
+                self.__get_now(),
+                settings.passwordResetTime,
+            ),
+        )
+
     @override
     @pydantic.validate_call(config=_validate_call_config)
     def get_original_scopes(
         self, refresh_token: str, request: oauthlib.common.Request
     ) -> list[str]:
-        """Return the scopes that a refresh token was originally associated with.
+        """Return the scopes to attach to a refreshed access token.
 
-        These will be passed on to the refreshed access token if the client did not
-        specify a scope during the request.
+        oauthlib uses this when the client does not specify a scope on refresh.
+        Compute from the user's current account type and auth settings, not the
+        scopes that were stored when the refresh token was issued.
         """
         token = self.__token_store.find_active_refresh_token(
             refresh_token, now=self.__get_now()
         )
         assert token is not None
-        return sorted(s.api_name for s in token.scopes)
+        live_scopes = self._live_scopes_for_username(token.username)
+        assert live_scopes is not None
+        return sorted(s.api_name for s in live_scopes)
 
     @override
     @pydantic.validate_call(config=_validate_call_config)
@@ -472,17 +497,19 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         )
         if found_access_token is None:
             return None
-        else:
-            # Values defined by:
-            # https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
-            # except ot_fullname, which is custom to us. if you add other custom fields,
-            # please prefix them with ot-.
-            return {
-                "scope": serialize_scopes(found_access_token.scopes),
-                "username": found_access_token.username,
-                "ot_fullname": found_access_token.fullname,
-                # "active": True is set implicitly by oauthlib.
-            }
+        live_scopes = self._live_scopes_for_username(found_access_token.username)
+        if live_scopes is None:
+            return None
+        # Values defined by:
+        # https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
+        # except ot_fullname, which is custom to us. if you add other custom fields,
+        # please prefix them with ot-.
+        return {
+            "scope": serialize_scopes(live_scopes),
+            "username": found_access_token.username,
+            "ot_fullname": found_access_token.fullname,
+            # "active": True is set implicitly by oauthlib.
+        }
 
 
 class _CustomInvalidCredentialsError(oauthlib.oauth2.InvalidGrantError):

--- a/auth-server/auth_server/users/scopes.py
+++ b/auth-server/auth_server/users/scopes.py
@@ -45,6 +45,10 @@ def get_scope_set_of_account_type(
                 Scope.USERS_WRITE_SELF,
                 Scope.AUDIT_LOG_WRITE,
             }
+            # These three scopes are granted to users only while the matching
+            # requireAdminCreds* setting is false. Token issuance snapshots this
+            # set, but introspection recomputes it from live settings so a policy
+            # change takes effect without waiting for re-login (RQA-5854).
             if not settings.requireAdminCredsWhenUpdatingRobotSoftware:
                 result.add(Scope.UPDATES_WRITE)
             if not settings.requireAdminCredsWhenSendingProtocolToRobot:

--- a/auth-server/auth_server/users/scopes.py
+++ b/auth-server/auth_server/users/scopes.py
@@ -16,7 +16,11 @@ def get_scope_set_of_account_type(
 
     A user who must reset their password is restricted to reading and writing their
     own account, so they can change their password but nothing else until they do.
+
+    ``settings`` is unused. requireAdminCreds* flags are enforced at request time
+    so user tokens always include the matching write scopes (RQA-5854, RQA-5855).
     """
+    del settings
     if must_reset_password:
         # Grant the user only the permissions that they need to set a new password,
         # not to actually do anything on the robot.
@@ -36,7 +40,11 @@ def get_scope_set_of_account_type(
             return {Scope.USERS_READ_OTHERS}
 
         elif account_type == AccountType.USER:
-            result = {
+            # User tokens always include these write scopes. requireAdminCreds* is a
+            # separate request-time gate so flipping a flag cannot leave stale
+            # permissions on an old token, and so a user is not 403'd for a missing
+            # scope when the flag is on (RQA-5854, RQA-5855).
+            return {
                 Scope.PROTOCOL_ANALYSES_WRITE,
                 Scope.RESTART_WRITE,
                 Scope.ROBOT_CONTROL_WRITE,
@@ -44,18 +52,10 @@ def get_scope_set_of_account_type(
                 Scope.USERS_READ_SELF,
                 Scope.USERS_WRITE_SELF,
                 Scope.AUDIT_LOG_WRITE,
+                Scope.UPDATES_WRITE,
+                Scope.PROTOCOLS_WRITE,
+                Scope.RUN_SIGNOFF_WRITE,
             }
-            # These three scopes are granted to users only while the matching
-            # requireAdminCreds* setting is false. Token issuance snapshots this
-            # set, but introspection recomputes it from live settings so a policy
-            # change takes effect without waiting for re-login (RQA-5854).
-            if not settings.requireAdminCredsWhenUpdatingRobotSoftware:
-                result.add(Scope.UPDATES_WRITE)
-            if not settings.requireAdminCredsWhenSendingProtocolToRobot:
-                result.add(Scope.PROTOCOLS_WRITE)
-            if not settings.requireAdminCredsForSignoffProtocol:
-                result.add(Scope.RUN_SIGNOFF_WRITE)
-            return result
 
         else:
             assert_never(account_type)

--- a/auth-server/tests/integration/test_oauth_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_oauth_flows.tavern.yaml
@@ -42,6 +42,7 @@ stages:
         active: true
         username: testadmin
         ot_fullname: Test Admin
+        ot_account_type: admin
         scope: *returned_scope
 
   - name: Introspect the refresh token and confirm it's inactive (only access tokens are active)
@@ -92,6 +93,7 @@ stages:
         active: true
         username: testadmin
         ot_fullname: Test Admin
+        ot_account_type: admin
         scope: *returned_scope
 
   - name: Introspect the new refresh token and confirm it's inactive (only access tokens are active)

--- a/auth-server/tests/integration/test_oauth_scopes_and_settings.tavern.yaml
+++ b/auth-server/tests/integration/test_oauth_scopes_and_settings.tavern.yaml
@@ -54,6 +54,21 @@ stages:
     response:
       status_code: 200
 
+  - name: Existing user tokens should gain updates.write without re-login
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/introspect'
+      data:
+        client_id: opentrons_app
+        token: '{user_access_token}'
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tests.integration.utils:verify_oauth_scopes
+        extra_kwargs:
+          expected_present: updates.write run_signoff.write
+          expected_absent: protocols.write
+
   - name: Regular users should now get updates.write but not protocols.write
     request:
       method: POST
@@ -101,6 +116,20 @@ stages:
     response:
       status_code: 200
 
+  - name: Existing user tokens should gain protocols.write without re-login
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/introspect'
+      data:
+        client_id: opentrons_app
+        token: '{user_access_token}'
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tests.integration.utils:verify_oauth_scopes
+        extra_kwargs:
+          expected_present: updates.write protocols.write run_signoff.write
+
   - name: Regular users should now get both updates.write and protocols.write
     request:
       method: POST
@@ -145,6 +174,21 @@ stages:
           requireAdminCredsForSignoffProtocol: true
     response:
       status_code: 200
+
+  - name: Existing user tokens should lose run_signoff.write without re-login
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/introspect'
+      data:
+        client_id: opentrons_app
+        token: '{user_access_token}'
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tests.integration.utils:verify_oauth_scopes
+        extra_kwargs:
+          expected_present: updates.write protocols.write
+          expected_absent: run_signoff.write
 
   - name: Regular users should lose run_signoff.write when signoff is admin-only
     request:

--- a/auth-server/tests/integration/test_oauth_scopes_and_settings.tavern.yaml
+++ b/auth-server/tests/integration/test_oauth_scopes_and_settings.tavern.yaml
@@ -1,4 +1,4 @@
-test_name: Robot settings affect OAuth scopes returned to regular users
+test_name: User tokens keep write scopes when requireAdminCreds* settings change
 
 marks:
   - usefixtures:
@@ -7,130 +7,7 @@ marks:
       - seed_users
 
 stages:
-  - name: With default settings, regular users should not get admin-only scopes
-    request:
-      method: POST
-      url: '{run_server.base_url}/auth/oauth2/token'
-      data:
-        client_id: opentrons_app
-        grant_type: password
-        username: testuser
-        password: testuserpassword
-    response:
-      status_code: 200
-      verify_response_with:
-        function: tests.integration.utils:verify_oauth_scopes
-        extra_kwargs:
-          expected_present: run_signoff.write
-          expected_absent: updates.write protocols.write
-      save:
-        json:
-          user_access_token: access_token
-
-  - name: Token introspection should match default-settings login scopes
-    request:
-      method: POST
-      url: '{run_server.base_url}/auth/oauth2/introspect'
-      data:
-        client_id: opentrons_app
-        token: '{user_access_token}'
-    response:
-      status_code: 200
-      verify_response_with:
-        function: tests.integration.utils:verify_oauth_scopes
-        extra_kwargs:
-          expected_present: run_signoff.write
-          expected_absent: updates.write protocols.write
-
-  - name: Allow regular users to update robot software
-    request:
-      method: PATCH
-      url: '{run_server.base_url}/auth/settings'
-      headers:
-        Authorization: '{admin_access_token}'
-      json:
-        data:
-          requireAdminCredsWhenUpdatingRobotSoftware: false
-    response:
-      status_code: 200
-
-  - name: Existing user tokens should gain updates.write without re-login
-    request:
-      method: POST
-      url: '{run_server.base_url}/auth/oauth2/introspect'
-      data:
-        client_id: opentrons_app
-        token: '{user_access_token}'
-    response:
-      status_code: 200
-      verify_response_with:
-        function: tests.integration.utils:verify_oauth_scopes
-        extra_kwargs:
-          expected_present: updates.write run_signoff.write
-          expected_absent: protocols.write
-
-  - name: Regular users should now get updates.write but not protocols.write
-    request:
-      method: POST
-      url: '{run_server.base_url}/auth/oauth2/token'
-      data:
-        client_id: opentrons_app
-        grant_type: password
-        username: testuser
-        password: testuserpassword
-    response:
-      status_code: 200
-      verify_response_with:
-        function: tests.integration.utils:verify_oauth_scopes
-        extra_kwargs:
-          expected_present: updates.write run_signoff.write
-          expected_absent: protocols.write
-      save:
-        json:
-          user_access_token: access_token
-
-  - name: Token introspection should match updates-enabled login scopes
-    request:
-      method: POST
-      url: '{run_server.base_url}/auth/oauth2/introspect'
-      data:
-        client_id: opentrons_app
-        token: '{user_access_token}'
-    response:
-      status_code: 200
-      verify_response_with:
-        function: tests.integration.utils:verify_oauth_scopes
-        extra_kwargs:
-          expected_present: updates.write run_signoff.write
-          expected_absent: protocols.write
-
-  - name: Allow regular users to send protocols to the robot
-    request:
-      method: PATCH
-      url: '{run_server.base_url}/auth/settings'
-      headers:
-        Authorization: '{admin_access_token}'
-      json:
-        data:
-          requireAdminCredsWhenSendingProtocolToRobot: false
-    response:
-      status_code: 200
-
-  - name: Existing user tokens should gain protocols.write without re-login
-    request:
-      method: POST
-      url: '{run_server.base_url}/auth/oauth2/introspect'
-      data:
-        client_id: opentrons_app
-        token: '{user_access_token}'
-    response:
-      status_code: 200
-      verify_response_with:
-        function: tests.integration.utils:verify_oauth_scopes
-        extra_kwargs:
-          expected_present: updates.write protocols.write run_signoff.write
-
-  - name: Regular users should now get both updates.write and protocols.write
+  - name: With default settings, regular users still get the gated write scopes
     request:
       method: POST
       url: '{run_server.base_url}/auth/oauth2/token'
@@ -149,7 +26,7 @@ stages:
         json:
           user_access_token: access_token
 
-  - name: Token introspection should match fully-enabled login scopes
+  - name: Token introspection should include account type and the same write scopes
     request:
       method: POST
       url: '{run_server.base_url}/auth/oauth2/introspect'
@@ -162,8 +39,9 @@ stages:
         function: tests.integration.utils:verify_oauth_scopes
         extra_kwargs:
           expected_present: updates.write protocols.write run_signoff.write
+          expected_account_type: user
 
-  - name: Require admin credentials for protocol signoff
+  - name: Require admin credentials for software update, protocol send, and signoff
     request:
       method: PATCH
       url: '{run_server.base_url}/auth/settings'
@@ -171,11 +49,13 @@ stages:
         Authorization: '{admin_access_token}'
       json:
         data:
+          requireAdminCredsWhenUpdatingRobotSoftware: true
+          requireAdminCredsWhenSendingProtocolToRobot: true
           requireAdminCredsForSignoffProtocol: true
     response:
       status_code: 200
 
-  - name: Existing user tokens should lose run_signoff.write without re-login
+  - name: Existing user tokens should still include the write scopes (RQA-5855)
     request:
       method: POST
       url: '{run_server.base_url}/auth/oauth2/introspect'
@@ -187,10 +67,10 @@ stages:
       verify_response_with:
         function: tests.integration.utils:verify_oauth_scopes
         extra_kwargs:
-          expected_present: updates.write protocols.write
-          expected_absent: run_signoff.write
+          expected_present: updates.write protocols.write run_signoff.write
+          expected_account_type: user
 
-  - name: Regular users should lose run_signoff.write when signoff is admin-only
+  - name: A new user login should also still include the write scopes
     request:
       method: POST
       url: '{run_server.base_url}/auth/oauth2/token'
@@ -204,23 +84,4 @@ stages:
       verify_response_with:
         function: tests.integration.utils:verify_oauth_scopes
         extra_kwargs:
-          expected_present: updates.write protocols.write
-          expected_absent: run_signoff.write
-      save:
-        json:
-          user_access_token: access_token
-
-  - name: Token introspection should match signoff-restricted login scopes
-    request:
-      method: POST
-      url: '{run_server.base_url}/auth/oauth2/introspect'
-      data:
-        client_id: opentrons_app
-        token: '{user_access_token}'
-    response:
-      status_code: 200
-      verify_response_with:
-        function: tests.integration.utils:verify_oauth_scopes
-        extra_kwargs:
-          expected_present: updates.write protocols.write
-          expected_absent: run_signoff.write
+          expected_present: updates.write protocols.write run_signoff.write

--- a/auth-server/tests/integration/utils.py
+++ b/auth-server/tests/integration/utils.py
@@ -13,13 +13,15 @@ def verify_oauth_scopes(
     *,
     expected_present: str = "",
     expected_absent: str = "",
+    expected_account_type: str = "",
 ) -> None:
     """Verify that an OAuth response's scope field includes and excludes specific scopes.
 
     `expected_present` and `expected_absent` are space-separated scope API names
     (e.g. ``"updates.write protocols.write"``).
     """
-    parsed_actual = parse_scopes(response.json().get("scope", ""))
+    body = response.json()
+    parsed_actual = parse_scopes(body.get("scope", ""))
     parsed_expected_present = parse_scopes(expected_present)
     parsed_expected_absent = parse_scopes(expected_absent)
 
@@ -34,3 +36,6 @@ def verify_oauth_scopes(
         "Unexpected scopes present in response: "
         f"{sorted(scope.api_name for scope in unexpected)}"
     )
+
+    if expected_account_type:
+        assert body.get("ot_account_type") == expected_account_type

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -36,6 +36,7 @@ from server_utils.audit.audit_logger import AuditLogger
 from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import (
     get_access_control_status,
+    require_admin_creds,
     require_scopes,
 )
 from server_utils.auth.scopes import Scope
@@ -212,7 +213,10 @@ protocols_router = LightRouter()
         },
         status.HTTP_503_SERVICE_UNAVAILABLE: {"model": ErrorBody[LastAnalysisPending]},
     },
-    dependencies=[Depends(require_scopes(Scope.PROTOCOLS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.PROTOCOLS_WRITE)),
+        Depends(require_admin_creds("requireAdminCredsWhenSendingProtocolToRobot")),
+    ],
 )
 async def create_protocol(  # noqa: C901
     protocol_directory: Annotated[Path, Depends(get_protocol_directory)],

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -46,10 +46,13 @@ from server_utils.auth.resource_server.fastapi import (
     AuthorizationError,
     RequireAuthenticationResult,
     get_access_control_status,
+    get_admin_creds_settings,
+    require_admin_account,
     require_authentication,
     require_scopes,
 )
 from server_utils.auth.resource_server.types import (
+    AdminCredsSettingsData,
     AuthorizationNotRequiredResult,
     AuthorizedResult,
 )
@@ -519,6 +522,7 @@ async def remove_run(
 
 def _require_signoff_scope(
     authentication: RequireAuthenticationResult,
+    require_admin: bool,
 ) -> None:
     authorization_result = check_authorization(
         authentication, {Scope.RUN_SIGNOFF_WRITE}
@@ -527,6 +531,8 @@ def _require_signoff_scope(
         authorization_result, (AuthorizationNotRequiredResult, AuthorizedResult)
     ):
         raise AuthorizationError(authorization_result, {Scope.RUN_SIGNOFF_WRITE})
+    if require_admin:
+        require_admin_account(authentication)
 
 
 @PydanticResponse.wrap_route(
@@ -562,6 +568,9 @@ async def update_run(  # noqa: C901
     authentication: Annotated[
         RequireAuthenticationResult, Depends(require_authentication)
     ],
+    admin_creds: Annotated[
+        AdminCredsSettingsData | None, Depends(get_admin_creds_settings)
+    ] = None,
 ) -> PydanticResponse[SimpleBody[Union[Run, BadRun]]]:
     """Update a run by its ID.
 
@@ -576,9 +585,16 @@ async def update_run(  # noqa: C901
         access_control_status: Whether access control (Compliance Ready Software) is
             currently enabled on the robot.
         authentication: The authenticated user, if any.
+        admin_creds: Live requireAdminCreds* flags. None in unit tests that call
+            this function directly.
     """
     if request_body.data.signedBy is not None:
-        _require_signoff_scope(authentication)
+        require_admin = (
+            admin_creds.requireAdminCredsForSignoffProtocol
+            if admin_creds is not None
+            else False
+        )
+        _require_signoff_scope(authentication, require_admin)
 
     try:
         run_data: Run | BadRun | None = None

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -46,6 +46,8 @@ from server_utils.audit.audit_server import (
 )
 from server_utils.auth.resource_server.fastapi import AuthorizationError
 from server_utils.auth.resource_server.types import (
+    AdminCredentialsRequiredResult,
+    AdminCredsSettingsData,
     AuthenticatedResult,
     AuthenticationNotRequiredResult,
 )
@@ -1270,6 +1272,102 @@ async def test_update_run_signed_by_requires_run_signoff_write_scope(
         )
 
     assert exc_info.value.required_scopes == {Scope.RUN_SIGNOFF_WRITE}
+
+
+async def test_update_run_signed_by_requires_admin_when_setting_true(
+    mock_run_data_manager: RunDataManager,
+    mock_run_store: RunStore,
+    mock_audit_client: AuditClient,
+    mock_persistence_directory_root: Path,
+    mock_protocol_store: ProtocolStore,
+) -> None:
+    """It should reject user signoff when requireAdminCredsForSignoffProtocol is true."""
+    with pytest.raises(AuthorizationError) as exc_info:
+        await update_run(
+            runId="run-id",
+            request_body=RequestModel(data=RunUpdate(signedBy="Alice Example")),
+            run_data_manager=mock_run_data_manager,
+            run_store=mock_run_store,
+            audit_client=mock_audit_client,
+            persistence_directory_root=Path(),
+            protocol_store=mock_protocol_store,
+            access_control_status=True,
+            authentication=AuthenticatedResult(
+                scope=serialize_scopes(
+                    {Scope.ROBOT_CONTROL_WRITE, Scope.RUN_SIGNOFF_WRITE}
+                ),
+                username="testuser",
+                fullname="Test User",
+                account_type="user",
+            ),
+            admin_creds=AdminCredsSettingsData(
+                requireAdminCredsForSignoffProtocol=True,
+            ),
+        )
+
+    assert isinstance(
+        exc_info.value.authorization_error, AdminCredentialsRequiredResult
+    )
+
+
+async def test_update_run_signed_by_allows_admin_when_setting_true(
+    decoy: Decoy,
+    mock_run_data_manager: RunDataManager,
+    mock_run_store: RunStore,
+    mock_audit_client: AuditClient,
+    mock_persistence_directory_root: Path,
+    mock_protocol_store: ProtocolStore,
+) -> None:
+    """It should allow admin signoff when requireAdminCredsForSignoffProtocol is true."""
+    expected_response = Run(
+        id="run-id",
+        protocolId=None,
+        logPeriodId=None,
+        createdAt=datetime(year=2021, month=1, day=1),
+        status=pe_types.EngineStatus.SUCCEEDED,
+        current=True,
+        actions=[],
+        errors=[],
+        pipettes=[],
+        modules=[],
+        labware=[],
+        labwareOffsets=[],
+        liquids=[],
+        liquidClasses=[],
+        outputFileIds=[],
+        hasEverEnteredErrorRecovery=False,
+        signedBy="Alice Example",
+    )
+
+    decoy.when(
+        await mock_run_data_manager.set_signed_by(
+            run_id="run-id", signed_by="Alice Example"
+        )
+    ).then_return(expected_response)
+
+    result = await update_run(
+        runId="run-id",
+        request_body=RequestModel(data=RunUpdate(signedBy="Alice Example")),
+        run_data_manager=mock_run_data_manager,
+        run_store=mock_run_store,
+        audit_client=mock_audit_client,
+        persistence_directory_root=Path(),
+        protocol_store=mock_protocol_store,
+        access_control_status=True,
+        authentication=AuthenticatedResult(
+            scope=serialize_scopes(
+                {Scope.ROBOT_CONTROL_WRITE, Scope.RUN_SIGNOFF_WRITE}
+            ),
+            username="testadmin",
+            fullname="Test Admin",
+            account_type="admin",
+        ),
+        admin_creds=AdminCredsSettingsData(
+            requireAdminCredsForSignoffProtocol=True,
+        ),
+    )
+
+    assert result.content.data.signedBy == "Alice Example"
 
 
 async def test_update_run_signed_by(

--- a/server-utils/server_utils/auth/resource_server/auth_server.py
+++ b/server-utils/server_utils/auth/resource_server/auth_server.py
@@ -12,6 +12,7 @@ from abc import ABC, abstractmethod
 import aiohttp
 
 from .types import (
+    AdminCredsSettingsResponse,
     AuthSettingsResponse,
     ClientIDType,
     TokenIntrospectionRequestFormData,
@@ -40,6 +41,15 @@ class Client(ABC):
     @abstractmethod
     async def get_auth_settings(self) -> AuthSettingsResponse:
         """Ask the Opentrons auth-server what the current system-wide auth settings are.
+
+        If there's an internal error (e.g. the auth server is unconnectable),
+        the implementation should raise it as an exception.
+        """
+        pass
+
+    @abstractmethod
+    async def get_admin_creds_settings(self) -> AdminCredsSettingsResponse:
+        """Ask the Opentrons auth-server for the requireAdminCreds* flags.
 
         If there's an internal error (e.g. the auth server is unconnectable),
         the implementation should raise it as an exception.
@@ -108,6 +118,13 @@ class LocalHTTPClient(Client):
         response.raise_for_status()
         parsed_response = AuthSettingsResponse.model_validate_json(response_bytes)
         return parsed_response
+
+    @typing.override
+    async def get_admin_creds_settings(self) -> AdminCredsSettingsResponse:
+        async with self._session.get(ALL_AUTH_SETTINGS_ENDPOINT_PATH) as response:
+            response_bytes = await response.read()
+        response.raise_for_status()
+        return AdminCredsSettingsResponse.model_validate_json(response_bytes)
 
     @typing.override
     async def introspect_token(self, token: str) -> TokenIntrospectionResponse:

--- a/server-utils/server_utils/auth/resource_server/authentication_checker.py
+++ b/server-utils/server_utils/auth/resource_server/authentication_checker.py
@@ -13,6 +13,7 @@ from .auth_server import (
     Client as AuthServerClient,
 )
 from .types import (
+    AdminCredsSettingsData,
     AuthenticatedResult,
     AuthenticationNotRequiredResult,
     AuthenticationResult,
@@ -42,6 +43,11 @@ class AuthenticationChecker(ABC):
         """Check whether access control is currently enabled."""
         pass
 
+    @abstractmethod
+    async def admin_creds_settings(self) -> AdminCredsSettingsData:
+        """Return the live requireAdminCreds* flags."""
+        pass
+
 
 class FailedClosedAuthenticationChecker(AuthenticationChecker):
     """An `AuthenticationChecker` that always denies access.
@@ -57,6 +63,14 @@ class FailedClosedAuthenticationChecker(AuthenticationChecker):
     async def access_control_status(self) -> bool:
         return True
 
+    @override
+    async def admin_creds_settings(self) -> AdminCredsSettingsData:
+        return AdminCredsSettingsData(
+            requireAdminCredsWhenUpdatingRobotSoftware=True,
+            requireAdminCredsWhenSendingProtocolToRobot=True,
+            requireAdminCredsForSignoffProtocol=True,
+        )
+
 
 class AlwaysAllowedAuthenticationChecker(AuthenticationChecker):
     """An `AuthenticationChecker` that always allows access."""
@@ -68,6 +82,14 @@ class AlwaysAllowedAuthenticationChecker(AuthenticationChecker):
     @override
     async def access_control_status(self) -> bool:
         return False
+
+    @override
+    async def admin_creds_settings(self) -> AdminCredsSettingsData:
+        return AdminCredsSettingsData(
+            requireAdminCredsWhenUpdatingRobotSoftware=False,
+            requireAdminCredsWhenSendingProtocolToRobot=False,
+            requireAdminCredsForSignoffProtocol=False,
+        )
 
 
 class AuthServerAuthenticationChecker(AuthenticationChecker):
@@ -108,6 +130,7 @@ class AuthServerAuthenticationChecker(AuthenticationChecker):
                     scope=token_info.scope,
                     username=token_info.username,
                     fullname=token_info.ot_fullname,
+                    account_type=token_info.ot_account_type or "",
                 )
             return NotAnActiveTokenResult()
 
@@ -115,3 +138,8 @@ class AuthServerAuthenticationChecker(AuthenticationChecker):
     async def access_control_status(self) -> bool:
         """See base class for documentation."""
         return (await self._client.get_auth_settings()).data.accessControlEnabled
+
+    @override
+    async def admin_creds_settings(self) -> AdminCredsSettingsData:
+        """See base class for documentation."""
+        return (await self._client.get_admin_creds_settings()).data

--- a/server-utils/server_utils/auth/resource_server/error_responses.py
+++ b/server-utils/server_utils/auth/resource_server/error_responses.py
@@ -3,18 +3,27 @@
 This module should be framework-agnostic, not tied to FastAPI or whatever.
 """
 
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 import fastapi
 from pydantic import BaseModel, Field
 
 from .types import (
+    AdminCredentialsRequiredResult,
     InsufficientScopeResult,
     MissingTokenResult,
     NotAnActiveTokenResult,
     UnableToContactAuthServerResult,
 )
 from server_utils.auth.scopes import Scope
+
+AuthorizationFailure: TypeAlias = (
+    MissingTokenResult
+    | NotAnActiveTokenResult
+    | InsufficientScopeResult
+    | AdminCredentialsRequiredResult
+    | UnableToContactAuthServerResult
+)
 
 
 # todo(mm, 2026-02-10): Follow the server's existing error response conventions,
@@ -41,15 +50,20 @@ class AuthorizationErrorResponse(BaseModel):
         list[str],
         Field(description="The authorization scopes carried by the request."),
     ]
+    adminCredentialsRequired: Annotated[
+        bool,
+        Field(
+            description=(
+                "If true, the token is valid and has the action's scopes, but a "
+                "requireAdminCreds* setting currently restricts this action to admin "
+                "or service accounts."
+            )
+        ),
+    ] = False
 
 
 def build_response_for_error(
-    error: (
-        MissingTokenResult
-        | NotAnActiveTokenResult
-        | InsufficientScopeResult
-        | UnableToContactAuthServerResult
-    ),
+    error: AuthorizationFailure,
     required_scopes: set[Scope],
 ) -> tuple[int, dict[str, str], AuthorizationErrorResponse]:
     """Turn the given authorization error into an HTTP response.
@@ -92,6 +106,17 @@ def build_response_for_error(
                     providedScopes=provided_scopes_str_list,
                 ),
             )
+        case AdminCredentialsRequiredResult():
+            return (
+                fastapi.status.HTTP_403_FORBIDDEN,
+                headers,
+                AuthorizationErrorResponse(
+                    debugMessage="This action requires admin credentials.",
+                    requiredScopes=required_scopes_str_list,
+                    providedScopes=[],
+                    adminCredentialsRequired=True,
+                ),
+            )
         case UnableToContactAuthServerResult():
             return (
                 fastapi.status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -105,12 +130,7 @@ def build_response_for_error(
 
 
 def _build_response_headers_for_error(
-    error: (
-        MissingTokenResult
-        | NotAnActiveTokenResult
-        | InsufficientScopeResult
-        | UnableToContactAuthServerResult
-    ),
+    error: AuthorizationFailure,
 ) -> dict[str, str]:
     """Return the headers that should be sent for an error response.
 
@@ -140,6 +160,12 @@ def _build_response_headers_for_error(
                 )
             }
         case InsufficientScopeResult():
+            return {
+                "WWW-Authenticate": _www_authenticate(
+                    "Bearer", {"error": "insufficient_scope"}
+                )
+            }
+        case AdminCredentialsRequiredResult():
             return {
                 "WWW-Authenticate": _www_authenticate(
                     "Bearer", {"error": "insufficient_scope"}

--- a/server-utils/server_utils/auth/resource_server/fastapi.py
+++ b/server-utils/server_utils/auth/resource_server/fastapi.py
@@ -11,6 +11,7 @@ from typing import (
     Awaitable,
     Callable,
     Final,
+    Literal,
     Type,
     TypeAlias,
 )
@@ -28,6 +29,8 @@ from .authentication_checker import (
 from .authorization_checker import check as check_authorization
 from .error_responses import build_response_for_error
 from .types import (
+    AdminCredentialsRequiredResult,
+    AdminCredsSettingsData,
     AuthenticatedResult,
     AuthenticationNotRequiredResult,
     AuthorizationNotRequiredResult,
@@ -122,6 +125,14 @@ RequireAuthenticationResult: TypeAlias = (
     AuthenticationNotRequiredResult | AuthenticatedResult
 )
 RequireScopesResult: TypeAlias = AuthorizationNotRequiredResult | AuthorizedResult
+
+_ADMIN_ACCOUNT_TYPES: Final[frozenset[str]] = frozenset({"admin", "service"})
+
+AdminCredsSetting: TypeAlias = Literal[
+    "requireAdminCredsWhenUpdatingRobotSoftware",
+    "requireAdminCredsWhenSendingProtocolToRobot",
+    "requireAdminCredsForSignoffProtocol",
+]
 
 
 async def require_authentication(
@@ -223,6 +234,54 @@ def require_scopes(
     return dependency
 
 
+async def get_admin_creds_settings(
+    authentication_checker: Annotated[
+        AuthenticationChecker, fastapi.Depends(get_authentication_checker)
+    ],
+) -> AdminCredsSettingsData:
+    """A FastAPI dependency to retrieve the live requireAdminCreds* flags."""
+    return await authentication_checker.admin_creds_settings()
+
+
+def require_admin_account(
+    authentication: RequireAuthenticationResult,
+) -> None:
+    """Reject non-admin callers when access control is on.
+
+    No-op when access control is disabled.
+    """
+    if isinstance(authentication, AuthenticationNotRequiredResult):
+        return
+    if authentication.account_type in _ADMIN_ACCOUNT_TYPES:
+        return
+    raise AuthorizationError(AdminCredentialsRequiredResult(), set())
+
+
+def require_admin_creds(
+    setting: AdminCredsSetting,
+) -> Callable[..., Awaitable[None]]:
+    """A FastAPI dependency that requires an admin account when a requireAdminCreds* flag is true.
+
+    Use next to `require_scopes()` on protocol upload, software update, and similar
+    actions. User tokens keep the matching write scopes (RQA-5855). This gate is what
+    actually denies the user when the flag is on (RQA-5854).
+    """
+
+    async def dependency(
+        authentication: Annotated[
+            RequireAuthenticationResult, fastapi.Depends(require_authentication)
+        ],
+        admin_creds: Annotated[
+            AdminCredsSettingsData, fastapi.Depends(get_admin_creds_settings)
+        ],
+    ) -> None:
+        if not getattr(admin_creds, setting):
+            return
+        require_admin_account(authentication)
+
+    return dependency
+
+
 async def get_access_control_status(
     authentication_checker: Annotated[
         AuthenticationChecker, fastapi.Depends(get_authentication_checker)
@@ -243,6 +302,7 @@ class AuthorizationError(Exception):
         self,
         authorization_error: (
             InsufficientScopeResult
+            | AdminCredentialsRequiredResult
             | MissingTokenResult
             | NotAnActiveTokenResult
             | UnableToContactAuthServerResult

--- a/server-utils/server_utils/auth/resource_server/types.py
+++ b/server-utils/server_utils/auth/resource_server/types.py
@@ -37,6 +37,8 @@ class AuthenticatedResult:
     scope: str
     username: str
     fullname: str
+    account_type: str = ""
+    """The account type from auth-server (`admin`, `user`, `auditor`, `service`)."""
 
 
 @dataclass
@@ -64,6 +66,13 @@ class NotAnActiveTokenResult:
 @dataclass
 class UnableToContactAuthServerResult:
     """The authorization server couldn't be contacted."""
+
+    pass
+
+
+@dataclass
+class AdminCredentialsRequiredResult:
+    """The token is valid, but this action currently requires an admin account."""
 
     pass
 
@@ -100,6 +109,7 @@ class TokenIntrospectionResponse(_StrictBaseModel):
     scope: str = ""
     username: str | None = None
     ot_fullname: str | None = None
+    ot_account_type: str | None = None
 
 
 class TokenIntrospectionRequestFormData(TypedDict):
@@ -123,6 +133,25 @@ class AuthSettingsResponseData(_StrictBaseModel):
     """Response body data from auth-server's /settings endpoint."""
 
     accessControlEnabled: bool
+
+
+class AdminCredsSettingsData(pydantic.BaseModel):
+    """The requireAdminCreds* flags from GET /auth/settings.
+
+    Extra fields on that endpoint are ignored. Defaults match auth-server.
+    """
+
+    model_config = {"extra": "ignore"}
+
+    requireAdminCredsWhenUpdatingRobotSoftware: bool = True
+    requireAdminCredsWhenSendingProtocolToRobot: bool = True
+    requireAdminCredsForSignoffProtocol: bool = False
+
+
+class AdminCredsSettingsResponse(_StrictBaseModel):
+    """A response body from auth-server's GET /auth/settings endpoint."""
+
+    data: AdminCredsSettingsData
 
 
 ClientIDType: TypeAlias = Literal["opentrons_app"]

--- a/server-utils/tests/auth/resource_server/test_admin_creds.py
+++ b/server-utils/tests/auth/resource_server/test_admin_creds.py
@@ -1,0 +1,130 @@
+"""Tests for the requireAdminCreds* request-time gate."""
+
+from typing import override
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from server_utils.auth.resource_server.authentication_checker import (
+    AuthenticationChecker,
+)
+from server_utils.auth.resource_server.fastapi import (
+    AuthorizationError,
+    handle_authorization_error,
+    install_authentication_checker,
+    require_admin_account,
+    require_admin_creds,
+)
+from server_utils.auth.resource_server.types import (
+    AdminCredentialsRequiredResult,
+    AdminCredsSettingsData,
+    AuthenticatedResult,
+    AuthenticationNotRequiredResult,
+    AuthenticationResult,
+)
+
+
+def test_require_admin_account_noop_when_access_control_off() -> None:
+    """CRS off should not require an admin account."""
+    require_admin_account(AuthenticationNotRequiredResult())
+
+
+@pytest.mark.parametrize("account_type", ["admin", "service"])
+def test_require_admin_account_allows_admin_roles(account_type: str) -> None:
+    """Admin and service accounts should pass."""
+    require_admin_account(
+        AuthenticatedResult(
+            scope="",
+            username="privileged",
+            fullname="Privileged",
+            account_type=account_type,
+        )
+    )
+
+
+def test_require_admin_account_denies_user() -> None:
+    """A user account should get a distinct admin-credentials 403."""
+    with pytest.raises(AuthorizationError) as exc_info:
+        require_admin_account(
+            AuthenticatedResult(
+                scope="protocols.write updates.write run_signoff.write",
+                username="operator",
+                fullname="Operator",
+                account_type="user",
+            )
+        )
+    assert isinstance(
+        exc_info.value.authorization_error, AdminCredentialsRequiredResult
+    )
+
+
+class _StubChecker(AuthenticationChecker):
+    """Return a fixed account type and requireAdminCredsWhenSendingProtocolToRobot flag."""
+
+    def __init__(self, *, account_type: str, flag: bool) -> None:
+        self._account_type = account_type
+        self._flag = flag
+
+    @override
+    async def check(self, token: str | None) -> AuthenticationResult:
+        return AuthenticatedResult(
+            scope="protocols.write",
+            username="operator",
+            fullname="Operator",
+            account_type=self._account_type,
+        )
+
+    @override
+    async def access_control_status(self) -> bool:
+        return True
+
+    @override
+    async def admin_creds_settings(self) -> AdminCredsSettingsData:
+        return AdminCredsSettingsData(
+            requireAdminCredsWhenUpdatingRobotSoftware=False,
+            requireAdminCredsWhenSendingProtocolToRobot=self._flag,
+            requireAdminCredsForSignoffProtocol=False,
+        )
+
+
+def _client(*, account_type: str, flag: bool) -> TestClient:
+    app = FastAPI()
+    install_authentication_checker(
+        app.state, _StubChecker(account_type=account_type, flag=flag)
+    )
+    app.exception_handler(AuthorizationError)(handle_authorization_error)
+
+    @app.post(
+        "/upload",
+        dependencies=[
+            Depends(require_admin_creds("requireAdminCredsWhenSendingProtocolToRobot"))
+        ],
+    )
+    def upload() -> dict[str, str]:
+        return {"ok": "ok"}
+
+    return TestClient(app)
+
+
+def test_require_admin_creds_allows_user_when_flag_false() -> None:
+    """Users keep the write scope; the flag off means the request is allowed."""
+    response = _client(account_type="user", flag=False).post("/upload")
+    assert response.status_code == 200
+    assert response.json() == {"ok": "ok"}
+
+
+def test_require_admin_creds_denies_user_when_flag_true() -> None:
+    """A user with the write scope still gets an admin-credentials 403 (RQA-5855)."""
+    response = _client(account_type="user", flag=True).post("/upload")
+    assert response.status_code == 403
+    body = response.json()
+    assert body["adminCredentialsRequired"] is True
+    assert body["debugMessage"] == "This action requires admin credentials."
+
+
+def test_require_admin_creds_allows_admin_when_flag_true() -> None:
+    """Admins are not blocked by requireAdminCreds*."""
+    response = _client(account_type="admin", flag=True).post("/upload")
+    assert response.status_code == 200
+    assert response.json() == {"ok": "ok"}

--- a/server-utils/tests/auth/resource_server/test_auth_server.py
+++ b/server-utils/tests/auth/resource_server/test_auth_server.py
@@ -16,6 +16,8 @@ from server_utils.auth.resource_server.auth_server import (
     LocalHTTPClient,
 )
 from server_utils.auth.resource_server.types import (
+    AdminCredsSettingsData,
+    AdminCredsSettingsResponse,
     AuthSettingsResponse,
     AuthSettingsResponseData,
     TokenIntrospectionResponse,
@@ -146,6 +148,30 @@ async def test_settings(mock_server: tuple[AppMock, LocalHTTPClient]) -> None:
     settings_result = await client.get_auth_settings()
     assert settings_result == AuthSettingsResponse(
         data=AuthSettingsResponseData(accessControlEnabled=True)
+    )
+
+
+async def test_admin_creds_settings(
+    mock_server: tuple[AppMock, LocalHTTPClient],
+) -> None:
+    """Test that the client can retrieve requireAdminCreds* flags from GET /auth/settings."""
+    app_mock, client = mock_server
+
+    app_mock.all_auth_settings_response = {
+        "data": {
+            "maxNumberOfLoginAttempts": 5,
+            "requireAdminCredsWhenUpdatingRobotSoftware": False,
+            "requireAdminCredsWhenSendingProtocolToRobot": True,
+            "requireAdminCredsForSignoffProtocol": True,
+        }
+    }
+    result = await client.get_admin_creds_settings()
+    assert result == AdminCredsSettingsResponse(
+        data=AdminCredsSettingsData(
+            requireAdminCredsWhenUpdatingRobotSoftware=False,
+            requireAdminCredsWhenSendingProtocolToRobot=True,
+            requireAdminCredsForSignoffProtocol=True,
+        )
     )
 
 

--- a/server-utils/tests/auth/resource_server/test_authentication_checker.py
+++ b/server-utils/tests/auth/resource_server/test_authentication_checker.py
@@ -138,9 +138,13 @@ async def test_passes_active_token(
     )
     decoy.when(await mock_client.introspect_token("asdasf")).then_return(
         TokenIntrospectionResponse(
-            active=True, username="hi", ot_fullname="lo", scope=serialize_scopes(set())
+            active=True,
+            username="hi",
+            ot_fullname="lo",
+            ot_account_type="user",
+            scope=serialize_scopes(set()),
         )
     )
     assert await subject.check("asdasf") == AuthenticatedResult(
-        scope="", username="hi", fullname="lo"
+        scope="", username="hi", fullname="lo", account_type="user"
     )

--- a/update-server/otupdate/common/update.py
+++ b/update-server/otupdate/common/update.py
@@ -24,6 +24,7 @@ from server_utils.audit.audit_server import (
 from server_utils.audit.fastapi import get_audit_client, get_audit_logger
 from server_utils.auth.resource_server.fastapi import (
     RequireAuthenticationResult,
+    require_admin_creds,
     require_authentication,
     require_scopes,
 )
@@ -77,6 +78,9 @@ def require_session(
     summary="Create an update session.",
     dependencies=[
         fastapi.Depends(require_scopes(Scope.UPDATES_WRITE)),
+        fastapi.Depends(
+            require_admin_creds("requireAdminCredsWhenUpdatingRobotSoftware")
+        ),
         fastapi.Depends(get_audit_logger("start update session")),
     ],
 )
@@ -164,6 +168,9 @@ async def status(
     summary="Upload a system update file.",
     dependencies=[
         fastapi.Depends(require_scopes(Scope.UPDATES_WRITE)),
+        fastapi.Depends(
+            require_admin_creds("requireAdminCredsWhenUpdatingRobotSoftware")
+        ),
         fastapi.Depends(get_audit_logger("upload update file")),
     ],
 )
@@ -239,6 +246,9 @@ async def file_upload(
     summary="Commit a validated update.",
     dependencies=[
         fastapi.Depends(require_scopes(Scope.UPDATES_WRITE)),
+        fastapi.Depends(
+            require_admin_creds("requireAdminCredsWhenUpdatingRobotSoftware")
+        ),
         fastapi.Depends(get_audit_logger("commit update")),
     ],
 )
@@ -278,6 +288,9 @@ async def commit(
     summary="Cancel the active update session.",
     dependencies=[
         fastapi.Depends(require_scopes(Scope.UPDATES_WRITE)),
+        fastapi.Depends(
+            require_admin_creds("requireAdminCredsWhenUpdatingRobotSoftware")
+        ),
         fastapi.Depends(get_audit_logger("cancel update")),
     ],
 )


### PR DESCRIPTION
# Overview

[RQA-5854](https://opentrons.atlassian.net/browse/RQA-5854) and [RQA-5855](https://opentrons.atlassian.net/browse/RQA-5855) are the same product model applied to different actions. User tokens should always include `run_signoff.write`, `protocols.write`, and `updates.write`. The `requireAdminCreds*` settings are a separate live gate: when a flag is on, only admin or service accounts may perform that action. Deny must be an admin-credentials 403, not a missing-scope 403.

Previously those three write scopes were assigned from the flags at login (signoff default false, protocol-send and software-update default true). Robot-server then authorized from stored token scopes. That caused both bugs:

- RQA-5854: a user token issued while signoff was open still signed off after the flag was turned on (HTTP 200). The App already denied this with a live setting + `accountType` check.
- RQA-5855: a fresh user token never received `protocols.write` / `updates.write` at the defaults, so protocol send and software update failed as missing-scope 403 instead of an admin-creds gate.

This PR always grants those write scopes to users, puts `ot_account_type` on introspect, and enforces the live flags at the resource server:

- `POST /protocols` (`requireAdminCredsWhenSendingProtocolToRobot`). Protocol delete is unchanged.
- `PATCH /runs/{id}` when `signedBy` is set (`requireAdminCredsForSignoffProtocol`).
- update-server begin / file / commit / cancel (`requireAdminCredsWhenUpdatingRobotSoftware`). Pipette and module firmware endpoints are unchanged.

When the flag is on, non-admin callers get HTTP 403 with `adminCredentialsRequired: true` and debug message `"This action requires admin credentials."`

**Acceptance**
- User tokens include `run_signoff.write`, `protocols.write`, and `updates.write` at default settings, and after all three flags are turned on, without re-login.
- With `requireAdminCredsForSignoffProtocol: true`, a user with `run_signoff.write` cannot sign off; an admin can.
- With `requireAdminCredsWhenSendingProtocolToRobot: true`, a user with `protocols.write` cannot upload a protocol; an admin can.
- With `requireAdminCredsWhenUpdatingRobotSoftware: true`, a user with `updates.write` cannot start a software update; an admin can.
- CRS off is unchanged (no token required).
- Admin and service tokens still have all scopes.

Base: `chore_release-10.0.0`.

## Test Plan and Hands on Testing

Automated:
- `cd server-utils && make lint && make test tests=tests/auth/resource_server`
- `cd auth-server && make lint && make test tests=tests/integration/test_oauth_scopes_and_settings.tavern.yaml`
- `cd auth-server && make test tests=tests/integration/test_oauth_flows.tavern.yaml`
- `cd robot-server && make lint && make test tests=tests/runs/router/test_base_router.py`
- `cd update-server && make lint`

Hands on (KansasFLEX, CRS on), after this is on a robot build:
- Login as user at default settings. Introspect should include `run_signoff.write`, `protocols.write`, and `updates.write`.
- As admin, set all three `requireAdminCreds*` flags true. Re-introspect the same user token: those scopes should still be present.
- User `PATCH /runs/{id}` with `signedBy` should 403 with `adminCredentialsRequired: true`. Admin signoff should 200.
- User `POST /protocols` should 403 with `adminCredentialsRequired: true`. Admin upload should succeed.
- User `POST /server/update/begin` should 403 with `adminCredentialsRequired: true`. Admin begin should succeed.

## Changelog

- **auth-server:** user tokens always include `protocols.write`, `updates.write`, and `run_signoff.write`. `requireAdminCreds*` no longer strips those scopes.
- **auth-server:** `POST /auth/oauth2/introspect` includes `ot_account_type` (`admin`, `user`, `auditor`, `service`) and still recomputes live scopes (password-reset restriction).
- **robot-server / update-server:** protocol upload, run signoff, and software update require an admin or service account when the matching live flag is true.
- **Behavior change:** tightening a `requireAdminCreds*` flag takes effect on the next request. Existing user tokens keep the write scopes; the endpoint denies them with `adminCredentialsRequired` instead of a missing-scope 403.

## Review requests

- Confirm always granting the three write scopes, then gating by account type + live settings, is the intended 10.0.0 product model.
- Confirm protocol delete should stay scope-only (no admin-creds gate), and pipette/module firmware updates should stay out of `requireAdminCredsWhenUpdatingRobotSoftware`.
- Confirm `adminCredentialsRequired: true` on 403 is a usable signal for App/ODD, versus treating it as a generic insufficient_scope WWW-Authenticate.

## Risk assessment

- **Attention level:** medium. This is authorization policy for CRS-on robots. A mistake is either a leftover privilege or an unexpected 403 after a settings toggle.
- **Blast radius:** auth-server scope assignment, robot-server protocol upload and run signoff, update-server software update session endpoints, plus a shared resource-server helper in server-utils.
- **Trade-off:** we do not invalidate sessions when an admin patches settings. Users stay logged in; the next request is gated. App signoff already has its own live-setting check (`useSignRunFlow`).
- **Mitigation:** tavern coverage that user tokens keep the write scopes after flags go true; robot-server unit tests for user-vs-admin signoff; server-utils tests for the admin-credentials 403 body.

[RQA-5854]: https://opentrons.atlassian.net/browse/RQA-5854
[RQA-5855]: https://opentrons.atlassian.net/browse/RQA-5855