### PR TITLE
fix(odd): fix animation for robot encryption key modal

### DIFF
--- a/app/src/organisms/ODD/RobotSettingsDashboard/RobotEncryptionKey/RobotEncryptionKeyModal.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/RobotEncryptionKey/RobotEncryptionKeyModal.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useLayoutEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import NiceModal, { useModal } from '@ebay/nice-modal-react'
+import clsx from 'clsx'
 
 import { StyledText } from '@opentrons/components'
 import { useCACertPasswordQuery } from '@opentrons/react-api-client'
@@ -33,7 +34,7 @@ function RobotEncryptionKeyModalElement({
     modal.remove()
     clearClientData()
   }
-  const { password, valid_from_utc, valid_until_utc } = useCACertPasswordQuery({
+  const { data, isLoading } = useCACertPasswordQuery({
     refetchInterval: query =>
       !!query
         ? refetchTimeForPassword(
@@ -41,13 +42,16 @@ function RobotEncryptionKeyModalElement({
             new Date(query.data.valid_until_utc)
           )
         : BACKUP_REFETCH_TIME_MS,
-  }).data?.data ?? {
-    password: '',
+  })
+
+  const { password, valid_from_utc, valid_until_utc } = data?.data ?? {
+    password: null,
     valid_from_utc: new Date().toISOString(),
     valid_until_utc: new Date(
       Date.now() + BACKUP_REFETCH_TIME_MS
     ).toISOString(),
   }
+
   const header = {
     title: t('device_settings:robot_encryption_key'),
     onClick: close,
@@ -65,11 +69,15 @@ function RobotEncryptionKeyModalElement({
 
   const [lastPassword, setLastPassword] = useState<string | null>(null)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     return () => {
       setLastPassword(password)
     }
   }, [password])
+
+  if (isLoading || password == null) {
+    return <></>
+  }
 
   return (
     <OddModal
@@ -89,7 +97,7 @@ function RobotEncryptionKeyModalElement({
           </StyledText>
           <StyledText
             oddStyle="bodyTextRegular"
-            className={styles.password}
+            className={clsx({ [styles.password]: lastPassword != null })}
             key={password}
           >
             {password}

--- a/app/src/organisms/ODD/RobotSettingsDashboard/RobotEncryptionKey/robot_encryption_key_modal.module.css
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/RobotEncryptionKey/robot_encryption_key_modal.module.css
@@ -13,8 +13,8 @@
 }
 
 .password_container {
-  display: flex;
   position: relative;
+  display: flex;
   overflow: hidden;
   width: 100%;
   height: calc(var(--spacing-16) * 2 + 40px);

--- a/app/src/organisms/ODD/RobotSettingsDashboard/RobotEncryptionKey/robot_encryption_key_modal.module.css
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/RobotEncryptionKey/robot_encryption_key_modal.module.css
@@ -14,6 +14,7 @@
 
 .password_container {
   display: flex;
+  position: relative;
   overflow: hidden;
   width: 100%;
   height: calc(var(--spacing-16) * 2 + 40px);
@@ -26,11 +27,11 @@
 
 .last_password {
   position: absolute;
-  animation: fade-out 0.2s forwards ease-in;
+  animation: fade-out 0.2s ease-in forwards;
 }
 
 .password {
-  animation: fade-in 0.2s forwards ease-in;
+  animation: fade-in 0.2s 0.2s ease-out both;
 }
 
 @keyframes fade-out {


### PR DESCRIPTION
# Overview

https://github.com/user-attachments/assets/aa058f90-90e0-4c30-ab19-9784bfdd7079

Fixes the animation on the text in the robot encryption key modal. Prevents weird visuals while query is loading and stops initial password from animating in. Also adds slight delay to improve the feel.

## Test Plan and Hands on Testing

Trigger the robot encryption key modal on the ODD. It should pop up with a password already present, and that password should not animate in. 

## Risk assessment

Low