### PR TITLE
fix(app, auth-server): max login attempts behavior

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -146,6 +146,7 @@
   "desktop_login_to_manage_compliance_ready_software_settings": "Log in to manage Compliance Ready Software settings",
   "desktop_logins": "logins",
   "desktop_maximum_login_attempts_before_account_deactivation": "Maximum login attempts before account deactivation",
+  "desktop_maximum_login_attempts_invalid": "Must be a whole number between 1 and {{max}}",
   "desktop_minimum_length_for_documentation_for_robot_actions": "Edit minimum length for documentation for robot actions",
   "desktop_minimum_password_length": "Minimum password length",
   "desktop_minimum_password_length_invalid": "Must be a whole number between 1 and {{max}}",

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/InputSetting.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/InputSetting.tsx
@@ -14,7 +14,7 @@ export interface InputSettingProps {
   min?: number
   max?: number
   validate?: (value: string) => string | null
-  onBlur: (value: string) => void
+  onBlur: (value: string) => void | Promise<void>
 }
 
 export function InputSetting({
@@ -62,11 +62,13 @@ export function InputSetting({
             }
           }}
           onBlur={event => {
-            const value = event.target.value
-            const validationError = validate?.(value) ?? null
+            const blurredValue = event.target.value
+            const validationError = validate?.(blurredValue) ?? null
             setError(validationError)
             if (validationError == null) {
-              onBlur(value)
+              void Promise.resolve(onBlur(blurredValue)).catch(() => {
+                setInputValue(value)
+              })
             }
           }}
         />

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/__tests__/ComplianceReadySoftwareSettings.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/__tests__/ComplianceReadySoftwareSettings.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 
 import {
+  DocumentedMutationError,
   useAuditSettingsMutation,
   useAuditSettingsQuery,
   useAuthSettingsMutation,
@@ -166,6 +167,7 @@ describe('ComplianceReadySoftwareSettings', () => {
     } as ReturnType<typeof useAuditSettingsQuery>)
     vi.mocked(useAuthSettingsMutation).mockReturnValue({
       mutate: mockPatchAuthSettings,
+      mutateAsync: mockPatchAuthSettings,
     } as any)
     vi.mocked(usePatchRobotServerAccessControlSettingsMutation).mockReturnValue(
       {
@@ -174,6 +176,7 @@ describe('ComplianceReadySoftwareSettings', () => {
     )
     vi.mocked(useAuditSettingsMutation).mockReturnValue({
       mutate: mockPatchAuditSettings,
+      mutateAsync: mockPatchAuditSettings,
     } as any)
     vi.mocked(useUsersQuery).mockReturnValue(
       mockSuccessQueryResults({
@@ -399,6 +402,27 @@ describe('ComplianceReadySoftwareSettings', () => {
       expect(mockPatchAuthSettings).toHaveBeenCalledWith({
         data: { maxNumberOfLoginAttempts: 3 },
       })
+    })
+  })
+
+  it('should revert auth input values when documentation is cancelled', async () => {
+    mockPatchAuthSettings.mockRejectedValue(
+      new DocumentedMutationError('no_documentation_report')
+    )
+
+    render()
+    expandAccordion()
+
+    const loginAttemptsField = screen.getByLabelText(
+      'Maximum login attempts before account deactivation'
+    )
+    fireEvent.change(loginAttemptsField, { target: { value: '1' } })
+    expect(loginAttemptsField).toHaveValue(1)
+
+    fireEvent.blur(loginAttemptsField)
+
+    await waitFor(() => {
+      expect(loginAttemptsField).toHaveValue(5)
     })
   })
   it('should update audit input values without patching until blur', async () => {

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/__tests__/InputSetting.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/__tests__/InputSetting.test.tsx
@@ -1,0 +1,23 @@
+import '@testing-library/jest-dom/vitest'
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { InputSetting } from '../InputSetting'
+
+describe('InputSetting', () => {
+  it('reverts to the saved value when onBlur fails', async () => {
+    const onBlur = vi.fn().mockRejectedValue(new Error('patch failed'))
+    render(
+      <InputSetting label="Maximum login attempts" value="5" onBlur={onBlur} />
+    )
+
+    const input = screen.getByLabelText('Maximum login attempts')
+    fireEvent.change(input, { target: { value: '1' } })
+    fireEvent.blur(input)
+
+    await waitFor(() => {
+      expect(input).toHaveValue(5)
+    })
+  })
+})

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/__tests__/complianceReadySettingsHelper.test.ts
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/__tests__/complianceReadySettingsHelper.test.ts
@@ -83,8 +83,20 @@ describe('getFieldValuesFromSettings', () => {
 describe('getAuthInputPatch', () => {
   it('should patch maxNumberOfLoginAttempts input', () => {
     expect(
-      getAuthInputPatch('maxNumberOfLoginAttempts', '10', BASE_FIELD_VALUES)
-    ).toEqual({ data: { maxNumberOfLoginAttempts: 10 } })
+      getAuthInputPatch('maxNumberOfLoginAttempts', '3', BASE_FIELD_VALUES)
+    ).toEqual({ data: { maxNumberOfLoginAttempts: 3 } })
+  })
+
+  it('should not patch maxNumberOfLoginAttempts when value is invalid', () => {
+    expect(
+      getAuthInputPatch('maxNumberOfLoginAttempts', '0', BASE_FIELD_VALUES)
+    ).toBeNull()
+    expect(
+      getAuthInputPatch('maxNumberOfLoginAttempts', '6', BASE_FIELD_VALUES)
+    ).toBeNull()
+    expect(
+      getAuthInputPatch('maxNumberOfLoginAttempts', '3.5', BASE_FIELD_VALUES)
+    ).toBeNull()
   })
 
   it('should patch idleLogout input with minute conversion', () => {

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/complianceReadySettingsHelper.ts
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/complianceReadySettingsHelper.ts
@@ -21,6 +21,7 @@ import type {
 const SECONDS_PER_MINUTE = 60
 const SECONDS_PER_DAY = 24 * 60 * 60
 export const MAX_PASSWORD_COMPLEXITY_MINIMUM_LENGTH = 256
+export const MAX_NUMBER_OF_LOGIN_ATTEMPTS = 5
 
 export function isValidLogoutIdleTime(value: string): boolean {
   const parsedValue = Number(value)
@@ -33,6 +34,18 @@ export function isValidPasswordComplexityMinimumLength(value: string): boolean {
     Number.isInteger(parsedValue) &&
     parsedValue > 0 &&
     parsedValue <= MAX_PASSWORD_COMPLEXITY_MINIMUM_LENGTH
+  )
+}
+
+export function isValidMaxNumberOfLoginAttempts(value: string): boolean {
+  if (value === '') {
+    return true
+  }
+  const parsedValue = Number(value)
+  return (
+    Number.isInteger(parsedValue) &&
+    parsedValue > 0 &&
+    parsedValue <= MAX_NUMBER_OF_LOGIN_ATTEMPTS
   )
 }
 
@@ -134,6 +147,9 @@ export function getAuthInputPatch(
 ): PatchAuthSettingsRequest | null {
   switch (id) {
     case 'maxNumberOfLoginAttempts':
+      if (!isValidMaxNumberOfLoginAttempts(value)) {
+        return null
+      }
       return {
         data: { maxNumberOfLoginAttempts: value === '' ? null : Number(value) },
       }

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/index.tsx
@@ -114,9 +114,8 @@ export function ComplianceReadySoftwareSettings({
   ): Promise<void> => {
     const authPatch = getAuthInputPatch(id, value, fieldValues)
     if (authPatch != null) {
-      return patchAuthSettings(authPatch).then(() => undefined)
+      await patchAuthSettings(authPatch)
     }
-    return Promise.resolve()
   }
 
   const handleAuditSettingInputBlur = async (
@@ -125,9 +124,8 @@ export function ComplianceReadySoftwareSettings({
   ): Promise<void> => {
     const auditPatch = getAuditInputPatch(id, value, fieldValues)
     if (auditPatch != null) {
-      return patchAuditSettings(auditPatch).then(() => undefined)
+      await patchAuditSettings(auditPatch)
     }
-    return Promise.resolve()
   }
 
   const handleToggleChange = (

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/index.tsx
@@ -20,7 +20,9 @@ import {
   getAuthInputPatch,
   getFieldValuesFromSettings,
   isValidLogoutIdleTime,
+  isValidMaxNumberOfLoginAttempts,
   isValidPasswordComplexityMinimumLength,
+  MAX_NUMBER_OF_LOGIN_ATTEMPTS,
   MAX_PASSWORD_COMPLEXITY_MINIMUM_LENGTH,
 } from './complianceReadySettingsHelper'
 import {
@@ -200,6 +202,15 @@ export function ComplianceReadySoftwareSettings({
             )}
             value={String(fieldValues.maxNumberOfLoginAttempts)}
             units={t('desktop_logins')}
+            min={1}
+            max={MAX_NUMBER_OF_LOGIN_ATTEMPTS}
+            validate={value =>
+              isValidMaxNumberOfLoginAttempts(value)
+                ? null
+                : t('desktop_maximum_login_attempts_invalid', {
+                    max: MAX_NUMBER_OF_LOGIN_ATTEMPTS,
+                  })
+            }
             onBlur={value => {
               handleAuthSettingInputBlur('maxNumberOfLoginAttempts', value)
             }}

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/index.tsx
@@ -87,9 +87,9 @@ export function ComplianceReadySoftwareSettings({
   const auditSettingsQuery = useAuditSettingsQuery()
   const robotServerAccessControlSettingsQuery =
     useGetRobotServerAccessControlSettingsQuery()
-  const { mutate: patchAuthSettings } =
+  const { mutateAsync: patchAuthSettings } =
     useAuthSettingsMutation(documentationState)
-  const { mutate: patchAuditSettings } =
+  const { mutateAsync: patchAuditSettings } =
     useAuditSettingsMutation(documentationState)
   const { mutate: patchRobotServerAccessControlSettings } =
     usePatchRobotServerAccessControlSettingsMutation(documentationState)
@@ -108,23 +108,23 @@ export function ComplianceReadySoftwareSettings({
     ]
   )
 
-  const handleAuthSettingInputBlur = (
+  const handleAuthSettingInputBlur = async (
     id: AuthSettingFieldId,
     value: string
-  ): void => {
+  ): Promise<void> => {
     const authPatch = getAuthInputPatch(id, value, fieldValues)
     if (authPatch != null) {
-      patchAuthSettings(authPatch)
+      await patchAuthSettings(authPatch)
     }
   }
 
-  const handleAuditSettingInputBlur = (
+  const handleAuditSettingInputBlur = async (
     id: AuditServerSettingFieldId,
     value: string
-  ): void => {
+  ): Promise<void> => {
     const auditPatch = getAuditInputPatch(id, value, fieldValues)
     if (auditPatch != null) {
-      patchAuditSettings(auditPatch)
+      await patchAuditSettings(auditPatch)
     }
   }
 
@@ -196,7 +196,6 @@ export function ComplianceReadySoftwareSettings({
           isLastSection={false}
         >
           <InputSetting
-            key={String(fieldValues.maxNumberOfLoginAttempts)}
             label={t(
               'desktop_maximum_login_attempts_before_account_deactivation'
             )}
@@ -211,9 +210,9 @@ export function ComplianceReadySoftwareSettings({
                     max: MAX_NUMBER_OF_LOGIN_ATTEMPTS,
                   })
             }
-            onBlur={value => {
+            onBlur={value =>
               handleAuthSettingInputBlur('maxNumberOfLoginAttempts', value)
-            }}
+            }
           />
           <Divider />
           <ComplianceReadyToggleField
@@ -225,13 +224,12 @@ export function ComplianceReadySoftwareSettings({
             }}
           >
             <InputSetting
-              key={String(fieldValues.passwordResetTime)}
               label={t('desktop_length_of_time')}
               value={String(fieldValues.passwordResetTime)}
               units={t('desktop_days')}
-              onBlur={value => {
+              onBlur={value =>
                 handleAuthSettingInputBlur('passwordResetTime', value)
-              }}
+              }
             />
           </ComplianceReadyToggleField>
           <Divider />
@@ -254,7 +252,6 @@ export function ComplianceReadySoftwareSettings({
               }}
             />
             <InputSetting
-              key={String(fieldValues.passwordComplexityMinimumLength)}
               label={t('desktop_minimum_password_length')}
               value={String(fieldValues.passwordComplexityMinimumLength)}
               units={t('desktop_characters')}
@@ -267,17 +264,16 @@ export function ComplianceReadySoftwareSettings({
                       max: MAX_PASSWORD_COMPLEXITY_MINIMUM_LENGTH,
                     })
               }
-              onBlur={value => {
+              onBlur={value =>
                 handleAuthSettingInputBlur(
                   'passwordComplexityMinimumLength',
                   value
                 )
-              }}
+              }
             />
           </ComplianceReadyToggleField>
           <Divider />
           <InputSetting
-            key={String(fieldValues.idleLogout)}
             label={t('desktop_auto_logout_inactivity_length')}
             value={String(fieldValues.idleLogout)}
             units={t('desktop_minutes')}
@@ -286,9 +282,7 @@ export function ComplianceReadySoftwareSettings({
                 ? null
                 : t('desktop_idle_logout_must_be_greater_than_zero')
             }
-            onBlur={value => {
-              handleAuthSettingInputBlur('idleLogout', value)
-            }}
+            onBlur={value => handleAuthSettingInputBlur('idleLogout', value)}
           />
         </ComplianceReadySettingsSection>
 
@@ -346,18 +340,17 @@ export function ComplianceReadySoftwareSettings({
             }}
           >
             <InputSetting
-              key={String(fieldValues.minLengthOfReasonForInteraction)}
               label={t(
                 'desktop_minimum_length_for_documentation_for_robot_actions'
               )}
               value={String(fieldValues.minLengthOfReasonForInteraction)}
               units={t('desktop_characters')}
-              onBlur={value => {
+              onBlur={value =>
                 handleAuditSettingInputBlur(
                   'minLengthOfReasonForInteraction',
                   value
                 )
-              }}
+              }
             />
           </ComplianceReadyToggleField>
           <Divider />

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/index.tsx
@@ -114,8 +114,9 @@ export function ComplianceReadySoftwareSettings({
   ): Promise<void> => {
     const authPatch = getAuthInputPatch(id, value, fieldValues)
     if (authPatch != null) {
-      await patchAuthSettings(authPatch)
+      return patchAuthSettings(authPatch).then(() => undefined)
     }
+    return Promise.resolve()
   }
 
   const handleAuditSettingInputBlur = async (
@@ -124,8 +125,9 @@ export function ComplianceReadySoftwareSettings({
   ): Promise<void> => {
     const auditPatch = getAuditInputPatch(id, value, fieldValues)
     if (auditPatch != null) {
-      await patchAuditSettings(auditPatch)
+      return patchAuditSettings(auditPatch).then(() => undefined)
     }
+    return Promise.resolve()
   }
 
   const handleToggleChange = (

--- a/auth-server/auth_server/settings/models.py
+++ b/auth-server/auth_server/settings/models.py
@@ -23,6 +23,8 @@ class SettingsResponseData(_StrictBaseModel):
 
     maxNumberOfLoginAttempts: int | None = pydantic.Field(
         default=5,
+        ge=1,
+        le=5,
         description="Max number of login attempts before account deactivation. Set to null to remove the limit.",
     )
     passwordResetTime: float | None = pydantic.Field(
@@ -65,7 +67,9 @@ class PatchSettingsRequestData(_StrictBaseModel):
     maxNumberOfLoginAttempts: Annotated[
         int | None,
         pydantic.Field(
-            description="Max number of login attempts before account deactivation."
+            ge=1,
+            le=MAX_NUMBER_OF_LOGIN_ATTEMPTS,
+            description="Max number of login attempts before account deactivation.",
         ),
     ] = None
     passwordResetTime: Annotated[

--- a/auth-server/auth_server/settings/models.py
+++ b/auth-server/auth_server/settings/models.py
@@ -68,7 +68,7 @@ class PatchSettingsRequestData(_StrictBaseModel):
         int | None,
         pydantic.Field(
             ge=1,
-            le=MAX_NUMBER_OF_LOGIN_ATTEMPTS,
+            le=5,
             description="Max number of login attempts before account deactivation.",
         ),
     ] = None

--- a/auth-server/tests/integration/test_settings.tavern.yaml
+++ b/auth-server/tests/integration/test_settings.tavern.yaml
@@ -58,7 +58,7 @@ stages:
       json:
         data:
           idleLogout: 60.0
-          maxNumberOfLoginAttempts: 10
+          maxNumberOfLoginAttempts: 3
           passwordResetTime: 2592000.0
           passwordComplexityMinimumLength: 8
           passwordComplexitySpecialCharacters: true
@@ -67,7 +67,7 @@ stages:
       status_code: 200
       json:
         data:
-          maxNumberOfLoginAttempts: 10
+          maxNumberOfLoginAttempts: 3
           passwordResetTime: 2592000.0
           passwordComplexityMinimumLength: 8
           passwordComplexitySpecialCharacters: true
@@ -84,7 +84,7 @@ stages:
       status_code: 200
       json:
         data:
-          maxNumberOfLoginAttempts: 10
+          maxNumberOfLoginAttempts: 3
           passwordResetTime: 2592000.0
           passwordComplexityMinimumLength: 8
           passwordComplexitySpecialCharacters: true
@@ -101,7 +101,7 @@ stages:
       status_code: 200
       json:
         data:
-          maxNumberOfLoginAttempts: 10
+          maxNumberOfLoginAttempts: 3
           passwordResetTime: 2592000.0
           passwordComplexityMinimumLength: 8
           passwordComplexitySpecialCharacters: true
@@ -128,7 +128,7 @@ stages:
         Authorization: '{admin_access_token}'
       json:
         data:
-          maxNumberOfLoginAttempts: 10
+          maxNumberOfLoginAttempts: 3
           passwordResetTime: 2592000.0
           passwordComplexityMinimumLength: 8
           passwordComplexitySpecialCharacters: true
@@ -138,7 +138,7 @@ stages:
       status_code: 200
       json:
         data:
-          maxNumberOfLoginAttempts: 10
+          maxNumberOfLoginAttempts: 3
           passwordResetTime: 2592000.0
           passwordComplexityMinimumLength: 8
           passwordComplexitySpecialCharacters: true
@@ -226,12 +226,12 @@ stages:
         Authorization: '{admin_access_token}'
       json:
         data:
-          maxNumberOfLoginAttempts: 10
+          maxNumberOfLoginAttempts: 3
     response:
       status_code: 200
       json:
         data:
-          maxNumberOfLoginAttempts: 10
+          maxNumberOfLoginAttempts: 3
           passwordResetTime: null
           passwordComplexityMinimumLength: null
           passwordComplexitySpecialCharacters: null

--- a/auth-server/tests/settings/test_models.py
+++ b/auth-server/tests/settings/test_models.py
@@ -1,0 +1,39 @@
+import pytest
+from pydantic import ValidationError
+
+from auth_server.settings.models import (
+    MAX_NUMBER_OF_LOGIN_ATTEMPTS,
+    PatchSettingsRequestData,
+    SettingsResponseData,
+)
+
+
+def test_max_number_of_login_attempts_accepts_valid_values() -> None:
+    assert (
+        SettingsResponseData(maxNumberOfLoginAttempts=1).maxNumberOfLoginAttempts == 1
+    )
+    assert (
+        SettingsResponseData(
+            maxNumberOfLoginAttempts=MAX_NUMBER_OF_LOGIN_ATTEMPTS
+        ).maxNumberOfLoginAttempts
+        == MAX_NUMBER_OF_LOGIN_ATTEMPTS
+    )
+    assert PatchSettingsRequestData(maxNumberOfLoginAttempts=None).model_dump(
+        exclude_unset=True
+    ) == {"maxNumberOfLoginAttempts": None}
+
+
+@pytest.mark.parametrize("invalid_value", [0, 6, MAX_NUMBER_OF_LOGIN_ATTEMPTS + 1])
+def test_patch_settings_rejects_out_of_range_login_attempts(
+    invalid_value: int,
+) -> None:
+    with pytest.raises(ValidationError):
+        PatchSettingsRequestData(maxNumberOfLoginAttempts=invalid_value)
+
+
+@pytest.mark.parametrize("invalid_value", [0, 6, MAX_NUMBER_OF_LOGIN_ATTEMPTS + 1])
+def test_settings_response_rejects_out_of_range_login_attempts(
+    invalid_value: int,
+) -> None:
+    with pytest.raises(ValidationError):
+        SettingsResponseData(maxNumberOfLoginAttempts=invalid_value)

--- a/auth-server/tests/settings/test_models.py
+++ b/auth-server/tests/settings/test_models.py
@@ -2,10 +2,11 @@ import pytest
 from pydantic import ValidationError
 
 from auth_server.settings.models import (
-    MAX_NUMBER_OF_LOGIN_ATTEMPTS,
     PatchSettingsRequestData,
     SettingsResponseData,
 )
+
+MAX_NUMBER_OF_LOGIN_ATTEMPTS = 5
 
 
 def test_max_number_of_login_attempts_accepts_valid_values() -> None:

--- a/auth-server/tests/settings/test_store.py
+++ b/auth-server/tests/settings/test_store.py
@@ -38,8 +38,8 @@ def test_reset_settings(settings_store: SettingsStore) -> None:
     "updates, expected_changes",
     [
         pytest.param(
-            PatchSettingsRequestData(maxNumberOfLoginAttempts=10),
-            SettingsResponseData(maxNumberOfLoginAttempts=10),
+            PatchSettingsRequestData(maxNumberOfLoginAttempts=3),
+            SettingsResponseData(maxNumberOfLoginAttempts=3),
             id="single-field",
         ),
         pytest.param(


### PR DESCRIPTION
Closes [RQA-5911](https://opentrons.atlassian.net/browse/RQA-5911)

# Overview

add a top boundary for max login attempts, when blur out reset state of input field if no documentation supplied.

## Test Plan and Hands on Testing

https://github.com/user-attachments/assets/85d33b83-ec1d-41fd-b872-6dd31dd55cad

## Review requests

- are we ok with 5 top bound (sue req)

## Risk assessment

- low. bug fixes. 


[RQA-5911]: https://opentrons.atlassian.net/browse/RQA-5911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ