### PR TITLE
fix(app): trust robot status over HTTP errors during auto-commit updates

### DIFF
--- a/app/src/resources/robot-update/useRobotUpdateOrchestrator/__tests__/pollRobotUpdateStatus.test.ts
+++ b/app/src/resources/robot-update/useRobotUpdateOrchestrator/__tests__/pollRobotUpdateStatus.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getRobotUpdateSessionStatus } from '@opentrons/api-client'
+
+import { STATUS_POLL_MS } from '../constants'
+import { pollRobotUpdateStatus } from '../pollRobotUpdateStatus'
+
+import type {
+  HostConfig,
+  RobotUpdateSessionStatus,
+} from '@opentrons/api-client'
+import type { Dispatch } from '/app/redux/types'
+
+vi.mock('@opentrons/api-client', () => ({
+  getRobotUpdateSessionStatus: vi.fn(),
+}))
+
+const HOST_CONFIG = { hostname: '192.168.1.2' } as HostConfig
+const dispatch = vi.fn() as Dispatch
+
+function poll(
+  isDone: (status: RobotUpdateSessionStatus) => boolean,
+  completeOnRequestError: boolean
+): Promise<RobotUpdateSessionStatus> {
+  return pollRobotUpdateStatus({
+    hostConfig: HOST_CONFIG,
+    pathPrefix: '/server/update',
+    token: 'token',
+    dispatch,
+    isDone,
+    signal: new AbortController().signal,
+    completeOnRequestError,
+  })
+}
+
+function status(
+  stage: RobotUpdateSessionStatus['stage']
+): RobotUpdateSessionStatus {
+  return { stage, progress: 0.5, message: stage }
+}
+
+describe('pollRobotUpdateStatus', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.mocked(getRobotUpdateSessionStatus).mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('rejects a request error when completeOnRequestError is false', async () => {
+    vi.mocked(getRobotUpdateSessionStatus).mockRejectedValue(
+      new Error('Network Error')
+    )
+
+    await expect(
+      poll(s => s.stage === 'ready-for-restart', false)
+    ).rejects.toThrow('Network Error')
+  })
+
+  it('treats a request error as completion after a status was seen', async () => {
+    vi.mocked(getRobotUpdateSessionStatus)
+      .mockResolvedValueOnce({ data: status('writing') } as any)
+      .mockRejectedValue(new Error('Network Error'))
+
+    const result = poll(s => s.stage === 'ready-for-restart', true)
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(STATUS_POLL_MS)
+
+    await expect(result).resolves.toMatchObject({ stage: 'writing' })
+  })
+
+  it('treats a request error as completion before any status was seen', async () => {
+    vi.mocked(getRobotUpdateSessionStatus).mockRejectedValue(
+      new Error('Network Error')
+    )
+
+    await expect(
+      poll(s => s.stage === 'ready-for-restart', true)
+    ).resolves.toMatchObject({ stage: 'done', message: '' })
+  })
+})

--- a/app/src/resources/robot-update/useRobotUpdateOrchestrator/pollRobotUpdateStatus.ts
+++ b/app/src/resources/robot-update/useRobotUpdateOrchestrator/pollRobotUpdateStatus.ts
@@ -10,25 +10,50 @@ import type {
 } from '@opentrons/api-client'
 import type { Dispatch } from '/app/redux/types'
 
+// Used when auto-commit has likely rebooted before we observed a status.
+export const UNREACHABLE_SESSION_STATUS: RobotUpdateSessionStatus = {
+  stage: 'done',
+  progress: null,
+  message: '',
+}
+
+export interface PollRobotUpdateStatusParams {
+  hostConfig: HostConfig
+  pathPrefix: string
+  token: string
+  dispatch: Dispatch
+  isDone: (status: RobotUpdateSessionStatus) => boolean
+  // Cancels polling (ex, user starts another update). Rejects with AbortError.
+  signal: AbortSignal
+  // When true, a failed status GET completes the poll instead of rejecting.
+  // Needed after auto-commit reboot since /status never succeeds, and
+  // treating that as an error would fail an otherwise successful update.
+  completeOnRequestError: boolean
+}
+
 /**
  * Poll update-server status until `isDone` is true.
  */
-export function pollRobotUpdateStatus(
-  hostConfig: HostConfig,
-  pathPrefix: string,
-  token: string,
-  dispatch: Dispatch,
-  isDone: (status: RobotUpdateSessionStatus) => boolean,
-  signal?: AbortSignal
-): Promise<RobotUpdateSessionStatus> {
+export function pollRobotUpdateStatus({
+  hostConfig,
+  pathPrefix,
+  token,
+  dispatch,
+  isDone,
+  signal,
+  completeOnRequestError,
+}: PollRobotUpdateStatusParams): Promise<RobotUpdateSessionStatus> {
   return new Promise((resolve, reject) => {
     let cancelled = false
     let timeoutId: ReturnType<typeof setTimeout> | null = null
+    let lastStatus: RobotUpdateSessionStatus | null = null
 
     const cleanup = (): void => {
       cancelled = true
-      if (timeoutId != null) clearTimeout(timeoutId)
-      signal?.removeEventListener('abort', onAbort)
+      if (timeoutId != null) {
+        clearTimeout(timeoutId)
+      }
+      signal.removeEventListener('abort', onAbort)
     }
 
     const onAbort = (): void => {
@@ -36,18 +61,21 @@ export function pollRobotUpdateStatus(
       reject(new DOMException('Aborted', 'AbortError'))
     }
 
-    signal?.addEventListener('abort', onAbort, { once: true })
+    signal.addEventListener('abort', onAbort, { once: true })
 
     const tick = (): void => {
-      if (cancelled || signal?.aborted) {
+      if (cancelled || signal.aborted) {
         onAbort()
         return
       }
 
       getRobotUpdateSessionStatus(hostConfig, pathPrefix, token)
         .then(response => {
-          if (cancelled) return
+          if (cancelled) {
+            return
+          }
           const status = response.data
+          lastStatus = status
           dispatch(
             robotUpdateStatus(
               status.stage,
@@ -71,7 +99,16 @@ export function pollRobotUpdateStatus(
           timeoutId = setTimeout(tick, STATUS_POLL_MS)
         })
         .catch((error: unknown) => {
-          if (cancelled) return
+          if (cancelled) {
+            return
+          }
+
+          if (completeOnRequestError) {
+            cleanup()
+            resolve(lastStatus ?? UNREACHABLE_SESSION_STATUS)
+            return
+          }
+
           cleanup()
           reject(error instanceof Error ? error : new Error(String(error)))
         })

--- a/app/src/resources/robot-update/useRobotUpdateOrchestrator/runRobotUpdateFlow.ts
+++ b/app/src/resources/robot-update/useRobotUpdateOrchestrator/runRobotUpdateFlow.ts
@@ -40,7 +40,10 @@ import { pollRobotUpdateStatus } from './pollRobotUpdateStatus'
 
 import type { AxiosError } from 'axios'
 import type { Store } from 'redux'
-import type { HostConfig } from '@opentrons/api-client'
+import type {
+  HostConfig,
+  RobotUpdateSessionStatus,
+} from '@opentrons/api-client'
 import type {
   CreateRobotUpdateSessionVariables,
   DocumentationState,
@@ -153,14 +156,69 @@ export function runRobotUpdateFlow(deps: RobotUpdateFlowDeps): Promise<void> {
       const hostConfigFor = (): HostConfig =>
         buildHostConfig(robot, deps.getAccessToken())
 
-      return pollRobotUpdateStatus(
-        hostConfigFor(),
+      const watchUntilReadyForRestart = (
+        uploadFailed: boolean,
+        uploadError: unknown
+      ): Promise<RobotUpdateSessionStatus | 'already-finished'> => {
+        return pollRobotUpdateStatus({
+          hostConfig: hostConfigFor(),
+          pathPrefix,
+          token,
+          dispatch,
+          isDone: status => {
+            if (uploadFailed && status.stage === AWAITING_FILE) {
+              return true
+            }
+            return (
+              status.stage === READY_FOR_RESTART ||
+              (!ctx.autoCommitAndRestart && status.stage === DONE)
+            )
+          },
+          signal,
+          completeOnRequestError: ctx.autoCommitAndRestart,
+        }).then(status => {
+          if (uploadFailed && status.stage === AWAITING_FILE) {
+            if (isRobotOnTargetVersion(store, robot)) {
+              dispatch(setRobotUpdateSessionStep(FINISHED))
+              dispatch(finishDiscovery())
+              return 'already-finished'
+            }
+            return Promise.reject(
+              uploadError instanceof Error
+                ? uploadError
+                : new Error(
+                    i18n.t('unable_to_start_update_session', {
+                      ns: 'device_settings',
+                    })
+                  )
+            )
+          } else if (status.stage === DONE && !ctx.autoCommitAndRestart) {
+            return commitIfNeeded(deps, false, pathPrefix, token).then(() =>
+              pollRobotUpdateStatus({
+                hostConfig: hostConfigFor(),
+                pathPrefix,
+                token,
+                dispatch,
+                isDone: s => s.stage === READY_FOR_RESTART,
+                signal,
+                completeOnRequestError: false,
+              })
+            )
+          } else {
+            return status
+          }
+        })
+      }
+
+      return pollRobotUpdateStatus({
+        hostConfig: hostConfigFor(),
         pathPrefix,
         token,
         dispatch,
-        status => status.stage === AWAITING_FILE,
-        signal
-      )
+        isDone: status => status.stage === AWAITING_FILE,
+        signal,
+        completeOnRequestError: false,
+      })
         .then(() =>
           uploadUpdateFile(
             deps,
@@ -169,37 +227,28 @@ export function runRobotUpdateFlow(deps: RobotUpdateFlowDeps): Promise<void> {
             pathPrefix,
             token,
             systemFilePath
+          ).then(
+            () => ({ failed: false as const, error: null }),
+            (error: unknown) => {
+              if (!ctx.autoCommitAndRestart) {
+                return Promise.reject(error)
+              }
+              // Status is the source of truth, not client network errors.
+              return { failed: true as const, error }
+            }
           )
         )
-        .then(() =>
-          pollRobotUpdateStatus(
-            hostConfigFor(),
-            pathPrefix,
-            token,
-            dispatch,
-            status =>
-              status.stage === READY_FOR_RESTART ||
-              (!ctx.autoCommitAndRestart && status.stage === DONE),
-            signal
-          )
+        .then(uploadResult =>
+          watchUntilReadyForRestart(uploadResult.failed, uploadResult.error)
         )
-        .then(status => {
-          if (status.stage === DONE && !ctx.autoCommitAndRestart) {
-            return commitIfNeeded(deps, false, pathPrefix, token).then(() =>
-              pollRobotUpdateStatus(
-                hostConfigFor(),
-                pathPrefix,
-                token,
-                dispatch,
-                s => s.stage === READY_FOR_RESTART,
-                signal
-              )
-            )
+        .then(result => {
+          if (result === 'already-finished') {
+            return
           }
-          return status
+          return beginRestartPhase(deps, robot, ctx.autoCommitAndRestart).then(
+            () => finishAfterRestart(deps, robot)
+          )
         })
-        .then(() => beginRestartPhase(deps, robot, ctx.autoCommitAndRestart))
-        .then(() => finishAfterRestart(deps, robot))
     })
     .catch((error: unknown) => {
       reportFlowError(dispatch, error)
@@ -483,4 +532,21 @@ function finishAfterRestart(
     }
     dispatch(finishDiscovery())
   })
+}
+
+function isRobotOnTargetVersion(
+  store: Store<State>,
+  robot: ViewableRobot
+): boolean {
+  const currentRobot = getRobotUpdateRobot(store.getState()) ?? robot
+  const targetVersion = getRobotUpdateTargetVersion(
+    store.getState(),
+    currentRobot.name
+  )
+  const robotVersion = getRobotApiVersion(currentRobot)
+  return (
+    targetVersion != null &&
+    robotVersion != null &&
+    robotVersion === targetVersion
+  )
 }


### PR DESCRIPTION
Closes [RQA-5895](https://opentrons.atlassian.net/browse/RQA-5895)

# Overview

During or after a successful Flex software update, the desktop app often showed a transport error instead of success. Current robots auto-commit and reboot once the image is on disk, so the client can lose the HTTP connection while the apply is still running, and the update will resolve successfully. 

The app now treats those drops as “keep watching the robot”: poll session status, wait for rediscovery, and only fail if the robot reports an error, never left awaiting-file, or comes back on the wrong version. 

## Test Plan and Hands on Testing

- [x] Verified zip file updates work as expected on CRS and non-CRS modes.
- [ ] Verified banner updates work as expected on CRS and non-CRS modes. [Testing using this special build](https://github.com/Opentrons/opentrons/actions/runs/32171218852).
 
## Changelog

- Fixed the robot update UI showing errors despite the robot completing the update successfully in the background.

## Risk assessment

- lowish, the diff looks scarier than it is - we just add some logic to swallow errors unless we are uploading the update file to the robot


[RQA-5895]: https://opentrons.atlassian.net/browse/RQA-5895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ