### PR TITLE
fix(app): Keep full-layout on-screen keyboards in sync with their inputs

### DIFF
--- a/app/src/atoms/AccordionKeyboard/AccordionKeyboard.stories.tsx
+++ b/app/src/atoms/AccordionKeyboard/AccordionKeyboard.stories.tsx
@@ -4,6 +4,7 @@ import { legacy_createStore } from 'redux'
 
 import {
   DIRECTION_COLUMN,
+  InputField,
   POSITION_ABSOLUTE,
   SPACING,
   VIEWPORT,
@@ -16,6 +17,7 @@ import { FullKeyboard } from '../SoftwareKeyboard'
 
 import type { Meta, StoryObj } from '@storybook/react'
 import type { Store, StoreEnhancer } from 'redux'
+import type { KeyboardReactInterface } from 'react-simple-keyboard'
 
 const dummyConfig = {
   config: {
@@ -48,12 +50,22 @@ export default meta
 type Story = StoryObj<typeof AccordionKeyboardComponent>
 
 const Keyboard = (): JSX.Element => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [value, setValue] = useState('')
   const [isKeyboardOpen, setIsKeyboardOpen] = useState(true)
-  const keyboardRef = useRef(null)
+  const keyboardRef = useRef<KeyboardReactInterface | null>(null)
+  const inputElementRef = useRef<HTMLInputElement>(null)
   return (
     <div style={{ flexDirection: DIRECTION_COLUMN, gap: SPACING.spacing16 }}>
+      <form id="test_form">
+        <InputField
+          ref={inputElementRef}
+          value={value}
+          type="text"
+          onChange={e => {
+            setValue(e.target.value)
+          }}
+        />
+      </form>
       <div
         style={{
           position: POSITION_ABSOLUTE,
@@ -69,9 +81,8 @@ const Keyboard = (): JSX.Element => {
           }}
         >
           <FullKeyboard
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
-            onChange={e => e != null && setValue(String(e))}
             keyboardRef={keyboardRef}
+            inputElementRef={inputElementRef}
           />
         </AccordionKeyboardComponent>
       </div>

--- a/app/src/atoms/SoftwareKeyboard/FullKeyboard/FullKeyboard.stories.tsx
+++ b/app/src/atoms/SoftwareKeyboard/FullKeyboard/FullKeyboard.stories.tsx
@@ -17,6 +17,7 @@ import { FullKeyboard } from '.'
 
 import type { Meta, StoryObj } from '@storybook/react'
 import type { Store, StoreEnhancer } from 'redux'
+import type { KeyboardReactInterface } from 'react-simple-keyboard'
 
 const dummyConfig = {
   config: {
@@ -51,24 +52,29 @@ type Story = StoryObj<typeof FullKeyboard>
 const Keyboard = (): JSX.Element => {
   const [showKeyboard, setShowKeyboard] = useState(false)
   const [value, setValue] = useState<string>('')
-  const keyboardRef = useRef(null)
+  const keyboardRef = useRef<KeyboardReactInterface | null>(null)
+  const inputElementRef = useRef<HTMLInputElement>(null)
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing16}>
       <form id="test_form">
         <InputField
+          ref={inputElementRef}
           value={value}
           type="text"
           placeholder="When focusing, the keyboard shows up"
-          // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
-          onFocus={() => setShowKeyboard(true)}
+          onFocus={() => {
+            setShowKeyboard(true)
+          }}
+          onChange={e => {
+            setValue(e.target.value)
+          }}
         />
       </form>
       <Flex position={POSITION_ABSOLUTE} top="20%" left="0" width="64rem">
         {showKeyboard && (
           <FullKeyboard
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
-            onChange={e => e != null && setValue(String(e))}
             keyboardRef={keyboardRef}
+            inputElementRef={inputElementRef}
           />
         )}
       </Flex>

--- a/app/src/atoms/SoftwareKeyboard/FullKeyboard/__tests__/FullKeyboard.test.tsx
+++ b/app/src/atoms/SoftwareKeyboard/FullKeyboard/__tests__/FullKeyboard.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import '@testing-library/jest-dom/vitest'
 
-import { renderHook, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { renderWithProviders } from '/app/__testing-utils__'
@@ -11,7 +11,7 @@ import { getAppLanguage } from '/app/redux/config'
 
 import { FullKeyboard } from '..'
 
-import type { ComponentProps } from 'react'
+import type { KeyboardReactInterface } from 'react-simple-keyboard'
 
 vi.mock('/app/redux/config', async () => {
   const actual = await vi.importActual('/app/redux/config')
@@ -21,8 +21,23 @@ vi.mock('/app/redux/config', async () => {
   }
 })
 
-const render = (props: ComponentProps<typeof FullKeyboard>) => {
-  return renderWithProviders(<FullKeyboard {...props} />)[0]
+function TestKeyboard(): JSX.Element {
+  const keyboardRef = useRef<KeyboardReactInterface | null>(null)
+  const inputElementRef = useRef<HTMLInputElement>(null)
+
+  return (
+    <>
+      <input data-testid="FullKeyboard_Input" ref={inputElementRef} />
+      <FullKeyboard
+        keyboardRef={keyboardRef}
+        inputElementRef={inputElementRef}
+      />
+    </>
+  )
+}
+
+const render = () => {
+  return renderWithProviders(<TestKeyboard />)[0]
 }
 
 const expectButtonsToBePresent = (buttonNames: string[]) => {
@@ -42,12 +57,7 @@ describe('FullKeyboard', () => {
   })
 
   it('should render FullKeyboard keyboard', () => {
-    const { result } = renderHook(() => useRef(null))
-    const props = {
-      onChange: vi.fn(),
-      keyboardRef: result.current,
-    }
-    render(props)
+    render()
     const expectedButtonNames = [
       'q',
       'w',
@@ -88,12 +98,7 @@ describe('FullKeyboard', () => {
 
   it('should render full keyboard when hitting ABC key', async () => {
     const user = userEvent.setup()
-    const { result } = renderHook(() => useRef(null))
-    const props = {
-      onChange: vi.fn(),
-      keyboardRef: result.current,
-    }
-    render(props)
+    render()
     const shiftKey = screen.getByRole('button', { name: 'ABC' })
     await user.click(shiftKey)
     const expectedButtonNames = [
@@ -136,12 +141,7 @@ describe('FullKeyboard', () => {
 
   it('should render full keyboard when hitting 123 key', async () => {
     const user = userEvent.setup()
-    const { result } = renderHook(() => useRef(null))
-    const props = {
-      onChange: vi.fn(),
-      keyboardRef: result.current,
-    }
-    render(props)
+    render()
     const numberKey = screen.getByRole('button', { name: '123' })
     await user.click(numberKey)
     const expectedButtonNames = [
@@ -185,12 +185,7 @@ describe('FullKeyboard', () => {
 
   it('should render the software keyboards when hitting #+= key', async () => {
     const user = userEvent.setup()
-    const { result } = renderHook(() => useRef(null))
-    const props = {
-      onChange: vi.fn(),
-      keyboardRef: result.current,
-    }
-    render(props)
+    render()
     const numberKey = screen.getByRole('button', { name: '123' })
     await user.click(numberKey)
     const symbolKey = screen.getByRole('button', { name: '#+=' })
@@ -228,28 +223,19 @@ describe('FullKeyboard', () => {
     expectButtonsToBePresent(expectedButtonNames)
   })
 
-  it('should call mock function when clicking a key', async () => {
+  it('should update the input when clicking keys', async () => {
     const user = userEvent.setup()
-    const { result } = renderHook(() => useRef(null))
-    const props = {
-      onChange: vi.fn(),
-      keyboardRef: result.current,
-    }
-    render(props)
-    const aKey = screen.getByRole('button', { name: 'a' })
-    await user.click(aKey)
-    expect(props.onChange).toHaveBeenCalled()
+    render()
+    await user.click(screen.getByRole('button', { name: 'a' }))
+    await user.click(screen.getByRole('button', { name: 'b' }))
+    await user.click(screen.getByRole('button', { name: 'c' }))
+    expect(screen.getByTestId('FullKeyboard_Input')).toHaveValue('abc')
   })
 
   it('should render chinese default labels when app language is zh-CN', () => {
     vi.mocked(getAppLanguage).mockReturnValue('zh-CN')
-    const { result } = renderHook(() => useRef(null))
-    const props = {
-      onChange: vi.fn(),
-      keyboardRef: result.current,
-    }
 
-    render(props)
+    render()
 
     expect(screen.getByRole('button', { name: '空格' })).toBeInTheDocument()
     expect(
@@ -260,13 +246,8 @@ describe('FullKeyboard', () => {
   it('should update labels when toggling keyboard language', async () => {
     vi.mocked(getAppLanguage).mockReturnValue('zh-CN')
     const user = userEvent.setup()
-    const { result } = renderHook(() => useRef(null))
-    const props = {
-      onChange: vi.fn(),
-      keyboardRef: result.current,
-    }
 
-    render(props)
+    render()
 
     const globeKey = screen
       .getAllByRole('button')

--- a/app/src/atoms/SoftwareKeyboard/FullKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/FullKeyboard/index.tsx
@@ -18,6 +18,10 @@ import type { KeyboardLanguage, LayoutName } from '../types'
 import '../index.css'
 import './index.css'
 
+import { useSoftwareKeyboardControl } from '../utils/useSoftwareKeyboardControl'
+
+import type { SoftwareKeyboardControlOptions } from '../utils/useSoftwareKeyboardControl'
+
 const SPECIAL_LAYOUT_KEYS = ['{numbers}', '{abc}', '{shift}', '{symbols}']
 const PREVIEW_LABEL_RENDERING_DURATION_MS = 800
 const PREVIEW_LABEL_EN = 'English (US)'
@@ -25,14 +29,18 @@ const PREVIEW_LABEL_CH = '简体拼音'
 
 // TODO (kk:04/05/2024) add debug to make debugging easy
 interface FullKeyboardProps {
-  onChange: (input: string) => void
   keyboardRef: MutableRefObject<KeyboardReactInterface | null>
+  /**
+   * The underlying element that the software keyboard should type into.
+   * See `useSoftwareKeyboardControl()`.
+   */
+  inputElementRef: SoftwareKeyboardControlOptions['inputElementRef']
   debug?: boolean
 }
 
 export function FullKeyboard({
-  onChange,
   keyboardRef,
+  inputElementRef,
   debug = false,
 }: FullKeyboardProps): JSX.Element {
   const [layoutName, setLayoutName] = useState<LayoutName>('default')
@@ -137,6 +145,11 @@ export function FullKeyboard({
     }
   }, [keyboardLanguage, spacePreviewLabel])
 
+  const { beforeInputUpdate, onChange } = useSoftwareKeyboardControl({
+    keyboardRef,
+    inputElementRef,
+  })
+
   return (
     <Keyboard
       keyboardRef={r => {
@@ -144,6 +157,7 @@ export function FullKeyboard({
       }}
       theme="hg-theme-default oddTheme1"
       onChange={onChange}
+      beforeInputUpdate={beforeInputUpdate}
       onKeyPress={onKeyPress}
       layoutName={layoutName}
       layout={fullKeyboardLayout}

--- a/app/src/atoms/SoftwareKeyboard/IndividualKey/IndividualKey.stories.tsx
+++ b/app/src/atoms/SoftwareKeyboard/IndividualKey/IndividualKey.stories.tsx
@@ -12,6 +12,7 @@ import {
 import { IndividualKey } from '.'
 
 import type { Meta, StoryObj } from '@storybook/react'
+import type { KeyboardReactInterface } from 'react-simple-keyboard'
 
 const meta: Meta<typeof IndividualKey> = {
   title: 'ODD/Atoms/SoftwareKeyboard/IndividualKey',
@@ -23,29 +24,33 @@ export default meta
 
 type Story = StoryObj<typeof IndividualKey>
 
-const Keyboard = ({ ...args }): JSX.Element => {
+const Keyboard = ({ keyText }: { keyText: string }): JSX.Element => {
   const [showKeyboard, setShowKeyboard] = useState(false)
   const [value, setValue] = useState<string>('')
-  const keyboardRef = useRef(null)
+  const keyboardRef = useRef<KeyboardReactInterface | null>(null)
+  const inputElementRef = useRef<HTMLInputElement>(null)
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing16}>
       <form id="test_form">
         <InputField
+          ref={inputElementRef}
           value={value}
           type="text"
-          placeholder="When focusing, the numpad shows up"
+          placeholder="When focusing, the keyboard shows up"
           onFocus={() => {
             setShowKeyboard(true)
+          }}
+          onChange={e => {
+            setValue(e.target.value)
           }}
         />
       </form>
       <Flex position={POSITION_ABSOLUTE} top="20%" width="15rem">
         {showKeyboard && (
           <IndividualKey
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
-            onChange={e => e != null && setValue(String(e))}
             keyboardRef={keyboardRef}
-            keyText={args.keyText}
+            inputElementRef={inputElementRef}
+            keyText={keyText}
           />
         )}
       </Flex>
@@ -53,9 +58,9 @@ const Keyboard = ({ ...args }): JSX.Element => {
   )
 }
 
-export const IndividualKeySoftwareKeyboard: Story = args => (
-  <Keyboard {...args} />
-)
-IndividualKeySoftwareKeyboard.args = {
-  keyText: 'hello',
+export const IndividualKeySoftwareKeyboard: Story = {
+  render: args => <Keyboard keyText={args.keyText} />,
+  args: {
+    keyText: 'hello',
+  },
 }

--- a/app/src/atoms/SoftwareKeyboard/IndividualKey/__tests__/IndividualKey.test.tsx
+++ b/app/src/atoms/SoftwareKeyboard/IndividualKey/__tests__/IndividualKey.test.tsx
@@ -1,41 +1,50 @@
 import { useRef } from 'react'
-import { renderHook, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import '@testing-library/jest-dom/vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 
 import { IndividualKey } from '..'
 
-import type { ComponentProps } from 'react'
+import type { KeyboardReactInterface } from 'react-simple-keyboard'
 
-const render = (props: ComponentProps<typeof IndividualKey>) => {
-  return renderWithProviders(<IndividualKey {...props} />)[0]
+function TestKeyboard(): JSX.Element {
+  const keyboardRef = useRef<KeyboardReactInterface | null>(null)
+  const inputElementRef = useRef<HTMLInputElement>(null)
+
+  return (
+    <>
+      <input data-testid="IndividualKey_Input" ref={inputElementRef} />
+      <IndividualKey
+        keyboardRef={keyboardRef}
+        inputElementRef={inputElementRef}
+        keyText="mockKey"
+      />
+    </>
+  )
+}
+
+const render = () => {
+  return renderWithProviders(<TestKeyboard />)[0]
 }
 
 describe('IndividualKey', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('should render the text key', () => {
-    const { result } = renderHook(() => useRef(null))
-    const props = {
-      onChange: vi.fn(),
-      keyboardRef: result.current,
-      keyText: 'mockKey',
-    }
-    render(props)
+    render()
     screen.getByRole('button', { name: 'mockKey' })
   })
 
-  it('should call mock function when clicking text key', async () => {
+  it('should update the input when clicking keys', async () => {
     const user = userEvent.setup()
-    const { result } = renderHook(() => useRef(null))
-    const props = {
-      onChange: vi.fn(),
-      keyboardRef: result.current,
-      keyText: 'mockKey',
-    }
-    render(props)
-    const textKey = screen.getByRole('button', { name: 'mockKey' })
-    await user.click(textKey)
-    expect(props.onChange).toHaveBeenCalled()
+    render()
+    await user.click(screen.getByRole('button', { name: 'mockKey' }))
+    expect(screen.getByTestId('IndividualKey_Input')).toHaveValue('mockKey')
   })
 })

--- a/app/src/atoms/SoftwareKeyboard/IndividualKey/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/IndividualKey/index.tsx
@@ -4,24 +4,30 @@ import {
   customDisplayForIndividual,
   softwareKeyboardButtonAttributes,
 } from '../constants'
+import { useSoftwareKeyboardControl } from '../utils/useSoftwareKeyboardControl'
 
 import type { MutableRefObject } from 'react'
 import type { KeyboardReactInterface } from 'react-simple-keyboard'
+import type { SoftwareKeyboardControlOptions } from '../utils/useSoftwareKeyboardControl'
 
 import '../index.css'
 import './index.css'
 
 // TODO (kk:04/05/2024) add debug to make debugging easy
 interface IndividualKeyProps {
-  onChange: (input: string) => void
   keyboardRef: MutableRefObject<KeyboardReactInterface | null>
+  /**
+   * The underlying element that the software keyboard should type into.
+   * See `useSoftwareKeyboardControl()`.
+   */
+  inputElementRef: SoftwareKeyboardControlOptions['inputElementRef']
   keyText: string
   debug?: boolean
 }
 
 export function IndividualKey({
-  onChange,
   keyboardRef,
+  inputElementRef,
   keyText,
   debug = false,
 }: IndividualKeyProps): JSX.Element {
@@ -30,6 +36,12 @@ export function IndividualKey({
       default: [`${keyText}`],
     },
   }
+
+  const { beforeInputUpdate, onChange } = useSoftwareKeyboardControl({
+    keyboardRef,
+    inputElementRef,
+  })
+
   return (
     <Keyboard
       keyboardRef={r => {
@@ -37,6 +49,7 @@ export function IndividualKey({
       }}
       theme="hg-theme-default oddTheme1 individual-key"
       onChange={onChange}
+      beforeInputUpdate={beforeInputUpdate}
       layoutName="default"
       display={customDisplayForIndividual}
       useButtonTag={false} // Exclude from the tab order.

--- a/app/src/organisms/ODD/DocumentationRequired/DocumentationRequired.tsx
+++ b/app/src/organisms/ODD/DocumentationRequired/DocumentationRequired.tsx
@@ -119,11 +119,8 @@ export function DocumentationRequired({
           onToggle={handleKeyboardToggle}
         >
           <FullKeyboard
-            onChange={(input: string) => {
-              handleInputChange(input)
-              textAreaRef.current?.focus()
-            }}
             keyboardRef={keyboardRef}
+            inputElementRef={textAreaRef}
           />
         </AccordionKeyboard>
       </div>

--- a/app/src/organisms/ODD/NetworkSettings/WifiPasswordInput.tsx
+++ b/app/src/organisms/ODD/NetworkSettings/WifiPasswordInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import clsx from 'clsx'
 
@@ -32,17 +32,7 @@ export function WifiPasswordInput({
     !isUnboxingFlowOngoing && styles.main_wrapper_with_top_margin
   )
 
-  useEffect(() => {
-    if (inputRef.current != null) {
-      inputRef.current.focus()
-    }
-    keyboardRef.current?.setInput(password)
-    keyboardRef.current?.setCaretPosition(password.length)
-  }, [password])
-
-  usePlaceCaretAtEndOnToggle(inputRef, showPassword, true, end => {
-    keyboardRef.current?.setCaretPosition(end)
-  })
+  usePlaceCaretAtEndOnToggle(inputRef, showPassword, true)
 
   return (
     <>
@@ -72,13 +62,7 @@ export function WifiPasswordInput({
         </div>
       </div>
       <div className={styles.keyboard_wrapper}>
-        <FullKeyboard
-          onChange={e => {
-            e != null && setPassword(String(e))
-            inputRef?.current?.focus()
-          }}
-          keyboardRef={keyboardRef}
-        />
+        <FullKeyboard keyboardRef={keyboardRef} inputElementRef={inputRef} />
       </div>
     </>
   )

--- a/app/src/organisms/ODD/NetworkSettings/WifiSsidInput.tsx
+++ b/app/src/organisms/ODD/NetworkSettings/WifiSsidInput.tsx
@@ -30,6 +30,7 @@ export function WifiSsidInput({
 }: WifiSsidInputProps): JSX.Element {
   const { t } = useTranslation(['device_settings', 'shared'])
   const keyboardRef = useRef(null)
+  const inputRef = useRef<HTMLInputElement>(null)
   const isUnboxingFlowOngoing = useIsUnboxingFlowOngoing()
 
   return (
@@ -48,6 +49,7 @@ export function WifiSsidInput({
           {t('enter_network_name')}
         </LegacyStyledText>
         <TouchInputField
+          ref={inputRef}
           autoFocus
           aria-label="wifi_ssid"
           value={inputSsid}
@@ -59,12 +61,7 @@ export function WifiSsidInput({
         />
       </Flex>
       <Flex width="100%" position={POSITION_FIXED} left="0" bottom="0">
-        <FullKeyboard
-          onChange={e => {
-            e != null && setInputSsid(e)
-          }}
-          keyboardRef={keyboardRef}
-        />
+        <FullKeyboard inputElementRef={inputRef} keyboardRef={keyboardRef} />
       </Flex>
     </>
   )

--- a/app/src/organisms/ODD/OnDeviceLogin/LoginFieldController.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginFieldController.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from 'react'
 import { Controller } from 'react-hook-form'
 
 import { LoginFieldInput } from './LoginFieldInput'
@@ -20,17 +21,23 @@ export interface LoginFieldControllerProps {
   keyboardRef: RefObject<KeyboardReactInterface | null>
 }
 
-export function LoginFieldController({
-  control,
-  step,
-  t,
-  isPasswordResetRequired,
-  loginError,
-  confirmPasswordError,
-  usernameError,
-  onClearFieldErrors,
-  keyboardRef,
-}: LoginFieldControllerProps): JSX.Element | null {
+export const LoginFieldController = forwardRef<
+  HTMLInputElement,
+  LoginFieldControllerProps
+>(function LoginFieldController(
+  {
+    control,
+    step,
+    t,
+    isPasswordResetRequired,
+    loginError,
+    confirmPasswordError,
+    usernameError,
+    onClearFieldErrors,
+    keyboardRef,
+  },
+  ref
+): JSX.Element | null {
   if (step === 'username') {
     return (
       <Controller
@@ -39,6 +46,7 @@ export function LoginFieldController({
         name="username"
         render={({ field }) => (
           <LoginFieldInput
+            ref={ref}
             field={field}
             label={t('access_control:username')}
             error={usernameError}
@@ -63,6 +71,7 @@ export function LoginFieldController({
         name="password"
         render={({ field }) => (
           <LoginFieldInput
+            ref={ref}
             field={field}
             label={
               isPasswordResetRequired
@@ -88,6 +97,7 @@ export function LoginFieldController({
         name="confirmPassword"
         render={({ field }) => (
           <LoginFieldInput
+            ref={ref}
             field={field}
             label={t('access_control:on_device_login_confirm_password')}
             error={confirmPasswordError}
@@ -102,4 +112,4 @@ export function LoginFieldController({
   }
 
   return null
-}
+})

--- a/app/src/organisms/ODD/OnDeviceLogin/LoginFieldController.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginFieldController.tsx
@@ -4,9 +4,7 @@ import { Controller } from 'react-hook-form'
 import { LoginFieldInput } from './LoginFieldInput'
 
 import type { TFunction } from 'i18next'
-import type { RefObject } from 'react'
 import type { Control } from 'react-hook-form'
-import type { KeyboardReactInterface } from 'react-simple-keyboard'
 import type { LoginFormValues, LoginStep } from './index'
 
 export interface LoginFieldControllerProps {
@@ -18,7 +16,6 @@ export interface LoginFieldControllerProps {
   confirmPasswordError: string | null
   usernameError: string | null
   onClearFieldErrors: () => void
-  keyboardRef: RefObject<KeyboardReactInterface | null>
 }
 
 export const LoginFieldController = forwardRef<
@@ -34,7 +31,6 @@ export const LoginFieldController = forwardRef<
     confirmPasswordError,
     usernameError,
     onClearFieldErrors,
-    keyboardRef,
   },
   ref
 ): JSX.Element | null {
@@ -53,7 +49,6 @@ export const LoginFieldController = forwardRef<
             isPasswordField={false}
             onClearError={onClearFieldErrors}
             autoFocus
-            keyboardRef={keyboardRef}
           />
         )}
       />
@@ -82,7 +77,6 @@ export const LoginFieldController = forwardRef<
             isPasswordField={true}
             onClearError={onClearFieldErrors}
             autoFocus
-            keyboardRef={keyboardRef}
           />
         )}
       />
@@ -104,7 +98,6 @@ export const LoginFieldController = forwardRef<
             isPasswordField={true}
             onClearError={onClearFieldErrors}
             autoFocus
-            keyboardRef={keyboardRef}
           />
         )}
       />

--- a/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
@@ -7,7 +7,6 @@ import { PasswordVisibilityToggle } from '/app/molecules/PasswordVisibilityToggl
 
 import type { ChangeEvent, RefObject } from 'react'
 import type { ControllerRenderProps } from 'react-hook-form'
-import type { KeyboardReactInterface } from 'react-simple-keyboard'
 import type { LoginFormValues } from './index'
 
 // todo(mm, 2026-08-21): It seems like LoginFieldInput and LoginFieldController could
@@ -24,22 +23,13 @@ export interface LoginFieldInputProps {
   isPasswordField: boolean
   onClearError?: () => void
   autoFocus?: boolean
-  keyboardRef?: RefObject<KeyboardReactInterface | null>
 }
 
 export const LoginFieldInput = forwardRef<
   HTMLInputElement,
   LoginFieldInputProps
 >(function LoginFieldInput(
-  {
-    field,
-    label,
-    error,
-    isPasswordField,
-    onClearError,
-    autoFocus,
-    keyboardRef,
-  },
+  { field, label, error, isPasswordField, onClearError, autoFocus },
   ref
 ): JSX.Element {
   const [showPassword, setShowPassword] = useState(false)
@@ -47,9 +37,7 @@ export const LoginFieldInput = forwardRef<
   const isPasswordHidden = isPasswordField && !showPassword
   const inputType: 'text' | 'password' = isPasswordHidden ? 'password' : 'text'
 
-  usePlaceCaretAtEndOnToggle(inputRef, showPassword, isPasswordField, end => {
-    keyboardRef?.current?.setCaretPosition(end)
-  })
+  usePlaceCaretAtEndOnToggle(inputRef, showPassword, isPasswordField)
 
   return (
     <TouchInputField

--- a/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { forwardRef, useRef, useState } from 'react'
 
 import { setRefs, TouchInputField } from '@opentrons/components'
 
@@ -6,14 +6,19 @@ import { usePlaceCaretAtEndOnToggle } from '/app/local-resources/access-control/
 import { PasswordVisibilityToggle } from '/app/molecules/PasswordVisibilityToggle'
 
 import type { ChangeEvent, RefObject } from 'react'
-import type { ControllerRenderProps, FieldPath } from 'react-hook-form'
+import type { ControllerRenderProps } from 'react-hook-form'
 import type { KeyboardReactInterface } from 'react-simple-keyboard'
 import type { LoginFormValues } from './index'
 
-export interface LoginFieldInputProps<
-  TFieldName extends FieldPath<LoginFormValues> = FieldPath<LoginFormValues>,
-> {
-  field: ControllerRenderProps<LoginFormValues, TFieldName>
+// todo(mm, 2026-08-21): It seems like LoginFieldInput and LoginFieldController could
+// be refactored so only one needs to know about form fields.
+type FieldProps =
+  | ControllerRenderProps<LoginFormValues, 'username'>
+  | ControllerRenderProps<LoginFormValues, 'password'>
+  | ControllerRenderProps<LoginFormValues, 'confirmPassword'>
+
+export interface LoginFieldInputProps {
+  field: FieldProps
   label: string
   error: string | null
   isPasswordField: boolean
@@ -22,17 +27,21 @@ export interface LoginFieldInputProps<
   keyboardRef?: RefObject<KeyboardReactInterface | null>
 }
 
-export function LoginFieldInput<
-  TFieldName extends FieldPath<LoginFormValues> = FieldPath<LoginFormValues>,
->({
-  field,
-  label,
-  error,
-  isPasswordField,
-  onClearError,
-  autoFocus,
-  keyboardRef,
-}: LoginFieldInputProps<TFieldName>): JSX.Element {
+export const LoginFieldInput = forwardRef<
+  HTMLInputElement,
+  LoginFieldInputProps
+>(function LoginFieldInput(
+  {
+    field,
+    label,
+    error,
+    isPasswordField,
+    onClearError,
+    autoFocus,
+    keyboardRef,
+  },
+  ref
+): JSX.Element {
   const [showPassword, setShowPassword] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const isPasswordHidden = isPasswordField && !showPassword
@@ -44,7 +53,7 @@ export function LoginFieldInput<
 
   return (
     <TouchInputField
-      ref={setRefs(inputRef, field.ref)}
+      ref={setRefs(ref, inputRef, field.ref)}
       autoFocus={autoFocus}
       type={inputType}
       label={label}
@@ -69,4 +78,4 @@ export function LoginFieldInput<
       }
     />
   )
-}
+})

--- a/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
@@ -5,7 +5,7 @@ import { setRefs, TouchInputField } from '@opentrons/components'
 import { usePlaceCaretAtEndOnToggle } from '/app/local-resources/access-control/usePlaceCaretAtEndOnToggle'
 import { PasswordVisibilityToggle } from '/app/molecules/PasswordVisibilityToggle'
 
-import type { ChangeEvent, RefObject } from 'react'
+import type { ChangeEvent } from 'react'
 import type { ControllerRenderProps } from 'react-hook-form'
 import type { LoginFormValues } from './index'
 

--- a/app/src/organisms/ODD/OnDeviceLogin/__tests__/OnDeviceLogin.test.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/__tests__/OnDeviceLogin.test.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { fireEvent, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
@@ -141,6 +142,16 @@ describe('OnDeviceLogin', () => {
     expect(
       screen.getByLabelText('access_control:on_device_login_confirm_password')
     ).toBeInTheDocument()
+  })
+
+  it('types into the login field with the software keyboard', async () => {
+    const user = userEvent.setup()
+    renderLogin({ initialStep: 'username' })
+
+    await user.click(screen.getByRole('button', { name: 'a' }))
+    await user.click(screen.getByRole('button', { name: 'b' }))
+
+    expect(screen.getByLabelText('access_control:username')).toHaveValue('ab')
   })
 
   it('advances from username to password', () => {

--- a/app/src/organisms/ODD/OnDeviceLogin/index.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/index.tsx
@@ -58,7 +58,7 @@ export function OnDeviceLogin({
     null
   )
   const [usernameError, setUsernameError] = useState<string | null>(null)
-  const { control, watch, setValue } = useForm<LoginFormValues>({
+  const { control, watch } = useForm<LoginFormValues>({
     defaultValues: {
       username: initialUsername ?? '',
       password: '',
@@ -67,24 +67,11 @@ export function OnDeviceLogin({
   })
 
   const keyboardRef = useRef<KeyboardReactInterface | null>(null)
+  const inputElementRef = useRef<HTMLInputElement>(null)
 
   const username = watch('username')
   const password = watch('password')
   const confirmPassword = watch('confirmPassword')
-
-  const activeFieldName: LoginFieldName =
-    step === 'username'
-      ? 'username'
-      : step === 'confirmPassword'
-        ? 'confirmPassword'
-        : 'password'
-
-  const keyboardFieldValue =
-    step === 'username'
-      ? username
-      : step === 'confirmPassword'
-        ? confirmPassword
-        : password
 
   const clearFieldErrors = (): void => {
     setConfirmPasswordError(null)
@@ -92,15 +79,6 @@ export function OnDeviceLogin({
     setUsernameError(null)
     onClearLoginError?.()
   }
-
-  // Keep the software keyboard's value and caret in sync with the active field,
-  // including after username -> password so new keys insert at the end.
-  useEffect(() => {
-    const kb = keyboardRef.current
-    if (kb == null) return
-    kb.setInput(keyboardFieldValue)
-    kb.setCaretPosition(keyboardFieldValue.length)
-  }, [step, keyboardFieldValue])
 
   const handleNext = useCallback((): void => {
     if (step === 'username') {
@@ -248,6 +226,7 @@ export function OnDeviceLogin({
         <div className={styles.content_container}>
           <div className={styles.form_inner_container}>
             <LoginFieldController
+              ref={inputElementRef}
               control={control}
               step={step}
               t={t}
@@ -256,21 +235,14 @@ export function OnDeviceLogin({
               confirmPasswordError={confirmPasswordError}
               usernameError={usernameError}
               onClearFieldErrors={clearFieldErrors}
-              keyboardRef={keyboardRef}
             />
           </div>
         </div>
       </div>
       <div className={styles.keyboard_container}>
         <FullKeyboard
-          onChange={(input: string) => {
-            setValue(activeFieldName, input, {
-              shouldDirty: true,
-              shouldTouch: true,
-            })
-            clearFieldErrors()
-          }}
           keyboardRef={keyboardRef}
+          inputElementRef={inputElementRef}
         />
       </div>
     </>

--- a/app/src/organisms/ODD/QuickTransferFlow/NameQuickTransfer.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/NameQuickTransfer.tsx
@@ -29,6 +29,7 @@ export function NameQuickTransfer(props: NameQuickTransferProps): JSX.Element {
   const { t } = useTranslation('quick_transfer')
   const [name, setName] = useState('')
   const keyboardRef = useRef(null)
+  const inputRef = useRef<HTMLInputElement>(null)
   const [isSaving, setIsSaving] = useState<boolean>(false)
 
   let error: string | null = null
@@ -42,6 +43,10 @@ export function NameQuickTransfer(props: NameQuickTransferProps): JSX.Element {
         header={t('name_your_transfer')}
         buttonText={t('save')}
         onClickButton={() => {
+          // todo(mm, 2026-08-21): If the async save task has an error, this will get us
+          // stuck in a "saving" state forever. We could fix this by making this
+          // component take a prop like "isSaving", which higher-level code could
+          // populate from React Query.
           setIsSaving(true)
           onSave(name)
         }}
@@ -65,12 +70,13 @@ export function NameQuickTransfer(props: NameQuickTransferProps): JSX.Element {
           width="100%"
         >
           <TouchInputField
+            ref={inputRef}
             autoFocus
             type="text"
             value={name}
             textAlign={TYPOGRAPHY.textAlignCenter}
             onChange={e => {
-              setName(e.target.value as string)
+              setName(e.target.value)
             }}
           />
           <StyledText
@@ -90,12 +96,7 @@ export function NameQuickTransfer(props: NameQuickTransferProps): JSX.Element {
         </Flex>
       </Flex>
       <Flex width="100%" position={POSITION_FIXED} left="0" bottom="0">
-        <FullKeyboard
-          onChange={(input: string) => {
-            setName(input)
-          }}
-          keyboardRef={keyboardRef}
-        />
+        <FullKeyboard keyboardRef={keyboardRef} inputElementRef={inputRef} />
       </Flex>
     </Flex>,
     getTopPortalEl()

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/NameQuickTransfer.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/NameQuickTransfer.test.tsx
@@ -8,17 +8,8 @@ import { i18n } from '/app/i18n'
 import { NameQuickTransfer } from '../NameQuickTransfer'
 
 import type { ComponentProps } from 'react'
-import type { TouchInputField } from '@opentrons/components'
 
 vi.mock('../utils')
-
-vi.mock('@opentrons/components', async importOriginal => {
-  const actualComponents = await importOriginal<typeof TouchInputField>()
-  return {
-    ...actualComponents,
-    TouchInputField: vi.fn(),
-  }
-})
 
 const render = (props: ComponentProps<typeof NameQuickTransfer>) => {
   return renderWithProviders(<NameQuickTransfer {...props} />, {

--- a/app/src/pages/ODD/RunSummary/SignRun.tsx
+++ b/app/src/pages/ODD/RunSummary/SignRun.tsx
@@ -87,13 +87,6 @@ export function SignRun({
     trimmedName === '' || isLoading || nameError || loginGate !== 'done'
 
   useEffect(() => {
-    if (inputRef.current != null) {
-      inputRef.current.focus()
-    }
-    keyboardRef.current?.setInput(name)
-  }, [name])
-
-  useEffect(() => {
     if (isSigned) {
       onSigned?.()
     }
@@ -175,11 +168,8 @@ export function SignRun({
             onToggle={handleKeyboardToggle}
           >
             <FullKeyboard
-              onChange={(input: string) => {
-                handleNameChange(input)
-                inputRef.current?.focus()
-              }}
               keyboardRef={keyboardRef}
+              inputElementRef={inputRef}
             />
           </AccordionKeyboard>
         </div>


### PR DESCRIPTION
## Overview

This goes towards EXEC-2824, addressing various problems with our on-screen keyboards typing the wrong text into the wrong place. It continues the pattern set by PR #22296 / commit 2d927d4.

This PR focuses on *full-layout* on-screen keyboards, like the one for entering a Wi-Fi password.

## Test Plan and Hands on Testing

Same test plan as #22296, but in different places:

* [ ] The ODD "Documentation required" screen
* [x] The ODD Wi-Fi SSID input
* [x] The ODD Wi-Fi password input
* [x] The ODD login form (all pages)
* [ ] The ODD "Sign run" form
* [x] The ODD "Name Quick Transfer Protocol" form

## Review requests

Double-check the way that I'm updating the call sites that were using `usePlaceCaretAtEndOnToggle()`. I think we still need `usePlaceCaretAtEndOnToggle()` to move the caret within the native `<input>` element. But I removed the extra part that updated the caret in the software keyboard, because `useSoftwareKeyboardControl()` is responsible for that now.

## Risk assessment

Medium.