### PR TITLE
refactor(app): add a show/hide button to the login modal on the desktop app

### DIFF
--- a/app/src/molecules/PasswordVisibilityToggle/__tests__/PasswordVisibilityToggle.test.tsx
+++ b/app/src/molecules/PasswordVisibilityToggle/__tests__/PasswordVisibilityToggle.test.tsx
@@ -69,4 +69,49 @@ describe('PasswordVisibilityToggle', () => {
       'button'
     )
   })
+
+  it('renders an icon-only button with a static accessible name', () => {
+    render({ ...props, iconOnly: true })
+    expect(
+      screen.getByRole('button', { name: 'Toggle password visibility' })
+    ).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.queryByText('Show')).toBeNull()
+    expect(screen.queryByText('Hide')).toBeNull()
+  })
+
+  it('sets aria-pressed when the icon-only password is visible', () => {
+    render({ ...props, isVisible: true, iconOnly: true })
+    expect(
+      screen.getByRole('button', { name: 'Toggle password visibility' })
+    ).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('calls onToggle when the icon-only button is pressed', () => {
+    render({ ...props, iconOnly: true })
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Toggle password visibility' })
+    )
+    expect(props.onToggle).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not steal focus from an adjacent password input when the icon-only button is clicked', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <>
+        <input aria-label="password" defaultValue="secret" />
+        <PasswordVisibilityToggle {...props} iconOnly />
+      </>,
+      { i18nInstance: i18n }
+    )
+    const input = screen.getByLabelText('password')
+    input.focus()
+    expect(input).toHaveFocus()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Toggle password visibility' })
+    )
+
+    expect(input).toHaveFocus()
+    expect(props.onToggle).toHaveBeenCalledTimes(1)
+  })
 })

--- a/app/src/molecules/PasswordVisibilityToggle/index.tsx
+++ b/app/src/molecules/PasswordVisibilityToggle/index.tsx
@@ -4,33 +4,58 @@ import { Icon, StyledText } from '@opentrons/components'
 
 import styles from './passwordvisibilitytoggle.module.css'
 
+import type { MouseEvent } from 'react'
+
 interface PasswordVisibilityToggleProps {
   /** Whether the password is currently visible (i.e. input type="text"). */
   isVisible: boolean
   /** Called when the user taps the toggle. */
   onToggle: () => void
+  /** Render only the eye icon, for use inside an InputField. */
+  iconOnly?: boolean
 }
 
 /**
- * "Show / Hide" button rendered next to a password input.
+ * "Show / Hide" control for a password input.
+ * Use `iconOnly` to place the eye icon inside a desktop InputField.
  */
 export function PasswordVisibilityToggle({
   isVisible,
   onToggle,
+  iconOnly = false,
 }: PasswordVisibilityToggleProps): JSX.Element {
   const { t } = useTranslation('device_settings')
+  const iconName = isVisible ? 'eye-slash' : 'eye'
+
+  const handleMouseDown = (e: MouseEvent<HTMLButtonElement>): void => {
+    // This prevents focus from moving from the password field to this toggle button,
+    // but lets the click event go through.
+    e.preventDefault()
+  }
+
+  if (iconOnly) {
+    return (
+      <button
+        type="button"
+        aria-label={t('toggle_password_visibility')}
+        aria-pressed={isVisible}
+        onMouseDown={handleMouseDown}
+        onClick={onToggle}
+        className={styles.icon_only_button}
+      >
+        <Icon name={iconName} className={styles.icon_only} />
+      </button>
+    )
+  }
+
   return (
     <button
       type="button"
-      onMouseDown={e => {
-        // This prevents focus from moving from the password field to this toggle button,
-        // but lets the click event go through.
-        e.preventDefault()
-      }}
+      onMouseDown={handleMouseDown}
       onClick={onToggle}
       className={styles.toggle_button}
     >
-      <Icon name={isVisible ? 'eye-slash' : 'eye'} className={styles.icon} />
+      <Icon name={iconName} className={styles.icon} />
       <StyledText
         oddStyle="bodyTextSemiBold"
         desktopStyle="bodyDefaultSemiBold"

--- a/app/src/molecules/PasswordVisibilityToggle/passwordvisibilitytoggle.module.css
+++ b/app/src/molecules/PasswordVisibilityToggle/passwordvisibilitytoggle.module.css
@@ -18,6 +18,26 @@
   flex-shrink: 0;
 }
 
+.icon_only_button {
+  display: flex;
+  width: 1.5rem;
+  height: 1.5rem;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background-color: transparent;
+  color: var(--black-90);
+  cursor: pointer;
+}
+
+.icon_only {
+  width: 1.5rem;
+  height: 1.5rem;
+  flex-shrink: 0;
+}
+
 @media (height = 600px) and (width = 1024px) {
   .toggle_button {
     width: 7.375rem;

--- a/app/src/organisms/Desktop/LoginModal/__tests__/LoginModal.test.tsx
+++ b/app/src/organisms/Desktop/LoginModal/__tests__/LoginModal.test.tsx
@@ -188,8 +188,33 @@ describe('LoginModal', () => {
     screen.getByText('Compliance Ready Software login')
     expect(screen.getByLabelText('Username')).toHaveFocus()
     screen.getByLabelText('Password')
+    screen.getByRole('button', { name: 'Toggle password visibility' })
     screen.getByRole('button', { name: 'Forgot password?' })
     expect(screen.getByRole('button', { name: 'Log in' })).toBeEnabled()
+  })
+
+  it('masks the password and reveals it when the visibility toggle is clicked', () => {
+    renderAndOpenLoginModal()
+
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'secret-password' },
+    })
+    const passwordInput = screen.getByLabelText('Password')
+    expect(passwordInput).toHaveAttribute('type', 'password')
+    expect(passwordInput).toHaveValue('secret-password')
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Toggle password visibility' })
+    )
+
+    expect(passwordInput).toHaveAttribute('type', 'text')
+    expect(passwordInput).toHaveValue('secret-password')
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Toggle password visibility' })
+    )
+
+    expect(passwordInput).toHaveAttribute('type', 'password')
   })
 
   it('shows required field errors when log in is clicked with empty fields', () => {

--- a/app/src/organisms/Desktop/LoginModal/index.tsx
+++ b/app/src/organisms/Desktop/LoginModal/index.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from 'react'
+import { useId, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
@@ -20,7 +20,9 @@ import {
 import { useHost } from '@opentrons/react-api-client'
 
 import { getTopPortalEl } from '/app/App/portal'
+import { usePlaceCaretAtEndOnToggle } from '/app/local-resources/access-control/usePlaceCaretAtEndOnToggle'
 import { ApiHostProvider } from '/app/local-resources/api-host-provider/ApiHostProvider'
+import { PasswordVisibilityToggle } from '/app/molecules/PasswordVisibilityToggle'
 import { logOut } from '/app/redux/robot-auth'
 import { useStoreLoginState } from '/app/resources/access-control/useStoreLoginState'
 import {
@@ -406,6 +408,14 @@ function LoginView(props: LoginViewProps): JSX.Element {
     onForgotPasswordClick,
   } = props
   const { t } = useTranslation()
+  const [showPassword, setShowPassword] = useState(false)
+  const passwordInputRef = useRef<HTMLInputElement>(null)
+
+  usePlaceCaretAtEndOnToggle(passwordInputRef, showPassword, true)
+
+  const handleTogglePasswordVisibility = (): void => {
+    setShowPassword(current => !current)
+  }
 
   return (
     <>
@@ -431,14 +441,22 @@ function LoginView(props: LoginViewProps): JSX.Element {
           }}
         />
         <InputField
+          ref={passwordInputRef}
           name="password"
           title={t('access_control:login_form_password_field')}
-          type="password"
+          type={showPassword ? 'text' : 'password'}
           value={formData.logInPassword}
           error={formData.passwordRequiredError ?? formData.error ?? undefined}
           onChange={event => {
             onLogInPasswordChange(event.target.value)
           }}
+          rightElement={
+            <PasswordVisibilityToggle
+              isVisible={showPassword}
+              onToggle={handleTogglePasswordVisibility}
+              iconOnly
+            />
+          }
         />
         <div>
           <BasicButton type="button" underLine onClick={onForgotPasswordClick}>


### PR DESCRIPTION
Closes [RQA-6016](https://opentrons.atlassian.net/browse/RQA-6016)

# Overview

Product has requested a hide/show button for the login modal on the desktop app!

### Current behavior

<img width="1020" height="768" alt="Screenshot 2026-08-27 at 10 15 48 AM" src="https://github.com/user-attachments/assets/0ff2416c-70c0-49fe-b88e-3a0dcae10c13" />

### Future behavior

https://github.com/user-attachments/assets/910ae515-a1eb-4024-a4b0-ff4e2cf61b3d

## Test Plan and Hands on Testing

- See videos.

## Risk assessment

- low, relatively additive behavior


[RQA-6016]: https://opentrons.atlassian.net/browse/RQA-6016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ