### PR TITLE
fix(app): change button on file browser to 'save'

### DIFF
--- a/app-shell/src/audit/__tests__/audit.test.ts
+++ b/app-shell/src/audit/__tests__/audit.test.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+import { dialog } from 'electron'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -35,6 +36,11 @@ vi.mock('../../http', () => ({
 vi.mock('../../usb', () => ({
   getSerialPortHttpAgent: vi.fn(),
 }))
+vi.mock('electron', () => ({
+  dialog: {
+    showOpenDialog: vi.fn(),
+  },
+}))
 
 const flush = (): Promise<void> =>
   new Promise(resolve => setTimeout(resolve, 0))
@@ -44,6 +50,16 @@ const downloadPayload = {
   fileName: 'logperiod.zip',
   hostname: '192.168.1.100',
   port: 31950,
+}
+
+const mockShowOpenDialogCanceled = {
+  canceled: true,
+  filePaths: [],
+}
+
+const mockShowOpenDialogSelected = {
+  canceled: false,
+  filePaths: ['/existing/audit-logs'],
 }
 
 describe('audit module dispatches', () => {
@@ -58,6 +74,9 @@ describe('audit module dispatches', () => {
       audit: { logDirectory: '/existing/audit-logs' },
     } as Config)
     vi.mocked(Dialogs.showOpenDirectoryDialog).mockResolvedValue([])
+    vi.mocked(dialog.showOpenDialog).mockResolvedValue(
+      mockShowOpenDialogCanceled
+    )
     vi.mocked(Http.fetchToFile).mockResolvedValue(
       path.join('/existing/audit-logs', 'logperiod.zip')
     )
@@ -117,9 +136,9 @@ describe('audit module dispatches', () => {
   })
 
   it('downloads the audit log and reports success with deletion key', async () => {
-    vi.mocked(Dialogs.showOpenDirectoryDialog).mockResolvedValue([
-      '/existing/audit-logs',
-    ])
+    vi.mocked(dialog.showOpenDialog).mockResolvedValue(
+      mockShowOpenDialogSelected
+    )
     vi.mocked(Http.fetchToFile).mockImplementation(
       async (_url, destination, options) => {
         options?.onResponse?.({
@@ -153,9 +172,9 @@ describe('audit module dispatches', () => {
   it('routes over the serial port agent for a USB host', async () => {
     const mockAgent = { usbAgent: true }
     vi.mocked(getSerialPortHttpAgent).mockReturnValue(mockAgent as any)
-    vi.mocked(Dialogs.showOpenDirectoryDialog).mockResolvedValue([
-      '/existing/audit-logs',
-    ])
+    vi.mocked(dialog.showOpenDialog).mockResolvedValue(
+      mockShowOpenDialogSelected
+    )
 
     handleAction(
       downloadAuditLog({ ...downloadPayload, hostname: OPENTRONS_USB })
@@ -170,9 +189,9 @@ describe('audit module dispatches', () => {
   })
 
   it('dispatches failure when the download response is missing a deletion key', async () => {
-    vi.mocked(Dialogs.showOpenDirectoryDialog).mockResolvedValue([
-      '/existing/audit-logs',
-    ])
+    vi.mocked(dialog.showOpenDialog).mockResolvedValue(
+      mockShowOpenDialogSelected
+    )
     vi.mocked(Http.fetchToFile).mockImplementation(
       async (_url, destination, options) => {
         options?.onResponse?.({
@@ -196,9 +215,9 @@ describe('audit module dispatches', () => {
   })
 
   it('dispatches failure when the download fails', async () => {
-    vi.mocked(Dialogs.showOpenDirectoryDialog).mockResolvedValue([
-      '/existing/audit-logs',
-    ])
+    vi.mocked(dialog.showOpenDialog).mockResolvedValue(
+      mockShowOpenDialogSelected
+    )
     vi.mocked(Http.fetchToFile).mockRejectedValue(new Error('network error'))
 
     handleAction(downloadAuditLog(downloadPayload))

--- a/app-shell/src/audit/index.ts
+++ b/app-shell/src/audit/index.ts
@@ -1,5 +1,6 @@
 import { mkdir, rmdir } from 'fs/promises'
 import path from 'path'
+import { dialog } from 'electron'
 
 import {
   logPeriodDownloadCanceled,
@@ -20,7 +21,11 @@ import { fetchToFile } from '../http'
 import { buildRobotHttpUrl } from '../robot-update/httpUrl'
 import { getSerialPortHttpAgent } from '../usb'
 
-import type { BrowserWindow } from 'electron'
+import type {
+  BrowserWindow,
+  OpenDialogOptions,
+  OpenDialogReturnValue,
+} from 'electron'
 import type {
   DownloadAuditLogPayload,
   DownloadAuditLogsPayload,
@@ -81,12 +86,20 @@ async function downloadAuditLog(
 
   if (!directory) {
     const defaultDirectory = config.audit.logDirectory
-    const dialogOptions = {
+    const dialogOptions: OpenDialogOptions = {
       defaultPath: defaultDirectory ?? '',
+      buttonLabel: 'Save',
       properties: ['openDirectory', 'createDirectory'],
     }
-    const filePaths = await showOpenDirectoryDialog(mainWindow, dialogOptions)
-    directory = filePaths[0]?.toString()
+
+    const filePaths = await dialog
+      .showOpenDialog(mainWindow, dialogOptions)
+      .then((result: OpenDialogReturnValue) => {
+        return result.canceled ? [] : result.filePaths
+      })
+
+    directory = filePaths[0]
+
     if (!directory) {
       dispatch(logPeriodDownloadCanceled({ logPeriodId }) as Action)
       return false
@@ -140,12 +153,19 @@ async function downloadAuditLogs(
 
   if (!directory) {
     const defaultDirectory = config.audit.logDirectory
-    const dialogOptions = {
+    const dialogOptions: OpenDialogOptions = {
       defaultPath: defaultDirectory ?? '',
+      buttonLabel: 'Save',
       properties: ['openDirectory', 'createDirectory'],
     }
-    const filePaths = await showOpenDirectoryDialog(mainWindow, dialogOptions)
-    directory = filePaths[0]?.toString()
+
+    const filePaths = await dialog
+      .showOpenDialog(mainWindow, dialogOptions)
+      .then((result: OpenDialogReturnValue) => {
+        return result.canceled ? [] : result.filePaths
+      })
+
+    directory = filePaths[0]
   }
 
   const folderName =


### PR DESCRIPTION
# Overview

Updates confirm button on file browser to 'Save'

Closes [RQA-5908](https://opentrons.atlassian.net/browse/RQA-5908)

## Test Plan and Hands on Testing

Download an audit log, the pop up in the file browser should say 'Save'. Worth checking on windows / linux probably. 

## Risk assessment

Low

[RQA-5908]: https://opentrons.atlassian.net/browse/RQA-5908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ