### PR TITLE
refactor(app): Update "Personal account settings" to match designs

### DIFF
--- a/app/src/molecules/PasswordVisibilityToggle/index.tsx
+++ b/app/src/molecules/PasswordVisibilityToggle/index.tsx
@@ -12,7 +12,7 @@ interface PasswordVisibilityToggleProps {
 }
 
 /**
- * On-device display "Show / Hide" button rendered next to a password input.
+ * "Show / Hide" button rendered next to a password input.
  */
 export function PasswordVisibilityToggle({
   isVisible,
@@ -30,8 +30,11 @@ export function PasswordVisibilityToggle({
       onClick={onToggle}
       className={styles.toggle_button}
     >
-      <Icon name={isVisible ? 'eye-slash' : 'eye'} size="3rem" />
-      <StyledText oddStyle="bodyTextSemiBold">
+      <Icon name={isVisible ? 'eye-slash' : 'eye'} className={styles.icon} />
+      <StyledText
+        oddStyle="bodyTextSemiBold"
+        desktopStyle="bodyDefaultSemiBold"
+      >
         {isVisible ? t('hide') : t('show')}
       </StyledText>
     </button>

--- a/app/src/molecules/PasswordVisibilityToggle/passwordvisibilitytoggle.module.css
+++ b/app/src/molecules/PasswordVisibilityToggle/passwordvisibilitytoggle.module.css
@@ -1,9 +1,33 @@
 .toggle_button {
   display: flex;
-  width: 7.375rem;
-  height: 2.75rem;
   flex-direction: row;
+  flex-shrink: 0;
   align-items: center;
+  padding: 0;
+  border: none;
   background-color: transparent;
-  gap: var(--spacing-12);
+  color: var(--black-90);
+  cursor: pointer;
+  gap: var(--spacing-4);
+  white-space: nowrap;
+}
+
+.icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
+}
+
+@media (height = 600px) and (width = 1024px) {
+  .toggle_button {
+    width: 7.375rem;
+    height: 2.75rem;
+    cursor: default;
+    gap: var(--spacing-12);
+  }
+
+  .icon {
+    width: 3rem;
+    height: 3rem;
+  }
 }

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/PasswordInputField.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/PasswordInputField.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useLayoutEffect, useRef, useState } from 'react'
 
 import { InputField } from '@opentrons/components'
 
@@ -16,6 +16,11 @@ export interface PasswordInputFieldProps {
   onBlur?: (event: FocusEvent<HTMLInputElement>) => void
 }
 
+interface InputSelection {
+  start: number
+  end: number
+}
+
 export function PasswordInputField({
   value,
   placeholder,
@@ -24,11 +29,46 @@ export function PasswordInputField({
   onBlur,
 }: PasswordInputFieldProps): JSX.Element {
   const [showPassword, setShowPassword] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const selectionRef = useRef<InputSelection | null>(null)
+
+  useLayoutEffect(() => {
+    const input = inputRef.current
+    const selection = selectionRef.current
+    if (input == null || selection == null) {
+      return
+    }
+
+    // Chrome resets the caret to the start when input type changes.
+    // Restore immediately, then again on the next frame in case Chrome
+    // overwrites the selection after the type attribute update.
+    const restoreSelection = (): void => {
+      input.setSelectionRange(selection.start, selection.end)
+    }
+    restoreSelection()
+    const frameId = requestAnimationFrame(restoreSelection)
+
+    return () => {
+      cancelAnimationFrame(frameId)
+    }
+  }, [showPassword])
+
+  const handleToggle = (): void => {
+    const input = inputRef.current
+    if (input != null) {
+      selectionRef.current = {
+        start: input.selectionStart ?? input.value.length,
+        end: input.selectionEnd ?? input.value.length,
+      }
+    }
+    setShowPassword(current => !current)
+  }
 
   return (
     <div className={styles.password_field_row}>
       <div className={styles.password_field_input}>
         <InputField
+          ref={inputRef}
           type={showPassword ? 'text' : 'password'}
           value={value}
           placeholder={placeholder}
@@ -39,9 +79,7 @@ export function PasswordInputField({
       </div>
       <PasswordVisibilityToggle
         isVisible={showPassword}
-        onToggle={() => {
-          setShowPassword(current => !current)
-        }}
+        onToggle={handleToggle}
       />
     </div>
   )

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/PasswordInputField.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/PasswordInputField.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
-import { useTranslation } from 'react-i18next'
 
-import { Icon, InputField } from '@opentrons/components'
+import { InputField } from '@opentrons/components'
+
+import { PasswordVisibilityToggle } from '/app/molecules/PasswordVisibilityToggle'
 
 import styles from './passwordinputfield.module.css'
 
@@ -22,34 +23,26 @@ export function PasswordInputField({
   onChange,
   onBlur,
 }: PasswordInputFieldProps): JSX.Element {
-  const { t } = useTranslation('device_settings')
   const [showPassword, setShowPassword] = useState(false)
 
   return (
-    <InputField
-      type={showPassword ? 'text' : 'password'}
-      value={value}
-      placeholder={placeholder}
-      error={error}
-      onChange={onChange}
-      onBlur={onBlur}
-      rightElement={
-        <button
-          type="button"
-          className={styles.password_visibility_button}
-          aria-label={t('toggle_password_visibility')}
-          onMouseDown={e => {
-            // This prevents focus from moving from the password field to this toggle button,
-            // but lets the click event go through.
-            e.preventDefault()
-          }}
-          onClick={() => {
-            setShowPassword(current => !current)
-          }}
-        >
-          <Icon name={showPassword ? 'eye-slash' : 'eye'} size="1.25rem" />
-        </button>
-      }
-    />
+    <div className={styles.password_field_row}>
+      <div className={styles.password_field_input}>
+        <InputField
+          type={showPassword ? 'text' : 'password'}
+          value={value}
+          placeholder={placeholder}
+          error={error}
+          onChange={onChange}
+          onBlur={onBlur}
+        />
+      </div>
+      <PasswordVisibilityToggle
+        isVisible={showPassword}
+        onToggle={() => {
+          setShowPassword(current => !current)
+        }}
+      />
+    </div>
   )
 }

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/PersonalAccountSettings.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/PersonalAccountSettings.tsx
@@ -65,7 +65,7 @@ function LoggedOutMessage(): JSX.Element {
 export function PersonalAccountSettings({
   robotName,
 }: PersonalAccountSettingsProps): JSX.Element {
-  const { t } = useTranslation(['device_settings', 'shared']) as {
+  const { t } = useTranslation('device_settings') as {
     t: TFunction
   }
   const dispatch = useDispatch()
@@ -103,11 +103,7 @@ export function PersonalAccountSettings({
             <StyledText desktopStyle="bodyLargeSemiBold">
               {t('desktop_personal_account_settings') as string}
             </StyledText>
-            {isEditing ? (
-              <BasicButton type="button" underLine onClick={handleCancelEdit}>
-                {t('shared:cancel')}
-              </BasicButton>
-            ) : (
+            {!isEditing && (
               <BasicButton
                 type="button"
                 underLine

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/__tests__/PasswordInputField.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/__tests__/PasswordInputField.test.tsx
@@ -70,7 +70,7 @@ describe('PasswordInputField', () => {
   it('preserves caret position when toggling password visibility', async () => {
     const user = userEvent.setup()
     render({ ...props, value: 'secret' })
-    const input = screen.getByDisplayValue('secret')
+    const input = screen.getByDisplayValue<HTMLInputElement>('secret')
     input.focus()
     input.setSelectionRange(3, 3)
     expect(input.selectionStart).toBe(3)

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/__tests__/PasswordInputField.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/__tests__/PasswordInputField.test.tsx
@@ -67,6 +67,22 @@ describe('PasswordInputField', () => {
     expect(input).toHaveAttribute('type', 'text')
   })
 
+  it('preserves caret position when toggling password visibility', async () => {
+    const user = userEvent.setup()
+    render({ ...props, value: 'secret' })
+    const input = screen.getByDisplayValue('secret')
+    input.focus()
+    input.setSelectionRange(3, 3)
+    expect(input.selectionStart).toBe(3)
+    expect(input.selectionEnd).toBe(3)
+
+    await user.click(screen.getByRole('button', { name: 'Show' }))
+
+    expect(input).toHaveFocus()
+    expect(input.selectionStart).toBe(3)
+    expect(input.selectionEnd).toBe(3)
+  })
+
   it('calls onChange when the value changes', () => {
     render(props)
     fireEvent.change(screen.getByPlaceholderText(PASSWORD_PLACEHOLDER), {

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/__tests__/PasswordInputField.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/__tests__/PasswordInputField.test.tsx
@@ -40,26 +40,28 @@ describe('PasswordInputField', () => {
     )
   })
 
-  it('reveals the password when the visibility toggle is clicked', () => {
+  it('renders a Show button by default', () => {
+    render(props)
+    screen.getByRole('button', { name: 'Show' })
+  })
+
+  it('reveals the password when the Show button is clicked', () => {
     render({ ...props, value: 'secret' })
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Toggle password visibility' })
-    )
+    fireEvent.click(screen.getByRole('button', { name: 'Show' }))
     const input = screen.getByDisplayValue('secret')
     expect(input).toHaveAttribute('type', 'text')
     expect(input).toHaveValue('secret')
+    screen.getByRole('button', { name: 'Hide' })
   })
 
-  it('keeps focus on the password input when the visibility toggle is clicked', async () => {
+  it('keeps focus on the password input when the Show button is clicked', async () => {
     const user = userEvent.setup()
     render({ ...props, value: 'secret' })
     const input = screen.getByDisplayValue('secret')
     input.focus()
     expect(input).toHaveFocus()
 
-    await user.click(
-      screen.getByRole('button', { name: 'Toggle password visibility' })
-    )
+    await user.click(screen.getByRole('button', { name: 'Show' }))
 
     expect(input).toHaveFocus()
     expect(input).toHaveAttribute('type', 'text')

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/__tests__/PersonalAccountSettings.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/__tests__/PersonalAccountSettings.test.tsx
@@ -129,8 +129,11 @@ describe('PersonalAccountSettings', () => {
     expect(screen.getByDisplayValue('alice')).toBeInTheDocument()
     expect(screen.getByDisplayValue('Alice Example')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    expect(
+      screen.queryByRole('button', { name: 'Edit' })
+    ).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Cancel' })[1]!)
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
     expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: 'Save' })

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/__tests__/PersonalAccountSettingsEditForm.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/__tests__/PersonalAccountSettingsEditForm.test.tsx
@@ -41,6 +41,7 @@ describe('PersonalAccountSettingsEditForm', () => {
     render(props)
     expect(screen.getByDisplayValue('alice')).toBeInTheDocument()
     expect(screen.getByDisplayValue('Alice Example')).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: 'Show' })).toHaveLength(2)
     const saveButton = screen.getByRole('button', { name: 'Save' })
     expect(saveButton).toBeDisabled()
     fireEvent.click(saveButton)

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/passwordinputfield.module.css
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/passwordinputfield.module.css
@@ -1,8 +1,11 @@
-.password_visibility_button {
+.password_field_row {
   display: flex;
-  padding: 0;
-  border: none;
-  background: transparent;
-  color: inherit;
-  cursor: pointer;
+  width: 100%;
+  align-items: center;
+  gap: var(--spacing-16);
+}
+
+.password_field_input {
+  min-width: 0;
+  flex: 1;
 }


### PR DESCRIPTION
Closes [RQA-5954](https://opentrons.atlassian.net/browse/RQA-5954)

# Overview

Updates the "Personal account settings" section with the hide/show buttons and removes an extra cancel button while actively editing account details. 

### Current Behavior

<img width="1920" height="1745" alt="image (3)" src="https://github.com/user-attachments/assets/ff8e7c51-2edf-4b69-9197-bbc7c1b65a80" />

### Fixed Behavior

https://github.com/user-attachments/assets/f8f82255-3d84-4aa2-888c-c72f18893704


## Test Plan and Hands on Testing

- See video

## Risk assessment

- very low, localized to this one section, follows show/hide patterns used elsewhere


[RQA-5954]: https://opentrons.atlassian.net/browse/RQA-5954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ