### PR TITLE
fix(odd): fix timing bugs for sign run and download log modals

### DIFF
--- a/app/src/App/ODDTopLevelRedirects/hooks/__tests__/useCurrentRunRoute.test.ts
+++ b/app/src/App/ODDTopLevelRedirects/hooks/__tests__/useCurrentRunRoute.test.ts
@@ -57,7 +57,7 @@ describe('useCurrentRunRoute', () => {
     expect(result.current).toBe(`/runs/${MOCK_RUN_ID}/summary`)
   })
 
-  it('returns the summary route for a started run that has a stopped status', () => {
+  it('returns the summary route for a run that has a stopped status', () => {
     vi.mocked(useNotifyRunQuery).mockReturnValue({
       data: {
         data: {
@@ -132,18 +132,5 @@ describe('useCurrentRunRoute', () => {
     const { result } = renderHook(() => useCurrentRunRoute(MOCK_RUN_ID))
 
     expect(result.current).toBe(`/runs/${MOCK_RUN_ID}/run`)
-  })
-
-  it('returns null for cancelled run before starting', () => {
-    vi.mocked(useNotifyRunQuery).mockReturnValue({
-      data: {
-        data: { id: MOCK_RUN_ID, status: RUN_STATUS_STOPPED, startedAt: null },
-      },
-      isFetching: false,
-    } as any)
-
-    const { result } = renderHook(() => useCurrentRunRoute(MOCK_RUN_ID))
-
-    expect(result.current).toBeNull()
   })
 })

--- a/app/src/App/ODDTopLevelRedirects/hooks/useCurrentRunRoute.ts
+++ b/app/src/App/ODDTopLevelRedirects/hooks/useCurrentRunRoute.ts
@@ -37,7 +37,6 @@ export function useCurrentRunRoute(currentRunId: string): string | null {
   } else if (hasRunStarted) {
     return `/runs/${runId}/run`
   } else {
-    // includes runs cancelled before starting and runs not yet started
     return null
   }
 }

--- a/app/src/App/ODDTopLevelRedirects/hooks/useCurrentRunRoute.ts
+++ b/app/src/App/ODDTopLevelRedirects/hooks/useCurrentRunRoute.ts
@@ -37,6 +37,7 @@ export function useCurrentRunRoute(currentRunId: string): string | null {
   } else if (hasRunStarted) {
     return `/runs/${runId}/run`
   } else {
+    console.error(`Unexpected run route found for run ${runId}`, runStatus)
     return null
   }
 }

--- a/app/src/App/ODDTopLevelRedirects/hooks/useCurrentRunRoute.ts
+++ b/app/src/App/ODDTopLevelRedirects/hooks/useCurrentRunRoute.ts
@@ -25,7 +25,7 @@ export function useCurrentRunRoute(currentRunId: string): string | null {
     return null
   } else if (
     runStatus === RUN_STATUS_SUCCEEDED ||
-    (runStatus === RUN_STATUS_STOPPED && hasRunStarted) ||
+    runStatus === RUN_STATUS_STOPPED ||
     runStatus === RUN_STATUS_FAILED
   ) {
     return `/runs/${runId}/summary`

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/ProtocolSetupModulesAndDeck.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/ProtocolSetupModulesAndDeck.tsx
@@ -1,9 +1,7 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
 
-import { RUN_STATUS_STOPPED } from '@opentrons/api-client'
 import {
   COLORS,
   DIRECTION_COLUMN,
@@ -25,11 +23,7 @@ import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
 import { useDeckConfigurationCompatibility } from '/app/resources/deck_configuration/hooks'
 import { useAttachedModules } from '/app/resources/modules'
-import {
-  DEFAULT_STATUS_REFETCH_INTERVAL,
-  useMostRecentCompletedAnalysis,
-  useNotifyRunQuery,
-} from '/app/resources/runs'
+import { useMostRecentCompletedAnalysis } from '/app/resources/runs'
 import {
   getAttachedProtocolModuleMatches,
   getProtocolModulesInfo,
@@ -60,16 +54,6 @@ export function ProtocolSetupModulesAndDeck({
   setSetupScreen,
 }: ProtocolSetupModulesAndDeckProps): JSX.Element {
   const { i18n, t } = useTranslation('protocol_setup')
-  const navigate = useNavigate()
-  const { data: runRecord } = useNotifyRunQuery(runId, {
-    refetchInterval: DEFAULT_STATUS_REFETCH_INTERVAL,
-  })
-  const runStatus = runRecord?.data.status ?? null
-  useEffect(() => {
-    if (runStatus === RUN_STATUS_STOPPED) {
-      navigate('/protocols')
-    }
-  }, [runStatus, navigate])
   const [showSetupInstructionsModal, setShowSetupInstructionsModal] =
     useState<boolean>(false)
   const [showMapView, setShowMapView] = useState<boolean>(false)

--- a/app/src/pages/ODD/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -88,24 +88,13 @@ import { ConfirmAttachedModal } from '../ConfirmAttachedModal'
 import { ConfirmSetupStepsCompleteModal } from '../ConfirmSetupStepsCompleteModal'
 
 import type { UseQueryResult } from 'react-query'
-import type { NavigateFunction } from 'react-router-dom'
 import type * as SharedData from '@opentrons/shared-data'
-
-let mockNavigate = vi.fn()
 
 vi.mock('@opentrons/shared-data', async importOriginal => {
   const sharedData = await importOriginal<typeof SharedData>()
   return {
     ...sharedData,
     getDeckDefFromRobotType: vi.fn(),
-  }
-})
-
-vi.mock('react-router-dom', async importOriginal => {
-  const reactRouterDom = await importOriginal<NavigateFunction>()
-  return {
-    ...reactRouterDom,
-    useNavigate: () => mockNavigate,
   }
 })
 
@@ -230,7 +219,6 @@ describe('ProtocolSetup', () => {
 
   beforeEach(() => {
     mockLaunchLPC = vi.fn()
-    mockNavigate = vi.fn()
 
     MockProtocolSetupLabware.mockImplementation(
       vi.fn(({ setIsConfirmed, setSetupScreen }) => {
@@ -612,19 +600,6 @@ describe('ProtocolSetup', () => {
       name: ANALYTICS_PROTOCOL_RUN_ACTION.START,
       properties: {},
     })
-  })
-
-  it('should redirect to the protocols page when a run is stopped', () => {
-    render(`/runs/${RUN_ID}/setup/`)
-    expect(mockNavigate).toHaveBeenCalledWith('/protocols')
-  })
-
-  it('should not redirect when cancel modal is open and run is stopped', () => {
-    render(`/runs/${RUN_ID}/setup/`)
-    mockNavigate.mockClear()
-    fireEvent.click(screen.getByRole('button', { name: 'close' }))
-    expect(vi.mocked(ConfirmCancelRunModal)).toHaveBeenCalled()
-    expect(mockNavigate).not.toHaveBeenCalledWith('/protocols')
   })
 
   it('should show action needed when modules are not calibrated', () => {

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import first from 'lodash/first'
 import last from 'lodash/last'
 import { css } from 'styled-components'
 
-import { RUN_STATUS_IDLE, RUN_STATUS_STOPPED } from '@opentrons/api-client'
+import { RUN_STATUS_IDLE } from '@opentrons/api-client'
 import {
   ALIGN_CENTER,
   BORDERS,
@@ -800,13 +800,8 @@ export function ProtocolSetup(): JSX.Element {
     useNotifyCurrentMaintenanceRun({ refetchInterval: MAINTENANCE_RUN_POLL_MS })
       .data?.data.id != null
 
-  const navigate = useNavigate()
   const [showConfirmCancelModal, setShowConfirmCancelModal] =
     useState<boolean>(false)
-
-  if (runStatus === RUN_STATUS_STOPPED && !showConfirmCancelModal) {
-    navigate('/protocols')
-  }
 
   const { data: mostRecentAnalysis = null } =
     useProtocolAnalysisAsDocumentQuery(

--- a/app/src/pages/ODD/RunSummary/SignRun.tsx
+++ b/app/src/pages/ODD/RunSummary/SignRun.tsx
@@ -67,14 +67,15 @@ export function SignRun({
     }
   }
 
-  const { signRun, isLoading, loginGate, correctName } = useSignRunFlow(
-    runId,
-    robotName,
-    async () => await showLoginModal(),
-    popToast,
-    eatToast,
-    onSigned
-  )
+  const { signRun, isSigned, isLoading, loginGate, correctName } =
+    useSignRunFlow(
+      runId,
+      robotName,
+      async () => await showLoginModal(),
+      popToast,
+      eatToast,
+      onSigned
+    )
 
   const trimmedName = name.trim()
 
@@ -87,6 +88,12 @@ export function SignRun({
     }
     keyboardRef.current?.setInput(name)
   }, [name])
+
+  useEffect(() => {
+    if (isSigned) {
+      onSigned?.()
+    }
+  }, [isSigned, onSigned])
 
   const handleNameChange = (value: string): void => {
     setName(value)

--- a/app/src/pages/ODD/RunSummary/index.tsx
+++ b/app/src/pages/ODD/RunSummary/index.tsx
@@ -221,8 +221,11 @@ export function RunSummary(): JSX.Element {
     !hasSignedBy
 
   const logPeriodId = runRecord?.data.logPeriodId ?? null
-  const { isLoading: isLogDeletedLoading, isDeleted: isLogDeleted } =
-    useIsLogDeleted(logPeriodId ?? '')
+  const {
+    isLoading: isLogDeletedLoading,
+    isDeleted: isLogDeleted,
+    isError: isLogDeletedError,
+  } = useIsLogDeleted(logPeriodId ?? '')
 
   const isDownloadingRequired =
     ((accessControlEnabled?.data.accessControlEnabled ?? false) &&
@@ -234,6 +237,7 @@ export function RunSummary(): JSX.Element {
     isDownloadingRequired &&
     !shouldPromptSignRun &&
     !isLogDeletedLoading &&
+    !isLogDeletedError &&
     !isLogDeleted
 
   let headerText: string | null = null

--- a/app/src/resources/access-control/useSignRunFlow.ts
+++ b/app/src/resources/access-control/useSignRunFlow.ts
@@ -13,6 +13,8 @@ import {
 import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useLogout } from '/app/redux/robot-auth'
 
+import { useNotifyRunQuery } from '../runs'
+
 // login gate states to control login prompting
 // idle: need to prompt for login
 // prompting: login prompt in flight, or waiting for post-login /self
@@ -23,6 +25,7 @@ type LoginGate = 'idle' | 'prompting' | 'needsadmin' | 'done'
 export interface SignRunFlowResult {
   signRun: (name: string) => void
   isLoading: boolean
+  isSigned: boolean
   loginGate: LoginGate
   correctName: string | undefined
 }
@@ -44,6 +47,9 @@ export function useSignRunFlow(
   const documentationState = useDocumentationState()
   const { signRun: signRunMutation, isLoading: isSignRunLoading } =
     useSignRunMutation(documentationState)
+
+  const { data: run } = useNotifyRunQuery(runId)
+  const isSigned = !!run?.data?.signedBy
 
   const { data: authSettings, isLoading: isAuthSettingsLoading } =
     useAuthSettingsQuery()
@@ -170,6 +176,7 @@ export function useSignRunFlow(
     signRun,
     isLoading,
     loginGate,
+    isSigned,
     correctName: self?.data?.fullName,
   }
 }


### PR DESCRIPTION
# Overview

Fixes assorted issues for ODD 'sign run' and 'download log' modals.

### Sign Run
If you signed run on desktop, the sign run modal would stay up on the ODD. Now it dismisses and moves to the 'download logs' modal

### Download Logs
If downloading hit an error, the download log modal would stay up on the ODD. Now when the ODD detects an error it will dismiss the modal. 

### Run Summary
When a run was canceled during setup, the ODD would just navigate to the protocols tab, and not show either necessary modals. This changes it so that the ODD instead navigates to the run summary page - popping the modals and more closely matching the desktop UX.

## Test Plan and Hands on Testing

- Signing a run from the desktop app should dismiss the Sign Run modal on the ODD
- Hitting 'cancel' on the file browser popup for audit log download post run should dismiss the Download Logs modal on the ODD
- Canceling a run during setup should navigate the user to the run summary page, and pop the Sign Run and Download Logs modals if necessary.

## Changelog

Canceling a run during setup will navigate the user to the run summary screen.

## Risk assessment

Low