### PR TITLE
(docs): Revise Flex tip compatibility intro

### DIFF
--- a/docs/flex/docs/labware/types.md
+++ b/docs/flex/docs/labware/types.md
@@ -116,17 +116,17 @@ When ordering or reordering, tips are available as racks or refills. Both racks 
 
 ### Tip-pipette compatibility
 
-Flex pipettes only accept tips with capacities less than or equal to the pipette capacity.
+See the following table for Flex pipette and tip compatibility.
 
 | Pipette capacity | Compatible tips             |
 | :--------------- | :-------------------------- |
 | 1–50 µL          | 20 µL, 50 µL tips             |
 | 1–200 µL         | 20 µL, 50 µL, 200 µL tips |
-| 5–1000 µL        | 50 µL, 200 µL, and 1000 µL tips |
+| 5–1000 µL        | 50 µL, 200 µL, 1000 µL tips |
 
-Flex pipette tips are designed for Opentrons Flex pipettes. Flex tips are not backwards compatible with Opentrons OT-2 pipettes, nor can you use OT-2 tips on Flex pipettes. 
+Flex pipette tips are designed for Opentrons Flex pipettes. Flex tips are not backwards compatible with Opentrons OT-2 pipettes, nor can you use OT-2 tips on Flex pipettes.
 
-Other industry-standard tips may work with Flex pipettes, but this is not recommended. To ensure optimum performance, you should only use Opentrons Flex tips with Flex pipettes.
+Other industry-standard tips may work with Flex pipettes, but this is not recommended. To ensure optimum performance, only use Opentrons Flex tips with Flex pipettes.
 
 ### Tip rack adapter 
 


### PR DESCRIPTION
# Overview

This is a small revision to the Flex manual, [Tip-pipette compatibility section](https://docs.opentrons.com/flex/labware/types/#tip-pipette-compatibility). The current into sentence is a little confusing. This is our attempt to simplify it.

Also an opportunity to fix a couple of other inconsistent items.

Sandbox: https://sandbox.docs.opentrons.com/docs-flex-revise-tip-compatibility/flex/labware/types/#tip-pipette-compatibility

RTC-1049

## Test Plan and Hands on Testing

Test prose for clarity.

## Changelog

- Changes intro sentence in tip compatibility section
- Removes an "and" from the table. It isn't used consistently and tables don't need 'em.
- Small revision to last sentence in that section.

## Review requests

Do these changes make what we're trying to do in the compatibility table easier to understand?

## Risk assessment

Low.
