### PR TITLE
fix(server-utils, robot-server): don't delete the persistence directory on reset

### DIFF
--- a/auth-server/tests/persistence/test_persistence_directory.py
+++ b/auth-server/tests/persistence/test_persistence_directory.py
@@ -41,16 +41,18 @@ async def test_prepare_root_creates_directory(tmp_path: Path) -> None:
 
 
 async def test_prepare_root_resets_marked_directory(tmp_path: Path) -> None:
-    """prepare_root should delete and recreate a directory marked for reset."""
+    """prepare_root should clear the contents of a directory marked for reset."""
     target = tmp_path / "persistence"
     target.mkdir()
     (target / "some_data.txt").write_text("important data")
     (target / "_TO_BE_DELETED_ON_REBOOT").write_text("marker")
+    original_inode = target.stat().st_ino
 
     result = await prepare_root(target)
 
     assert result == target
     assert target.exists()
+    assert target.stat().st_ino == original_inode
     assert not (target / "some_data.txt").exists()
     assert not (target / "_TO_BE_DELETED_ON_REBOOT").exists()
 

--- a/robot-server/robot_server/persistence/images_directory.py
+++ b/robot-server/robot_server/persistence/images_directory.py
@@ -2,13 +2,14 @@
 
 from logging import getLogger
 from pathlib import Path
-from shutil import rmtree
 from tempfile import mkdtemp
 from typing import Optional
 
 from anyio import Path as AsyncPath
 from anyio import to_thread
 from typing_extensions import Final
+
+from server_utils.persistence.persistence_directory import clear_directory_contents
 
 _log = getLogger(__name__)
 
@@ -60,12 +61,14 @@ async def prepare_images_directory(images_directory: Optional[Path]) -> Path:
         return new_temporary_directory
     else:
         if await _is_marked_for_reset(directory_to_reset=images_directory):
-            _log.info(f"{images_directory} was marked for reset. Deleting it.")
-            # FIXME(jh, 2025-10-16): Like the persistance dir, this can leave the images dir
-            # in a half-deleted state if it deletes the marker file, and then some
-            # of the other files, and then the device is power-cycled before it can
-            # finish.
-            await to_thread.run_sync(rmtree, images_directory)
+            _log.info(
+                f"{images_directory} was marked for reset. Clearing its contents."
+            )
+            # FIXME(jh, 2025-10-16): Like the persistence dir, this can leave the
+            # images dir in a half-cleared state if it deletes the marker file,
+            # and then some of the other files, and then the device is power-cycled
+            # before it can finish.
+            await to_thread.run_sync(clear_directory_contents, images_directory)
 
         await AsyncPath(images_directory).mkdir(parents=True, exist_ok=True)
         _log.info(f"Using directory {images_directory} for images.")

--- a/server-utils/server_utils/persistence/persistence_directory.py
+++ b/server-utils/server_utils/persistence/persistence_directory.py
@@ -54,6 +54,15 @@ def cleanup_persistence_temp_directory(persistence_root: Path) -> None:
         _log.warning(f"Error deleting {temp_directory.resolve()}.", exc_info=True)
 
 
+def clear_directory_contents(directory: Path) -> None:
+    """Delete everything inside directory without removing directory itself."""
+    for child in directory.iterdir():
+        if child.is_symlink() or not child.is_dir():
+            child.unlink()
+        else:
+            rmtree(child)
+
+
 class PersistenceResetter:
     """A FastAPI dependency to reset the server's persistence directory.
 
@@ -112,13 +121,16 @@ async def prepare_root(
             directory_to_reset=persistence_directory_root,
         ):
             _log.info(
-                f"{persistence_directory_root} was marked for reset. Deleting it."
+                f"{persistence_directory_root} was marked for reset."
+                " Clearing its contents."
             )
             # FIXME(mm, 2024-01-23): This can leave the persistence directory
-            # in a half-deleted state if it deletes the marker file, and then some
+            # in a half-cleared state if it deletes the marker file, and then some
             # of the other files, and then the device is power-cycled before it can
             # finish.
-            await to_thread.run_sync(rmtree, persistence_directory_root)
+            await to_thread.run_sync(
+                clear_directory_contents, persistence_directory_root
+            )
 
         await AsyncPath(persistence_directory_root).mkdir(parents=True, exist_ok=True)
         _log.info(f"Using directory {persistence_directory_root} for persistence.")


### PR DESCRIPTION
Closes [RQA-5835](https://opentrons.atlassian.net/browse/RQA-5835)

# Overview

Clearing run and/or protocol history leaves `/health` in a 500 status after reboot, with Device or resource busy on `/var/lib/opentrons-robot-server`. A second restart brings it back successfully, but the restart after the reset does not.

The code has always rmtree’d the persistence root, which was fine in 9.1.x. [oe-core #313](https://github.com/Opentrons/oe-core/pull/313) added `PrivateTmp=yes` so crashed services don’t leak /tmp files, however, that also bind-mounts the systemd `StateDirectory` into the service, so deleting the directory itself now fails with `EBUSY` after the contents (and the reset marker) are already gone.

To fix, we delete what’s inside the directory, leave the directory/mount alone. All checked setting still get wiped. Now, startup no longer depends on removing a mount point.

## Test Plan and Hands on Testing

- Verified that clearing run history, protocol history, and other data successfully reboots the robot, and the robot shows up again in the desktop app.

## Changelog

- Fixed a bug in which resetting run or protocol history would cause the robot not to respond appropriately on `/health` checks until power cycled an additional time.

## Risk assessment

- lowish, there's really no effective difference in desired behavioral outcome here, just a slightly different operation to achieve that outcome.

[RQA-5835]: https://opentrons.atlassian.net/browse/RQA-5835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ