### PR TITLE
fix(app): do not stall lpc when proto uses no lw

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/__tests__/useLPCLabwareInfo.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/__tests__/useLPCLabwareInfo.test.ts
@@ -203,4 +203,30 @@ describe('useLPCLabwareInfo', () => {
 
     expect(result.current.legacyOffsets).toEqual([])
   })
+
+  it('should handle empty stored offsets', () => {
+    vi.mocked(useNotifySearchLabwareOffsets).mockReturnValue({
+      data: undefined,
+    } as any)
+
+    vi.mocked(getUniqueValidLwLocationInfoByAnalysis).mockReturnValue([])
+    vi.mocked(getLPCSearchParams).mockReturnValue({ filters: [] })
+
+    const { result } = renderHook(() => {
+      return useLPCLabwareInfo({
+        runId: RUN_ID,
+        robotType: FLEX_ROBOT_TYPE,
+        labwareDefs: LABWARE_DEFS,
+        protocolData: PROTOCOL_DATA,
+      })
+    })
+
+    expect(result.current.storedOffsets).toEqual([])
+    expect(getLPCLabwareInfoFrom).toHaveBeenCalledWith({
+      currentOffsets: [],
+      lwLocInfo: [],
+      labwareDefs: LABWARE_DEFS,
+      protocolData: PROTOCOL_DATA,
+    })
+  })
 })

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/index.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/index.ts
@@ -87,7 +87,13 @@ function useFlexLPCLabwareInfo({
       refetchInterval: REFETCH_OFFSET_SEARCH_MS,
     }
   )
-  const storedOffsets = lwOffsetsData?.data
+
+  const storedOffsets = useMemo(
+    () =>
+      lwOffsetsData?.data ??
+      (searchLwOffsetsParams?.filters?.length === 0 ? [] : null),
+    [lwOffsetsData?.data, searchLwOffsetsParams?.filters]
+  )
 
   const labwareInfo = useMemo(
     () =>

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/index.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/index.ts
@@ -91,7 +91,7 @@ function useFlexLPCLabwareInfo({
   const storedOffsets = useMemo(
     () =>
       lwOffsetsData?.data ??
-      (searchLwOffsetsParams?.filters?.length === 0 ? [] : null),
+      (searchLwOffsetsParams?.filters?.length === 0 ? [] : undefined),
     [lwOffsetsData?.data, searchLwOffsetsParams?.filters]
   )
 


### PR DESCRIPTION
Some recent query optimizations disabled the labware offsets search query if there was no labware to search for, which is good, but it also had the knock-on effect of making lpc always say it wasn't ready, which means the ODD shows a skeleton forever for protocols that use no labware. Make that system short-circuit if the query is disabled because there's no labware and return an empty array instead.

Closes RQA-5964
## testing
- [x] upload the protocol in the bug and check the odd correctly gets to runsetup when you start it