### PR TITLE
refactor(app): update ODD Account view to reflect designs

### DIFF
--- a/app/src/assets/localization/en/access_control.json
+++ b/app/src/assets/localization/en/access_control.json
@@ -21,7 +21,7 @@
   "forgot_password_heading": "Forgot password?",
   "forgot_password_link": "Forgot password?",
   "forgot_password_subheading": "Log in to an admin account to reset the password for your account.",
-  "legal_name": "Legal Name",
+  "legal_name": "Legal name",
   "log_in_link": "Log in",
   "log_out": "Log out",
   "login_error_incorrect": "Incorrect username or password.",

--- a/app/src/assets/localization/en/anonymous.json
+++ b/app/src/assets/localization/en/anonymous.json
@@ -1,7 +1,7 @@
 {
   "a_robot_software_update_is_available": "A robot software update is required to run protocols with this version of the desktop app. <robotLink>Go to Robot</robotLink>",
   "about_flex_gripper": "About Gripper",
-  "account_page_footer": "Manage robot users in the desktop app",
+  "account_page_footer": "Manage user account details in the desktop app",
   "alternative_security_types_description": "The robot supports connecting to various enterprise access points. Connect via USB and finish setup in the desktop app.",
   "attach_a_pipette": "Attach a pipette to your robot",
   "attach_a_pipette_for_quick_transfer": "To create a quick transfer, you need to attach a pipette to your robot.",

--- a/app/src/assets/localization/en/branded.json
+++ b/app/src/assets/localization/en/branded.json
@@ -1,7 +1,7 @@
 {
   "a_robot_software_update_is_available": "A robot software update is required to run protocols with this version of the Opentrons App. <robotLink>Go to Robot</robotLink>",
   "about_flex_gripper": "About Flex Gripper",
-  "account_page_footer": "Manage robot users in the Opentrons App",
+  "account_page_footer": "Manage user account details in the Opentrons App",
   "alternative_security_types_description": "The Opentrons App supports connecting Flex to various enterprise access points. Connect via USB and finish setup in the app.",
   "attach_a_pipette": "Attach a pipette to your Flex",
   "attach_a_pipette_for_quick_transfer": "To create a quick transfer, you need to attach a pipette to your Opentrons Flex.",

--- a/app/src/pages/ODD/Account/__tests__/Account.test.tsx
+++ b/app/src/pages/ODD/Account/__tests__/Account.test.tsx
@@ -55,9 +55,9 @@ describe('Account', () => {
     screen.getByRole('heading', { name: 'Account' })
     screen.getByText('Username')
     screen.getByText('george_clooney')
-    screen.getByText('Legal Name')
+    screen.getByText('Legal name')
     screen.getByText('George Clooney')
-    screen.getByText('Manage robot users in the Opentrons App')
+    screen.getByText('Manage user account details in the Opentrons App')
   })
 
   it('renders a blank page, then navigates to the previous page, when the user is not logged in', async () => {
@@ -71,7 +71,7 @@ describe('Account', () => {
 
     screen.getByRole('heading', { name: 'Account' })
     screen.getByText('Username')
-    screen.getByText('Legal Name')
+    screen.getByText('Legal name')
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(-1)


### PR DESCRIPTION
Closes [RQA-5997](https://opentrons.atlassian.net/browse/RQA-5997)

# Overview

Updates the Account view on the ODD to match designs by using sentence case and changing up the footer copy.

### Current behavior

<img width="1091" height="640" alt="Screenshot 2026-08-24 at 11 38 51 AM" src="https://github.com/user-attachments/assets/c68bc552-276b-44c7-8b05-68956b35afb6" />

### Fixed behavior

<img width="1079" height="637" alt="Screenshot 2026-08-24 at 11 34 30 AM" src="https://github.com/user-attachments/assets/f11d0639-5e5c-4602-9dd6-28b613071d3a" />


## Test Plan and Hands on Testing

- See images

## Risk assessment

- none, just copy updates


[RQA-5997]: https://opentrons.atlassian.net/browse/RQA-5997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ