### PR TITLE
refactor(app): Update robot update success modal btn to sentence case

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -246,7 +246,7 @@
   "estop_pressed": "E-stop pressed",
   "ethernet": "Ethernet",
   "ethernet_connection_description": "Connect an Ethernet cable to the back of the robot and a network switch or hub.",
-  "exit": "exit",
+  "exit": "Exit",
   "factory_mode": "Factory Mode",
   "factory_reset": "Factory Reset",
   "factory_reset_description": "Resets all settings. You’ll have to redo initial setup before using the robot again.",

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
@@ -31,7 +31,6 @@ import {
   useRobotInitializationStatus,
 } from '/app/resources/health/useRobotInitializationStatus'
 
-import { FOOTER_BUTTON_STYLE } from './UpdateRobotModal'
 import { useRobotUpdateInfo } from './useRobotUpdateInfo'
 
 import type { ChangeEventHandler } from 'react'
@@ -181,15 +180,9 @@ function RobotUpdateProgressFooter({
     <Flex
       alignItems={ALIGN_CENTER}
       justifyContent={JUSTIFY_FLEX_END}
-      padding={`${SPACING.spacing16} 0`}
+      padding={`0 ${SPACING.spacing24} ${SPACING.spacing24}`}
     >
-      <PrimaryButton
-        onClick={closeRobotUpdate}
-        marginRight={SPACING.spacing12}
-        css={FOOTER_BUTTON_STYLE}
-      >
-        {t('exit')}
-      </PrimaryButton>
+      <PrimaryButton onClick={closeRobotUpdate}>{t('exit')}</PrimaryButton>
     </Flex>
   )
 }

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
@@ -13,7 +13,7 @@ import {
   JUSTIFY_FLEX_END,
   LegacyStyledText,
   Modal,
-  NewPrimaryBtn,
+  PrimaryButton,
   SPACING,
 } from '@opentrons/components'
 import { useCreateLiveCommandMutation } from '@opentrons/react-api-client'
@@ -183,13 +183,13 @@ function RobotUpdateProgressFooter({
       justifyContent={JUSTIFY_FLEX_END}
       padding={`${SPACING.spacing16} 0`}
     >
-      <NewPrimaryBtn
+      <PrimaryButton
         onClick={closeRobotUpdate}
         marginRight={SPACING.spacing12}
         css={FOOTER_BUTTON_STYLE}
       >
         {t('exit')}
-      </NewPrimaryBtn>
+      </PrimaryButton>
     </Flex>
   )
 }

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/__tests__/RobotUpdateProgressModal.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/__tests__/RobotUpdateProgressModal.test.tsx
@@ -133,7 +133,7 @@ describe('DownloadUpdateModal', () => {
     })
     render(props)
 
-    const exitButton = screen.getByText('exit')
+    const exitButton = screen.getByRole('button', { name: 'Exit' })
 
     expect(
       screen.getByText('Robot software successfully updated')
@@ -158,7 +158,7 @@ describe('DownloadUpdateModal', () => {
     }
 
     render(props)
-    const exitButton = screen.getByText('exit')
+    const exitButton = screen.getByRole('button', { name: 'Exit' })
 
     expect(screen.getByText('test error')).toBeInTheDocument()
     fireEvent.click(exitButton)


### PR DESCRIPTION
Closes [RQA-5917](https://opentrons.atlassian.net/browse/RQA-5917)

# Overview

Updates the robot update success modal exit button to sentence case instead of caps. Adjust some padding values, too.

### Current Behavior

<img width="1920" height="1427" alt="image" src="https://github.com/user-attachments/assets/6a065375-3542-4ebe-a56e-906bdd0e54cf" />

### Fixed Behavior

<img width="1021" height="770" alt="Screenshot 2026-08-20 at 11 48 20 AM" src="https://github.com/user-attachments/assets/21142eb4-85c2-47fa-b648-1233711026d5" />

## Test Plan and Hands on Testing

- See image

## Risk assessment

- none, just css and copy swaps


[RQA-5917]: https://opentrons.atlassian.net/browse/RQA-5917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ