### PR TITLE
refactor(app): update "documentation required" modal "confirm" button disabled state

### DIFF
--- a/app/src/assets/localization/en/access_control.json
+++ b/app/src/assets/localization/en/access_control.json
@@ -12,7 +12,7 @@
   "desktop_password_expired_new_password_field": "New password",
   "desktop_password_expired_subheading": "Create a new password to use",
   "documentation_is_required": "Documentation is required",
-  "documentation_required": "Documentation Required",
+  "documentation_required": "Documentation required for robot action",
   "download_audit_logs": "Download audit logs",
   "download_audit_logs_description": "Once a protocol run is complete, audit logs must be downloaded locally before continuing.",
   "download_now": "Download now",

--- a/app/src/assets/localization/en/access_control.json
+++ b/app/src/assets/localization/en/access_control.json
@@ -11,6 +11,7 @@
   "desktop_password_expired_mismatch": "Passwords do not match.",
   "desktop_password_expired_new_password_field": "New password",
   "desktop_password_expired_subheading": "Create a new password to use",
+  "documentation_is_required": "Documentation is required",
   "documentation_required": "Documentation Required",
   "download_audit_logs": "Download audit logs",
   "download_audit_logs_description": "Once a protocol run is complete, audit logs must be downloaded locally before continuing.",

--- a/app/src/assets/localization/en/access_control.json
+++ b/app/src/assets/localization/en/access_control.json
@@ -12,7 +12,7 @@
   "desktop_password_expired_new_password_field": "New password",
   "desktop_password_expired_subheading": "Create a new password to use",
   "documentation_is_required": "Documentation is required",
-  "documentation_required": "Documentation required for robot action",
+  "documentation_required": "Documentation required",
   "download_audit_logs": "Download audit logs",
   "download_audit_logs_description": "Once a protocol run is complete, audit logs must be downloaded locally before continuing.",
   "download_now": "Download now",

--- a/app/src/organisms/Desktop/DocumentationRequired/DocumentationRequired.tsx
+++ b/app/src/organisms/Desktop/DocumentationRequired/DocumentationRequired.tsx
@@ -46,10 +46,15 @@ export function DocumentationRequired({
 
   const trimmedNote = inputText.trim()
   const handleConfirm = (): void => {
-    if (trimmedNote === '') return
+    if (trimmedNote === '') {
+      setError(t('documentation_is_required') as string)
+      return
+    }
     if (trimmedNote.length < minReportLength) {
       setError(
-        '' + t('must_be_at_least_characters', { minLength: minReportLength })
+        t('must_be_at_least_characters', {
+          minLength: minReportLength,
+        }) as string
       )
       return
     }
@@ -59,7 +64,7 @@ export function DocumentationRequired({
   const footer = (
     <div className={styles.button_container}>
       <SecondaryButton onClick={onClose}>{t('cancel_action')}</SecondaryButton>
-      <PrimaryButton onClick={handleConfirm} disabled={trimmedNote === ''}>
+      <PrimaryButton onClick={handleConfirm}>
         {t('shared:confirm')}
       </PrimaryButton>
     </div>

--- a/app/src/organisms/Desktop/DocumentationRequired/__tests__/DocumentationRequired.test.tsx
+++ b/app/src/organisms/Desktop/DocumentationRequired/__tests__/DocumentationRequired.test.tsx
@@ -43,21 +43,9 @@ describe('DocumentationRequired', () => {
     screen.getByRole('button', { name: 'Cancel action' })
   })
 
-  it('keeps the confirm button disabled until a non-empty note is entered', () => {
+  it('keeps the confirm button enabled even when the note is empty', () => {
     render(props)
-    const confirm = screen.getByRole('button', { name: 'Confirm' })
-    expect(confirm).toBeDisabled()
-
-    editNote('starting QC run')
-
-    expect(confirm).toBeEnabled()
-  })
-
-  it('treats whitespace-only input as empty and keeps confirm disabled', () => {
-    render(props)
-    editNote('   \n\t  ')
-
-    expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeEnabled()
   })
 
   it('calls onConfirm with the trimmed note when confirm is clicked', () => {
@@ -68,10 +56,33 @@ describe('DocumentationRequired', () => {
     expect(props.onConfirm).toHaveBeenCalledWith('starting QC run')
   })
 
-  it('does not call onConfirm when the note is empty', () => {
+  it('shows a required error and does not confirm when the note is empty', () => {
     render(props)
     fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+
     expect(props.onConfirm).not.toHaveBeenCalled()
+    screen.getByText('Documentation is required')
+  })
+
+  it('treats whitespace-only input as empty and shows a required error', () => {
+    render(props)
+    editNote('   \n\t  ')
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+
+    expect(props.onConfirm).not.toHaveBeenCalled()
+    screen.getByText('Documentation is required')
+  })
+
+  it('clears the required error when the user edits the note', () => {
+    render(props)
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    screen.getByText('Documentation is required')
+
+    editNote('starting QC run')
+
+    expect(
+      screen.queryByText('Documentation is required')
+    ).not.toBeInTheDocument()
   })
 
   it('shows a min-length error and does not confirm when the note is too short', () => {

--- a/app/src/organisms/Desktop/DocumentationRequired/__tests__/DocumentationRequired.test.tsx
+++ b/app/src/organisms/Desktop/DocumentationRequired/__tests__/DocumentationRequired.test.tsx
@@ -36,7 +36,7 @@ describe('DocumentationRequired', () => {
 
   it('renders header, the per-user note label, action list, and the confirm + cancel buttons', () => {
     render(props)
-    screen.getByText('Documentation Required')
+    screen.getByText('Documentation required for robot action')
     screen.getByText('Note for robot audit log by alice')
     screen.getByText('Action list')
     screen.getByRole('button', { name: 'Confirm' })

--- a/app/src/organisms/Desktop/DocumentationRequired/__tests__/DocumentationRequired.test.tsx
+++ b/app/src/organisms/Desktop/DocumentationRequired/__tests__/DocumentationRequired.test.tsx
@@ -36,7 +36,7 @@ describe('DocumentationRequired', () => {
 
   it('renders header, the per-user note label, action list, and the confirm + cancel buttons', () => {
     render(props)
-    screen.getByText('Documentation required for robot action')
+    screen.getByText('Documentation required')
     screen.getByText('Note for robot audit log by alice')
     screen.getByText('Action list')
     screen.getByRole('button', { name: 'Confirm' })

--- a/app/src/organisms/ODD/DocumentationRequired/DocumentationRequired.tsx
+++ b/app/src/organisms/ODD/DocumentationRequired/DocumentationRequired.tsx
@@ -51,10 +51,15 @@ export function DocumentationRequired({
 
   const trimmedNote = inputText.trim()
   const handleConfirm = (): void => {
-    if (trimmedNote === '') return
+    if (trimmedNote === '') {
+      setError(t('documentation_is_required') as string)
+      return
+    }
     if (trimmedNote.length < minReportLength) {
       setError(
-        '' + t('must_be_at_least_characters', { minLength: minReportLength })
+        t('must_be_at_least_characters', {
+          minLength: minReportLength,
+        }) as string
       )
       return
     }
@@ -74,7 +79,6 @@ export function DocumentationRequired({
           header={t('documentation_required')}
           buttonText={t('shared:confirm')}
           onClickButton={handleConfirm}
-          buttonIsDisabled={trimmedNote === ''}
           secondaryButtonProps={{
             buttonText: 'View actions',
             buttonType: 'tertiaryHighLight',

--- a/app/src/organisms/ODD/DocumentationRequired/__tests__/DocumentationRequired.test.tsx
+++ b/app/src/organisms/ODD/DocumentationRequired/__tests__/DocumentationRequired.test.tsx
@@ -48,21 +48,9 @@ describe('DocumentationRequired', () => {
     screen.getByRole('button', { name: 'Back to previous page' })
   })
 
-  it('keeps the confirm button disabled until a non-empty note is entered', () => {
+  it('keeps the confirm button enabled even when the note is empty', () => {
     render(props)
-    const confirm = screen.getByRole('button', { name: 'Confirm' })
-    expect(confirm).toBeDisabled()
-
-    editNote('starting QC run')
-
-    expect(confirm).toBeEnabled()
-  })
-
-  it('treats whitespace-only input as empty and keeps confirm disabled', () => {
-    render(props)
-    editNote('   \n\t  ')
-
-    expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeEnabled()
   })
 
   it('calls onConfirm with the trimmed note when confirm is clicked', () => {
@@ -73,10 +61,33 @@ describe('DocumentationRequired', () => {
     expect(props.onConfirm).toHaveBeenCalledWith('starting QC run')
   })
 
-  it('does not call onConfirm when the note is empty', () => {
+  it('shows a required error and does not confirm when the note is empty', () => {
     render(props)
     fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+
     expect(props.onConfirm).not.toHaveBeenCalled()
+    screen.getByText('Documentation is required')
+  })
+
+  it('treats whitespace-only input as empty and shows a required error', () => {
+    render(props)
+    editNote('   \n\t  ')
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+
+    expect(props.onConfirm).not.toHaveBeenCalled()
+    screen.getByText('Documentation is required')
+  })
+
+  it('clears the required error when the user edits the note', () => {
+    render(props)
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    screen.getByText('Documentation is required')
+
+    editNote('starting QC run')
+
+    expect(
+      screen.queryByText('Documentation is required')
+    ).not.toBeInTheDocument()
   })
 
   it('shows a min-length error and does not confirm when the note is too short', () => {

--- a/app/src/organisms/ODD/DocumentationRequired/__tests__/DocumentationRequired.test.tsx
+++ b/app/src/organisms/ODD/DocumentationRequired/__tests__/DocumentationRequired.test.tsx
@@ -42,7 +42,7 @@ describe('DocumentationRequired', () => {
 
   it('renders header, the per-user note label, and the confirm + back buttons', () => {
     render(props)
-    screen.getByText('Documentation required for robot action')
+    screen.getByText('Documentation required')
     screen.getByText('Note for robot audit log by alice')
     screen.getByRole('button', { name: 'Confirm' })
     screen.getByRole('button', { name: 'Back to previous page' })

--- a/app/src/organisms/ODD/DocumentationRequired/__tests__/DocumentationRequired.test.tsx
+++ b/app/src/organisms/ODD/DocumentationRequired/__tests__/DocumentationRequired.test.tsx
@@ -42,7 +42,7 @@ describe('DocumentationRequired', () => {
 
   it('renders header, the per-user note label, and the confirm + back buttons', () => {
     render(props)
-    screen.getByText('Documentation Required')
+    screen.getByText('Documentation required for robot action')
     screen.getByText('Note for robot audit log by alice')
     screen.getByRole('button', { name: 'Confirm' })
     screen.getByRole('button', { name: 'Back to previous page' })


### PR DESCRIPTION
Closes [RQA-5938](https://opentrons.atlassian.net/browse/RQA-5938) and [RQA-5937](https://opentrons.atlassian.net/browse/RQA-5937)

# Overview

Updates the "documentation required" modal behavior to match designs:

- We remove the disabled state from the confirm button in favor of showing an error state for the input field.
- We update the modal title copy.

### Current Behavior

<img width="1027" height="769" alt="Screenshot 2026-08-20 at 12 36 32 PM" src="https://github.com/user-attachments/assets/86117ca4-e7e0-4c46-bf47-c94b8323989f" />

### Fixed Behavior

<img width="1021" height="761" alt="Screenshot 2026-08-20 at 3 23 01 PM" src="https://github.com/user-attachments/assets/4c2f1974-556e-4e82-ad46-93a8c80f5a3a" />

## Test Plan and Hands on Testing

- See images.
- Verified that typing a character clears the error state, and typing less than the minimum number of characters displays the "Must be at least X characters long" state.

## Risk assessment

- very low, just simple logic, CSS, and copy changes for one touch point.


[RQA-5938]: https://opentrons.atlassian.net/browse/RQA-5938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-5937]: https://opentrons.atlassian.net/browse/RQA-5937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ