### PR TITLE
fix(app): Keep AlphanumericKeyboard state in sync with the real DOM state

### DIFF
--- a/app/src/atoms/SoftwareKeyboard/AlphanumericKeyboard/AlphanumericKeyboard.stories.tsx
+++ b/app/src/atoms/SoftwareKeyboard/AlphanumericKeyboard/AlphanumericKeyboard.stories.tsx
@@ -17,6 +17,7 @@ import { AlphanumericKeyboard } from '.'
 
 import type { Meta, StoryObj } from '@storybook/react'
 import type { Store, StoreEnhancer } from 'redux'
+import type { KeyboardReactInterface } from 'react-simple-keyboard'
 
 const dummyConfig = {
   config: {
@@ -52,24 +53,29 @@ type Story = StoryObj<typeof AlphanumericKeyboard>
 const Keyboard = (): JSX.Element => {
   const [showKeyboard, setShowKeyboard] = useState(false)
   const [value, setValue] = useState<string>('')
-  const keyboardRef = useRef(null)
+  const keyboardRef = useRef<KeyboardReactInterface | null>(null)
+  const inputElementRef = useRef<HTMLInputElement>(null)
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing16}>
       <form id="test_form">
         <InputField
+          ref={inputElementRef}
           value={value}
           type="text"
           placeholder="When focusing, the keyboard shows up"
-          // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
-          onFocus={() => setShowKeyboard(true)}
+          onFocus={() => {
+            setShowKeyboard(true)
+          }}
+          onChange={e => {
+            setValue(e.target.value)
+          }}
         />
       </form>
       <Flex position={POSITION_ABSOLUTE} top="20%" left="0" width="64rem">
         {showKeyboard && (
           <AlphanumericKeyboard
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
-            onChange={(e: string) => e != null && setValue(String(e))}
             keyboardRef={keyboardRef}
+            inputElementRef={inputElementRef}
           />
         )}
       </Flex>

--- a/app/src/atoms/SoftwareKeyboard/AlphanumericKeyboard/__tests__/CustomKeyboard.test.tsx
+++ b/app/src/atoms/SoftwareKeyboard/AlphanumericKeyboard/__tests__/CustomKeyboard.test.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react'
-import { renderHook, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import '@testing-library/jest-dom/vitest'
 
@@ -9,20 +9,34 @@ import { renderWithProviders } from '/app/__testing-utils__'
 
 import { AlphanumericKeyboard } from '..'
 
-import type { ComponentProps } from 'react'
+import type { KeyboardReactInterface } from 'react-simple-keyboard'
 
-const render = (props: ComponentProps<typeof AlphanumericKeyboard>) => {
-  return renderWithProviders(<AlphanumericKeyboard {...props} />)[0]
+function TestKeyboard(): JSX.Element {
+  const keyboardRef = useRef<KeyboardReactInterface | null>(null)
+  const inputElementRef = useRef<HTMLInputElement>(null)
+
+  return (
+    <>
+      <input data-testid="AlphanumericKeyboard_Input" ref={inputElementRef} />
+      <AlphanumericKeyboard
+        keyboardRef={keyboardRef}
+        inputElementRef={inputElementRef}
+      />
+    </>
+  )
+}
+
+const render = () => {
+  return renderWithProviders(<TestKeyboard />)[0]
 }
 
 describe('AlphanumericKeyboard', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('should render alphanumeric keyboard - lower case', () => {
-    const { result } = renderHook(() => useRef(null))
-    const props = {
-      onChange: vi.fn(),
-      keyboardRef: result.current,
-    }
-    render(props)
+    render()
     const buttons = screen.getAllByRole('button')
     const expectedButtonNames = [
       'q',
@@ -62,12 +76,7 @@ describe('AlphanumericKeyboard', () => {
   })
   it('should render alphanumeric keyboard - upper case, when clicking ABC key', async () => {
     const user = userEvent.setup()
-    const { result } = renderHook(() => useRef(null))
-    const props = {
-      onChange: vi.fn(),
-      keyboardRef: result.current,
-    }
-    render(props)
+    render()
     const shiftKey = screen.getByRole('button', { name: 'ABC' })
     await user.click(shiftKey)
 
@@ -111,12 +120,7 @@ describe('AlphanumericKeyboard', () => {
 
   it('should render alphanumeric keyboard - numbers, when clicking number key', async () => {
     const user = userEvent.setup()
-    const { result } = renderHook(() => useRef(null))
-    const props = {
-      onChange: vi.fn(),
-      keyboardRef: result.current,
-    }
-    render(props)
+    render()
     const numberKey = screen.getByRole('button', { name: '123' })
     await user.click(numberKey)
     const buttons = screen.getAllByRole('button')
@@ -142,12 +146,7 @@ describe('AlphanumericKeyboard', () => {
 
   it('should render alphanumeric keyboard - lower case when layout is numbers and clicking abc ', async () => {
     const user = userEvent.setup()
-    const { result } = renderHook(() => useRef(null))
-    const props = {
-      onChange: vi.fn(),
-      keyboardRef: result.current,
-    }
-    render(props)
+    render()
     const numberKey = screen.getByRole('button', { name: '123' })
     await user.click(numberKey)
     const abcKey = screen.getByRole('button', { name: 'abc' })
@@ -192,12 +191,7 @@ describe('AlphanumericKeyboard', () => {
 
   it('should switch each alphanumeric keyboard properly', async () => {
     const user = userEvent.setup()
-    const { result } = renderHook(() => useRef(null))
-    const props = {
-      onChange: vi.fn(),
-      keyboardRef: result.current,
-    }
-    render(props)
+    render()
     // lower case keyboard -> upper case keyboard
     const ABCKey = screen.getByRole('button', { name: 'ABC' })
     await user.click(ABCKey)
@@ -210,5 +204,14 @@ describe('AlphanumericKeyboard', () => {
     const abcKey = screen.getByRole('button', { name: 'abc' })
     await user.click(abcKey)
     screen.getByRole('button', { name: 'a' })
+  })
+
+  it('should update the input when clicking keys', async () => {
+    const user = userEvent.setup()
+    render()
+    await user.click(screen.getByRole('button', { name: 'a' }))
+    await user.click(screen.getByRole('button', { name: 'b' }))
+    await user.click(screen.getByRole('button', { name: 'c' }))
+    expect(screen.getByTestId('AlphanumericKeyboard_Input')).toHaveValue('abc')
   })
 })

--- a/app/src/atoms/SoftwareKeyboard/AlphanumericKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/AlphanumericKeyboard/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useSelector } from 'react-redux'
 import Keyboard from 'react-simple-keyboard'
 
@@ -18,27 +18,28 @@ import type { LayoutName } from '../types'
 import '../index.css'
 import './index.css'
 
+import { useSoftwareKeyboardControl } from '../utils/useSoftwareKeyboardControl'
+
+import type { SoftwareKeyboardControlOptions } from '../utils/useSoftwareKeyboardControl'
+
 // TODO (kk:04/05/2024) add debug to make debugging easy
 interface AlphanumericKeyboardProps {
-  onChange: (input: string) => void
   keyboardRef: MutableRefObject<KeyboardReactInterface | null>
-  value?: string
+  /**
+   * The underlying element that the software keyboard should type into.
+   * See `useSoftwareKeyboardControl()`.
+   */
+  inputElementRef: SoftwareKeyboardControlOptions['inputElementRef']
   debug?: boolean
 }
 
 export function AlphanumericKeyboard({
-  onChange,
   keyboardRef,
-  value,
+  inputElementRef,
   debug = false,
 }: AlphanumericKeyboardProps): JSX.Element {
   const [layoutName, setLayoutName] = useState<LayoutName>('default')
 
-  useEffect(() => {
-    if (value !== undefined && keyboardRef.current != null) {
-      keyboardRef.current.setInput(value)
-    }
-  }, [value, keyboardRef])
   const appLanguage = useSelector(getAppLanguage)
 
   const onKeyPress = (button: string): void => {
@@ -73,6 +74,11 @@ export function AlphanumericKeyboard({
     setLayoutName('default')
   }
 
+  const { beforeInputUpdate, onChange } = useSoftwareKeyboardControl({
+    keyboardRef,
+    inputElementRef,
+  })
+
   return (
     <Keyboard
       keyboardRef={r => {
@@ -80,6 +86,7 @@ export function AlphanumericKeyboard({
       }}
       theme="hg-theme-default oddTheme1 alphanumericKeyboard"
       onChange={onChange}
+      beforeInputUpdate={beforeInputUpdate}
       onKeyPress={onKeyPress}
       layoutName={layoutName}
       layout={alphanumericKeyboardLayout}

--- a/app/src/atoms/SoftwareKeyboard/AlphanumericKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/AlphanumericKeyboard/index.tsx
@@ -30,7 +30,7 @@ export function AlphanumericKeyboard({
   onChange,
   keyboardRef,
   value,
-  debug = false, // If true, <ENTER> will input a \n
+  debug = false,
 }: AlphanumericKeyboardProps): JSX.Element {
   const [layoutName, setLayoutName] = useState<LayoutName>('default')
 
@@ -91,7 +91,7 @@ export function AlphanumericKeyboard({
       useButtonTag={false} // Exclude from the tab order.
       buttonAttributes={softwareKeyboardButtonAttributes}
       width="100%"
-      debug={debug} // If true, <ENTER> will input a \n
+      debug={debug}
       preventMouseDownDefault // Don't steal focus from inputs.
     />
   )

--- a/app/src/atoms/SoftwareKeyboard/FullKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/FullKeyboard/index.tsx
@@ -156,7 +156,7 @@ export function FullKeyboard({
       mergeDisplay={true}
       useButtonTag={false} // Exclude from the tab order.
       buttonAttributes={softwareKeyboardButtonAttributes}
-      debug={debug} // If true, <ENTER> will input a \n
+      debug={debug}
       baseClass="fullKeyboard"
       buttonTheme={[
         {

--- a/app/src/atoms/SoftwareKeyboard/IndividualKey/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/IndividualKey/index.tsx
@@ -43,7 +43,7 @@ export function IndividualKey({
       buttonAttributes={softwareKeyboardButtonAttributes}
       {...numericalKeyboard}
       width="100%"
-      debug={debug} // If true, <ENTER> will input a \n
+      debug={debug}
       preventMouseDownDefault // Don't steal focus from inputs.
     />
   )

--- a/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/index.tsx
@@ -50,7 +50,7 @@ export function NumericalKeyboard({
       buttonAttributes={softwareKeyboardButtonAttributes}
       layoutName={layoutName}
       layout={numericalKeyboardLayout}
-      debug={debug} // If true, <ENTER> will input a \n
+      debug={debug}
       preventMouseDownDefault // Don't steal focus from inputs.
     />
   )

--- a/app/src/atoms/SoftwareKeyboard/utils/useSoftwareKeyboardControl.ts
+++ b/app/src/atoms/SoftwareKeyboard/utils/useSoftwareKeyboardControl.ts
@@ -1,0 +1,139 @@
+import { useMemo } from 'react'
+
+import type { ComponentProps, RefObject } from 'react'
+import type { KeyboardReactInterface } from 'react-simple-keyboard'
+import type Keyboard from 'react-simple-keyboard'
+
+export interface SoftwareKeyboardControlOptions {
+  /**
+   * The underlying <input> or <textarea> element that the software keyboard should
+   * type into.
+   */
+  inputElementRef: RefObject<HTMLInputElement | HTMLTextAreaElement>
+
+  /**
+   * The software keyboard.
+   */
+  keyboardRef: RefObject<KeyboardReactInterface>
+}
+
+/** Props that should be passed to react-simple-keyboard. */
+export interface SoftwareKeyboardControlResult {
+  beforeInputUpdate: ComponentProps<typeof Keyboard>['beforeInputUpdate']
+  onChange: ComponentProps<typeof Keyboard>['onChange']
+}
+
+/**
+ * This links a react-simple-keyboard instance to an input element, so tapping the keys
+ * will "type" into it.
+ *
+ * Also, react-simple-keyboard unfortunately wants to maintain its own internal copy of
+ * the full input value and the caret position. This is redundant with our React state
+ * and the DOM state, and it causes various problems when it falls out of sync with them.
+ * So this keeps the internal state refreshed to match the latest from the DOM.
+ * https://github.com/hodgef/simple-keyboard/issues/2756
+ *
+ * So this keeps the internal state in sync.
+ */
+export function useSoftwareKeyboardControl(
+  options: SoftwareKeyboardControlOptions
+): SoftwareKeyboardControlResult {
+  const { inputElementRef, keyboardRef } = options
+
+  const result = useMemo<SoftwareKeyboardControlResult>(
+    () => ({
+      // This will run any time the user taps a react-simple-keyboard button, just before
+      // react-simple-keyboard computes what the new value of the input field will be
+      // with the new character inserted.
+      //
+      // This makes sure, before it does that computation, it has the input field's
+      // latest value and caret position. They may have been changed in the meantime
+      // by React code, by a hardware keyboard, etc.
+      beforeInputUpdate: keyboard => {
+        const inputElement = inputElementRef.current
+        if (
+          inputElement instanceof HTMLInputElement ||
+          inputElement instanceof HTMLTextAreaElement
+        ) {
+          keyboard.setInput(inputElement.value)
+          keyboard.setCaretPosition(
+            inputElement.selectionStart,
+            inputElement.selectionEnd
+          )
+        } else {
+          console.error(
+            `useSoftwareKeyboardControl requires <input> or <textarea>, but got: ${inputElement}. This is a bug in the caller.`,
+            inputElement
+          )
+          keyboard.setInput('')
+          keyboard.setCaretPosition(0)
+        }
+      },
+
+      // This will run after the user has tapped a react-simple-keyboard button,
+      // and react-simple-keyboard has computed the new value of the input field,
+      // with the new character inserted.
+      //
+      // This programmatically dispatches an input event with the new value. We're
+      // careful to do this in a way that looks to React as if it's just a normal,
+      // native input event from a hardware keyboard, so React will call all our event
+      // handlers as normal. We're also careful to   We are careful to do this in a way that React will detect
+      // * Update the input field's value and dispatch an event as if the user had typed
+      //   with a hardware keyboard.
+      // * Be careful to position the cursor correctly. (By default, programmatically
+      //   editing an input's value like this would normally move the cursor to the end,
+      //   which we don't want.)
+      onChange: newValue => {
+        const inputElement = inputElementRef.current
+        if (!(
+          inputElement instanceof HTMLTextAreaElement ||
+          inputElement instanceof HTMLInputElement
+        )) {
+          console.error(
+            `useSoftwareKeyboardControl requires <input> or <textarea>, but got: ${inputElement}. This is a bug in the caller.`,
+            inputElement
+          )
+          return
+        }
+
+        // This is https://stackoverflow.com/questions/23892547 with a couple additions:
+        //
+        // 1. We call setSelectionRange(). Without this, programmatically setting the
+        //    input value causes the cursor to jump to the end.
+        // 2. We focus() the element first. Without this, if you enter multiple characters
+        //    into the middle of the input, and the input isn't focused, the cursor jumps
+        //    to the end. I don't fully understand this, but it seems like setSelectionRange()
+        //    requires it., like setSelectionRange() isn't having the effect it should.
+        inputElement.focus()
+        setValue(inputElement, newValue)
+        inputElement.setSelectionRange(
+          keyboardRef.current?.getCaretPosition() ?? null,
+          keyboardRef.current?.getCaretPositionEnd() ?? null
+        )
+        inputElement.dispatchEvent(new Event('input', { bubbles: true }))
+      },
+    }),
+    [inputElementRef, keyboardRef]
+  )
+
+  return result
+}
+
+/**
+ * This just does `inputElement.value = newValue`, except it uses the native browser
+ * implementation, bypassing React's wrapper. Apparently this is necessary for React
+ * to detect the change.
+ *
+ * https://stackoverflow.com/questions/23892547
+ */
+function setValue(
+  inputElement: HTMLInputElement | HTMLTextAreaElement,
+  newValue: string
+): void {
+  const prototype =
+    inputElement instanceof HTMLTextAreaElement
+      ? HTMLTextAreaElement.prototype
+      : HTMLInputElement.prototype
+  const nativeSetter = Object.getOwnPropertyDescriptor(prototype, 'value')!.set!
+  nativeSetter.call(inputElement, newValue)
+}

--- a/app/src/atoms/SoftwareKeyboard/utils/useSoftwareKeyboardControl.ts
+++ b/app/src/atoms/SoftwareKeyboard/utils/useSoftwareKeyboardControl.ts
@@ -32,8 +32,6 @@ export interface SoftwareKeyboardControlResult {
  * and the DOM state, and it causes various problems when it falls out of sync with them.
  * So this keeps the internal state refreshed to match the latest from the DOM.
  * https://github.com/hodgef/simple-keyboard/issues/2756
- *
- * So this keeps the internal state in sync.
  */
 export function useSoftwareKeyboardControl(
   options: SoftwareKeyboardControlOptions

--- a/app/src/atoms/SoftwareKeyboard/utils/useSoftwareKeyboardControl.ts
+++ b/app/src/atoms/SoftwareKeyboard/utils/useSoftwareKeyboardControl.ts
@@ -60,8 +60,7 @@ export function useSoftwareKeyboardControl(
           )
         } else {
           console.error(
-            `useSoftwareKeyboardControl requires <input> or <textarea>, but got: ${inputElement}. This is a bug in the caller.`,
-            inputElement
+            `useSoftwareKeyboardControl requires <input> or <textarea>, but got: ${inputElement}. This is a bug in the caller.`
           )
           keyboard.setInput('')
           keyboard.setCaretPosition(0)
@@ -83,8 +82,7 @@ export function useSoftwareKeyboardControl(
           inputElement instanceof HTMLInputElement
         )) {
           console.error(
-            `useSoftwareKeyboardControl requires <input> or <textarea>, but got: ${inputElement}. This is a bug in the caller.`,
-            inputElement
+            `useSoftwareKeyboardControl requires <input> or <textarea>, but got: ${inputElement}. This is a bug in the caller.`
           )
           return
         }

--- a/app/src/atoms/SoftwareKeyboard/utils/useSoftwareKeyboardControl.ts
+++ b/app/src/atoms/SoftwareKeyboard/utils/useSoftwareKeyboardControl.ts
@@ -75,12 +75,7 @@ export function useSoftwareKeyboardControl(
       // This programmatically dispatches an input event with the new value. We're
       // careful to do this in a way that looks to React as if it's just a normal,
       // native input event from a hardware keyboard, so React will call all our event
-      // handlers as normal. We're also careful to   We are careful to do this in a way that React will detect
-      // * Update the input field's value and dispatch an event as if the user had typed
-      //   with a hardware keyboard.
-      // * Be careful to position the cursor correctly. (By default, programmatically
-      //   editing an input's value like this would normally move the cursor to the end,
-      //   which we don't want.)
+      // handlers as normal.
       onChange: newValue => {
         const inputElement = inputElementRef.current
         if (!(
@@ -101,7 +96,7 @@ export function useSoftwareKeyboardControl(
         // 2. We focus() the element first. Without this, if you enter multiple characters
         //    into the middle of the input, and the input isn't focused, the cursor jumps
         //    to the end. I don't fully understand this, but it seems like setSelectionRange()
-        //    requires it., like setSelectionRange() isn't having the effect it should.
+        //    requires it.
         inputElement.focus()
         setValue(inputElement, newValue)
         inputElement.setSelectionRange(

--- a/app/src/pages/ODD/RobotNameEditor/index.tsx
+++ b/app/src/pages/ODD/RobotNameEditor/index.tsx
@@ -61,9 +61,9 @@ export function RobotNameEditor(): JSX.Element {
   const localRobot = useSelector(getLocalRobot)
   const ipAddress = localRobot?.ip
   const previousName = localRobot?.name != null ? localRobot.name : null
-  const [newName, setNewName] = useState<string>('')
-  const [isShowConfirmRobotName, setIsShowConfirmRobotName] =
-    useState<boolean>(false)
+  const [robotNameConfirmation, setRobotNameConfirmation] = useState<
+    string | null
+  >(null)
   const keyboardRef = useRef<KeyboardReactInterface | null>(null)
   const dispatch = useDispatch<Dispatch>()
   const isUnboxingFlowOngoing = useIsUnboxingFlowOngoing()
@@ -122,7 +122,6 @@ export function RobotNameEditor(): JSX.Element {
     handleSubmit,
     control,
     formState: { errors },
-    reset,
     trigger,
     watch,
   } = useForm({
@@ -143,7 +142,6 @@ export function RobotNameEditor(): JSX.Element {
       dispatch(removeRobot(sameNameRobotInUnavailable.name))
     }
     updateRobotName(newName)
-    reset({ newRobotName: '' })
   }
 
   const documentationState = useDocumentationState()
@@ -153,11 +151,10 @@ export function RobotNameEditor(): JSX.Element {
     {
       onSuccess: (data: UpdatedRobotName) => {
         if (data.name != null) {
-          setNewName(data.name)
           if (!isUnboxingFlowOngoing) {
             navigate('/robot-settings')
           } else {
-            setIsShowConfirmRobotName(true)
+            setRobotNameConfirmation(data.name)
           }
           if (previousName != null) {
             dispatch(removeRobot(previousName))
@@ -187,8 +184,8 @@ export function RobotNameEditor(): JSX.Element {
 
   return (
     <>
-      {isShowConfirmRobotName && isUnboxingFlowOngoing ? (
-        <ConfirmRobotName robotName={newName} />
+      {robotNameConfirmation != null && isUnboxingFlowOngoing ? (
+        <ConfirmRobotName robotName={robotNameConfirmation} />
       ) : (
         <>
           {isUnboxingFlowOngoing ? (
@@ -287,7 +284,6 @@ export function RobotNameEditor(): JSX.Element {
                     onChange={e => {
                       const newVal = e.target.value
                       field.onChange(newVal)
-                      setNewName(newVal)
                       void trigger('newRobotName')
                     }}
                   />
@@ -320,7 +316,6 @@ export function RobotNameEditor(): JSX.Element {
                 <AlphanumericKeyboard
                   onChange={(input: string) => {
                     field.onChange(input)
-                    setNewName(input)
                     void trigger('newRobotName')
                   }}
                   keyboardRef={keyboardRef}

--- a/app/src/pages/ODD/RobotNameEditor/index.tsx
+++ b/app/src/pages/ODD/RobotNameEditor/index.tsx
@@ -65,6 +65,7 @@ export function RobotNameEditor(): JSX.Element {
     string | null
   >(null)
   const keyboardRef = useRef<KeyboardReactInterface | null>(null)
+  const inputElementRef = useRef<HTMLInputElement>(null)
   const dispatch = useDispatch<Dispatch>()
   const isUnboxingFlowOngoing = useIsUnboxingFlowOngoing()
   const connectableRobots = useSelector((state: State) =>
@@ -274,6 +275,7 @@ export function RobotNameEditor(): JSX.Element {
                 name="newRobotName"
                 render={({ field, fieldState }) => (
                   <TouchInputField
+                    ref={inputElementRef}
                     autoFocus
                     data-testid="name-robot_input"
                     name="newRobotName"
@@ -314,12 +316,8 @@ export function RobotNameEditor(): JSX.Element {
               name="newRobotName"
               render={({ field }) => (
                 <AlphanumericKeyboard
-                  onChange={(input: string) => {
-                    field.onChange(input)
-                    void trigger('newRobotName')
-                  }}
+                  inputElementRef={inputElementRef}
                   keyboardRef={keyboardRef}
-                  value={newRobotName}
                 />
               )}
             />

--- a/app/src/pages/ODD/RobotNameEditor/index.tsx
+++ b/app/src/pages/ODD/RobotNameEditor/index.tsx
@@ -311,15 +311,9 @@ export function RobotNameEditor(): JSX.Element {
           </Flex>
 
           <Flex width="100%" position={POSITION_FIXED} left="0" bottom="0">
-            <Controller
-              control={control}
-              name="newRobotName"
-              render={({ field }) => (
-                <AlphanumericKeyboard
-                  inputElementRef={inputElementRef}
-                  keyboardRef={keyboardRef}
-                />
-              )}
+            <AlphanumericKeyboard
+              inputElementRef={inputElementRef}
+              keyboardRef={keyboardRef}
             />
           </Flex>
         </>


### PR DESCRIPTION
## Overview

This partially closes EXEC-2824. It sets the pattern for the solution. Then, as a proof of concept, it applies it to `AlphanumericKeyboard`, one of our 3 software keyboard variants, which is only used in one place.

## Details

If we have an input field containing `hello`, and the user taps the `!` button, react-simple-keyboard will send us an `onChange` event with the new text, `hello!`, and the new caret position, `6`. To do that, it needs to know the prior value (`hello`), and it needs to know the prior caret position (`5`).

react-simple-keyboard maintains its own internal copies of the value and caret position. It does not keep them in sync with the real DOM, or with React. When they fall out of sync (for example, because the real DOM is being typed into via a hardware keyboard), we get weird bugs like text getting overwritten or text getting inserted into the wrong place. 

Our challenge, then, is to establish a two-way sync between react-simple-keyboard and everything else.

A prior PR (#21497) introduced `StatelessNumericalKeyboard`. It tried to solve this by passing the React-controlled input value down into the keyboard as a prop. I think this helped, but it only synchronized the input _value_, not the caret position.

This PR attempts to synchronize both, with a ref-based API, roughly like this:

```tsx
const inputRef = useRef()
const [value, setValue] = useState("")

return <div>
  <input
    value={value}
    onChange={e => setValue(e.target.value)}
    ref={inputRef}
  />
  <AlphanumericKeyboard inputRef={inputRef} />
</div>
```

The keyboard is given a ref to the DOM node that it's meant to be typing into. It can then bypass React and use low-level DOM access to read and write it.

Bypassing React for low-level DOM access helps us synchronize the caret position. It's timing-sensitive relative to when we synchronize the value, and React gets in the way of that.

It also keeps the codepaths of the hardware and software keyboards relative to each other. Either way, when you type a character, it'll go through the same React `onChange` event handler on the `<input>` element. So everything consuming that can act normal, and the `<input>` can be integrated with libraries like react-hook-form in the normal way.

The downside is that the implementation is dense and sensitive.[^1]

## Test Plan and Hands on Testing

Try editing the robot name on the ODD. Through any sequence of:

* Adding or deleting text with the software keyboard.
* Adding or deleting text with the hardware keyboard.
* Focusing or unfocusing the input element.
* Moving the cursor within the input element, either by tapping it, or with the arrow keys.
* Selecting a range of text within the input element, e.g. with Shift+Left / Shift+Right.

Then:

* Text should be inserted in the correct position, where the caret says it will be inserted.
* The caret should not jump around randomly.

## Review requests

* Any better ideas? Any qualms about me repeating this pattern for the remaining ~30 pages that have a software keyboard?
* I would love some ideas for keeping this tested, going forward.

  Most of our tests run in react-testing-library and jsdom. I don't think those are sufficient to detect problems with caret positioning. I doubt they can emulate the browser faithfully enough.

  I would love something like Vitest's [browser mode](https://vitest.dev/guide/browser/), but I don't think we're set up for that.

  I could add a Storybook story and just...write a bunch of manual testing steps in `<p>` tags, or something? Would that be helpful?

## Risk assessment

High, especially if we continue this pattern to the rest of the software keyboards. This is some funky shit.

[^1]: Like me :)