### PR TITLE
refactor(app): add "Usage Settings" subsection in Advanced Settings

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/GantryHoming.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/GantryHoming.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 
 import {
   ALIGN_CENTER,
-  Box,
+  DIRECTION_COLUMN,
   Flex,
   JUSTIFY_SPACE_BETWEEN,
   LegacyStyledText,
@@ -40,24 +40,30 @@ export function GantryHoming({
   }
 
   return (
-    <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
-      <Box width="70%">
-        <LegacyStyledText
-          css={TYPOGRAPHY.pSemiBold}
-          paddingBottom={SPACING.spacing4}
+    <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing16}>
+      <LegacyStyledText css={TYPOGRAPHY.h2SemiBold}>
+        {t('usage_settings')}
+      </LegacyStyledText>
+      <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
+        <Flex
+          flexDirection={DIRECTION_COLUMN}
+          gridGap={SPACING.spacing4}
+          width="70%"
         >
-          {t('gantry_homing')}
-        </LegacyStyledText>
-        <LegacyStyledText forwardedAs="p">
-          {t('gantry_homing_description')}
-        </LegacyStyledText>
-      </Box>
-      <ToggleButton
-        label="gantry_homing"
-        toggledOn={!value}
-        onClick={handleClick}
-        disabled={isRobotBusy}
-      />
+          <LegacyStyledText css={TYPOGRAPHY.pSemiBold}>
+            {t('gantry_homing')}
+          </LegacyStyledText>
+          <LegacyStyledText forwardedAs="p">
+            {t('gantry_homing_description')}
+          </LegacyStyledText>
+        </Flex>
+        <ToggleButton
+          label="gantry_homing"
+          toggledOn={!value}
+          onClick={handleClick}
+          disabled={isRobotBusy}
+        />
+      </Flex>
     </Flex>
   )
 }

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/GantryHoming.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/GantryHoming.test.tsx
@@ -30,7 +30,7 @@ const mockSettings = {
 const render = (isRobotBusy = false) => {
   return renderWithProviders(
     <MemoryRouter>
-      <GantryHoming settings={mockSettings} isRobotBusy />
+      <GantryHoming settings={mockSettings} isRobotBusy={isRobotBusy} />
     </MemoryRouter>,
     { i18nInstance: i18n }
   )
@@ -39,6 +39,7 @@ const render = (isRobotBusy = false) => {
 describe('RobotSettings DisableHoming', () => {
   it('should render title, description and toggle button', () => {
     render()
+    screen.getByText('Usage Settings')
     screen.getByText('Home Gantry on Restart')
     screen.getByText('Homes the gantry along the z-axis.')
     const toggleButton = screen.getByRole('switch', { name: 'gantry_homing' })

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsAdvanced.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsAdvanced.tsx
@@ -187,7 +187,10 @@ export function RobotSettingsAdvanced({
             />
           </>
         )}
-        <Divider marginY={SPACING.spacing16} />
+        <Divider
+          marginTop={SPACING.spacing16}
+          marginBottom={SPACING.spacing24}
+        />
         <GantryHoming
           settings={findSettings('disableHomeOnBoot')}
           isRobotBusy={isRobotBusy || isEstopNotDisengaged}


### PR DESCRIPTION
Closes [RQA-5921](https://opentrons.atlassian.net/browse/RQA-5921)

# Overview

Adds the "Usage Settings" subsection to the robot's advanced settings menu to match designs.

### Current Behavior

<img width="1920" height="1766" alt="image (2)" src="https://github.com/user-attachments/assets/38498162-54ed-4306-b572-941029a9a3ed" />

### Fixed Behavior

<img width="1018" height="770" alt="Screenshot 2026-08-20 at 12 10 52 PM" src="https://github.com/user-attachments/assets/9c1f5640-7ba4-4d5f-94fe-24313e118617" />

## Test Plan and Hands on Testing

- See images

## Risk assessment

- none, just CSS and copy


[RQA-5921]: https://opentrons.atlassian.net/browse/RQA-5921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ