### PR TITLE
fix(api): Disallow dynamic pipetting on the ot2 during analysis.

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -343,7 +343,9 @@ class InstrumentContext(publisher.CommandPublisher):
         end_move_to_location: Optional[types.Location] = None
         end_meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None
         if end_location is not None:
-            validation.validate_dynamic_locations(location, end_location)
+            validation.validate_dynamic_locations(
+                location, end_location, self._protocol_core.robot_type
+            )
             end_target = validation.validate_location(
                 location=end_location, last_location=None
             )
@@ -619,7 +621,9 @@ class InstrumentContext(publisher.CommandPublisher):
         end_move_to_location: Optional[types.Location] = None
         end_meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None
         if end_location is not None:
-            validation.validate_dynamic_locations(location, end_location)
+            validation.validate_dynamic_locations(
+                location, end_location, self._protocol_core.robot_type
+            )
             end_target = validation.validate_location(
                 location=end_location, last_location=None
             )

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -700,8 +700,11 @@ ValidTarget = Union[WellTarget, PointTarget, DisposalTarget]
 def validate_dynamic_locations(
     location: Optional[Union[Location, Well, TrashBin, WasteChute]],
     end_location: Location,
+    robot_type: RobotType,
 ) -> None:
     """Given that we have an end_location we check that they're a vaild dynamic pair."""
+    if robot_type == "OT-2 Standard":
+        raise ValueError("Dyanmic pipetting not allowed on OT-2")
     if location is None:
         raise ValueError("Location must be supplied if using an End Location.")
     if not isinstance(location, Location):


### PR DESCRIPTION
# Overview
Currently using dynamic aspirate/dispense/mix doesn't raise an error during analysis but does raise an error at runtime because the OT2 motion planner is not able to do dynamic pipetting. 

This just raises an error during analysis now.