### PR TITLE
refactor(app): Update "documentation required" modal to match designs

### DIFF
--- a/app/src/molecules/TouchTextAreaField/touchtextareafield.module.css
+++ b/app/src/molecules/TouchTextAreaField/touchtextareafield.module.css
@@ -20,6 +20,7 @@
   display: flex;
   width: 100%;
   flex-direction: column;
+  gap: var(--spacing-8);
 }
 
 .label_row {
@@ -37,47 +38,47 @@
 
 .textarea_row {
   display: flex;
+  width: 100%;
   align-items: center;
 }
 
 .textarea {
   width: 100%;
   height: 100%;
-  padding: var(--spacing-8);
-  border: 1px solid var(--grey-50);
-  border-radius: var(--border-radius-4);
+  padding: var(--spacing-16) var(--spacing-24);
+  border: 2px solid var(--grey-50);
+  border-radius: var(--border-radius-8);
   background-color: var(--white);
-  font-size: var(--font-size-22);
+  font-size: var(--font-size-38);
   font-style: normal;
   font-weight: var(--font-weight-regular);
-  line-height: var(--line-height-28);
+  line-height: var(--line-height-48);
   resize: none;
 }
 
 .textarea:focus {
-  border: 1px solid var(--blue-50);
+  border: 3px solid var(--blue-50);
   outline: none;
 }
 
 .textarea:disabled {
-  border: 1px solid var(--grey-30);
+  border: 2px solid var(--grey-30);
   background-color: var(--grey-20);
 }
 
 .textarea_error {
-  border: 1px solid var(--red-50);
+  border: 2px solid var(--red-50);
 }
 
 .textarea_error:focus {
-  border: 1px solid var(--red-50);
+  border: 2px solid var(--red-50);
 }
 
 .label_text {
-  padding-bottom: var(--spacing-4);
-  color: var(--grey-60);
-  font-size: var(--font-size-h3);
+  color: var(--black-90);
+  font-size: var(--font-size-22);
   font-weight: var(--font-weight-regular);
-  line-height: var(--line-height-20);
+  line-height: var(--line-height-28);
 }
 
 .label_text_error {
@@ -93,12 +94,10 @@
 }
 
 .caption_text {
-  padding-top: var(--spacing-4);
   color: var(--grey-60);
 }
 
 .error_text {
-  padding-top: var(--spacing-4);
   color: var(--red-50);
 }
 

--- a/app/src/organisms/ActionItems/actionlist.module.css
+++ b/app/src/organisms/ActionItems/actionlist.module.css
@@ -1,10 +1,8 @@
 .actions_list {
   display: flex;
   width: 100%;
-  height: 15.5rem;
   flex-direction: column;
   gap: var(--spacing-8);
-  overflow-y: scroll;
 }
 
 .action {

--- a/app/src/organisms/Desktop/DocumentationRequired/documentationrequired.module.css
+++ b/app/src/organisms/Desktop/DocumentationRequired/documentationrequired.module.css
@@ -10,6 +10,7 @@
   min-height: 0;
   flex: 1;
   gap: var(--spacing-4);
+  overflow-y: auto;
 }
 
 .action_list div {

--- a/app/src/organisms/ODD/DocumentationRequired/ActionsView.tsx
+++ b/app/src/organisms/ODD/DocumentationRequired/ActionsView.tsx
@@ -6,6 +6,8 @@ import { COLORS } from '@opentrons/components'
 import { OddModal } from '/app/molecules/OddModal'
 import { ActionList } from '/app/organisms/ActionItems/ActionList'
 
+import styles from './documentationrequired.module.css'
+
 import type { IconName } from '@opentrons/components'
 import type { DocumentedAction } from '@opentrons/react-api-client'
 
@@ -28,8 +30,12 @@ const ActionsViewImpl = ({
       header={actionViewHeader}
       modalZIndex={1002}
       onOutsideClick={modal.remove}
+      overflow="hidden"
     >
-      <ActionList actionsToDocument={actionsToDocument} />
+      <ActionList
+        actionsToDocument={actionsToDocument}
+        className={styles.actions_view_list}
+      />
     </OddModal>
   )
 }

--- a/app/src/organisms/ODD/DocumentationRequired/documentationrequired.module.css
+++ b/app/src/organisms/ODD/DocumentationRequired/documentationrequired.module.css
@@ -1,5 +1,6 @@
 .container {
   display: flex;
+  width: 100%;
   height: 100%;
   flex-direction: column;
 }
@@ -7,10 +8,9 @@
 .content_container {
   display: flex;
   width: 100%;
-  max-width: 59rem;
   flex: 1;
   flex-direction: column;
-  padding: 0 var(--spacing-60) var(--spacing-120);
+  padding: 0 6.25rem var(--spacing-120);
   margin-top: 7.75rem;
   gap: var(--spacing-24);
 }

--- a/app/src/organisms/ODD/DocumentationRequired/documentationrequired.module.css
+++ b/app/src/organisms/ODD/DocumentationRequired/documentationrequired.module.css
@@ -52,3 +52,16 @@
   background-color: var(--white);
   inset: 0;
 }
+
+.actions_view_list {
+  max-height: 28.625rem;
+  color: var(--black-90);
+  font-size: var(--font-size-22);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-28);
+  overflow-y: auto;
+}
+
+.actions_view_list::-webkit-scrollbar {
+  display: none;
+}


### PR DESCRIPTION
Closes [RQA-5988](https://opentrons.atlassian.net/browse/RQA-5988), [RQA-5990](https://opentrons.atlassian.net/browse/RQA-5990), and [RQA-5991](https://opentrons.atlassian.net/browse/RQA-5991)

# Overview

Adjusts CSS related to the docmentation modal and its child "actions requiring documentation" modal to match designs.

### Current behavior

<img width="1090" height="635" alt="Screenshot 2026-08-24 at 10 59 14 AM" src="https://github.com/user-attachments/assets/a084a9ea-a40f-4608-923f-3485e0dbf343" />

<img width="1083" height="634" alt="Screenshot 2026-08-24 at 10 59 22 AM" src="https://github.com/user-attachments/assets/de672f23-83fd-4ffa-9dcd-ad19a6799039" />


### Fixed behavior

<img width="1083" height="635" alt="Screenshot 2026-08-24 at 10 33 29 AM" src="https://github.com/user-attachments/assets/f296d431-a7cd-485c-ade9-a8c6446a938c" />

<img width="1079" height="637" alt="Screenshot 2026-08-24 at 10 42 45 AM" src="https://github.com/user-attachments/assets/03f65b38-8b3d-4b68-aeb3-6d0ae606a0d8" />


## Test Plan and Hands on Testing

- See images

## Risk assessment

- effectively none, just CSS changes


[RQA-5988]: https://opentrons.atlassian.net/browse/RQA-5988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-5990]: https://opentrons.atlassian.net/browse/RQA-5990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-5991]: https://opentrons.atlassian.net/browse/RQA-5991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ