### PR TITLE
refactor(app): fix "reset password" flow requiring documentation

### DIFF
--- a/app/src/organisms/Desktop/LoginModal/__tests__/LoginModal.test.tsx
+++ b/app/src/organisms/Desktop/LoginModal/__tests__/LoginModal.test.tsx
@@ -338,8 +338,70 @@ describe('LoginModal', () => {
     screen.getByText('Your password has expired')
     screen.getByText('Create a new password to use')
     expect(screen.getByLabelText('New password')).toHaveFocus()
-    screen.getByLabelText('Confirm password')
+    expect(screen.getByLabelText('New password')).toHaveAttribute(
+      'type',
+      'password'
+    )
+    expect(screen.getByLabelText('Confirm password')).toHaveAttribute(
+      'type',
+      'password'
+    )
+    expect(
+      screen.getAllByRole('button', { name: 'Toggle password visibility' })
+    ).toHaveLength(2)
     screen.getByRole('button', { name: 'Confirm' })
+  })
+
+  it('toggles new and confirm password visibility independently', () => {
+    mockLoginRequiringPasswordReset()
+
+    renderAndOpenLoginModal()
+    logInWithTempPassword()
+
+    fireEvent.change(screen.getByLabelText('New password'), {
+      target: { value: 'new-password' },
+    })
+    fireEvent.change(screen.getByLabelText('Confirm password'), {
+      target: { value: 'new-password' },
+    })
+
+    const [newPasswordToggle, confirmPasswordToggle] = screen.getAllByRole(
+      'button',
+      { name: 'Toggle password visibility' }
+    )
+
+    fireEvent.click(newPasswordToggle)
+    expect(screen.getByLabelText('New password')).toHaveAttribute(
+      'type',
+      'text'
+    )
+    expect(screen.getByLabelText('Confirm password')).toHaveAttribute(
+      'type',
+      'password'
+    )
+    expect(newPasswordToggle).toHaveAttribute('aria-pressed', 'true')
+    expect(confirmPasswordToggle).toHaveAttribute('aria-pressed', 'false')
+
+    fireEvent.click(confirmPasswordToggle)
+    expect(screen.getByLabelText('New password')).toHaveAttribute(
+      'type',
+      'text'
+    )
+    expect(screen.getByLabelText('Confirm password')).toHaveAttribute(
+      'type',
+      'text'
+    )
+    expect(confirmPasswordToggle).toHaveAttribute('aria-pressed', 'true')
+
+    fireEvent.click(newPasswordToggle)
+    expect(screen.getByLabelText('New password')).toHaveAttribute(
+      'type',
+      'password'
+    )
+    expect(screen.getByLabelText('Confirm password')).toHaveAttribute(
+      'type',
+      'text'
+    )
   })
 
   it('logs out when closing the set new password view', () => {

--- a/app/src/organisms/Desktop/LoginModal/__tests__/LoginModal.test.tsx
+++ b/app/src/organisms/Desktop/LoginModal/__tests__/LoginModal.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { useRobot } from '/app/redux-resources/robots'
 import { mockConnectableRobot } from '/app/redux/discovery/__fixtures__'
 import { logOut } from '/app/redux/robot-auth'
@@ -22,6 +23,9 @@ import type { AuthUser, OAuth2TokenResponse } from '@opentrons/api-client'
 
 vi.mock('/app/resources/access-control/useStoreLoginState')
 vi.mock('/app/resources/auth')
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
 vi.mock('/app/resources/client_data/encryptionKeys')
 vi.mock('/app/redux/shell/remote', () => ({
   appShellListener: vi.fn(),
@@ -114,13 +118,15 @@ function mockLoginSSLError(): void {
 function mockSetNewPasswordSuccess(
   onSubmit?: (username: string, password: string) => void
 ): void {
-  vi.mocked(useSetNewPasswordAndSignIn).mockImplementation(({ onSuccess }) => ({
-    submitNewPassword: (username: string, password: string) => {
-      onSubmit?.(username, password)
-      onSuccess(username, password)
-    },
-    isLoading: false,
-  }))
+  vi.mocked(useSetNewPasswordAndSignIn).mockImplementation(
+    (_documentationState, { onSuccess }) => ({
+      submitNewPassword: (username: string, password: string) => {
+        onSubmit?.(username, password)
+        onSuccess(username, password)
+      },
+      isLoading: false,
+    })
+  )
 }
 
 const renderAndOpenLoginModal = (): void => {

--- a/app/src/organisms/Desktop/LoginModal/index.tsx
+++ b/app/src/organisms/Desktop/LoginModal/index.tsx
@@ -504,6 +504,21 @@ function SetNewPasswordView(props: SetNewPasswordViewProps): JSX.Element {
     onPasswordFieldBlur,
   } = props
   const { t } = useTranslation()
+  const [showNewPassword, setShowNewPassword] = useState(false)
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false)
+  const newPasswordInputRef = useRef<HTMLInputElement>(null)
+  const confirmPasswordInputRef = useRef<HTMLInputElement>(null)
+
+  usePlaceCaretAtEndOnToggle(newPasswordInputRef, showNewPassword, true)
+  usePlaceCaretAtEndOnToggle(confirmPasswordInputRef, showConfirmPassword, true)
+
+  const handleToggleNewPasswordVisibility = (): void => {
+    setShowNewPassword(current => !current)
+  }
+
+  const handleToggleConfirmPasswordVisibility = (): void => {
+    setShowConfirmPassword(current => !current)
+  }
 
   return (
     <>
@@ -518,12 +533,13 @@ function SetNewPasswordView(props: SetNewPasswordViewProps): JSX.Element {
 
       <div className={styles.fields_container}>
         <InputField
+          ref={newPasswordInputRef}
           autoFocus
           name="newPassword"
           title={t(
             'access_control:desktop_password_expired_new_password_field'
           )}
-          type="password"
+          type={showNewPassword ? 'text' : 'password'}
           value={formData.newPassword}
           error={formData.error ?? undefined}
           onChange={event => {
@@ -532,13 +548,21 @@ function SetNewPasswordView(props: SetNewPasswordViewProps): JSX.Element {
           onBlur={() => {
             onPasswordFieldBlur()
           }}
+          rightElement={
+            <PasswordVisibilityToggle
+              isVisible={showNewPassword}
+              onToggle={handleToggleNewPasswordVisibility}
+              iconOnly
+            />
+          }
         />
         <InputField
+          ref={confirmPasswordInputRef}
           name="confirmPassword"
           title={t(
             'access_control:desktop_password_expired_confirm_password_field'
           )}
-          type="password"
+          type={showConfirmPassword ? 'text' : 'password'}
           value={formData.confirmPassword}
           error={formData.confirmPasswordError ?? undefined}
           onChange={event => {
@@ -547,6 +571,13 @@ function SetNewPasswordView(props: SetNewPasswordViewProps): JSX.Element {
           onBlur={() => {
             onPasswordFieldBlur()
           }}
+          rightElement={
+            <PasswordVisibilityToggle
+              isVisible={showConfirmPassword}
+              onToggle={handleToggleConfirmPasswordVisibility}
+              iconOnly
+            />
+          }
         />
       </div>
     </>

--- a/app/src/organisms/Desktop/LoginModal/index.tsx
+++ b/app/src/organisms/Desktop/LoginModal/index.tsx
@@ -20,6 +20,7 @@ import {
 import { useHost } from '@opentrons/react-api-client'
 
 import { getTopPortalEl } from '/app/App/portal'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { usePlaceCaretAtEndOnToggle } from '/app/local-resources/access-control/usePlaceCaretAtEndOnToggle'
 import { ApiHostProvider } from '/app/local-resources/api-host-provider/ApiHostProvider'
 import { PasswordVisibilityToggle } from '/app/molecules/PasswordVisibilityToggle'
@@ -178,8 +179,9 @@ function LoginModalImpl(props: LoginModalImplProps): JSX.Element {
     onError: handleError,
   })
 
+  const documentationState = useDocumentationState(undefined, robotName)
   const { submitNewPassword, isLoading: isSetNewPasswordLoading } =
-    useSetNewPasswordAndSignIn({
+    useSetNewPasswordAndSignIn(documentationState, {
       onSuccess: (successfulUsername, _newPassword) => {
         dispatch(logOut({ robotName }))
         setScreen({
@@ -308,8 +310,9 @@ function LoginModalImpl(props: LoginModalImplProps): JSX.Element {
       <Modal
         title={t('access_control:desktop_login_modal_header')}
         onClose={uncloseable ? undefined : handleClose}
-        // Above SignRun and other run-header modals (zIndexOverlay: 1000).
-        zIndexOverlay={10001}
+        // Login is 10001 so it sits above SignRun (1000) and documentation (10000).
+        // Drop to 9999 on set-new-password so the documentation modal is visible.
+        zIndexOverlay={screen.kind === 'setNewPassword' ? 9999 : 10001}
         footer={<div className={styles.modal_footer_container}>{footer}</div>}
       >
         <div className={styles.content_container}>

--- a/app/src/organisms/ODD/OnDeviceLogin/LoginModal.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginModal.tsx
@@ -2,6 +2,7 @@ import { useCallback, useId, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import NiceModal, { useModal } from '@ebay/nice-modal-react'
+import clsx from 'clsx'
 
 import {
   POSITION_FIXED,
@@ -11,6 +12,7 @@ import {
 } from '@opentrons/components'
 import { useAuthSettingsQuery } from '@opentrons/react-api-client'
 
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { getLocalRobot } from '/app/redux/discovery'
 import { useUsernameForRobot } from '/app/redux/robot-auth'
 import { useStoreLoginState } from '/app/resources/access-control/useStoreLoginState'
@@ -105,8 +107,9 @@ const LoginModalImpl = NiceModal.create((): JSX.Element => {
     [submitPassword]
   )
 
+  const documentationState = useDocumentationState()
   const { submitNewPassword, isLoading: isSetNewPasswordLoading } =
-    useSetNewPasswordAndSignIn({
+    useSetNewPasswordAndSignIn(documentationState, {
       onSuccess: handleNewPasswordSuccess,
       onError: message => {
         setLoginError(message)
@@ -138,7 +141,12 @@ const LoginModalImpl = NiceModal.create((): JSX.Element => {
       : loginUsername
 
   return (
-    <div className={styles.overlay}>
+    <div
+      className={clsx(
+        styles.overlay,
+        isChoosingNewPassword && styles.overlay_below_documentation
+      )}
+    >
       <OnDeviceLogin
         key={phase}
         step={step}

--- a/app/src/organisms/ODD/OnDeviceLogin/OnDeviceLogin.module.css
+++ b/app/src/organisms/ODD/OnDeviceLogin/OnDeviceLogin.module.css
@@ -44,3 +44,8 @@
   background-color: var(--white);
   inset: 0;
 }
+
+/* Sit below the documentation overlay (z-index 1000) while choosing a new password. */
+.overlay_below_documentation {
+  z-index: 999;
+}

--- a/app/src/organisms/ODD/OnDeviceLogin/__tests__/LoginModal.test.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/__tests__/LoginModal.test.tsx
@@ -9,6 +9,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { mockConnectableRobot } from '/app/redux/discovery/__fixtures__'
 import { robotAuthReducer } from '/app/redux/robot-auth/slice'
 import {
@@ -29,6 +30,9 @@ vi.mock('/app/redux/discovery', async importOriginal => {
 })
 
 vi.mock('/app/resources/auth')
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
 
 const OAUTH_RESPONSE: OAuth2TokenResponse = {
   token_type: 'Bearer',
@@ -56,12 +60,14 @@ function mockSuccessfulLogin(): void {
     isAuthLoading: false,
   }))
 
-  vi.mocked(useSetNewPasswordAndSignIn).mockImplementation(({ onSuccess }) => ({
-    submitNewPassword: (username: string, password: string) => {
-      onSuccess(username, password)
-    },
-    isLoading: false,
-  }))
+  vi.mocked(useSetNewPasswordAndSignIn).mockImplementation(
+    (_documentationState, { onSuccess }) => ({
+      submitNewPassword: (username: string, password: string) => {
+        onSuccess(username, password)
+      },
+      isLoading: false,
+    })
+  )
 }
 
 function setupLoginModalTrigger(): () => ReturnType<typeof showLoginModal> {
@@ -225,7 +231,7 @@ describe('LoginModal', () => {
       isAuthLoading: false,
     }))
     vi.mocked(useSetNewPasswordAndSignIn).mockImplementation(
-      ({ onSuccess }) => ({
+      (_documentationState, { onSuccess }) => ({
         submitNewPassword: (username: string, password: string) => {
           onSuccess(username, password)
         },
@@ -264,12 +270,14 @@ describe('LoginModal', () => {
       },
       isAuthLoading: false,
     }))
-    vi.mocked(useSetNewPasswordAndSignIn).mockImplementation(({ onError }) => ({
-      submitNewPassword: () => {
-        onError('Must include at least one special character')
-      },
-      isLoading: false,
-    }))
+    vi.mocked(useSetNewPasswordAndSignIn).mockImplementation(
+      (_documentationState, { onError }) => ({
+        submitNewPassword: () => {
+          onError('Must include at least one special character')
+        },
+        isLoading: false,
+      })
+    )
 
     const clickOpenLoginModal = setupLoginModalTrigger()
     void clickOpenLoginModal()

--- a/app/src/resources/auth/hooks/__tests__/useSetNewPasswordAndSignIn.test.ts
+++ b/app/src/resources/auth/hooks/__tests__/useSetNewPasswordAndSignIn.test.ts
@@ -1,18 +1,15 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { DocumentedMutationError } from '@opentrons/react-api-client'
+
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
+
 import { useSetNewPasswordAndSignIn } from '../useSetNewPasswordAndSignIn'
 
 const mockUpdateSelf = vi.fn()
 const mockUseHost = vi.fn()
-
-vi.mock('@opentrons/api-client', async importOriginal => {
-  const actual = (await importOriginal()) as Record<string, unknown>
-  return {
-    ...actual,
-    updateSelf: (...args: unknown[]) => mockUpdateSelf(...args),
-  }
-})
+const mockUseUpdateSelfMutation = vi.fn()
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -25,6 +22,8 @@ vi.mock('@opentrons/react-api-client', async importOriginal => {
   return {
     ...actual,
     useHost: () => mockUseHost(),
+    useUpdateSelfMutation: (...args: unknown[]) =>
+      mockUseUpdateSelfMutation(...args),
   }
 })
 
@@ -35,9 +34,14 @@ describe('useSetNewPasswordAndSignIn', () => {
 
   beforeEach(() => {
     mockUpdateSelf.mockReset()
+    mockUseUpdateSelfMutation.mockReset()
     onSuccess.mockReset()
     onError.mockReset()
     mockUseHost.mockReturnValue(host)
+    mockUseUpdateSelfMutation.mockReturnValue({
+      updateSelf: mockUpdateSelf,
+      isLoading: false,
+    })
     mockUpdateSelf.mockResolvedValue({
       data: {
         username: 'alice',
@@ -49,23 +53,35 @@ describe('useSetNewPasswordAndSignIn', () => {
     })
   })
 
-  it('patches self with the new password', async () => {
-    const { result } = renderHook(() =>
-      useSetNewPasswordAndSignIn({ onSuccess, onError })
+  const renderSubject = (): {
+    result: { current: ReturnType<typeof useSetNewPasswordAndSignIn> }
+  } =>
+    renderHook(() =>
+      useSetNewPasswordAndSignIn(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE, {
+        onSuccess,
+        onError,
+      })
     )
+
+  it('passes documentation state to useUpdateSelfMutation', () => {
+    renderSubject()
+
+    expect(mockUseUpdateSelfMutation).toHaveBeenCalledWith(
+      ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+    )
+  })
+
+  it('patches self with the new password', async () => {
+    const { result } = renderSubject()
 
     act(() => {
       result.current.submitNewPassword('alice', 'new-secret')
     })
 
     await waitFor(() => {
-      expect(mockUpdateSelf).toHaveBeenCalledWith(
-        host,
-        {
-          data: { password: 'new-secret' },
-        },
-        ''
-      )
+      expect(mockUpdateSelf).toHaveBeenCalledWith({
+        data: { password: 'new-secret' },
+      })
     })
     await waitFor(() => {
       expect(onSuccess).toHaveBeenCalledWith('alice', 'new-secret')
@@ -76,9 +92,7 @@ describe('useSetNewPasswordAndSignIn', () => {
   it('reports not signed in when host or token is missing', () => {
     mockUseHost.mockReturnValue({ hostname: 'localhost' })
 
-    const { result } = renderHook(() =>
-      useSetNewPasswordAndSignIn({ onSuccess, onError })
-    )
+    const { result } = renderSubject()
 
     act(() => {
       result.current.submitNewPassword('alice', 'new-secret')
@@ -105,9 +119,7 @@ describe('useSetNewPasswordAndSignIn', () => {
       },
     })
 
-    const { result } = renderHook(() =>
-      useSetNewPasswordAndSignIn({ onSuccess, onError })
-    )
+    const { result } = renderSubject()
 
     act(() => {
       result.current.submitNewPassword('alice', 'short')
@@ -129,9 +141,7 @@ describe('useSetNewPasswordAndSignIn', () => {
       },
     })
 
-    const { result } = renderHook(() =>
-      useSetNewPasswordAndSignIn({ onSuccess, onError })
-    )
+    const { result } = renderSubject()
 
     act(() => {
       result.current.submitNewPassword('alice', 'same-as-current')
@@ -159,9 +169,7 @@ describe('useSetNewPasswordAndSignIn', () => {
       },
     })
 
-    const { result } = renderHook(() =>
-      useSetNewPasswordAndSignIn({ onSuccess, onError })
-    )
+    const { result } = renderSubject()
 
     act(() => {
       result.current.submitNewPassword('alice', 'short')
@@ -183,9 +191,7 @@ describe('useSetNewPasswordAndSignIn', () => {
       },
     })
 
-    const { result } = renderHook(() =>
-      useSetNewPasswordAndSignIn({ onSuccess, onError })
-    )
+    const { result } = renderSubject()
 
     act(() => {
       result.current.submitNewPassword('alice', 'password123')
@@ -202,9 +208,7 @@ describe('useSetNewPasswordAndSignIn', () => {
   it('reports failure when patch self request fails', async () => {
     mockUpdateSelf.mockRejectedValue(new Error('network'))
 
-    const { result } = renderHook(() =>
-      useSetNewPasswordAndSignIn({ onSuccess, onError })
-    )
+    const { result } = renderSubject()
 
     act(() => {
       result.current.submitNewPassword('alice', 'new-secret')
@@ -215,6 +219,24 @@ describe('useSetNewPasswordAndSignIn', () => {
         'set_new_password_error_update_failed'
       )
     })
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  it('does not report an error when the documentation modal is cancelled', async () => {
+    mockUpdateSelf.mockRejectedValue(
+      new DocumentedMutationError('no_documentation_report')
+    )
+
+    const { result } = renderSubject()
+
+    act(() => {
+      result.current.submitNewPassword('alice', 'new-secret')
+    })
+
+    await waitFor(() => {
+      expect(mockUpdateSelf).toHaveBeenCalled()
+    })
+    expect(onError).not.toHaveBeenCalled()
     expect(onSuccess).not.toHaveBeenCalled()
   })
 })

--- a/app/src/resources/auth/hooks/useSetNewPasswordAndSignIn.ts
+++ b/app/src/resources/auth/hooks/useSetNewPasswordAndSignIn.ts
@@ -1,12 +1,16 @@
-import { useCallback, useState } from 'react'
+import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { updateSelf } from '@opentrons/api-client'
-import { useHost } from '@opentrons/react-api-client'
+import {
+  isDocumentedMutationError,
+  useHost,
+  useUpdateSelfMutation,
+} from '@opentrons/react-api-client'
 
 import { mapSetNewPasswordError } from '../mapAuthUserMutationError'
 
 import type { TFunction } from 'i18next'
+import type { DocumentationState } from '@opentrons/react-api-client'
 
 export interface UseSetNewPasswordAndSignInOptions {
   onSuccess: (username: string, password: string) => void
@@ -26,6 +30,7 @@ interface UseSetNewPasswordAndSignInResult {
  * sign the user in again with the new password so they receive a full-scope token.
  */
 export function useSetNewPasswordAndSignIn(
+  documentationState: DocumentationState,
   options: UseSetNewPasswordAndSignInOptions
 ): UseSetNewPasswordAndSignInResult {
   const { onSuccess, onError } = options
@@ -33,11 +38,11 @@ export function useSetNewPasswordAndSignIn(
     t: TFunction
   }
   const host = useHost()
-  const [isLoading, setIsLoading] = useState(false)
+  const { updateSelf, isLoading } = useUpdateSelfMutation(documentationState)
 
   const submitNewPassword = useCallback(
     (username: string, password: string): void => {
-      if (host == null || host.token == null) {
+      if (host?.token == null) {
         console.error('useSetNewPasswordAndSignIn: missing host token')
         onError(
           t('set_new_password_error_session_expired', {
@@ -47,26 +52,22 @@ export function useSetNewPasswordAndSignIn(
         return
       }
 
-      setIsLoading(true)
-      void (async () => {
-        try {
-          // ok so usually using react-api-client functions outside of mutations is bad
-          // but here, we need to specifically not ask for documentation as were in the middle of login
-          // eslint-disable-next-line opentrons/no-direct-mutating
-          await updateSelf(host, { data: { password } }, '')
+      void updateSelf({ data: { password } })
+        .then(() => {
           onSuccess(username, password)
-        } catch (error) {
+        })
+        .catch((error: unknown) => {
+          if (isDocumentedMutationError(error)) {
+            return
+          }
           console.error(
             'useSetNewPasswordAndSignIn: failed to update password',
             error
           )
           onError(mapSetNewPasswordError(error, t))
-        } finally {
-          setIsLoading(false)
-        }
-      })()
+        })
     },
-    [host, onError, onSuccess, t]
+    [host, onError, onSuccess, t, updateSelf]
   )
 
   return {


### PR DESCRIPTION
Closes [RQA-5893](https://opentrons.atlassian.net/browse/RQA-5893)

# Overview

After resetting a user's password via the admin console, once the user enters their OTP and attempts to update to a new password, the update fails due to a lack of supplied documentation.  To fix, we pop the documentation modal following existing patterns elsewhere in the app.

305a48cb4160bd4b960f5d688918ebd676bd42dc includes a minor visual update to add the show/hide buttons for that password update modal!

### Current behavior

https://github.com/user-attachments/assets/83382b88-dd2e-4eea-9af8-c44fa38c09cf

### Fixed behavior

https://github.com/user-attachments/assets/2b19071b-dcd1-463b-a79f-7877d3317fc8

<img width="470" height="350" alt="Screenshot 2026-08-28 at 4 49 21 PM" src="https://github.com/user-attachments/assets/808545a2-0aca-4497-aa5d-d3741d544fae" />


## Test Plan and Hands on Testing

- See videos

## Changelog

- Fixed users getting blocked when selecting a new password after an admin reset their password.

## Risk assessment

- lowish, all patterned behavior contained to the update password flow


[RQA-5893]: https://opentrons.atlassian.net/browse/RQA-5893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ