### PR TITLE
refactor(app): ensure audit log actions are underlined

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/FileManagementSectionHeader.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/FileManagementSectionHeader.tsx
@@ -21,11 +21,15 @@ export function FileManagementSectionHeader(
       <StyledText desktopStyle="bodyLargeSemiBold">{titleText}</StyledText>
       {showButtons ? (
         <div className={styles.file_management_header_button_group}>
-          <BasicButton onClick={onDownloadSelected} iconName="download">
+          <BasicButton
+            onClick={onDownloadSelected}
+            iconName="download"
+            underLine
+          >
             {t('download_selected')}
           </BasicButton>
           {onDeleteSelected != null ? (
-            <BasicButton onClick={onDeleteSelected}>
+            <BasicButton onClick={onDeleteSelected} underLine>
               {t('delete_selected')}
             </BasicButton>
           ) : null}


### PR DESCRIPTION
Closes [RQA-5984](https://opentrons.atlassian.net/browse/RQA-5984)

# Overview

Adds an underline to the download and delete audit log actions.

### Current behavior

<img width="1920" height="453" alt="image (8)" src="https://github.com/user-attachments/assets/7a260051-8cc1-4c33-96c3-3ab2534f1d53" />

### Fixed behavior

<img width="915" height="152" alt="Screenshot 2026-08-24 at 9 45 27 AM" src="https://github.com/user-attachments/assets/3228a4a8-fdd4-4dc1-aea6-91042b7f6d88" />

## Test Plan and Hands on Testing

- See images

## Risk assessment

- none, simple CSS


[RQA-5984]: https://opentrons.atlassian.net/browse/RQA-5984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ