### PR TITLE
fix(api,robot-server): Set appropriate groups for protocol user

### DIFF
--- a/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
@@ -160,9 +160,18 @@ def pyro_behavior(
     return decorator  # type: ignore
 
 
-def synchronous(func: Callable[P, T]) -> Callable[P, T]:
+def synchronous(func: Callable[P, T]) -> Callable[P, T]:  # noqa: C901
     """Decorator that makes an async function callable synchronously."""
     if not inspect.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        def _do(*args: P.args, **kwargs: P.kwargs) -> Any:
+            try:
+                return func(*args, **kwargs)
+            except BaseException:
+                log.exception(f"Pyro call of {func}")
+                raise
+
         return func  # no-op for non-async functions
 
     @functools.wraps(func)
@@ -190,7 +199,11 @@ def synchronous(func: Callable[P, T]) -> Callable[P, T]:
 
             # Execute the coroutine
             future = asyncio.run_coroutine_threadsafe(coro, loop)
-            return future.result()
+            try:
+                return future.result()
+            except BaseException:
+                log.exception(f"Pyro call of {func}")
+                raise
 
         else:
             raise RuntimeError("Instance event loop is not running.")

--- a/robot-server/robot_server/runs/run_process_pyro_provider.py
+++ b/robot-server/robot_server/runs/run_process_pyro_provider.py
@@ -4,6 +4,7 @@ import asyncio
 import enum
 import logging
 import os
+import pwd
 import subprocess
 import sys
 import time
@@ -57,8 +58,7 @@ class RunProcessPyroProvider:
         self._run_processes: Optional[List[_RunProcess]] = None
         self._simulating_run_processes: Optional[List[_RunProcess]] = None
 
-        # The protocol subprocess username defaults to root unless otherwise specified
-        self._protocol_username: str = "root"
+        self._update_user_subprocess(False)
 
         self._teardown_signal = asyncio.Event()
         self._process_maintainer_task: asyncio.Task[None] | None = None
@@ -73,7 +73,6 @@ class RunProcessPyroProvider:
         If feature flag is on for running as a user with limited permissions then
         ensure the protocol user name is set.
         """
-        self._protocol_username = _ROOT_USER_NAME
         self._update_user_subprocess(access_control_mode)
         if feature_flags.protocol_subprocess_enabled():
             register_process_types()
@@ -239,7 +238,12 @@ class RunProcessPyroProvider:
         return cast(DirectedRunProcess, cast(object, run_proxy))
 
     @staticmethod
-    def _open_process(process_name: str, user_name: str) -> subprocess.Popen[bytes]:
+    def _open_process(
+        process_name: str,
+        user_name: str,
+        main_group_id: int,
+        supplemental_group_ids: list[int],
+    ) -> subprocess.Popen[bytes]:
         return subprocess.Popen(
             args=[
                 sys.executable,
@@ -250,6 +254,8 @@ class RunProcessPyroProvider:
             ],
             env={k: v for k, v in os.environ.items()},
             user=user_name,
+            group=main_group_id,
+            extra_groups=supplemental_group_ids,
         )
 
     @staticmethod
@@ -278,12 +284,25 @@ class RunProcessPyroProvider:
 
     def _start_run_process(self, process_name: str) -> subprocess.Popen[bytes]:
         return self._open_process(
-            process_name=process_name, user_name=self._protocol_username
+            process_name=process_name,
+            user_name=self._process_username,
+            main_group_id=self._process_gid,
+            supplemental_group_ids=self._supplemental_gids,
         )
+
+    def _set_user_subprocess_for(self, username: str) -> None:
+        gid = pwd.getpwnam(username).pw_gid
+        supplemental_gids = os.getgrouplist(username, gid)
+        _log.info(
+            f"Configuring subprocesses to run as {username}: username={username}, main gid={gid}, supplemental gids={', '.join([str(gid) for gid in supplemental_gids])}"
+        )
+        self._process_username = username
+        self._process_gid = gid
+        self._supplemental_gids = supplemental_gids
 
     def _update_user_subprocess(self, access_control_mode: bool) -> None:
         """Update which system user should execute the protocol subprocess."""
         if feature_flags.run_protocol_as_restricted_user() or access_control_mode:
-            self._protocol_username = _RESTRICTED_USER_NAME
+            self._set_user_subprocess_for(_RESTRICTED_USER_NAME)
         else:
-            self._protocol_username = _ROOT_USER_NAME
+            self._set_user_subprocess_for(_ROOT_USER_NAME)


### PR DESCRIPTION
# Overview

We've been setting the protocol process user using the `user` argument of `Popen`, which is nice. The thing is that unlike something like ssh or su, `Popen` does _exactly_ what you tell it - `user=` sets the user, but implies nothing about the groups. Popen doesn't look up group membership for the user or anything. So we executed protocols with user `ot-protocol` and primary group `root`, and no supplemental groups.

This meant a couple things:
- Protocols couldn't access FAT32 usb drives, because they're owned by `root/ot-protocol`, so neither the user or primary group match
- Protocols could access anything with ownership `x/root`, umask 0070

Both of these are bad!

To fix this, we just have to specify the main gid and the supplemental gids with the appropriate arguments to popen, which we can get from the group db and the user db. Not that bad. The annoying thing is that setting the groups appropriately makes us notice that actually we're not properly allowing access to the persistence db, which is an oe-core change, so there's a PR there too (https://github.com/Opentrons/oe-core/pull/375)

Also, the details and stack trace of exceptions in a pyro callee don't make it to the pyro caller consistently, so log them.

## Test Plan and Hands on Testing

- [x] Put this code on a robot and try to access a USB drive from a protocol. It should work

## Changelog

- Set primary and supplemental gids of protocol user
- Log exceptions in pyro callees

## Review requests

Look good?

## Risk assessment

Medium; it's a low level thing, but it's also used all the time so it's tough to miss issues.

Closes RQA-6023
