### PR TITLE
fix(app): dismiss run on desktop when signing run

### DIFF
--- a/app/src/local-resources/access-control/DocumentationRequiredModalContext.tsx
+++ b/app/src/local-resources/access-control/DocumentationRequiredModalContext.tsx
@@ -2,6 +2,7 @@ import { createContext } from 'react'
 
 import type {
   DocumentationReport,
+  DocumentationState,
   DocumentedAction,
 } from '@opentrons/react-api-client'
 
@@ -18,7 +19,7 @@ export interface DocumentationRequiredModalContextType {
   }: {
     robotName: string
   }) => Promise<{ username: string } | null>
-  showSignRunModal: () => Promise<boolean>
+  showSignRunModal: (documentationState: DocumentationState) => Promise<boolean>
   showDownloadLogsModal: (logPeriodId: string) => Promise<boolean>
 }
 

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/__tests__/ProtocolRunHeader.test.tsx
@@ -7,7 +7,6 @@ import { useModulesQuery } from '@opentrons/react-api-client'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
-import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { useIsRobotViewable } from '/app/redux-resources/robots'
 import { useRunGeneratedDataFiles } from '/app/resources/dataFiles/useRunGeneratedDataFiles'
 import {
@@ -52,9 +51,6 @@ vi.mock('../RunHeaderProtocolName')
 vi.mock('/app/resources/dataFiles/useRunGeneratedDataFiles')
 vi.mock('../hooks')
 vi.mock('/app/local-resources/images/hooks/useInitializeCameraState')
-vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
-  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
-}))
 
 const MOCK_PROTOCOL = 'MOCK_PROTOCOL'
 const MOCK_RUN_ID = 'MOCK_RUN_ID'

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/index.tsx
@@ -12,7 +12,6 @@ import {
 } from '@opentrons/components'
 import { useModulesQuery } from '@opentrons/react-api-client'
 
-import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useInitializeCameraState } from '/app/local-resources/images/hooks/useInitializeCameraState'
 import { isCancellableStatus } from '/app/local-resources/runs/utils'
 import { useIsRobotViewable } from '/app/redux-resources/robots'
@@ -72,9 +71,7 @@ export function ProtocolRunHeader(
     runId,
   })
 
-  const documentationState = useDocumentationState()
-  const { closeCurrentRun, isClosingCurrentRun } =
-    useCloseCurrentRun(documentationState)
+  const { closeCurrentRun, isClosingCurrentRun } = useCloseCurrentRun()
   const isDownloadAuditLogsInFlight = useRef(false)
 
   const {

--- a/app/src/organisms/Desktop/SignRunModal/SignRun.tsx
+++ b/app/src/organisms/Desktop/SignRunModal/SignRun.tsx
@@ -22,18 +22,22 @@ import { useCurrentRunId, useNotifyAllRunsQuery } from '/app/resources/runs'
 
 import styles from './signrunmodal.module.css'
 
+import type { DocumentationState } from '@opentrons/react-api-client'
+
 // Above typical desktop modal overlays so the toast remains visible on login.
 const TOAST_ABOVE_LOGIN_Z_INDEX = 10002
 
 export interface SignRunModalProps {
   runId: string
   robotName: string
+  documentationState: DocumentationState
   onSigned?: () => void
 }
 
 export function SignRunModal({
   runId,
   robotName,
+  documentationState,
   onSigned,
 }: SignRunModalProps): JSX.Element {
   const { t, i18n } = useTranslation(['access_control', 'shared'])
@@ -72,6 +76,7 @@ export function SignRunModal({
     showLoginModal,
     popToast,
     eatToast,
+    documentationState,
     onSigned
   )
 
@@ -178,40 +183,49 @@ export function SignRunModal({
   )
 }
 
-const SignRunModalImpl = NiceModal.create((): JSX.Element | null => {
-  const modal = useModal()
-  const robotName = useCurrentRobotName()
+const SignRunModalImpl = NiceModal.create(
+  ({
+    documentationState,
+  }: {
+    documentationState: DocumentationState
+  }): JSX.Element | null => {
+    const modal = useModal()
+    const robotName = useCurrentRobotName()
 
-  useEffect(() => {
+    useEffect(() => {
+      if (robotName == null) {
+        modal.resolve(false)
+        modal.remove()
+      }
+    }, [modal, robotName])
+
     if (robotName == null) {
-      modal.resolve(false)
-      modal.remove()
+      return null
     }
-  }, [modal, robotName])
 
-  if (robotName == null) {
-    return null
+    return (
+      <ApiHostProvider robotName={robotName}>
+        <SignRunModalCurrentRun
+          robotName={robotName}
+          onSigned={() => {
+            modal.resolve(true)
+            modal.remove()
+          }}
+          documentationState={documentationState}
+        />
+      </ApiHostProvider>
+    )
   }
-
-  return (
-    <ApiHostProvider robotName={robotName}>
-      <SignRunModalCurrentRun
-        robotName={robotName}
-        onSigned={() => {
-          modal.resolve(true)
-          modal.remove()
-        }}
-      />
-    </ApiHostProvider>
-  )
-})
+)
 
 function SignRunModalCurrentRun({
   robotName,
   onSigned,
+  documentationState,
 }: {
   robotName: string
   onSigned: () => void
+  documentationState: DocumentationState
 }): JSX.Element | null {
   const modal = useModal()
   const runId = useCurrentRunId()
@@ -229,10 +243,16 @@ function SignRunModalCurrentRun({
   }
 
   return (
-    <SignRunModal runId={runId} robotName={robotName} onSigned={onSigned} />
+    <SignRunModal
+      runId={runId}
+      robotName={robotName}
+      documentationState={documentationState}
+      onSigned={onSigned}
+    />
   )
 }
 
 /** Open the desktop sign-run modal and await whether the run was signed. */
-export const showSignRunModal = (): Promise<boolean> =>
-  NiceModal.show(SignRunModalImpl)
+export const showSignRunModal = (
+  documentationState: DocumentationState
+): Promise<boolean> => NiceModal.show(SignRunModalImpl, { documentationState })

--- a/app/src/organisms/LocationConflictModal/ChooseModuleToConfigureModal.tsx
+++ b/app/src/organisms/LocationConflictModal/ChooseModuleToConfigureModal.tsx
@@ -29,7 +29,6 @@ import {
 
 import { getTopPortalEl } from '/app/App/portal'
 import { SmallButton } from '/app/atoms/buttons'
-import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useModuleUSBPort } from '/app/local-resources/modules'
 import { ODDFixtureOption } from '/app/molecules/ODDFixtureOption'
 import { OddModal } from '/app/molecules/OddModal'
@@ -313,8 +312,7 @@ function NoUnconfiguredModules(props: NoUnconfiguredModulesProps): JSX.Element {
   } = props
   const { t } = useTranslation('protocol_setup')
   const navigate = useNavigate()
-  const documentationState = useDocumentationState()
-  const { closeCurrentRun } = useCloseCurrentRun(documentationState)
+  const { closeCurrentRun } = useCloseCurrentRun()
   const handleCancelRun = (): void => {
     closeCurrentRun()
   }

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/AnalysisFailedModal.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/AnalysisFailedModal.tsx
@@ -11,7 +11,6 @@ import {
 } from '@opentrons/components'
 
 import { SmallButton } from '/app/atoms/buttons'
-import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { OddModal } from '/app/molecules/OddModal'
 import { useCloseCurrentRun } from '/app/resources/runs'
 
@@ -38,9 +37,7 @@ export function AnalysisFailedModal({
     hasExitIcon: true,
   }
 
-  const documentationState = useDocumentationState()
-  const { closeCurrentRun, isClosingCurrentRun } =
-    useCloseCurrentRun(documentationState)
+  const { closeCurrentRun, isClosingCurrentRun } = useCloseCurrentRun()
 
   const handleRestartSetup = (): void => {
     closeCurrentRun({

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/__tests__/AnalysisFailedModal.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/__tests__/AnalysisFailedModal.test.tsx
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
-import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { useCloseCurrentRun } from '/app/resources/runs'
 
 import { AnalysisFailedModal } from '../AnalysisFailedModal'
@@ -18,9 +17,6 @@ const mockNavigate = vi.fn()
 const mockCloseCurrentRun = vi.fn()
 
 vi.mock('/app/resources/runs')
-vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
-  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
-}))
 vi.mock('react-router-dom', async importOriginal => {
   const reactRouterDom = await importOriginal<NavigateFunction>()
   return {

--- a/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/__tests__/ConfirmCancelRunModal.test.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/__tests__/ConfirmCancelRunModal.test.tsx
@@ -3,11 +3,7 @@ import { fireEvent, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { when } from 'vitest-when'
 
-import { RUN_STATUS_IDLE, RUN_STATUS_STOPPED } from '@opentrons/api-client'
-import {
-  useDeleteRunMutation,
-  useStopRunMutation,
-} from '@opentrons/react-api-client'
+import { useStopRunMutation } from '@opentrons/react-api-client'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
@@ -15,36 +11,22 @@ import { useTrackProtocolRunEvent } from '/app/redux-resources/analytics'
 import { useTrackEvent } from '/app/redux/analytics'
 import { getLocalRobot } from '/app/redux/discovery'
 import { mockConnectedRobot } from '/app/redux/discovery/__fixtures__'
-import { useCloseCurrentRun, useNotifyRunQuery } from '/app/resources/runs'
 
 import { CancelingRunModal } from '../../CancelingRunModal'
 import { ConfirmCancelRunModal } from '../../ConfirmCancelRunModal'
 
 import type { ComponentProps } from 'react'
-import type { NavigateFunction } from 'react-router-dom'
 
 vi.mock('@opentrons/react-api-client')
-vi.mock('/app/resources/runs')
 vi.mock('/app/redux-resources/analytics')
 vi.mock('/app/redux/analytics')
 vi.mock('../../CancelingRunModal')
 vi.mock('/app/redux/discovery')
-const mockNavigate = vi.fn()
 const mockStopRun = vi.fn()
-const mockDeleteRun = vi.fn()
-const mockCloseCurrentRun = vi.fn()
 const mockTrackEvent = vi.fn()
 const mockTrackProtocolRunEvent = vi.fn(
   () => new Promise(resolve => resolve({}))
 )
-
-vi.mock('react-router-dom', async importOriginal => {
-  const actual = await importOriginal<NavigateFunction>()
-  return {
-    ...actual,
-    useNavigate: () => mockNavigate,
-  }
-})
 
 const render = (props: ComponentProps<typeof ConfirmCancelRunModal>) => {
   return renderWithProviders(
@@ -66,10 +48,7 @@ describe('ConfirmCancelRunModal', () => {
   let props: ComponentProps<typeof ConfirmCancelRunModal>
 
   beforeEach(() => {
-    mockNavigate.mockClear()
     mockStopRun.mockClear()
-    mockDeleteRun.mockClear()
-    mockCloseCurrentRun.mockClear()
     mockTrackEvent.mockClear()
     mockTrackProtocolRunEvent.mockClear()
     mockFn.mockClear()
@@ -83,16 +62,6 @@ describe('ConfirmCancelRunModal', () => {
     vi.mocked(useStopRunMutation).mockReturnValue({
       stopRun: mockStopRun,
     } as any)
-    vi.mocked(useDeleteRunMutation).mockReturnValue({
-      deleteRun: mockDeleteRun,
-    } as any)
-    vi.mocked(useCloseCurrentRun).mockReturnValue({
-      closeCurrentRun: mockCloseCurrentRun,
-      isClosingCurrentRun: false,
-    })
-    mockCloseCurrentRun.mockImplementation((options?: any) => {
-      options?.onSuccess?.()
-    })
     vi.mocked(useTrackEvent).mockReturnValue(mockTrackEvent)
     when(useTrackProtocolRunEvent).calledWith(RUN_ID, ROBOT_NAME).thenReturn({
       trackProtocolRunEvent: mockTrackProtocolRunEvent,
@@ -105,14 +74,6 @@ describe('ConfirmCancelRunModal', () => {
       ...mockConnectedRobot,
       name: ROBOT_NAME,
     })
-
-    vi.mocked(useNotifyRunQuery).mockReturnValue({
-      data: {
-        data: {
-          status: RUN_STATUS_IDLE,
-        },
-      },
-    } as any)
   })
 
   it('should render correct text and buttons', () => {
@@ -125,15 +86,6 @@ describe('ConfirmCancelRunModal', () => {
     expect(screen.getAllByRole('button').length).toBe(2)
     screen.getByText('Go back')
     screen.getByText('Cancel run')
-  })
-
-  it('should render the canceling run modal when run is closing', () => {
-    vi.mocked(useCloseCurrentRun).mockReturnValue({
-      closeCurrentRun: mockCloseCurrentRun,
-      isClosingCurrentRun: true,
-    })
-    render(props)
-    screen.getByText('mock CancelingRunModal')
   })
 
   it('when tapping go back, the mock function is called', () => {
@@ -150,6 +102,13 @@ describe('ConfirmCancelRunModal', () => {
     expect(mockStopRun).toHaveBeenCalled()
   })
 
+  it('when tapping cancel run, should show the canceling run modal', () => {
+    render(props)
+    const button = screen.getByText('Cancel run')
+    fireEvent.click(button)
+    screen.getByText('mock CancelingRunModal')
+  })
+
   it('when tapping cancel run with error, should remain in canceling state', () => {
     mockStopRun.mockImplementation((_id: string, options: any) => {
       options.onError()
@@ -162,7 +121,22 @@ describe('ConfirmCancelRunModal', () => {
     screen.getByText('mock CancelingRunModal')
   })
 
-  it('when stop run succeeds and run is not active, run is closed and navigates to /protocols', () => {
+  it('when stop run succeeds, tracks cancel and does not navigate', () => {
+    mockStopRun.mockImplementation((_id: string, options: any) => {
+      options.onSuccess()
+    })
+
+    render(props)
+    const button = screen.getByText('Cancel run')
+    fireEvent.click(button)
+
+    expect(mockTrackProtocolRunEvent).toHaveBeenCalledWith({
+      name: 'runCancel',
+    })
+    screen.getByText('mock CancelingRunModal')
+  })
+
+  it('when stop run succeeds and run is not active, still only stops', () => {
     props = {
       ...props,
       isActiveRun: false,
@@ -179,130 +153,7 @@ describe('ConfirmCancelRunModal', () => {
     expect(mockTrackProtocolRunEvent).toHaveBeenCalledWith({
       name: 'runCancel',
     })
-    expect(mockCloseCurrentRun).toHaveBeenCalledWith(
-      expect.objectContaining({
-        onSuccess: expect.any(Function),
-        onError: expect.any(Function),
-      })
-    )
-    expect(mockNavigate).toHaveBeenCalledWith('/protocols')
-  })
-
-  it('when stop run succeeds with protocolId, navigates to protocol-specific page', () => {
-    props = {
-      ...props,
-      isActiveRun: false,
-      protocolId: 'test-protocol-id',
-    }
-
-    mockStopRun.mockImplementation((_id: string, options: any) => {
-      options.onSuccess()
-    })
-
-    render(props)
-    const button = screen.getByText('Cancel run')
-    fireEvent.click(button)
-
-    expect(mockCloseCurrentRun).toHaveBeenCalledWith(
-      expect.objectContaining({
-        onSuccess: expect.any(Function),
-        onError: expect.any(Function),
-      })
-    )
-    expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
-    expect(mockNavigate).toHaveBeenCalledWith('/protocols/test-protocol-id')
-  })
-
-  it('when run is active, stop run does not close or navigate', () => {
-    mockStopRun.mockImplementation((_id: string, options: any) => {
-      options.onSuccess()
-    })
-
-    render(props)
-    const button = screen.getByText('Cancel run')
-    fireEvent.click(button)
-
-    expect(mockCloseCurrentRun).not.toHaveBeenCalled()
-    expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
-    expect(mockNavigate).not.toHaveBeenCalled()
-  })
-
-  it('when stop run errors and run is not active, still closes and navigates', () => {
-    props = {
-      ...props,
-      isActiveRun: false,
-    }
-
-    mockStopRun.mockImplementation((_id: string, options: any) => {
-      options.onError()
-    })
-
-    render(props)
-    const button = screen.getByText('Cancel run')
-    fireEvent.click(button)
-
-    expect(mockCloseCurrentRun).toHaveBeenCalledWith(
-      expect.objectContaining({
-        onSuccess: expect.any(Function),
-        onError: expect.any(Function),
-      })
-    )
-    expect(mockNavigate).toHaveBeenCalledWith('/protocols')
-    expect(mockTrackProtocolRunEvent).not.toHaveBeenCalled()
-  })
-
-  it('when run status becomes stopped via polling, run is closed and navigates to /protocols', () => {
-    props = {
-      ...props,
-      isActiveRun: false,
-    }
-
-    vi.mocked(useNotifyRunQuery).mockReturnValue({
-      data: {
-        data: {
-          status: RUN_STATUS_STOPPED,
-        },
-      },
-    } as any)
-
-    render(props)
-
-    expect(mockCloseCurrentRun).toHaveBeenCalled()
-    expect(mockNavigate).toHaveBeenCalledWith('/protocols')
-  })
-
-  it('when run status becomes stopped via polling with protocolId, navigates to protocol-specific page', () => {
-    props = {
-      ...props,
-      isActiveRun: false,
-      protocolId: 'test-protocol-id',
-    }
-
-    vi.mocked(useNotifyRunQuery).mockReturnValue({
-      data: {
-        data: {
-          status: RUN_STATUS_STOPPED,
-        },
-      },
-    } as any)
-
-    render(props)
-
-    expect(mockCloseCurrentRun).toHaveBeenCalled()
-    expect(mockNavigate).toHaveBeenCalledWith('/protocols/test-protocol-id')
-  })
-
-  it('when run status becomes stopped via polling and run is active, run is not closed', () => {
-    vi.mocked(useNotifyRunQuery).mockReturnValue({
-      data: {
-        data: {
-          status: RUN_STATUS_STOPPED,
-        },
-      },
-    } as any)
-
-    render(props)
-
-    expect(mockCloseCurrentRun).not.toHaveBeenCalled()
+    expect(mockStopRun).toHaveBeenCalledWith(RUN_ID, expect.any(Object))
+    screen.getByText('mock CancelingRunModal')
   })
 })

--- a/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
@@ -1,9 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
-import { useNavigate } from 'react-router-dom'
 
-import { RUN_STATUS_STOPPED } from '@opentrons/api-client'
 import { COLORS, LegacyStyledText } from '@opentrons/components'
 import {
   isDocumentedMutationError,
@@ -11,55 +9,36 @@ import {
 } from '@opentrons/react-api-client'
 
 import { SmallButton } from '/app/atoms/buttons'
-import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { OddModal } from '/app/molecules/OddModal'
 import { useTrackProtocolRunEvent } from '/app/redux-resources/analytics'
 import { ANALYTICS_PROTOCOL_RUN_ACTION } from '/app/redux/analytics'
 import { getLocalRobot } from '/app/redux/discovery'
-import { useCloseCurrentRun, useNotifyRunQuery } from '/app/resources/runs'
 
 import { CancelingRunModal } from '../CancelingRunModal'
 import styles from './confirmcancelmodal.module.css'
 
-import type { DocumentedAction } from '@opentrons/react-api-client'
 import type { OddModalHeaderBaseProps } from '/app/molecules/OddModal/types'
 
 interface ConfirmCancelRunModalProps {
   runId: string
   setShowConfirmCancelRunModal: (showConfirmCancelRunModal: boolean) => void
   isActiveRun: boolean
-  protocolId?: string | null
 }
-
-const ACTIVE_RUN_CANCEL_ACTIONS: DocumentedAction[] = ['stop_run']
-const INACTIVE_RUN_CANCEL_ACTIONS: DocumentedAction[] = [
-  'stop_run',
-  'dismiss_run',
-]
 
 export function ConfirmCancelRunModal({
   runId,
   setShowConfirmCancelRunModal,
   isActiveRun,
-  protocolId,
 }: ConfirmCancelRunModalProps): JSX.Element {
   const { t } = useTranslation(['run_details', 'shared'])
   const localRobot = useSelector(getLocalRobot)
-  const { data, isError: isRunFetchError } = useNotifyRunQuery(runId)
-  const { status: runStatus, current: isRunCurrent } = data?.data ?? {}
   const robotName = localRobot?.name ?? ''
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
-  const navigate = useNavigate()
   const [isCanceling, setIsCanceling] = useState(false)
-  const dismissStartedRef = useRef(false)
 
-  const { documentationState, clearDocreport } = useLinkedDocumentationState(
-    isActiveRun ? ACTIVE_RUN_CANCEL_ACTIONS : INACTIVE_RUN_CANCEL_ACTIONS,
-    runId
-  )
+  const documentationState = useDocumentationState()
   const { stopRun } = useStopRunMutation(documentationState)
-  const { closeCurrentRun, isClosingCurrentRun } =
-    useCloseCurrentRun(documentationState)
 
   const modalHeader: OddModalHeaderBaseProps = {
     title: t('cancel_run_modal_heading'),
@@ -68,65 +47,21 @@ export function ConfirmCancelRunModal({
     iconColor: COLORS.yellow50,
   }
 
-  const navigateAway = useCallback((): void => {
-    if (protocolId != null) {
-      navigate(`/protocols/${protocolId}`)
-    } else {
-      navigate('/protocols')
-    }
-  }, [protocolId, navigate])
-
-  const dismissAndNavigate = useCallback((): void => {
-    if (isActiveRun || dismissStartedRef.current) {
-      return
-    }
-    dismissStartedRef.current = true
-    setIsCanceling(true)
-    closeCurrentRun({
-      onSuccess: () => {
-        navigateAway()
-      },
-      onError: (error: unknown) => {
-        clearDocreport()
-        dismissStartedRef.current = false
-        if (isDocumentedMutationError(error)) {
-          setIsCanceling(false)
-        } else {
-          navigateAway()
-        }
-      },
-    })
-  }, [isActiveRun, closeCurrentRun, navigateAway, clearDocreport])
-
   const handleCancelRun = (): void => {
     setIsCanceling(true)
     stopRun(runId, {
       onSuccess: () => {
         trackProtocolRunEvent({ name: ANALYTICS_PROTOCOL_RUN_ACTION.CANCEL })
-        dismissAndNavigate()
       },
       onError: (error: unknown) => {
-        clearDocreport()
         if (isDocumentedMutationError(error)) {
           setIsCanceling(false)
-        } else {
-          dismissAndNavigate()
         }
       },
     })
   }
 
-  useEffect(() => {
-    if (
-      runStatus === RUN_STATUS_STOPPED ||
-      isRunFetchError ||
-      isRunCurrent === false
-    ) {
-      dismissAndNavigate()
-    }
-  }, [runStatus, isRunCurrent, isRunFetchError, dismissAndNavigate])
-
-  return isCanceling || isClosingCurrentRun ? (
+  return isCanceling ? (
     <CancelingRunModal />
   ) : (
     <OddModal

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -749,7 +749,6 @@ function PrepareToRun({
           runId={runId}
           setShowConfirmCancelRunModal={setShowConfirmCancelModal}
           isActiveRun={false}
-          protocolId={protocolId}
         />
       ) : null}
     </>

--- a/app/src/pages/ODD/RunSummary/SignRun.tsx
+++ b/app/src/pages/ODD/RunSummary/SignRun.tsx
@@ -23,15 +23,18 @@ import { useCurrentRunId, useNotifyAllRunsQuery } from '/app/resources/runs'
 import styles from './signrun.module.css'
 
 import type { KeyboardReactInterface } from 'react-simple-keyboard'
+import type { DocumentationState } from '@opentrons/react-api-client'
 
 // Above OnDeviceLogin overlay (z-index: 10001) so the toast is visible on login.
 const TOAST_ABOVE_LOGIN_Z_INDEX = 10002
 
 export function SignRun({
   runId,
+  documentationState,
   onSigned,
 }: {
   runId: string
+  documentationState: DocumentationState
   onSigned?: () => void
 }): JSX.Element {
   const { t, i18n } = useTranslation(['access_control', 'shared'])
@@ -74,6 +77,7 @@ export function SignRun({
       async () => await showLoginModal(),
       popToast,
       eatToast,
+      documentationState,
       onSigned
     )
 
@@ -184,34 +188,41 @@ export function SignRun({
   )
 }
 
-const SignRunModalImpl = NiceModal.create((): JSX.Element | null => {
-  const modal = useModal()
-  const runId = useCurrentRunId()
-  const { isFetched } = useNotifyAllRunsQuery({ pageLength: 0 })
+const SignRunModalImpl = NiceModal.create(
+  ({
+    documentationState,
+  }: {
+    documentationState: DocumentationState
+  }): JSX.Element | null => {
+    const modal = useModal()
+    const runId = useCurrentRunId()
+    const { isFetched } = useNotifyAllRunsQuery({ pageLength: 0 })
 
-  useEffect(() => {
-    if (isFetched && runId == null) {
-      modal.resolve(false)
-      modal.remove()
+    useEffect(() => {
+      if (isFetched && runId == null) {
+        modal.resolve(false)
+        modal.remove()
+      }
+    }, [isFetched, modal, runId])
+
+    if (runId == null) {
+      return null
     }
-  }, [isFetched, modal, runId])
 
-  if (runId == null) {
-    return null
+    return (
+      <div className={styles.overlay}>
+        <SignRun
+          runId={runId}
+          documentationState={documentationState}
+          onSigned={() => {
+            modal.resolve(true)
+            modal.remove()
+          }}
+        />
+      </div>
+    )
   }
-
-  return (
-    <div className={styles.overlay}>
-      <SignRun
-        runId={runId}
-        onSigned={() => {
-          modal.resolve(true)
-          modal.remove()
-        }}
-      />
-    </div>
-  )
-})
+)
 
 /** Open the ODD sign-run modal and await whether the run was signed. */
 export const showSignRunModal = (): Promise<boolean> =>

--- a/app/src/pages/ODD/RunSummary/index.tsx
+++ b/app/src/pages/ODD/RunSummary/index.tsx
@@ -157,7 +157,7 @@ export function RunSummary(): JSX.Element {
   const { trackEventWithRobotSerial } = useTrackEventWithRobotSerial()
 
   const documentationState = useDocumentationState()
-  const { closeCurrentRun } = useCloseCurrentRun(documentationState)
+  const { closeCurrentRun } = useCloseCurrentRun()
   // Close the current run only if it's active and then execute the onSuccess callback. Prefer this wrapper over
   // closeCurrentRun directly, since the callback is swallowed if currentRun is null.
   const closeCurrentRunIfValid = (onSettled?: () => void): void => {
@@ -425,7 +425,7 @@ export function RunSummary(): JSX.Element {
   )
 
   if (shouldPromptSignRun && !showSplash) {
-    return <SignRun runId={runId} />
+    return <SignRun runId={runId} documentationState={documentationState} />
   }
 
   if (shouldPromptDownloadLog && !showSplash) {

--- a/app/src/resources/access-control/useSignRunFlow.ts
+++ b/app/src/resources/access-control/useSignRunFlow.ts
@@ -10,10 +10,11 @@ import {
   useSignRunMutation,
 } from '@opentrons/react-api-client'
 
-import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useLogout } from '/app/redux/robot-auth'
 
 import { useNotifyRunQuery } from '../runs'
+
+import type { DocumentationState } from '@opentrons/react-api-client'
 
 // login gate states to control login prompting
 // idle: need to prompt for login
@@ -39,12 +40,12 @@ export function useSignRunFlow(
   }) => Promise<{ username: string } | null>,
   popToast: () => void,
   eatToast: () => void,
+  documentationState: DocumentationState,
   onSigned?: () => void
 ): SignRunFlowResult {
   const queryClient = useQueryClient()
   const host = useHost()
   const logout = useLogout()
-  const documentationState = useDocumentationState()
   const { signRun: signRunMutation, isLoading: isSignRunLoading } =
     useSignRunMutation(documentationState)
 

--- a/app/src/resources/runs/useCloseCurrentRun.ts
+++ b/app/src/resources/runs/useCloseCurrentRun.ts
@@ -1,9 +1,17 @@
-import { useCallback, useContext, useEffect, useRef, useState } from 'react'
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { useSelector } from 'react-redux'
 
 import { useDismissCurrentRunMutation } from '@opentrons/react-api-client'
 
 import { DocumentationRequiredModalContext } from '/app/local-resources/access-control/DocumentationRequiredModalContext'
+import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
 import { getIsOnDevice } from '/app/redux/config'
 import { useCurrentRunId } from '/app/resources/runs'
 
@@ -11,7 +19,7 @@ import { useIsSigningRequired } from './useIsSigningRequired'
 
 import type { AxiosError } from 'axios'
 import type { Run } from '@opentrons/api-client'
-import type { DocumentationState } from '@opentrons/react-api-client'
+import type { DocumentedAction } from '@opentrons/react-api-client'
 
 type CloseCallback = (options?: CloseOptions) => void
 
@@ -21,12 +29,28 @@ interface CloseOptions {
   onSettled?: () => void
 }
 
-export function useCloseCurrentRun(documentationState: DocumentationState): {
+export function useCloseCurrentRun(): {
   closeCurrentRun: CloseCallback
   isClosingCurrentRun: boolean
 } {
   const currentRunId = useCurrentRunId()
   const isOnDevice = useSelector(getIsOnDevice)
+
+  const {
+    isSigningRequired,
+    isLoading: isSigningRequiredLoading,
+    isDownloadingRequired,
+    logPeriodId,
+  } = useIsSigningRequired()
+
+  const actionsToDocument: DocumentedAction[] = useMemo(
+    () => (isSigningRequired ? ['sign_run', 'dismiss_run'] : ['dismiss_run']),
+    [isSigningRequired]
+  )
+  const { documentationState } = useLinkedDocumentationState(
+    actionsToDocument,
+    currentRunId
+  )
 
   const { dismissCurrentRun, isLoading: isDismissing } =
     useDismissCurrentRunMutation(documentationState)
@@ -37,13 +61,6 @@ export function useCloseCurrentRun(documentationState: DocumentationState): {
 
   const isDismissInFlight = useRef(false)
   const lastDismissedRunId = useRef<string | null>(null)
-
-  const {
-    isSigningRequired,
-    isLoading: isSigningRequiredLoading,
-    isDownloadingRequired,
-    logPeriodId,
-  } = useIsSigningRequired()
 
   const [isClosePending, setIsClosePending] = useState(false)
   const isSignRunPending = useRef(false)
@@ -69,14 +86,14 @@ export function useCloseCurrentRun(documentationState: DocumentationState): {
     }
   }
 
-  const handleDismiss = useCallback(() => {
+  const handleDismiss = useCallback(async () => {
     isDismissInFlight.current = true
     const callerOptions = closeOptions.current ?? {}
 
     if (currentRunId != null) {
       // on the ODD, if downloading is required, runs can now only be dismissed on the Desktop app.
       if (isOnDevice && isDownloadingRequired && logPeriodId != null) {
-        void showDownloadLogsModal(logPeriodId)
+        await showDownloadLogsModal(logPeriodId)
           .then(downloaded => {
             if (!downloaded) {
               console.warn('failed to download logs')
@@ -138,7 +155,7 @@ export function useCloseCurrentRun(documentationState: DocumentationState): {
         return
       }
       isSignRunPending.current = true
-      void showSignRunModal().then(signed => {
+      void showSignRunModal(documentationState).then(signed => {
         if (!signed) {
           resetClosePending()
           throw new Error(
@@ -151,6 +168,7 @@ export function useCloseCurrentRun(documentationState: DocumentationState): {
     }
     handleDismiss()
   }, [
+    documentationState,
     handleDismiss,
     isClosePending,
     isSigningRequired,

--- a/app/src/resources/runs/useRestartRun.ts
+++ b/app/src/resources/runs/useRestartRun.ts
@@ -2,14 +2,10 @@ import { useCloneRun } from './useCloneRun'
 import { useCloseCurrentRun } from './useCloseCurrentRun'
 import { useMostRecentRunId } from './useMostRecentRunId'
 
-import type { DocumentationState } from '@opentrons/react-api-client'
-
-export function useRestartRun(
-  documentationState: DocumentationState
-): () => void {
+export function useRestartRun(): () => void {
   const mostRecentRunId = useMostRecentRunId()
   const { cloneRun } = useCloneRun(mostRecentRunId!)
-  const { closeCurrentRun } = useCloseCurrentRun(documentationState)
+  const { closeCurrentRun } = useCloseCurrentRun()
 
   return () => {
     if (mostRecentRunId != null) {


### PR DESCRIPTION
# Overview

<img width="1023" height="766" alt="Screenshot 2026-08-20 at 4 39 12 PM" src="https://github.com/user-attachments/assets/5fb11004-9c53-4846-a252-030696e3d6f2" />

Signing a run on desktop now also dismisses the run, without requiring a second documentation modal popup. Also changes ODD behavior to navigate to run summary after canceling on the ODD in order to align behavior when you cancel on the desktop with when you cancel on the ODD.

## Test Plan and Hands on Testing

On a CRS bot with signing runs required:
1. Start a run
2. Finish the run, by canceling or completing the run.
3. Sign the run on the desktop app.
4. A documentation modal should pop up - it should list 'signing run' and 'dismissing run'
5. Submitting this should dismiss the run.

## Changelog

Canceling a run on the ODD now navigates you to the run summary page, to align behavior with when you cancel a run from the desktop app.

## Risk assessment

This code is so goddamn weird. Medium.