### PR TITLE
fix(app): require login before downloading audit logs

### DIFF
--- a/app/src/assets/localization/en/access_control.json
+++ b/app/src/assets/localization/en/access_control.json
@@ -5,6 +5,7 @@
   "audit_log_download_required": "Audit log download required",
   "audit_log_download_required_description": "Download the robot's audit logs before continuing.",
   "cancel_action": "Cancel action",
+  "delete_audit_logs_permission_required": "Permission required to delete audit logs. Log in with an authorized account.",
   "desktop_login_form_heading": "Log in",
   "desktop_login_form_subheading": "Log in to access robot controls.",
   "desktop_login_modal_header": "Compliance Ready Software login",

--- a/app/src/local-resources/access-control/__fixtures__/documentationState.ts
+++ b/app/src/local-resources/access-control/__fixtures__/documentationState.ts
@@ -13,12 +13,25 @@ type AskForDocumentation = (
   username?: string
 ) => Promise<DocumentationReport>
 
+type AccessControlEnabledState = Extract<
+  DocumentationState,
+  { accessControlEnabled: true }
+>
+type ReasonNotRequiredState = Extract<
+  AccessControlEnabledState,
+  { reasonForInteractionRequired: false }
+>
+type ReasonRequiredState = Extract<
+  AccessControlEnabledState,
+  { reasonForInteractionRequired: true }
+>
+
 export const ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE: DocumentationState = {
   isLoading: false,
   accessControlEnabled: false,
 }
 
-export function createReasonNotRequiredDocumentationState(): DocumentationState {
+export function createReasonNotRequiredDocumentationState(): ReasonNotRequiredState {
   return {
     isLoading: false,
     accessControlEnabled: true,
@@ -30,7 +43,7 @@ export function createReasonNotRequiredDocumentationState(): DocumentationState 
 
 export function createReasonRequiredWithDocReport(
   docreport: DocumentationReport
-): DocumentationState {
+): ReasonRequiredState {
   return {
     isLoading: false,
     accessControlEnabled: true,
@@ -44,7 +57,7 @@ export function createReasonRequiredWithDocReport(
 
 export function createReasonRequiredWithoutDocReport(
   askForDocumentation: AskForDocumentation
-): DocumentationState {
+): ReasonRequiredState {
   return {
     isLoading: false,
     accessControlEnabled: true,

--- a/app/src/local-resources/access-control/__tests__/utils.test.ts
+++ b/app/src/local-resources/access-control/__tests__/utils.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  getAuditLogDeleteErrorMessage,
   getProtocolOrRunCreationErrorMessage,
+  isForbiddenError,
   isProtocolWritePermissionError,
 } from '../utils'
 
@@ -20,6 +22,53 @@ const permissionDeniedError = {
     },
   },
 }
+
+describe('isForbiddenError', () => {
+  it('is true for a 403 axios error', () => {
+    expect(isForbiddenError(permissionDeniedError)).toBe(true)
+  })
+
+  it('is false for a non-403 axios error', () => {
+    expect(
+      isForbiddenError({
+        isAxiosError: true,
+        response: { status: 500 },
+      })
+    ).toBe(false)
+  })
+
+  it('is false for a non-axios error', () => {
+    expect(
+      isForbiddenError(new Error('One or more logPeriods failed to delete'))
+    ).toBe(false)
+  })
+})
+
+describe('getAuditLogDeleteErrorMessage', () => {
+  const permissionMessage =
+    'Permission required to delete audit logs. Log in with an authorized account.'
+  const generalMessage = 'One or more logPeriods failed to delete'
+
+  it('returns the permission copy for a 403', () => {
+    expect(
+      getAuditLogDeleteErrorMessage(
+        permissionDeniedError,
+        permissionMessage,
+        generalMessage
+      )
+    ).toBe(permissionMessage)
+  })
+
+  it('returns the general copy for other errors', () => {
+    expect(
+      getAuditLogDeleteErrorMessage(
+        new Error(generalMessage),
+        permissionMessage,
+        generalMessage
+      )
+    ).toBe(generalMessage)
+  })
+})
 
 describe('isProtocolWritePermissionError', () => {
   it('is true for a 403 missing protocols.write', () => {

--- a/app/src/local-resources/access-control/utils.ts
+++ b/app/src/local-resources/access-control/utils.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 
+import type { AxiosError } from 'axios'
 import type {
   DocumentationReport,
   DocumentationState,
@@ -36,12 +37,27 @@ export const ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE: DocumentationState = {
   accessControlEnabled: false,
 }
 
+export function isForbiddenError(error: unknown): error is AxiosError {
+  return axios.isAxiosError(error) && error.response?.status === 403
+}
+
+export function getAuditLogDeleteErrorMessage(
+  error: unknown,
+  permissionErrorMessage: string,
+  generalErrorMessage: string
+): string {
+  if (isForbiddenError(error)) {
+    return permissionErrorMessage
+  }
+  return generalErrorMessage
+}
+
 export function isProtocolWritePermissionError(error: unknown): boolean {
-  if (!axios.isAxiosError(error) || error.response?.status !== 403) {
+  if (!isForbiddenError(error)) {
     return false
   }
   const requiredScopes = (
-    error.response.data as { requiredScopes?: unknown } | undefined
+    error.response?.data as { requiredScopes?: unknown } | undefined
   )?.requiredScopes
   return (
     Array.isArray(requiredScopes) &&

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
@@ -18,6 +18,7 @@ import {
 
 import { Skeleton } from '/app/atoms/Skeleton'
 import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
+import { getAuditLogDeleteErrorMessage } from '/app/local-resources/access-control/utils'
 import { DownloadAuditLogsModal } from '/app/organisms/Desktop/DownloadAuditLogsModal'
 import { useToaster } from '/app/organisms/ToasterOven'
 import { useEnsureAuditLogAuthorization } from '/app/resources/audit/useEnsureAuditLogAuthorization'
@@ -52,7 +53,7 @@ interface ComplianceReadySoftwareFilesProps {
 export function ComplianceReadySoftwareFiles({
   robotName,
 }: ComplianceReadySoftwareFilesProps): ReactNode {
-  const { t } = useTranslation('device_details')
+  const { t } = useTranslation(['device_details', 'access_control'])
   const { data: logPeriodSummariesData, status: logPeriodSummaryStatus } =
     useLogPeriodSummariesQuery()
   const { documentationState } = useLinkedDocumentationState(
@@ -224,7 +225,16 @@ export function ComplianceReadySoftwareFiles({
         })
         .catch((e: Error) => {
           if (!isDocumentedMutationError(e)) {
-            makeToast(e.message, ERROR_TOAST)
+            makeToast(
+              getAuditLogDeleteErrorMessage(
+                e,
+                t(
+                  'access_control:delete_audit_logs_permission_required'
+                ) as string,
+                e.message
+              ),
+              ERROR_TOAST
+            )
           } else {
             restoreDeleteModal()
           }

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
@@ -17,9 +17,10 @@ import {
 } from '@opentrons/react-api-client'
 
 import { Skeleton } from '/app/atoms/Skeleton'
-import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
 import { DownloadAuditLogsModal } from '/app/organisms/Desktop/DownloadAuditLogsModal'
 import { useToaster } from '/app/organisms/ToasterOven'
+import { useEnsureAuditLogAuthorization } from '/app/resources/audit/useEnsureAuditLogAuthorization'
 import { useDeleteSelectedLogPeriods } from '/app/resources/devices/hooks/useDeleteSelectedLogPeriods'
 import { useDownloadSelectedLogPeriods } from '/app/resources/devices/hooks/useDownloadSelectedLogPeriods'
 
@@ -33,6 +34,7 @@ import { LogPeriodRow } from './LogPeriodRow'
 import type { ReactNode } from 'react'
 import type { LogPeriodSummary } from '@opentrons/api-client'
 import type { IconProps } from '@opentrons/components'
+import type { DocumentedAction } from '@opentrons/react-api-client'
 import type { MakeToastOptions } from '/app/organisms/ToasterOven/ToasterContext'
 import type { DownloadedLogPeriod } from '/app/resources/devices/hooks/useDownloadSelectedLogPeriods'
 
@@ -40,6 +42,8 @@ const TOAST_STYLE: MakeToastOptions = {
   closeButton: true,
   width: '80%',
 }
+
+const DELETE_LOG_PERIODS_ACTIONS: DocumentedAction[] = ['delete_log_periods']
 
 interface ComplianceReadySoftwareFilesProps {
   robotName: string
@@ -51,7 +55,15 @@ export function ComplianceReadySoftwareFiles({
   const { t } = useTranslation('device_details')
   const { data: logPeriodSummariesData, status: logPeriodSummaryStatus } =
     useLogPeriodSummariesQuery()
-  const documentationState = useDocumentationState()
+  const { documentationState } = useLinkedDocumentationState(
+    DELETE_LOG_PERIODS_ACTIONS,
+    robotName,
+    robotName
+  )
+  const ensureAuthorized = useEnsureAuditLogAuthorization(
+    documentationState,
+    DELETE_LOG_PERIODS_ACTIONS
+  )
   const downloadLogPeriodsMutation = useDownloadSelectedLogPeriods(robotName)
   const {
     deleteSelectedLogPeriods,
@@ -98,6 +110,7 @@ export function ComplianceReadySoftwareFiles({
 
   const [showDeleteRecordsModal, setShowDeleteRecordsModal] =
     useState<boolean>(false)
+  const [isAuthorizing, setIsAuthorizing] = useState(false)
 
   const handleNoLogsSelected = useCallback(
     (type: 'delete' | 'download'): void => {
@@ -161,6 +174,23 @@ export function ComplianceReadySoftwareFiles({
       if (showModal) {
         setShowDeleteRecordsModal(false)
       }
+      const restoreDeleteModal = (): void => {
+        if (showModal) {
+          setShowDeleteRecordsModal(true)
+        }
+      }
+      setIsAuthorizing(true)
+      try {
+        await ensureAuthorized()
+      } catch (error) {
+        if (!isDocumentedMutationError(error)) {
+          makeToast((error as Error).message, ERROR_TOAST)
+        }
+        restoreDeleteModal()
+        return
+      } finally {
+        setIsAuthorizing(false)
+      }
       void downloadLogPeriodsMutation
         .mutateAsync({ logPeriods })
         .then(downloadedPeriods => {
@@ -196,14 +226,17 @@ export function ComplianceReadySoftwareFiles({
           if (!isDocumentedMutationError(e)) {
             makeToast(e.message, ERROR_TOAST)
           } else {
-            if (showModal) {
-              // reopen the delete modal if we fail; no flicker in practice
-              setShowDeleteRecordsModal(true)
-            }
+            restoreDeleteModal()
           }
         })
     },
-    [downloadLogPeriodsMutation, t, makeToast, deleteSelectedLogPeriods]
+    [
+      deleteSelectedLogPeriods,
+      downloadLogPeriodsMutation,
+      ensureAuthorized,
+      makeToast,
+      t,
+    ]
   )
 
   const handleDownloadSelected = useCallback(async (): Promise<void> => {
@@ -311,7 +344,9 @@ export function ComplianceReadySoftwareFiles({
       {showRequiredDownloadModal && (
         <DownloadAuditLogsModal
           onDownload={handleDownloadAndDeleteRequired}
-          isLoading={downloadLogPeriodsMutation.isLoading || isDeleting}
+          isLoading={
+            isAuthorizing || downloadLogPeriodsMutation.isLoading || isDeleting
+          }
         />
       )}
       <div className={fileManagerStyles.file_management_group}>

--- a/app/src/organisms/Desktop/DownloadAuditLogsModal/index.tsx
+++ b/app/src/organisms/Desktop/DownloadAuditLogsModal/index.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import NiceModal, { useModal } from '@ebay/nice-modal-react'
 
 import { Icon, Modal, PrimaryButton, StyledText } from '@opentrons/components'
+import { isDocumentedMutationError } from '@opentrons/react-api-client'
 
 import { getTopPortalEl } from '/app/App/portal'
 import { ApiHostProvider } from '/app/local-resources/api-host-provider/ApiHostProvider'
@@ -92,11 +93,13 @@ function DownloadAuditLogsModalContent({
     downloadAndDeleteAuditLog()
       .then(() => {
         modal.resolve(true)
+        modal.remove()
       })
-      .catch(error => {
+      .catch((error: unknown) => {
+        if (isDocumentedMutationError(error)) {
+          return
+        }
         modal.reject(error)
-      })
-      .finally(() => {
         modal.remove()
       })
   }

--- a/app/src/resources/audit/__tests__/useEnsureAuditLogAuthorization.test.ts
+++ b/app/src/resources/audit/__tests__/useEnsureAuditLogAuthorization.test.ts
@@ -1,0 +1,180 @@
+import { useStore } from 'react-redux'
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { isDocumentedMutationError } from '@opentrons/react-api-client'
+
+import {
+  ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+  createReasonNotRequiredDocumentationState,
+  createReasonRequiredWithDocReport,
+  createReasonRequiredWithoutDocReport,
+} from '/app/local-resources/access-control/__fixtures__/documentationState'
+import { getUsernameForRobot, useCurrentRobotName } from '/app/redux/robot-auth'
+
+import { useEnsureAuditLogAuthorization } from '../useEnsureAuditLogAuthorization'
+
+import type {
+  DocumentationReport,
+  DocumentationState,
+  DocumentedAction,
+} from '@opentrons/react-api-client'
+
+vi.mock('react-redux', async importOriginal => {
+  const actual = await importOriginal()
+  return {
+    ...(actual as Record<string, unknown>),
+    useStore: vi.fn(),
+  }
+})
+
+vi.mock('/app/redux/robot-auth', async importOriginal => {
+  const actual = await importOriginal()
+  return {
+    ...(actual as Record<string, unknown>),
+    useCurrentRobotName: vi.fn(),
+    getUsernameForRobot: vi.fn(),
+  }
+})
+
+const ACTIONS: DocumentedAction[] = ['download_log_period']
+const ROBOT_NAME = 'otie'
+const DOC_REPORT = 'because I said so' as DocumentationReport
+
+const mockStore = {
+  getState: vi.fn(() => ({})),
+}
+
+function renderEnsure(documentationState: DocumentationState) {
+  return renderHook(() =>
+    useEnsureAuditLogAuthorization(documentationState, ACTIONS)
+  )
+}
+
+describe('useEnsureAuditLogAuthorization', () => {
+  beforeEach(() => {
+    vi.mocked(useStore).mockReturnValue(mockStore as never)
+    vi.mocked(useCurrentRobotName).mockReturnValue(ROBOT_NAME)
+    vi.mocked(getUsernameForRobot).mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does nothing when access control is disabled', async () => {
+    const { result } = renderEnsure(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE)
+
+    await act(async () => {
+      await result.current()
+    })
+
+    expect(getUsernameForRobot).not.toHaveBeenCalled()
+  })
+
+  it('throws when access control queries are still loading', async () => {
+    const { result } = renderEnsure({ isLoading: true })
+
+    await act(async () => {
+      await expect(result.current()).rejects.toSatisfy(
+        error =>
+          isDocumentedMutationError(error) &&
+          error.type === 'access_control_loading'
+      )
+    })
+  })
+
+  it('throws when no robot is selected', async () => {
+    vi.mocked(useCurrentRobotName).mockReturnValue(null)
+    const { result } = renderEnsure(createReasonNotRequiredDocumentationState())
+
+    await act(async () => {
+      await expect(result.current()).rejects.toThrow('no robot selected')
+    })
+  })
+
+  it('prompts for login when there is no username', async () => {
+    const documentationState = createReasonNotRequiredDocumentationState()
+    const { result } = renderEnsure(documentationState)
+
+    await act(async () => {
+      await result.current()
+    })
+
+    expect(documentationState.askForLogin).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not prompt for login when a username is already present', async () => {
+    vi.mocked(getUsernameForRobot).mockReturnValue('alice')
+    const documentationState = createReasonNotRequiredDocumentationState()
+    const { result } = renderEnsure(documentationState)
+
+    await act(async () => {
+      await result.current()
+    })
+
+    expect(documentationState.askForLogin).not.toHaveBeenCalled()
+  })
+
+  it('throws login_cancelled when login is dismissed', async () => {
+    const documentationState = createReasonNotRequiredDocumentationState()
+    vi.mocked(documentationState.askForLogin).mockResolvedValue(null)
+    const { result } = renderEnsure(documentationState)
+
+    await act(async () => {
+      await expect(result.current()).rejects.toSatisfy(
+        error =>
+          isDocumentedMutationError(error) && error.type === 'login_cancelled'
+      )
+    })
+  })
+
+  it('prompts for documentation after a successful login', async () => {
+    const askForDocumentation = vi.fn().mockResolvedValue(DOC_REPORT)
+    const documentationState =
+      createReasonRequiredWithoutDocReport(askForDocumentation)
+    const { result } = renderEnsure(documentationState)
+
+    await act(async () => {
+      await result.current()
+    })
+
+    expect(documentationState.askForLogin).toHaveBeenCalledTimes(1)
+    expect(askForDocumentation).toHaveBeenCalledWith(
+      ACTIONS,
+      undefined,
+      undefined,
+      'alice'
+    )
+  })
+
+  it('skips documentation when a report is already present', async () => {
+    vi.mocked(getUsernameForRobot).mockReturnValue('alice')
+    const documentationState = createReasonRequiredWithDocReport(DOC_REPORT)
+    const { result } = renderEnsure(documentationState)
+
+    await act(async () => {
+      await result.current()
+    })
+
+    expect(documentationState.askForDocumentation).not.toHaveBeenCalled()
+  })
+
+  it('throws no_documentation_report when documentation is cancelled', async () => {
+    vi.mocked(getUsernameForRobot).mockReturnValue('alice')
+    const askForDocumentation = vi
+      .fn()
+      .mockResolvedValue('' as DocumentationReport)
+    const documentationState =
+      createReasonRequiredWithoutDocReport(askForDocumentation)
+    const { result } = renderEnsure(documentationState)
+
+    await act(async () => {
+      await expect(result.current()).rejects.toSatisfy(
+        error =>
+          isDocumentedMutationError(error) &&
+          error.type === 'no_documentation_report'
+      )
+    })
+  })
+})

--- a/app/src/resources/audit/useDownloadAndDeleteAuditLog.ts
+++ b/app/src/resources/audit/useDownloadAndDeleteAuditLog.ts
@@ -2,17 +2,22 @@ import { useState } from 'react'
 import { useDispatch } from 'react-redux'
 
 import {
+  isDocumentedMutationError,
   useDeleteLogPeriodMutation,
   useLogPeriodDetailsQuery,
 } from '@opentrons/react-api-client'
 
-import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
 import { logPeriodDeleteStarted } from '/app/redux/audit'
 
 import { useUpdateClientDataLogDeletion } from '../client_data/audit'
 import { useDownloadLogPeriod } from '../devices/hooks/useDownloadLogPeriod'
+import { useEnsureAuditLogAuthorization } from './useEnsureAuditLogAuthorization'
 
+import type { DocumentedAction } from '@opentrons/react-api-client'
 import type { Dispatch } from '/app/redux/types'
+
+const DOWNLOAD_LOG_PERIOD_ACTIONS: DocumentedAction[] = ['download_log_period']
 
 export function useDownloadAndDeleteAuditLog(logPeriodId: string): {
   downloadAndDeleteAuditLog: () => Promise<void>
@@ -25,25 +30,34 @@ export function useDownloadAndDeleteAuditLog(logPeriodId: string): {
 
   const updateLogDeletionStatus = useUpdateClientDataLogDeletion(logPeriodId)
 
-  const documentationState = useDocumentationState()
+  const { documentationState } = useLinkedDocumentationState(
+    DOWNLOAD_LOG_PERIOD_ACTIONS,
+    logPeriodId
+  )
 
   const logPeriodDetailsQuery = useLogPeriodDetailsQuery(logPeriodId)
   const logPeriodDetails = logPeriodDetailsQuery.data
 
   const { downloadLogPeriod } = useDownloadLogPeriod(logPeriodDetails)
-  const { deleteLogPeriod } = useDeleteLogPeriodMutation(documentationState, [
-    'download_log_period',
-  ])
+  const { deleteLogPeriod } = useDeleteLogPeriodMutation(
+    documentationState,
+    DOWNLOAD_LOG_PERIOD_ACTIONS
+  )
+  const ensureAuthorized = useEnsureAuditLogAuthorization(
+    documentationState,
+    DOWNLOAD_LOG_PERIOD_ACTIONS
+  )
 
   const downloadAndDeleteAuditLog = async (): Promise<void> => {
     setIsLoading(true)
-    updateLogDeletionStatus('pending')
     try {
       if (logPeriodDetails == null) {
         throw new Error(
           'Log period details not found for period ID: ' + logPeriodId
         )
       }
+      await ensureAuthorized()
+      updateLogDeletionStatus('pending')
       const deletionKey = await downloadLogPeriod()
       if (deletionKey == null) {
         throw new Error('Deletion key not found for period ID: ' + logPeriodId)
@@ -52,8 +66,10 @@ export function useDownloadAndDeleteAuditLog(logPeriodId: string): {
       await deleteLogPeriod({ logPeriodId, deletionKey })
       updateLogDeletionStatus('completed')
     } catch (error) {
-      updateLogDeletionStatus('failed')
-      setError(error as Error)
+      if (!isDocumentedMutationError(error)) {
+        updateLogDeletionStatus('failed')
+        setError(error as Error)
+      }
       throw error
     } finally {
       setIsLoading(false)

--- a/app/src/resources/audit/useEnsureAuditLogAuthorization.ts
+++ b/app/src/resources/audit/useEnsureAuditLogAuthorization.ts
@@ -1,0 +1,118 @@
+import { useCallback } from 'react'
+import { useStore } from 'react-redux'
+
+import { DocumentedMutationError } from '@opentrons/react-api-client'
+
+import { getUsernameForRobot, useCurrentRobotName } from '/app/redux/robot-auth'
+
+import type {
+  DocumentationState,
+  DocumentedAction,
+} from '@opentrons/react-api-client'
+import type { State } from '/app/redux/types'
+
+type AccessControlEnabledState = Extract<
+  DocumentationState,
+  { accessControlEnabled: true }
+>
+
+export interface EnsureAuditLogAuthorizationParams {
+  documentationState: DocumentationState
+  actionsToDocument: DocumentedAction[]
+  robotName: string | null
+  getUsername: () => string | null
+}
+
+/**
+ * Require a login (and documentation, if needed) before an audit-log download.
+ */
+export function useEnsureAuditLogAuthorization(
+  documentationState: DocumentationState,
+  actionsToDocument: DocumentedAction[]
+): () => Promise<void> {
+  const store = useStore<State>()
+  const robotName = useCurrentRobotName()
+
+  return useCallback(
+    () =>
+      ensureAuditLogAuthorization({
+        documentationState,
+        actionsToDocument,
+        robotName,
+        getUsername: () => getUsernameForRobot(store.getState(), robotName),
+      }),
+    [actionsToDocument, documentationState, robotName, store]
+  )
+}
+
+function ensureAuditLogAuthorization({
+  documentationState,
+  actionsToDocument,
+  robotName,
+  getUsername,
+}: EnsureAuditLogAuthorizationParams): Promise<void> {
+  if (documentationState.isLoading) {
+    return Promise.reject(new DocumentedMutationError('access_control_loading'))
+  }
+  if (!documentationState.accessControlEnabled) {
+    return Promise.resolve()
+  }
+  if (robotName == null) {
+    return Promise.reject(
+      new Error('Unable to authorize audit log download: no robot selected')
+    )
+  }
+
+  return requireUsername(documentationState, getUsername).then(username =>
+    requireDocumentation(documentationState, actionsToDocument, username)
+  )
+}
+
+function requireUsername(
+  documentationState: AccessControlEnabledState,
+  getUsername: () => string | null
+): Promise<string> {
+  const currentUsername = getUsername()
+  if (currentUsername != null && currentUsername.length > 0) {
+    return Promise.resolve(currentUsername)
+  }
+
+  return documentationState.askForLogin().then(loginResult => {
+    const loggedInUsername = loginResult?.username ?? ''
+    if (loggedInUsername.length === 0) {
+      return Promise.reject(new DocumentedMutationError('login_cancelled'))
+    }
+
+    return loggedInUsername
+  })
+}
+
+function requireDocumentation(
+  documentationState: AccessControlEnabledState,
+  actionsToDocument: DocumentedAction[],
+  username: string
+): Promise<void> {
+  if (!documentationState.reasonForInteractionRequired) {
+    return Promise.resolve()
+  }
+
+  if (documentationState.docreport === '') {
+    return Promise.reject(
+      new DocumentedMutationError('no_documentation_report')
+    )
+  }
+
+  if (documentationState.docreport != null) {
+    return Promise.resolve()
+  }
+
+  return documentationState
+    .askForDocumentation(actionsToDocument, undefined, undefined, username)
+    .then(report => {
+      if (report.length === 0) {
+        return Promise.reject(
+          new DocumentedMutationError('no_documentation_report')
+        )
+      }
+    })
+}

--- a/app/src/resources/devices/hooks/useDeleteSelectedLogPeriods.ts
+++ b/app/src/resources/devices/hooks/useDeleteSelectedLogPeriods.ts
@@ -9,6 +9,7 @@ import {
   useHost,
 } from '@opentrons/react-api-client'
 
+import { isForbiddenError } from '/app/local-resources/access-control/utils'
 import { logPeriodDeleteStarted } from '/app/redux/audit'
 
 import type { QueryKey } from 'react-query'
@@ -51,6 +52,7 @@ export function useDeleteSelectedLogPeriods(
 
       const processSequentially = async (): Promise<void> => {
         let hasDeleteError = false
+        let permissionError: unknown = null
         // process one logPeriod at a time so deletions are applied sequentially
         // rather than concurrently, and a single failure doesn't abort the rest
         // enforce deletion key is present for each deletion request
@@ -68,9 +70,17 @@ export function useDeleteSelectedLogPeriods(
             logPeriodId,
             { deletionKey },
             userNotes
-          ).catch(_ => (hasDeleteError = true))
+          ).catch(error => {
+            hasDeleteError = true
+            if (isForbiddenError(error)) {
+              permissionError = error
+            }
+          })
         }
 
+        if (isForbiddenError(permissionError)) {
+          throw permissionError
+        }
         if (hasDeleteError) {
           throw new Error('One or more logPeriods failed to delete')
         }


### PR DESCRIPTION
Closes [RQA-6033](https://opentrons.atlassian.net/browse/RQA-6033)

# Overview

After a protocol run, "Download now" opened the OS save dialog before login. Saving wrote audit logs to disk even if the user cancelled login. Different user groups cannot download logs, so login ought to succeed before any save.

This PR collects login (and documentation, if required) before the Electron save dialog pops up.

The gate is shared by two places on the desktop app:
- the post-run download + delete modal
- the File Manager tab's download-then-delete modal

### Current behavior

https://github.com/user-attachments/assets/522c9929-52e9-460e-8999-c1e000eb89db

### Fixed behavior

https://github.com/user-attachments/assets/b82e7022-46d8-4c04-bd19-199671b2e6c7


Lastly, we improve the error message copy when we do not have correct permissions for downloading to make it a bit less generic:

<img width="502" height="55" alt="Screenshot 2026-08-31 at 5 07 09 PM" src="https://github.com/user-attachments/assets/eff98b49-5e90-45a1-903c-ad23e7cb95bb" />

## Test Plan and Hands on Testing

- [x] Not logged in: "Download now" shows login before the save dialog.
- [x] Cancel login: save dialog does not appear, the download modal stays open, and no files are on disk.
- [x] Successful login: save dialog appears and download + delete proceeds
- [x] Logged-in user without download permission: login is not re-prompted and the error propagates as expected. 

## Changelog

- Add `useEnsureAuditLogAuthorization` to require login (and documentation) before an audit-log download
- Call it from the post-run download+delete path and from File Manager download+delete
- Keep the download modal open when login or documentation is cancelled (`DocumentedMutationError`)

## Review requests

- Am I missing any other desktop audit log download modal entry point?

## Risk assessment

- medium-ish, we now have logic to gate the audit log downloads, which could potentially break that flow if not implemented to spec.

[RQA-6033]: https://opentrons.atlassian.net/browse/RQA-6033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ