### PR TITLE
fix(app): Fix height and internal padding in the Compliance Ready Software setup wizard

### DIFF
--- a/app/src/organisms/Desktop/EnableCRSWizard/enablecrswizard.module.css
+++ b/app/src/organisms/Desktop/EnableCRSWizard/enablecrswizard.module.css
@@ -2,9 +2,9 @@
   display: flex;
   min-height: 18.5rem;
   flex-direction: column;
-  padding-inline: var(--spacing-24);
-  padding-block-start: var(--spacing-24);
   gap: var(--spacing-24);
+  padding-block-start: var(--spacing-24);
+  padding-inline: var(--spacing-24);
 }
 
 .step_body {

--- a/app/src/organisms/Desktop/EnableCRSWizard/enablecrswizard.module.css
+++ b/app/src/organisms/Desktop/EnableCRSWizard/enablecrswizard.module.css
@@ -1,8 +1,9 @@
 .content {
   display: flex;
-  min-height: 25rem;
+  min-height: 18.5rem;
   flex-direction: column;
-  padding: var(--spacing-24);
+  padding-inline: var(--spacing-24);
+  padding-block-start: var(--spacing-24);
   gap: var(--spacing-24);
 }
 
@@ -24,7 +25,7 @@
   flex-direction: row;
   align-items: center;
   justify-content: flex-end;
-  padding: var(--spacing-16) var(--spacing-24) var(--spacing-24);
+  padding: var(--spacing-24);
   gap: var(--spacing-8);
 }
 


### PR DESCRIPTION
## Overview

This closes RQA-5930.

## Test Plan and Hands on Testing

<img width="1024" height="800" alt="Screenshot 2026-08-19 at 5 05 45 PM" src="https://github.com/user-attachments/assets/845d73a3-412f-4a51-b4a7-2a7fdde3eeba" />

## Changelog

* Hack: edit the content height by eye to get the overall modal to be approximately the correct height.
* Fix the padding between the content and the footer, which was accidentally too much.

## Review requests

Is there a better way to do this, instead of hacking the content height by eye?

I think the root problem is that our `ModalShell` in React fundamentally does not work like it does in Figma.

In Figma, the overall modal container has a fixed height, and then the header, main content, and footer are laid out with `flex` so the content can expand to take advantage of extra space.

In React, it's block layout instead of flex layout. So if we want the overall modal to have a fixed height, we need to get there "backwards," by setting the content size. I think.

## Risk assessment

Low. Changes are locally contained.