### PR TITLE
refactor(app): update CRS desktop login cta to match designs

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/PersonalAccountSettings.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/PersonalAccountSettings.tsx
@@ -2,7 +2,12 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
 
-import { BasicButton, Divider, Icon, StyledText } from '@opentrons/components'
+import {
+  BasicButton,
+  Divider,
+  InfoScreen,
+  StyledText,
+} from '@opentrons/components'
 import { useUpdateSelfMutation } from '@opentrons/react-api-client'
 
 import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
@@ -42,23 +47,9 @@ function LoggedOutMessage(): JSX.Element {
   const { t } = useTranslation('device_settings')
 
   return (
-    <div className={styles.logged_out_message}>
-      <Icon
-        name="information"
-        size="1.25rem"
-        className={styles.logged_out_icon}
-      />
-      <StyledText
-        desktopStyle="bodyDefaultRegular"
-        className={styles.logged_out_message_text}
-      >
-        {
-          t(
-            'desktop_login_to_manage_compliance_ready_software_settings'
-          ) as string
-        }
-      </StyledText>
-    </div>
+    <InfoScreen
+      content={t('desktop_login_to_manage_compliance_ready_software_settings')}
+    />
   )
 }
 

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/__tests__/PersonalAccountSettings.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/__tests__/PersonalAccountSettings.test.tsx
@@ -142,6 +142,8 @@ describe('PersonalAccountSettings', () => {
       perRobotAuthStates: {},
       mostRecentRobotName: null,
     })
+    screen.getByTestId('InfoScreen')
+    screen.getByLabelText('alert')
     screen.getByText('Log in to manage Compliance Ready Software settings')
     expect(
       screen.queryByText('Personal account settings')
@@ -192,6 +194,8 @@ describe('PersonalAccountSettings', () => {
       </QueryClientProvider>
     )
 
+    screen.getByTestId('InfoScreen')
+    screen.getByLabelText('alert')
     screen.getByText('Log in to manage Compliance Ready Software settings')
     expect(screen.queryByText('alice')).not.toBeInTheDocument()
   })

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/personalaccountsettings.module.css
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/personalaccountsettings.module.css
@@ -38,27 +38,3 @@
 .field_value_text {
   color: var(--grey-60);
 }
-
-.logged_out_message {
-  display: flex;
-  width: 100%;
-  min-height: 132px;
-  box-sizing: border-box;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: var(--spacing-40) var(--spacing-16);
-  border-radius: var(--border-radius-8);
-  background-color: var(--grey-30);
-  gap: var(--spacing-12);
-}
-
-.logged_out_icon {
-  flex-shrink: 0;
-  color: var(--grey-60);
-}
-
-.logged_out_message_text {
-  color: var(--grey-60);
-  text-align: center;
-}


### PR DESCRIPTION
Closes [RQA-5959](https://opentrons.atlassian.net/browse/RQA-5959)

# Overview

Updates the desktop's CRS login CTA to match designs.

### Current behavior

<img width="1025" height="767" alt="Screenshot 2026-08-21 at 12 03 51 PM" src="https://github.com/user-attachments/assets/328c03d5-2819-4f3e-9a16-f3df61f46ad2" />

### Fixed behavior

<img width="1027" height="772" alt="Screenshot 2026-08-21 at 12 06 19 PM" src="https://github.com/user-attachments/assets/0094d760-5681-4983-86a5-7de69c77d0aa" />


## Test Plan and Hands on Testing

- See images

## Risk assessment

- none, just copy and CSS

[RQA-5959]: https://opentrons.atlassian.net/browse/RQA-5959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ