### PR TITLE
fix(app): add loading state for single run deletion

### DIFF
--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns/HistoricalProtocolRun.tsx
@@ -9,7 +9,9 @@ import {
   StyledText,
   Tag,
 } from '@opentrons/components'
+import { useDeleteRunMutation } from '@opentrons/react-api-client'
 
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { DisplayRunStatus } from '/app/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/DisplayRunStatus'
 import { useRunGeneratedDataFiles } from '/app/resources/dataFiles/useRunGeneratedDataFiles'
 import { EMPTY_TIMESTAMP } from '/app/resources/runs'
@@ -67,6 +69,11 @@ export function HistoricalProtocolRun(
     }
   }
 
+  const documentationState = useDocumentationState()
+
+  const { deleteRun, isLoading: isDeletingRunSingle } =
+    useDeleteRunMutation(documentationState)
+
   return (
     <>
       <Flex
@@ -114,7 +121,7 @@ export function HistoricalProtocolRun(
             <Tag type="default" text={duration} shrinkToContent />
           </Flex>
         </Flex>
-        {isDeleting ? (
+        {isDeleting || isDeletingRunSingle ? (
           <Icon name="ot-spinner" spin size="1rem" color={COLORS.grey60} />
         ) : (
           <OverflowMenu
@@ -122,6 +129,8 @@ export function HistoricalProtocolRun(
             robotName={robotName}
             robotIsBusy={robotIsBusy}
             runHasImages={imageFileCount > 0}
+            deleteRun={deleteRun}
+            isDeletingRun={isDeletingRunSingle}
           />
         )}
       </Flex>

--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns/HistoricalProtocolRunOverflowMenu.tsx
@@ -37,7 +37,6 @@ import {
 import {
   isDocumentedMutationError,
   useDeleteRunImages,
-  useDeleteRunMutation,
 } from '@opentrons/react-api-client'
 
 import { getModalPortalEl, getTopPortalEl } from '/app/App/portal'
@@ -68,6 +67,7 @@ import { RobotOutOfStorageModal } from '../RobotOutOfStorageModal.tsx'
 import type { Dispatch, MouseEventHandler, SetStateAction } from 'react'
 import type { Run, RunData } from '@opentrons/api-client'
 import type { IconProps } from '@opentrons/components'
+import type { UseDeleteRunMutationResult } from '@opentrons/react-api-client'
 import type { RunControls } from '/app/organisms/RunTimeControl'
 
 export interface HistoricalProtocolRunOverflowMenuProps {
@@ -75,6 +75,8 @@ export interface HistoricalProtocolRunOverflowMenuProps {
   robotName: string
   robotIsBusy: boolean
   runHasImages: boolean
+  deleteRun: UseDeleteRunMutationResult['deleteRun']
+  isDeletingRun: boolean
 }
 
 export function HistoricalProtocolRunOverflowMenu(
@@ -167,6 +169,8 @@ interface MenuDropdownProps extends HistoricalProtocolRunOverflowMenuProps {
   setShowRobotOutOfStorageModal: Dispatch<SetStateAction<boolean>>
   setShowOverflowMenu: Dispatch<SetStateAction<boolean>>
   runControls: RunControls
+  deleteRun: UseDeleteRunMutationResult['deleteRun']
+  isDeletingRun: boolean
 }
 function MenuDropdown(props: MenuDropdownProps): JSX.Element {
   const { t } = useTranslation('device_details')
@@ -182,6 +186,8 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
     setShowRobotOutOfStorageModal,
     setShowOverflowMenu,
     runControls,
+    deleteRun,
+    isDeletingRun,
   } = props
 
   const { id: runId } = run
@@ -203,8 +209,6 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
   const trackEvent = useTrackEvent()
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
 
-  const { deleteRun, isLoading: isDeletingRun } =
-    useDeleteRunMutation(documentationState)
   const robot = useRobot(robotName)
   const robotType = useRobotType(robotName)
 

--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns/__tests__/HistoricalProtocolRun.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns/__tests__/HistoricalProtocolRun.test.tsx
@@ -5,9 +5,14 @@ import { when } from 'vitest-when'
 import '@testing-library/jest-dom/vitest'
 
 import { RUN_STATUS_SUCCEEDED } from '@opentrons/api-client'
+import {
+  useDeleteRunMutation,
+  useRunDataFileMetadata,
+} from '@opentrons/react-api-client'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { getStoredProtocols } from '/app/redux/protocol-storage'
 import { storedProtocolData as storedProtocolDataFixture } from '/app/redux/protocol-storage/__fixtures__'
 import {
@@ -27,6 +32,10 @@ import type { RunTimeParameter } from '@opentrons/shared-data'
 vi.mock('/app/redux/protocol-storage')
 vi.mock('/app/resources/runs')
 vi.mock('../HistoricalProtocolRunOverflowMenu')
+vi.mock('@opentrons/react-api-client')
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
 
 const run = {
   current: false,
@@ -69,6 +78,13 @@ describe('RecentProtocolRuns', () => {
       completedAt: '2022-05-04T18:24:41.833862+00:00',
     })
     vi.mocked(getStoredProtocols).mockReturnValue([storedProtocolDataFixture])
+    vi.mocked(useRunDataFileMetadata).mockReturnValue({
+      data: undefined,
+    } as UseQueryResult<any, unknown>)
+    vi.mocked(useDeleteRunMutation).mockReturnValue({
+      deleteRun: vi.fn(),
+      isLoading: false,
+    } as any)
   })
 
   it('renders the correct information derived from run and protocol', () => {

--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns/__tests__/HistoricalProtocolRunOverflowMenu.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns/__tests__/HistoricalProtocolRunOverflowMenu.test.tsx
@@ -4,10 +4,7 @@ import { fireEvent, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { when } from 'vitest-when'
 
-import {
-  useDeleteRunImages,
-  useDeleteRunMutation,
-} from '@opentrons/react-api-client'
+import { useDeleteRunImages } from '@opentrons/react-api-client'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
@@ -86,9 +83,6 @@ describe('HistoricalProtocolRunOverflowMenu', () => {
       downloadRunRecord: mockDownloadRunRecord,
       isDownloading: false,
     })
-    vi.mocked(useDeleteRunMutation).mockReturnValue({
-      deleteRun: vi.fn(),
-    } as any)
 
     when(useTrackProtocolRunEvent).calledWith(RUN_ID, ROBOT_NAME).thenReturn({
       trackProtocolRunEvent: mockTrackProtocolRunEvent,
@@ -126,6 +120,8 @@ describe('HistoricalProtocolRunOverflowMenu', () => {
       robotName: ROBOT_NAME,
       robotIsBusy: false,
       runHasImages: true,
+      deleteRun: vi.fn(),
+      isDeletingRun: false,
     }
     when(vi.mocked(useRobot))
       .calledWith(ROBOT_NAME)
@@ -163,7 +159,6 @@ describe('HistoricalProtocolRunOverflowMenu', () => {
     expect(useRunControls).toHaveBeenCalled()
     expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
     fireEvent.click(deleteBtn)
-    expect(useDeleteRunMutation).toHaveBeenCalled()
   })
 
   it('disables the rerun protocol menu item if robot software update is available', () => {

--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns/index.tsx
@@ -174,7 +174,7 @@ export function RecentProtocolRuns({
                       new Date(b.createdAt).getTime() -
                       new Date(a.createdAt).getTime()
                   )
-                  .map((run, index) => {
+                  .map(run => {
                     const protocol = protocols?.data?.data.find(
                       protocol => protocol.id === run.protocolId
                     )
@@ -192,7 +192,7 @@ export function RecentProtocolRuns({
                         robotName={robotName}
                         robotIsBusy={robotIsBusy}
                         isDeleting={deletingIds.has(run.id)}
-                        key={index}
+                        key={run.id}
                       />
                     )
                   })}

--- a/react-api-client/src/runs/index.ts
+++ b/react-api-client/src/runs/index.ts
@@ -27,6 +27,7 @@ export * from './useErrorRecoveryPolicy'
 export * from './useRunLoadedLabwareDefinitions'
 export * from './useAddCameraSettingsToRunMutation'
 
+export type { UseDeleteRunMutationResult } from './useDeleteRunMutation'
 export type { UsePlayRunMutationResult } from './usePlayRunMutation'
 export type { UsePauseRunMutationResult } from './usePauseRunMutation'
 export type { UseStopRunMutationResult } from './useStopRunMutation'

--- a/react-api-client/src/runs/useDeleteRunMutation.ts
+++ b/react-api-client/src/runs/useDeleteRunMutation.ts
@@ -46,19 +46,19 @@ export function useDeleteRunMutation(
   >(
     documentationState,
     ['delete_run'],
-    ({
+    async ({
       variables: { runId },
       userNotes,
-    }: DocumentedMutationParameters<DeleteRunParams>) =>
-      deleteRun(host!, runId, userNotes).then(response => {
-        queryClient.removeQueries(getQueryKey(host, 'runs', runId))
-        queryClient
-          .invalidateQueries(getQueryKey(host, 'runs'))
-          .catch((e: Error) => {
-            console.error(`error invalidating runs query: ${e.message}`)
-          })
-        return response.data
-      }),
+    }: DocumentedMutationParameters<DeleteRunParams>) => {
+      const response = await deleteRun(host!, runId, userNotes)
+      queryClient.removeQueries(getQueryKey(host, 'runs', runId))
+      await queryClient
+        .invalidateQueries(getQueryKey(host, 'runs'))
+        .catch((e: Error) => {
+          console.error(`error invalidating runs query: ${e.message}`)
+        })
+      return response.data
+    },
     options
   )
 


### PR DESCRIPTION
# Overview

Fixes UI for single run deletion in progress from Run History tab of device details. Adds spinner to indicate that run deletion is in progress as we do for bulk run deletion.

Closes RQA-5872

### Before

https://github.com/user-attachments/assets/e4df5b05-b74a-4810-bdaa-89db4d83c370

### After

https://github.com/user-attachments/assets/c6be9231-2835-4de3-b122-8d02730bdb86


## Test Plan and Hands on Testing

- navigate to device details > Run History tab
- delete a run
- verify that loading spinner renders during deletion instead of the overflow menu button

## Changelog

- refactor single run record deletion UI

## Review requests

see test plan

## Risk assessment

low