### PR TITLE
docs: Change Flex pipette systematic error value to 1.50%

### DIFF
--- a/docs/flex/docs/system-description/pipettes.md
+++ b/docs/flex/docs/system-description/pipettes.md
@@ -76,7 +76,7 @@ Flex 1-channel pipettes meet the following accuracy and precision specifications
       <td>50 µL</td>
       <td>10</td>
       <td>0.50%</td>
-      <td>±1.00%</td>
+      <td>±1.50%</td>
     </tr>
     <tr>
       <td>50 µL</td>


### PR DESCRIPTION
# Overview

This fixes an erroneous value in the 1-channel pipette specs table in the Flex manual. The value should be "1.50%." The manual and website show "1.00%." Website is being fixed. This PR takes care of our docs. See image attached. See linked JIRA issue for source (Slack).

<img width="1652" height="518" alt="Screenshot 2026-08-31 at 11 36 16 AM" src="https://github.com/user-attachments/assets/100646da-bce0-4218-a34a-d54bbbb9996f" />

Sandbox:  [1-channel pipette specifications](https://sandbox.docs.opentrons.com/flex-manual-update-pipette-specs/flex/system-description/pipettes/#1-channel-pipette-specifications)

RTC-1059

## Test Plan and Hands on Testing

n/a

## Changelog

Changes a reported value to 1.50% from 1.00%.

## Review requests

- Do we have these specs anywhere else?

## Risk assessment

Trivial
