### PR TITLE
fix(ci): gate GitHub releases on successful PyPI publishes

### DIFF
--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -198,8 +198,35 @@ jobs:
           repository_url: 'https://test.pypi.org/legacy/'
           password: '${{ secrets.TEST_PYPI_DEPLOY_TOKEN_OPENTRONS }}'
       - if: startsWith(env.OT_TAG, 'v')
+        id: pypi-upload
         name: 'upload to real pypi'
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
         with:
           packages-dir: api/dist/
           repository-url: https://upload.pypi.org/legacy/
+      - if: startsWith(github.ref, 'refs/tags/v')
+        name: 'confirm the pypi upload actually ran'
+        run: |
+          if [ "${{ steps.pypi-upload.outcome }}" != "success" ]; then
+            echo "::error::Release tag ${{ github.ref_name }} did not publish opentrons to PyPI" \
+                 "(upload outcome: ${{ steps.pypi-upload.outcome || 'skipped' }}, OT_TAG: '${OT_TAG:-}')."
+            exit 1
+          fi
+
+  # A release tag that does not reach PyPI must be a hard failure rather than a
+  # silently skipped job, because "Create github release for tag" gates on this.
+  publish-required:
+    name: 'require pypi publish on release tags'
+    needs: [deploy]
+    runs-on: 'ubuntu-24.04'
+    if: always() && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: 'check deploy result'
+        run: |
+          result='${{ needs.deploy.result }}'
+          if [ "$result" != "success" ]; then
+            echo "::error::Release tag ${{ github.ref_name }} did not publish the opentrons package" \
+                 "to PyPI (deploy job result: $result)."
+            exit 1
+          fi
+          echo "opentrons package published for ${{ github.ref_name }}."

--- a/.github/workflows/app-build-deploy.yaml
+++ b/.github/workflows/app-build-deploy.yaml
@@ -208,6 +208,9 @@ jobs:
         if: needs.determine-build-type.outputs.type == 'release'
         with:
           allowUpdates: true
+          # Only applies when this step creates the release, which happens if it wins the
+          # race with "Create github release for tag". Never publish that one live.
+          draft: true
           omitBodyDuringUpdate: true
           omitDraftDuringUpdate: true
           omitNameDuringUpdate: true
@@ -219,6 +222,7 @@ jobs:
         if: needs.determine-build-type.outputs.type == 'release'
         with:
           allowUpdates: true
+          draft: true
           omitBodyDuringUpdate: true
           omitDraftDuringUpdate: true
           omitNameDuringUpdate: true
@@ -230,6 +234,7 @@ jobs:
         if: needs.determine-build-type.outputs.type == 'release'
         with:
           allowUpdates: true
+          draft: true
           omitBodyDuringUpdate: true
           omitDraftDuringUpdate: true
           omitNameDuringUpdate: true

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -306,6 +306,9 @@ jobs:
         if: needs.determine-build-type.outputs.type == 'release'
         with:
           allowUpdates: true
+          # Only applies when this step creates the release, which happens if it wins the
+          # race with "Create github release for tag". Never publish that one live.
+          draft: true
           omitBodyDuringUpdate: true
           omitDraftDuringUpdate: true
           omitNameDuringUpdate: true
@@ -317,6 +320,7 @@ jobs:
         if: needs.determine-build-type.outputs.type == 'release'
         with:
           allowUpdates: true
+          draft: true
           omitBodyDuringUpdate: true
           omitDraftDuringUpdate: true
           omitNameDuringUpdate: true
@@ -328,6 +332,7 @@ jobs:
         if: needs.determine-build-type.outputs.type == 'release'
         with:
           allowUpdates: true
+          draft: true
           omitBodyDuringUpdate: true
           omitDraftDuringUpdate: true
           omitNameDuringUpdate: true

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -177,11 +177,38 @@ jobs:
           repository_url: 'https://test.pypi.org/legacy/'
           password: '${{ secrets.TEST_PYPI_DEPLOY_TOKEN_OPENTRONS_SHARED_DATA }}'
       - if: startsWith(env.OT_TAG, 'v')
+        id: pypi-upload
         name: 'upload to pypi'
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
         with:
           packages-dir: shared-data/dist/
           repository-url: https://upload.pypi.org/legacy/
+      - if: startsWith(github.ref, 'refs/tags/v')
+        name: 'confirm the pypi upload actually ran'
+        run: |
+          if [ "${{ steps.pypi-upload.outcome }}" != "success" ]; then
+            echo "::error::Release tag ${{ github.ref_name }} did not publish opentrons-shared-data to PyPI" \
+                 "(upload outcome: ${{ steps.pypi-upload.outcome || 'skipped' }}, OT_TAG: '${OT_TAG:-}')."
+            exit 1
+          fi
+
+  # A release tag that does not reach PyPI must be a hard failure rather than a
+  # silently skipped job, because "Create github release for tag" gates on this.
+  publish-required:
+    name: 'require pypi publish on release tags'
+    needs: [python-deploy]
+    runs-on: 'ubuntu-24.04'
+    if: always() && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: 'check deploy result'
+        run: |
+          result='${{ needs.python-deploy.result }}'
+          if [ "$result" != "success" ]; then
+            echo "::error::Release tag ${{ github.ref_name }} did not publish the opentrons-shared-data" \
+                 "package to PyPI (python-deploy job result: $result)."
+            exit 1
+          fi
+          echo "opentrons-shared-data package published for ${{ github.ref_name }}."
 
   publish-switch:
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/tag-releases.yaml
+++ b/.github/workflows/tag-releases.yaml
@@ -9,9 +9,75 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Robot-stack release tags publish opentrons and opentrons-shared-data to PyPI from
+  # separate workflows. Those are independent runs, so without this wait a release could be
+  # cut while a PyPI publish had failed or been skipped. Other tags (labware-library@,
+  # components@, ai-client@, ...) do not trigger those workflows, so they skip this job.
+  await-pypi-deploys:
+    runs-on: 'ubuntu-24.04'
+    name: 'Wait for PyPI deploys'
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      actions: read
+    steps:
+      - name: 'wait for api and shared-data deploys'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # Deliberately excludes "App test, build, and deploy": it uploads installers into
+          # this release, so gating release creation on it would deadlock.
+          REQUIRED_WORKFLOWS: 'API test/lint/deploy,shared-data test/lint/deploy'
+          HEAD_SHA: ${{ github.sha }}
+          TIMEOUT_MINUTES: '90'
+        run: |
+          set -euo pipefail
+          deadline=$(( SECONDS + TIMEOUT_MINUTES * 60 ))
+          failed=0
+          IFS=',' read -ra workflows <<< "$REQUIRED_WORKFLOWS"
+          for workflow in "${workflows[@]}"; do
+            echo "::group::${workflow}"
+            conclusion=''
+            while :; do
+              # The tag push fans out to sibling runs on the same commit; find this one.
+              read -r status conclusion < <(
+                gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${HEAD_SHA}&per_page=100" \
+                  --jq "[.workflow_runs[]
+                         | select(.name == \"${workflow}\" and .event == \"push\")]
+                        | sort_by(.run_started_at)
+                        | last
+                        | \"\(.status) \(.conclusion // \"\")\"" 2>/dev/null || echo "missing "
+              )
+              if [ "$status" = "missing" ] || [ -z "$status" ] || [ "$status" = "null" ]; then
+                echo "waiting: run not registered yet"
+              elif [ "$status" != "completed" ]; then
+                echo "waiting: $status"
+              else
+                echo "completed: $conclusion"
+                break
+              fi
+              if [ "$SECONDS" -ge "$deadline" ]; then
+                echo "::error::Timed out after ${TIMEOUT_MINUTES}m waiting for '${workflow}'."
+                failed=1
+                break
+              fi
+              sleep 30
+            done
+            if [ "$status" = "completed" ] && [ "$conclusion" != "success" ]; then
+              echo "::error::'${workflow}' concluded '${conclusion}' for ${GITHUB_REF_NAME}; not creating a release."
+              failed=1
+            fi
+            echo "::endgroup::"
+          done
+          if [ "$failed" -ne 0 ]; then
+            exit 1
+          fi
+          echo "All required PyPI deploys succeeded for ${GITHUB_REF_NAME}."
+
   create-release:
     runs-on: 'ubuntu-24.04'
     name: 'Create changelogs and release'
+    needs: [await-pypi-deploys]
+    # await-pypi-deploys is skipped for non-v tags, which would otherwise skip this job too.
+    if: always() && needs.await-pypi-deploys.result != 'failure' && needs.await-pypi-deploys.result != 'cancelled'
     steps:
       # this could be improved by replacing this checkout with something like
       # mkdir opentrons ; git init . ;

--- a/scripts/deploy/create-release.js
+++ b/scripts/deploy/create-release.js
@@ -15,6 +15,8 @@
 //             false-positive. Set this flag to not do that check.
 // The release will be created as a prerelease if this is a prerelease tag.
 // It will always be created as a draft so that humans can review it before it goes live.
+// If a release for the tag already exists, its changelog is filled in instead and its
+// draft state is left alone.
 //
 // The changelog content will be in the body of the release.
 
@@ -187,6 +189,25 @@ async function buildChangelog(project, currentVersion, previousVersion) {
   return changelog
 }
 
+// The app build uploads its installers into the release for the tag, and will create the
+// release itself if it does not exist yet. Since this script can now run after that upload,
+// adopt any existing release for the tag rather than failing on a duplicate.
+async function existingReleaseForTag(octokit, tag) {
+  try {
+    const { data } = await octokit.rest.repos.getReleaseByTag({
+      owner: REPO_DETAILS.owner,
+      repo: REPO_DETAILS.repo,
+      tag,
+    })
+    return data
+  } catch (error) {
+    if (error.status === 404) {
+      return null
+    }
+    throw error
+  }
+}
+
 async function createRelease(token, tag, project, version, changelog, deploy) {
   const title = titleForRelease(project, version)
   const isPre = !!semver.prerelease(version)
@@ -195,6 +216,21 @@ async function createRelease(token, tag, project, version, changelog, deploy) {
       auth: token,
       userAgent: 'Opentrons Release Creator',
     })
+    const existing = await existingReleaseForTag(octokit, tag)
+    if (existing !== null) {
+      console.log(
+        `Release for ${tag} already exists (id ${existing.id}); adding the changelog to it.`
+      )
+      const { data } = await octokit.rest.repos.updateRelease({
+        owner: REPO_DETAILS.owner,
+        repo: REPO_DETAILS.repo,
+        release_id: existing.id,
+        name: title,
+        body: changelog,
+        prerelease: isPre,
+      })
+      return data.html_url
+    }
     const { data } = await octokit.rest.repos.createRelease({
       owner: REPO_DETAILS.owner,
       repo: REPO_DETAILS.repo,


### PR DESCRIPTION
## Summary
- Block `Create github release for tag` on `v*` tags until `API test/lint/deploy` and `shared-data test/lint/deploy` both succeed, so a failed or skipped `opentrons` PyPI upload cannot ship a GitHub release the way `v9.1.2` did.
- Fail those PyPI workflows when a `v*` tag does not actually upload, instead of treating a skipped deploy job as success.
- If the app workflow creates the GitHub release first, keep it as a draft and have `create-release.js` fill in the changelog rather than erroring on a duplicate.

## Test plan
- [ ] Confirm a non-`v*` tag (e.g. `labware-library@` / `workflow_dispatch`) still creates a GitHub release without waiting on PyPI workflows.
- [ ] Confirm a `v*` tag whose API deploy fails or is skipped does **not** create a GitHub release, and that both `API test/lint/deploy` and `Create github release for tag` are red.
- [ ] Confirm a `v*` tag whose API and shared-data deploys succeed still creates a draft GitHub release with changelog and app installers.
- [ ] Confirm app installer uploads still attach when they win the race and create the release first (release remains draft).