### PR TITLE
refactor(app): update "verify robot encryption key" modal to match designs

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -498,7 +498,7 @@
   "value_percent": "{{value}}%",
   "verify": "Verify",
   "verify_robot_encryption_key": "Verify robot encryption key",
-  "verify_the_robot_encryption_key_to_use_the_robot": "Verify the robot encryption key to use the robot. The encryption key can be found under settings on the on-device touchscreen.",
+  "verify_the_robot_encryption_key_to_use_the_robot": "Enter the encryption key displayed on your robot's touchscreen into the field below.",
   "view_details": "View details",
   "view_network_details": "View network details",
   "view_realtime_video": "View real-time video of the deck while a running a protocol.",

--- a/app/src/organisms/Desktop/RobotCertImport/RobotCertImportModal.tsx
+++ b/app/src/organisms/Desktop/RobotCertImport/RobotCertImportModal.tsx
@@ -56,11 +56,10 @@ export function RobotCertImportModal(
       zIndexOverlay={10000}
     >
       <div className={styles.robot_cert_import_container}>
-        <div>
+        <div className={styles.text_block}>
           <StyledText desktopStyle="headingSmallBold">
             {t('verify_robot_encryption_key')}
           </StyledText>
-
           <StyledText desktopStyle="bodyDefaultRegular">
             {t('verify_the_robot_encryption_key_to_use_the_robot')}
           </StyledText>

--- a/app/src/organisms/Desktop/RobotCertImport/robot_cert_import.module.css
+++ b/app/src/organisms/Desktop/RobotCertImport/robot_cert_import.module.css
@@ -12,3 +12,9 @@
   flex-direction: column;
   row-gap: var(--spacing-24);
 }
+
+.text_block {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-8);
+}


### PR DESCRIPTION
Closes [RQA-5967](https://opentrons.atlassian.net/browse/RQA-5967)

# Overview

Updates the "verify robot encrpytion key" modal to match designs. Chatting with Design, we don't need the extra padding that's above the "verify" button and below the input field that currently exists in Figma.

### Current behavior

<img width="628" height="407" alt="Screenshot 2026-08-21 at 12 29 53 PM" src="https://github.com/user-attachments/assets/e116c088-b11d-4050-b9cf-612cbd1a0e8d" />

### Fixed behavior

<img width="1010" height="684" alt="Screenshot 2026-08-21 at 12 29 01 PM" src="https://github.com/user-attachments/assets/afcfed81-598f-43ba-b6e8-a2921c75e37e" />

## Test Plan and Hands on Testing

- See images

## Risk assessment

- none, just css and copy


[RQA-5967]: https://opentrons.atlassian.net/browse/RQA-5967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ