### PR TITLE
feat(ai-client): unblock the Runtime Parameters step for the OT-2

### DIFF
--- a/opentrons-ai-client/src/assets/localization/en/create_protocol.json
+++ b/opentrons-ai-client/src/assets/localization/en/create_protocol.json
@@ -81,7 +81,6 @@
   "runtime_parameters_section_textbody": "OpentronsAI can add adjustable parameters for sample count, pipettes, labware, and more. Available for Python protocols only.",
   "runtime_parameters_section_title": "Runtime Parameters",
   "runtime_parameters_title": "Runtime Parameters",
-  "runtime_parameters_unavailable": "Runtime Parameters are only available for Python protocols on Opentrons Flex.",
   "search_for_labware_placeholder": "Search for labware...",
   "section_confirm_button": "Confirm",
   "serial_dilution": "Serial dilution",

--- a/opentrons-ai-client/src/components/organisms/RuntimeParametersSection/__tests__/RuntimeParametersSection.test.tsx
+++ b/opentrons-ai-client/src/components/organisms/RuntimeParametersSection/__tests__/RuntimeParametersSection.test.tsx
@@ -1,5 +1,5 @@
 import { FormProvider, useForm } from 'react-hook-form'
-import { screen, waitFor } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
 import { renderWithProviders } from '/ai-client/__testing-utils__'
@@ -47,7 +47,7 @@ describe('RuntimeParametersSection', () => {
     expect(screen.getByText('Optional')).toBeInTheDocument()
   })
 
-  it('should not render the input field when robot type is OT2', async () => {
+  it('should render the input field when robot type is OT2', () => {
     renderWithProviders(
       <TestFormProviderComponent robotType={OPENTRONS_OT2} />,
       {
@@ -55,16 +55,10 @@ describe('RuntimeParametersSection', () => {
       }
     )
 
-    await waitFor(() => {
-      expect(
-        screen.queryByTestId('RuntimeParametersSection_inputArea')
-      ).not.toBeInTheDocument()
-    })
-
     expect(
-      screen.getByText(
-        'Runtime Parameters are only available for Python protocols on Opentrons Flex.'
-      )
+      screen.getByTestId('RuntimeParametersSection_inputArea')
     ).toBeInTheDocument()
+    expect(screen.getByText('Define Runtime Parameters')).toBeInTheDocument()
+    expect(screen.getByText('Optional')).toBeInTheDocument()
   })
 })

--- a/opentrons-ai-client/src/components/organisms/RuntimeParametersSection/index.tsx
+++ b/opentrons-ai-client/src/components/organisms/RuntimeParametersSection/index.tsx
@@ -1,4 +1,3 @@
-import { useFormContext, useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -6,31 +5,16 @@ import {
   COLORS,
   DIRECTION_COLUMN,
   Flex,
-  InfoScreen,
   SPACING,
   StyledText,
 } from '@opentrons/components'
 
 import { ControlledTextAreaField } from '/ai-client/components/atoms/ControlledTextAreaField'
-import {
-  OPENTRONS_FLEX,
-  ROBOT_FIELD_NAME,
-} from '/ai-client/components/organisms/InstrumentsSection'
 
 const RUNTIME_PARAMETERS_FIELD_NAME = 'runtime_parameters'
 
-export function RuntimeParametersSection(): JSX.Element | null {
+export function RuntimeParametersSection(): JSX.Element {
   const { t } = useTranslation('create_protocol')
-  const { control } = useFormContext()
-
-  const robotType = useWatch({ control, name: ROBOT_FIELD_NAME })
-
-  // Only show this section when robot type is Flex
-  const shouldShowSection = robotType === OPENTRONS_FLEX
-
-  if (!shouldShowSection) {
-    return <InfoScreen content={t('runtime_parameters_unavailable')} />
-  }
 
   return (
     <Flex

--- a/opentrons-ai-client/src/resources/utils/createProtocolUtils.tsx
+++ b/opentrons-ai-client/src/resources/utils/createProtocolUtils.tsx
@@ -12,7 +12,6 @@ import {
   NO_PIPETTES,
   OPENTRONS_FLEX,
   OPENTRONS_OT2,
-  ROBOT_FIELD_NAME,
   TWO_PIPETTES,
 } from '/ai-client/components/organisms/InstrumentsSection'
 
@@ -243,10 +242,8 @@ export function generatePromptPreviewRuntimeParametersItems(
   t: any
 ): string[] {
   const { runtime_parameters } = watch()
-  const robotType = watch(ROBOT_FIELD_NAME)
 
-  // Only show in preview if robot is Flex
-  if (robotType !== OPENTRONS_FLEX || !runtime_parameters) {
+  if (!runtime_parameters) {
     return []
   }
 
@@ -404,12 +401,11 @@ export function generateChatPrompt(
   const fixtureSection =
     values.fixtures.length > 0 ? `\n\n${t('fixtures_title')}:\n${fixtures}` : ''
 
-  const runtimeParametersSection =
-    values.instruments.robot === OPENTRONS_FLEX && values.runtime_parameters
-      ? `\n\n${t(
-          'runtime_parameters_title'
-        )}:\n- ${values.runtime_parameters.replace(/\n/g, '\n- ')}`
-      : ''
+  const runtimeParametersSection = values.runtime_parameters
+    ? `\n\n${t(
+        'runtime_parameters_title'
+      )}:\n- ${values.runtime_parameters.replace(/\n/g, '\n- ')}`
+    : ''
 
   const prompt = `${t('create_protocol_prompt_robot', { robotType }) + '\n'}
 


### PR DESCRIPTION
# Overview

The create-protocol wizard blocks the Runtime Parameters (RTP) step for the OT-2 — it only shows for Opentrons Flex, rendering an "only available on Flex" info card instead. That restriction dates from when only Flex supported RTP; RTP works on both robots now (OT-2 RTP is driven via the desktop app), so the block is a stale bug that customers hit directly.

This removes the `robotType === OPENTRONS_FLEX` condition from all three places it gated RTP:

- `RuntimeParametersSection` — the section now always renders the input; the now-unreachable "unavailable" `InfoScreen` branch and its `runtime_parameters_unavailable` locale string are removed, along with the form watch that only existed to feed the gate.
- `generatePromptPreviewRuntimeParametersItems` — RTP text now appears in the prompt-preview panel whenever it's set, regardless of robot.
- `generateChatPrompt` — RTP is now included in the prompt sent to the backend whenever it's set, regardless of robot.

The ticket's original caveat ("keep blocking RTP for PD protocols") is moot: #22007 (AUTH-2850) removed the Protocol Designer format option entirely, so the PD half of these gates is already gone and every wizard protocol is Python.

**Possible follow-up (out of scope):** `opentrons-ai-server`'s example protocols may be Flex-centric, so generated OT-2 RTP code quality could lag until OT-2 RTP examples are added — flagged to the reporter.

Ticket: AUTH-2442

## Test Plan and Hands on Testing

- [x] `make test` — 206/206 tests pass across 48 files; the `RuntimeParametersSection` OT-2 case flipped from "hidden" to "shown"
- [x] Full monorepo `pnpm tsc --build` — zero type errors
- [x] Repo-wide grep for `runtime_parameters_unavailable` — clean
- [x] Manual wizard walkthrough as OT-2 (same dev-tenant live setup as #22007)

## Changelog

- Removed the Flex-only gate from `RuntimeParametersSection`, `generatePromptPreviewRuntimeParametersItems`, and `generateChatPrompt`
- Removed the dead `runtime_parameters_unavailable` locale string
- Updated `RuntimeParametersSection` tests

## Review requests

Sanity-check the scope call: this unblocks the UI/prompt path only; backend OT-2 RTP example protocols are left as a possible follow-up.

## Risk assessment

Low — deletes a UI-side restriction; Flex behavior unchanged (all 206 existing tests green).
