### PR TITLE
fix(app): Remove confusing error messages when resetting runtime parameters

### DIFF
--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ChooseEnum.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ChooseEnum.tsx
@@ -12,8 +12,6 @@ import {
 
 import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 
-import { useToaster } from '../../../ToasterOven'
-
 import type { ChoiceParameter } from '@opentrons/shared-data'
 
 interface ChooseEnumProps {
@@ -29,14 +27,11 @@ export function ChooseEnum({
   setParameter,
   rawValue,
 }: ChooseEnumProps): JSX.Element | null {
-  const { makeSnackbar } = useToaster()
-
   const { t } = useTranslation(['protocol_setup', 'shared'])
   const options = 'choices' in parameter ? parameter.choices : null
   const handleOnClick = (newValue: string | number | boolean): void => {
     setParameter(newValue, parameter.variableName)
   }
-  const resetValueDisabled = parameter.default === rawValue
 
   return (
     <>
@@ -46,9 +41,7 @@ export function ChooseEnum({
         buttonType="tertiaryLowLight"
         buttonText={t('restore_default')}
         onClickButton={() => {
-          resetValueDisabled
-            ? makeSnackbar(t('no_custom_values') as string)
-            : setParameter(parameter.default, parameter.variableName)
+          setParameter(parameter.default, parameter.variableName)
         }}
       />
       <Flex

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ChooseNumber.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ChooseNumber.tsx
@@ -50,7 +50,6 @@ export function ChooseNumber({
   }
 
   const paramValueAsNumber = paramValue !== '' ? Number(paramValue) : null
-  const resetValueDisabled = parameter.default === paramValueAsNumber
   const { min, max } = parameter
   const error =
     Number.isNaN(paramValueAsNumber) ||
@@ -83,10 +82,6 @@ export function ChooseNumber({
         buttonType="tertiaryLowLight"
         buttonText={t('restore_default')}
         onClickButton={() => {
-          if (resetValueDisabled) {
-            makeSnackbar(t('no_custom_values') as string)
-            return
-          }
           setParamValue(String(parameter.default))
         }}
       />

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/__tests__/ChooseEnum.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/__tests__/ChooseEnum.test.tsx
@@ -12,7 +12,6 @@ import { ChooseEnum } from '../ChooseEnum'
 
 import type { ComponentProps } from 'react'
 
-vi.mocked('../../../../ToasterOven')
 const render = (props: ComponentProps<typeof ChooseEnum>) => {
   return renderWithProviders(<ChooseEnum {...props} />, {
     i18nInstance: i18n,
@@ -58,16 +57,16 @@ describe('ChooseEnum', () => {
   it('calls the prop if reset default is clicked when the default has changed', () => {
     render(props)
     fireEvent.click(screen.getByText('Restore default value'))
-    expect(props.setParameter).toHaveBeenCalled()
+    expect(props.setParameter).toHaveBeenCalledWith('none', 'DEFAULT_OFFSETS')
   })
-  it('calls does not call prop if reset default is clicked when the default has not changed', () => {
+  it('still restores the default if reset default is clicked when already at the default', () => {
     props = {
       ...props,
       rawValue: 'none',
     }
     render(props)
     fireEvent.click(screen.getByText('Restore default value'))
-    expect(props.setParameter).not.toHaveBeenCalled()
+    expect(props.setParameter).toHaveBeenCalledWith('none', 'DEFAULT_OFFSETS')
   })
   it('should render the text and buttons for choice param', () => {
     render(props)


### PR DESCRIPTION
## Overview

Here's a fix for a random small bug I noticed.

When you're setting up a protocol and choosing runtime parameters on the ODD, you can tap a "Reset to default" button, and it will set the input back to whatever the .py file specified as the default. But if you tap the button when the input is *already at* the default, you get this error message:

> No custom values specified

This may have been inherited from another part of the UI where you're given a list of values and you have to select the ones you want to reset. In this context, the message doesn't make sense.

This removes the error message and turns the button tap into a silent no-op.

## Test Plan and Hands on Testing

Tested in the dev app.

## Review requests

Agreed with this solution?

## Risk assessment

Low.