### PR TITLE
fix(app): use robot name from ApiHostProvider if present

### DIFF
--- a/app/src/redux/robot-auth/hooks.ts
+++ b/app/src/redux/robot-auth/hooks.ts
@@ -2,6 +2,8 @@ import { useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useMatch } from 'react-router-dom'
 
+import { useHost } from '@opentrons/react-api-client'
+
 import { getIsOnDevice } from '../config'
 import { getLocalRobot } from '../discovery'
 import {
@@ -80,8 +82,12 @@ export function useCurrentRobotName(): string | null {
   const isOnDevice = useSelector(getIsOnDevice)
   const deviceRouteMatch = useMatch('/devices/:robotName/*')
   const localRobotName = useSelector(getLocalRobot)?.name ?? null
-  const desktopRobotName = deviceRouteMatch?.params?.robotName ?? null
-  return isOnDevice ? localRobotName : desktopRobotName
+  const desktopRouteRobotName = deviceRouteMatch?.params?.robotName ?? null
+  const desktopHostRobotName = useHost()?.robotName ?? null
+
+  return isOnDevice
+    ? localRobotName
+    : (desktopRouteRobotName ?? desktopHostRobotName)
 }
 
 /** Log out of the robot the user is currently acting on. */


### PR DESCRIPTION
# Overview

Currently, DocumentationRequired uses a redux selector that needs the current robot name to tell if a user is logged in or not. The hook in question used to only pull this name from the device route, which was problematic for popouts like the 'send protocol to robot' screen, since those did not have a robot name on the route. This fixes the `useCurrentRobotName` to also pull the robot name from any present ApiHostProvider contexts. 

Fixes [RQA 6036](https://opentrons.atlassian.net/browse/RQA-6036)

## Test Plan and Hands on Testing

Sending a protocol or csv file to a CRS enabled robot from the 'Start Setup' dropdown on the protocols tab of the app should prompt for login - login should work. Worth testing that this also works for robots connected over USB.

## Risk assessment

Low, but no clue why I didn't do this originally. What the hell. 