### PR TITLE
fix(app): fix overflow button on file manager records

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -248,6 +248,7 @@
   "open_lid": "Open lid",
   "ot2_camera": "OT-2 Camera",
   "overflow_menu_about": "About module",
+  "overflow_menu_button": "overflow menu button",
   "overflow_menu_close_vent": "Close vent",
   "overflow_menu_deactivate_block": "Deactivate block",
   "overflow_menu_deactivate_lid": "Deactivate lid",

--- a/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/ComplianceReadyFiles/LogPeriodRow.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/ComplianceReadyFiles/LogPeriodRow.tsx
@@ -1,15 +1,10 @@
 import { useTranslation } from 'react-i18next'
 
-import {
-  ALIGN_FLEX_END,
-  ListItem,
-  OverflowBtn,
-  StyledText,
-  Tag,
-} from '@opentrons/components'
+import { ListItem, StyledText, Tag } from '@opentrons/components'
 
 import { formatTimestamp } from '/app/transformations/runs'
 
+import { OverflowMenuButton } from '../OverflowMenuButton'
 import styles from './compliancereadyfiles.module.css'
 
 import type { ReactNode } from 'react'
@@ -49,8 +44,7 @@ export function LogPeriodRow(props: LogPeriodRowProps): ReactNode {
           shrinkToContent
         />
       </div>
-      <OverflowBtn
-        justifySelf={ALIGN_FLEX_END}
+      <OverflowMenuButton
         onClick={() => {
           handleOverflowClick(logPeriodSummary)
         }}

--- a/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/ComplianceReadyFiles/compliancereadyfiles.module.css
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/ComplianceReadyFiles/compliancereadyfiles.module.css
@@ -17,7 +17,7 @@
   display: grid;
   width: 100%;
   align-items: center;
-  padding: var(--spacing-24);
+  padding: var(--spacing-16) var(--spacing-24);
 }
 
 .record_content {

--- a/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/OverflowMenuButton/index.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/OverflowMenuButton/index.tsx
@@ -1,0 +1,24 @@
+import { COLORS, Icon } from '@opentrons/components'
+
+import styles from './overflowmenubutton.module.css'
+
+import type { ReactNode } from 'react'
+
+interface OverflowMenuButtonProps {
+  onClick: () => void
+}
+
+export function OverflowMenuButton(props: OverflowMenuButtonProps): ReactNode {
+  const { onClick } = props
+
+  return (
+    <button
+      type="button"
+      className={styles.overflow_button}
+      aria-label="overflow menu button"
+      onClick={onClick}
+    >
+      <Icon name="overflow-btn-touchscreen" color={COLORS.grey60} />
+    </button>
+  )
+}

--- a/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/OverflowMenuButton/index.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/OverflowMenuButton/index.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next'
+
 import { COLORS, Icon } from '@opentrons/components'
 
 import styles from './overflowmenubutton.module.css'
@@ -10,12 +12,13 @@ interface OverflowMenuButtonProps {
 
 export function OverflowMenuButton(props: OverflowMenuButtonProps): ReactNode {
   const { onClick } = props
+  const { t } = useTranslation('device_details')
 
   return (
     <button
       type="button"
       className={styles.overflow_button}
-      aria-label="overflow menu button"
+      aria-label={t('overflow_menu_button')}
       onClick={onClick}
     >
       <Icon name="overflow-btn-touchscreen" color={COLORS.grey60} />

--- a/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/OverflowMenuButton/overflowmenubutton.module.css
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/OverflowMenuButton/overflowmenubutton.module.css
@@ -1,0 +1,17 @@
+.overflow_button {
+  display: flex;
+  width: 3rem;
+  height: 3.75rem;
+  border-radius: var(--border-radius-8);
+  background-color: transparent;
+  cursor: default;
+
+  &:hover {
+    background-color: var(--grey-30);
+  }
+
+  &:active,
+  &:focus {
+    background-color: var(--grey-35);
+  }
+}

--- a/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/ProtocolRunRecords/index.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/ProtocolRunRecords/index.tsx
@@ -2,13 +2,10 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
-  ALIGN_FLEX_END,
   Chip,
   COLORS,
   FLEX_MIN_CONTENT,
   ListItem,
-  OverflowBtn,
-  SPACING,
   StyledText,
 } from '@opentrons/components'
 import { useAllProtocolsQuery } from '@opentrons/react-api-client'
@@ -19,6 +16,7 @@ import { formatTimestamp } from '/app/transformations/runs'
 
 import { ConfirmRunRecordModal } from '../FileManagerWizardFlows/ConfirmRunRecordModal'
 import { DownloadDeleteRunRecordWizard } from '../FileManagerWizardFlows/DownloadDeleteRunRecordWizard'
+import { OverflowMenuButton } from '../OverflowMenuButton'
 import styles from './protocolrunrecords.module.css'
 
 import type { ReactNode } from 'react'
@@ -90,12 +88,7 @@ export function ProtocolRunRecords(): ReactNode {
         const protocol = protocols.find(({ id }) => run.protocolId === id)
         const { chipType, listItemType } = runStatusToRecordProps(run.status)
         return (
-          <ListItem
-            key={run.id}
-            type={listItemType}
-            padding={SPACING.spacing24}
-            className={styles.record}
-          >
+          <ListItem key={run.id} type={listItemType} className={styles.record}>
             <div className={styles.record_content}>
               <StyledText
                 oddStyle="bodyTextSemiBold"
@@ -114,8 +107,7 @@ export function ProtocolRunRecords(): ReactNode {
                 background={false}
               />
             </div>
-            <OverflowBtn
-              justifySelf={ALIGN_FLEX_END}
+            <OverflowMenuButton
               onClick={() => {
                 handleOverflowClick(run)
               }}

--- a/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/ProtocolRunRecords/protocolrunrecords.module.css
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/ProtocolRunRecords/protocolrunrecords.module.css
@@ -1,6 +1,7 @@
 .container {
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: var(--spacing-8);
 }
 
@@ -29,6 +30,8 @@
 .record_content {
   display: grid;
   width: 100%;
+  align-items: center;
+  padding: var(--spacing-16) var(--spacing-24);
   gap: var(--spacing-24);
   grid-template-columns: 33% 33% 33%;
 }


### PR DESCRIPTION
# Overview

Fixes padding and overflow button style for file record list items in file manager (both protocol run records and audit logs).

Closes RQA-5966


#### audit logs
<img width="989" height="559" alt="Screenshot 2026-08-25 at 10 04 54 AM" src="https://github.com/user-attachments/assets/576784e3-0fef-4423-9030-a2aa09d7dd90" />

#### protocol run records
<img width="1000" height="577" alt="Screenshot 2026-08-25 at 10 07 05 AM" src="https://github.com/user-attachments/assets/deb6fd1d-5c01-4bbf-b61c-5661f73e6042" />

#### overflow button
<img width="166" height="218" alt="Screenshot 2026-08-25 at 10 07 15 AM" src="https://github.com/user-attachments/assets/0f316a8f-0873-4e26-9e1c-34eabd5ba43d" />

## Test Plan and Hands on Testing

- push this branch to an ODD on a CRS robot
- navigate to settings > file manager
- in audit logs, inspect that style matches designs
- repeat for protocol run records

## Changelog

- add shared overflow button component to file manager
- implement in run records and audit logs
- fix top/bottom padding in those records (24px -> 16px)

## Review requests

see test plan

## Risk assessment

Low. All style