### PR TITLE
fix(app): logout if user exits password reset modal

### DIFF
--- a/app/src/organisms/Desktop/LoginModal/__tests__/LoginModal.test.tsx
+++ b/app/src/organisms/Desktop/LoginModal/__tests__/LoginModal.test.tsx
@@ -8,6 +8,7 @@ import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { useRobot } from '/app/redux-resources/robots'
 import { mockConnectableRobot } from '/app/redux/discovery/__fixtures__'
+import { logOut } from '/app/redux/robot-auth'
 import { useStoreLoginState } from '/app/resources/access-control/useStoreLoginState'
 import {
   useOAuth2PasswordLogin,
@@ -333,6 +334,22 @@ describe('LoginModal', () => {
     expect(screen.getByLabelText('New password')).toHaveFocus()
     screen.getByLabelText('Confirm password')
     screen.getByRole('button', { name: 'Confirm' })
+  })
+
+  it('logs out when closing the set new password view', () => {
+    mockLoginRequiringPasswordReset()
+
+    renderAndOpenLoginModal()
+    logInWithTempPassword()
+
+    fireEvent.click(
+      screen.getByTestId(
+        'ModalHeader_icon_close_Compliance Ready Software login'
+      )
+    )
+
+    expect(vi.mocked(logOut)).toHaveBeenCalledWith({ robotName: ROBOT_NAME })
+    expect(screen.queryByText('Your password has expired')).toBeNull()
   })
 
   it('returns to login after setting a new password', () => {

--- a/app/src/organisms/Desktop/LoginModal/index.tsx
+++ b/app/src/organisms/Desktop/LoginModal/index.tsx
@@ -146,6 +146,9 @@ function LoginModalImpl(props: LoginModalImplProps): JSX.Element {
     useState<boolean>(false)
 
   const handleClose = (): void => {
+    if (screen.kind === 'setNewPassword') {
+      dispatch(logOut({ robotName }))
+    }
     modal.resolve(null)
     modal.remove()
   }

--- a/react-api-client/src/auth/users/useCreateUserMutation.ts
+++ b/react-api-client/src/auth/users/useCreateUserMutation.ts
@@ -1,7 +1,10 @@
+import { useQueryClient } from 'react-query'
+
 import { createUser } from '@opentrons/api-client'
 
 import { useDocumentedMutation } from '../../accessControl'
-import { getQueryKey, useHost } from '../../api'
+import { useHost } from '../../api'
+import { getUsersQueryKey } from './useUsersQuery'
 
 import type { AxiosError } from 'axios'
 import type {
@@ -36,12 +39,15 @@ export function useCreateUserMutation(
   > = {}
 ): UseCreateUserMutationResult {
   const host = useHost()
+  const queryClient = useQueryClient()
   const mutation = useDocumentedMutation(
     documentationState,
     ['create_user'],
-    getQueryKey(host, 'auth', 'users'),
     ({ variables: data, userNotes }) =>
-      createUser(host!, data, userNotes).then(response => response.data),
+      createUser(host!, data, userNotes).then(response => {
+        void queryClient.invalidateQueries(getUsersQueryKey(host))
+        return response.data
+      }),
     options
   )
 


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-5944 and https://opentrons.atlassian.net/browse/RQA-5936
update users list after adding a new user. 
logout user when exiting reset password flow.

## Risk assessment

low. bug fix
