### PR TITLE
refactor(app): Update various slideout states to match designs

### DIFF
--- a/app/src/assets/localization/en/access_control.json
+++ b/app/src/assets/localization/en/access_control.json
@@ -40,6 +40,7 @@
   "on_device_login_password_required": "Password required",
   "on_device_login_password_updated": "Password updated",
   "on_device_login_username_required": "Username required",
+  "send_protocol_admin_credentials_required": "Admin credentials are required to send protocols to this robot.",
   "set_new_password_error_session_expired": "Your session has expired. Log in again to set a new password.",
   "set_new_password_error_update_failed": "Failed to update password. Try again.",
   "set_new_password_success": "Password reset for {{username}}",

--- a/app/src/local-resources/access-control/__tests__/utils.test.ts
+++ b/app/src/local-resources/access-control/__tests__/utils.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getProtocolOrRunCreationErrorMessage,
+  isProtocolWritePermissionError,
+} from '../utils'
+
+const GENERAL_ERROR = 'Protocol run could not be created on the robot.'
+const PERMISSION_ERROR =
+  'Admin credentials are required to send protocols to this robot.'
+
+const permissionDeniedError = {
+  isAxiosError: true,
+  response: {
+    status: 403,
+    data: {
+      debugMessage: 'missing scopes',
+      requiredScopes: ['protocols.write'],
+      providedScopes: ['users.read.self', 'users.write.self'],
+    },
+  },
+}
+
+describe('isProtocolWritePermissionError', () => {
+  it('is true for a 403 missing protocols.write', () => {
+    expect(isProtocolWritePermissionError(permissionDeniedError)).toBe(true)
+  })
+
+  it('is false for other 403s', () => {
+    expect(
+      isProtocolWritePermissionError({
+        isAxiosError: true,
+        response: {
+          status: 403,
+          data: { requiredScopes: ['robot.settings.write'] },
+        },
+      })
+    ).toBe(false)
+  })
+
+  it('is false for non-axios errors', () => {
+    expect(isProtocolWritePermissionError(new Error('nope'))).toBe(false)
+  })
+})
+
+describe('getProtocolOrRunCreationErrorMessage', () => {
+  it('returns the permission copy for a protocols.write 403', () => {
+    expect(
+      getProtocolOrRunCreationErrorMessage(
+        permissionDeniedError,
+        GENERAL_ERROR,
+        PERMISSION_ERROR
+      )
+    ).toBe(PERMISSION_ERROR)
+  })
+
+  it('returns JSON API error detail when present', () => {
+    expect(
+      getProtocolOrRunCreationErrorMessage(
+        {
+          isAxiosError: true,
+          response: {
+            status: 400,
+            data: {
+              errors: [{ id: 'BadRequest', title: 'Bad', detail: 'oh no' }],
+            },
+          },
+        },
+        GENERAL_ERROR,
+        PERMISSION_ERROR
+      )
+    ).toBe('oh no')
+  })
+
+  it('returns the general message when the 403 body is an object without JSON API errors', () => {
+    expect(
+      getProtocolOrRunCreationErrorMessage(
+        {
+          isAxiosError: true,
+          response: {
+            status: 403,
+            data: {
+              debugMessage: 'missing scopes',
+              requiredScopes: ['updates.write'],
+              providedScopes: [],
+            },
+          },
+        },
+        GENERAL_ERROR,
+        PERMISSION_ERROR
+      )
+    ).toBe(GENERAL_ERROR)
+  })
+
+  it('returns the general message for a non-axios error', () => {
+    expect(
+      getProtocolOrRunCreationErrorMessage(
+        new Error('boom'),
+        GENERAL_ERROR,
+        PERMISSION_ERROR
+      )
+    ).toBe(GENERAL_ERROR)
+  })
+})

--- a/app/src/local-resources/access-control/utils.ts
+++ b/app/src/local-resources/access-control/utils.ts
@@ -1,7 +1,13 @@
+import axios from 'axios'
+
 import type {
   DocumentationReport,
   DocumentationState,
 } from '@opentrons/react-api-client'
+
+const PROTOCOLS_WRITE_SCOPE = 'protocols.write'
+
+const MAX_ERROR_DETAIL_LENGTH = 255
 
 export function isDocumentationReportValid(
   docreport: DocumentationReport,
@@ -28,4 +34,39 @@ export function isDocumentationProvided(state: DocumentationState): boolean {
 export const ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE: DocumentationState = {
   isLoading: false,
   accessControlEnabled: false,
+}
+
+export function isProtocolWritePermissionError(error: unknown): boolean {
+  if (!axios.isAxiosError(error) || error.response?.status !== 403) {
+    return false
+  }
+  const requiredScopes = (
+    error.response.data as { requiredScopes?: unknown } | undefined
+  )?.requiredScopes
+  return (
+    Array.isArray(requiredScopes) &&
+    requiredScopes.includes(PROTOCOLS_WRITE_SCOPE)
+  )
+}
+
+export function getProtocolOrRunCreationErrorMessage(
+  error: unknown,
+  generalErrorMessage: string,
+  permissionErrorMessage: string
+): string {
+  if (isProtocolWritePermissionError(error)) {
+    return permissionErrorMessage
+  }
+  if (axios.isAxiosError(error)) {
+    const detail = (
+      error.response?.data as
+        { errors?: Array<{ detail?: unknown }> } | undefined
+    )?.errors?.[0]?.detail
+    if (typeof detail === 'string' && detail.length > 0) {
+      return detail.length > MAX_ERROR_DETAIL_LENGTH
+        ? generalErrorMessage
+        : detail
+    }
+  }
+  return generalErrorMessage
 }

--- a/app/src/organisms/Desktop/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseProtocolSlideout/index.tsx
@@ -62,6 +62,7 @@ import {
   getRunTimeParameterValuesForRun,
 } from '/app/transformations/runs'
 
+import { SendingButtonLabel } from '../ChooseRobotSlideout'
 import { FileCard } from '../ChooseRobotSlideout/FileCard'
 
 import type { MouseEventHandler } from 'react'
@@ -225,6 +226,9 @@ export function ChooseProtocolSlideoutComponent(
       : []
   )
   const handleProceed: MouseEventHandler<HTMLButtonElement> = () => {
+    if (isCreatingRun) {
+      return
+    }
     if (selectedProtocol != null) {
       trackCreateProtocolRunEvent({ name: 'createProtocolRecordRequest' })
       const dataFilesForProtocolMap = runTimeParametersOverrides.reduce<
@@ -595,14 +599,10 @@ export function ChooseProtocolSlideoutComponent(
   const singlePageFooter = (
     <PrimaryButton
       onClick={handleProceed}
-      disabled={isCreatingRun || selectedProtocol == null}
+      disabled={selectedProtocol == null}
       width="100%"
     >
-      {isCreatingRun ? (
-        <Icon name="ot-spinner" spin size="1rem" />
-      ) : (
-        t('shared:proceed_to_setup')
-      )}
+      {isCreatingRun ? <SendingButtonLabel /> : t('shared:proceed_to_setup')}
     </PrimaryButton>
   )
 
@@ -613,7 +613,7 @@ export function ChooseProtocolSlideoutComponent(
           setCurrentPage(2)
         }}
         width="100%"
-        disabled={isCreatingRun || selectedProtocol == null}
+        disabled={selectedProtocol == null}
       >
         {t('shared:continue_to_param')}
       </PrimaryButton>
@@ -637,19 +637,7 @@ export function ChooseProtocolSlideoutComponent(
           disabled={hasParamError}
           {...targetPropsHover}
         >
-          {isCreatingRun ? (
-            <Flex
-              gridGap={SPACING.spacing4}
-              alignItems={ALIGN_CENTER}
-              whiteSpace={NO_WRAP}
-              marginLeft={`-${SPACING.spacing4}`}
-            >
-              <Icon name="ot-spinner" spin size="1rem" />
-              {t('shared:confirm_values')}
-            </Flex>
-          ) : (
-            t('shared:confirm_values')
-          )}
+          {isCreatingRun ? <SendingButtonLabel /> : t('shared:confirm_values')}
         </PrimaryButton>
         {hasMissingFileParam ? (
           <Tooltip tooltipProps={tooltipPropsHover}>

--- a/app/src/organisms/Desktop/ChooseRobotSlideout/AvailableRobotOption.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotSlideout/AvailableRobotOption.tsx
@@ -2,13 +2,12 @@ import { useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { NavLink } from 'react-router-dom'
+import clsx from 'clsx'
 import { css } from 'styled-components'
 
 import {
   Box,
   COLORS,
-  DIRECTION_COLUMN,
-  Flex,
   Icon,
   LegacyStyledText,
   SIZE_1,
@@ -26,6 +25,8 @@ import { getRobotModelByName, OPENTRONS_USB } from '/app/redux/discovery'
 import { appShellUSBRequestor } from '/app/redux/shell/remote'
 import { useNetworkInterfaces } from '/app/resources/networking/hooks'
 import { useCurrentRunId, useNotifyRunQuery } from '/app/resources/runs'
+
+import styles from './availablerobotoption.module.css'
 
 import type { Dispatch as ReactDispatch, ReactNode } from 'react'
 import type { Runs } from '@opentrons/api-client'
@@ -128,17 +129,13 @@ export function AvailableRobotOptionComponent(
       >
         <img
           src={robotModel === 'OT-2' ? OT2_PNG : FLEX_PNG}
-          css={css`
-            width: 4rem;
-            height: 3.5625rem;
-          `}
+          className={styles.robot_image}
           alt={robotModel === 'OT-2' ? 'Image of `OT-2 image' : 'Flex image'}
         />
-        <Flex
-          flexDirection={DIRECTION_COLUMN}
-          marginLeft={SPACING.spacing16}
-          marginTop={SPACING.spacing8}
-          marginBottom={SPACING.spacing16}
+        <div
+          className={clsx(styles.details, {
+            [styles.details_with_chip]: isComplianceReady,
+          })}
         >
           <LegacyStyledText
             forwardedAs="h6"
@@ -165,15 +162,17 @@ export function AvailableRobotOptionComponent(
             </LegacyStyledText>
           </Box>
           {isComplianceReady ? (
-            <StatusLabel
-              status={t('protocol_list:compliance_ready')}
-              backgroundColor={COLORS.blue30}
-              showIcon={false}
-              // override capitalization since both words should be capitalized in this instance
-              capitalizeStatus={false}
-            />
+            <div className={styles.compliance_chip}>
+              <StatusLabel
+                status={t('protocol_list:compliance_ready')}
+                backgroundColor={COLORS.blue30}
+                showIcon={false}
+                // override capitalization since both words should be capitalized in this instance
+                capitalizeStatus={false}
+              />
+            </div>
           ) : null}
-        </Flex>
+        </div>
         {(isError || isSelectedRobotOnDifferentSoftwareVersion) &&
         isSelected ? (
           <>

--- a/app/src/organisms/Desktop/ChooseRobotSlideout/SendingButtonLabel.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotSlideout/SendingButtonLabel.tsx
@@ -1,0 +1,16 @@
+import { useTranslation } from 'react-i18next'
+
+import { Icon } from '@opentrons/components'
+
+import styles from './availablerobotoption.module.css'
+
+export function SendingButtonLabel(): JSX.Element {
+  const { t } = useTranslation('protocol_details')
+
+  return (
+    <span className={styles.sending_label}>
+      {t('sending')}
+      <Icon name="ot-spinner" spin size="1rem" data-testid="sending-spinner" />
+    </span>
+  )
+}

--- a/app/src/organisms/Desktop/ChooseRobotSlideout/availablerobotoption.module.css
+++ b/app/src/organisms/Desktop/ChooseRobotSlideout/availablerobotoption.module.css
@@ -1,0 +1,20 @@
+.details {
+  display: flex;
+  flex-direction: column;
+  margin: var(--spacing-8) 0 var(--spacing-16) var(--spacing-16);
+}
+
+.details_with_chip {
+  margin-bottom: 0;
+}
+
+/* StatusLabel applies 4px vertical margins; Figma stacks the chip flush. */
+.compliance_chip {
+  margin-top: calc(-1 * var(--spacing-4));
+  margin-bottom: calc(-1 * var(--spacing-4));
+}
+
+.robot_image {
+  width: 4rem;
+  height: 3.5625rem;
+}

--- a/app/src/organisms/Desktop/ChooseRobotSlideout/availablerobotoption.module.css
+++ b/app/src/organisms/Desktop/ChooseRobotSlideout/availablerobotoption.module.css
@@ -18,3 +18,11 @@
   width: 4rem;
   height: 3.5625rem;
 }
+
+.sending_label {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-8);
+}

--- a/app/src/organisms/Desktop/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotSlideout/index.tsx
@@ -71,6 +71,8 @@ import type { UseCreateRun } from '/app/organisms/Desktop/ChooseRobotToRunProtoc
 import type { Robot } from '/app/redux/discovery/types'
 import type { Dispatch, State } from '/app/redux/types'
 
+export { SendingButtonLabel } from './SendingButtonLabel'
+
 export const CARD_OUTLINE_BORDER_STYLE = css`
   border-style: ${BORDERS.styleSolid};
   border-width: 1px;

--- a/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -5,11 +5,9 @@ import { useNavigate } from 'react-router-dom'
 import first from 'lodash/first'
 
 import {
-  ALIGN_CENTER,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
   Flex,
-  Icon,
   NO_WRAP,
   PrimaryButton,
   SecondaryButton,
@@ -37,7 +35,7 @@ import {
   getRunTimeParameterValuesForRun,
 } from '/app/transformations/runs'
 
-import { ChooseRobotSlideout } from '../ChooseRobotSlideout'
+import { ChooseRobotSlideout, SendingButtonLabel } from '../ChooseRobotSlideout'
 import { RobotOutOfStorageModal } from '../Devices/RobotOutOfStorageModal.tsx'
 import { useCreateRunFromProtocol } from './useCreateRunFromProtocol'
 
@@ -150,6 +148,9 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
     runTimeParameters?.length > 0 ? ['confirm_parameters'] : []
   )
   const handleProceed: MouseEventHandler<HTMLButtonElement> = () => {
+    if (isCreatingRun) {
+      return
+    }
     if (isRobotOutOfStorage) {
       setShowRobotOutOfStorageModal(true)
       return
@@ -247,18 +248,12 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
   const singlePageButton = (
     <PrimaryButton
       disabled={
-        isCreatingRun ||
-        selectedRobot == null ||
-        isSelectedRobotOnDifferentSoftwareVersion
+        selectedRobot == null || isSelectedRobotOnDifferentSoftwareVersion
       }
       width="100%"
       onClick={handleProceed}
     >
-      {isCreatingRun ? (
-        <Icon name="ot-spinner" spin size="1rem" />
-      ) : (
-        t('shared:proceed_to_setup')
-      )}
+      {isCreatingRun ? <SendingButtonLabel /> : t('shared:proceed_to_setup')}
     </PrimaryButton>
   )
 
@@ -283,7 +278,6 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
               onClick={handleProceedToRTP}
               width="100%"
               disabled={
-                isCreatingRun ||
                 selectedRobot == null ||
                 isSelectedRobotOnDifferentSoftwareVersion
               }
@@ -312,15 +306,7 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
               {...targetProps}
             >
               {isCreatingRun ? (
-                <Flex
-                  gridGap={SPACING.spacing4}
-                  alignItems={ALIGN_CENTER}
-                  whiteSpace={NO_WRAP}
-                  marginLeft={`-${SPACING.spacing4}`}
-                >
-                  <Icon name="ot-spinner" spin size="1rem" />
-                  {t('shared:confirm_values')}
-                </Flex>
+                <SendingButtonLabel />
               ) : (
                 t('shared:confirm_values')
               )}

--- a/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol.ts
+++ b/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol.ts
@@ -8,6 +8,7 @@ import {
 } from '@opentrons/react-api-client'
 
 import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
+import { getProtocolOrRunCreationErrorMessage } from '/app/local-resources/access-control/utils'
 import { getValidCustomLabwareFiles } from '/app/redux/custom-labware/selectors'
 
 import type { UseMutateFunction } from 'react-query'
@@ -43,7 +44,7 @@ export function useCreateRunFromProtocol(
   const contextHost = useHost()
   const host =
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
-  const { t } = useTranslation('shared')
+  const { t } = useTranslation(['shared', 'access_control'])
 
   const customLabwareFiles = useSelector((state: State) =>
     getValidCustomLabwareFiles(state)
@@ -95,16 +96,18 @@ export function useCreateRunFromProtocol(
     host
   )
 
-  let error =
-    protocolError != null || runError != null
-      ? (protocolError?.response?.data?.errors?.[0]?.detail ??
-        protocolError?.response?.data ??
-        runError?.response?.data?.errors?.[0]?.detail ??
-        runError?.response?.data ??
-        t('protocol_run_general_error_msg'))
+  const mutationError = protocolError ?? runError
+  if (mutationError != null) {
+    console.error(mutationError)
+  }
+  const error =
+    mutationError != null
+      ? getProtocolOrRunCreationErrorMessage(
+          mutationError,
+          t('protocol_run_general_error_msg') as string,
+          t('access_control:send_protocol_admin_credentials_required') as string
+        )
       : null
-  error != null && console.error(error)
-  error = error?.length > 255 ? t('protocol_run_general_error_msg') : error
 
   const errorCode =
     protocolError?.response?.status ?? runError?.response?.status ?? null

--- a/app/src/organisms/Desktop/SendProtocolToFlexSlideout/index.tsx
+++ b/app/src/organisms/Desktop/SendProtocolToFlexSlideout/index.tsx
@@ -27,7 +27,7 @@ import { appShellUSBRequestor } from '/app/redux/shell/remote'
 import { getAnalysisStatus } from '/app/transformations/analysis'
 import { getProtocolDisplayName } from '/app/transformations/protocols'
 
-import { ChooseRobotSlideout } from '../ChooseRobotSlideout'
+import { ChooseRobotSlideout, SendingButtonLabel } from '../ChooseRobotSlideout'
 
 import type { AxiosError } from 'axios'
 import type { IconProps, StyleProps } from '@opentrons/components'
@@ -59,6 +59,7 @@ export function SendProtocolToFlexSlideout(
 
   const [selectedRobot, setSelectedRobot] = useState<Robot | null>(null)
   const [runCreationError, setRunCreationError] = useState<string | null>(null)
+  const [isSending, setIsSending] = useState(false)
 
   const isSelectedRobotOnDifferentSoftwareVersion =
     useIsRobotOnWrongVersionOfSoftware(selectedRobot?.name ?? '')
@@ -121,6 +122,10 @@ export function SendProtocolToFlexSlideout(
   const icon: IconProps = { name: 'ot-spinner', spin: true }
 
   const handleSendClick = (): void => {
+    if (isSending) {
+      return
+    }
+    setIsSending(true)
     setRunCreationError(null)
     const toastId = makeToast(selectedRobot?.name ?? '', INFO_TOAST, {
       heading: `${t('sending')} ${protocolDisplayName}`,
@@ -175,6 +180,9 @@ export function SendProtocolToFlexSlideout(
         }
         onCloseClick()
       })
+      .finally(() => {
+        setIsSending(false)
+      })
   }
 
   return (
@@ -196,13 +204,14 @@ export function SendProtocolToFlexSlideout(
             onClick={handleSendClick}
             width="100%"
           >
-            {t('protocol_details:send')}
+            {isSending ? <SendingButtonLabel /> : t('protocol_details:send')}
           </PrimaryButton>
         }
         selectedRobot={selectedRobot}
         setSelectedRobot={setSelectedRobot}
         robotType={FLEX_ROBOT_TYPE}
         runCreationError={runCreationError}
+        isCreatingRun={isSending}
         reset={() => {
           setRunCreationError(null)
         }}

--- a/app/src/organisms/Desktop/SendProtocolToFlexSlideout/index.tsx
+++ b/app/src/organisms/Desktop/SendProtocolToFlexSlideout/index.tsx
@@ -8,10 +8,14 @@ import {
   PrimaryButton,
   SUCCESS_TOAST,
 } from '@opentrons/components'
-import { useCreateProtocolMutation } from '@opentrons/react-api-client'
+import {
+  isDocumentedMutationError,
+  useCreateProtocolMutation,
+} from '@opentrons/react-api-client'
 import { FLEX_DISPLAY_NAME, FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+import { isProtocolWritePermissionError } from '/app/local-resources/access-control/utils'
 import { ApiHostProvider } from '/app/local-resources/api-host-provider/ApiHostProvider'
 import { useToaster } from '/app/organisms/ToasterOven'
 import { getValidCustomLabwareFiles } from '/app/redux/custom-labware'
@@ -47,9 +51,14 @@ export function SendProtocolToFlexSlideout(
   const { isExpanded, onCloseClick, storedProtocolData } = props
   const { protocolKey, srcFileNames, srcFiles, mostRecentAnalysis } =
     storedProtocolData
-  const { t } = useTranslation(['protocol_details', 'protocol_list'])
+  const { t } = useTranslation([
+    'protocol_details',
+    'protocol_list',
+    'access_control',
+  ])
 
   const [selectedRobot, setSelectedRobot] = useState<Robot | null>(null)
+  const [runCreationError, setRunCreationError] = useState<string | null>(null)
 
   const isSelectedRobotOnDifferentSoftwareVersion =
     useIsRobotOnWrongVersionOfSoftware(selectedRobot?.name ?? '')
@@ -112,6 +121,7 @@ export function SendProtocolToFlexSlideout(
   const icon: IconProps = { name: 'ot-spinner', spin: true }
 
   const handleSendClick = (): void => {
+    setRunCreationError(null)
     const toastId = makeToast(selectedRobot?.name ?? '', INFO_TOAST, {
       heading: `${t('sending')} ${protocolDisplayName}`,
       icon,
@@ -130,33 +140,41 @@ export function SendProtocolToFlexSlideout(
         })
         onCloseClick()
       })
-      .catch(
-        (
-          error: AxiosError<{
-            errors: Array<{ id: string; detail: string; title: string }>
-          }>
-        ) => {
-          eatToast(toastId)
-          const [errorDetail] = error?.response?.data?.errors ?? []
-          const { id, detail, title } = errorDetail ?? {}
-          if (id != null && detail != null && title != null) {
-            makeToast(detail, ERROR_TOAST, {
-              closeButton: true,
-              disableTimeout: true,
-              heading: `${protocolDisplayName} ${title} - ${
-                selectedRobot?.name ?? ''
-              }`,
-            })
-          } else {
-            makeToast(selectedRobot?.name ?? '', ERROR_TOAST, {
-              closeButton: true,
-              disableTimeout: true,
-              heading: `${t('unsuccessfully_sent')} ${protocolDisplayName}`,
-            })
-          }
-          onCloseClick()
+      .catch((error: unknown) => {
+        eatToast(toastId)
+        if (isDocumentedMutationError(error)) {
+          return
         }
-      )
+        if (isProtocolWritePermissionError(error)) {
+          setRunCreationError(
+            t(
+              'access_control:send_protocol_admin_credentials_required'
+            ) as string
+          )
+          return
+        }
+        const axiosError = error as AxiosError<{
+          errors: Array<{ id: string; detail: string; title: string }>
+        }>
+        const [errorDetail] = axiosError.response?.data?.errors ?? []
+        const { id, detail, title } = errorDetail ?? {}
+        if (id != null && detail != null && title != null) {
+          makeToast(detail, ERROR_TOAST, {
+            closeButton: true,
+            disableTimeout: true,
+            heading: `${protocolDisplayName} ${title} - ${
+              selectedRobot?.name ?? ''
+            }`,
+          })
+        } else {
+          makeToast(selectedRobot?.name ?? '', ERROR_TOAST, {
+            closeButton: true,
+            disableTimeout: true,
+            heading: `${t('unsuccessfully_sent')} ${protocolDisplayName}`,
+          })
+        }
+        onCloseClick()
+      })
   }
 
   return (
@@ -184,6 +202,10 @@ export function SendProtocolToFlexSlideout(
         selectedRobot={selectedRobot}
         setSelectedRobot={setSelectedRobot}
         robotType={FLEX_ROBOT_TYPE}
+        runCreationError={runCreationError}
+        reset={() => {
+          setRunCreationError(null)
+        }}
         isAnalysisError={analysisStatus === 'error'}
         isAnalysisStale={analysisStatus === 'stale'}
       />


### PR DESCRIPTION
Closes [RQA-5980](https://opentrons.atlassian.net/browse/RQA-5980)

# Overview

Updates the various desktop app slideout behavior to match designs, namely:

- We no longer show a toast when a user doesn't have permission to send a protocol to a robot (which only sometimes happens...we often get a redirect to a failed protocol analysis). We now show more descriptive copy in the same pattern as before: copy below the robot card.
- Some robot card CSS for CRS bots didn't match designs, so it's updated here.
- We remove the disabled state when sending a protocol to the robot and instead show "Sending" with a spinner. Clicking the button simple doesn't perform the onClick now.

### Current behavior

https://github.com/user-attachments/assets/c958076f-dcdd-414e-99c7-2bdc74d45994

### Fixed behavior

https://github.com/user-attachments/assets/77224c96-36a9-461d-be5c-27e13e83c5fa

## Test Plan and Hands on Testing

- See videos

## Changelog

- Updated the various desktop app slideouts to properly show errors when users without permissions attempt to send protocols to a CRS-enabled robot.

## Risk assessment

- low, it's a large diff, but it's just updating copy and modifying CSS in the various slideout components. 


[RQA-5980]: https://opentrons.atlassian.net/browse/RQA-5980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ