### PR TITLE
fix(app): only validate create account when clicking "Next"

### DIFF
--- a/app/src/organisms/Desktop/EnableCRSWizard/index.tsx
+++ b/app/src/organisms/Desktop/EnableCRSWizard/index.tsx
@@ -411,7 +411,9 @@ function CreateAdminAccountPage({
       header={header}
       footer={
         <div className={styles.footer}>
-          <SecondaryButton onClick={onBack}>{t('shared:back')}</SecondaryButton>
+          <SecondaryButton type="button" onClick={onBack}>
+            {t('shared:back')}
+          </SecondaryButton>
           <PrimaryButton type="submit" form={formId}>
             {t('shared:next')}
           </PrimaryButton>
@@ -459,6 +461,9 @@ function CreateAdminAccountPage({
                   autoFocus
                   error={fieldState.error?.message}
                   {...field}
+                  // Validate only on Next submit. Form mode is onBlur, so
+                  // Back would otherwise mark empty fields as required on mousedown.
+                  onBlur={undefined}
                 />
               )}
             />
@@ -471,6 +476,7 @@ function CreateAdminAccountPage({
                   title={t('setup_wizard_legal_name')}
                   error={fieldState.error?.message}
                   {...field}
+                  onBlur={undefined}
                 />
               )}
             />


### PR DESCRIPTION
Closes [RQA-5928](https://opentrons.atlassian.net/browse/RQA-5928)

# Overview

Similar to https://github.com/Opentrons/opentrons/pull/22348 -blur actions cause the "create account" input field to render an errored state. To fix, we make onBlur undefined and only validate the form when clicking "Next".

### Current behavior

https://github.com/user-attachments/assets/ee791eb6-ab06-4645-a6ec-d3557490e59f

### Fixed behavior

https://github.com/user-attachments/assets/d0ffdefb-bf7f-44ad-adec-915ebcdcc234

## Test Plan and Hands on Testing

- See videos

## Risk assessment

- none, just CSS

[RQA-5928]: https://opentrons.atlassian.net/browse/RQA-5928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ