### PR TITLE
fix(robot-server): allow deletion of non-current runs that have not been signed

### DIFF
--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -501,7 +501,6 @@ async def remove_run(
         await run_data_manager.delete(
             run_id=runId, access_control_status=access_control_status
         )
-
     except RunConflictError as e:
         raise RunNotIdle().as_error(status.HTTP_409_CONFLICT) from e
     except RunSignoffRequiredError as e:

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -422,9 +422,10 @@ class RunDataManager:
                 be deleted.
             RunNotFoundError: The given run identifier was not found in the database.
         """
-        self._raise_if_run_requires_signoff(run_id, access_control_status)
-
         if run_id == self._run_orchestrator_store.current_run_id:
+            # We will only raise for a signoff if the run is current. Uncurrent unsigned
+            # runs are allowed to be deleted.
+            self._raise_if_run_requires_signoff(run_id, access_control_status)
             await self._run_orchestrator_store.clear()
 
         self._runs_publisher.clean_up_run(run_id=run_id)

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -424,7 +424,8 @@ class RunDataManager:
         """
         if run_id == self._run_orchestrator_store.current_run_id:
             # We will only raise for a signoff if the run is current. Uncurrent unsigned
-            # runs are allowed to be deleted.
+            # runs are allowed to be deleted, as they can come from runs interrupted by
+            # a power cycle or runs created before signoff was required.
             self._raise_if_run_requires_signoff(run_id, access_control_status)
             await self._run_orchestrator_store.clear()
 

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -782,11 +782,12 @@ async def test_delete_historical_run(
 
 
 @pytest.mark.parametrize(
-    ("signed_by", "access_control_status", "expect_signoff_required"),
+    ("signed_by", "access_control_status", "expect_signoff_required", "current_run_id"),
     [
-        pytest.param(None, True, True, id="signoff_required"),
-        pytest.param("Alice Example", True, False, id="already_signed"),
-        pytest.param(None, False, False, id="access_control_disabled"),
+        pytest.param(None, True, True, "test-run-id", id="signoff_required"),
+        pytest.param("Alice Example", True, False, "test-run-id", id="already_signed"),
+        pytest.param(None, False, False, "test-run-id", id="access_control_disabled"),
+        pytest.param(None, True, False, "not-run-id", id="not_current_run"),
     ],
 )
 async def test_delete_signoff_enforcement(
@@ -798,6 +799,7 @@ async def test_delete_signoff_enforcement(
     signed_by: str | None,
     access_control_status: bool,
     expect_signoff_required: bool,
+    current_run_id: str,
 ) -> None:
     """It should enforce signoff before deleting a run when required."""
     run_id = "test-run-id"
@@ -815,7 +817,7 @@ async def test_delete_signoff_enforcement(
             log_period_id=None,
         )
     )
-    decoy.when(mock_run_orchestrator_store.current_run_id).then_return(run_id)
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return(current_run_id)
 
     if expect_signoff_required:
         with pytest.raises(RunSignoffRequiredError, match=run_id):
@@ -827,11 +829,13 @@ async def test_delete_signoff_enforcement(
         decoy.verify(mock_run_store.remove(run_id=run_id), times=0)
     else:
         await subject.delete(run_id=run_id, access_control_status=access_control_status)
-
-        decoy.verify(
-            await mock_run_orchestrator_store.clear(),
-            mock_run_store.remove(run_id=run_id),
-        )
+        if current_run_id == run_id:
+            decoy.verify(
+                await mock_run_orchestrator_store.clear(),
+                mock_run_store.remove(run_id=run_id),
+            )
+        else:
+            decoy.verify(mock_run_store.remove(run_id=run_id))
 
 
 async def test_uncurrent(


### PR DESCRIPTION
# Overview

Addresses RQA-5947.

When in ACM mode and a signature is required for a run, it is possible to enter a situation where the run is no longer current but has not been signed. This can happen if the Flex loses power in a middle of a run or before it is signed, but could also happen if one were to enable or re-enable run signing after runs have been completed with the mode off.

When in this situation, it was impossible to delete these runs without turning off run signing, as deleting them required them to be signed and yet since they were no longer current, they could not be signed. Automatic protocol deletion could delete them, but this can be turned off and this would not be a good solution for removing them.

As part of a fix for this, we will now allow runs to be deleted without being signed as long as they are not current. If one attempts to delete a run that is finished but has not been uncurrented, we will raise the existing run signoff error.

Note that this is separate from the log period download. A previous run ran in ACM mode with logging will still contain the run log, runs interrupted with a power cycle will not but will still contain all audit logs up to the power cycle. Deleting the run without deleting the audit logs will result in a name of `N/A`, but log period start and end will still be accurate.

## Test Plan and Hands on Testing

Tested on a robot, ensuring non-current runs without signatures could be deleted while a current run without one could not be deleted.

## Changelog

- Allow runs that are not current and unsigned to be deleted via `DELETE` run endpoint when run signing is required

## Review requests

## Risk assessment

Low. It is still impossible to delete run that is current and awaiting to be signed (or mid-run), and this allows the deletion of runs that either entered a bad state or were pre-existing before compliance settings were changed.