### PR TITLE
fix(api): Increase pyro worker thread limit to account for high-demand protocols

### DIFF
--- a/api/src/opentrons/util/pyro/pyro_daemon_utility.py
+++ b/api/src/opentrons/util/pyro/pyro_daemon_utility.py
@@ -31,7 +31,7 @@ def create_pyro_daemon_with_monitored_start(
     registry()
 
     # Handle Pyro registration and publication of our synchronized object
-    Pyro5.config.THREADPOOL_SIZE = 200  # type: ignore
+    Pyro5.config.THREADPOOL_SIZE = 512  # type: ignore
     with pyro.Daemon() as daemon:  # type: ignore
         utility = DaemonUtility(daemon)
         # Create a guaranteed synchronous adapted alias to the resource


### PR DESCRIPTION
# Overview
Covers: RQA-5725

Our previous pyro threadpool limit was set to 200 after some cursory testing on protocols with modules. However, when running with concurrent modules we actually have seen the count get quite close to that limit and on a few occasions we got a `No free workers` error from one of our Pyro daemons. The fix here is pretty simple, we're bumping the count to a threshold which should give us lots of wiggle room. This will also give us some future-facing freedom if we ever expand the number of services talking to one of our central services (like the protocol run).

@nshiland Did some great data collecting on this one to track our thread usage across the smoke test protocols, thanks Nick!


## Test Plan and Hands on Testing

- [x] Run a smoke test with concurrent modules several times, ensure we can no longer reproduce `No free workers` daemon-level error and that run proceeds without issues

## Changelog
Bumped the threadpool limit to `512`

## Review requests

## Risk assessment
Low - we float around 150 of these workers during a concurrent module protocol like the Smoke test, occasionally raising higher during spikes. It is unrealistic that under the current process configuration we will cross 512.