### PR TITLE
fix(auth-server): only set scopes if supplied in token request

### DIFF
--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -386,10 +386,15 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         access_token = token["access_token"]
         refresh_token = token.get("refresh_token", None)
 
-        # This cast is because request.scopes is apparently mis-typed as a str; it's actually a list[str].
-        scopes = cast(Any, request.scopes)
-        assert _is_list_of_type(scopes, str)
-        scopes = {Scope.from_api_name(s) for s in scopes}
+        # When the client omits `scope`, store nothing so effective scopes are
+        # calculated from current settings and user state at use time. When the
+        # client explicitly requests scopes, store that ceiling.
+        if request.scope is not None:
+            scopes = cast(Any, request.scopes)
+            assert _is_list_of_type(scopes, str)
+            stored_scopes = {Scope.from_api_name(s) for s in scopes}
+        else:
+            stored_scopes = set()
 
         expires_in = token["expires_in"]
 
@@ -409,7 +414,7 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
                 access_token=access_token,
                 refresh_token=refresh_token,
                 expires_at=expires_at,
-                scopes=scopes,
+                scopes=stored_scopes,
                 fullname=user.full_name,
             )
         )
@@ -492,7 +497,10 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
 
     def __get_effective_token_scopes(self, token: _TokenIssuance) -> set[Scope]:
         """Return granted token scopes, updated for current settings and user state."""
-        return token.scopes & self.__get_live_scopes_for_username(token.username)
+        live_scopes = self.__get_live_scopes_for_username(token.username)
+        if not token.scopes:
+            return live_scopes
+        return token.scopes & live_scopes
 
     def __get_live_scopes_for_username(self, username: str) -> set[Scope]:
         user = self.__user_store.get(username)
@@ -563,6 +571,7 @@ class _TokenIssuance:
     # todo(mm, 2026-01-29): We might want expires_at to be a CLOCK_BOOTTIME value or something
     # to resist problems from clock adjustment.
     expires_at: datetime
+    # Empty when the client did not request an explicit scope ceiling.
     scopes: set[Scope]
     fullname: str
 

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -390,6 +390,7 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         # calculated from current settings and user state at use time. When the
         # client explicitly requests scopes, store that ceiling.
         if request.scope is not None:
+            # This cast is because request.scopes is apparently mis-typed as a str; it's actually a list[str].
             scopes = cast(Any, request.scopes)
             assert _is_list_of_type(scopes, str)
             stored_scopes = {Scope.from_api_name(s) for s in scopes}

--- a/auth-server/auth_server/oauth2/router.py
+++ b/auth-server/auth_server/oauth2/router.py
@@ -20,9 +20,10 @@ router = fastapi.APIRouter(prefix="/auth")
         The OAuth 2 token endpoint, as specified in RFC 6749.
 
         Omit `scope` to receive the scopes appropriate for the authenticated user
-        under current server settings. Clients may optionally include `scope` to
-        request a subset of those permissions; granted scopes are stored on the
-        token and may be further restricted when settings or user state changes.
+        under current server settings. Those scopes are calculated at use time and
+        may change when settings or user state changes. Clients may optionally
+        include `scope` to request a subset of those permissions; that ceiling is
+        stored on the token and further restricted when settings or user state changes.
         """),
     dependencies=[fastapi.Depends(skip_audit_logger)],
 )

--- a/auth-server/tests/integration/test_password_expiration.tavern.yaml
+++ b/auth-server/tests/integration/test_password_expiration.tavern.yaml
@@ -176,6 +176,22 @@ stages:
       strict:
         - json:off
 
+  - name: Existing token introspection reflects expanded scopes after password change
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/introspect'
+      data:
+        client_id: opentrons_app
+        token: '{password_expired_user_access_token}'
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tests.integration.utils:verify_oauth_scopes
+        extra_kwargs:
+          expected_present: '{user_scopes_str}'
+      strict:
+        - json:off
+
   - name: Admin sees resetPassword false after the password is changed
     request:
       method: GET


### PR DESCRIPTION
# Overview

follow up work for https://opentrons.atlassian.net/browse/RQA-5854.
only store scopes if given by the req.

## Test Plan and Hands on Testing

- tested with postman and tavern tests sufficient 

## Changelog

- follow up from convo yesterday, only store scopes if given by req, fixes the intersection problem with settings scopes. 

## Risk assessment

bug fix. low. 
