### PR TITLE
refactor(app): update user management table css to match designs

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement.tsx
@@ -52,33 +52,23 @@ function UserManagementTable({
   const { t } = useTranslation('device_settings')
 
   return (
-    <table className={styles.table}>
-      <thead>
-        <tr>
-          <th className={styles.header_cell}>
-            <StyledText desktopStyle="bodyDefaultRegular">
-              {t('desktop_username')}
-            </StyledText>
-          </th>
-          <th className={styles.header_cell}>
-            <StyledText desktopStyle="bodyDefaultRegular">
-              {t('desktop_legal_name')}
-            </StyledText>
-          </th>
-          <th className={styles.header_cell}>
-            <StyledText desktopStyle="bodyDefaultRegular">
-              {t('desktop_role')}
-            </StyledText>
-          </th>
-          <th className={styles.header_cell}>
-            <StyledText desktopStyle="bodyDefaultRegular">
-              {t('desktop_status')}
-            </StyledText>
-          </th>
-          <th className={styles.header_cell} aria-hidden />
-        </tr>
-      </thead>
-      <tbody>
+    <div className={styles.list}>
+      <div className={styles.header_row}>
+        <StyledText desktopStyle="bodyDefaultRegular">
+          {t('desktop_username')}
+        </StyledText>
+        <StyledText desktopStyle="bodyDefaultRegular">
+          {t('desktop_legal_name')}
+        </StyledText>
+        <StyledText desktopStyle="bodyDefaultRegular">
+          {t('desktop_role')}
+        </StyledText>
+        <StyledText desktopStyle="bodyDefaultRegular">
+          {t('desktop_status')}
+        </StyledText>
+        <span className={styles.overflow_cell_inner} aria-hidden />
+      </div>
+      <div className={styles.rows}>
         {users.map(user => (
           <UserManagementTableRow
             key={user.username}
@@ -90,8 +80,8 @@ function UserManagementTable({
             onDeactivate={onDeactivate}
           />
         ))}
-      </tbody>
-    </table>
+      </div>
+    </div>
   )
 }
 
@@ -222,23 +212,25 @@ export function UserManagement({
 
   return (
     <Accordion id="user-management" title={t('desktop_user_management')}>
-      <UserManagementTable
-        users={users}
-        onEdit={setUserToEdit}
-        onDelete={setUserToDelete}
-        onActivate={setUserToActivate}
-        onResetPassword={setUserToResetPassword}
-        onDeactivate={setUserToDeactivate}
-      />
-      <div className={styles.add_user_button}>
-        <EmptySelectorButton
-          iconName="plus"
-          onClick={() => {
-            setShowAddUserModal(true)
-          }}
-          text={t('desktop_add_user')}
-          textAlignment="left"
+      <div className={styles.content}>
+        <UserManagementTable
+          users={users}
+          onEdit={setUserToEdit}
+          onDelete={setUserToDelete}
+          onActivate={setUserToActivate}
+          onResetPassword={setUserToResetPassword}
+          onDeactivate={setUserToDeactivate}
         />
+        <div className={styles.add_user_button}>
+          <EmptySelectorButton
+            iconName="plus"
+            onClick={() => {
+              setShowAddUserModal(true)
+            }}
+            text={t('desktop_add_user')}
+            textAlignment="left"
+          />
+        </div>
       </div>
       {showAddUserModal ? (
         <AddUserModal

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagementTableRow.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagementTableRow.tsx
@@ -1,6 +1,8 @@
 import { useTranslation } from 'react-i18next'
 
 import {
+  Chip,
+  ListItem,
   MenuItem,
   OverflowBtn,
   StyledText,
@@ -45,42 +47,29 @@ export function UserManagementTableRow({
     }
 
   return (
-    <tr>
-      <td className={styles.body_cell}>
-        <StyledText
-          desktopStyle="bodyDefaultRegular"
-          className={styles.body_cell_text}
-        >
+    <ListItem type="default">
+      <div className={styles.row}>
+        <StyledText desktopStyle="bodyDefaultRegular" className={styles.cell}>
           {user.username}
         </StyledText>
-      </td>
-      <td className={styles.body_cell}>
-        <StyledText
-          desktopStyle="bodyDefaultRegular"
-          className={styles.body_cell_text}
-        >
+        <StyledText desktopStyle="bodyDefaultRegular" className={styles.cell}>
           {user.fullName}
         </StyledText>
-      </td>
-      <td className={styles.body_cell}>
-        <StyledText
-          desktopStyle="bodyDefaultRegular"
-          className={styles.body_cell_text}
-        >
+        <StyledText desktopStyle="bodyDefaultRegular" className={styles.cell}>
           {t(`desktop_user_role_${user.accountType}`)}
         </StyledText>
-      </td>
-      <td className={styles.body_cell}>
-        <StyledText
-          desktopStyle="bodyDefaultRegular"
-          className={styles.body_cell_text}
-        >
-          {user.locked
-            ? t('desktop_user_status_locked')
-            : t('desktop_user_status_active')}
-        </StyledText>
-      </td>
-      <td className={styles.overflow_cell}>
+        <div className={styles.cell}>
+          <Chip
+            type={user.locked ? 'warning' : 'neutral'}
+            background={user.locked}
+            hasIcon={false}
+            text={
+              user.locked
+                ? t('desktop_user_status_locked')
+                : t('desktop_user_status_active')
+            }
+          />
+        </div>
         <div className={styles.overflow_cell_inner}>
           <OverflowBtn
             onClick={handleOverflowClick}
@@ -115,7 +104,7 @@ export function UserManagementTableRow({
             </>
           ) : null}
         </div>
-      </td>
-    </tr>
+      </div>
+    </ListItem>
   )
 }

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/usermanagement.module.css
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/usermanagement.module.css
@@ -1,35 +1,49 @@
-.table {
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-16);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-8);
+}
+
+.header_row,
+.row {
+  display: grid;
   width: 100%;
-  border-collapse: collapse;
+  align-items: center;
+  padding: 0 var(--spacing-12);
+  gap: var(--spacing-24);
+  grid-template-columns: repeat(4, 1fr) 1.1875rem;
 }
 
-.header_cell {
-  padding-bottom: var(--spacing-8);
-  color: var(--grey-60);
-  font-weight: normal;
-  text-align: left;
-}
-
-.body_cell {
-  padding: var(--spacing-12) 0;
-  border-top: 1px solid var(--grey-30);
-  vertical-align: top;
-}
-
-.body_cell_text {
+.header_row {
+  align-items: start;
   color: var(--grey-60);
 }
 
-.overflow_cell {
-  padding: var(--spacing-12) 0;
-  border-top: 1px solid var(--grey-30);
-  vertical-align: top;
+.rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.row {
+  flex: 1;
+  padding: var(--spacing-12);
+}
+
+.cell {
+  min-width: 0;
 }
 
 .overflow_cell_inner {
   position: relative;
-  width: fit-content;
-  margin-left: auto;
+  width: 1.1875rem;
+  flex-shrink: 0;
 }
 
 .overflow_menu {


### PR DESCRIPTION
Closes [RQA-5992](https://opentrons.atlassian.net/browse/RQA-5992)

# Overview

Updates the User management table in the desktop app to match designs. 

### Current behavior

<img width="1023" height="766" alt="Screenshot 2026-08-24 at 11 01 41 AM" src="https://github.com/user-attachments/assets/42bf510a-148c-4319-a6ce-f3f9f8e559de" />


### Fixed behavior

<img width="917" height="464" alt="Screenshot 2026-08-24 at 11 17 56 AM" src="https://github.com/user-attachments/assets/1532b932-bbc3-4654-8834-14ed5df552d6" />


## Test Plan and Hands on Testing

- See images.

## Risk assessment

- effectively none, just CSS refactors.


[RQA-5992]: https://opentrons.atlassian.net/browse/RQA-5992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ