### PR TITLE
fix(app, odd): only require documentation once to start protocol run

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionBtnDisabledUtils.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionBtnDisabledUtils.ts
@@ -17,6 +17,7 @@ import {
 import { useIsDoorOpen } from '../../../hooks'
 import { useIsFixtureMismatch } from './useIsFixtureMismatch'
 
+import type { RunControls } from '/app/organisms/RunTimeControl'
 import type { BaseActionButtonProps } from '..'
 import type { DoorResult } from '../../../../../../../DoorOpenControl/useIsDoorOpen'
 
@@ -30,6 +31,7 @@ interface UseActionButtonDisabledUtilsProps extends BaseActionButtonProps {
   isRobotOnWrongVersionOfSoftware: boolean
   isClosingCurrentRun: boolean
   isCameraReadyToRun: boolean
+  protocolRunControls: RunControls
 }
 
 type UseActionButtonDisabledUtilsResult =

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionButtonProperties.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionButtonProperties.ts
@@ -1,10 +1,11 @@
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
 import { RUN_STATUS_IDLE } from '@opentrons/api-client'
 import { useAddCameraSettingsToRunMutation } from '@opentrons/react-api-client'
 
-import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
 import {
   isModuleConfirmationStatus,
   isRunAgainStatus,
@@ -31,11 +32,13 @@ import {
 } from '/app/redux/protocol-runs'
 import { useIsRobotOutOfStorage } from '/app/resources/devices'
 
+import { useRunHeaderRunControls } from '../../../hooks'
 import { isAnyHeaterShakerShaking } from '../../../RunHeaderModalContainer/modals'
 import { useActionBtnDisabledUtils } from './useActionBtnDisabledUtils'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type { IconName } from '@opentrons/components'
+import type { DocumentedAction } from '@opentrons/react-api-client'
 import type { StepKey } from '/app/redux/protocol-runs'
 import type { State } from '/app/redux/types'
 import type { BaseActionButtonProps } from '..'
@@ -71,7 +74,6 @@ export function useActionButtonProperties({
   runRecord,
   robotAnalyticsData,
   robotSerialNumber,
-  protocolRunControls,
   attachedModules,
   runHeaderModalContainerUtils,
   isResetRunLoadingRef,
@@ -87,7 +89,7 @@ export function useActionButtonProperties({
   buttonIconName: IconName | null
 } {
   const { t } = useTranslation(['run_details', 'shared'])
-  const { play, pause, reset } = protocolRunControls
+
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
   const robotType = useRobotType(robotName)
   const { reportCameraEnablementSettings } = useCameraAnalytics({
@@ -100,9 +102,27 @@ export function useActionButtonProperties({
   const missingSetupSteps = useSelector<State, StepKey[]>((state: State) =>
     getMissingSetupSteps(state, runId)
   )
-  const documentationState = useDocumentationState()
-  const { addCameraSettingsToRun } =
-    useAddCameraSettingsToRunMutation(documentationState)
+
+  const actionsToDocument: DocumentedAction[] = useMemo(
+    () =>
+      !areCameraPreferencesConfirmed
+        ? ['update_camera_settings_for_run', 'play_run']
+        : ['play_run'],
+    [areCameraPreferencesConfirmed]
+  )
+  const { documentationState: linkedDocumentationState } =
+    useLinkedDocumentationState(actionsToDocument, runId)
+
+  const protocolRunControls = useRunHeaderRunControls(
+    runId,
+    robotName,
+    linkedDocumentationState
+  )
+  const { play, pause, reset } = protocolRunControls
+
+  const { addCameraSettingsToRun } = useAddCameraSettingsToRunMutation(
+    linkedDocumentationState
+  )
   const runCameraSettings = useSelector((state: State) =>
     getCameraUsageState(state, runId)
   )

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/index.tsx
@@ -3,7 +3,6 @@ import { RunHeaderSectionUpper } from './RunHeaderSectionUpper'
 
 import type { MutableRefObject } from 'react'
 import type { AttachedModule, Run, RunStatus } from '@opentrons/api-client'
-import type { RunControls } from '/app/organisms/RunTimeControl'
 import type { ProtocolRunHeaderProps } from '..'
 import type { UseRunHeaderModalContainerResult } from '../RunHeaderModalContainer'
 
@@ -12,7 +11,6 @@ export type RunHeaderContentProps = ProtocolRunHeaderProps & {
   runStatus: RunStatus | null
   isResetRunLoadingRef: MutableRefObject<boolean>
   attachedModules: AttachedModule[]
-  protocolRunControls: RunControls
   runHeaderModalContainerUtils: UseRunHeaderModalContainerResult
   isClosingCurrentRun: boolean
   robotName: string

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/RunHeaderModalContainer.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/RunHeaderModalContainer.tsx
@@ -14,7 +14,6 @@ import {
 } from './modals'
 
 import type { RunStatus } from '@opentrons/api-client'
-import type { RunControls } from '/app/organisms/RunTimeControl'
 import type { UseRunHeaderModalContainerResult } from '.'
 import type { UseRunErrorsResult } from '../hooks'
 
@@ -22,7 +21,6 @@ export interface RunHeaderModalContainerProps {
   runId: string
   runStatus: RunStatus | null
   robotName: string
-  protocolRunControls: RunControls
   runHeaderModalContainerUtils: UseRunHeaderModalContainerResult
   runErrors: UseRunErrorsResult
 }
@@ -31,7 +29,7 @@ export interface RunHeaderModalContainerProps {
 export function RunHeaderModalContainer(
   props: RunHeaderModalContainerProps
 ): JSX.Element | null {
-  const { runId, runStatus, runHeaderModalContainerUtils } = props
+  const { runId, runStatus, runHeaderModalContainerUtils, robotName } = props
   const robotProtocolAnalysis = useMostRecentCompletedAnalysis(runId)
 
   const {
@@ -84,7 +82,8 @@ export function RunHeaderModalContainer(
         <HeaterShakerIsRunningModal
           closeModal={HSRunningModalUtils.toggleModal}
           module={HSRunningModalUtils.module}
-          startRun={props.protocolRunControls.play}
+          runId={runId}
+          robotName={robotName}
         />
       ) : null}
       {HSConfirmationModalUtils.showModal && (

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/HeaterShakerIsRunningModal/HeaterShakerIsRunningModal.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/HeaterShakerIsRunningModal/HeaterShakerIsRunningModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -18,15 +18,19 @@ import {
 import { useCreateLiveCommandMutation } from '@opentrons/react-api-client'
 import { HEATERSHAKER_MODULE_TYPE } from '@opentrons/shared-data'
 
-import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
 import { useIsHeaterShakerInProtocol } from '/app/organisms/ModuleCard/hooks'
 import { useAttachedModules } from '/app/resources/modules'
 
+import { useRunHeaderRunControls } from '../../../hooks'
 import { HeaterShakerModuleCard } from './HeaterShakerModuleCard'
 import { getActiveHeaterShaker } from './utils'
 
 import type { AttachedModule, HeaterShakerModule } from '@opentrons/api-client'
-import type { HeaterShakerDeactivateShakerCreateCommand } from '@opentrons/shared-data'
+import type {
+  HeaterShakerDeactivateShakerCreateCommand,
+  RunTimeCommand,
+} from '@opentrons/shared-data'
 
 export type UseHeaterShakerIsRunningModalResult =
   | { showModal: true; module: HeaterShakerModule; toggleModal: () => void }
@@ -59,16 +63,16 @@ export function useHeaterShakerIsRunningModal(
 interface HeaterShakerIsRunningModalProps {
   closeModal: () => void
   module: HeaterShakerModule
-  startRun: () => void
+  runId: string
+  robotName: string
 }
 
 export const HeaterShakerIsRunningModal = (
   props: HeaterShakerIsRunningModalProps
 ): JSX.Element => {
-  const { closeModal, module, startRun } = props
+  const { closeModal, module, runId, robotName } = props
   const { t } = useTranslation('heater_shaker')
-  const documentationState = useDocumentationState()
-  const { createLiveCommand } = useCreateLiveCommandMutation(documentationState)
+
   const attachedModules = useAttachedModules()
   const moduleIds = attachedModules
     .filter(
@@ -78,6 +82,35 @@ export const HeaterShakerIsRunningModal = (
         module.data.speedStatus !== 'idle'
     )
     .map(module => module.id)
+
+  const moduleCommands = useMemo(() => {
+    return moduleIds.map(moduleId => {
+      const stopShakeCommand: RunTimeCommand = {
+        commandType: 'heaterShaker/deactivateShaker',
+        params: { moduleId },
+        id: '',
+        createdAt: '',
+        startedAt: '',
+        status: 'queued',
+        completedAt: '',
+      }
+      return stopShakeCommand
+    })
+  }, [moduleIds])
+
+  const { documentationState: linkedDocumentationState } =
+    useLinkedDocumentationState([...moduleCommands, 'play_run'], runId)
+
+  const { play } = useRunHeaderRunControls(runId, robotName)
+
+  const { play: playWithModuleCommands } = useRunHeaderRunControls(
+    runId,
+    robotName,
+    linkedDocumentationState
+  )
+  const { createLiveCommand } = useCreateLiveCommandMutation(
+    linkedDocumentationState
+  )
 
   const title = (
     <Flex flexDirection={DIRECTION_ROW}>
@@ -93,7 +126,7 @@ export const HeaterShakerIsRunningModal = (
   )
 
   const handleContinueShaking = (): void => {
-    startRun()
+    play()
     closeModal()
   }
 
@@ -114,7 +147,8 @@ export const HeaterShakerIsRunningModal = (
         )
       })
     })
-    handleContinueShaking()
+    playWithModuleCommands()
+    closeModal()
   }
 
   return (

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/HeaterShakerIsRunningModal/__tests__/HeaterShakerIsRunningModal.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/HeaterShakerIsRunningModal/__tests__/HeaterShakerIsRunningModal.test.tsx
@@ -10,6 +10,7 @@ import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resource
 import { useAttachedModules } from '/app/resources/modules'
 import { useMostRecentCompletedAnalysis } from '/app/resources/runs'
 
+import { useRunHeaderRunControls } from '../../../../hooks'
 import { HeaterShakerIsRunningModal } from '../HeaterShakerIsRunningModal'
 import { HeaterShakerModuleCard } from '../HeaterShakerModuleCard'
 
@@ -28,6 +29,7 @@ vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
 }))
 vi.mock('/app/resources/modules')
 vi.mock('/app/resources/runs')
+vi.mock('../../../../hooks')
 vi.mock('../HeaterShakerModuleCard')
 
 const mockMovingHeaterShakerOne = {
@@ -83,11 +85,13 @@ const render = (props: ComponentProps<typeof HeaterShakerIsRunningModal>) => {
 describe('HeaterShakerIsRunningModal', () => {
   let props: ComponentProps<typeof HeaterShakerIsRunningModal>
   let mockCreateLiveCommand = vi.fn()
+  let mockPlay = vi.fn()
   beforeEach(() => {
     props = {
       closeModal: vi.fn(),
       module: mockHeaterShaker,
-      startRun: vi.fn(),
+      runId: '123',
+      robotName: 'otie',
     }
     vi.mocked(HeaterShakerModuleCard).mockReturnValue(
       <div>mock HeaterShakerModuleCard</div>
@@ -95,6 +99,10 @@ describe('HeaterShakerIsRunningModal', () => {
     vi.mocked(useAttachedModules).mockReturnValue([mockMovingHeaterShakerOne])
     mockCreateLiveCommand = vi.fn()
     mockCreateLiveCommand.mockResolvedValue(null)
+    mockPlay = vi.fn()
+    vi.mocked(useRunHeaderRunControls).mockReturnValue({
+      play: mockPlay,
+    } as any)
     vi.mocked(useCreateLiveCommandMutation).mockReturnValue({
       createLiveCommand: mockCreateLiveCommand,
     } as any)
@@ -163,7 +171,7 @@ describe('HeaterShakerIsRunningModal', () => {
         },
       },
     })
-    expect(props.startRun).toHaveBeenCalled()
+    expect(mockPlay).toHaveBeenCalled()
     expect(props.closeModal).toHaveBeenCalled()
   })
 
@@ -178,6 +186,8 @@ describe('HeaterShakerIsRunningModal', () => {
     })
     fireEvent.click(button)
     expect(mockCreateLiveCommand).toHaveBeenCalledTimes(2)
+    expect(mockPlay).toHaveBeenCalled()
+    expect(props.closeModal).toHaveBeenCalled()
   })
 
   it('renders the keep shaking and start run button and calls startRun and closeModal', () => {
@@ -186,7 +196,7 @@ describe('HeaterShakerIsRunningModal', () => {
       name: /Keep shaking and start run/i,
     })
     fireEvent.click(button)
-    expect(props.startRun).toHaveBeenCalled()
+    expect(mockPlay).toHaveBeenCalled()
     expect(props.closeModal).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/useRunHeaderModalContainer.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/useRunHeaderModalContainer.ts
@@ -1,10 +1,11 @@
+import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 
 import { useAddCameraSettingsToRunMutation } from '@opentrons/react-api-client'
 import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
-import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
 import { useErrorRecoveryFlows } from '/app/organisms/ErrorRecoveryFlows'
 import { useApplyOffsets } from '/app/organisms/LabwarePositionCheck'
 import {
@@ -30,6 +31,7 @@ import {
   useQuickProtocolDetailsForRun,
 } from '/app/resources/runs'
 
+import { useRunHeaderRunControls } from '../hooks'
 import { getFallbackRobotSerialNumber } from '../utils'
 import {
   useHeaterShakerConfirmationModal,
@@ -44,8 +46,11 @@ import {
 } from './modals'
 
 import type { AttachedModule, Run, RunStatus } from '@opentrons/api-client'
+import type {
+  AuditLogAction,
+  DocumentedAction,
+} from '@opentrons/react-api-client/src/accessControl/types'
 import type { UseErrorRecoveryResult } from '/app/organisms/ErrorRecoveryFlows'
-import type { RunControls } from '/app/organisms/RunTimeControl'
 import type { State } from '/app/redux/types'
 import type { ProtocolRunHeaderProps } from '..'
 import type { UseRunErrorsResult } from '../hooks'
@@ -67,7 +72,6 @@ interface OffsetCOnflictModalUtils {
 
 interface UseRunHeaderModalContainerProps extends ProtocolRunHeaderProps {
   attachedModules: AttachedModule[]
-  protocolRunControls: RunControls
   runStatus: RunStatus | null
   runRecord: Run | null
   runErrors: UseRunErrorsResult
@@ -93,7 +97,6 @@ export function useRunHeaderModalContainer({
   runStatus,
   runRecord,
   attachedModules,
-  protocolRunControls,
   runErrors,
   closeCurrentRun,
 }: UseRunHeaderModalContainerProps): UseRunHeaderModalContainerResult {
@@ -115,13 +118,28 @@ export function useRunHeaderModalContainer({
   const isThisRunCurrent = runId === useCurrentRunId()
   const flexOffsetsApplied = useSelector(selectAreOffsetsApplied(runId))
   const areCameraPreferencesConfirmed = runRecord?.data.cameraSettings != null
-  const documentationState = useDocumentationState()
+
+  const actionsToDocument: DocumentedAction[] = useMemo(() => {
+    return [
+      !areCameraPreferencesConfirmed ? 'update_camera_settings_for_run' : null,
+      !flexOffsetsApplied ? 'apply_offsets' : null,
+      'play_run',
+    ].filter((action): action is AuditLogAction => action != null)
+  }, [areCameraPreferencesConfirmed, flexOffsetsApplied])
+  const { documentationState: linkedDocumentationState } =
+    useLinkedDocumentationState(actionsToDocument, runId)
+
+  const protocolRunControls = useRunHeaderRunControls(
+    runId,
+    robotName,
+    linkedDocumentationState
+  )
   const { applyOffsets, isApplyingOffsets } = useApplyOffsets(
     runId,
-    documentationState
+    linkedDocumentationState
   )
   const { mutateAsync: addCameraSettingsToRun } =
-    useAddCameraSettingsToRunMutation(documentationState)
+    useAddCameraSettingsToRunMutation(linkedDocumentationState)
   const runCameraSettings = useSelector((state: State) =>
     getCameraUsageState(state, runId)
   )

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/__tests__/ProtocolRunHeader.test.tsx
@@ -17,11 +17,7 @@ import {
 
 import { ProtocolRunHeader } from '..'
 import { RunProgressMeter } from '../../../../RunProgressMeter'
-import {
-  useRunAnalytics,
-  useRunErrors,
-  useRunHeaderRunControls,
-} from '../hooks'
+import { useRunAnalytics, useRunErrors } from '../hooks'
 import { RunHeaderBannerContainer } from '../RunHeaderBannerContainer'
 import { RunHeaderContent } from '../RunHeaderContent'
 import {
@@ -100,7 +96,6 @@ describe('ProtocolRunHeader', () => {
     vi.mocked(useRunGeneratedDataFiles).mockReturnValue({ jpeg: [], csv: [] })
     vi.mocked(useRunAnalytics).mockImplementation(() => {})
     vi.mocked(useRunErrors).mockReturnValue([] as any)
-    vi.mocked(useRunHeaderRunControls).mockReturnValue({} as any)
     vi.mocked(useRunHeaderModalContainer).mockReturnValue(
       MOCK_RUN_HEADER_MODAL_CONTAINER_UTILS as any
     )
@@ -183,7 +178,6 @@ describe('ProtocolRunHeader', () => {
       expect.objectContaining({
         runStatus: RUN_STATUS_RUNNING,
         runErrors: [],
-        protocolRunControls: expect.any(Object),
       }),
       expect.anything()
     )
@@ -213,7 +207,6 @@ describe('ProtocolRunHeader', () => {
         runStatus: RUN_STATUS_RUNNING,
         isResetRunLoadingRef: expect.any(Object),
         attachedModules: [],
-        protocolRunControls: expect.any(Object),
       }),
       expect.anything()
     )

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/hooks/useRunHeaderRunControls.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/hooks/useRunHeaderRunControls.ts
@@ -3,12 +3,14 @@ import { useNavigate } from 'react-router-dom'
 import { useRunControls } from '/app/organisms/RunTimeControl'
 
 import type { Run } from '@opentrons/api-client'
+import type { DocumentationState } from '@opentrons/react-api-client'
 import type { RunControls } from '/app/organisms/RunTimeControl'
 
 // Provides desktop run controls, routing the user to the run preview tab after a "run again" action.
 export function useRunHeaderRunControls(
   runId: string,
-  robotName: string
+  robotName: string,
+  playDocumentationState?: DocumentationState
 ): RunControls {
   const navigate = useNavigate()
 
@@ -17,5 +19,5 @@ export function useRunHeaderRunControls(
       `/devices/${robotName}/protocol-runs/${createRunResponse.data.id}/run-preview`
     )
   }
-  return useRunControls(runId, handleRunReset)
+  return useRunControls(runId, handleRunReset, playDocumentationState)
 }

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/index.tsx
@@ -27,7 +27,7 @@ import { useIsDownloadAuditLogsRequired } from '/app/resources/runs/useIsDownloa
 import { EQUIPMENT_POLL_MS } from '../../../../DoorOpenControl/constants'
 import { showDownloadLogsModal } from '../../../DownloadAuditLogsModal'
 import { RunProgressMeter } from '../../../RunProgressMeter'
-import { useRunAnalytics, useRunErrors, useRunHeaderRunControls } from './hooks'
+import { useRunAnalytics, useRunErrors } from './hooks'
 import { RunHeaderBannerContainer } from './RunHeaderBannerContainer'
 import { RunHeaderContent } from './RunHeaderContent'
 import {
@@ -104,12 +104,11 @@ export function ProtocolRunHeader(
   ])
 
   const enteredER = runRecord?.data.hasEverEnteredErrorRecovery ?? false
-  const protocolRunControls = useRunHeaderRunControls(runId, robotName)
+
   const runHeaderModalContainerUtils = useRunHeaderModalContainer({
     ...props,
     attachedModules,
     runStatus,
-    protocolRunControls,
     runRecord: runRecord ?? null,
     runErrors,
     closeCurrentRun,
@@ -138,7 +137,6 @@ export function ProtocolRunHeader(
         runStatus={runStatus}
         runHeaderModalContainerUtils={runHeaderModalContainerUtils}
         runErrors={runErrors}
-        protocolRunControls={protocolRunControls}
         {...props}
       />
       <Flex ref={protocolRunHeaderRef} css={CONTAINER_STYLE}>
@@ -160,7 +158,6 @@ export function ProtocolRunHeader(
           runStatus={runStatus}
           isResetRunLoadingRef={isResetRunLoadingRef}
           attachedModules={attachedModules}
-          protocolRunControls={protocolRunControls}
           runHeaderModalContainerUtils={runHeaderModalContainerUtils}
           isClosingCurrentRun={isClosingCurrentRun}
           numberOfAtomicCommands={

--- a/app/src/organisms/RunTimeControl/__tests__/hooks.test.tsx
+++ b/app/src/organisms/RunTimeControl/__tests__/hooks.test.tsx
@@ -50,7 +50,11 @@ describe('useRunControls hook', () => {
     const mockResumeRunFromRecoveryAssumingFalsePositive = vi.fn()
 
     when(useRunActionMutations)
-      .calledWith(mockPausedRun.id, ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE)
+      .calledWith(
+        mockPausedRun.id,
+        ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+        undefined
+      )
       .thenReturn({
         playRun: mockPlayRun,
         pauseRun: mockPauseRun,

--- a/app/src/organisms/RunTimeControl/hooks.ts
+++ b/app/src/organisms/RunTimeControl/hooks.ts
@@ -12,6 +12,7 @@ import {
 
 import type { UseQueryOptions } from 'react-query'
 import type { Run, RunData, RunStatus } from '@opentrons/api-client'
+import type { DocumentationState } from '@opentrons/react-api-client'
 
 export interface RunControls {
   play: () => void
@@ -29,7 +30,8 @@ export interface RunControls {
 
 export function useRunControls(
   runId: string | null,
-  onCloneRunSuccess?: (createRunResponse: Run) => unknown
+  onCloneRunSuccess?: (createRunResponse: Run) => unknown,
+  playDocumentationState?: DocumentationState
 ): RunControls {
   const documentationState = useDocumentationState()
 
@@ -42,7 +44,7 @@ export function useRunControls(
     isPauseRunActionLoading,
     isStopRunActionLoading,
     isResumeRunFromRecoveryActionLoading,
-  } = useRunActionMutations(runId!, documentationState)
+  } = useRunActionMutations(runId!, documentationState, playDocumentationState)
 
   const {
     cloneRun,

--- a/app/src/pages/ODD/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -255,7 +255,11 @@ describe('ProtocolSetup', () => {
       .calledWith(ROBOT_NAME)
       .thenReturn(FLEX_ROBOT_TYPE)
     when(vi.mocked(useRunControls))
-      .calledWith(RUN_ID)
+      .calledWith(
+        RUN_ID,
+        undefined,
+        ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+      )
       .thenReturn({
         play: mockPlay,
         pause: () => {},

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -34,7 +34,7 @@ import {
   getModuleDisplayName,
 } from '@opentrons/shared-data'
 
-import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
 import { useScrollPosition } from '/app/local-resources/dom-utils'
 import { useInitializeCameraState } from '/app/local-resources/images/hooks/useInitializeCameraState'
 import { getIncompleteInstrumentCount } from '/app/local-resources/instruments'
@@ -122,6 +122,8 @@ import type { TFunction } from 'i18next'
 import type { FlattenSimpleInterpolation } from 'styled-components'
 import type { Dispatch, SetStateAction } from 'react'
 import type { Run, RunStatus } from '@opentrons/api-client'
+import type { DocumentedAction } from '@opentrons/react-api-client'
+import type { AuditLogAction } from '@opentrons/react-api-client/src/accessControl/types'
 import type { OnDeviceRouteParams } from '/app/App/types'
 import type {
   ProtocolSetupStepProps,
@@ -777,10 +779,7 @@ export function ProtocolSetup(): JSX.Element {
   const robotSerialNumber =
     localRobot?.status != null ? getRobotSerialNumber(localRobot) : null
   const trackEvent = useTrackEvent()
-  const { play } = useRunControls(runId)
-  const documentationState = useDocumentationState()
-  const { addCameraSettingsToRun } =
-    useAddCameraSettingsToRunMutation(documentationState)
+
   const [showAnalysisFailedModal, setShowAnalysisFailedModal] =
     useState<boolean>(true)
   const robotType = useRobotType(robotName)
@@ -855,10 +854,6 @@ export function ProtocolSetup(): JSX.Element {
   const robotAnalyticsData = useRobotAnalyticsData(robotName)
 
   const offsetsConfirmed = useSelector(selectAreOffsetsApplied(runId))
-  const { applyOffsets, isApplyingOffsets } = useApplyOffsets(
-    runId,
-    documentationState
-  )
 
   const [cameraSettingsConfirmed, setCameraSettingsConfirmed] = useState(false)
   const { data: initialRobotCameraSettings } = useNotifyCamera({
@@ -897,6 +892,29 @@ export function ProtocolSetup(): JSX.Element {
   if (cameraSettingsApplied && !cameraSettingsConfirmed) {
     setCameraSettingsConfirmed(true)
   }
+
+  const actionsToDocument = useMemo(() => {
+    const actions: DocumentedAction[] = [
+      !cameraSettingsApplied ? 'update_camera_settings_for_run' : null,
+      !offsetsConfirmed ? 'apply_offsets' : null,
+      'play_run',
+    ].filter((action): action is AuditLogAction => action != null)
+    console.log('actionsToDocument', actions)
+    return actions
+  }, [cameraSettingsApplied, offsetsConfirmed])
+
+  const { documentationState: playDocumentationState } =
+    useLinkedDocumentationState(actionsToDocument, runId)
+  const { play } = useRunControls(runId, undefined, playDocumentationState)
+
+  const { addCameraSettingsToRun } = useAddCameraSettingsToRunMutation(
+    playDocumentationState
+  )
+
+  const { applyOffsets, isApplyingOffsets } = useApplyOffsets(
+    runId,
+    playDocumentationState
+  )
 
   const proceedToRun = (): void => {
     // Camera settings do not require explicit confirmation by *any* user,

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -120,7 +120,7 @@ export interface AttachingModuleAction {
  * DocumentedActions for one-off mutations without more needed context.
  * These should match keys in audit_log.json
  */
-type AuditLogAction =
+export type AuditLogAction =
   | 'acknowledge_estop'
   | 'stop_run'
   | 'play_run'

--- a/react-api-client/src/runs/useRunActionMutations.ts
+++ b/react-api-client/src/runs/useRunActionMutations.ts
@@ -27,7 +27,8 @@ interface UseRunActionMutations {
 
 export function useRunActionMutations(
   runId: string,
-  documentationState: DocumentationState
+  documentationState: DocumentationState,
+  playDocumentationState?: DocumentationState
 ): UseRunActionMutations {
   const host = useHost()
   const queryClient = useQueryClient()
@@ -41,7 +42,7 @@ export function useRunActionMutations(
   }
 
   const { playRun, isLoading: isPlayRunActionLoading } = usePlayRunMutation(
-    documentationState,
+    playDocumentationState ?? documentationState,
     [],
     {
       onSuccess,


### PR DESCRIPTION
# Overview

Previously, starting a run would prompt the user for documentation separately to apply offsets and camera settings and then actually start the run. This PR combines those into one documentation prompt when required. Additionally combines all 'stop heater shaker' prompts into one prompt along with start run. 

https://github.com/user-attachments/assets/c9f6525b-ca94-4fbc-abb1-667208284129

https://github.com/user-attachments/assets/5f943be7-7100-401b-a279-f4963bb1afa6

fixes [RQA-6013](https://opentrons.atlassian.net/browse/RQA-6013)


## Test Plan and Hands on Testing

1. Start setup for a protocol run on a CRS bot in the ODD or app.
2. For applying camera settings and confirming offsets, confirming those steps should launch individual documentation prompts. 
3. When you press play without taking those steps, each uncompleted setup action should be added to the listed actions in the documentation modal along with 'playing protocol' 

## Review requests

Oh god this is a rats nest. Did I miss anywhere you can start a run from?

## Risk assessment

Medium since this code is so tangled 

[RQA-6013]: https://opentrons.atlassian.net/browse/RQA-6013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ