### PR TITLE
fix(app,robot-server): Do not require authentication and documentation for robot-side protocol analysis

### DIFF
--- a/api-client/src/protocols/createProtocolAnalysis.ts
+++ b/api-client/src/protocols/createProtocolAnalysis.ts
@@ -23,8 +23,7 @@ export function createProtocolAnalysis(
   protocolKey: string,
   runTimeParameterValues?: RunTimeParameterValuesCreateData,
   runTimeParameterFiles?: RunTimeParameterFilesCreateData,
-  forceReAnalyze?: boolean,
-  userNotes?: string
+  forceReAnalyze?: boolean
 ): ResponsePromise<ProtocolAnalysisSummaryResult> {
   const data = {
     runTimeParameterValues: runTimeParameterValues ?? {},
@@ -34,9 +33,6 @@ export function createProtocolAnalysis(
   const response = request<
     ProtocolAnalysisSummaryResult,
     { data: CreateProtocolAnalysisData }
-  >(POST, `/protocols/${protocolKey}/analyses`, config, {
-    body: { data },
-    userNotes,
-  })
+  >(POST, `/protocols/${protocolKey}/analyses`, config, { body: { data } })
   return response
 }

--- a/app/src/assets/localization/en/audit_log.json
+++ b/app/src/assets/localization/en/audit_log.json
@@ -18,7 +18,6 @@
   "create_camera_image_settings": "Updating camera image settings",
   "create_offsets": "Saving new labware offsets",
   "create_protocol": "Creating protocol",
-  "create_protocol_analysis": "Analyzing protocol on robot",
   "create_run": "Creating run",
   "create_user": "Creating user",
   "delete_log_period": "Deleting log period",

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useCompatibleAnalysis.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useCompatibleAnalysis.ts
@@ -13,7 +13,6 @@ import {
 import { getRunTimeParameterDataFromRun } from './utils'
 
 import type { Run } from '@opentrons/api-client'
-import type { DocumentationState } from '@opentrons/react-api-client'
 import type {
   CompletedProtocolAnalysis,
   RunTimeCommand,
@@ -22,16 +21,13 @@ import type {
 // TODO(jh, 03-14-25): Remove this adapter logic and Mixpanel event once analytics
 //  indicate that users no longer run old analyses.
 
-/**
- * If analysis is incompatible with LPC, force reanalysis and use that fresh analysis,
- * otherwise, use the current analysis.
- */
+// If analysis is incompatible with LPC, force reanalysis and use that fresh analysis,
+// otherwise, use the current analysis.
 export function useCompatibleAnalysis(
   runId: string | null,
   runRecord: Run | undefined,
   mostRecentAnalysis: CompletedProtocolAnalysis | null,
-  isFlex: boolean,
-  documentationState: DocumentationState
+  isFlex: boolean
 ): CompletedProtocolAnalysis | null {
   const [compatibleAnalysis, setCompatibleAnalysis] =
     useState<CompletedProtocolAnalysis | null>(null)
@@ -42,10 +38,8 @@ export function useCompatibleAnalysis(
 
   const trackEvent = useTrackEvent()
   const protocolId = runRecord?.data.protocolId ?? ''
-  const { createProtocolAnalysis } = useCreateProtocolAnalysisMutation(
-    documentationState,
-    protocolId
-  )
+  const { createProtocolAnalysis } =
+    useCreateProtocolAnalysisMutation(protocolId)
   const { data: freshAnalysis } = useProtocolAnalysisAsDocumentQuery(
     protocolId,
     compatibleAnalysisId,

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useCompatibleAnalysis.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useCompatibleAnalysis.ts
@@ -21,8 +21,10 @@ import type {
 // TODO(jh, 03-14-25): Remove this adapter logic and Mixpanel event once analytics
 //  indicate that users no longer run old analyses.
 
-// If analysis is incompatible with LPC, force reanalysis and use that fresh analysis,
-// otherwise, use the current analysis.
+/**
+ * If analysis is incompatible with LPC, force reanalysis and use that fresh analysis,
+ * otherwise, use the current analysis.
+ */
 export function useCompatibleAnalysis(
   runId: string | null,
   runRecord: Run | undefined,

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
@@ -7,7 +7,6 @@ import {
 } from '@opentrons/react-api-client'
 import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 
-import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useMaintenanceRunDocumentation } from '/app/local-resources/access-control/useMaintenanceRunDocumentation'
 import { isDocumentationProvided } from '/app/local-resources/access-control/utils'
 import { useInitLPCStore } from '/app/organisms/LabwarePositionCheck/LPCFlows/hooks/useInitLPCStore'
@@ -113,23 +112,12 @@ export function useLPCFlows({
   const { data: runRecord } = useNotifyRunQuery(runId ?? null, {
     refetchInterval: RUN_RECORD_INTERVAL_MS,
   })
-
   const mostRecentAnalysis = useMostRecentCompletedAnalysis(runId)
-
-  // useCompatibleAnalysis() may need to trigger a new analysis, and that may require
-  // the user to log in and enter a reason for interaction.
-  //
-  // todo(mm, 2026-08-10): This could perhaps be combined with our call to
-  // useMaintenanceRunDocumentation() to avoid prompting the user twice,
-  // but it's unclear which hook should be responsible for that.
-  const analysisDocumentationState = useDocumentationState()
-
   const compatibleFlexAnalysis = useCompatibleAnalysis(
     runId,
     runRecord,
     mostRecentAnalysis,
-    isFlex,
-    analysisDocumentationState
+    isFlex
   )
   const compatibleRobotAnalysis = isFlex
     ? compatibleFlexAnalysis

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ProtocolSetupParameters.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ProtocolSetupParameters.tsx
@@ -169,13 +169,10 @@ export function ProtocolSetupParameters({
     }
   }
 
-  // todo(mm, 2026-08-10): This could perhaps be useLinkedDocumentationState so a single
-  // prompt could be reused across the multiple setup requests, but the promise chaining
-  // inside handleConfirmValues is hurting my brain.
-  const documentationState = useDocumentationState()
-
   const { createProtocolAnalysis, isLoading: isAnalysisLoading } =
-    useCreateProtocolAnalysisMutation(documentationState, protocolId, host)
+    useCreateProtocolAnalysisMutation(protocolId, host)
+
+  const documentationState = useDocumentationState()
 
   const { uploadCsvFile } = useUploadCsvFileMutation(
     documentationState,
@@ -276,7 +273,6 @@ export function ProtocolSetupParameters({
       setChooseCsvFileScreen(parameter)
     } else {
       // bad param
-      parameter.type satisfies never
       console.error('error: bad param. not expected to reach this')
     }
   }

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ProtocolSetupParameters.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ProtocolSetupParameters.tsx
@@ -273,6 +273,7 @@ export function ProtocolSetupParameters({
       setChooseCsvFileScreen(parameter)
     } else {
       // bad param
+      parameter.type satisfies never
       console.error('error: bad param. not expected to reach this')
     }
   }

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/__tests__/ProtocolSetupParameters.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/__tests__/ProtocolSetupParameters.test.tsx
@@ -77,11 +77,7 @@ describe('ProtocolSetupParameters', () => {
     vi.mocked(ChooseCsvFile).mockReturnValue(<div>mock ChooseCsvFile</div>)
     vi.mocked(useHost).mockReturnValue(MOCK_HOST_CONFIG)
     when(vi.mocked(useCreateProtocolAnalysisMutation))
-      .calledWith(
-        ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
-        expect.anything(),
-        expect.anything()
-      )
+      .calledWith(expect.anything(), expect.anything())
       .thenReturn({ createProtocolAnalysis: mockCreateProtocolAnalysis } as any)
     when(vi.mocked(useCreateRunMutation))
       .calledWith(

--- a/app/src/resources/runs/useCloneRun.ts
+++ b/app/src/resources/runs/useCloneRun.ts
@@ -8,7 +8,7 @@ import {
   useHost,
 } from '@opentrons/react-api-client'
 
-import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import {
   getRunTimeParameterFilesForRun,
   getRunTimeParameterValuesForRun,
@@ -33,10 +33,7 @@ export function useCloneRun(
   const queryClient = useQueryClient()
   const { data: runRecord, isLoading: isLoadingRun } = useNotifyRunQuery(runId)
   const protocolKey = runRecord?.data.protocolId ?? null
-  const { documentationState, clearDocreport } = useLinkedDocumentationState(
-    ['create_protocol_analysis', 'create_run'],
-    null
-  )
+  const documentationState = useDocumentationState()
   const { createRun, isLoading: isCloning } = useCreateRunMutation(
     documentationState,
     {
@@ -53,13 +50,11 @@ export function useCloneRun(
     }
   )
   const { createProtocolAnalysis } = useCreateProtocolAnalysisMutation(
-    documentationState,
     protocolKey,
     host
   )
   const cloneRun = (options?: { onError?: (error: unknown) => void }): void => {
     if (runRecord != null) {
-      clearDocreport()
       const { protocolId, labwareOffsets } = runRecord.data
       const runTimeParameters =
         'runTimeParameters' in runRecord.data

--- a/auth-server/auth_server/users/scopes.py
+++ b/auth-server/auth_server/users/scopes.py
@@ -37,7 +37,6 @@ def get_scope_set_of_account_type(
 
         elif account_type == AccountType.USER:
             result = {
-                Scope.PROTOCOL_ANALYSES_WRITE,
                 Scope.RESTART_WRITE,
                 Scope.ROBOT_CONTROL_WRITE,
                 Scope.ROBOT_SETTINGS_WRITE,

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -147,7 +147,6 @@ type AuditLogAction =
   | 'attach_pipette_left'
   | 'attach_pipette_right'
   | 'create_protocol'
-  | 'create_protocol_analysis'
   | 'launching_error_recovery'
   | 'resume_run_from_recovery'
   | 'create_run'

--- a/react-api-client/src/protocols/__tests__/useCreateProtocolAnalysisMutation.test.tsx
+++ b/react-api-client/src/protocols/__tests__/useCreateProtocolAnalysisMutation.test.tsx
@@ -5,7 +5,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createProtocolAnalysis } from '@opentrons/api-client'
 
 import { useCreateProtocolAnalysisMutation } from '..'
-import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../../accessControl/__fixtures__/documentationState'
 import { useHost } from '../../api'
 
 import type * as React from 'react'
@@ -43,11 +42,7 @@ describe('useCreateProtocolAnalysisMutation hook', () => {
     vi.mocked(createProtocolAnalysis).mockRejectedValue('oh no')
 
     const { result } = renderHook(
-      () =>
-        useCreateProtocolAnalysisMutation(
-          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
-          'fake-protocol-key'
-        ),
+      () => useCreateProtocolAnalysisMutation('fake-protocol-key'),
       {
         wrapper,
       }
@@ -70,11 +65,7 @@ describe('useCreateProtocolAnalysisMutation hook', () => {
     } as Response<ProtocolAnalysisSummaryResult>)
 
     const { result } = renderHook(
-      () =>
-        useCreateProtocolAnalysisMutation(
-          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
-          'fake-protocol-key'
-        ),
+      () => useCreateProtocolAnalysisMutation('fake-protocol-key'),
       {
         wrapper,
       }

--- a/react-api-client/src/protocols/useCreateProtocolAnalysisMutation.ts
+++ b/react-api-client/src/protocols/useCreateProtocolAnalysisMutation.ts
@@ -1,8 +1,7 @@
-import { useQueryClient } from 'react-query'
+import { useMutation, useQueryClient } from 'react-query'
 
 import { createProtocolAnalysis } from '@opentrons/api-client'
 
-import { useDocumentedMutation } from '../accessControl'
 import { getQueryKey, useHost } from '../api'
 
 import type { AxiosError } from 'axios'
@@ -18,7 +17,6 @@ import type {
   RunTimeParameterFilesCreateData,
   RunTimeParameterValuesCreateData,
 } from '@opentrons/api-client'
-import type { DocumentationState } from '../accessControl'
 
 export interface CreateProtocolAnalysisVariables {
   protocolKey: string
@@ -45,7 +43,6 @@ export type UseCreateProtocolAnalysisMutationOptions = UseMutationOptions<
 >
 
 export function useCreateProtocolAnalysisMutation(
-  documentationState: DocumentationState,
   protocolId: string | null,
   hostOverride?: HostConfig | null,
   options: UseCreateProtocolAnalysisMutationOptions | undefined = {}
@@ -54,34 +51,38 @@ export function useCreateProtocolAnalysisMutation(
   const host =
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
   const queryClient = useQueryClient()
-  const mutation = useDocumentedMutation<
+  // Protocol analysis endpoint, does not require documentation.
+  // eslint-disable-next-line opentrons/no-direct-use-mutation
+  const mutation = useMutation<
     ProtocolAnalysisSummaryResult,
     AxiosError<ErrorResponse>,
     CreateProtocolAnalysisVariables
   >(
-    documentationState,
-    ['create_protocol_analysis'],
     getQueryKey(host, 'protocols', protocolId, 'analyses'),
-    async ({ variables, userNotes }) => {
-      const {
-        protocolKey,
-        runTimeParameterValues,
-        runTimeParameterFiles,
-        forceReAnalyze,
-      } = variables
-      const response = await createProtocolAnalysis(
+    ({
+      protocolKey,
+      runTimeParameterValues,
+      runTimeParameterFiles,
+      forceReAnalyze,
+    }) =>
+      createProtocolAnalysis(
         host!,
         protocolKey,
         runTimeParameterValues,
         runTimeParameterFiles,
-        forceReAnalyze,
-        userNotes
+        forceReAnalyze
       )
-      // Note: Not awaiting invalidateQueries() to preserve prior behavior.
-      // Not sure this is what we actually want.
-      void queryClient.invalidateQueries(getQueryKey(host, 'protocols'))
-      return response.data
-    },
+        .then(response => {
+          queryClient
+            .invalidateQueries(getQueryKey(host, 'protocols'))
+            .catch((e: Error) => {
+              throw e
+            })
+          return response.data
+        })
+        .catch((e: Error) => {
+          throw e
+        }),
     options
   )
   return {

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -33,7 +33,7 @@ from opentrons.util.performance_helpers import TrackingFunctions
 from opentrons_shared_data.robot import user_facing_robot_type
 from opentrons_shared_data.robot.types import RobotType
 from server_utils.audit.audit_logger import AuditLogger
-from server_utils.audit.fastapi import get_audit_logger
+from server_utils.audit.fastapi import get_audit_logger, skip_audit_logger
 from server_utils.auth.resource_server.fastapi import (
     get_access_control_status,
     require_scopes,
@@ -770,7 +770,7 @@ async def delete_protocol_by_id(
         status.HTTP_422_UNPROCESSABLE_ENTITY: {"model": ErrorBody[FileIdNotFound]},
         status.HTTP_503_SERVICE_UNAVAILABLE: {"model": ErrorBody[LastAnalysisPending]},
     },
-    dependencies=[Depends(require_scopes(Scope.PROTOCOL_ANALYSES_WRITE))],
+    dependencies=[Depends(skip_audit_logger)],
 )
 async def create_protocol_analysis(
     protocolId: str,

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -770,7 +770,12 @@ async def delete_protocol_by_id(
         status.HTTP_422_UNPROCESSABLE_ENTITY: {"model": ErrorBody[FileIdNotFound]},
         status.HTTP_503_SERVICE_UNAVAILABLE: {"model": ErrorBody[LastAnalysisPending]},
     },
-    dependencies=[Depends(skip_audit_logger)],
+    dependencies=[
+        # Although protocol analyses do store data on the robot and do indirectly affect
+        # system behavior, the client currently triggers them implicitly, and thus isn't
+        # prepared for them to require authentication or audit log notes.
+        Depends(skip_audit_logger)
+    ],
 )
 async def create_protocol_analysis(
     protocolId: str,

--- a/robot-server/tests/test_access_control_coverage.py
+++ b/robot-server/tests/test_access_control_coverage.py
@@ -17,6 +17,8 @@ IGNORED_ENDPOINTS: set[tuple[str, str]] = {
     ("delete", "/clientData/{key}"),
     # This is spiritually a GET endpoint. It doesn't actually control or modify anything.
     ("post", "/labwareOffsets/searches"),
+    # Protocol analyses are just disposable simulations.
+    ("post", "/protocols/{protocolId}/analyses"),
 }
 
 

--- a/robot-server/tests/test_access_control_coverage.py
+++ b/robot-server/tests/test_access_control_coverage.py
@@ -17,7 +17,9 @@ IGNORED_ENDPOINTS: set[tuple[str, str]] = {
     ("delete", "/clientData/{key}"),
     # This is spiritually a GET endpoint. It doesn't actually control or modify anything.
     ("post", "/labwareOffsets/searches"),
-    # Protocol analyses are just disposable simulations.
+    # Although protocol analyses do store data on the robot and do indirectly affect
+    # system behavior, the client currently triggers them implicitly, and thus isn't
+    # prepared for them to require authentication or audit log notes.
     ("post", "/protocols/{protocolId}/analyses"),
 }
 

--- a/server-utils/server_utils/auth/scopes.py
+++ b/server-utils/server_utils/auth/scopes.py
@@ -27,11 +27,6 @@ class Scope(enum.Enum):
         "Edit settings related to authentication, authorization, and access control.",
     )
 
-    PROTOCOL_ANALYSES_WRITE = (
-        "protocol_analyses.write",
-        "Create robot-side protocol analyses.",
-    )
-
     PROTOCOLS_WRITE = (
         "protocols.write",
         "Upload or delete protocols.",


### PR DESCRIPTION
## Overview

This closes RQA-6012, and reverts PR #22213 / commit 4ad17d7.

After some hands-on testing and in-person discussions, we'd prefer for protocol analysis to *not* require authentication and documentation. It came off as an internal implementation detail, and it also made the login and documentation modals pop up at *weird times,* because of the frontend's practice of sending the requests implicitly when components mount.

## Test Plan and Hands on Testing

* [x] Smoke test in the desktop app with a dev server
  * Unauthenticated analysis request goes through with no failures
  * No "enter documentation" modals popping up for protocol analysis

## Changelog

This is mostly just a straight revert of PR #22213 / commit 4ad17d7, but keeping other minor fixups, and updating some comments.

## Review requests

None.

## Risk assessment

Low.