### PR TITLE
fix(hardware): validate move completions by message index

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import time
 from collections import defaultdict
-from typing import Iterator, List, Optional, Set, Tuple, Union
+from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
 
 import numpy as np
 from opentrons_shared_data.errors.exceptions import (
@@ -90,6 +90,16 @@ _AcceptableMoves = Union[MoveCompleted, TipActionResponse]
 _CompletionPacket = Tuple[ArbitrationId, _AcceptableMoves]
 _Completions = List[_CompletionPacket]
 
+#: Maps the message index of a request that sets up a move to the
+#: (node id, group id, seq id) that request was sent for. Recorded by
+#: MoveGroupRunner._send_groups and handed to the MoveScheduler, which uses it to tell
+#: the completions of its own moves from every other completion on the bus.
+_ExpectedCompletions = Dict[int, Tuple[int, int, int]]
+
+#: Stands in for the gear motor id of a completion that did not come from a gear motor.
+#: GearMotorId values are 0 and 1, so -1 cannot collide with a real one.
+_NO_GEAR_MOTOR = -1
+
 
 class MoveGroupRunner:
     """A move command scheduler."""
@@ -111,6 +121,9 @@ class MoveGroupRunner:
         self._start_at_index = start_at_index
         self._ignore_stalls = ignore_stalls
         self._is_prepped: bool = False
+        # Populated by _send_groups. None means no moves have been sent yet, which is
+        # not the same thing as an empty mapping: see MoveScheduler.__init__.
+        self._expected_completions: Optional[_ExpectedCompletions] = None
 
     @staticmethod
     def _has_moves(move_groups: MoveGroups) -> bool:
@@ -256,16 +269,30 @@ class MoveGroupRunner:
         return node_set
 
     async def _send_groups(self, can_messenger: CanMessenger) -> None:
-        """Send commands to set up the message groups."""
+        """Send commands to set up the message groups.
+
+        Each request is built into a local before it is sent so that the message index
+        BaseMessage.__post_init__ assigned to it can be recorded. Firmware echoes that
+        index in the completion it sends for the move, so the recorded mapping is
+        exactly the set of completions this runner should ever accept.
+
+        The mapping is replaced rather than added to, because a runner can be prepped
+        more than once and completions left over from an earlier prep must not be
+        accepted against a later one.
+        """
+        expected: _ExpectedCompletions = {}
+        self._expected_completions = expected
         for group_i, group in enumerate(self._move_groups):
             for seq_i, sequence in enumerate(group):
                 for node, step in sequence.items():
-                    await can_messenger.send(
-                        node_id=node,
-                        message=self._get_message_type(
-                            step, group_i + self._start_at_index, seq_i
-                        ),
+                    group_id = group_i + self._start_at_index
+                    message = self._get_message_type(step, group_id, seq_i)
+                    expected[message.payload.message_index.value] = (
+                        node.value,
+                        group_id,
+                        seq_i,
                     )
+                    await can_messenger.send(node_id=node, message=message)
 
     def _convert_velocity(
         self, velocity: Union[float, np.float64], interrupts: int
@@ -402,7 +429,11 @@ class MoveGroupRunner:
         self, can_messenger: CanMessenger, start_at_index: int
     ) -> _Completions:
         """Run all the move groups."""
-        scheduler = MoveScheduler(self._move_groups, start_at_index)
+        scheduler = MoveScheduler(
+            self._move_groups,
+            start_at_index,
+            expected_completions=self._expected_completions,
+        )
         try:
             can_messenger.add_listener(scheduler)
             completions = await scheduler.run(can_messenger)
@@ -414,8 +445,24 @@ class MoveGroupRunner:
 class MoveScheduler:
     """A message listener that manages the sending of execute move group messages."""
 
-    def __init__(self, move_groups: MoveGroups, start_at_index: int = 0) -> None:
-        """Constructor."""
+    def __init__(
+        self,
+        move_groups: MoveGroups,
+        start_at_index: int = 0,
+        expected_completions: Optional[_ExpectedCompletions] = None,
+    ) -> None:
+        """Constructor.
+
+        Args:
+            move_groups: The move groups this scheduler waits for.
+            start_at_index: The group id the first of those move groups was sent with.
+            expected_completions: The message indices of the requests that set these
+                move groups up, as recorded by MoveGroupRunner._send_groups. When this
+                is None no completion can be validated and all of them are accepted,
+                which is only the case for a scheduler built without a preceding
+                _send_groups; an empty mapping means no moves were sent and so no
+                completion is expected. This mapping is never mutated.
+        """
         # For each move group create a set identifying the node and seq id.
         self._moves: List[Set[Tuple[int, int]]] = []
         self._durations: List[float] = []
@@ -454,6 +501,10 @@ class MoveScheduler:
         self._errors: List[EnumeratedError] = []
         self._current_group: Optional[int] = None
         self._should_stop = False
+        self._expected_completions = expected_completions
+        self._seen_completions: Set[Tuple[int, int]] = set()
+        self._dropped_foreign_completions = 0
+        self._dropped_duplicate_completions = 0
 
     def _remove_move_group(
         self, message: _AcceptableMoves, arbitration_id: ArbitrationId
@@ -469,10 +520,6 @@ class MoveScheduler:
                 f"Received completion for {node_id} group {group_id} seq {seq_id}"
                 f", which {'is' if in_group else 'isnt'} in group"
             )
-            if self._moves[group_id] and len(self._moves[group_id]) == 0:
-                log.error(
-                    f"Python bug proven if check {bool(not self._moves[group_id])} len check {len(self._moves[group_id]) == 0}"
-                )
             if not self._moves[group_id]:
                 log.debug(
                     f"Move group {group_id + self._start_at_index} has completed."
@@ -480,8 +527,10 @@ class MoveScheduler:
                 self._event.set()
         except KeyError:
             log.warning(
-                f"Got a move ack for ({node_id}, {seq_id}) which is not in this "
-                "group; may have leaked from an earlier timed-out group"
+                f"Got a move ack from node {node_id} for group "
+                f"{message.payload.group_id.value} seq {seq_id} with message index "
+                f"{message.payload.message_index.value}, which is not one of the moves "
+                "this group is still waiting for"
             )
         except IndexError:
             # If we have two move groups running at once, we need to handle
@@ -586,10 +635,110 @@ class MoveScheduler:
                 )
             )
 
+    @staticmethod
+    def _completion_key(message: _AcceptableMoves) -> Tuple[int, int]:
+        """Build the deduplication key for a move completion.
+
+        One TipActionRequest is answered twice, once per gear motor, and both responses
+        echo the message index of that single request; they differ only in gear motor
+        id. Every other kind of request is answered exactly once, so its message index
+        alone identifies its completion.
+        """
+        index = message.payload.message_index.value
+        if isinstance(message, TipActionResponse):
+            return (index, message.payload.gear_motor_id.value)
+        return (index, _NO_GEAR_MOTOR)
+
+    def _is_expected_completion(
+        self, message: _AcceptableMoves, arbitration_id: ArbitrationId
+    ) -> bool:
+        """Check whether a completion answers one of this scheduler's own moves.
+
+        Firmware echoes the message index of the request that set a move up in the
+        completion it sends for that move, and message indices are unique and
+        monotonically increasing for the life of the process. So a completion carrying
+        an index these move groups did not send belongs to another runner or to a group
+        that has already finished, and a completion carrying an index that was already
+        answered is a duplicate delivery. Neither may satisfy a pending move or report a
+        position: every move uses the same few (node id, seq id) pairs, so neither is
+        otherwise distinguishable from a real completion.
+
+        A completion whose index is one of ours but which arrives for a different
+        (node id, group id, seq id) than we sent that index for is logged and accepted
+        rather than dropped. Rejecting on originating node would turn a node that
+        answers from a subnode id into a move that never completes, which is a worse
+        failure than the one this check exists to prevent.
+
+        Args:
+            message: The completion that arrived.
+            arbitration_id: The arbitration id it arrived with.
+
+        Returns:
+            True if the completion should be handled, False if it must be dropped.
+        """
+        if self._expected_completions is None:
+            return True
+        index = message.payload.message_index.value
+        expected = self._expected_completions.get(index)
+        group_id = message.payload.group_id.value
+        seq_id = message.payload.seq_id.value
+        node_id = arbitration_id.parts.originating_node_id
+        if expected is None:
+            self._dropped_foreign_completions += 1
+            log.debug(
+                f"Dropping completion from node {node_id} for group {group_id} seq "
+                f"{seq_id} with message index {index}: no move was sent with that index"
+            )
+            return False
+        key = self._completion_key(message)
+        if key in self._seen_completions:
+            self._dropped_duplicate_completions += 1
+            log.warning(
+                f"Dropping duplicate delivery of the completion for group {group_id} "
+                f"seq {seq_id} with message index {index}: that move was already "
+                "answered"
+            )
+            return False
+        self._seen_completions.add(key)
+        if (node_id, group_id, seq_id) != expected:
+            log.error(
+                f"Message index {index} was sent for (node, group, seq) {expected} but "
+                f"its completion arrived for {(node_id, group_id, seq_id)}"
+            )
+        return True
+
+    def _group_index(self, message: _AcceptableMoves) -> Optional[int]:
+        """Map a completion's group id onto this scheduler's list of move groups.
+
+        Returns None if the group id is not one of this scheduler's groups. The bare
+        subtraction can go negative, and a negative index would quietly address the
+        last group instead of raising IndexError.
+        """
+        group_index = message.payload.group_id.value - self._start_at_index
+        if group_index < 0 or group_index >= len(self._moves):
+            return None
+        return group_index
+
+    def _dropped_completion_summary(self) -> str:
+        """Describe the completions this scheduler refused, for error reporting."""
+        return (
+            f"{self._dropped_foreign_completions} for moves this group did not send, "
+            f"{self._dropped_duplicate_completions} duplicate deliveries"
+        )
+
     def __call__(
         self, message: MessageDefinition, arbitration_id: ArbitrationId
     ) -> None:
         """Incoming message handler."""
+        if isinstance(message, (MoveCompleted, TipActionResponse)):
+            # This has to happen before either handler runs, because both of them
+            # mutate scheduler state and _handle_tip_action_motors mutates it before
+            # _remove_move_group is even reached. Note that ErrorMessage is
+            # deliberately not checked this way: firmware sends some of those with a
+            # message index of 0 (estop released, cancelling with no active move), and
+            # dropping them would hide estop and collision errors from _handle_error.
+            if not self._is_expected_completion(message, arbitration_id):
+                return
         if isinstance(message, MoveCompleted):
             self._remove_move_group(message, arbitration_id)
             self._handle_move_completed(message, arbitration_id)
@@ -604,12 +753,28 @@ class MoveScheduler:
 
     def _handle_tip_action_motors(self, message: TipActionResponse) -> bool:
         gear_id = GearMotorId(message.payload.gear_motor_id.value)
-        group_id = message.payload.group_id.value - self._start_at_index
         seq_id = message.payload.seq_id.value
-        self._expected_tip_action_motors[group_id][seq_id].remove(gear_id)
-        if len(self._expected_tip_action_motors[group_id][seq_id]) == 0:
-            return True
-        return False
+        group_index = self._group_index(message)
+        expected_motors: List[GearMotorId] = (
+            self._expected_tip_action_motors[group_index][seq_id]
+            if group_index is not None
+            and seq_id < len(self._expected_tip_action_motors[group_index])
+            else []
+        )
+        if gear_id not in expected_motors:
+            # A concurrently running gear axis runner shares this bus and its responses
+            # arrive here too. Removing a gear motor that is not expected used to raise
+            # ValueError out of a CAN listener callback, and CanMessenger._read_task
+            # only catches BinarySerializableException, so that aborted dispatch of the
+            # frame to every listener after this one.
+            log.warning(
+                f"Ignoring tip action response from gear motor {gear_id.name} for group "
+                f"{message.payload.group_id.value} seq {seq_id}, which this scheduler "
+                "is not waiting for"
+            )
+            return False
+        expected_motors.remove(gear_id)
+        return not expected_motors
 
     def _get_nodes_in_move_group(self, group_id: int) -> List[NodeId]:
         nodes = []
@@ -723,14 +888,15 @@ class MoveScheduler:
             full_duration = full_time - start_time
             second_duration = full_time - first_time
             missing_nodes = self._get_nodes_in_move_group(group_id)
+            dropped = self._dropped_completion_summary()
             if not missing_nodes:
                 log.warning(
-                    f"Move timeout fired with no missing nodes after {full_duration}s full, second-phase {second_duration} on a {full_timeout}s timeout; may not have been scheduled"
+                    f"Move timeout fired with no missing nodes after {full_duration}s full, second-phase {second_duration} on a {full_timeout}s timeout; may not have been scheduled. Dropped completions: {dropped}"
                 )
                 return
             missing_node_msg = ", ".join(node.name for node in missing_nodes)
             log.error(
-                f"Move set {str(group_id)} timed out of max duration {full_duration}s full, second-phase {second_duration}. Expected time: {expected_time}. Missing: {missing_node_msg}"
+                f"Move set {str(group_id)} timed out of max duration {full_duration}s full, second-phase {second_duration}. Expected time: {expected_time}. Missing: {missing_node_msg}. Dropped completions: {dropped}"
             )
 
             raise MotionFailedError(
@@ -740,6 +906,7 @@ class MoveScheduler:
                     "full-timeout": str(full_timeout),
                     "expected-time": str(expected_time),
                     "elapsed": str(time.monotonic() - start_time),
+                    "dropped-completions": dropped,
                 },
             )
 
@@ -749,6 +916,9 @@ class MoveScheduler:
             self._start_at_index, self._start_at_index + len(self._moves)
         ):
             await self._run_one_group(group_id, can_messenger)
+
+        if self._dropped_foreign_completions or self._dropped_duplicate_completions:
+            log.info(f"Dropped move completions: {self._dropped_completion_summary()}")
 
         def _reify_queue_iter() -> Iterator[_CompletionPacket]:
             while not self._completion_queue.empty():

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -1,6 +1,8 @@
 """Tests for the move scheduler."""
 
-from typing import Any, List
+import asyncio
+import logging
+from typing import Any, Dict, List, Tuple
 
 import pytest
 from mock import AsyncMock, MagicMock, call, patch
@@ -19,6 +21,7 @@ from opentrons_hardware.firmware_bindings import ArbitrationId, ArbitrationIdPar
 from opentrons_hardware.firmware_bindings.constants import (
     ErrorCode,
     ErrorSeverity,
+    GearMotorId,
     MotorDriverErrorCode,
     MoveAckId,
     NodeId,
@@ -1503,3 +1506,364 @@ async def test_single_move_driver_error(
     with pytest.raises(MotionFailedError):
         await subject.run(can_messenger=mock_can_messenger)
     assert mock_sender.call_count == 1
+
+
+def _completion(
+    node: NodeId,
+    group_id: int,
+    seq_id: int,
+    message_index: int,
+    position_um: int = 0,
+    ack_id: int = 1,
+) -> Tuple[md.MoveCompleted, ArbitrationId]:
+    """Build a MoveCompleted that carries a chosen message index.
+
+    BaseMessage.__post_init__ only assigns an index when the payload does not already
+    have one, so stamping the payload before building the message preserves the choice.
+    """
+    payload = MoveCompletedPayload(
+        group_id=UInt8Field(group_id),
+        seq_id=UInt8Field(seq_id),
+        current_position_um=UInt32Field(position_um),
+        encoder_position_um=Int32Field(position_um),
+        position_flags=MotorPositionFlagsField(0),
+        ack_id=UInt8Field(ack_id),
+    )
+    payload.message_index = UInt32Field(message_index)
+    return md.MoveCompleted(payload=payload), _build_arb(node)
+
+
+def _tip_response(
+    node: NodeId,
+    group_id: int,
+    seq_id: int,
+    message_index: int,
+    gear_motor_id: int,
+) -> Tuple[md.TipActionResponse, ArbitrationId]:
+    """Build a TipActionResponse that carries a chosen message index."""
+    payload = TipActionResponsePayload(
+        group_id=UInt8Field(group_id),
+        seq_id=UInt8Field(seq_id),
+        current_position_um=UInt32Field(0),
+        encoder_position_um=Int32Field(0),
+        position_flags=MotorPositionFlagsField(0),
+        ack_id=UInt8Field(1),
+        action=PipetteTipActionTypeField(0),
+        success=UInt8Field(1),
+        gear_motor_id=GearMotorIdField(gear_motor_id),
+    )
+    payload.message_index = UInt32Field(message_index)
+    return md.TipActionResponse(payload=payload), _build_arb(node)
+
+
+@pytest.fixture
+def move_group_three_seq_one_node() -> MoveGroups:
+    """One group of three sequences on a single Z node."""
+    return [
+        [
+            {
+                NodeId.head_r: MoveGroupSingleAxisStep(
+                    distance_mm=float64(33.246),
+                    velocity_mm_sec=float64(50),
+                    duration_sec=float64(1),
+                )
+            },
+            {
+                NodeId.head_r: MoveGroupSingleAxisStep(
+                    distance_mm=float64(48.396),
+                    velocity_mm_sec=float64(50),
+                    duration_sec=float64(1),
+                )
+            },
+            {
+                NodeId.head_r: MoveGroupSingleAxisStep(
+                    distance_mm=float64(33.249),
+                    velocity_mm_sec=float64(50),
+                    duration_sec=float64(1),
+                )
+            },
+        ]
+    ]
+
+
+def test_stale_foreign_completion_does_not_satisfy_live_move(
+    move_group_three_seq_one_node: MoveGroups,
+) -> None:
+    """A completion for a move this group did not send must be ignored.
+
+    This reproduces a field failure. Duplicate CAN frames belonging to an earlier move
+    group were matched against the group that was executing, because every move reuses
+    the same (node id, seq id) pairs. That satisfied the pending set early and let a
+    stale position win the position vote, so the API cached a Z position of 0 while the
+    axis was really 114.891 mm down, then computed the next move from there.
+    """
+    subject = MoveScheduler(
+        move_group_three_seq_one_node,
+        0,
+        expected_completions={
+            1001: (NodeId.head_r.value, 0, 0),
+            1002: (NodeId.head_r.value, 0, 1),
+            1003: (NodeId.head_r.value, 0, 2),
+        },
+    )
+
+    # A frame for a live (node, seq) but carrying an index this group never sent.
+    subject(*_completion(NodeId.head_r, 0, 2, message_index=277193, position_um=0))
+
+    assert subject._moves[0] == {
+        (NodeId.head_r.value, 0),
+        (NodeId.head_r.value, 1),
+        (NodeId.head_r.value, 2),
+    }, "the stale completion must not satisfy a pending move"
+    assert subject._completion_queue.empty(), "its position must not become a candidate"
+    assert not subject._event.is_set(), "the group must not be declared complete"
+    assert subject._dropped_foreign_completions == 1
+
+    # The real completions still work, and the position that survives is the real one.
+    subject(*_completion(NodeId.head_r, 0, 0, 1001, position_um=33246))
+    subject(*_completion(NodeId.head_r, 0, 1, 1002, position_um=81642))
+    subject(*_completion(NodeId.head_r, 0, 2, 1003, position_um=114891))
+
+    assert subject._event.is_set()
+    completions = []
+    while not subject._completion_queue.empty():
+        completions.append(subject._completion_queue.get_nowait())
+    assert len(completions) == 3
+    positions = MoveGroupRunner._accumulate_move_completions(completions)
+    assert positions[NodeId.head_r].motor_position == pytest.approx(114.891)
+
+
+def test_duplicate_completion_is_dropped(
+    move_group_three_seq_one_node: MoveGroups,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A completion delivered more than once must only be counted once."""
+    subject = MoveScheduler(
+        move_group_three_seq_one_node,
+        0,
+        expected_completions={
+            1001: (NodeId.head_r.value, 0, 0),
+            1002: (NodeId.head_r.value, 0, 1),
+            1003: (NodeId.head_r.value, 0, 2),
+        },
+    )
+    with caplog.at_level(logging.WARNING):
+        subject(*_completion(NodeId.head_r, 0, 0, 1001, position_um=33246))
+        subject(*_completion(NodeId.head_r, 0, 0, 1001, position_um=33246))
+
+    assert subject._completion_queue.qsize() == 1
+    assert subject._moves[0] == {(NodeId.head_r.value, 1), (NodeId.head_r.value, 2)}
+    assert subject._dropped_duplicate_completions == 1
+    assert subject._dropped_foreign_completions == 0
+    assert "duplicate delivery" in caplog.text
+
+
+def test_schedulers_only_consume_their_own_completions(
+    move_group_three_seq_one_node: MoveGroups,
+) -> None:
+    """Concurrent runners share a bus and must not consume each other's completions.
+
+    ot3controller.move() and home() both run two MoveGroupRunners through
+    asyncio.gather, each with start_at_index 0, and every scheduler is a listener on
+    the same messenger. Message index membership is what separates them.
+    """
+    first = MoveScheduler(
+        move_group_three_seq_one_node,
+        0,
+        expected_completions={2001: (NodeId.head_r.value, 0, 0)},
+    )
+    second = MoveScheduler(
+        move_group_three_seq_one_node,
+        0,
+        expected_completions={3001: (NodeId.head_r.value, 0, 0)},
+    )
+    for message in (
+        _completion(NodeId.head_r, 0, 0, 2001, position_um=1000),
+        _completion(NodeId.head_r, 0, 0, 3001, position_um=2000),
+    ):
+        first(*message)
+        second(*message)
+
+    assert first._completion_queue.qsize() == 1
+    assert second._completion_queue.qsize() == 1
+    assert first._dropped_foreign_completions == 1
+    assert second._dropped_foreign_completions == 1
+    assert first._completion_queue.get_nowait()[1].payload.message_index.value == 2001
+    assert second._completion_queue.get_nowait()[1].payload.message_index.value == 3001
+
+
+def test_tip_action_two_responses_share_one_message_index(
+    move_group_tip_action_single: MoveGroups,
+) -> None:
+    """Both gear motor responses to one tip action request must be accepted.
+
+    A single TipActionRequest is answered twice, once per gear motor, and both
+    responses echo that one request's message index. Deduplicating on the index alone
+    would drop the second response and hang tip handling, so the key includes the gear
+    motor id.
+    """
+    subject = MoveScheduler(
+        move_group_tip_action_single,
+        0,
+        expected_completions={1001: (NodeId.pipette_left.value, 0, 0)},
+    )
+    subject(*_tip_response(NodeId.pipette_left, 0, 0, 1001, gear_motor_id=1))
+    assert subject._expected_tip_action_motors[0][0] == [GearMotorId.left]
+    assert not subject._event.is_set()
+
+    subject(*_tip_response(NodeId.pipette_left, 0, 0, 1001, gear_motor_id=0))
+    assert subject._expected_tip_action_motors[0][0] == []
+    assert subject._event.is_set()
+    assert subject._completion_queue.qsize() == 1
+    assert subject._dropped_duplicate_completions == 0
+
+    # A third copy is a duplicate delivery and must be dropped, not raise.
+    subject(*_tip_response(NodeId.pipette_left, 0, 0, 1001, gear_motor_id=0))
+    assert subject._dropped_duplicate_completions == 1
+    assert subject._completion_queue.qsize() == 1
+
+
+def test_tip_action_response_for_unexpected_gear_motor_is_ignored(
+    move_group_single: MoveGroups,
+) -> None:
+    """A tip action response for a move this scheduler does not own must not raise.
+
+    A concurrently running gear axis runner's responses arrive at every scheduler. This
+    used to raise ValueError out of a CAN listener callback, and
+    CanMessenger._read_task only catches BinarySerializableException, so the frame was
+    never dispatched to any listener registered after this one.
+    """
+    subject = MoveScheduler(move_group_single)
+    before = set(subject._moves[0])
+
+    subject(*_tip_response(NodeId.pipette_left, 0, 0, 1001, gear_motor_id=0))
+
+    assert subject._moves[0] == before
+    assert subject._completion_queue.empty()
+    assert not subject._event.is_set()
+
+
+def test_completion_for_out_of_range_group_is_ignored(
+    move_group_single: MoveGroups,
+) -> None:
+    """A group id below start_at_index must not address the last group.
+
+    group_id - start_at_index goes negative for a foreign frame, and a negative index
+    would quietly select this scheduler's last group instead of raising IndexError.
+    """
+    subject = MoveScheduler(move_group_single, 1)
+    before = set(subject._moves[0])
+
+    subject(*_tip_response(NodeId.pipette_left, 0, 0, 1001, gear_motor_id=0))
+
+    assert subject._moves[0] == before
+    assert subject._completion_queue.empty()
+
+
+async def test_send_groups_records_message_indices(
+    mock_can_messenger: AsyncMock, move_group_multiple: MoveGroups
+) -> None:
+    """Prep must record the message index of every request it sends."""
+    subject = MoveGroupRunner(move_groups=move_group_multiple)
+    await subject.prep(mock_can_messenger)
+
+    sent = [c.kwargs["message"] for c in mock_can_messenger.send.call_args_list]
+    assert subject._expected_completions is not None
+    assert set(subject._expected_completions) == {
+        m.payload.message_index.value for m in sent
+    }
+    assert len(subject._expected_completions) == len(sent) == 5
+    assert (NodeId.gantry_y.value, 1, 0) in subject._expected_completions.values()
+
+
+async def test_send_groups_records_nonzero_start_index(
+    mock_can_messenger: AsyncMock, move_group_multiple: MoveGroups
+) -> None:
+    """Recorded group ids must be the ones that go on the wire."""
+    subject = MoveGroupRunner(move_groups=move_group_multiple, start_at_index=2)
+    await subject.prep(mock_can_messenger)
+
+    assert subject._expected_completions is not None
+    assert {group for _, group, _ in subject._expected_completions.values()} == {
+        2,
+        3,
+        4,
+    }
+
+
+async def test_reprep_replaces_expected_message_indices(
+    mock_can_messenger: AsyncMock, move_group_multiple: MoveGroups
+) -> None:
+    """Prepping a runner again must not keep the previous prep's expectations.
+
+    Runners are reused in a loop, so carrying indices over would let one iteration
+    accept the previous iteration's completions.
+    """
+    subject = MoveGroupRunner(move_groups=move_group_multiple)
+    await subject.prep(mock_can_messenger)
+    assert subject._expected_completions is not None
+    first = set(subject._expected_completions)
+
+    await subject.prep(mock_can_messenger)
+    assert subject._expected_completions is not None
+    second = set(subject._expected_completions)
+
+    assert len(second) == len(first)
+    assert first.isdisjoint(second)
+
+
+async def test_move_forwards_expected_completions(
+    mock_can_messenger: AsyncMock, move_group_single: MoveGroups
+) -> None:
+    """The scheduler must be given the runner's recorded expectations."""
+    subject = MoveGroupRunner(move_groups=move_group_single)
+    with patch(
+        "opentrons_hardware.hardware_control.move_group_runner.MoveScheduler"
+    ) as scheduler_cls:
+        scheduler_cls.return_value.run = AsyncMock(return_value=[])
+        await subject.prep(mock_can_messenger)
+        await subject.execute(mock_can_messenger)
+    assert (
+        scheduler_cls.call_args.kwargs["expected_completions"]
+        is subject._expected_completions
+    )
+
+
+async def test_move_without_prep_does_not_validate() -> None:
+    """A scheduler built without a preceding prep must accept every completion.
+
+    None and an empty mapping are not the same: None disables validation, while an
+    empty mapping would reject every completion and hang.
+    """
+    subject = MoveGroupRunner(move_groups=[])
+    assert subject._expected_completions is None
+    with patch(
+        "opentrons_hardware.hardware_control.move_group_runner.MoveScheduler"
+    ) as scheduler_cls:
+        scheduler_cls.return_value.run = AsyncMock(return_value=[])
+        await subject._move(MagicMock(), 0)
+    assert scheduler_cls.call_args.kwargs["expected_completions"] is None
+
+
+async def test_dropped_completion_counts_reach_the_timeout_error(
+    mock_can_messenger: AsyncMock, move_group_single: MoveGroups
+) -> None:
+    """A move that times out must report how many completions were refused.
+
+    If the premise that firmware echoes a request's message index were ever wrong for
+    some kind of move, this is what turns the resulting timeout into a diagnosis.
+    """
+    expected: Dict[int, Tuple[int, int, int]] = {1001: (NodeId.head.value, 0, 0)}
+    subject = MoveScheduler(move_group_single, 0, expected_completions=expected)
+    subject(*_completion(NodeId.head, 0, 0, message_index=999))
+
+    with patch(
+        "opentrons_hardware.hardware_control.move_group_runner.asyncio.wait_for",
+        AsyncMock(side_effect=asyncio.TimeoutError),
+    ):
+        with pytest.raises(MotionFailedError) as exc_info:
+            await subject.run(can_messenger=mock_can_messenger)
+
+    assert exc_info.value.detail["dropped-completions"] == (
+        "1 for moves this group did not send, 0 duplicate deliveries"
+    )

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
@@ -27,6 +27,7 @@ from opentrons_hardware.firmware_bindings.messages.fields import (
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     Acknowledgement,
     AddLinearMoveRequest,
+    AddSensorLinearMoveRequest,
     BindSensorOutputRequest,
     ExecuteMoveGroupRequest,
     MoveCompleted,
@@ -57,6 +58,46 @@ from opentrons_hardware.sensors.sensor_driver import SensorDriver
 from opentrons_hardware.sensors.sensor_types import SensorInformation
 from opentrons_hardware.sensors.types import SensorDataType
 from opentrons_hardware.sensors.utils import SensorThresholdInformation
+
+
+def _with_echoed_move_indices(
+    responder: CanLoopback.LoopbackResponder,
+) -> CanLoopback.LoopbackResponder:
+    """Make a responder echo the message index of the request each completion answers.
+
+    Firmware copies the message index of the request that set a move up into the
+    completion it sends for that move, and MoveScheduler relies on that to tell the
+    completions of its own moves from the rest of the traffic on the bus. A responder
+    that invents an index instead would have its completions ignored.
+    """
+    sent: Dict[Tuple[int, int, int], int] = {}
+
+    def _wrapped(
+        node_id: NodeId, message: MessageDefinition
+    ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+        if isinstance(message, (AddLinearMoveRequest, AddSensorLinearMoveRequest)):
+            sent[
+                (
+                    node_id.value,
+                    message.payload.group_id.value,
+                    message.payload.seq_id.value,
+                )
+            ] = message.payload.message_index.value
+        responses = responder(node_id, message)
+        for _, response, source in responses:
+            if isinstance(response, MoveCompleted):
+                index = sent.get(
+                    (
+                        source.value,
+                        response.payload.group_id.value,
+                        response.payload.seq_id.value,
+                    )
+                )
+                if index is not None:
+                    response.payload.message_index = UInt32Field(index)
+        return responses
+
+    return _wrapped
 
 
 @pytest.fixture
@@ -239,7 +280,7 @@ async def test_liquid_probe(
                     assert message.payload.velocity_mm.value == velocity
             return []
 
-    message_send_loopback.add_responder(move_responder)
+    message_send_loopback.add_responder(_with_echoed_move_indices(move_responder))
 
     position = await liquid_probe(
         messenger=mock_messenger,
@@ -338,7 +379,7 @@ async def test_capacitive_probe(
         else:
             return []
 
-    message_send_loopback.add_responder(move_responder)
+    message_send_loopback.add_responder(_with_echoed_move_indices(move_responder))
 
     status = await capacitive_probe(
         mock_messenger, target_node, motor_node, distance, speed
@@ -425,7 +466,7 @@ async def test_capacitive_sweep(
         else:
             return []
 
-    message_send_loopback.add_responder(move_responder)
+    message_send_loopback.add_responder(_with_echoed_move_indices(move_responder))
 
     result = await capacitive_pass(
         mock_messenger, target_node, motor_node, distance, speed


### PR DESCRIPTION
# Overview

`MoveScheduler` identified the move completions it was waiting for by `(node id, seq id)` within a group id. That key is not unique in practice: every move goes out with group id 0 and seq ids 0 through 2 over the same motor nodes, and every scheduler is registered as a listener on the shared CAN bus, so it sees all traffic rather than only the traffic for its own moves. A duplicate delivery or a completion left over from an earlier, already-finished group is therefore indistinguishable from a real one.

Two things go wrong when such a completion is accepted:

- It satisfies a pending move, so the group can be reported complete while a motor is still moving.
- It puts a stale position into the completion queue, and because `_accumulate_move_completions` picks the entry with the highest seq id per node, that stale position can win and become the node's cached position.

Because moves are sent as a duration plus a velocity computed against the cached position, a wrong cached position makes the *next* move travel the wrong distance.

The fix keys completion matching on something that actually is unique. Firmware copies the message index of the request that set a move up into the completion it sends for that move, and message indices are unique and monotonically increasing for the life of the process. `MoveGroupRunner._send_groups` now records the index of every request it issues, and `MoveScheduler` refuses any completion that does not carry one of those indices, or that carries one it has already answered.

There is no ticket for this; it was found while reading the scheduler. Happy to open a support thread first if that is preferred.

## Details

A few things that are worth calling out because they are not obvious from the diff:

**Deduplication key.** One `TipActionRequest` is answered twice, once per gear motor, and both responses echo the message index of that single request. Deduplicating on message index alone would drop the second one, so the key is `(message index, gear motor id)`, with a `_NO_GEAR_MOTOR` sentinel of `-1` for non-gear completions (`GearMotorId` values are 0 and 1, so it cannot collide).

**Validation runs before either handler.** The check is done in `__call__` before dispatching, because both `_remove_move_group` and `_handle_tip_action_motors` mutate scheduler state, and the latter does so before `_remove_move_group` is even reached.

**`ErrorMessage` is deliberately not validated this way.** Firmware sends some error messages with a message index of 0 — estop released, cancelling with no active move — and dropping those would hide estop and collision errors from `_handle_error`.

**Mismatched-but-known indices are logged, not dropped.** If a completion carries one of our indices but arrives for a different `(node id, group id, seq id)` than we sent it for, it is logged at error level and still accepted. Rejecting based on originating node would turn a node that answers from a subnode id into a move that never completes, which is a worse failure than the one this check prevents.

**`expected_completions=None` means "cannot validate".** That is distinct from an empty mapping, which means "no moves were sent, so expect nothing". `None` only arises for a `MoveScheduler` constructed without a preceding `_send_groups`, and in that case every completion is accepted, preserving today's behavior for that path.

**Re-prepping replaces rather than extends the mapping**, so completions left over from an earlier prep of the same runner cannot be accepted against a later one.

Separately, `_handle_tip_action_motors` used to call `list.remove()` unconditionally and raise `ValueError` out of a CAN listener callback when a response arrived for a gear motor it was not waiting for. A concurrently running gear axis runner triggers this today, and since `CanMessenger._read_task` only catches `BinarySerializableException`, that exception aborted dispatch of the frame to every listener registered after the scheduler that raised. It now logs and ignores the response. The related `_group_index` helper guards the bare `group_id - start_at_index` subtraction, which could go negative and quietly address the last group instead of raising `IndexError`.

## Test Plan and Hands on Testing

Unit tests, in `test_move_group_runner.py` and `test_tool_sensors.py`, cover:

- A completion carrying an unknown message index is refused and does not satisfy a pending move.
- A duplicate delivery of an already-answered completion is refused.
- Both gear motor responses to a single tip action request are still accepted, despite sharing a message index.
- A stale completion can no longer win the highest-seq-id selection in `_accumulate_move_completions`.
- A tip action response for an unexpected gear motor is ignored rather than raising out of the listener callback.
- Group ids outside the scheduler's range return `None` from `_group_index` instead of wrapping to the last group.
- `_send_groups` records the message index of each request it issues and forwards the mapping to the scheduler.

`63 passed` for the two touched test files locally.

Hands on tests covered:
- Uploading a protocol to robot via standard OT Desktop app
- Starting a run via touchscreen
- Checking visually for issues with the protocol-- None noticed. Run completed successfully. 

## Changelog

- `MoveGroupRunner._send_groups` builds each request into a local before sending so it can record the assigned message index, and stores a `{message index: (node id, group id, seq id)}` mapping on the runner.
- `MoveScheduler` accepts an `expected_completions` argument and drops any `MoveCompleted` or `TipActionResponse` whose message index was not sent by this runner, or which was already answered.
- Deduplication is keyed on `(message index, gear motor id)` so both responses to a tip action request are accepted.
- `_handle_tip_action_motors` logs and ignores responses for gear motors it is not waiting for instead of raising `ValueError` out of the CAN listener callback.
- Added `_group_index` to bounds-check the group id offset instead of allowing a negative index.
- Move timeout errors now report how many completions were refused, split into foreign and duplicate, both in the log and in the `MotionFailedError` detail dictionary under `dropped-completions`.
- Removed a leftover "Python bug proven" log statement in `_remove_move_group` and made the adjacent unmatched-ack warning name the group id and message index.

## Review requests

- The main thing I would like checked is the premise: that firmware always echoes the message index of the setup request in the corresponding completion, for every message type that ends up as a `MoveCompleted` or `TipActionResponse`. If there is any path where it does not, this change would turn a working move into a hang. I am reasonably confident based on the firmware behavior but I would like someone who knows it well to confirm.
- Please also sanity check the decision to exempt `ErrorMessage` from validation, and the decision to log-and-accept rather than drop when a known index arrives with an unexpected `(node, group, seq)`.
- Is there an existing internal ticket for the wrong-distance-move symptom that this should be linked to?

## Risk assessment

Medium. This is in the path of every move on the machine.

The failure mode this introduces, if the premise above is wrong, is a move that never gets its completion and times out — a hang rather than silent misbehavior. That is why the dropped-completion counters were added and are surfaced in both the timeout log and the `MotionFailedError` details: if a completion is ever refused in error, it should be diagnosable from the error rather than presenting as a mysterious timeout.

Mitigations built into the change:

- When no mapping is available (`None`), behavior is unchanged and all completions are accepted, so any code path constructing a `MoveScheduler` without `_send_groups` is untouched.
- The `(node, group, seq)` mismatch case accepts rather than rejects, deliberately biasing toward the old behavior where the new check is least certain.
- `ErrorMessage` is exempt so estop and collision handling is unaffected.

Coupling worth a reviewer's attention: tip handling and the sensor/probe paths in `test_tool_sensors.py` share this scheduler, so tip pickup, tip drop, and liquid probe are all downstream of this change even though none of them are the reported symptom.
