### PR TITLE
fix(app): add compliance ready label to robot slideout cards

### DIFF
--- a/app/src/assets/localization/en/protocol_list.json
+++ b/app/src/assets/localization/en/protocol_list.json
@@ -1,4 +1,5 @@
 {
+  "compliance_ready": "Compliance Ready",
   "csv_file_required": "CSV file required for analysis. Add the CSV during run setup.",
   "delete_protocol_message": " and its run history will be permanently deleted.",
   "delete_this_protocol": "Delete this protocol?",

--- a/app/src/organisms/Desktop/ChooseRobotSlideout/AvailableRobotOption.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotSlideout/AvailableRobotOption.tsx
@@ -20,13 +20,14 @@ import { useAccessControlEnabledQuery } from '@opentrons/react-api-client'
 import FLEX_PNG from '/app/assets/images/FLEX.png'
 import OT2_PNG from '/app/assets/images/OT2-R_HERO.png'
 import { StatusLabel } from '/app/atoms/StatusLabel'
+import { ApiHostProvider } from '/app/local-resources/api-host-provider/ApiHostProvider'
 import { MiniCard } from '/app/molecules/MiniCard'
 import { getRobotModelByName, OPENTRONS_USB } from '/app/redux/discovery'
 import { appShellUSBRequestor } from '/app/redux/shell/remote'
 import { useNetworkInterfaces } from '/app/resources/networking/hooks'
 import { useCurrentRunId, useNotifyRunQuery } from '/app/resources/runs'
 
-import type { Dispatch as ReactDispatch } from 'react'
+import type { Dispatch as ReactDispatch, ReactNode } from 'react'
 import type { Runs } from '@opentrons/api-client'
 import type { IconName } from '@opentrons/components'
 import type { Robot } from '/app/redux/discovery/types'
@@ -43,7 +44,7 @@ interface AvailableRobotOptionProps {
   showIdleOnly?: boolean
 }
 
-export function AvailableRobotOption(
+export function AvailableRobotOptionComponent(
   props: AvailableRobotOptionProps
 ): JSX.Element | null {
   const {
@@ -203,5 +204,17 @@ export function AvailableRobotOption(
         </LegacyStyledText>
       ) : null}
     </>
+  )
+}
+
+export function AvailableRobotOption(
+  props: AvailableRobotOptionProps
+): ReactNode {
+  const { robot } = props
+  const { name: robotName } = robot
+  return (
+    <ApiHostProvider robotName={robotName}>
+      <AvailableRobotOptionComponent {...props} />
+    </ApiHostProvider>
   )
 }

--- a/app/src/organisms/Desktop/ChooseRobotSlideout/AvailableRobotOption.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotSlideout/AvailableRobotOption.tsx
@@ -15,9 +15,11 @@ import {
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
+import { useAccessControlEnabledQuery } from '@opentrons/react-api-client'
 
 import FLEX_PNG from '/app/assets/images/FLEX.png'
 import OT2_PNG from '/app/assets/images/OT2-R_HERO.png'
+import { StatusLabel } from '/app/atoms/StatusLabel'
 import { MiniCard } from '/app/molecules/MiniCard'
 import { getRobotModelByName, OPENTRONS_USB } from '/app/redux/discovery'
 import { appShellUSBRequestor } from '/app/redux/shell/remote'
@@ -101,6 +103,10 @@ export function AvailableRobotOption(
 
   const { ethernet, wifi } = useNetworkInterfaces(robotName)
 
+  const { data: complianceReadyData } = useAccessControlEnabledQuery({})
+  const isComplianceReady =
+    complianceReadyData?.data.accessControlEnabled ?? false
+
   let iconName: IconName | null = null
   if (ethernet?.ipAddress != null) {
     iconName = 'ethernet'
@@ -157,6 +163,15 @@ export function AvailableRobotOption(
               />
             </LegacyStyledText>
           </Box>
+          {isComplianceReady ? (
+            <StatusLabel
+              status={t('protocol_list:compliance_ready')}
+              backgroundColor={COLORS.blue30}
+              showIcon={false}
+              // override capitalization since both words should be capitalized in this instance
+              capitalizeStatus={false}
+            />
+          ) : null}
         </Flex>
         {(isError || isSelectedRobotOnDifferentSoftwareVersion) &&
         isSelected ? (

--- a/app/src/organisms/Desktop/ChooseRobotSlideout/AvailableRobotOption.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotSlideout/AvailableRobotOption.tsx
@@ -46,7 +46,7 @@ interface AvailableRobotOptionProps {
 
 export function AvailableRobotOptionComponent(
   props: AvailableRobotOptionProps
-): JSX.Element | null {
+): ReactNode | null {
   const {
     robot,
     onClick,

--- a/app/src/organisms/Desktop/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotSlideout/index.tsx
@@ -49,7 +49,6 @@ import {
 import { ToggleButton } from '/app/atoms/buttons'
 import { Slideout } from '/app/atoms/Slideout'
 import { MultiSlideout } from '/app/atoms/Slideout/MultiSlideout'
-import { ApiHostProvider } from '/app/local-resources/api-host-provider/ApiHostProvider'
 import { UploadInput } from '/app/molecules/UploadInput'
 import { useFeatureFlag } from '/app/redux/config'
 import {

--- a/app/src/organisms/Desktop/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotSlideout/index.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useReducer,
+  useRef,
+  useState,
+} from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { NavLink } from 'react-router-dom'
@@ -329,7 +336,7 @@ export function ChooseRobotSlideout(
           const isSelected =
             selectedRobot != null && selectedRobot.ip === robot.ip
           return (
-            <ApiHostProvider key={robot.ip} robotName={robot.name}>
+            <Fragment key={robot.ip}>
               <AvailableRobotOption
                 robot={robot}
                 onClick={() => {
@@ -376,7 +383,7 @@ export function ChooseRobotSlideout(
                   )}
                 </LegacyStyledText>
               )}
-            </ApiHostProvider>
+            </Fragment>
           )
         })
       )}

--- a/app/src/organisms/Desktop/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotSlideout/index.tsx
@@ -1,11 +1,4 @@
-import {
-  Fragment,
-  useCallback,
-  useEffect,
-  useReducer,
-  useRef,
-  useState,
-} from 'react'
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { NavLink } from 'react-router-dom'
@@ -49,6 +42,7 @@ import {
 import { ToggleButton } from '/app/atoms/buttons'
 import { Slideout } from '/app/atoms/Slideout'
 import { MultiSlideout } from '/app/atoms/Slideout/MultiSlideout'
+import { ApiHostProvider } from '/app/local-resources/api-host-provider/ApiHostProvider'
 import { UploadInput } from '/app/molecules/UploadInput'
 import { useFeatureFlag } from '/app/redux/config'
 import {
@@ -335,7 +329,7 @@ export function ChooseRobotSlideout(
           const isSelected =
             selectedRobot != null && selectedRobot.ip === robot.ip
           return (
-            <Fragment key={robot.ip}>
+            <ApiHostProvider key={robot.ip} robotName={robot.name}>
               <AvailableRobotOption
                 robot={robot}
                 onClick={() => {
@@ -382,7 +376,7 @@ export function ChooseRobotSlideout(
                   )}
                 </LegacyStyledText>
               )}
-            </Fragment>
+            </ApiHostProvider>
           )
         })
       )}


### PR DESCRIPTION
# Overview

Adds "Compliance Ready" status label components to compliance ready robots in ChooseRobotSlideout

Closes RQA-5975

## Test Plan and Hands on Testing

- select a protocol > start setup/send to flex (from overflow menu)
- in slideout, confirm that compliance-ready bots render a "Compliance Ready" status label

<img width="301" height="416" alt="Screenshot 2026-08-21 at 1 29 09 PM" src="https://github.com/user-attachments/assets/e8254641-ea5e-4228-83e2-7d81090b0941" />

## Changelog

- add host provider wrapper to `AvailableRobotOption`
- conditionally render compliance ready status in the option card

## Review requests

see test plan

## Risk assessment

low