### PR TITLE
refactor(app, components): Update ODD password and login screens to match designs

### DIFF
--- a/app/src/assets/localization/en/access_control.json
+++ b/app/src/assets/localization/en/access_control.json
@@ -32,6 +32,7 @@
   "login_form_password_field": "Password",
   "login_form_username_field": "Username",
   "must_be_at_least_characters": "Must be at least {{minLength}} characters long",
+  "must_include_at_least_one_special_character": "Must include at least one special character",
   "on_device_login": "Login",
   "on_device_login_confirm_password": "Confirm password",
   "on_device_login_new_password": "New password",

--- a/app/src/local-resources/access-control/usePlaceCaretAtEndOnToggle.ts
+++ b/app/src/local-resources/access-control/usePlaceCaretAtEndOnToggle.ts
@@ -1,0 +1,56 @@
+import { useLayoutEffect, useRef } from 'react'
+
+import type { RefObject } from 'react'
+
+/**
+ * After password visibility toggles, restore the caret at the end of the input.
+ * Chrome resets selection when the input type changes; a follow-up animation
+ * frame covers the case where that reset happens after layout effects.
+ */
+export function usePlaceCaretAtEndOnToggle(
+  inputRef: RefObject<HTMLInputElement | null>,
+  showPassword: boolean,
+  enabled: boolean,
+  onCaretPlaced?: (end: number) => void
+): void {
+  const isFirstRenderRef = useRef(true)
+  const onCaretPlacedRef = useRef(onCaretPlaced)
+  onCaretPlacedRef.current = onCaretPlaced
+
+  useLayoutEffect(() => {
+    if (!enabled) {
+      return
+    }
+    if (isFirstRenderRef.current) {
+      isFirstRenderRef.current = false
+      return
+    }
+
+    const placeCaret = (): void => {
+      const input = inputRef.current
+      if (input == null) {
+        return
+      }
+      const end = placeCaretAtEnd(input)
+      onCaretPlacedRef.current?.(end)
+    }
+
+    placeCaret()
+    const frameId = window.requestAnimationFrame(placeCaret)
+    return () => {
+      window.cancelAnimationFrame(frameId)
+    }
+  }, [showPassword, enabled, inputRef])
+}
+
+/**
+ * Focus the input and put the caret at the end of its value.
+ * Changing an input between type="password" and type="text" resets the caret
+ * to the start in Chrome; call this after that type change.
+ */
+function placeCaretAtEnd(input: HTMLInputElement): number {
+  const end = input.value.length
+  input.focus()
+  input.setSelectionRange(end, end)
+  return end
+}

--- a/app/src/molecules/PasswordVisibilityToggle/index.tsx
+++ b/app/src/molecules/PasswordVisibilityToggle/index.tsx
@@ -22,9 +22,13 @@ export function PasswordVisibilityToggle({
   return (
     <button
       type="button"
+      tabIndex={-1}
+      onPointerDown={e => {
+        // Keep focus (and the caret) on the password field for mouse and touch.
+        e.preventDefault()
+      }}
       onMouseDown={e => {
-        // This prevents focus from moving from the password field to this toggle button,
-        // but lets the click event go through.
+        // Fallback for browsers that do not emit pointer events.
         e.preventDefault()
       }}
       onClick={onToggle}

--- a/app/src/molecules/PasswordVisibilityToggle/index.tsx
+++ b/app/src/molecules/PasswordVisibilityToggle/index.tsx
@@ -22,13 +22,9 @@ export function PasswordVisibilityToggle({
   return (
     <button
       type="button"
-      tabIndex={-1}
-      onPointerDown={e => {
-        // Keep focus (and the caret) on the password field for mouse and touch.
-        e.preventDefault()
-      }}
       onMouseDown={e => {
-        // Fallback for browsers that do not emit pointer events.
+        // This prevents focus from moving from the password field to this toggle button,
+        // but lets the click event go through.
         e.preventDefault()
       }}
       onClick={onToggle}

--- a/app/src/molecules/PasswordVisibilityToggle/passwordvisibilitytoggle.module.css
+++ b/app/src/molecules/PasswordVisibilityToggle/passwordvisibilitytoggle.module.css
@@ -1,8 +1,8 @@
 .toggle_button {
   display: flex;
   width: 7.375rem;
-  height: 2.75rem;
   flex-direction: row;
+  flex-shrink: 0;
   align-items: center;
   background-color: transparent;
   gap: var(--spacing-12);

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/PasswordInputField.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/PasswordInputField.tsx
@@ -1,7 +1,9 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Icon, InputField } from '@opentrons/components'
+
+import { usePlaceCaretAtEndOnToggle } from '/app/local-resources/access-control/usePlaceCaretAtEndOnToggle'
 
 import styles from './passwordinputfield.module.css'
 
@@ -24,9 +26,13 @@ export function PasswordInputField({
 }: PasswordInputFieldProps): JSX.Element {
   const { t } = useTranslation('device_settings')
   const [showPassword, setShowPassword] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  usePlaceCaretAtEndOnToggle(inputRef, showPassword, true)
 
   return (
     <InputField
+      ref={inputRef}
       type={showPassword ? 'text' : 'password'}
       value={value}
       placeholder={placeholder}
@@ -38,6 +44,9 @@ export function PasswordInputField({
           type="button"
           className={styles.password_visibility_button}
           aria-label={t('toggle_password_visibility')}
+          onPointerDown={e => {
+            e.preventDefault()
+          }}
           onMouseDown={e => {
             // This prevents focus from moving from the password field to this toggle button,
             // but lets the click event go through.

--- a/app/src/organisms/ODD/NetworkSettings/WifiPasswordInput.tsx
+++ b/app/src/organisms/ODD/NetworkSettings/WifiPasswordInput.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx'
 import { StyledText, TouchInputField } from '@opentrons/components'
 
 import { FullKeyboard } from '/app/atoms/SoftwareKeyboard'
+import { usePlaceCaretAtEndOnToggle } from '/app/local-resources/access-control/usePlaceCaretAtEndOnToggle'
 import { PasswordVisibilityToggle } from '/app/molecules/PasswordVisibilityToggle'
 import { useIsUnboxingFlowOngoing } from '/app/redux-resources/config'
 
@@ -36,7 +37,12 @@ export function WifiPasswordInput({
       inputRef.current.focus()
     }
     keyboardRef.current?.setInput(password)
+    keyboardRef.current?.setCaretPosition(password.length)
   }, [password])
+
+  usePlaceCaretAtEndOnToggle(inputRef, showPassword, true, end => {
+    keyboardRef.current?.setCaretPosition(end)
+  })
 
   return (
     <>

--- a/app/src/organisms/ODD/NetworkSettings/WifiPasswordInput.tsx
+++ b/app/src/organisms/ODD/NetworkSettings/WifiPasswordInput.tsx
@@ -45,26 +45,24 @@ export function WifiPasswordInput({
           <StyledText oddStyle="bodyTextRegular">
             {t('enter_password')}
           </StyledText>
-          <div className={styles.input_row}>
-            <div className={styles.input_field_wrapper}>
-              <TouchInputField
-                aria-label="wifi_password"
-                value={password}
-                type={showPassword ? 'text' : 'password'}
-                ref={inputRef}
-                autoFocus
-                onChange={e => {
-                  setPassword(e.target.value)
+          <TouchInputField
+            aria-label="wifi_password"
+            value={password}
+            type={showPassword ? 'text' : 'password'}
+            ref={inputRef}
+            autoFocus
+            onChange={e => {
+              setPassword(e.target.value)
+            }}
+            accessory={
+              <PasswordVisibilityToggle
+                isVisible={showPassword}
+                onToggle={() => {
+                  setShowPassword(currentState => !currentState)
                 }}
               />
-            </div>
-            <PasswordVisibilityToggle
-              isVisible={showPassword}
-              onToggle={() => {
-                setShowPassword(currentState => !currentState)
-              }}
-            />
-          </div>
+            }
+          />
         </div>
       </div>
       <div className={styles.keyboard_wrapper}>

--- a/app/src/organisms/ODD/NetworkSettings/wifipasswordinput.module.css
+++ b/app/src/organisms/ODD/NetworkSettings/wifipasswordinput.module.css
@@ -14,18 +14,6 @@
   gap: var(--spacing-8);
 }
 
-.input_row {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--spacing-24);
-}
-
-.input_field_wrapper {
-  width: 42.625rem;
-}
-
 .keyboard_wrapper {
   position: fixed;
   bottom: 0;

--- a/app/src/organisms/ODD/OnDeviceLogin/LoginFieldController.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginFieldController.tsx
@@ -3,7 +3,9 @@ import { Controller } from 'react-hook-form'
 import { LoginFieldInput } from './LoginFieldInput'
 
 import type { TFunction } from 'i18next'
+import type { RefObject } from 'react'
 import type { Control } from 'react-hook-form'
+import type { KeyboardReactInterface } from 'react-simple-keyboard'
 import type { LoginFormValues, LoginStep } from './index'
 
 export interface LoginFieldControllerProps {
@@ -14,6 +16,7 @@ export interface LoginFieldControllerProps {
   loginError: string | null
   confirmPasswordError: string | null
   onClearFieldErrors: () => void
+  keyboardRef: RefObject<KeyboardReactInterface | null>
 }
 
 export function LoginFieldController({
@@ -24,6 +27,7 @@ export function LoginFieldController({
   loginError,
   confirmPasswordError,
   onClearFieldErrors,
+  keyboardRef,
 }: LoginFieldControllerProps): JSX.Element | null {
   if (step === 'username') {
     return (
@@ -39,6 +43,7 @@ export function LoginFieldController({
             isPasswordField={false}
             onClearError={onClearFieldErrors}
             autoFocus
+            keyboardRef={keyboardRef}
           />
         )}
       />
@@ -66,6 +71,7 @@ export function LoginFieldController({
             isPasswordField={true}
             onClearError={onClearFieldErrors}
             autoFocus
+            keyboardRef={keyboardRef}
           />
         )}
       />
@@ -86,6 +92,7 @@ export function LoginFieldController({
             isPasswordField={true}
             onClearError={onClearFieldErrors}
             autoFocus
+            keyboardRef={keyboardRef}
           />
         )}
       />

--- a/app/src/organisms/ODD/OnDeviceLogin/LoginFieldController.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginFieldController.tsx
@@ -15,6 +15,7 @@ export interface LoginFieldControllerProps {
   isPasswordResetRequired: boolean
   loginError: string | null
   confirmPasswordError: string | null
+  usernameError: string | null
   onClearFieldErrors: () => void
   keyboardRef: RefObject<KeyboardReactInterface | null>
 }
@@ -26,6 +27,7 @@ export function LoginFieldController({
   isPasswordResetRequired,
   loginError,
   confirmPasswordError,
+  usernameError,
   onClearFieldErrors,
   keyboardRef,
 }: LoginFieldControllerProps): JSX.Element | null {
@@ -39,7 +41,7 @@ export function LoginFieldController({
           <LoginFieldInput
             field={field}
             label={t('access_control:username')}
-            error={null}
+            error={usernameError}
             isPasswordField={false}
             onClearError={onClearFieldErrors}
             autoFocus

--- a/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
@@ -2,10 +2,12 @@ import { useRef, useState } from 'react'
 
 import { setRefs, TouchInputField } from '@opentrons/components'
 
+import { usePlaceCaretAtEndOnToggle } from '/app/local-resources/access-control/usePlaceCaretAtEndOnToggle'
 import { PasswordVisibilityToggle } from '/app/molecules/PasswordVisibilityToggle'
 
-import type { ChangeEvent } from 'react'
+import type { ChangeEvent, RefObject } from 'react'
 import type { ControllerRenderProps, FieldPath } from 'react-hook-form'
+import type { KeyboardReactInterface } from 'react-simple-keyboard'
 import type { LoginFormValues } from './index'
 
 export interface LoginFieldInputProps<
@@ -17,6 +19,7 @@ export interface LoginFieldInputProps<
   isPasswordField: boolean
   onClearError?: () => void
   autoFocus?: boolean
+  keyboardRef?: RefObject<KeyboardReactInterface | null>
 }
 
 export function LoginFieldInput<
@@ -28,11 +31,16 @@ export function LoginFieldInput<
   isPasswordField,
   onClearError,
   autoFocus,
+  keyboardRef,
 }: LoginFieldInputProps<TFieldName>): JSX.Element {
   const [showPassword, setShowPassword] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const isPasswordHidden = isPasswordField && !showPassword
   const inputType: 'text' | 'password' = isPasswordHidden ? 'password' : 'text'
+
+  usePlaceCaretAtEndOnToggle(inputRef, showPassword, isPasswordField, end => {
+    keyboardRef?.current?.setCaretPosition(end)
+  })
 
   return (
     <TouchInputField

--- a/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
@@ -4,8 +4,6 @@ import { setRefs, TouchInputField } from '@opentrons/components'
 
 import { PasswordVisibilityToggle } from '/app/molecules/PasswordVisibilityToggle'
 
-import styles from './OnDeviceLogin.module.css'
-
 import type { ChangeEvent } from 'react'
 import type { ControllerRenderProps, FieldPath } from 'react-hook-form'
 import type { LoginFormValues } from './index'
@@ -36,7 +34,7 @@ export function LoginFieldInput<
   const isPasswordHidden = isPasswordField && !showPassword
   const inputType: 'text' | 'password' = isPasswordHidden ? 'password' : 'text'
 
-  const inputField = (
+  return (
     <TouchInputField
       ref={setRefs(inputRef, field.ref)}
       autoFocus={autoFocus}
@@ -51,20 +49,16 @@ export function LoginFieldInput<
         field.onChange(e.target.value)
         onClearError?.()
       }}
+      accessory={
+        isPasswordField ? (
+          <PasswordVisibilityToggle
+            isVisible={showPassword}
+            onToggle={() => {
+              setShowPassword(prev => !prev)
+            }}
+          />
+        ) : null
+      }
     />
-  )
-
-  if (!isPasswordField) return inputField
-
-  return (
-    <div className={styles.password_field_row}>
-      <div className={styles.password_field_input}>{inputField}</div>
-      <PasswordVisibilityToggle
-        isVisible={showPassword}
-        onToggle={() => {
-          setShowPassword(prev => !prev)
-        }}
-      />
-    </div>
   )
 }

--- a/app/src/organisms/ODD/OnDeviceLogin/LoginModal.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginModal.tsx
@@ -3,12 +3,17 @@ import { useQueryClient } from 'react-query'
 import { useDispatch, useSelector } from 'react-redux'
 import NiceModal, { useModal } from '@ebay/nice-modal-react'
 
-import { getSelfQueryKey, useHost } from '@opentrons/react-api-client'
+import {
+  getSelfQueryKey,
+  useAuthSettingsQuery,
+  useHost,
+} from '@opentrons/react-api-client'
 
 import { getLocalRobot } from '/app/redux/discovery'
 import { logOut, useUsernameForRobot } from '/app/redux/robot-auth'
 import { useStoreLoginState } from '/app/resources/access-control/useStoreLoginState'
 import {
+  DEFAULT_MIN_PASSWORD_LENGTH,
   useOAuth2PasswordLogin,
   useSetNewPasswordAndSignIn,
 } from '/app/resources/auth'
@@ -99,8 +104,23 @@ const LoginModalImpl = NiceModal.create((): JSX.Element => {
       onSuccess: handleNewPasswordSuccess,
       onError: message => {
         setLoginError(message)
+        setStep('password')
       },
     })
+
+  const { data: authSettings } = useAuthSettingsQuery({
+    enabled: isChoosingNewPassword,
+  })
+  const passwordComplexity =
+    isChoosingNewPassword && authSettings?.data != null
+      ? {
+          minLength:
+            authSettings.data.passwordComplexityMinimumLength ??
+            DEFAULT_MIN_PASSWORD_LENGTH,
+          requireSpecialCharacters:
+            authSettings.data.passwordComplexitySpecialCharacters === true,
+        }
+      : null
 
   const handleCancel = (): void => {
     dismissModal()
@@ -129,6 +149,7 @@ const LoginModalImpl = NiceModal.create((): JSX.Element => {
         onClearLoginError={() => {
           setLoginError(null)
         }}
+        passwordComplexity={passwordComplexity}
         onCancel={handleCancel}
       />
     </div>

--- a/app/src/organisms/ODD/OnDeviceLogin/OnDeviceLogin.module.css
+++ b/app/src/organisms/ODD/OnDeviceLogin/OnDeviceLogin.module.css
@@ -31,19 +31,6 @@
   color: var(--red-50);
 }
 
-.password_field_row {
-  display: flex;
-  width: 100%;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  gap: var(--spacing-12);
-}
-
-.password_field_input {
-  flex: 1;
-}
-
 .keyboard_container {
   position: fixed;
   bottom: 0;

--- a/app/src/organisms/ODD/OnDeviceLogin/OnDeviceLoginModal.stories.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/OnDeviceLoginModal.stories.tsx
@@ -60,6 +60,7 @@ export const Default: Story = {
     onCancel: action('onCancel'),
     loginError: null,
     onClearLoginError: action('onClearLoginError'),
+    passwordComplexity: null,
   },
 }
 

--- a/app/src/organisms/ODD/OnDeviceLogin/__tests__/LoginModal.test.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/__tests__/LoginModal.test.tsx
@@ -259,4 +259,44 @@ describe('LoginModal', () => {
     await new Promise(resolve => setTimeout(resolve, 50))
     expect(modalResolved).toBe(false)
   })
+
+  it('returns to the new-password step with a policy error when setting a password fails', async () => {
+    vi.mocked(useOAuth2PasswordLogin).mockImplementation(({ onSuccess }) => ({
+      submitPassword: (username: string, _password: string) => {
+        onSuccess(
+          username,
+          mockAuthUser({ resetPassword: true }),
+          OAUTH_RESPONSE
+        )
+      },
+      isAuthLoading: false,
+    }))
+    vi.mocked(useSetNewPasswordAndSignIn).mockImplementation(({ onError }) => ({
+      submitNewPassword: () => {
+        onError('Must include at least one special character')
+      },
+      isLoading: false,
+    }))
+
+    const clickOpenLoginModal = setupLoginModalTrigger()
+    void clickOpenLoginModal()
+    await waitForLoginModalOpen()
+
+    fillField('Username', 'alice')
+    clickPrimary('Next')
+    fillField('Password', 'temp-pass')
+    clickPrimary('Confirm')
+
+    await screen.findByRole('heading', { name: 'New password' })
+
+    fillField('New password', 'newpass123')
+    clickPrimary('Next')
+    fillField('Confirm password', 'newpass123')
+    clickPrimary('Confirm')
+
+    expect(
+      await screen.findByText('Must include at least one special character')
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText('New password')).toBeInTheDocument()
+  })
 })

--- a/app/src/organisms/ODD/OnDeviceLogin/__tests__/OnDeviceLogin.test.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/__tests__/OnDeviceLogin.test.tsx
@@ -155,6 +155,19 @@ describe('OnDeviceLogin', () => {
     ).toBeInTheDocument()
   })
 
+  it('keeps next enabled and shows a required error when the username is empty', () => {
+    const { onStepChange } = renderLogin({ initialStep: 'username' })
+
+    const nextButton = screen.getByRole('button', { name: 'next' })
+    expect(nextButton).toBeEnabled()
+    fireEvent.click(nextButton)
+
+    expect(
+      screen.getByText('on_device_login_username_required')
+    ).toBeInTheDocument()
+    expect(onStepChange).not.toHaveBeenCalled()
+  })
+
   it('submits credentials from the password step during normal login', () => {
     const { submitPassword } = renderLogin({
       initialStep: 'password',
@@ -165,6 +178,39 @@ describe('OnDeviceLogin', () => {
     clickPrimary('confirm')
 
     expect(submitPassword).toHaveBeenCalledWith('alice', 'secret123')
+  })
+
+  it('keeps confirm enabled and shows a required error when the password is empty', () => {
+    const { submitPassword } = renderLogin({
+      initialStep: 'password',
+      initialUsername: 'alice',
+    })
+
+    const confirmButton = screen.getByRole('button', { name: 'confirm' })
+    expect(confirmButton).toBeEnabled()
+    fireEvent.click(confirmButton)
+
+    expect(
+      screen.getByText('on_device_login_password_required')
+    ).toBeInTheDocument()
+    expect(submitPassword).not.toHaveBeenCalled()
+  })
+
+  it('keeps next enabled and shows a required error when the new password is empty', () => {
+    const { onStepChange } = renderLogin({
+      initialStep: 'password',
+      isPasswordResetRequired: true,
+      initialUsername: 'alice',
+    })
+
+    const nextButton = screen.getByRole('button', { name: 'next' })
+    expect(nextButton).toBeEnabled()
+    fireEvent.click(nextButton)
+
+    expect(
+      screen.getByText('on_device_login_password_required')
+    ).toBeInTheDocument()
+    expect(onStepChange).not.toHaveBeenCalled()
   })
 
   it('shows a length error when the new password is too short', () => {
@@ -266,6 +312,23 @@ describe('OnDeviceLogin', () => {
 
     expect(
       screen.getByText('on_device_login_password_mismatch')
+    ).toBeInTheDocument()
+    expect(submitPassword).not.toHaveBeenCalled()
+  })
+
+  it('keeps confirm enabled and shows a required error when confirm password is empty', () => {
+    const { submitPassword } = renderLogin({
+      initialStep: 'confirmPassword',
+      isPasswordResetRequired: true,
+      initialUsername: 'alice',
+    })
+
+    const confirmButton = screen.getByRole('button', { name: 'confirm' })
+    expect(confirmButton).toBeEnabled()
+    fireEvent.click(confirmButton)
+
+    expect(
+      screen.getByText('on_device_login_password_required')
     ).toBeInTheDocument()
     expect(submitPassword).not.toHaveBeenCalled()
   })

--- a/app/src/organisms/ODD/OnDeviceLogin/__tests__/OnDeviceLogin.test.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/__tests__/OnDeviceLogin.test.tsx
@@ -51,6 +51,7 @@ function renderLogin(
         onCancel={onCancel}
         onClearLoginError={onClearLoginError}
         loginError={null}
+        passwordComplexity={null}
         {...rest}
       />
     )
@@ -164,6 +165,74 @@ describe('OnDeviceLogin', () => {
     clickPrimary('confirm')
 
     expect(submitPassword).toHaveBeenCalledWith('alice', 'secret123')
+  })
+
+  it('shows a length error when the new password is too short', () => {
+    const { onStepChange } = renderLogin({
+      initialStep: 'password',
+      isPasswordResetRequired: true,
+      initialUsername: 'alice',
+      passwordComplexity: { minLength: 8, requireSpecialCharacters: true },
+    })
+
+    fillField('access_control:on_device_login_new_password', 'abc')
+    clickPrimary('next')
+
+    expect(screen.getByText('must_be_at_least_characters')).toBeInTheDocument()
+    expect(onStepChange).not.toHaveBeenCalled()
+  })
+
+  it('shows a special-character error when length is met but a special character is missing', () => {
+    const { onStepChange } = renderLogin({
+      initialStep: 'password',
+      isPasswordResetRequired: true,
+      initialUsername: 'alice',
+      passwordComplexity: { minLength: 8, requireSpecialCharacters: true },
+    })
+
+    fillField('access_control:on_device_login_new_password', 'password1')
+    clickPrimary('next')
+
+    expect(
+      screen.getByText('must_include_at_least_one_special_character')
+    ).toBeInTheDocument()
+    expect(onStepChange).not.toHaveBeenCalled()
+  })
+
+  it('shows the length error when both password policy rules fail', () => {
+    const { onStepChange } = renderLogin({
+      initialStep: 'password',
+      isPasswordResetRequired: true,
+      initialUsername: 'alice',
+      passwordComplexity: { minLength: 8, requireSpecialCharacters: true },
+    })
+
+    fillField('access_control:on_device_login_new_password', 'short')
+    clickPrimary('next')
+
+    expect(screen.getByText('must_be_at_least_characters')).toBeInTheDocument()
+    expect(
+      screen.queryByText('must_include_at_least_one_special_character')
+    ).not.toBeInTheDocument()
+    expect(onStepChange).not.toHaveBeenCalled()
+  })
+
+  it('advances to confirm password when the new password meets complexity rules', () => {
+    const { onStepChange, submitPassword } = renderLogin({
+      initialStep: 'password',
+      isPasswordResetRequired: true,
+      initialUsername: 'alice',
+      passwordComplexity: { minLength: 8, requireSpecialCharacters: true },
+    })
+
+    fillField('access_control:on_device_login_new_password', 'password!')
+    clickPrimary('next')
+
+    expect(onStepChange).toHaveBeenCalledWith('confirmPassword')
+    expect(submitPassword).not.toHaveBeenCalled()
+    expect(
+      screen.queryByText('must_be_at_least_characters')
+    ).not.toBeInTheDocument()
   })
 
   it('advances to confirm password when reset is required', () => {

--- a/app/src/organisms/ODD/OnDeviceLogin/index.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/index.tsx
@@ -57,6 +57,7 @@ export function OnDeviceLogin({
   const [passwordPolicyError, setPasswordPolicyError] = useState<string | null>(
     null
   )
+  const [usernameError, setUsernameError] = useState<string | null>(null)
   const { control, watch, setValue } = useForm<LoginFormValues>({
     defaultValues: {
       username: initialUsername ?? '',
@@ -88,6 +89,7 @@ export function OnDeviceLogin({
   const clearFieldErrors = (): void => {
     setConfirmPasswordError(null)
     setPasswordPolicyError(null)
+    setUsernameError(null)
     onClearLoginError?.()
   }
 
@@ -102,12 +104,26 @@ export function OnDeviceLogin({
 
   const handleNext = useCallback((): void => {
     if (step === 'username') {
-      if (username.trim() === '') return
+      if (username.trim() === '') {
+        setUsernameError(
+          t('on_device_login_username_required', {
+            ns: 'access_control',
+          }) as string
+        )
+        return
+      }
       onStepChange('password')
       return
     }
     if (step === 'password') {
-      if (password.trim() === '') return
+      if (password.trim() === '') {
+        setPasswordPolicyError(
+          t('on_device_login_password_required', {
+            ns: 'access_control',
+          }) as string
+        )
+        return
+      }
       if (isPasswordResetRequired) {
         if (passwordComplexity != null) {
           const complexityError = getPasswordComplexityError(
@@ -140,7 +156,14 @@ export function OnDeviceLogin({
       submitPassword(username, password)
       return
     }
-    if (confirmPassword.trim() === '') return
+    if (confirmPassword.trim() === '') {
+      setConfirmPasswordError(
+        t('on_device_login_password_required', {
+          ns: 'access_control',
+        }) as string
+      )
+      return
+    }
     if (confirmPassword !== password) {
       setConfirmPasswordError(
         t('on_device_login_password_mismatch', {
@@ -163,12 +186,7 @@ export function OnDeviceLogin({
     t,
   ])
 
-  const primaryDisabled =
-    step === 'username'
-      ? username.trim() === ''
-      : step === 'password'
-        ? password.trim() === '' || isAuthLoading
-        : confirmPassword.trim() === '' || isAuthLoading
+  const primaryDisabled = isAuthLoading
 
   const header = isPasswordResetRequired
     ? t('on_device_login_new_password', { ns: 'access_control' })
@@ -236,6 +254,7 @@ export function OnDeviceLogin({
               isPasswordResetRequired={isPasswordResetRequired}
               loginError={passwordPolicyError ?? loginError}
               confirmPasswordError={confirmPasswordError}
+              usernameError={usernameError}
               onClearFieldErrors={clearFieldErrors}
               keyboardRef={keyboardRef}
             />

--- a/app/src/organisms/ODD/OnDeviceLogin/index.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/index.tsx
@@ -4,11 +4,13 @@ import { useTranslation } from 'react-i18next'
 
 import { FullKeyboard } from '/app/atoms/SoftwareKeyboard'
 import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
+import { getPasswordComplexityError } from '/app/resources/auth'
 
 import { LoginFieldController } from './LoginFieldController'
 import styles from './OnDeviceLogin.module.css'
 
 import type { KeyboardReactInterface } from 'react-simple-keyboard'
+import type { PasswordComplexityRequirements } from '/app/resources/auth'
 
 export type LoginStep = 'username' | 'password' | 'confirmPassword'
 
@@ -32,6 +34,8 @@ export interface OnDeviceLoginProps {
   /** Shown under the password field with error styling when login fails */
   loginError?: string | null
   onClearLoginError?: () => void
+  /** Robot password policy for client-side validation on the new-password step. */
+  passwordComplexity: PasswordComplexityRequirements | null
 }
 
 export function OnDeviceLogin({
@@ -44,11 +48,15 @@ export function OnDeviceLogin({
   initialUsername,
   loginError = null,
   onClearLoginError,
+  passwordComplexity,
 }: OnDeviceLoginProps): JSX.Element {
   const { t } = useTranslation(['shared', 'access_control'])
   const [confirmPasswordError, setConfirmPasswordError] = useState<
     string | null
   >(null)
+  const [passwordPolicyError, setPasswordPolicyError] = useState<string | null>(
+    null
+  )
   const { control, watch, setValue } = useForm<LoginFormValues>({
     defaultValues: {
       username: initialUsername ?? '',
@@ -79,6 +87,7 @@ export function OnDeviceLogin({
 
   const clearFieldErrors = (): void => {
     setConfirmPasswordError(null)
+    setPasswordPolicyError(null)
     onClearLoginError?.()
   }
 
@@ -98,7 +107,31 @@ export function OnDeviceLogin({
     if (step === 'password') {
       if (password.trim() === '') return
       if (isPasswordResetRequired) {
+        if (passwordComplexity != null) {
+          const complexityError = getPasswordComplexityError(
+            password,
+            passwordComplexity
+          )
+          if (complexityError === 'tooShort') {
+            setPasswordPolicyError(
+              t('must_be_at_least_characters', {
+                ns: 'access_control',
+                minLength: passwordComplexity.minLength,
+              }) as string
+            )
+            return
+          }
+          if (complexityError === 'missingSpecialCharacters') {
+            setPasswordPolicyError(
+              t('must_include_at_least_one_special_character', {
+                ns: 'access_control',
+              }) as string
+            )
+            return
+          }
+        }
         setConfirmPasswordError(null)
+        setPasswordPolicyError(null)
         onStepChange('confirmPassword')
         return
       }
@@ -124,6 +157,7 @@ export function OnDeviceLogin({
     isPasswordResetRequired,
     onStepChange,
     submitPassword,
+    passwordComplexity,
     t,
   ])
 
@@ -198,7 +232,7 @@ export function OnDeviceLogin({
               step={step}
               t={t}
               isPasswordResetRequired={isPasswordResetRequired}
-              loginError={loginError}
+              loginError={passwordPolicyError ?? loginError}
               confirmPasswordError={confirmPasswordError}
               onClearFieldErrors={clearFieldErrors}
             />
@@ -212,6 +246,7 @@ export function OnDeviceLogin({
               shouldDirty: true,
               shouldTouch: true,
             })
+            clearFieldErrors()
           }}
           keyboardRef={keyboardRef}
         />

--- a/app/src/organisms/ODD/OnDeviceLogin/index.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/index.tsx
@@ -91,11 +91,13 @@ export function OnDeviceLogin({
     onClearLoginError?.()
   }
 
-  // reset keyboard input when switching steps
+  // Keep the software keyboard's value and caret in sync with the active field,
+  // including after username -> password so new keys insert at the end.
   useEffect(() => {
     const kb = keyboardRef.current
     if (kb == null) return
     kb.setInput(keyboardFieldValue)
+    kb.setCaretPosition(keyboardFieldValue.length)
   }, [step, keyboardFieldValue])
 
   const handleNext = useCallback((): void => {
@@ -235,6 +237,7 @@ export function OnDeviceLogin({
               loginError={passwordPolicyError ?? loginError}
               confirmPasswordError={confirmPasswordError}
               onClearFieldErrors={clearFieldErrors}
+              keyboardRef={keyboardRef}
             />
           </div>
         </div>

--- a/app/src/resources/auth/__tests__/getPasswordComplexityError.test.ts
+++ b/app/src/resources/auth/__tests__/getPasswordComplexityError.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getPasswordComplexityError,
+  PASSWORD_SPECIAL_CHARACTERS,
+} from '../getPasswordComplexityError'
+
+describe('getPasswordComplexityError', () => {
+  it('returns tooShort when the password is shorter than the minimum', () => {
+    expect(
+      getPasswordComplexityError('short', {
+        minLength: 8,
+        requireSpecialCharacters: false,
+      })
+    ).toBe('tooShort')
+  })
+
+  it('returns tooShort when both length and special-character rules fail', () => {
+    expect(
+      getPasswordComplexityError('abc', {
+        minLength: 8,
+        requireSpecialCharacters: true,
+      })
+    ).toBe('tooShort')
+  })
+
+  it('returns missingSpecialCharacters when length is met but a special character is required', () => {
+    expect(
+      getPasswordComplexityError('password1', {
+        minLength: 8,
+        requireSpecialCharacters: true,
+      })
+    ).toBe('missingSpecialCharacters')
+  })
+
+  it('returns null when the password meets length and special-character rules', () => {
+    expect(
+      getPasswordComplexityError('password!', {
+        minLength: 8,
+        requireSpecialCharacters: true,
+      })
+    ).toBeNull()
+  })
+
+  it('returns null when special characters are not required', () => {
+    expect(
+      getPasswordComplexityError('password1', {
+        minLength: 8,
+        requireSpecialCharacters: false,
+      })
+    ).toBeNull()
+  })
+
+  it('counts unicode code points for length', () => {
+    expect(
+      getPasswordComplexityError('☃'.repeat(7), {
+        minLength: 8,
+        requireSpecialCharacters: false,
+      })
+    ).toBe('tooShort')
+    expect(
+      getPasswordComplexityError('☃'.repeat(8), {
+        minLength: 8,
+        requireSpecialCharacters: false,
+      })
+    ).toBeNull()
+  })
+
+  it('accepts every punctuation character used by auth-server', () => {
+    for (const character of PASSWORD_SPECIAL_CHARACTERS) {
+      expect(
+        getPasswordComplexityError(`password${character}`, {
+          minLength: 8,
+          requireSpecialCharacters: true,
+        })
+      ).toBeNull()
+    }
+  })
+})

--- a/app/src/resources/auth/__tests__/mapAuthUserMutationError.test.ts
+++ b/app/src/resources/auth/__tests__/mapAuthUserMutationError.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  mapAuthUserMutationError,
+  mapSetNewPasswordError,
+} from '../mapAuthUserMutationError'
+
+import type { TFunction } from 'i18next'
+
+const t = ((key: string) => key) as TFunction
+
+function axiosError(errors: Array<{ id: string; meta?: object }>): unknown {
+  return {
+    isAxiosError: true,
+    response: {
+      data: { errors },
+    },
+  }
+}
+
+describe('mapAuthUserMutationError', () => {
+  it('prefers passwordTooShort when special-character and length errors are both present', () => {
+    const result = mapAuthUserMutationError<{ password: string }>(
+      axiosError([
+        { id: 'passwordMissingSpecialCharacters' },
+        { id: 'passwordTooShort', meta: { requiredLength: 12 } },
+      ]),
+      t
+    )
+
+    expect(result).toEqual({
+      field: 'password',
+      error: {
+        type: 'server',
+        message: 'desktop_password_too_short',
+      },
+    })
+  })
+})
+
+describe('mapSetNewPasswordError', () => {
+  it('maps a too-short password to the descriptive length message', () => {
+    expect(
+      mapSetNewPasswordError(
+        axiosError([{ id: 'passwordTooShort', meta: { requiredLength: 8 } }]),
+        t
+      )
+    ).toBe('must_be_at_least_characters')
+  })
+
+  it('maps a missing special character to the descriptive special-character message', () => {
+    expect(
+      mapSetNewPasswordError(
+        axiosError([{ id: 'passwordMissingSpecialCharacters' }]),
+        t
+      )
+    ).toBe('must_include_at_least_one_special_character')
+  })
+
+  it('prefers the length message when both password policy errors are present', () => {
+    expect(
+      mapSetNewPasswordError(
+        axiosError([
+          { id: 'passwordMissingSpecialCharacters' },
+          { id: 'passwordTooShort', meta: { requiredLength: 10 } },
+        ]),
+        t
+      )
+    ).toBe('must_be_at_least_characters')
+  })
+
+  it('falls back to the generic update-failed message for unknown errors', () => {
+    expect(mapSetNewPasswordError(new Error('network'), t)).toBe(
+      'set_new_password_error_update_failed'
+    )
+  })
+})

--- a/app/src/resources/auth/getPasswordComplexityError.ts
+++ b/app/src/resources/auth/getPasswordComplexityError.ts
@@ -1,0 +1,42 @@
+/**
+ * Default minimum password length used when auth settings do not specify one.
+ * Keep in sync with `_DEFAULT_MIN_PASSWORD_LENGTH` in
+ * `auth-server/auth_server/users/user_data_manager.py`.
+ */
+export const DEFAULT_MIN_PASSWORD_LENGTH = 8
+
+/**
+ * Characters that satisfy the "require special characters" password rule.
+ * Keep in sync with Python `string.punctuation` used by auth-server.
+ */
+export const PASSWORD_SPECIAL_CHARACTERS = '!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'
+
+export interface PasswordComplexityRequirements {
+  minLength: number
+  requireSpecialCharacters: boolean
+}
+
+export type PasswordComplexityErrorKind =
+  'tooShort' | 'missingSpecialCharacters'
+
+/**
+ * Returns the first password-complexity failure for `password`.
+ * Length is preferred when both length and special-character rules fail.
+ */
+export function getPasswordComplexityError(
+  password: string,
+  requirements: PasswordComplexityRequirements
+): PasswordComplexityErrorKind | null {
+  if (Array.from(password).length < requirements.minLength) {
+    return 'tooShort'
+  }
+  if (
+    requirements.requireSpecialCharacters &&
+    !Array.from(password).some(character =>
+      PASSWORD_SPECIAL_CHARACTERS.includes(character)
+    )
+  ) {
+    return 'missingSpecialCharacters'
+  }
+  return null
+}

--- a/app/src/resources/auth/hooks/__tests__/useSetNewPasswordAndSignIn.test.ts
+++ b/app/src/resources/auth/hooks/__tests__/useSetNewPasswordAndSignIn.test.ts
@@ -114,7 +114,7 @@ describe('useSetNewPasswordAndSignIn', () => {
     })
 
     await waitFor(() => {
-      expect(onError).toHaveBeenCalledWith('desktop_password_too_short')
+      expect(onError).toHaveBeenCalledWith('must_be_at_least_characters')
     })
     expect(onSuccess).not.toHaveBeenCalled()
   })
@@ -143,6 +143,36 @@ describe('useSetNewPasswordAndSignIn', () => {
     expect(onSuccess).not.toHaveBeenCalled()
   })
 
+  it('prefers the length error when both password policy errors are returned', async () => {
+    mockUpdateSelf.mockRejectedValue({
+      isAxiosError: true,
+      response: {
+        data: {
+          errors: [
+            { id: 'passwordMissingSpecialCharacters' },
+            {
+              id: 'passwordTooShort',
+              meta: { requiredLength: 12, actualLength: 5 },
+            },
+          ],
+        },
+      },
+    })
+
+    const { result } = renderHook(() =>
+      useSetNewPasswordAndSignIn({ onSuccess, onError })
+    )
+
+    act(() => {
+      result.current.submitNewPassword('alice', 'short')
+    })
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith('must_be_at_least_characters')
+    })
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
   it('reports when the password is missing a special character', async () => {
     mockUpdateSelf.mockRejectedValue({
       isAxiosError: true,
@@ -163,7 +193,7 @@ describe('useSetNewPasswordAndSignIn', () => {
 
     await waitFor(() => {
       expect(onError).toHaveBeenCalledWith(
-        'desktop_password_missing_special_characters'
+        'must_include_at_least_one_special_character'
       )
     })
     expect(onSuccess).not.toHaveBeenCalled()

--- a/app/src/resources/auth/hooks/useSetNewPasswordAndSignIn.ts
+++ b/app/src/resources/auth/hooks/useSetNewPasswordAndSignIn.ts
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { updateSelf } from '@opentrons/api-client'
 import { useHost } from '@opentrons/react-api-client'
 
-import { mapAuthUserMutationError } from '../mapAuthUserMutationError'
+import { mapSetNewPasswordError } from '../mapAuthUserMutationError'
 
 import type { TFunction } from 'i18next'
 
@@ -42,7 +42,7 @@ export function useSetNewPasswordAndSignIn(
         onError(
           t('set_new_password_error_session_expired', {
             ns: 'access_control',
-          }) as string
+          })
         )
         return
       }
@@ -60,17 +60,7 @@ export function useSetNewPasswordAndSignIn(
             'useSetNewPasswordAndSignIn: failed to update password',
             error
           )
-          const formError = mapAuthUserMutationError<{ password: string }>(
-            error,
-            t
-          )
-          onError(
-            formError?.field === 'password'
-              ? formError.error.message
-              : (t('set_new_password_error_update_failed', {
-                  ns: 'access_control',
-                }) as string)
-          )
+          onError(mapSetNewPasswordError(error, t))
         } finally {
           setIsLoading(false)
         }

--- a/app/src/resources/auth/index.ts
+++ b/app/src/resources/auth/index.ts
@@ -1,2 +1,3 @@
 export * from './hooks'
 export * from './mapAuthUserMutationError'
+export * from './getPasswordComplexityError'

--- a/app/src/resources/auth/mapAuthUserMutationError.ts
+++ b/app/src/resources/auth/mapAuthUserMutationError.ts
@@ -21,26 +21,19 @@ export function mapAuthUserMutationError<T extends FieldValues>(
     return null
   }
 
-  const errorId = axios.isAxiosError(error)
-    ? error.response?.data?.errors?.[0]?.id
-    : null
+  const preferredError = getPreferredAuthErrorItem(error)
+  const errorId = preferredError?.id ?? null
 
   if (errorId === 'userAlreadyExists') {
     return {
       field: 'username' as Path<T>,
       error: {
         type: 'server',
-        message: t(
-          'desktop_personal_account_settings_username_exists_error'
-        ) as string,
+        message: t('desktop_personal_account_settings_username_exists_error'),
       },
     }
-  }
-
-  if (errorId === 'passwordTooShort') {
-    const requiredLength = axios.isAxiosError(error)
-      ? error.response?.data?.errors?.[0]?.meta?.requiredLength
-      : null
+  } else if (errorId === 'passwordTooShort') {
+    const requiredLength = preferredError?.meta?.requiredLength ?? null
 
     return {
       field: 'password' as Path<T>,
@@ -48,39 +41,103 @@ export function mapAuthUserMutationError<T extends FieldValues>(
         type: 'server',
         message:
           requiredLength != null
-            ? (t('desktop_password_too_short', {
+            ? t('desktop_password_too_short', {
                 minLength: requiredLength,
-              }) as string)
-            : (t('desktop_personal_account_settings_save_error') as string),
+              })
+            : t('desktop_personal_account_settings_save_error'),
       },
     }
-  }
-
-  if (errorId === 'passwordMissingSpecialCharacters') {
+  } else if (errorId === 'passwordMissingSpecialCharacters') {
     return {
       field: 'password' as Path<T>,
       error: {
         type: 'server',
-        message: t('desktop_password_missing_special_characters') as string,
+        message: t('desktop_password_missing_special_characters'),
       },
     }
-  }
-
-  if (errorId === 'passwordPreviouslyUsed') {
+  } else if (errorId === 'passwordPreviouslyUsed') {
     return {
       field: 'password' as Path<T>,
       error: {
         type: 'server',
-        message: t('desktop_password_previously_used') as string,
+        message: t('desktop_password_previously_used'),
+      },
+    }
+  } else {
+    return {
+      field: 'confirmPassword' as Path<T>,
+      error: {
+        type: 'server',
+        message: t('desktop_personal_account_settings_save_error'),
       },
     }
   }
+}
 
-  return {
-    field: 'confirmPassword' as Path<T>,
-    error: {
-      type: 'server',
-      message: t('desktop_personal_account_settings_save_error') as string,
-    },
+/** User-facing copy for the set-new-password (password reset) flow. */
+export function mapSetNewPasswordError(error: unknown, t: TFunction): string {
+  const preferredError = getPreferredAuthErrorItem(error)
+  const errorId = preferredError?.id ?? null
+
+  if (errorId === 'passwordTooShort') {
+    const requiredLength = preferredError?.meta?.requiredLength
+    return requiredLength != null
+      ? t('must_be_at_least_characters', {
+          ns: 'access_control',
+          minLength: requiredLength,
+        })
+      : t('set_new_password_error_update_failed', {
+          ns: 'access_control',
+        })
+  } else if (errorId === 'passwordMissingSpecialCharacters') {
+    return t('must_include_at_least_one_special_character', {
+      ns: 'access_control',
+    })
+  } else if (errorId === 'passwordPreviouslyUsed') {
+    return t('desktop_password_previously_used')
+  } else {
+    return t('set_new_password_error_update_failed', {
+      ns: 'access_control',
+    })
   }
+}
+
+interface AuthErrorItem {
+  id?: string
+  meta?: {
+    requiredLength?: number
+  }
+}
+
+function getAuthErrorItems(error: unknown): AuthErrorItem[] {
+  if (!axios.isAxiosError(error)) {
+    return []
+  }
+
+  const errors = error.response?.data?.errors
+  if (!Array.isArray(errors)) {
+    return []
+  }
+
+  return errors.filter(
+    (item): item is AuthErrorItem => item != null && typeof item === 'object'
+  )
+}
+
+/**
+ * Prefer length failures over special-character failures when both are present.
+ */
+function getPreferredAuthErrorItem(error: unknown): AuthErrorItem | null {
+  const items = getAuthErrorItems(error)
+  const tooShort = items.find(item => item.id === 'passwordTooShort')
+  if (tooShort != null) {
+    return tooShort
+  }
+  const missingSpecialCharacters = items.find(
+    item => item.id === 'passwordMissingSpecialCharacters'
+  )
+  if (missingSpecialCharacters != null) {
+    return missingSpecialCharacters
+  }
+  return items[0] ?? null
 }

--- a/components/src/molecules/TouchInputField/__tests__/TouchInputField.test.tsx
+++ b/components/src/molecules/TouchInputField/__tests__/TouchInputField.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { TouchInputField } from '../'
 import { renderWithProviders } from '../../../testing/utils'
+import styles from '../touchinputfield.module.css'
 
 import type { ComponentProps } from 'react'
 
@@ -79,6 +80,13 @@ describe('TouchInputField', () => {
 
     render(props)
     screen.getByText('error')
+  })
+
+  it('renders the label in the error style when error is provided', () => {
+    props.error = 'error'
+
+    render(props)
+    expect(screen.getByText('Speed')).toHaveClass(styles.label_error)
   })
 
   it('renders an accessory beside the input field', () => {

--- a/components/src/molecules/TouchInputField/__tests__/TouchInputField.test.tsx
+++ b/components/src/molecules/TouchInputField/__tests__/TouchInputField.test.tsx
@@ -81,6 +81,13 @@ describe('TouchInputField', () => {
     screen.getByText('error')
   })
 
+  it('renders an accessory beside the input field', () => {
+    props.accessory = <button type="button">Show</button>
+
+    render(props)
+    screen.getByRole('button', { name: 'Show' })
+  })
+
   it('bubbles click from units to onClick handler', () => {
     const onClick = vi.fn()
     props.onClick = onClick

--- a/components/src/molecules/TouchInputField/index.tsx
+++ b/components/src/molecules/TouchInputField/index.tsx
@@ -66,6 +66,8 @@ export interface TouchInputFieldProps {
   type?: 'text' | 'password' | 'number'
   /** optional props for data-testid */
   testId?: string
+  /** optional control rendered beside the input, vertically aligned to the field */
+  accessory?: ReactNode
 }
 
 export const TouchInputField = forwardRef<
@@ -89,6 +91,7 @@ export const TouchInputField = forwardRef<
     padding,
     type,
     testId,
+    accessory,
     ...inputProps
   } = props
 
@@ -133,64 +136,67 @@ export const TouchInputField = forwardRef<
           </div>
         ) : null}
 
-        <div
-          className={clsx(styles.outer, {
-            [styles.outer_error]: hasError,
-          })}
-          onClick={disabled === true ? undefined : onClick}
-        >
+        <div className={styles.input_set}>
           <div
-            style={inputFieldStyles}
-            className={clsx(
-              styles.input_field,
-              size === 'small'
-                ? styles.input_field_small
-                : styles.input_field_medium,
-              {
-                [styles.error]: hasError,
-              }
-            )}
-            onClick={() => {
-              internalRef.current?.focus()
-            }}
+            className={clsx(styles.outer, {
+              [styles.outer_error]: hasError,
+            })}
+            onClick={disabled === true ? undefined : onClick}
           >
-            <input
-              {...inputProps}
-              id={inputId}
-              data-testid={testId}
+            <div
+              style={inputFieldStyles}
               className={clsx(
-                styles.input,
-                size === 'small' ? styles.input_small : styles.input_medium,
-                type === 'password' ? styles.password_input : null,
-                textAlign === TYPOGRAPHY.textAlignCenter
-                  ? styles.align_center
-                  : styles.align_left
+                styles.input_field,
+                size === 'small'
+                  ? styles.input_field_small
+                  : styles.input_field_medium,
+                {
+                  [styles.error]: hasError,
+                }
               )}
-              value={value}
-              placeholder={placeHolder}
-              onWheel={event => {
-                event.currentTarget.blur()
+              onClick={() => {
+                internalRef.current?.focus()
               }}
-              type={type}
-              disabled={disabled}
-              ref={mergedRef}
-            />
-            {units != null ? (
-              <div
+            >
+              <input
+                {...inputProps}
+                id={inputId}
+                data-testid={testId}
                 className={clsx(
-                  styles.units,
+                  styles.input,
+                  size === 'small' ? styles.input_small : styles.input_medium,
+                  type === 'password' ? styles.password_input : null,
                   textAlign === TYPOGRAPHY.textAlignCenter
                     ? styles.align_center
-                    : styles.align_left,
-                  {
-                    [styles.units_disabled]: disabled,
-                  }
+                    : styles.align_left
                 )}
-              >
-                {units}
-              </div>
-            ) : null}
+                value={value}
+                placeholder={placeHolder}
+                onWheel={event => {
+                  event.currentTarget.blur()
+                }}
+                type={type}
+                disabled={disabled}
+                ref={mergedRef}
+              />
+              {units != null ? (
+                <div
+                  className={clsx(
+                    styles.units,
+                    textAlign === TYPOGRAPHY.textAlignCenter
+                      ? styles.align_center
+                      : styles.align_left,
+                    {
+                      [styles.units_disabled]: disabled,
+                    }
+                  )}
+                >
+                  {units}
+                </div>
+              ) : null}
+            </div>
           </div>
+          {accessory}
         </div>
 
         {caption != null ? (

--- a/components/src/molecules/TouchInputField/index.tsx
+++ b/components/src/molecules/TouchInputField/index.tsx
@@ -126,6 +126,9 @@ export const TouchInputField = forwardRef<
               htmlFor={inputId}
               className={clsx(
                 styles.label,
+                {
+                  [styles.label_error]: hasError,
+                },
                 textAlign === TYPOGRAPHY.textAlignCenter
                   ? styles.align_center
                   : styles.align_left

--- a/components/src/molecules/TouchInputField/touchinputfield.module.css
+++ b/components/src/molecules/TouchInputField/touchinputfield.module.css
@@ -132,6 +132,10 @@
   line-height: var(--line-height-28);
 }
 
+.label_error {
+  color: var(--red-50);
+}
+
 .caption {
   padding: var(--spacing-8) 0 0;
 }

--- a/components/src/molecules/TouchInputField/touchinputfield.module.css
+++ b/components/src/molecules/TouchInputField/touchinputfield.module.css
@@ -25,9 +25,18 @@
   column-gap: var(--spacing-8);
 }
 
-.outer {
+.input_set {
   display: flex;
   width: 100%;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--spacing-24);
+}
+
+.outer {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
   flex-direction: column;
   gap: var(--spacing-8);
 }


### PR DESCRIPTION
Closes [RQA-5940](https://opentrons.atlassian.net/browse/RQA-5940) and [RQA-5979](https://opentrons.atlassian.net/browse/RQA-5979)

# Overview

Updates the login and password flows to match designs by:

- Showing specific ODD password errors instead of a generic failure: "Must be at least [n] characters long" and "Must include at least one special character", preferring the length message when both fail. There's a lot of helpers to keep this behavior consistent, which is the majority of the code here. This was a Product request!
- Align "Show"/"Hide" with the input by adding an `accessory` prop on TouchInputField, and keep the caret at the end when toggling visibility.
- Match error styling and empty-field behavior to design: the field label turns red with the error, and username / password / new-password / confirm stay enabled instead of greying out.

<img width="1086" height="632" alt="Screenshot 2026-08-21 at 3 02 04 PM" src="https://github.com/user-attachments/assets/af7a0408-abe4-46dd-92e6-07ae61f5d168" />

https://github.com/user-attachments/assets/447f6451-35b0-499c-99ae-81857a450529

## Test Plan and Hands on Testing

- See image/video.

## Risk assessment

- pretty low - it's a lot of code but it's all localized to a few components

[RQA-5940]: https://opentrons.atlassian.net/browse/RQA-5940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-5979]: https://opentrons.atlassian.net/browse/RQA-5979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ