### PR TITLE
fix(step-generation): add setRailLights to case that does nothing

### DIFF
--- a/step-generation/src/getNextRobotStateAndWarnings/index.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/index.ts
@@ -208,6 +208,7 @@ function _getNextRobotStateAndWarningsSingleCommand(
       break
 
     // the following commands currently don't effect tracked robot state
+    case 'setRailLights':
     case 'touchTip': // pipetting
     case 'configureForVolume':
     case 'loadPipette': // setup VVV


### PR DESCRIPTION

# Overview
add setRailLights to case that does nothing for protocol-visualization and oai.


<img width="1111" height="462" alt="Screenshot 2026-08-28 at 10 14 26 AM" src="https://github.com/user-attachments/assets/bf88a888-20c0-4777-97a8-71d982b0c4dc" />

closes AUTH-3280

## Test Plan and Hands on Testing
- visualize the protocol that is attached to the ticket

## Changelog
- add `setRailLights` to switch statement

## Review requests


## Risk assessment
low
