### PR TITLE
fix(step-generation, shared-data): update liquid state for vacuumed labware

### DIFF
--- a/shared-data/js/getLabware.ts
+++ b/shared-data/js/getLabware.ts
@@ -170,7 +170,7 @@ export const getIsPipettableLabware = (
   labwareDef: LabwareDefinition
 ): boolean => {
   // assume the labware can be a pipetting target if labware definition's `allowedRoles` is undefined
-  if (labwareDef.allowedRoles == null) {
+  if (labwareDef.allowedRoles == null || labwareDef.allowedRoles.length === 0) {
     return true
   }
   return (

--- a/step-generation/src/getNextRobotStateAndWarnings/vacuumUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/vacuumUpdates.ts
@@ -1,3 +1,5 @@
+import { getIsPipettableLabware } from '@opentrons/shared-data'
+
 import {
   VACUUM_MODE_POWER,
   VACUUM_MODE_PRESSURE,
@@ -5,8 +7,10 @@ import {
   VACUUM_VENT_OPEN,
 } from '../constants'
 import { vacuumModuleStateGetter } from '../robotStateSelectors'
+import { getFullStackFromLabwares } from '../utils'
 
 import type {
+  LabwareDefinition,
   VacuumModuleOpenVentCreateCommand,
   VacuumModuleSetTargetPowerCreateCommand,
   VacuumModuleSetTargetPressureCreateCommand,
@@ -15,9 +19,83 @@ import type {
 } from '@opentrons/shared-data'
 import type {
   InvariantContext,
+  LabwareEntities,
   RobotStateAndWarnings,
+  TimelineFrame,
   VacuumModuleState,
 } from '../types'
+
+const getLabwareDimensionsEqual = (
+  def1: LabwareDefinition,
+  def2: LabwareDefinition
+): boolean => {
+  const [columns1, columns2] = [def1.ordering, def2.ordering]
+  if (Object.keys(columns1).length !== Object.keys(columns2).length) {
+    return false
+  }
+  for (let i = 0; i < columns1.length; i++) {
+    const [rows1, rows2] = [columns1[i], columns2[i]]
+    if (rows1.length !== rows2.length) {
+      return false
+    }
+  }
+  return true
+}
+
+const vacuumMergeLiquid = (
+  moduleId: string,
+  robotState: TimelineFrame,
+  labwareEntities: LabwareEntities
+): void => {
+  const { labware: labwareState, liquidState } = robotState
+  const fullStackOnVacuum = getFullStackFromLabwares(labwareState, moduleId)
+  const pipettableLabwareOnVacuumTopDown = fullStackOnVacuum.filter(
+    lwId =>
+      lwId in labwareEntities &&
+      getIsPipettableLabware(labwareEntities[lwId].def)
+  )
+  // assume sole filter plate if only one pipettable lw on vacuum during pump action
+  if (pipettableLabwareOnVacuumTopDown.length === 1) {
+    const liquidLabwareState =
+      liquidState.labware[pipettableLabwareOnVacuumTopDown[0]]
+    Object.entries(liquidLabwareState).forEach(([well, _]) => {
+      liquidLabwareState[well] = {}
+    })
+    return
+  }
+  if (pipettableLabwareOnVacuumTopDown.length === 2) {
+    const filterLw = pipettableLabwareOnVacuumTopDown[0]
+    const collectionLw = pipettableLabwareOnVacuumTopDown[1]
+    if (
+      !getLabwareDimensionsEqual(
+        labwareEntities[filterLw].def,
+        labwareEntities[collectionLw].def
+      )
+    ) {
+      console.log('filter and collection LW dimensions do not match')
+      return
+    }
+    const filterLwLiquidState = liquidState.labware[filterLw]
+    const collectionLwLiquidState = liquidState.labware[collectionLw]
+
+    // merge filter well ingredients into collection
+    Object.entries(collectionLwLiquidState).forEach(
+      ([well, collectionWellState]) => {
+        const filterWellState = filterLwLiquidState[well]
+        Object.entries(filterWellState).forEach(([ingredGroup, { volume }]) => {
+          collectionWellState[ingredGroup] = {
+            volume:
+              ingredGroup in collectionWellState
+                ? collectionWellState[ingredGroup].volume + volume
+                : volume,
+          }
+        })
+        // empty filter plate well
+        filterLwLiquidState[well] = {}
+      }
+    )
+  }
+}
 
 export const forVacuumOpenVent = (
   params: VacuumModuleOpenVentCreateCommand['params'],
@@ -52,10 +130,14 @@ export const forVacuumSetPumpPressure = (
 ): void => {
   const { moduleId, gaugePressure, duration, ventAfter = true, taskId } = params
   const { robotState } = robotStateAndWarnings
+  const { labwareEntities } = invariantContext
   const moduleState = vacuumModuleStateGetter(robotState, moduleId)
   if (moduleState == null) {
     return
   }
+
+  vacuumMergeLiquid(moduleId, robotState, labwareEntities)
+
   // if holding indefinitely or not venting after the pressure is reached for a duration, the pressure is held
   // taskId should not be null, but this is to satisfy type checks
   if (duration == null || taskId == null) {
@@ -86,10 +168,14 @@ export const forVacuumSetPumpPower = (
 ): void => {
   const { moduleId, percentPower, duration, ventAfter = true, taskId } = params
   const { robotState } = robotStateAndWarnings
+  const { labwareEntities } = invariantContext
   const moduleState = vacuumModuleStateGetter(robotState, moduleId)
   if (moduleState == null) {
     return
   }
+
+  vacuumMergeLiquid(moduleId, robotState, labwareEntities)
+
   // if holding indefinitely or not venting after the power is reached for a duration, the power is held
   // taskId should not be null, but this is to satisfy type checks
   if (duration == null || taskId == null) {
@@ -136,11 +222,15 @@ export const forVacuumStartRunProfile = (
 ): void => {
   const { moduleId, steps, taskId, ventAfter = true } = params
   const { robotState } = robotStateAndWarnings
+  const { labwareEntities } = invariantContext
   const moduleState = vacuumModuleStateGetter(robotState, moduleId)
   // taskId should not be null, but this is to satisfy type checks
   if (moduleState == null || taskId == null) {
     return
   }
+
+  vacuumMergeLiquid(moduleId, robotState, labwareEntities)
+
   moduleState.currentPumpActivity = {
     type: 'profile',
     profileElements: steps,

--- a/step-generation/src/getNextRobotStateAndWarnings/vacuumUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/vacuumUpdates.ts
@@ -30,7 +30,7 @@ const getLabwareDimensionsEqual = (
   def2: LabwareDefinition
 ): boolean => {
   const [columns1, columns2] = [def1.ordering, def2.ordering]
-  if (Object.keys(columns1).length !== Object.keys(columns2).length) {
+  if (columns1.length !== columns2.length) {
     return false
   }
   for (let i = 0; i < columns1.length; i++) {
@@ -64,19 +64,18 @@ const vacuumMergeLiquid = (
     return
   }
   if (pipettableLabwareOnVacuumTopDown.length === 2) {
-    const filterLw = pipettableLabwareOnVacuumTopDown[0]
-    const collectionLw = pipettableLabwareOnVacuumTopDown[1]
+    const filterLwId = pipettableLabwareOnVacuumTopDown[0]
+    const collectionLwId = pipettableLabwareOnVacuumTopDown[1]
     if (
       !getLabwareDimensionsEqual(
-        labwareEntities[filterLw].def,
-        labwareEntities[collectionLw].def
+        labwareEntities[filterLwId].def,
+        labwareEntities[collectionLwId].def
       )
     ) {
-      console.log('filter and collection LW dimensions do not match')
       return
     }
-    const filterLwLiquidState = liquidState.labware[filterLw]
-    const collectionLwLiquidState = liquidState.labware[collectionLw]
+    const filterLwLiquidState = liquidState.labware[filterLwId]
+    const collectionLwLiquidState = liquidState.labware[collectionLwId]
 
     // merge filter well ingredients into collection
     Object.entries(collectionLwLiquidState).forEach(


### PR DESCRIPTION
# Overview

Wires up liquid state updates for vacuum pump actions (pressure hold, power hold, or profile). If we have 2 stacked non-collar non-spacer labware on the main module area during pump action, we merge the liquid from the top (presumed filter) labware into the bottom (presumed collection) labware, and empty the top labware. If we have a single non-collar non-spacer labware on the main module area, we empty the labware (presumed filter).

We do not make this liquid merge update if:
- 0 or >2 pipettable labware are atop the vacuum module (the latter of these situations should not be a possible state)
- the dimensions of the 2 labware do not match

Closes RQA-5886

## Test Plan and Hands on Testing

#### Merging liquid from filter plate into collection plate
[VM_test_in_PD (8).py](https://github.com/user-attachments/files/31197027/VM_test_in_PD.8.py)
- create or import a protocol with 2 plates (collection + filter) on the vacuum module
- add liquid to each labware 
- create a vacuum pump action step
- inspect the labware state following this step. Verify that the top filter plate is empty, and the collection plate has merged its liquid with the liquid from the corresponding wells of the filter plate

#### Emptying liquid from a lone filter plate
[VM_test_in_PD (9).py](https://github.com/user-attachments/files/31197050/VM_test_in_PD.9.py)
- create or import a protocol with 1 plates (presumed filter) on the vacuum module
- add liquid to the labware 
- create a vacuum pump action step
- inspect the labware state following this step, and verify that the plate is empty


## Changelog

- add logic to update and merge liquid state in labware(s) seated on the main module area during a pump action
- fix util for getting whether a labware is "pipettable"

## Review requests

see test plan

## Risk assessment

low