### PR TITLE
fix(auth-server): Invalidate tokens when an account is locked (deactivated)

### DIFF
--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -440,7 +440,7 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         )
         if issuance is not None:
             user = self.__user_store.get_by_id(issuance.user_id)
-            if user is None:
+            if user is None or user.deactivated:
                 return False
             # Set `.user` per the oauthlib docs.
             request.user = user  # type: ignore[attr-defined]

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -397,9 +397,9 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
             # This cast is because request.scopes is apparently mis-typed as a str; it's actually a list[str].
             scopes = cast(Any, request.scopes)
             assert _is_list_of_type(scopes, str)
-            stored_scopes = {Scope.from_api_name(s) for s in scopes}
+            requested_scopes = frozenset(Scope.from_api_name(s) for s in scopes)
         else:
-            stored_scopes = set()
+            requested_scopes = frozenset[Scope]()
 
         expires_in = token["expires_in"]
 
@@ -419,7 +419,7 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
                 access_token=access_token,
                 refresh_token=refresh_token,
                 expires_at=expires_at,
-                scopes=stored_scopes,
+                requested_scopes=requested_scopes,
             )
         )
 
@@ -509,9 +509,9 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
     def __get_effective_token_scopes(self, token: _TokenIssuance) -> set[Scope]:
         """Return granted token scopes, updated for current settings and user state."""
         live_scopes = self.__get_live_scopes_for_token(token)
-        if not token.scopes:
+        if not token.requested_scopes:
             return live_scopes
-        return token.scopes & live_scopes
+        return set(token.requested_scopes) & live_scopes
 
     def __get_live_scopes_for_token(self, token: _TokenIssuance) -> set[Scope]:
         user = self.__get_user_for_token(token)
@@ -571,7 +571,7 @@ class _CustomInvalidCredentialsError(oauthlib.oauth2.InvalidGrantError):
         return json.dumps(result)
 
 
-@dataclass
+@dataclass(frozen=True)
 class _TokenIssuance:
     """Information about an access token that we've issued."""
 
@@ -582,8 +582,13 @@ class _TokenIssuance:
     # todo(mm, 2026-01-29): We might want expires_at to be a CLOCK_BOOTTIME value or something
     # to resist problems from clock adjustment.
     expires_at: datetime
-    # Empty when the client did not request an explicit scope ceiling.
-    scopes: set[Scope]
+    requested_scopes: frozenset[Scope]
+    """The scopes that the client requested, which may be different from the scopes we'll actually grant.
+
+    (OAuth 2 lets a client intentionally limit its own scopes.)
+
+    Empty when the client did not request any specific scopes.
+    """
 
 
 class _TokenStore:

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -106,7 +106,7 @@ class Backend:
 
     def revoke_all_tokens(self) -> None:
         """Invalidate every issued access and refresh token."""
-        self._token_store._tokens.clear()
+        self._token_store.revoke_all()
 
     def create_introspect_response(
         self, body_form_data: list[tuple[str, str]], headers: dict[str, str]
@@ -611,6 +611,9 @@ class _TokenStore:
             if self._is_active(token, now) and token.refresh_token == refresh_token:
                 return token
         return None
+
+    def revoke_all(self) -> None:
+        self._tokens.clear()
 
     @staticmethod
     def _is_active(token: _TokenIssuance, now: datetime) -> bool:

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -488,6 +488,9 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
 
         user = self.__get_user_for_token(found_access_token)
         if user is None:
+            # The user was deleted, maybe.
+            return None
+        if user.deactivated:
             return None
 
         # Values defined by:

--- a/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
@@ -704,6 +704,116 @@ stages:
         - json:off
 
 ---
+test_name: Locking a user invalidates their existing tokens
+
+marks:
+  - usefixtures:
+      - run_server
+      - admin_access_token
+      - seed_users
+
+stages:
+  - name: Log in as the regular user
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: password
+        username: testuser
+        password: testuserpassword
+    response:
+      status_code: 200
+      save:
+        json:
+          user_access_token: access_token
+          user_refresh_token: refresh_token
+
+  - name: Admin locks the user
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/byUsername/testuser'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          locked: true
+    response:
+      status_code: 200
+      json:
+        data:
+          locked: true
+      strict:
+        - json:off
+
+  - name: Pre-lock token is inactive
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/introspect'
+      data:
+        client_id: opentrons_app
+        token: '{user_access_token}'
+    response:
+      status_code: 200
+      json:
+        active: false
+      strict:
+        - json:off
+
+  - name: GET self with the pre-lock token is rejected
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        authorization: 'Bearer {user_access_token}'
+    response:
+      status_code: 401
+
+  - name: PATCH self with the pre-lock token is rejected
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        authorization: 'Bearer {user_access_token}'
+      json:
+        data:
+          fullName: Should Not Apply
+    response:
+      status_code: 401
+
+  - name: Refresh with the pre-lock token is rejected
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: refresh_token
+        refresh_token: '{user_refresh_token}'
+    response:
+      status_code: 400
+      json:
+        error: invalid_grant
+      strict:
+        - json:off
+
+  - name: Login is rejected while the account is locked
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: password
+        username: testuser
+        password: testuserpassword
+    response:
+      status_code: 400
+      json:
+        error: invalid_grant
+        opentrons_account_locked: true
+      strict:
+        - json:off
+
+---
 test_name: Creating a user with an existing username
 
 marks:


### PR DESCRIPTION
## Overview

This closes RQA-5952.

## Test Plan and Hands on Testing

I think the included integration test is sufficient, but check my work.

## Changelog

* Before calling an access token or refresh token "valid," make sure the user has not been deactivated. A deactivated user is treated exactly like a bogus token.
* Some minor refactors to clarify that we're storing token information *immutably.* If we need to fix anything else like this in the future, we should do it by folding in external information (like from `UserStore`) instead of mutating `_TokenStore` in-place. We were already doing this, but now we're doing it more, so I think it's worthwhile to visibly commit to this being our approach.

## Review requests

Anything else we want to add to the test?

## Risk assessment

Low.