### PR TITLE
fix(app, odd): fix broken MQTT notifications

### DIFF
--- a/app/src/resources/__tests__/useNotifyDataReady.test.ts
+++ b/app/src/resources/__tests__/useNotifyDataReady.test.ts
@@ -52,14 +52,14 @@ describe('useNotifyDataReady', () => {
     vi.clearAllMocks()
   })
 
-  it('should return queryOptionsNotify and shouldRefetch on a successful initial mount', () => {
+  it('should return queryOptionsNotify and refetch on a successful initial mount', () => {
     const { result } = renderHook(() =>
       useNotifyDataReady({
         topic: MOCK_TOPIC,
         options: MOCK_OPTIONS,
       } as any)
     )
-    expect(result.current.shouldRefetch).toEqual(true)
+    expect(result.current.refetch).toEqual(1)
     expect(result.current.queryOptionsNotify).toBeDefined()
     expect(mockDispatch).toHaveBeenCalledWith(
       notifySubscribeAction(MOCK_HOST_CONFIG.hostname, MOCK_TOPIC)
@@ -74,7 +74,7 @@ describe('useNotifyDataReady', () => {
         options: { ...MOCK_OPTIONS, forceHttpPolling: true },
       } as any)
     )
-    expect(result.current.shouldRefetch).toEqual(false)
+    expect(result.current.refetch).toEqual(0)
     expect(appShellListener).not.toHaveBeenCalled()
     expect(mockDispatch).not.toHaveBeenCalled()
   })
@@ -86,7 +86,7 @@ describe('useNotifyDataReady', () => {
         options: { ...MOCK_OPTIONS, enabled: false },
       } as any)
     )
-    expect(result.current.shouldRefetch).toEqual(false)
+    expect(result.current.refetch).toEqual(0)
     expect(appShellListener).not.toHaveBeenCalled()
     expect(mockDispatch).not.toHaveBeenCalled()
   })
@@ -98,12 +98,12 @@ describe('useNotifyDataReady', () => {
         options: { ...MOCK_OPTIONS, staleTime: Infinity },
       } as any)
     )
-    expect(result.current.shouldRefetch).toEqual(false)
+    expect(result.current.refetch).toEqual(0)
     expect(appShellListener).not.toHaveBeenCalled()
     expect(mockDispatch).not.toHaveBeenCalled()
   })
 
-  it('should set shouldRefetch to false if there is an error', () => {
+  it('should not request a refetch if there is an error', () => {
     vi.mocked(useHost).mockReturnValue({ hostname: null } as any)
     const errorSpy = vi.spyOn(console, 'error')
     errorSpy.mockImplementation(() => {})
@@ -115,10 +115,10 @@ describe('useNotifyDataReady', () => {
       } as any)
     )
 
-    expect(result.current.shouldRefetch).toEqual(false)
+    expect(result.current.refetch).toEqual(0)
   })
 
-  it('should set shouldRefetch to false and fire an analytics reporting event if the connection was refused', () => {
+  it('should restore polling and fire an analytics reporting event if the connection was refused', () => {
     vi.mocked(appShellListener).mockImplementation(function ({
       callback,
     }): any {
@@ -128,15 +128,15 @@ describe('useNotifyDataReady', () => {
     const { rerender, result } = renderHook(() =>
       useNotifyDataReady({
         topic: MOCK_TOPIC,
-        options: MOCK_OPTIONS,
+        options: { ...MOCK_OPTIONS, refetchInterval: 5000 },
       } as any)
     )
     expect(mockTrackEvent).toHaveBeenCalled()
     rerender()
-    expect(result.current.shouldRefetch).toEqual(false)
+    expect(result.current.queryOptionsNotify.refetchInterval).toEqual(5000)
   })
 
-  it('should set shouldRefetch to true if the refetch flag was returned', () => {
+  it('should increment refetch if the refetch flag was returned', () => {
     vi.mocked(appShellListener).mockImplementation(function ({
       callback,
     }): any {
@@ -149,10 +149,11 @@ describe('useNotifyDataReady', () => {
       } as any)
     )
     rerender()
-    expect(result.current.shouldRefetch).toEqual(true)
+    // One request from the initial mount, one from the notification.
+    expect(result.current.refetch).toEqual(2)
   })
 
-  it('should set shouldRefetch to true if the unsubscribe flag was returned', () => {
+  it('should increment refetch if the unsubscribe flag was returned', () => {
     vi.mocked(appShellListener).mockImplementation(function ({
       callback,
     }): any {
@@ -165,10 +166,11 @@ describe('useNotifyDataReady', () => {
       } as any)
     )
     rerender()
-    expect(result.current.shouldRefetch).toEqual(true)
+    // One request from the initial mount, one from the notification.
+    expect(result.current.refetch).toEqual(2)
   })
 
-  it('should handle multiple refetch requests during an active refetch', () => {
+  it('should increment refetch for every notification so requests cannot collapse into one', () => {
     let capturedCallback: any
     vi.mocked(appShellListener).mockImplementation(function ({
       callback,
@@ -176,95 +178,51 @@ describe('useNotifyDataReady', () => {
       capturedCallback = callback
     })
 
-    const mockOnSettled = vi.fn()
     const { result, rerender } = renderHook(() =>
       useNotifyDataReady({
         topic: MOCK_TOPIC,
-        options: { ...MOCK_OPTIONS, onSettled: mockOnSettled },
+        options: MOCK_OPTIONS,
       } as any)
     )
 
-    expect(result.current.shouldRefetch).toEqual(true)
+    expect(result.current.refetch).toEqual(1)
 
     capturedCallback({ refetch: true })
     rerender()
-    expect(result.current.shouldRefetch).toEqual(true)
+    expect(result.current.refetch).toEqual(2)
 
-    result.current.queryOptionsNotify.onSettled?.(undefined, null)
-    rerender()
-    expect(result.current.shouldRefetch).toEqual(true)
-
-    result.current.queryOptionsNotify.onSettled?.(undefined, null)
-    rerender()
-    expect(result.current.shouldRefetch).toEqual(false)
-
-    expect(mockOnSettled).toHaveBeenCalledTimes(2)
-  })
-
-  it('should not trigger additional refetch if notification arrives after refetch completes', () => {
-    let capturedCallback: any
-    vi.mocked(appShellListener).mockImplementation(function ({
-      callback,
-    }): any {
-      capturedCallback = callback
-    })
-
-    const mockOnSettled = vi.fn()
-    const { result, rerender } = renderHook(() =>
-      useNotifyDataReady({
-        topic: MOCK_TOPIC,
-        options: { ...MOCK_OPTIONS, onSettled: mockOnSettled },
-      } as any)
-    )
-
-    expect(result.current.shouldRefetch).toEqual(true)
-
-    result.current.queryOptionsNotify.onSettled?.(undefined, null)
-    rerender()
-    expect(result.current.shouldRefetch).toEqual(false)
-
-    capturedCallback({ refetch: true })
-    rerender()
-    expect(result.current.shouldRefetch).toEqual(true)
-
-    result.current.queryOptionsNotify.onSettled?.(undefined, null)
-    rerender()
-    expect(result.current.shouldRefetch).toEqual(false)
-  })
-
-  it('should only queue one additional refetch even with multiple notifications during active refetch', () => {
-    let capturedCallback: any
-    vi.mocked(appShellListener).mockImplementation(function ({
-      callback,
-    }): any {
-      capturedCallback = callback
-    })
-
-    const mockOnSettled = vi.fn()
-    const { result, rerender } = renderHook(() =>
-      useNotifyDataReady({
-        topic: MOCK_TOPIC,
-        options: { ...MOCK_OPTIONS, onSettled: mockOnSettled },
-      } as any)
-    )
-
-    expect(result.current.shouldRefetch).toEqual(true)
-
-    capturedCallback({ refetch: true })
+    // A notification arriving while a refetch is in flight must still be counted.
     capturedCallback({ refetch: true })
     capturedCallback({ unsubscribe: true })
     rerender()
-    expect(result.current.shouldRefetch).toEqual(true)
+    expect(result.current.refetch).toEqual(4)
+  })
+
+  it('should not reset refetch when the query settles', () => {
+    let capturedCallback: any
+    vi.mocked(appShellListener).mockImplementation(function ({
+      callback,
+    }): any {
+      capturedCallback = callback
+    })
+
+    const mockOnSettled = vi.fn()
+    const { result, rerender } = renderHook(() =>
+      useNotifyDataReady({
+        topic: MOCK_TOPIC,
+        options: { ...MOCK_OPTIONS, onSettled: mockOnSettled },
+      } as any)
+    )
+
+    capturedCallback({ refetch: true })
+    rerender()
+    expect(result.current.refetch).toEqual(2)
 
     result.current.queryOptionsNotify.onSettled?.(undefined, null)
     rerender()
-    expect(result.current.shouldRefetch).toEqual(true)
 
-    result.current.queryOptionsNotify.onSettled?.(undefined, null)
-    rerender()
-    expect(result.current.shouldRefetch).toEqual(false)
-
-    expect(mockOnSettled).toHaveBeenCalledTimes(2)
+    expect(result.current.refetch).toEqual(2)
+    expect(mockOnSettled).toHaveBeenCalledTimes(1)
   })
 
   it('should clean up the listener on dismount', () => {
@@ -305,11 +263,11 @@ describe('useNotifyDataReady', () => {
       } as any)
     )
 
-    expect(result.current.shouldRefetch).toEqual(false)
+    expect(result.current.refetch).toEqual(0)
     expect(appShellListener).not.toHaveBeenCalled()
   })
 
-  it('should return queryOptionsNotify with modified onSettled and refetchInterval', () => {
+  it('should return queryOptionsNotify with the original onSettled and polling disabled', () => {
     const { result } = renderHook(() =>
       useNotifyDataReady({
         topic: MOCK_TOPIC,
@@ -349,10 +307,10 @@ describe('useNotifyDataReady', () => {
         }),
       { initialProps: { enabled: false, refetchInterval: 5000 } }
     )
-    expect(result.current.shouldRefetch).toEqual(false)
+    expect(result.current.refetch).toEqual(0)
 
     rerender({ enabled: true, refetchInterval: 5000 })
 
-    expect(result.current.shouldRefetch).toEqual(true)
+    expect(result.current.refetch).toEqual(1)
   })
 })

--- a/app/src/resources/camera/useNotifyCamera.ts
+++ b/app/src/resources/camera/useNotifyCamera.ts
@@ -11,7 +11,7 @@ import type { QueryOptionsWithPolling } from '../useNotifyDataReady'
 export function useNotifyCamera(
   options: QueryOptionsWithPolling<CameraResponse, unknown> = {}
 ): UseQueryResult<CameraResponse> {
-  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
+  const { refetch, queryOptionsNotify } = useNotifyDataReady({
     topic: `robot-server/camera`,
     options,
   })
@@ -19,13 +19,13 @@ export function useNotifyCamera(
   const httpQueryResult = useCamera(queryOptionsNotify)
 
   useEffect(() => {
-    if (shouldRefetch) {
+    if (refetch > 0) {
       void httpQueryResult.refetch()
     }
 
-    // refetch is stable, the result object is not
+    // httpQueryResult.refetch is stable, the result object is not
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldRefetch])
+  }, [refetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/camera/useNotifyCamera.ts
+++ b/app/src/resources/camera/useNotifyCamera.ts
@@ -17,15 +17,13 @@ export function useNotifyCamera(
   })
 
   const httpQueryResult = useCamera(queryOptionsNotify)
+  const { refetch: refetchQuery } = httpQueryResult
 
   useEffect(() => {
     if (refetch > 0) {
-      void httpQueryResult.refetch()
+      void refetchQuery()
     }
-
-    // httpQueryResult.refetch is stable, the result object is not
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refetch])
+  }, [refetch, refetchQuery])
 
   return httpQueryResult
 }

--- a/app/src/resources/client_data/audit/useClientDataLogDeletion.ts
+++ b/app/src/resources/client_data/audit/useClientDataLogDeletion.ts
@@ -22,21 +22,16 @@ export function useClientDataLogDeletion(
     options,
   })
 
-  const httpQueryResult = useClientData<LogDeletionStatus>(
+  const { data, refetch: refetchQuery } = useClientData<LogDeletionStatus>(
     KEYS.LOG_DELETION,
     queryOptionsNotify
   )
 
   useEffect(() => {
     if (refetch > 0) {
-      void httpQueryResult.refetch()
+      void refetchQuery()
     }
-
-    // httpQueryResult.refetch is stable, the result object is not
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refetch])
-
-  const { data } = httpQueryResult
+  }, [refetch, refetchQuery])
 
   const logDeletionStatus =
     data?.data?.logPeriodId === logPeriodId ? data?.data?.status : 'pending'

--- a/app/src/resources/client_data/audit/useClientDataLogDeletion.ts
+++ b/app/src/resources/client_data/audit/useClientDataLogDeletion.ts
@@ -17,7 +17,7 @@ export function useClientDataLogDeletion(
     AxiosError
   > = {}
 ): 'pending' | 'completed' | 'failed' {
-  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
+  const { refetch, queryOptionsNotify } = useNotifyDataReady({
     topic: `robot-server/clientData/${KEYS.LOG_DELETION}`,
     options,
   })
@@ -28,13 +28,13 @@ export function useClientDataLogDeletion(
   )
 
   useEffect(() => {
-    if (shouldRefetch) {
+    if (refetch > 0) {
       void httpQueryResult.refetch()
     }
 
-    // refetch is stable, the result object is not
+    // httpQueryResult.refetch is stable, the result object is not
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldRefetch])
+  }, [refetch])
 
   const { data } = httpQueryResult
 

--- a/app/src/resources/client_data/encryptionKeys/useNotifyClientDataEncryptionKeys.ts
+++ b/app/src/resources/client_data/encryptionKeys/useNotifyClientDataEncryptionKeys.ts
@@ -25,15 +25,13 @@ export function useNotifyClientDataEncryptionKeys(
     KEYS.ENCRYPTION_KEYS,
     queryOptionsNotify
   )
+  const { refetch: refetchQuery } = httpQueryResult
 
   useEffect(() => {
     if (refetch > 0) {
-      void httpQueryResult.refetch()
+      void refetchQuery()
     }
-
-    // httpQueryResult.refetch is stable, the result object is not
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refetch])
+  }, [refetch, refetchQuery])
 
   return httpQueryResult
 }

--- a/app/src/resources/client_data/encryptionKeys/useNotifyClientDataEncryptionKeys.ts
+++ b/app/src/resources/client_data/encryptionKeys/useNotifyClientDataEncryptionKeys.ts
@@ -16,7 +16,7 @@ export function useNotifyClientDataEncryptionKeys(
     AxiosError
   > = {}
 ): UseQueryResult<ClientDataResponse<ClientDataEncryptionKeys>, AxiosError> {
-  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
+  const { refetch, queryOptionsNotify } = useNotifyDataReady({
     topic: `robot-server/clientData/${KEYS.ENCRYPTION_KEYS}`,
     options,
   })
@@ -27,13 +27,13 @@ export function useNotifyClientDataEncryptionKeys(
   )
 
   useEffect(() => {
-    if (shouldRefetch) {
+    if (refetch > 0) {
       void httpQueryResult.refetch()
     }
 
-    // refetch is stable, the result object is not
+    // httpQueryResult.refetch is stable, the result object is not
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldRefetch])
+  }, [refetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/client_data/lpc/useNotifyClientDataLPC.ts
+++ b/app/src/resources/client_data/lpc/useNotifyClientDataLPC.ts
@@ -26,15 +26,13 @@ export function useNotifyClientDataLPC(
     KEYS.LPC,
     queryOptionsNotify
   )
+  const { refetch: refetchQuery } = httpQueryResult
 
   useEffect(() => {
     if (refetch > 0) {
-      void httpQueryResult.refetch()
+      void refetchQuery()
     }
-
-    // httpQueryResult.refetch is stable, the result object is not
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refetch])
+  }, [refetch, refetchQuery])
 
   return httpQueryResult
 }

--- a/app/src/resources/client_data/lpc/useNotifyClientDataLPC.ts
+++ b/app/src/resources/client_data/lpc/useNotifyClientDataLPC.ts
@@ -17,7 +17,7 @@ export function useNotifyClientDataLPC(
     AxiosError
   > = {}
 ): UseQueryResult<ClientDataResponse<ClientDataLPC>, AxiosError> {
-  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
+  const { refetch, queryOptionsNotify } = useNotifyDataReady({
     topic: `robot-server/clientData/${KEYS.LPC}`,
     options,
   })
@@ -28,13 +28,13 @@ export function useNotifyClientDataLPC(
   )
 
   useEffect(() => {
-    if (shouldRefetch) {
+    if (refetch > 0) {
       void httpQueryResult.refetch()
     }
 
-    // refetch is stable, the result object is not
+    // httpQueryResult.refetch is stable, the result object is not
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldRefetch])
+  }, [refetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/client_data/recovery/useNotifyClientDataRecovery.ts
+++ b/app/src/resources/client_data/recovery/useNotifyClientDataRecovery.ts
@@ -16,7 +16,7 @@ export function useNotifyClientDataRecovery(
     AxiosError
   > = {}
 ): UseQueryResult<ClientDataResponse<ClientDataRecovery>, AxiosError> {
-  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
+  const { refetch, queryOptionsNotify } = useNotifyDataReady({
     topic: `robot-server/clientData/${KEYS.ERROR_RECOVERY}`,
     options,
   })
@@ -27,13 +27,13 @@ export function useNotifyClientDataRecovery(
   )
 
   useEffect(() => {
-    if (shouldRefetch) {
+    if (refetch > 0) {
       void httpQueryResult.refetch()
     }
 
-    // refetch is stable, the result object is not
+    // httpQueryResult.refetch is stable, the result object is not
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldRefetch])
+  }, [refetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/client_data/recovery/useNotifyClientDataRecovery.ts
+++ b/app/src/resources/client_data/recovery/useNotifyClientDataRecovery.ts
@@ -25,15 +25,13 @@ export function useNotifyClientDataRecovery(
     KEYS.ERROR_RECOVERY,
     queryOptionsNotify
   )
+  const { refetch: refetchQuery } = httpQueryResult
 
   useEffect(() => {
     if (refetch > 0) {
-      void httpQueryResult.refetch()
+      void refetchQuery()
     }
-
-    // httpQueryResult.refetch is stable, the result object is not
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refetch])
+  }, [refetch, refetchQuery])
 
   return httpQueryResult
 }

--- a/app/src/resources/dataFiles/useNotifyImageFileQuery.ts
+++ b/app/src/resources/dataFiles/useNotifyImageFileQuery.ts
@@ -12,7 +12,7 @@ export function useNotifyImageFileQuery(
   runId: string,
   options: QueryOptionsWithPolling<ImageFilesDataResponse, unknown> = {}
 ): UseQueryResult<ImageFilesDataResponse> {
-  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
+  const { refetch, queryOptionsNotify } = useNotifyDataReady({
     topic: `robot-server/dataFiles/${runId}/images`,
     options,
   })
@@ -20,13 +20,13 @@ export function useNotifyImageFileQuery(
   const httpQueryResult = useImageFileQuery(runId, queryOptionsNotify)
 
   useEffect(() => {
-    if (shouldRefetch) {
+    if (refetch > 0) {
       void httpQueryResult.refetch()
     }
 
-    // refetch is stable, the result object is not
+    // httpQueryResult.refetch is stable, the result object is not
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldRefetch])
+  }, [refetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/dataFiles/useNotifyImageFileQuery.ts
+++ b/app/src/resources/dataFiles/useNotifyImageFileQuery.ts
@@ -18,15 +18,13 @@ export function useNotifyImageFileQuery(
   })
 
   const httpQueryResult = useImageFileQuery(runId, queryOptionsNotify)
+  const { refetch: refetchQuery } = httpQueryResult
 
   useEffect(() => {
     if (refetch > 0) {
-      void httpQueryResult.refetch()
+      void refetchQuery()
     }
-
-    // httpQueryResult.refetch is stable, the result object is not
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refetch])
+  }, [refetch, refetchQuery])
 
   return httpQueryResult
 }

--- a/app/src/resources/deck_configuration/useNotifyDeckConfigurationQuery.ts
+++ b/app/src/resources/deck_configuration/useNotifyDeckConfigurationQuery.ts
@@ -11,7 +11,7 @@ import type { QueryOptionsWithPolling } from '../useNotifyDataReady'
 export function useNotifyDeckConfigurationQuery(
   options: QueryOptionsWithPolling<DeckConfiguration, unknown> = {}
 ): UseQueryResult<DeckConfiguration> {
-  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
+  const { refetch, queryOptionsNotify } = useNotifyDataReady({
     topic: 'robot-server/deck_configuration',
     options,
   })
@@ -19,13 +19,13 @@ export function useNotifyDeckConfigurationQuery(
   const httpQueryResult = useDeckConfigurationQuery(queryOptionsNotify)
 
   useEffect(() => {
-    if (shouldRefetch) {
+    if (refetch > 0) {
       void httpQueryResult.refetch()
     }
 
-    // refetch is stable, the result object is not
+    // httpQueryResult.refetch is stable, the result object is not
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldRefetch])
+  }, [refetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/deck_configuration/useNotifyDeckConfigurationQuery.ts
+++ b/app/src/resources/deck_configuration/useNotifyDeckConfigurationQuery.ts
@@ -17,15 +17,13 @@ export function useNotifyDeckConfigurationQuery(
   })
 
   const httpQueryResult = useDeckConfigurationQuery(queryOptionsNotify)
+  const { refetch: refetchQuery } = httpQueryResult
 
   useEffect(() => {
     if (refetch > 0) {
-      void httpQueryResult.refetch()
+      void refetchQuery()
     }
-
-    // httpQueryResult.refetch is stable, the result object is not
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refetch])
+  }, [refetch, refetchQuery])
 
   return httpQueryResult
 }

--- a/app/src/resources/labware_offsets/useNotifySearchLabwareOffsets.ts
+++ b/app/src/resources/labware_offsets/useNotifySearchLabwareOffsets.ts
@@ -25,15 +25,13 @@ export function useNotifySearchLabwareOffsets(
   })
 
   const httpQueryResult = useSearchLabwareOffsets(request, queryOptionsNotify)
+  const { refetch: refetchQuery } = httpQueryResult
 
   useEffect(() => {
     if (refetch > 0) {
-      void httpQueryResult.refetch()
+      void refetchQuery()
     }
-
-    // httpQueryResult.refetch is stable, the result object is not
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refetch])
+  }, [refetch, refetchQuery])
 
   return httpQueryResult
 }

--- a/app/src/resources/labware_offsets/useNotifySearchLabwareOffsets.ts
+++ b/app/src/resources/labware_offsets/useNotifySearchLabwareOffsets.ts
@@ -19,7 +19,7 @@ export function useNotifySearchLabwareOffsets(
     AxiosError
   > = {}
 ): UseQueryResult<SearchLabwareOffsetsResponse> {
-  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
+  const { refetch, queryOptionsNotify } = useNotifyDataReady({
     topic: 'robot-server/labwareOffsets',
     options,
   })
@@ -27,13 +27,13 @@ export function useNotifySearchLabwareOffsets(
   const httpQueryResult = useSearchLabwareOffsets(request, queryOptionsNotify)
 
   useEffect(() => {
-    if (shouldRefetch) {
+    if (refetch > 0) {
       void httpQueryResult.refetch()
     }
 
-    // refetch is stable, the result object is not
+    // httpQueryResult.refetch is stable, the result object is not
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldRefetch])
+  }, [refetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/maintenance_runs/notifications/useNotifyCurrentMaintenanceRun.ts
+++ b/app/src/resources/maintenance_runs/notifications/useNotifyCurrentMaintenanceRun.ts
@@ -17,15 +17,13 @@ export function useNotifyCurrentMaintenanceRun(
   })
 
   const httpQueryResult = useCurrentMaintenanceRun(queryOptionsNotify)
+  const { refetch: refetchQuery } = httpQueryResult
 
   useEffect(() => {
     if (refetch > 0) {
-      void httpQueryResult.refetch()
+      void refetchQuery()
     }
-
-    // httpQueryResult.refetch is stable, the result object is not
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refetch])
+  }, [refetch, refetchQuery])
 
   return httpQueryResult
 }

--- a/app/src/resources/maintenance_runs/notifications/useNotifyCurrentMaintenanceRun.ts
+++ b/app/src/resources/maintenance_runs/notifications/useNotifyCurrentMaintenanceRun.ts
@@ -11,7 +11,7 @@ import type { QueryOptionsWithPolling } from '../../useNotifyDataReady'
 export function useNotifyCurrentMaintenanceRun(
   options: QueryOptionsWithPolling<MaintenanceRun, Error> = {}
 ): UseQueryResult<MaintenanceRun> | UseQueryResult<MaintenanceRun, Error> {
-  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
+  const { refetch, queryOptionsNotify } = useNotifyDataReady({
     topic: 'robot-server/maintenance_runs/current_run',
     options,
   })
@@ -19,13 +19,13 @@ export function useNotifyCurrentMaintenanceRun(
   const httpQueryResult = useCurrentMaintenanceRun(queryOptionsNotify)
 
   useEffect(() => {
-    if (shouldRefetch) {
+    if (refetch > 0) {
       void httpQueryResult.refetch()
     }
 
-    // refetch is stable, the result object is not
+    // httpQueryResult.refetch is stable, the result object is not
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldRefetch])
+  }, [refetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/runs/__tests__/useNotifyRunQuery.test.tsx
+++ b/app/src/resources/runs/__tests__/useNotifyRunQuery.test.tsx
@@ -19,7 +19,7 @@ describe('useNotifyRunQuery', () => {
 
   beforeEach(() => {
     vi.mocked(useNotifyDataReady).mockReturnValue({
-      shouldRefetch: false,
+      refetch: 0,
       queryOptionsNotify,
     } as any)
     vi.mocked(useRunQuery).mockReturnValue({
@@ -46,9 +46,9 @@ describe('useNotifyRunQuery', () => {
     )
   })
 
-  it('should refetch in an effect when shouldRefetch is true, not during render', () => {
+  it('should refetch in an effect when a refetch is requested, not during render', () => {
     vi.mocked(useNotifyDataReady).mockReturnValue({
-      shouldRefetch: true,
+      refetch: 1,
       queryOptionsNotify,
     } as any)
     vi.mocked(useRunQuery).mockImplementation(() => {
@@ -62,7 +62,7 @@ describe('useNotifyRunQuery', () => {
     expect(refetch).toHaveBeenCalledTimes(1)
   })
 
-  it('should not refetch when shouldRefetch is false', () => {
+  it('should not refetch when no refetch has been requested', () => {
     renderHook(() => useNotifyRunQuery(MOCK_RUN_ID, MOCK_OPTIONS))
 
     expect(refetch).not.toHaveBeenCalled()
@@ -70,7 +70,7 @@ describe('useNotifyRunQuery', () => {
 
   it('should not refetch when runId is null', () => {
     vi.mocked(useNotifyDataReady).mockReturnValue({
-      shouldRefetch: true,
+      refetch: 1,
       queryOptionsNotify,
     } as any)
 
@@ -81,7 +81,7 @@ describe('useNotifyRunQuery', () => {
 
   it('should not refetch when runId is the string "null"', () => {
     vi.mocked(useNotifyDataReady).mockReturnValue({
-      shouldRefetch: true,
+      refetch: 1,
       queryOptionsNotify,
     } as any)
 
@@ -90,7 +90,7 @@ describe('useNotifyRunQuery', () => {
     expect(refetch).not.toHaveBeenCalled()
   })
 
-  it('should refetch when shouldRefetch becomes true after a rerender', () => {
+  it('should refetch when a refetch is requested after a rerender', () => {
     const { rerender } = renderHook(() =>
       useNotifyRunQuery(MOCK_RUN_ID, MOCK_OPTIONS)
     )
@@ -98,11 +98,32 @@ describe('useNotifyRunQuery', () => {
     expect(refetch).not.toHaveBeenCalled()
 
     vi.mocked(useNotifyDataReady).mockReturnValue({
-      shouldRefetch: true,
+      refetch: 1,
       queryOptionsNotify,
     } as any)
     rerender()
 
     expect(refetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('should refetch again for each subsequent refetch request', () => {
+    vi.mocked(useNotifyDataReady).mockReturnValue({
+      refetch: 1,
+      queryOptionsNotify,
+    } as any)
+
+    const { rerender } = renderHook(() =>
+      useNotifyRunQuery(MOCK_RUN_ID, MOCK_OPTIONS)
+    )
+
+    expect(refetch).toHaveBeenCalledTimes(1)
+
+    vi.mocked(useNotifyDataReady).mockReturnValue({
+      refetch: 2,
+      queryOptionsNotify,
+    } as any)
+    rerender()
+
+    expect(refetch).toHaveBeenCalledTimes(2)
   })
 })

--- a/app/src/resources/runs/useNotifyAllCommandsAsPreSerializedList.ts
+++ b/app/src/resources/runs/useNotifyAllCommandsAsPreSerializedList.ts
@@ -14,7 +14,7 @@ export function useNotifyAllCommandsAsPreSerializedList(
   params?: GetRunCommandsParams | null,
   options: QueryOptionsWithPolling<CommandsData, AxiosError> = {}
 ): UseQueryResult<CommandsData, AxiosError> {
-  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
+  const { refetch, queryOptionsNotify } = useNotifyDataReady({
     topic: `robot-server/runs/pre_serialized_commands/${runId}`,
     options,
   })
@@ -26,13 +26,13 @@ export function useNotifyAllCommandsAsPreSerializedList(
   )
 
   useEffect(() => {
-    if (shouldRefetch) {
+    if (refetch > 0) {
       void httpQueryResult.refetch()
     }
 
-    // refetch is stable, the result object is not
+    // httpQueryResult.refetch is stable, the result object is not
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldRefetch])
+  }, [refetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/runs/useNotifyAllCommandsAsPreSerializedList.ts
+++ b/app/src/resources/runs/useNotifyAllCommandsAsPreSerializedList.ts
@@ -24,15 +24,13 @@ export function useNotifyAllCommandsAsPreSerializedList(
     params,
     queryOptionsNotify
   )
+  const { refetch: refetchQuery } = httpQueryResult
 
   useEffect(() => {
     if (refetch > 0) {
-      void httpQueryResult.refetch()
+      void refetchQuery()
     }
-
-    // httpQueryResult.refetch is stable, the result object is not
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refetch])
+  }, [refetch, refetchQuery])
 
   return httpQueryResult
 }

--- a/app/src/resources/runs/useNotifyAllCommandsQuery.ts
+++ b/app/src/resources/runs/useNotifyAllCommandsQuery.ts
@@ -19,7 +19,7 @@ export function useNotifyAllCommandsQuery<TError = Error>(
   // running to succeeded, that may change the useAllCommandsQuery response, but it
   // will not necessarily change the command links. We might need an MQTT topic
   // covering "any change in `GET /runs/{id}/commands`".
-  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
+  const { refetch, queryOptionsNotify } = useNotifyDataReady({
     topic: 'robot-server/runs/commands_links',
     options,
   })
@@ -27,13 +27,13 @@ export function useNotifyAllCommandsQuery<TError = Error>(
   const httpQueryResult = useAllCommandsQuery(runId, params, queryOptionsNotify)
 
   useEffect(() => {
-    if (shouldRefetch) {
+    if (refetch > 0) {
       void httpQueryResult.refetch()
     }
 
-    // refetch is stable, the result object is not
+    // httpQueryResult.refetch is stable, the result object is not
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldRefetch])
+  }, [refetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/runs/useNotifyAllCommandsQuery.ts
+++ b/app/src/resources/runs/useNotifyAllCommandsQuery.ts
@@ -25,15 +25,13 @@ export function useNotifyAllCommandsQuery<TError = Error>(
   })
 
   const httpQueryResult = useAllCommandsQuery(runId, params, queryOptionsNotify)
+  const { refetch: refetchQuery } = httpQueryResult
 
   useEffect(() => {
     if (refetch > 0) {
-      void httpQueryResult.refetch()
+      void refetchQuery()
     }
-
-    // httpQueryResult.refetch is stable, the result object is not
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refetch])
+  }, [refetch, refetchQuery])
 
   return httpQueryResult
 }

--- a/app/src/resources/runs/useNotifyAllRunsQuery.ts
+++ b/app/src/resources/runs/useNotifyAllRunsQuery.ts
@@ -21,7 +21,7 @@ export function useNotifyAllRunsQuery(
   options: UseNotifyAllRunsQueryOptions = {},
   hostOverride?: HostConfig | null
 ): UseQueryResult<Runs, AxiosError> {
-  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
+  const { refetch, queryOptionsNotify } = useNotifyDataReady({
     topic: 'robot-server/runs',
     options,
     hostOverride,
@@ -34,13 +34,13 @@ export function useNotifyAllRunsQuery(
   )
 
   useEffect(() => {
-    if (shouldRefetch) {
+    if (refetch > 0) {
       void httpQueryResult.refetch()
     }
 
-    // refetch is stable, the result object is not
+    // httpQueryResult.refetch is stable, the result object is not
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldRefetch])
+  }, [refetch])
 
   return httpQueryResult
 }

--- a/app/src/resources/runs/useNotifyAllRunsQuery.ts
+++ b/app/src/resources/runs/useNotifyAllRunsQuery.ts
@@ -32,15 +32,13 @@ export function useNotifyAllRunsQuery(
     queryOptionsNotify as UseAllRunsQueryOptions,
     hostOverride
   )
+  const { refetch: refetchQuery } = httpQueryResult
 
   useEffect(() => {
     if (refetch > 0) {
-      void httpQueryResult.refetch()
+      void refetchQuery()
     }
-
-    // httpQueryResult.refetch is stable, the result object is not
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refetch])
+  }, [refetch, refetchQuery])
 
   return httpQueryResult
 }

--- a/app/src/resources/runs/useNotifyRunQuery.ts
+++ b/app/src/resources/runs/useNotifyRunQuery.ts
@@ -14,7 +14,7 @@ export function useNotifyRunQuery<TError = Error>(
   options: QueryOptionsWithPolling<Run, TError> = {},
   hostOverride?: HostConfig | null
 ): UseQueryResult<Run, TError> {
-  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
+  const { refetch, queryOptionsNotify } = useNotifyDataReady({
     topic: `robot-server/runs/${runId}` as NotifyTopic,
     options,
     hostOverride,
@@ -25,13 +25,13 @@ export function useNotifyRunQuery<TError = Error>(
   useEffect(() => {
     // Route params can turn a missing id into the literal string "null" (e.g. `/runs/${null}` → `/runs/null`). Treat that like no id.
     const isValidRunId = runId != null && runId !== 'null'
-    if (shouldRefetch && isValidRunId) {
+    if (refetch > 0 && isValidRunId) {
       void httpQueryResult.refetch()
     }
 
-    // refetch is stable, the result object is not
+    // httpQueryResult.refetch is stable, the result object is not
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldRefetch, runId])
+  }, [refetch, runId])
 
   return httpQueryResult
 }

--- a/app/src/resources/runs/useNotifyRunQuery.ts
+++ b/app/src/resources/runs/useNotifyRunQuery.ts
@@ -21,17 +21,15 @@ export function useNotifyRunQuery<TError = Error>(
   })
 
   const httpQueryResult = useRunQuery(runId, queryOptionsNotify, hostOverride)
+  const { refetch: refetchQuery } = httpQueryResult
 
   useEffect(() => {
     // Route params can turn a missing id into the literal string "null" (e.g. `/runs/${null}` → `/runs/null`). Treat that like no id.
     const isValidRunId = runId != null && runId !== 'null'
     if (refetch > 0 && isValidRunId) {
-      void httpQueryResult.refetch()
+      void refetchQuery()
     }
-
-    // httpQueryResult.refetch is stable, the result object is not
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refetch, runId])
+  }, [refetch, refetchQuery, runId])
 
   return httpQueryResult
 }

--- a/app/src/resources/useNotifyDataReady.ts
+++ b/app/src/resources/useNotifyDataReady.ts
@@ -15,8 +15,6 @@ import type { UseQueryOptions } from 'react-query'
 import type { HostConfig } from '@opentrons/api-client'
 import type { NotifyResponseData, NotifyTopic } from '/app/redux/shell/types'
 
-export type HTTPRefetchFrequency = 'once' | null
-
 export interface QueryOptionsWithPolling<
   TData,
   TError = Error,
@@ -33,14 +31,16 @@ interface UseNotifyDataReadyProps<TData, TError = Error> {
 interface UseNotifyDataReadyResults<TData, TError> {
   /* React Query options with notification-specific logic. */
   queryOptionsNotify: QueryOptionsWithPolling<TData, TError>
-  /* Whether notifications indicate the server has new data ready. Always returns false if notifications are disabled. */
-  shouldRefetch: boolean
+
+  /* Increments each time the shell indicates the server has new data ready. */
+  refetch: number
 }
 
 // React query hooks perform refetches when instructed by the shell via a refetch mechanism, which useNotifyDataReady manages.
-// The notification refetch states may be:
-// 'once' - The shell has received an MQTT update. Execute the HTTP refetch once.
-// null - The shell has not received an MQTT update. Don't execute an HTTP refetch.
+// `refetch` counts incoming refetch notifications, and consumers refetch whenever the count changes.
+// 0 means the shell has not requested an HTTP refetch yet, so don't execute one.
+// Counting rather than flagging keeps consecutive notifications from collapsing into a single refetch
+// when one arrives while an HTTP refetch is already in flight.
 //
 // Eagerly assume notifications are enabled unless specified by the client via React Query options or by the shell via errors.
 export function useNotifyDataReady<TData, TError = Error>({
@@ -58,8 +58,8 @@ export function useNotifyDataReady<TData, TError = Error>({
   const doTrackEvent = useTrackEvent()
   const forcePollingFF = useFeatureFlag('forceHttpPolling')
   const seenHostname = useRef<string | null>(null)
-  const [refetch, setRefetch] = useState<HTTPRefetchFrequency>(null)
-  const [pendingRefetch, setPendingRefetch] = useState(false)
+  const [refetch, setRefetch] = useState(0)
+
   const [
     hasEncounteredNotificationsError,
     setHasEncounteredNotificationsError,
@@ -78,7 +78,7 @@ export function useNotifyDataReady<TData, TError = Error>({
     () => {
       if (shouldUseNotifications) {
         // Always fetch on initial mount to keep latency as low as possible.
-        setRefetch('once')
+        setRefetch(refetch => refetch + 1)
         appShellListener({
           hostname,
           notifyTopic: topic,
@@ -115,18 +115,7 @@ export function useNotifyDataReady<TData, TError = Error>({
           })
         }
       } else if ('refetch' in data || 'unsubscribe' in data) {
-        setRefetch(currentRefetch => {
-          // A refetch is already in progress, mark that we need to do another
-          // one after the current refetch resolves.
-          if (currentRefetch === 'once') {
-            setPendingRefetch(true)
-            return currentRefetch
-          }
-          // No refetch is in progress, start one immediately.
-          else {
-            return 'once'
-          }
-        })
+        setRefetch(currentRefetch => currentRefetch + 1)
       }
     },
     // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
@@ -134,31 +123,15 @@ export function useNotifyDataReady<TData, TError = Error>({
     []
   )
 
-  const notifyOnSettled = useCallback(
-    (data: TData | undefined, error: TError | null) => {
-      if (refetch === 'once') {
-        setRefetch(pendingRefetch ? 'once' : null)
-        // We only ever need to queue up one additional refetch to get the latest
-        // data, so it's safe to the pending to false as soon as the refetch settles.
-        setPendingRefetch(false)
-      }
-      options.onSettled?.(data, error)
-    },
-    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [refetch, pendingRefetch, options.onSettled]
-  )
-
   const isNotifyEnabled =
     shouldUseNotifications && !hasEncounteredNotificationsError
   const queryOptionsNotify = {
     ...options,
-    onSettled: isNotifyEnabled ? notifyOnSettled : options.onSettled,
     refetchInterval: isNotifyEnabled ? false : options.refetchInterval,
   }
 
   return {
     queryOptionsNotify,
-    shouldRefetch: isNotifyEnabled && refetch != null,
+    refetch,
   }
 }


### PR DESCRIPTION
# Overview

My speedup PR broke `useNotifyDataReady`. Whenever a refetch request came in while the client was currently fetching, we used to have this nice `pendingRefresh` logic that worked nicely with the render level `shouldRefetch -> refetch` code. A request would come back, see pendingRefetch was true, and keep refetch true. Once we wrapped the consumer code in a useEffect, refetch _staying true_ meant that the useEffect did not fire again, refetch wouldn't get called again, and both refetch and pendingRefetch were never cleared. 

This PR changes refetch to a generation counter. Now whenever a refetch request comes in, the counter is incremented, the useEffect is retriggered, and a refetch is sent. We used to have a lot of code to handle multiple refetches being fired around the same time, but the useEffect + ReactQuery batching seems to squash it - I'm seeing a sane number of network requests in testing.

## Test Plan and Hands on Testing

1. Open the desktop app to a robot
2. Start a run on the desktop app, the ODD should update to the run page
3. Cancel the run on the desktop app, the ODD should clear. 

## Review requests

Does this generation counter approach sound good to you all

## Risk assessment

Hopefully medium....