### PR TITLE
feat(robot-server): audit log at robot-server boot when there are unsigned runs when run signoff is required

### DIFF
--- a/audit-server/audit_server/log_storage/log_data_manager.py
+++ b/audit-server/audit_server/log_storage/log_data_manager.py
@@ -14,10 +14,10 @@ from opentrons_shared_data.errors.exceptions import (
     PythonException,
 )
 
+from server_utils.audit import constants
 from server_utils.keys.key_server import Client as KeyClient
 from server_utils.keys.key_server import SignMessageData
 
-from . import constants
 from .models import LogPeriodDetails, LogPeriodSummary, TotalUsageSummary
 from .store import (
     LogStore,

--- a/audit-server/tests/log_storage/test_log_data_manager.py
+++ b/audit-server/tests/log_storage/test_log_data_manager.py
@@ -9,10 +9,10 @@ from decoy import Decoy, matchers
 from fastapi import UploadFile
 from opentrons_shared_data.errors.exceptions import KeyStorageUnavailableError
 
+from server_utils.audit import constants
 from server_utils.keys.key_server import Client as KeyClient
 from server_utils.keys.key_server import SignedMessageData, SignMessageData
 
-from audit_server.log_storage import constants
 from audit_server.log_storage.log_data_manager import (
     InvalidDeletionKeyError,
     LogDataManager,

--- a/robot-server/robot_server/app_setup.py
+++ b/robot-server/robot_server/app_setup.py
@@ -239,12 +239,12 @@ async def _report_unsigned_runs(
     message = f"{len(unsigned_runs)} unsigned runs found in run history:"
     for unsigned_run in unsigned_runs:
         if unsigned_run.protocol_id is None:
-            message += f" run with no protocol created at {unsigned_run.created_at},"
+            message += f" run with no protocol created at {unsigned_run.created_at};"
         else:
             protocol = protocol_store.get(protocol_id=unsigned_run.protocol_id)
             message += (
                 f" run for {protocol.source.main_file.name} ({protocol.source.content_hash})"
-                f" created at {unsigned_run.created_at}"
+                f" created at {unsigned_run.created_at};"
             )
 
     audit_client = get_audit_client(app_state)

--- a/robot-server/robot_server/app_setup.py
+++ b/robot-server/robot_server/app_setup.py
@@ -10,17 +10,24 @@ from fastapi.openapi.docs import get_redoc_html
 from fastapi.responses import HTMLResponse
 
 from opentrons import __version__
+from server_utils.audit.audit_server import (
+    SubmitAuditLogMessageData,
+)
 from server_utils.audit.fastapi import (
     audit_logger_middleware,
     build_audit_client,
+    get_audit_client,
     install_audit_client,
 )
 from server_utils.auth.resource_server.fastapi import (
     build_authentication_checker,
+    get_authentication_checker,
     install_authentication_checker,
 )
+from server_utils.fastapi_utils.app_state import AppState
 from server_utils.fastapi_utils.server_timing_middleware import server_timing_middleware
 
+from .access_control.settings.store import get_access_control_setting_store
 from .errors.exception_handlers import exception_handlers
 from .hardware import (
     FrontButtonLightBlinker,
@@ -29,11 +36,19 @@ from .hardware import (
 )
 from .persistence.fastapi_dependencies import (
     clean_up_persistence,
+    get_active_persistence_directory,
+    get_sql_engine,
     initialize_images_directory,
     start_initializing_persistence,
 )
+from .protocols.dependencies import (
+    get_protocol_directory,
+    get_protocol_reader,
+    get_protocol_store,
+)
 from .router import router
 from .runs.dependencies import (
+    get_run_store,
     mark_light_control_startup_finished,
     set_up_run_process_pyro_provider,
     start_light_control_task,
@@ -103,12 +118,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         start_initializing_persistence(
             app_state=app.state,
             persistence_directory_root=persistence_directory,
-            done_callbacks=[
-                # For OT-2 light control only. The Flex status bar isn't handled here
-                # because it's currently tied to hardware and run status, not to
-                # initialization of the persistence layer.
-                blinker.mark_persistence_init_complete
-            ],
+            done_callbacks=[_report_unsigned_runs],
         )
         exit_stack.push_async_callback(clean_up_persistence, app.state)
 
@@ -199,3 +209,49 @@ def _get_persistence_directory(settings: RobotServerSettings) -> Optional[Path]:
         return None
     else:
         return settings.persistence_directory
+
+
+async def _report_unsigned_runs(
+    app_state: AppState,
+) -> None:
+    if not get_authentication_checker(app_state).access_control_status():
+        return
+
+    sql_engine = await get_sql_engine(app_state)
+    access_control_settings_store = await get_access_control_setting_store(sql_engine)
+    if not access_control_settings_store.get_all().requireSignoffForProtocolLog:
+        return
+
+    run_store = await get_run_store(app_state, sql_engine)
+    unsigned_runs = [run for run in run_store.get_all() if run.signed_by is None]
+
+    if not unsigned_runs:
+        return
+
+    persistence_directory = await get_active_persistence_directory(app_state)
+    protocol_directory = await get_protocol_directory(app_state, persistence_directory)
+    protocol_store = await get_protocol_store(
+        app_state, sql_engine, protocol_directory, get_protocol_reader()
+    )
+
+    message = f"{len(unsigned_runs)} unsigned runs found in run history:"
+    for unsigned_run in unsigned_runs:
+        if unsigned_run.protocol_id is None:
+            message += f" run with no protocol created at {unsigned_run.created_at},"
+        else:
+            protocol = protocol_store.get(protocol_id=unsigned_run.protocol_id)
+            message += (
+                f" run for {protocol.source.main_file.name} ({protocol.source.content_hash})"
+                f" created at {unsigned_run.created_at}"
+            )
+
+    audit_client = get_audit_client(app_state)
+    await audit_client.submit_log_message(
+        SubmitAuditLogMessageData(
+            action="System warning",
+            accountName="system",
+            legalName="",
+            message=message,
+            reason=None,
+        )
+    )

--- a/robot-server/robot_server/app_setup.py
+++ b/robot-server/robot_server/app_setup.py
@@ -10,6 +10,7 @@ from fastapi.openapi.docs import get_redoc_html
 from fastapi.responses import HTMLResponse
 
 from opentrons import __version__
+from server_utils.audit import constants as log_constants
 from server_utils.audit.audit_server import (
     SubmitAuditLogMessageData,
 )
@@ -214,6 +215,7 @@ def _get_persistence_directory(settings: RobotServerSettings) -> Optional[Path]:
 async def _report_unsigned_runs(
     app_state: AppState,
 ) -> None:
+    """If access control enabled and run signoff required, log any unsigned runs."""
     if not get_authentication_checker(app_state).access_control_status():
         return
 
@@ -248,9 +250,9 @@ async def _report_unsigned_runs(
     audit_client = get_audit_client(app_state)
     await audit_client.submit_log_message(
         SubmitAuditLogMessageData(
-            action="System warning",
-            accountName="system",
-            legalName="",
+            action=log_constants.ACTION_UNSIGNED_RUNS_WARNING,
+            accountName=log_constants.ACCOUNT_NAME_SYSTEM,
+            legalName=log_constants.LEGAL_NAME_SYSTEM,
             message=message,
             reason=None,
         )

--- a/robot-server/robot_server/persistence/fastapi_dependencies.py
+++ b/robot-server/robot_server/persistence/fastapi_dependencies.py
@@ -59,7 +59,7 @@ class DatabaseFailedToInitialize(ErrorDetails):
 def start_initializing_persistence(  # noqa: C901
     app_state: AppState,
     persistence_directory_root: Optional[Path],
-    done_callbacks: Iterable[Callable[[], Awaitable[None]]],
+    done_callbacks: Iterable[Callable[[AppState], Awaitable[None]]],
 ) -> None:
     """Initialize the persistence layer to get it ready for use by endpoint functions.
 
@@ -145,7 +145,7 @@ def start_initializing_persistence(  # noqa: C901
             await sql_engine_init_task
         finally:
             for callback in done_callbacks:
-                await callback()
+                await callback(app_state)
 
     asyncio.create_task(wait_until_done_then_trigger_callbacks())
 

--- a/server-utils/server_utils/audit/constants.py
+++ b/server-utils/server_utils/audit/constants.py
@@ -1,3 +1,5 @@
+"""Constants for system generated audit log messages."""
+
 from typing import Final
 
 MESSAGE_ROBOT_BOOT: Final = "Robot started up"
@@ -13,6 +15,7 @@ ACTION_ROBOT_BOOT: Final = "robot-boot"
 ACTION_LOG_PERIOD_START: Final = "log-period-begin"
 ACTION_LOG_PERIOD_END: Final = "log-period-end"
 ACTION_LOG_LOGGING_ERROR: Final = "log-error"
+ACTION_UNSIGNED_RUNS_WARNING: Final = "unsigned-runs-warning"
 
 ACCOUNT_NAME_SYSTEM: Final = "system"
 LEGAL_NAME_SYSTEM: Final = ""


### PR DESCRIPTION
# Overview

Closes RQA-5948.

When a robot is in access control mode and run signoff is required, the user *must* sign off on a run before they can dismiss it. However while in this mode there are two somewhat common scenarios in which unsigned runs can exist: previously ran runs before run signoff was turned on, and power cycles interrupting runs before they are signed and uncurrented.

More because of the latter, we want some trail of these unsigned runs in the audit log. Therefore, when the robot server boots and after the database has initialized, we will do the following steps:
- Check if access control is enabled and if run signoff is required
- If so, check if there are any runs in the database that are not signed
- If so, get some information about their protocols for purposes of making a user friendly message
- Log it to the now new log period


## Test Plan and Hands on Testing

On robot testing:
- [x] Flex with unsigned runs with run signoff enabled logs to audit log
- [x] Flex with no unsigned runs with run signoff enabled does not log
- [x] Flex with unsigned runs with run signoff disabled does not log

## Changelog

- Log to audit server about unsigned runs when run signoff required
- Moved audit server message constants to server utils

## Review requests

## Risk assessment

Lowish, adds a new task to robot server boot but we do check settings before going further into creating/opening stores