### PR TITLE
fix(app): only validate service PIN when enabling CRS

### DIFF
--- a/app/src/organisms/Desktop/EnableCRSWizard/index.tsx
+++ b/app/src/organisms/Desktop/EnableCRSWizard/index.tsx
@@ -179,7 +179,7 @@ function EnterServicePINPage({
       header={header}
       footer={
         <div className={styles.footer}>
-          <SecondaryButton onClick={onBack}>
+          <SecondaryButton type="button" onClick={onBack}>
             {t('shared:cancel')}
           </SecondaryButton>
           <PrimaryButton variant="warning" type="submit" form={formId}>
@@ -225,6 +225,9 @@ function EnterServicePINPage({
                 autoFocus
                 error={fieldState.error?.message}
                 {...field}
+                // Validate only on enable-button submit. Form mode is onBlur, so
+                // Cancel would otherwise mark an empty PIN incorrect on mousedown.
+                onBlur={undefined}
               />
             )}
           />


### PR DESCRIPTION
Closes [RQA-5923](https://opentrons.atlassian.net/browse/RQA-5923)

# Overview

Mouse down actions on the cancel button the service PIN modal causes the form state to read as invalid. To fix, we make `onBlur` `undefined` and only validate the form when clicking "Enable Compliance Ready Software".

### Current behavior

https://github.com/user-attachments/assets/08b2966e-7e81-4ef8-988c-d687ed31a8fa

### Fixed behavior

https://github.com/user-attachments/assets/d3b54caa-dacd-4ed1-9060-1ab2f1f75937

## Test Plan and Hands on Testing

- See videos

## Risk assessment

- Effectively none, just CSS


[RQA-5923]: https://opentrons.atlassian.net/browse/RQA-5923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ