### PR TITLE
fix(app): remove react-scan lines

### DIFF
--- a/app/src/App/__tests__/DesktopApp.test.tsx
+++ b/app/src/App/__tests__/DesktopApp.test.tsx
@@ -1,7 +1,6 @@
 import { MemoryRouter } from 'react-router-dom'
 import { screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { when } from 'vitest-when'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
@@ -24,7 +23,6 @@ import { AlertsModal } from '/app/organisms/Desktop/Alerts/AlertsModal'
 
 import { ProtocolVisualization } from '/app/pages/Desktop/Protocols/ProtocolVisualization'
 import { useIsFlex, useRobot } from '/app/redux-resources/robots'
-import { useFeatureFlag } from '/app/redux/config'
 
 import { DesktopApp } from '../DesktopApp'
 import { useSoftwareUpdatePoll } from '../hooks/useSoftwareUpdatePoll'
@@ -104,7 +102,6 @@ describe('DesktopApp', () => {
     vi.mocked(LocalizationProvider).mockImplementation(
       (props: LocalizationProviderProps) => <>{props.children}</>
     )
-    when(vi.mocked(useFeatureFlag)).calledWith('reactScan').thenReturn(false)
   })
   afterEach(() => {
     vi.resetAllMocks()

--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -9,7 +9,6 @@
   "__dev_internal__quickTransferExportJSON": "Enable JSON Export for Quick Transfer",
   "__dev_internal__quickTransferProtocolContentsLog": "Enable QT Protocol Contents Logging",
   "__dev_internal__reactQueryDevtools": "Enable React Query Devtools",
-  "__dev_internal__reactScan": "Enable React Scan",
   "__dev_internal__robotSearchBar": "Adds a robot search bar on select pages",
   "__dev_internal__showGitDetails": "Show git commit details in Robot System Version",
   "add_audit_log_folder_button": "Select folder",

--- a/app/src/assets/localization/zh/app_settings.json
+++ b/app/src/assets/localization/zh/app_settings.json
@@ -10,7 +10,6 @@
   "__dev_internal__quickTransferExportJSON": "启用快速移液的 JSON 导出功能",
   "__dev_internal__quickTransferProtocolContentsLog": "启用 QT 协议内容日志记录",
   "__dev_internal__reactQueryDevtools": "启用开发者工具",
-  "__dev_internal__reactScan": "启用 React 组件扫描",
   "__dev_internal__robotSearchBar": "在指定页面上添加机器人搜索栏",
   "__dev_internal__showGitDetails": "在机器人系统版本中显示 git 提交详情",
   "add_folder_button": "添加实验耗材源文件夹",

--- a/app/src/redux/config/constants.ts
+++ b/app/src/redux/config/constants.ts
@@ -7,7 +7,6 @@ export const DEV_INTERNAL_FLAGS: DevInternalFlag[] = [
   'protocolTimeline',
   'enableLabwareCreator',
   'reactQueryDevtools',
-  'reactScan',
   'quickTransferProtocolContentsLog',
   'robotSearchBar',
   'showGitDetails',

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -15,7 +15,6 @@ export type DevInternalFlag =
   | 'protocolTimeline'
   | 'enableLabwareCreator'
   | 'reactQueryDevtools'
-  | 'reactScan'
   | 'quickTransferProtocolContentsLog'
   | 'robotSearchBar'
   | 'showGitDetails'


### PR DESCRIPTION


# Overview
react-scan was removed so the app should not display aything about react-scan

closes AUTH-3250

## Test Plan and Hands on Testing
- no react-scan in odd dev buttons
- no react-scan in ff in the desktop app settings

## Changelog
- remove react-scan from test
- remove react-scan from consts


## Review requests

## Risk assessment
low
