### PR TITLE
fix(app): preselect USB options

### DIFF
--- a/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/FileManagerWizardFlows/shared/UsbSelectionScreen.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/FileManagerWizardFlows/shared/UsbSelectionScreen.tsx
@@ -45,7 +45,10 @@ export function UsbSelectionScreen({
   useEffect(() => {
     // if previously selected path is not in the updated mount paths,
     // ensure the selected path is reset
-    if (selectedPath != null && !usbMountPaths.includes(selectedPath)) {
+    if (
+      selectedPath == null ||
+      (selectedPath != null && !usbMountPaths.includes(selectedPath))
+    ) {
       setSelectedPath(usbMountPaths.length > 0 ? usbMountPaths[0] : null)
     }
   }, [usbMountPaths, selectedPath])


### PR DESCRIPTION
# Overview

Ensure that if no USB is selected and the list of avaialable USB devices changes, we auto-select the first available option.

Closes RQA-5985

### Changing available devices

https://github.com/user-attachments/assets/5d43f949-5232-4d8d-8c3b-b633be45c9ca

### Introducing first available devices

https://github.com/user-attachments/assets/65569a2e-a807-4d3c-bd25-d901f73e4162


## Test Plan and Hands on Testing

- Remove any USB devices from the robot if they are plugged in
- Open Settings > File Manager on the ODD
- Select any tab (Audit logs, Diagnostic Files, or Protocol Run Records)
- Proceed with bulk or single download flow (from header or overflow menu)
- Plug in a USB device, and verify that the option is auto-selected 

## Changelog

- add a condition to the use effect that assigns selected path to ensure a path is always selected if there are >= 1 available paths (0 available paths will produce an InfoScreen)

## Review requests

see test plan

## Risk assessment

low