### PR TITLE
refactor(app): update device details tab gap size

### DIFF
--- a/app/src/pages/Desktop/Devices/DeviceDetails/devicedetails.module.css
+++ b/app/src/pages/Desktop/Devices/DeviceDetails/devicedetails.module.css
@@ -10,5 +10,5 @@
 .tab_group {
   display: flex;
   flex-direction: row;
-  gap: var(--spacing-8);
+  gap: var(--spacing-4);
 }


### PR DESCRIPTION
Closes [RQA-6041](https://opentrons.atlassian.net/browse/RQA-6041)

# Overview

Updates the tab gap size to match designs: 8px to 4px!

### Current behavior

<img width="1018" height="763" alt="Screenshot 2026-08-28 at 1 42 02 PM" src="https://github.com/user-attachments/assets/5f93a7d4-f1a9-45c0-a533-6fa03cbf29bc" />

### Fixed behavior

<img width="1020" height="763" alt="Screenshot 2026-08-28 at 1 45 16 PM" src="https://github.com/user-attachments/assets/37d4c638-7964-4891-a1a2-4652e9b96fba" />

## Test Plan and Hands on Testing

- See images

## Risk assessment

- none!


[RQA-6041]: https://opentrons.atlassian.net/browse/RQA-6041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ