### PR TITLE
fix(app): implement toasts for record download at caller

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -130,6 +130,7 @@
   "downloading_log_period": "Downloading log period",
   "downloading_log_periods": "Downloading log periods",
   "downloading_run_record": "Downloading protocol files",
+  "downloading_run_records": "Downloading run records",
   "drop_tips": "drop tips",
   "edit_settings": "Edit settings",
   "empty": "Empty",

--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns/__tests__/RecentProtocolRuns.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns/__tests__/RecentProtocolRuns.test.tsx
@@ -48,10 +48,9 @@ describe('RecentProtocolRuns', () => {
       <div>mock HistoricalProtocolRun</div>
     )
     vi.mocked(useDownloadSelectedRuns).mockReturnValue({
-      downloadRuns: mockDownloadRuns,
-      isDownloading: false,
-      hasError: false,
-    })
+      mutateAsync: mockDownloadRuns,
+      status: 'idle',
+    } as any)
     vi.mocked(useDeleteSelectedRuns).mockReturnValue({
       deleteSelectedRuns: mockDeleteRuns,
       deletingIds: new Set(),

--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns/index.tsx
@@ -7,6 +7,7 @@ import {
   INFO_TOAST,
   InfoScreen,
   StyledText,
+  SUCCESS_TOAST,
   WARNING_TOAST,
 } from '@opentrons/components'
 import { useAllProtocolsQuery } from '@opentrons/react-api-client'
@@ -48,8 +49,10 @@ export function RecentProtocolRuns({
   const [showDeleteRecordsModal, setShowDeleteRecordsModal] =
     useState<boolean>(false)
   const documentationState = useDocumentationState()
-  const { downloadRuns, isDownloading: isDownloadingRuns } =
-    useDownloadSelectedRuns(robotName)
+  const {
+    mutateAsync: downloadSelectedRuns,
+    status: downloadSelectedRunsStatus,
+  } = useDownloadSelectedRuns(robotName)
   const { deleteSelectedRuns, deletingIds } =
     useDeleteSelectedRuns(documentationState)
 
@@ -64,14 +67,17 @@ export function RecentProtocolRuns({
       handleNoRuns('download')
       return
     }
-    if (!isDownloadingRuns) {
+    if (downloadSelectedRunsStatus !== 'loading') {
       const toastIcon: IconProps = { name: 'ot-spinner', spin: true }
       const toastId = makeToast(
-        t('downloading_run_records') as string,
+        t('device_details:downloading_run_records') as string,
         INFO_TOAST,
-        { icon: toastIcon }
+        { icon: toastIcon, disableTimeout: true }
       )
-      void downloadRuns(runs)
+      void downloadSelectedRuns({ runs })
+        .then(() => {
+          makeToast(t('files_successfully_downloaded') as string, SUCCESS_TOAST)
+        })
         .catch((e: Error) => {
           makeToast(e.message, ERROR_TOAST, { closeButton: true })
         })

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/Troubleshooting.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/Troubleshooting.tsx
@@ -4,17 +4,22 @@ import {
   ALIGN_CENTER,
   ALIGN_END,
   Box,
+  ERROR_TOAST,
   Flex,
+  INFO_TOAST,
   JUSTIFY_SPACE_BETWEEN,
   LegacyStyledText,
   SPACING,
   SPACING_AUTO,
+  SUCCESS_TOAST,
   TYPOGRAPHY,
 } from '@opentrons/components'
 
 import { TertiaryButton } from '/app/atoms/buttons'
+import { useToaster } from '/app/organisms/ToasterOven'
 import { useDownloadRobotLogs } from '/app/resources/devices/hooks'
 
+import type { IconProps } from '@opentrons/components'
 import type { MouseEventHandler } from 'react'
 
 interface TroubleshootingProps {
@@ -24,12 +29,35 @@ interface TroubleshootingProps {
 export function Troubleshooting({
   robotName,
 }: TroubleshootingProps): JSX.Element {
-  const { t } = useTranslation('device_settings')
-  const { downloadLogs, isDownloading, canDownload } =
-    useDownloadRobotLogs(robotName)
+  const { t } = useTranslation(['device_settings', 'device_details'])
+  const { makeToast, eatToast } = useToaster()
+  const {
+    mutateAsync: downloadLogs,
+    status: downloadLogsStatus,
+    canDownload,
+  } = useDownloadRobotLogs(robotName)
 
   const handleClick: MouseEventHandler<HTMLButtonElement> = () => {
-    downloadLogs().catch(() => {})
+    if (downloadLogsStatus !== 'loading') {
+      const toastIcon: IconProps = { name: 'ot-spinner', spin: true }
+      const toastId = makeToast(t('downloading_logs') as string, INFO_TOAST, {
+        disableTimeout: true,
+        icon: toastIcon,
+      })
+      void downloadLogs({})
+        .then(() => {
+          makeToast(
+            t('device_details:files_successfully_downloaded') as string,
+            SUCCESS_TOAST
+          )
+        })
+        .catch((e: Error) => {
+          makeToast(e.message, ERROR_TOAST, { closeButton: true })
+        })
+        .finally(() => {
+          eatToast(toastId)
+        })
+    }
   }
 
   return (
@@ -55,7 +83,7 @@ export function Troubleshooting({
         </LegacyStyledText>
       </Box>
       <TertiaryButton
-        disabled={!canDownload || isDownloading}
+        disabled={!canDownload || downloadLogsStatus === 'loading'}
         marginLeft={SPACING_AUTO}
         onClick={handleClick}
         alignSelf={ALIGN_END}

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/Troubleshooting.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/Troubleshooting.tsx
@@ -19,8 +19,8 @@ import { TertiaryButton } from '/app/atoms/buttons'
 import { useToaster } from '/app/organisms/ToasterOven'
 import { useDownloadRobotLogs } from '/app/resources/devices/hooks'
 
-import type { IconProps } from '@opentrons/components'
 import type { MouseEventHandler } from 'react'
+import type { IconProps } from '@opentrons/components'
 
 interface TroubleshootingProps {
   robotName: string

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/Troubleshooting.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/Troubleshooting.test.tsx
@@ -111,10 +111,13 @@ describe('RobotSettings Troubleshooting', () => {
       downloadLogsButton.click()
     })
 
-    expect(downloadLogsButton).toBeDisabled()
     expect(MOCK_MAKE_TOAST).toBeCalledWith('Downloading logs...', 'info', {
       disableTimeout: true,
       icon: { name: 'ot-spinner', spin: true },
+    })
+
+    await waitFor(() => {
+      expect(downloadLogsButton).toBeDisabled()
     })
 
     await waitFor(

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
@@ -127,15 +127,15 @@ export function ComplianceReadySoftwareFiles({
         )
         await downloadLogPeriodsMutation
           .mutateAsync({ logPeriods })
-          .catch((error: Error) => {
-            makeToast(error.message, ERROR_TOAST, TOAST_STYLE)
-          })
           .then(() => {
             makeToast(
               t('files_successfully_downloaded') as string,
               SUCCESS_TOAST,
               TOAST_STYLE
             )
+          })
+          .catch((error: Error) => {
+            makeToast(error.message, ERROR_TOAST, TOAST_STYLE)
           })
           .finally(() => {
             eatToast(toastId)

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/DiagnosticFiles/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/DiagnosticFiles/index.tsx
@@ -1,7 +1,15 @@
 import { useTranslation } from 'react-i18next'
 
-import { CheckboxBasic, COLORS, StyledText } from '@opentrons/components'
+import {
+  CheckboxBasic,
+  COLORS,
+  ERROR_TOAST,
+  INFO_TOAST,
+  StyledText,
+  SUCCESS_TOAST,
+} from '@opentrons/components'
 
+import { useToaster } from '/app/organisms/ToasterOven'
 import {
   useDownloadCalibrationData,
   useDownloadRobotLogs,
@@ -11,6 +19,8 @@ import { FileManagementSectionHeader } from '../FileManagementSectionHeader'
 import { useRecordSelection } from '../hooks/useRecordSelection'
 import fileManagerStyles from '../robotsettingsfilemanager.module.css'
 import styles from './diagnosticfiles.module.css'
+
+import type { IconProps } from '@opentrons/components'
 
 const DIAGNOSTIC_ROWS = [
   { id: 'troubleshooting', i18nKey: 'troubleshooting_logs' },
@@ -25,8 +35,9 @@ export function DiagnosticsFiles({
   robotName,
 }: DiagnosticsFilesProps): JSX.Element {
   const { t } = useTranslation('device_details')
+  const { makeToast, eatToast } = useToaster()
 
-  const { downloadLogs, isDownloading: isDownloadingLogs } =
+  const { mutateAsync: downloadLogs, status: downloadLogsStatus } =
     useDownloadRobotLogs(robotName)
   const { downloadCalibration, isLoading: isLoadingCalibration } =
     useDownloadCalibrationData(robotName)
@@ -35,12 +46,40 @@ export function DiagnosticsFiles({
     useRecordSelection(DIAGNOSTIC_ROWS)
 
   const handleDownloadSelected = (): void => {
-    if (selectedIds.has('troubleshooting') && !isDownloadingLogs) {
-      downloadLogs().catch(() => {})
+    const shouldDownloadLogs =
+      selectedIds.has('troubleshooting') && downloadLogsStatus !== 'loading'
+    const shouldDownloadCalibration =
+      selectedIds.has('calibration') && !isLoadingCalibration
+
+    if (!shouldDownloadLogs && !shouldDownloadCalibration) {
+      return
     }
-    if (selectedIds.has('calibration') && !isLoadingCalibration) {
-      downloadCalibration().catch(() => {})
+
+    const toastIcon: IconProps = { name: 'ot-spinner', spin: true }
+    const toastId = makeToast(
+      t('downloading_diagnostic_files') as string,
+      INFO_TOAST,
+      { disableTimeout: true, icon: toastIcon }
+    )
+
+    const downloads: Array<Promise<unknown>> = []
+    if (shouldDownloadLogs) {
+      downloads.push(downloadLogs({}))
     }
+    if (shouldDownloadCalibration) {
+      downloads.push(downloadCalibration())
+    }
+
+    void Promise.all(downloads)
+      .then(() => {
+        makeToast(t('files_successfully_downloaded') as string, SUCCESS_TOAST)
+      })
+      .catch((e: Error) => {
+        makeToast(e.message, ERROR_TOAST, { closeButton: true })
+      })
+      .finally(() => {
+        eatToast(toastId)
+      })
   }
 
   return (

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ProtocolRunRecords/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ProtocolRunRecords/index.tsx
@@ -44,7 +44,7 @@ export function ProtocolRunRecords({
     [runData?.data]
   )
   const documentationState = useDocumentationState()
-  const { downloadRuns, isDownloading: isDownloadingRuns } =
+  const { mutateAsync: downloadSelectedRuns, status: downloadRunsStatus } =
     useDownloadSelectedRuns(robotName)
   const { deleteSelectedRuns, deletingIds } =
     useDeleteSelectedRuns(documentationState)
@@ -70,23 +70,21 @@ export function ProtocolRunRecords({
       handleNoRunsSelected('download')
       return
     }
-    if (!isDownloadingRuns) {
+    if (downloadRunsStatus !== 'loading') {
       const toastIcon: IconProps = { name: 'ot-spinner', spin: true }
       const toastId = makeToast(
         t('downloading_run_records') as string,
         INFO_TOAST,
         { disableTimeout: true, icon: toastIcon }
       )
-      void downloadRuns(
-        runs.filter(run => {
-          return selectedIds.has(run.id)
-        })
-      )
-        .catch((e: Error) => {
-          makeToast(e.message, ERROR_TOAST, { closeButton: true })
-        })
+      void downloadSelectedRuns({
+        runs: runs.filter(run => selectedIds.has(run.id)),
+      })
         .then(() => {
           makeToast(t('files_successfully_downloaded') as string, SUCCESS_TOAST)
+        })
+        .catch((e: Error) => {
+          makeToast(e.message, ERROR_TOAST, { closeButton: true })
         })
         .finally(() => {
           eatToast(toastId)
@@ -105,7 +103,7 @@ export function ProtocolRunRecords({
   const handleConfirmDeleteSelected = (): void => {
     setShowDeleteRecordsModal(false)
     const selectedRuns = runs.filter(run => selectedIds.has(run.id))
-    void downloadRuns(selectedRuns)
+    void downloadSelectedRuns({ runs: selectedRuns })
       .then(successfullyDownloadedRuns => {
         if (successfullyDownloadedRuns.length < selectedRuns.length) {
           makeToast(t('some_runs_not_deleted') as string, WARNING_TOAST, {

--- a/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/FileManagerWizardFlows/DeleteProtocolRunRecordsWizard.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/FileManagerWizardFlows/DeleteProtocolRunRecordsWizard.tsx
@@ -25,7 +25,7 @@ export function DeleteProtocolRunRecordsWizard({
   const allRuns = runData?.data ?? []
 
   const documentationState = useDocumentationState()
-  const { downloadRuns } = useDownloadSelectedRuns(robotName)
+  const { mutateAsync: downloadRuns } = useDownloadSelectedRuns(robotName)
   const { deleteSelectedRuns } = useDeleteSelectedRuns(documentationState)
 
   const copyProps: ComponentProps<typeof DownloadDeleteRecordFlow>['copy'] = {
@@ -43,7 +43,9 @@ export function DeleteProtocolRunRecordsWizard({
       copy={copyProps}
       showChoiceScreen={false}
       initialDeleteAfterDownload
-      onDownload={path => downloadRuns(allRuns, path)}
+      onDownload={path =>
+        downloadRuns({ runs: allRuns, callTimeUsbPath: path })
+      }
       onDelete={downloadedRuns =>
         deleteSelectedRuns(downloadedRuns).then(() => 'deleted' as const)
       }

--- a/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/FileManagerWizardFlows/DownloadDiagnosticFilesWizard/index.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/FileManagerWizardFlows/DownloadDiagnosticFilesWizard/index.tsx
@@ -32,12 +32,12 @@ export function DownloadDiagnosticFilesWizard({
   const [step, setStep] = useState<StepType>(STEP_TYPES.USB)
   const [errorSubText, setErrorSubText] = useState('')
 
-  const { downloadLogs } = useDownloadRobotLogs(robotName)
+  const { mutateAsync: downloadLogs } = useDownloadRobotLogs(robotName)
   const { downloadCalibration } = useDownloadCalibrationData(robotName)
 
   const handleContinueFromUsb = (usbPath: string): void => {
     setStep(STEP_TYPES.DOWNLOADING)
-    Promise.all([downloadLogs(usbPath), downloadCalibration(usbPath)])
+    Promise.all([downloadLogs({ usbPath }), downloadCalibration(usbPath)])
       .then(() => {
         setStep(STEP_TYPES.SUCCESS)
       })

--- a/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/FileManagerWizardFlows/DownloadProtocolRunRecordsWizard/__tests__/DownloadProtocolRunRecordsWizard.test.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/FileManagerWizardFlows/DownloadProtocolRunRecordsWizard/__tests__/DownloadProtocolRunRecordsWizard.test.tsx
@@ -51,9 +51,8 @@ describe('DownloadProtocolRunRecordsWizard', () => {
     mockDownloadRuns = vi.fn().mockResolvedValue([mockRun])
     mockDeleteSelectedRuns = vi.fn().mockResolvedValue(undefined)
     vi.mocked(useDownloadSelectedRuns).mockReturnValue({
-      downloadRuns: mockDownloadRuns,
-      isDownloading: false,
-      hasError: false,
+      mutateAsync: mockDownloadRuns,
+      status: 'idle',
     } as any)
     vi.mocked(useDeleteSelectedRuns).mockReturnValue({
       deleteSelectedRuns: mockDeleteSelectedRuns,
@@ -78,7 +77,10 @@ describe('DownloadProtocolRunRecordsWizard', () => {
     await waitFor(() => {
       screen.getByText('All protocol files downloaded')
     })
-    expect(mockDownloadRuns).toHaveBeenCalledWith([mockRun], '/mnt/usb1')
+    expect(mockDownloadRuns).toHaveBeenCalledWith({
+      runs: [mockRun],
+      callTimeUsbPath: '/mnt/usb1',
+    })
     expect(mockDeleteSelectedRuns).not.toHaveBeenCalled()
   })
 

--- a/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/FileManagerWizardFlows/DownloadProtocolRunRecordsWizard/index.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/FileManagerWizardFlows/DownloadProtocolRunRecordsWizard/index.tsx
@@ -25,7 +25,7 @@ export function DownloadProtocolRunRecordsWizard({
   const allRuns = runData?.data ?? []
 
   const documentationState = useDocumentationState()
-  const { downloadRuns } = useDownloadSelectedRuns(robotName)
+  const { mutateAsync: downloadRuns } = useDownloadSelectedRuns(robotName)
   const { deleteSelectedRuns } = useDeleteSelectedRuns(documentationState)
 
   const copyProps: ComponentProps<typeof DownloadDeleteRecordFlow>['copy'] = {
@@ -44,7 +44,9 @@ export function DownloadProtocolRunRecordsWizard({
       copy={copyProps}
       showChoiceScreen
       initialDeleteAfterDownload
-      onDownload={path => downloadRuns(allRuns, path)}
+      onDownload={path =>
+        downloadRuns({ runs: allRuns, callTimeUsbPath: path })
+      }
       onDelete={downloadedRuns =>
         deleteSelectedRuns(downloadedRuns).then(() => 'deleted' as const)
       }

--- a/app/src/resources/devices/hooks/__tests__/useDownloadSelectedRuns.test.tsx
+++ b/app/src/resources/devices/hooks/__tests__/useDownloadSelectedRuns.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from 'react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { when } from 'vitest-when'
@@ -9,6 +10,7 @@ import { saveFileToUsb } from '/app/redux/shell/remote'
 
 import { useDownloadSelectedRuns } from '../useDownloadSelectedRuns'
 
+import type * as React from 'react'
 import type { HostConfig, RunData } from '@opentrons/api-client'
 
 const mockJSZip = vi.hoisted(() => ({
@@ -50,7 +52,14 @@ const mockRunTwo = {
 } as unknown as RunData
 
 describe('useDownloadSelectedRuns', () => {
+  let wrapper: React.FunctionComponent<{ children: React.ReactNode }>
+
   beforeEach(() => {
+    const queryClient = new QueryClient()
+    wrapper = ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
     when(vi.mocked(useHost)).calledWith().thenReturn(HOST_CONFIG)
     vi.mocked(useAllProtocolsQuery).mockReturnValue({ data: undefined } as any)
     vi.mocked(getRunRaw).mockResolvedValue({
@@ -69,17 +78,21 @@ describe('useDownloadSelectedRuns', () => {
   })
 
   it('should reject and not fetch when given an empty array', async () => {
-    const { result } = renderHook(() => useDownloadSelectedRuns(ROBOT_NAME))
+    const { result } = renderHook(() => useDownloadSelectedRuns(ROBOT_NAME), {
+      wrapper,
+    })
 
-    await expect(result.current.downloadRuns([])).rejects.toThrow()
+    await expect(result.current.mutateAsync({ runs: [] })).rejects.toThrow()
 
     expect(getRunRaw).not.toHaveBeenCalled()
   })
 
   it('should fetch every run, zip them, and save via the browser when no usbPath is given', async () => {
-    const { result } = renderHook(() => useDownloadSelectedRuns(ROBOT_NAME))
+    const { result } = renderHook(() => useDownloadSelectedRuns(ROBOT_NAME), {
+      wrapper,
+    })
 
-    await result.current.downloadRuns([mockRunOne, mockRunTwo])
+    await result.current.mutateAsync({ runs: [mockRunOne, mockRunTwo] })
 
     expect(getRunRaw).toHaveBeenCalledWith(
       HOST_CONFIG,
@@ -109,9 +122,14 @@ describe('useDownloadSelectedRuns', () => {
   })
 
   it('should save to the usbPath instead of the browser when provided', async () => {
-    const { result } = renderHook(() => useDownloadSelectedRuns(ROBOT_NAME))
+    const { result } = renderHook(() => useDownloadSelectedRuns(ROBOT_NAME), {
+      wrapper,
+    })
 
-    await result.current.downloadRuns([mockRunOne], '/mnt/usb')
+    await result.current.mutateAsync({
+      runs: [mockRunOne],
+      callTimeUsbPath: '/mnt/usb',
+    })
 
     expect(saveFileToUsb).toHaveBeenCalledWith(
       `/mnt/usb/${ROBOT_NAME}-run-records.zip`,
@@ -120,59 +138,47 @@ describe('useDownloadSelectedRuns', () => {
     expect(mockSaveAs).not.toHaveBeenCalled()
   })
 
-  it('should prefer a call-time usbPath over the one passed to the hook', async () => {
-    const { result } = renderHook(() => useDownloadSelectedRuns(ROBOT_NAME))
-
-    await result.current.downloadRuns([mockRunOne], '/mnt/other-usb')
-
-    expect(saveFileToUsb).toHaveBeenCalledWith(
-      `/mnt/other-usb/${ROBOT_NAME}-run-records.zip`,
-      expect.any(ArrayBuffer)
-    )
-  })
-
-  it('should set hasError and stop downloading when a run fails to fetch', async () => {
+  it('should reject when every run fails to fetch', async () => {
     vi.mocked(getRunRaw).mockRejectedValue(new Error('nope'))
-    const { result } = renderHook(() => useDownloadSelectedRuns(ROBOT_NAME))
+    const { result } = renderHook(() => useDownloadSelectedRuns(ROBOT_NAME), {
+      wrapper,
+    })
 
-    await result.current.downloadRuns([mockRunOne]).catch(() => {})
+    await expect(
+      result.current.mutateAsync({ runs: [mockRunOne] })
+    ).rejects.toThrow('Failed to download any of the selected run records.')
 
     await waitFor(() => {
-      expect(result.current.hasError).toEqual(true)
+      expect(result.current.status).toEqual('error')
     })
-    expect(result.current.isDownloading).toEqual(false)
   })
 
-  it('should ignore a second call while a download is already in flight', async () => {
-    let resolveFirstFetch: () => void = () => {}
+  it('should report a loading status while a download is in flight', async () => {
+    let resolveFetch: () => void = () => {}
     vi.mocked(getRunRaw).mockImplementation(
       () =>
         new Promise(resolve => {
-          resolveFirstFetch = () => {
+          resolveFetch = () => {
             resolve({
               data: { arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)) },
             } as any)
           }
         })
     )
-    const { result } = renderHook(() => useDownloadSelectedRuns(ROBOT_NAME))
-
-    const firstCall = result.current.downloadRuns([mockRunOne])
-    await waitFor(() => {
-      expect(result.current.isDownloading).toEqual(true)
+    const { result } = renderHook(() => useDownloadSelectedRuns(ROBOT_NAME), {
+      wrapper,
     })
 
-    await result.current.downloadRuns([mockRunTwo]).catch(() => {})
+    const firstCall = result.current.mutateAsync({ runs: [mockRunOne] })
+    await waitFor(() => {
+      expect(result.current.status).toEqual('loading')
+    })
 
-    expect(getRunRaw).toHaveBeenCalledTimes(1)
-    expect(getRunRaw).toHaveBeenCalledWith(
-      HOST_CONFIG,
-      'run-1',
-      DEFAULT_RUN_DOWNLOAD_PARAMS,
-      'blob'
-    )
-
-    resolveFirstFetch()
+    resolveFetch()
     await firstCall
+
+    await waitFor(() => {
+      expect(result.current.status).toEqual('success')
+    })
   })
 })

--- a/app/src/resources/devices/hooks/__tests__/useDownloadSelectedRuns.test.tsx
+++ b/app/src/resources/devices/hooks/__tests__/useDownloadSelectedRuns.test.tsx
@@ -10,7 +10,7 @@ import { saveFileToUsb } from '/app/redux/shell/remote'
 
 import { useDownloadSelectedRuns } from '../useDownloadSelectedRuns'
 
-import type * as React from 'react'
+import type { FunctionComponent } from 'react'
 import type { HostConfig, RunData } from '@opentrons/api-client'
 
 const mockJSZip = vi.hoisted(() => ({
@@ -52,7 +52,7 @@ const mockRunTwo = {
 } as unknown as RunData
 
 describe('useDownloadSelectedRuns', () => {
-  let wrapper: React.FunctionComponent<{ children: React.ReactNode }>
+  let wrapper: FunctionComponent<{ children: React.ReactNode }>
 
   beforeEach(() => {
     const queryClient = new QueryClient()

--- a/app/src/resources/devices/hooks/useDownloadRobotLogs.ts
+++ b/app/src/resources/devices/hooks/useDownloadRobotLogs.ts
@@ -1,102 +1,76 @@
-import { useEffect, useRef, useState } from 'react'
-import { useTranslation } from 'react-i18next'
+import { useMutation } from 'react-query'
 import { saveAs } from 'file-saver'
 import JSZip from 'jszip'
 import last from 'lodash/last'
 
 import { GET, request } from '@opentrons/api-client'
-import { ERROR_TOAST, INFO_TOAST } from '@opentrons/components'
 import { useHost } from '@opentrons/react-api-client'
 
-// eslint-disable-next-line opentrons/no-imports-across-applications
-import { useToaster } from '/app/organisms/ToasterOven'
 import { useRobot } from '/app/redux-resources/robots'
 import { CONNECTABLE } from '/app/redux/discovery'
 import { saveFileToUsb } from '/app/redux/shell/remote'
 
-import type { IconProps } from '@opentrons/components'
+import type { UseMutationResult } from 'react-query'
 
-interface UseDownloadRobotLogsResult {
-  downloadLogs: (usbPath?: string) => Promise<void>
-  isDownloading: boolean
-  hasError: boolean
+export interface DownloadRobotLogsVariables {
+  usbPath?: string
+}
+
+type UseDownloadRobotLogsResult = UseMutationResult<
+  void,
+  unknown,
+  DownloadRobotLogsVariables
+> & {
   canDownload: boolean
 }
 
 export function useDownloadRobotLogs(
   robotName: string
 ): UseDownloadRobotLogsResult {
-  const { t } = useTranslation('device_settings')
   const robot = useRobot(robotName)
   const host = useHost()
-  const { makeToast, eatToast } = useToaster()
-  const [isDownloading, setIsDownloading] = useState(false)
-  const [hasError, setHasError] = useState(false)
-  const isMounted = useRef(false)
-
-  useEffect(() => {
-    isMounted.current = true
-    return () => {
-      isMounted.current = false
-    }
-  }, [])
 
   const canDownload =
     robot?.status === CONNECTABLE && robot?.health?.logs != null
 
-  const downloadLogs = (usbPath?: string): Promise<void> => {
-    if (!canDownload || host == null || robot?.health?.logs == null) {
-      return Promise.reject(
-        new Error('Unable to download robot logs: robot is not connectable')
-      )
+  const downloadLogs = async ({
+    usbPath,
+  }: DownloadRobotLogsVariables): Promise<void> => {
+    const logs = robot?.health?.logs
+    if (!canDownload || host == null || logs == null) {
+      throw new Error('Unable to download robot logs: robot is not connectable')
     }
 
-    setIsDownloading(true)
-    setHasError(false)
-    const toastIcon: IconProps = { name: 'ot-spinner', spin: true }
-    const toastId = makeToast(t('downloading_logs') as string, INFO_TOAST, {
-      disableTimeout: true,
-      icon: toastIcon,
-    })
-
     const zip = new JSZip()
-    return Promise.all(
-      robot.health.logs.map(log => {
+    const results = await Promise.allSettled(
+      logs.map(async log => {
         const logFileName = last(log.split('/')) ?? 'robot.log'
-        return request<string>(GET, log, host)
-          .then(res => {
-            zip.file(logFileName, res.data)
-          })
-          .catch((e: Error) => {
-            makeToast(e.message, ERROR_TOAST, { closeButton: true })
-          })
+        const res = await request<string>(GET, log, host)
+        zip.file(logFileName, res.data)
       })
     )
-      .then(() => zip.generateAsync({ type: 'arraybuffer' }))
-      .then(async buffer => {
-        const filename = `${robotName}_logs.zip`
-        if (usbPath != null) {
-          await saveFileToUsb(`${usbPath}/${filename}`, buffer)
-        } else {
-          saveAs(new Blob([buffer]), filename)
-        }
-      })
-      .then(() => {
-        eatToast(toastId)
-        if (isMounted.current) {
-          setIsDownloading(false)
-        }
-      })
-      .catch((e: Error) => {
-        eatToast(toastId)
-        makeToast(e.message, ERROR_TOAST, { closeButton: true })
-        if (isMounted.current) {
-          setHasError(true)
-          setIsDownloading(false)
-        }
-        throw e
-      })
+
+    // If every single log failed to download, abort early without generating an empty zip file
+    if (
+      results.length > 0 &&
+      results.every(result => result.status === 'rejected')
+    ) {
+      throw new Error('Failed to download any of the robot logs.')
+    }
+
+    const buffer = await zip.generateAsync({ type: 'arraybuffer' })
+    const filename = `${robotName}_logs.zip`
+    if (usbPath != null) {
+      await saveFileToUsb(`${usbPath}/${filename}`, buffer)
+    } else {
+      saveAs(new Blob([buffer]), filename)
+    }
   }
 
-  return { downloadLogs, isDownloading, hasError, canDownload }
+  // Downloading logs doesn't mutate robot state, so it doesn't need
+  // to go through useDocumentedMutation.
+  // eslint-disable-next-line opentrons/no-direct-use-mutation
+  const mutation = useMutation(downloadLogs)
+
+  return { ...mutation, canDownload }
 }

--- a/app/src/resources/devices/hooks/useDownloadSelectedRuns.ts
+++ b/app/src/resources/devices/hooks/useDownloadSelectedRuns.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMutation } from 'react-query'
 import { useSelector } from 'react-redux'
 import { saveAs } from 'file-saver'
 import JSZip from 'jszip'
@@ -11,42 +11,31 @@ import { saveFileToUsb } from '/app/redux/shell/remote'
 
 import { isEmptyDownloadResponse } from './utils/isEmptyDownloadResponse'
 
+import type { UseMutationResult } from 'react-query'
 import type { RunData } from '@opentrons/api-client'
 
-interface UseDownloadSelectedRunsResult {
-  downloadRuns: (
-    runs: readonly RunData[],
-    callTimeUsbPath?: string
-  ) => Promise<readonly RunData[]>
-  isDownloading: boolean
-  hasError: boolean
+export interface DownloadRunsVariables {
+  runs: readonly RunData[]
+  callTimeUsbPath?: string
 }
 
 export function useDownloadSelectedRuns(
   robotName: string
-): UseDownloadSelectedRunsResult {
+): UseMutationResult<readonly RunData[], unknown, DownloadRunsVariables> {
   const host = useHost()
-  const [isDownloading, setIsDownloading] = useState(false)
-  const [hasError, setHasError] = useState(false)
   const includeProtocolSource = useSelector(
     getIncludeProtocolSourceInRunDownload
   )
-
   const { data: protocols } = useAllProtocolsQuery()
 
-  const downloadRuns = async (
-    runs: readonly RunData[],
-    callTimeUsbPath?: string
-  ): Promise<readonly RunData[]> => {
+  const downloadRuns = async ({
+    runs,
+    callTimeUsbPath,
+  }: DownloadRunsVariables): Promise<readonly RunData[]> => {
     const currentHost = host
-    if (currentHost == null || runs.length === 0 || isDownloading) {
-      throw new Error(
-        'Unable to download: no host, nothing selected, or a download is already in progress.'
-      )
+    if (currentHost == null || runs.length === 0) {
+      throw new Error('Unable to download: no host, or nothing selected.')
     }
-
-    setIsDownloading(true)
-    setHasError(false)
 
     const zip = new JSZip()
     const params = {
@@ -87,29 +76,23 @@ export function useDownloadSelectedRuns(
 
     // If every single run failed, abort early without generating an empty zip file
     if (successfulRuns.length === 0) {
-      setHasError(true)
-      setIsDownloading(false)
       throw new Error('Failed to download any of the selected run records.')
     }
 
-    try {
-      const buffer = await zip.generateAsync({ type: 'arraybuffer' })
-      const filename = `${robotName}-run-records.zip`
+    const buffer = await zip.generateAsync({ type: 'arraybuffer' })
+    const filename = `${robotName}-run-records.zip`
 
-      if (callTimeUsbPath != null) {
-        await saveFileToUsb(`${callTimeUsbPath}/${filename}`, buffer)
-      } else {
-        saveAs(new Blob([buffer]), filename)
-      }
-
-      setIsDownloading(false)
-      return successfulRuns
-    } catch (e) {
-      setHasError(true)
-      setIsDownloading(false)
-      throw e
+    if (callTimeUsbPath != null) {
+      await saveFileToUsb(`${callTimeUsbPath}/${filename}`, buffer)
+    } else {
+      saveAs(new Blob([buffer]), filename)
     }
+
+    return successfulRuns
   }
 
-  return { downloadRuns, isDownloading, hasError }
+  // Downloading runs doesn't mutate robot state, so it doesn't need
+  // to go through useDocumentedMutation.
+  // eslint-disable-next-line opentrons/no-direct-use-mutation
+  return useMutation(downloadRuns)
 }


### PR DESCRIPTION
# Overview

This PR refactors download hooks for diagnostic/calibration data, run records, audit logs such that the logic for producing download, success, and error toasts lives in the calling components rather than in the hooks themselves. It also leverages useMutation in these hooks for accessing mutation state more reliably and efficiently.

Closes RQA-5987

https://github.com/user-attachments/assets/dd364a33-0a4a-45bb-91cc-dcfe895a3dee

## Test Plan and Hands on Testing

#### Desktop
- download/delete diagnostic files/calibration data, protocol run records, or audit logs and verify that loading and success/error toasts still render correctly

#### ODD
- download/delete diagnostic files/calibration data, protocol run records, or audit logs and verify that loading and success/error toasts _do not_ render

## Changelog

- refactor download hooks to leverage `useMutation` for mutation state
- move UI logic (for toasts) to download hook calling components rather than in the hooks themselves
- update tests

## Review requests

see test plan

## Risk assessment

low. moves UI logic out of download hooks and into implementations