### PR TITLE
fix(api): Create vacuum module object even if we cant configure the PID parameters.

### DIFF
--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -197,7 +197,11 @@ class VacuumModule(mod_abc.AbstractModule):
         try:
             await module._configure_device()
         except Exception:
-            log.exception("Could not configure device")
+            log.warning(
+                "Could not configure vacuum module defaults on port %s.",
+                port,
+                exc_info=True,
+            )
 
         try:
             await poller.start()
@@ -252,6 +256,12 @@ class VacuumModule(mod_abc.AbstractModule):
             await self._handle_status_bar_event(self._last_status_bar_event)
 
     def _async_error_callback(self, exception: Exception) -> None:
+        """Forward poller/firmware faults as async module errors."""
+        # Parse mismatches (e.g. an M121 pressure line consumed as M123 pump
+        # state) are comms glitches, not firmware faults. Do not escalate them
+        # as ASYNCHRONOUS_MODULE_ERROR or a run can be stopped.
+        if isinstance(exception, ValueError):
+            return
         self.error_callback(self._to_enumerated_error(exception))
 
     def _to_enumerated_error(self, exception: Exception) -> EnumeratedError:

--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -194,7 +194,10 @@ class VacuumModule(mod_abc.AbstractModule):
         )
 
         # Configure the default parameters
-        await module._configure_device()
+        try:
+            await module._configure_device()
+        except Exception:
+            log.exception("Could not configure device")
 
         try:
             await poller.start()
@@ -341,7 +344,6 @@ class VacuumModule(mod_abc.AbstractModule):
                     port=self.port, loop=self.loop
                 )
                 self._reader._driver = self._driver
-            await self._configure_device()
             self._unsubscribe_init = self._reader.set_initialized_callback(
                 self._initialized_callback
             )
@@ -350,6 +352,7 @@ class VacuumModule(mod_abc.AbstractModule):
             )
             await self._poller.stop()
             await self._poller.start()
+            await self._configure_device()
         except BaseException:
             log.exception("Got an error when trying to reconnect vacuum module.")
 

--- a/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
@@ -5,7 +5,9 @@ import mock
 import pytest
 from _pytest.fixtures import SubRequest
 from mock import AsyncMock, call
-from serial.serialutil import SerialException as PySerialSerialException
+from serial.serialutil import (  # type: ignore[import-untyped]
+    SerialException as PySerialSerialException,
+)
 
 from opentrons.drivers.asyncio.communication.async_serial import AsyncSerial
 from opentrons.drivers.asyncio.communication.errors import (

--- a/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
@@ -3,7 +3,7 @@ from typing import AsyncGenerator, List, Optional, Union
 from unittest import mock
 
 import pytest
-from decoy import Decoy
+from decoy import Decoy, matchers
 
 from opentrons_shared_data.errors.exceptions import (
     VacuumModulePressureNotReachedError,
@@ -1397,6 +1397,57 @@ async def test_execute_profile_continues_after_natural_duration_end(
             rate=None,
             vent_after=False,
         ),
+    )
+
+
+def test_async_error_callback_does_not_escalate_parse_errors(
+    subject: modules.VacuumModule,
+    module_error_callback: ModuleErrorCallback,
+    decoy: Decoy,
+) -> None:
+    """A poll parse miss must not become an asynchronous module error."""
+    parse_error = ValueError(
+        "Incorrect Response for get pump state: "
+        "M121 T:0.0 C:-5.7 A:1008.6 B:1007.4 H:1013.1 E:0 D:0 V:1"
+    )
+
+    subject._reader.on_error(parse_error)
+
+    decoy.verify(
+        module_error_callback(
+            matchers.Anything(),
+            matchers.Anything(),
+            matchers.Anything(),
+            matchers.Anything(),
+        ),
+        times=0,
+    )
+    assert subject._reader.error is not None
+    assert "Incorrect Response for get pump state" in subject._reader.error
+
+
+def test_reader_on_error_still_escalates_firmware_errors(
+    subject: modules.VacuumModule,
+    module_error_callback: ModuleErrorCallback,
+    decoy: Decoy,
+) -> None:
+    """Firmware poll errors should still reach the module error callback."""
+    _set_reader_async_error_context(
+        subject._reader,
+        mode=VacuumOperationMode.PRESSURE,
+        target=-500.0,
+        current=-300.0,
+    )
+    subject._reader.on_error(
+        WasteContainerFull("port", "async ERR401:waste full", "M121")
+    )
+    decoy.verify(
+        module_error_callback(
+            VacuumModuleWasteFullError("dummySerialFS", "pressure", -500.0, -300.0),
+            "vacuumModuleV1",
+            "/dev/ot_module_sim_vacuummodule0",
+            "dummySerialFS",
+        )
     )
 
 

--- a/api/tests/opentrons/hardware_control/test_poller.py
+++ b/api/tests/opentrons/hardware_control/test_poller.py
@@ -3,7 +3,9 @@ from typing import AsyncGenerator
 
 import pytest
 from decoy import Decoy, matchers
-from serial.serialutil import SerialException as PySerialSerialException
+from serial.serialutil import (  # type: ignore[import-untyped]
+    SerialException as PySerialSerialException,
+)
 
 from opentrons.hardware_control.poller import Poller, Reader
 
@@ -146,7 +148,9 @@ async def test_poller_disconnect_io_does_not_log_callback_traceback(
     io_error = PySerialSerialException("write failed: [Errno 5] Input/output error")
     decoy.when(await mock_reader.read()).then_raise(io_error)  # type: ignore[func-returns-value]
     decoy.when(
-        mock_reader.on_error(matchers.ErrorMatching(PySerialSerialException))
+        mock_reader.on_error(  # type: ignore[func-returns-value]
+            matchers.ErrorMatching(PySerialSerialException)
+        )
     ).then_raise(io_error)
 
     with caplog.at_level("DEBUG"):


### PR DESCRIPTION
# Overview

We should be more tolerant of gcode errors when creating the vacuum module object. This is important, especially when there are changes to the module firmware that we have to update first to align with the Python code. Also, fix some linting errors I overlooked.

## Test Plan and Hands on Testing

- [x] Make sure we still create the vacuum module if we can't configure the PID tunings.

## Changelog

- Add try/except around `_configure_device` when creating the VacuumModule object

## Review requests
## Risk assessment