### PR TITLE
fix(auth-server): Fix errors after a username is changed

### DIFF
--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -415,12 +415,11 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         self.__token_store.save(
             _TokenIssuance(
                 client_id=client_id,
-                username=user.username,
+                user_id=user.id,
                 access_token=access_token,
                 refresh_token=refresh_token,
                 expires_at=expires_at,
                 scopes=stored_scopes,
-                fullname=user.full_name,
             )
         )
 
@@ -440,7 +439,7 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
             refresh_token, now=self.__get_now()
         )
         if issuance is not None:
-            user = self.__user_store.get(issuance.username)
+            user = self.__user_store.get_by_id(issuance.user_id)
             if user is None:
                 return False
             # Set `.user` per the oauthlib docs.
@@ -486,29 +485,36 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         )
         if found_access_token is None:
             return None
-        else:
-            # Values defined by:
-            # https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
-            # except ot_fullname, which is custom to us. if you add other custom fields,
-            # please prefix them with ot-.
-            return {
-                "scope": serialize_scopes(
-                    self.__get_effective_token_scopes(found_access_token)
-                ),
-                "username": found_access_token.username,
-                "ot_fullname": found_access_token.fullname,
-                # "active": True is set implicitly by oauthlib.
-            }
+
+        user = self.__get_user_for_token(found_access_token)
+        if user is None:
+            return None
+
+        # Values defined by:
+        # https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
+        # except ot_fullname, which is custom to us. if you add other custom fields,
+        # please prefix them with ot_.
+        return {
+            "scope": serialize_scopes(
+                self.__get_effective_token_scopes(found_access_token)
+            ),
+            "username": user.username,
+            "ot_fullname": user.full_name,
+            # "active": True is set implicitly by oauthlib.
+        }
+
+    def __get_user_for_token(self, token: _TokenIssuance) -> ORMUser | None:
+        return self.__user_store.get_by_id(token.user_id)
 
     def __get_effective_token_scopes(self, token: _TokenIssuance) -> set[Scope]:
         """Return granted token scopes, updated for current settings and user state."""
-        live_scopes = self.__get_live_scopes_for_username(token.username)
+        live_scopes = self.__get_live_scopes_for_token(token)
         if not token.scopes:
             return live_scopes
         return token.scopes & live_scopes
 
-    def __get_live_scopes_for_username(self, username: str) -> set[Scope]:
-        user = self.__user_store.get(username)
+    def __get_live_scopes_for_token(self, token: _TokenIssuance) -> set[Scope]:
+        user = self.__get_user_for_token(token)
         if user is None:
             return set()
 
@@ -570,7 +576,7 @@ class _TokenIssuance:
     """Information about an access token that we've issued."""
 
     client_id: str
-    username: str
+    user_id: int
     access_token: str
     refresh_token: str | None
     # todo(mm, 2026-01-29): We might want expires_at to be a CLOCK_BOOTTIME value or something
@@ -578,7 +584,6 @@ class _TokenIssuance:
     expires_at: datetime
     # Empty when the client did not request an explicit scope ceiling.
     scopes: set[Scope]
-    fullname: str
 
 
 class _TokenStore:

--- a/auth-server/auth_server/users/store.py
+++ b/auth-server/auth_server/users/store.py
@@ -32,6 +32,14 @@ class UserStore:
                 session.expunge(user)
             return user
 
+    def get_by_id(self, user_id: int) -> User | None:
+        """Look up a user by primary key. Returns the User or None."""
+        with self._session() as session:
+            user = session.scalar(select(User).where(User.id == user_id))
+            if user is not None:
+                session.expunge(user)
+            return user
+
     def get_all(self) -> list[User]:
         """Return all users, ordered by username."""
         with self._session() as session:

--- a/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
@@ -537,6 +537,7 @@ test_name: /self routes still work after username change
 marks:
   - usefixtures:
       - run_server
+      - admin_access_token
       - seed_users
 
 stages:
@@ -579,12 +580,12 @@ stages:
         authorization: 'Bearer {user_access_token}'
       json:
         data:
-          username: testuser_new
+          username: testuser_2
     response:
       status_code: 200
       json:
         data:
-          username: testuser_new
+          username: testuser_2
           fullName: Test User
       strict:
         - json:off
@@ -600,7 +601,7 @@ stages:
       status_code: 200
       json:
         active: true
-        username: testuser_new
+        username: testuser_2
         ot_fullname: Test User
       strict:
         - json:off
@@ -615,7 +616,56 @@ stages:
       status_code: 200
       json:
         data:
-          username: testuser_new
+          username: testuser_2
+          fullName: Test User
+      strict:
+        - json:off
+
+  - name: Admin changes the user's username
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/byUsername/testuser_2'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          username: testuser_3
+    response:
+      status_code: 200
+      json:
+        data:
+          username: testuser_3
+          fullName: Test User
+      strict:
+        - json:off
+
+  - name: Pre-rename token is still active after admin username change
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/introspect'
+      data:
+        client_id: opentrons_app
+        token: '{user_access_token}'
+    response:
+      status_code: 200
+      json:
+        active: true
+        username: testuser_3
+        ot_fullname: Test User
+      strict:
+        - json:off
+
+  - name: GET self after admin username change returns the renamed user
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        authorization: 'Bearer {user_access_token}'
+    response:
+      status_code: 200
+      json:
+        data:
+          username: testuser_3
           fullName: Test User
       strict:
         - json:off
@@ -648,7 +698,7 @@ stages:
       status_code: 200
       json:
         data:
-          username: testuser_new
+          username: testuser_3
           fullName: Test User
       strict:
         - json:off

--- a/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
@@ -532,6 +532,92 @@ stages:
           resetPassword: false
 
 ---
+test_name: /self routes still work after username change
+
+marks:
+  - usefixtures:
+      - run_server
+      - seed_users
+
+stages:
+  - name: Log in as the regular user
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: password
+        username: testuser
+        password: testuserpassword
+    response:
+      status_code: 200
+      save:
+        json:
+          user_access_token: access_token
+
+  - name: GET self works before the username change
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        authorization: 'Bearer {user_access_token}'
+    response:
+      status_code: 200
+      json:
+        data:
+          username: testuser
+          fullName: Test User
+      strict:
+        - json:off
+
+  - name: Change only the username via self update
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        authorization: 'Bearer {user_access_token}'
+      json:
+        data:
+          username: testuser_new
+    response:
+      status_code: 200
+      json:
+        data:
+          username: testuser_new
+          fullName: Test User
+      strict:
+        - json:off
+
+  - name: Pre-rename token is still active
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/introspect'
+      data:
+        client_id: opentrons_app
+        token: '{user_access_token}'
+    response:
+      status_code: 200
+      json:
+        active: true
+      strict:
+        - json:off
+
+  - name: GET self with the pre-rename token returns the renamed user
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        authorization: 'Bearer {user_access_token}'
+    response:
+      status_code: 200
+      json:
+        data:
+          username: testuser_new
+          fullName: Test User
+      strict:
+        - json:off
+
+---
 test_name: Creating a user with an existing username
 
 marks:

--- a/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
@@ -554,6 +554,7 @@ stages:
       save:
         json:
           user_access_token: access_token
+          user_refresh_token: refresh_token
 
   - name: GET self works before the username change
     request:
@@ -599,6 +600,8 @@ stages:
       status_code: 200
       json:
         active: true
+        username: testuser_new
+        ot_fullname: Test User
       strict:
         - json:off
 
@@ -608,6 +611,39 @@ stages:
       url: '{run_server.base_url}/auth/users/self'
       headers:
         authorization: 'Bearer {user_access_token}'
+    response:
+      status_code: 200
+      json:
+        data:
+          username: testuser_new
+          fullName: Test User
+      strict:
+        - json:off
+
+  - name: Refresh token still works after username change
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: refresh_token
+        refresh_token: '{user_refresh_token}'
+    response:
+      status_code: 200
+      json:
+        access_token: !anystr
+      strict:
+        - json:off
+      save:
+        json:
+          refreshed_access_token: access_token
+
+  - name: GET self with the refreshed token returns the renamed user
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        authorization: 'Bearer {refreshed_access_token}'
     response:
       status_code: 200
       json:

--- a/auth-server/tests/users/test_store.py
+++ b/auth-server/tests/users/test_store.py
@@ -30,6 +30,42 @@ def test_get_returns_none_for_nonexistent_user(user_store: UserStore) -> None:
     assert user_store.get("nonexistent_user") is None
 
 
+def test_get_by_id_returns_user(user_store: UserStore) -> None:
+    """get_by_id should find a user by primary key."""
+    added = user_store.add(
+        username="test_user",
+        hashed_password=HASHED_PW,
+        full_name="Test User",
+        account_type=AccountType.USER,
+        now=_NOW,
+        reset_password=False,
+    )
+    fetched = user_store.get_by_id(added.id)
+    assert fetched is not None
+    assert fetched.username == "test_user"
+
+
+def test_get_by_id_returns_none_for_nonexistent_id(user_store: UserStore) -> None:
+    """get_by_id should return None when the id does not exist."""
+    assert user_store.get_by_id(999999) is None
+
+
+def test_get_by_id_stable_across_username_change(user_store: UserStore) -> None:
+    """get_by_id should still find the user after their username changes."""
+    added = user_store.add(
+        username="before_rename",
+        hashed_password=HASHED_PW,
+        full_name="Test User",
+        account_type=AccountType.USER,
+        now=_NOW,
+        reset_password=False,
+    )
+    user_store.update("before_rename", new_username="after_rename", now=_NOW)
+    fetched = user_store.get_by_id(added.id)
+    assert fetched is not None
+    assert fetched.username == "after_rename"
+
+
 def test_add_and_get_user(user_store: UserStore) -> None:
     """add should persist the user so get can find it."""
     user_store.add(


### PR DESCRIPTION
## Overview

This fixes RQA-5950. After a user changed their username, the server left the stale username in its in-memory token store. Depending on the exact server version and exactly what you did next, this would cause subsequent HTTP 500 errors or HTTP 403 errors.

## Changelog

In our in-memory token store, don't link tokens to users by their username. Instead, link them by their database primary key, which is immutable.

## Test Plan and Hands on Testing

I think we're good with the included integration test.

## Review requests

None in particular.

## Risk assessment

Low.