### PR TITLE
fix(app): Do not block typing the robot name after the first invalid character

### DIFF
--- a/app/src/atoms/SoftwareKeyboard/index.ts
+++ b/app/src/atoms/SoftwareKeyboard/index.ts
@@ -6,10 +6,7 @@ export { StatelessNumericalKeyboard } from './NumericalKeyboard/StatelessNumeric
 export { applyNumericalKeyboardKey } from './utils/applyNumericalKeyboardKey'
 export { isValidNumericalInput } from './utils/isValidNumericalInput'
 export type { NumericalKeyboardKey } from './types'
-export {
-  getInvalidCharForKeyboard,
-  shouldAcceptKeyboardInput,
-} from './utils/externalKeyboardGuard'
+export { getInvalidCharForKeyboard } from './utils/externalKeyboardGuard'
 export type {
   KeyboardType,
   NumericalOptions,

--- a/app/src/atoms/SoftwareKeyboard/utils/__tests__/externalKeyboardGuard.test.ts
+++ b/app/src/atoms/SoftwareKeyboard/utils/__tests__/externalKeyboardGuard.test.ts
@@ -1,83 +1,43 @@
 import { describe, expect, it } from 'vitest'
 
-import {
-  getInvalidCharForKeyboard,
-  shouldAcceptKeyboardInput,
-} from '../externalKeyboardGuard'
+import { getInvalidCharForKeyboard } from '../externalKeyboardGuard'
 
-describe('externalKeyboardGuard - alphanumeric', () => {
+describe('getInvalidCharForKeyboard - alphanumeric', () => {
   it('returns null for empty value', () => {
     expect(getInvalidCharForKeyboard('', 'alphanumeric')).toBeNull()
   })
 
   it('allows lowercase letters', () => {
     expect(getInvalidCharForKeyboard('abc', 'alphanumeric')).toBeNull()
-    expect(shouldAcceptKeyboardInput('abc', '', 'alphanumeric')).toBe(true)
   })
 
   it('allows uppercase letters', () => {
     expect(getInvalidCharForKeyboard('ABC', 'alphanumeric')).toBeNull()
-    expect(shouldAcceptKeyboardInput('ABC', '', 'alphanumeric')).toBe(true)
   })
 
   it('allows digits', () => {
     expect(getInvalidCharForKeyboard('123', 'alphanumeric')).toBeNull()
-    expect(shouldAcceptKeyboardInput('123', '', 'alphanumeric')).toBe(true)
   })
 
   it('detects invalid char after entry', () => {
-    expect(shouldAcceptKeyboardInput('a!', 'a', 'alphanumeric')).toBe(true)
     expect(getInvalidCharForKeyboard('a!', 'alphanumeric')).toBe('!')
-  })
-
-  it('blocks further additions while invalid char remains', () => {
-    expect(shouldAcceptKeyboardInput('a!b', 'a!', 'alphanumeric')).toBe(false)
-    expect(getInvalidCharForKeyboard('a!', 'alphanumeric')).toBe('!')
-  })
-
-  it('allows deletion while in invalid state', () => {
-    expect(shouldAcceptKeyboardInput('a', 'a!', 'alphanumeric')).toBe(true)
-    expect(getInvalidCharForKeyboard('a', 'alphanumeric')).toBeNull()
-  })
-
-  it('clears invalidChar only when all invalid chars are removed', () => {
-    expect(getInvalidCharForKeyboard('a!@', 'alphanumeric')).toBe('!')
-    expect(shouldAcceptKeyboardInput('a!', 'a!@', 'alphanumeric')).toBe(true)
-    expect(getInvalidCharForKeyboard('a!', 'alphanumeric')).toBe('!')
-    expect(shouldAcceptKeyboardInput('a', 'a!', 'alphanumeric')).toBe(true)
-    expect(getInvalidCharForKeyboard('a', 'alphanumeric')).toBeNull()
   })
 
   it('detects space character', () => {
-    expect(shouldAcceptKeyboardInput('a b', 'a', 'alphanumeric')).toBe(true)
     expect(getInvalidCharForKeyboard('a b', 'alphanumeric')).toBe(' ')
   })
 
-  it('handles paste: records first invalid char, blocks further additions', () => {
-    expect(shouldAcceptKeyboardInput('ab!c@', '', 'alphanumeric')).toBe(true)
+  it('reports the first invalid char when several are present', () => {
     expect(getInvalidCharForKeyboard('ab!c@', 'alphanumeric')).toBe('!')
-    expect(shouldAcceptKeyboardInput('ab!c@d', 'ab!c@', 'alphanumeric')).toBe(
-      false
-    )
-  })
-
-  it('stays in sync when value is cleared without onChange', () => {
-    expect(getInvalidCharForKeyboard('', 'alphanumeric')).toBeNull()
   })
 })
 
-describe('externalKeyboardGuard - numerical', () => {
+describe('getInvalidCharForKeyboard - numerical', () => {
   it('allows digits for int keyboard', () => {
     expect(getInvalidCharForKeyboard('123', 'numerical')).toBeNull()
-    expect(shouldAcceptKeyboardInput('123', '', 'numerical')).toBe(true)
   })
 
   it('detects decimal point on int keyboard', () => {
-    expect(
-      shouldAcceptKeyboardInput('1.', '1', 'numerical', {
-        isDecimal: false,
-      })
-    ).toBe(true)
     expect(
       getInvalidCharForKeyboard('1.', 'numerical', { isDecimal: false })
     ).toBe('.')
@@ -87,17 +47,9 @@ describe('externalKeyboardGuard - numerical', () => {
     expect(
       getInvalidCharForKeyboard('1.', 'numerical', { isDecimal: true })
     ).toBeNull()
-    expect(
-      shouldAcceptKeyboardInput('1.', '1', 'numerical', { isDecimal: true })
-    ).toBe(true)
   })
 
   it('detects hyphen when hasHyphen=false', () => {
-    expect(
-      shouldAcceptKeyboardInput('-1', '', 'numerical', {
-        hasHyphen: false,
-      })
-    ).toBe(true)
     expect(
       getInvalidCharForKeyboard('-1', 'numerical', { hasHyphen: false })
     ).toBe('-')
@@ -107,8 +59,5 @@ describe('externalKeyboardGuard - numerical', () => {
     expect(
       getInvalidCharForKeyboard('-1', 'numerical', { hasHyphen: true })
     ).toBeNull()
-    expect(
-      shouldAcceptKeyboardInput('-1', '', 'numerical', { hasHyphen: true })
-    ).toBe(true)
   })
 })

--- a/app/src/atoms/SoftwareKeyboard/utils/externalKeyboardGuard.ts
+++ b/app/src/atoms/SoftwareKeyboard/utils/externalKeyboardGuard.ts
@@ -61,16 +61,3 @@ export const getInvalidCharForKeyboard = (
 ): string | null => {
   return findFirstInvalidChar(value, buildAllowedSet(type, options))
 }
-
-export const shouldAcceptKeyboardInput = (
-  newValue: string,
-  prevValue: string,
-  type: KeyboardType,
-  options?: NumericalOptions
-): boolean => {
-  if (newValue.length > prevValue.length) {
-    const prevInvalid = getInvalidCharForKeyboard(prevValue, type, options)
-    if (prevInvalid !== null) return false
-  }
-  return true
-}

--- a/app/src/pages/ODD/RobotNameEditor/__tests__/RobotNameEditor.test.tsx
+++ b/app/src/pages/ODD/RobotNameEditor/__tests__/RobotNameEditor.test.tsx
@@ -170,7 +170,7 @@ describe('RobotNameEditor', () => {
     ).toBeInTheDocument()
   })
 
-  it('should block further input while invalid char is present', async () => {
+  it('should keep additional typed characters while an invalid char is present', async () => {
     render()
     const input = screen.getByRole('textbox')
     fireEvent.change(input, { target: { value: 'a!' } })
@@ -179,7 +179,7 @@ describe('RobotNameEditor', () => {
     })
     fireEvent.change(input, { target: { value: 'a!b' } })
     await waitFor(() => {
-      expect(input).toHaveValue('a!')
+      expect(input).toHaveValue('a!b')
     })
     expect(
       screen.getByText("Character '!' is not supported")

--- a/app/src/pages/ODD/RobotNameEditor/index.tsx
+++ b/app/src/pages/ODD/RobotNameEditor/index.tsx
@@ -30,7 +30,6 @@ import { SmallButton } from '/app/atoms/buttons'
 import {
   AlphanumericKeyboard,
   getInvalidCharForKeyboard,
-  shouldAcceptKeyboardInput,
 } from '/app/atoms/SoftwareKeyboard'
 import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { ConfirmRobotName } from '/app/organisms/ODD/NameRobot/ConfirmRobotName'
@@ -83,14 +82,16 @@ export function RobotNameEditor(): JSX.Element {
     errors: Record<string, FieldError>
   ): Record<string, FieldError> => {
     const newName = data.newRobotName
+    // It's a little unclear what characters the backend can actually support.
+    // Historically, the user was limited to whatever they could type on the on-screen
+    // keyboard, so, for now, keep restricting to those characters.
+    const invalidChar = getInvalidCharForKeyboard(newName, 'alphanumeric')
     let errorMessage: string | undefined
-    // In ODD users cannot input letters and numbers from software keyboard
-    // so the app only checks the length of input string
-    if (newName.length < 1 || newName.length > MAX_LENGTH) {
+    if (invalidChar != null) {
+      errorMessage = t('shared:character_not_supported', { char: invalidChar })
+    } else if (newName.length < 1 || newName.length > MAX_LENGTH) {
       errorMessage = t('name_rule_error_name_length')
-    }
-
-    if (
+    } else if (
       [...connectableRobots, ...reachableRobots].some(
         robot => newName === robot.name && robot.ip !== ipAddress
       )
@@ -132,7 +133,6 @@ export function RobotNameEditor(): JSX.Element {
   })
 
   const newRobotName = watch('newRobotName')
-  const invalidChar = getInvalidCharForKeyboard(newRobotName, 'alphanumeric')
 
   const onSubmit = (data: FormValues): void => {
     const newName = data.newRobotName
@@ -286,16 +286,6 @@ export function RobotNameEditor(): JSX.Element {
                     textAlign={TYPOGRAPHY.textAlignCenter}
                     onChange={e => {
                       const newVal = e.target.value
-                      if (
-                        !shouldAcceptKeyboardInput(
-                          newVal,
-                          newRobotName,
-                          'alphanumeric'
-                        )
-                      ) {
-                        field.onChange(newRobotName)
-                        return
-                      }
                       field.onChange(newVal)
                       setNewName(newVal)
                       void trigger('newRobotName')
@@ -311,15 +301,7 @@ export function RobotNameEditor(): JSX.Element {
             >
               {t('name_rule_description')}
             </LegacyStyledText>
-            {invalidChar != null ? (
-              <LegacyStyledText
-                forwardedAs="p"
-                fontWeight={TYPOGRAPHY.fontWeightRegular}
-                color={COLORS.red50}
-              >
-                {t('shared:character_not_supported', { char: invalidChar })}
-              </LegacyStyledText>
-            ) : errors.newRobotName != null ? (
+            {errors.newRobotName != null ? (
               <LegacyStyledText
                 forwardedAs="p"
                 fontWeight={TYPOGRAPHY.fontWeightRegular}
@@ -337,16 +319,6 @@ export function RobotNameEditor(): JSX.Element {
               render={({ field }) => (
                 <AlphanumericKeyboard
                   onChange={(input: string) => {
-                    if (
-                      !shouldAcceptKeyboardInput(
-                        input,
-                        newRobotName,
-                        'alphanumeric'
-                      )
-                    ) {
-                      keyboardRef.current?.setInput(newRobotName)
-                      return
-                    }
                     field.onChange(input)
                     setNewName(input)
                     void trigger('newRobotName')


### PR DESCRIPTION
## Overview

This closes the EXEC-2954 part of EXEC-2953. See EXEC-2953 for background information.

## Changelog

Instead of outright blocking invalid characters from being entered: allow them to be entered, but display an "invalid input" error message, and prevent submitting the form.

## Test Plan and Hands on Testing

* [x] Entering multiple invalid characters no longer causes the cursor to jump to the end of the input.
* [x] The network request to rename the robot is only sent if the new name is valid.

Before:

https://github.com/user-attachments/assets/8f380a7e-0f76-4973-bbab-fc4678e99ea2

After:

https://github.com/user-attachments/assets/3e7e6787-c975-4531-8224-d54f349d09db

## Review requests

No review requests code-wise. Just, whether EXEC-2953 makes sense in principle.

## Risk assessment

Low. Changes are locally contained.