### PR TITLE
refactor(app): fix "add user" modal dropdown menu clipping

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/AddUserModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/AddUserModal.tsx
@@ -138,6 +138,7 @@ export function AddUserModal({
   return createPortal(
     <ModalShell
       width="31.25rem"
+      overflow="visible"
       header={
         <WizardHeader
           title={t('desktop_add_user')}

--- a/components/src/modals/ModalShell.tsx
+++ b/components/src/modals/ModalShell.tsx
@@ -157,4 +157,7 @@ const Header = styled.div`
   background-color: ${COLORS.white};
   position: ${POSITION_STICKY};
   top: 0;
+  overflow: hidden;
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
 `


### PR DESCRIPTION
Closes [RQA-5935](https://opentrons.atlassian.net/browse/RQA-5935)

# Overview

The "Add User" role dropdown menu was clipping. To fix, we adjust the CSS to `overflow: visible`, so it flows outside the modal. We need to update `ModalShell` a bit here, too, because the top corners of the modal body do not have the correct border radius, because `overflow: visible` stopped clipping the header to the modal’s radius. The header is a full-width white bar, so it painted over the rounded top.

`ModalShell`’s header now inherits that top radius and clips to it, so the corners match the bottom again without changing how the dropdown overflows. This change should cleanly extend to all other usages of `ModalShell` without impacting UI.

### Current Behavior

<img width="1008" height="769" alt="Screenshot 2026-08-20 at 12 16 58 PM" src="https://github.com/user-attachments/assets/839d9615-9238-4782-a8bc-bdfd275561b3" />

### Fixed Behavior

<img width="524" height="443" alt="Screenshot 2026-08-20 at 12 26 06 PM" src="https://github.com/user-attachments/assets/6c79de0f-4e29-4826-948c-6cf1ba46b592" />

## Test Plan and Hands on Testing

- See images.
- Smoke tested a few other `ModalShell` usages to confirm that the UI isn't impacted elsewhere.

## Risk assessment

- lowish -- just CSS changes. We use `ModalShell` quite a bit, but we shouldn't see any regressions unless we have content that exists outside the modal headers (ex. a tooltip), which I don't think we do. 


[RQA-5935]: https://opentrons.atlassian.net/browse/RQA-5935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ