### PR TITLE
fix(robot-server): add missing await to app setup

### DIFF
--- a/robot-server/robot_server/app_setup.py
+++ b/robot-server/robot_server/app_setup.py
@@ -216,7 +216,10 @@ async def _report_unsigned_runs(
     app_state: AppState,
 ) -> None:
     """If access control enabled and run signoff required, log any unsigned runs."""
-    if not get_authentication_checker(app_state).access_control_status():
+    access_control_status = await get_authentication_checker(
+        app_state
+    ).access_control_status()
+    if not access_control_status:
         return
 
     sql_engine = await get_sql_engine(app_state)


### PR DESCRIPTION
# Overview

Fast followup fix for #22333 

In the previous PR, a function was added to both check if we were in access control mode and run signoff, and if so then potentially log unsigned runs. For the access control check, an `await` was forgotten for the inner `access_control_status()` check. This was causing a coroutine to be returned and not a boolean, which would cause false positives if *not* in access control mode.

Because of the fact that access control mode can't be turned off and run signoff can't be turned on before then, and the fact that if logging is disabled the audit log message would be a no-op, this mistake would in practice not cause any noticeable issues. But of course, functions that are to be awaited should be awaited, and `access_control_status()` is now awaited

## Test Plan and Hands on Testing

On-robot test to ensure correctness

## Changelog

- Add missing `await` to `_report_unsigned_runs`

## Review requests


## Risk assessment

Very low, small fix for correctness