### PR TITLE
feat(audit-server): log the robot version

### DIFF
--- a/audit-server/audit_server/log_storage/log_data_manager.py
+++ b/audit-server/audit_server/log_storage/log_data_manager.py
@@ -26,6 +26,7 @@ from .store import (
     PeriodIsActiveError,
 )
 from .types import LogPeriodEntries, StoredLog
+from audit_server._version import version
 from audit_server.log_ingest.models import AuditLogMessage
 from audit_server.settings.store import (
     SettingsStore,
@@ -291,49 +292,53 @@ class LogDataManager:
         ending_messages.append(signed_end_log)
         return self._store.end_period(ending_messages)
 
+    async def _do_create_system_messages_with_signing_error_handling(
+        self, action: str, message: str, tail_hash: str | None
+    ) -> tuple[list[StoredLog], str]:
+        """Handle signed message creation with error handling (swallow) for boot."""
+        message = self._build_system_message(action=action, message=message)
+        signed_message, sign_error = await self._sign_log(message, tail_hash)
+        messages = [signed_message]
+        tail_hash = signed_message.message_hash
+        if sign_error:
+            sign_error_message = self._build_sign_error_message(sign_error, tail_hash)
+            messages.append(sign_error_message)
+            tail_hash = sign_error_message.message_hash
+        return messages, tail_hash
+
     async def _do_rotate_periods(self) -> str:
         """Execute a log period rotation while handling possible error cases."""
         stop_result = await self._stop_period()
-        start_messages: list[StoredLog] = []
-        start_message = self._build_system_message(
+        tracking_tail_hash = stop_result if isinstance(stop_result, str) else None
+        (
+            start_messages,
+            tracking_tail_hash,
+        ) = await self._do_create_system_messages_with_signing_error_handling(
             action=constants.ACTION_LOG_PERIOD_START,
             message=constants.MESSAGE_LOG_PERIOD_START,
+            tail_hash=tracking_tail_hash,
         )
-        tracking_tail_hash = stop_result if isinstance(stop_result, str) else None
-        signed_start, sign_error = await self._sign_log(
-            start_message, tracking_tail_hash
+        (
+            version_messages,
+            tracking_tail_hash,
+        ) = await self._do_create_system_messages_with_signing_error_handling(
+            action=constants.ACTION_ROBOT_VERSION,
+            message=version,
+            tail_hash=tracking_tail_hash,
         )
-        # our start message has to be the first thing in the log, even if there are
-        # errors from the previous log
-        start_messages.append(signed_start)
-        tracking_tail_hash = signed_start.message_hash
-        # signing errors are swallowed here because log rotation is an automated process
-        # during boot that we can't handle.
-        if sign_error:
-            sign_error_message = self._build_sign_error_message(
-                sign_error, tracking_tail_hash
-            )
-            start_messages.append(sign_error_message)
-            tracking_tail_hash = sign_error_message.message_hash
+        start_messages.extend(version_messages)
 
-        # now we can note if this is a start after an unstoppe dperiod
+        # now we can note if this is a start after an unstopped period
         if isinstance(stop_result, NoActivePeriodError):
-            was_no_period_error = self._build_system_message(
-                constants.ACTION_LOG_LOGGING_ERROR, constants.MESSAGE_NO_PREVIOUS_PERIOD
+            (
+                was_no_period_messages,
+                tracking_tail_hash,
+            ) = await self._do_create_system_messages_with_signing_error_handling(
+                action=constants.ACTION_LOG_LOGGING_ERROR,
+                message=constants.MESSAGE_NO_PREVIOUS_PERIOD,
+                tail_hash=tracking_tail_hash,
             )
-            was_no_period_signed, sign_error = await self._sign_log(
-                was_no_period_error, tracking_tail_hash
-            )
-            start_messages.append(was_no_period_signed)
-            tracking_tail_hash = was_no_period_signed.message_hash
-            # signing errors are swallowed here because log rotation is an automated
-            # process during boot that we can't handle.
-            if sign_error:
-                sign_error_message = self._build_sign_error_message(
-                    sign_error, tracking_tail_hash
-                )
-                start_messages.append(sign_error_message)
-                tracking_tail_hash = sign_error_message.message_hash
+            start_messages.extend(was_no_period_messages)
         return self._store.start_period(start_messages)
 
     async def _sign_log(

--- a/audit-server/tests/log_storage/test_log_data_manager.py
+++ b/audit-server/tests/log_storage/test_log_data_manager.py
@@ -358,10 +358,26 @@ async def test_store_log_rotates_if_cannot_get_tail_hash(
             signatureVersion=3,
         )
     )
+
     decoy.when(
         await mock_key_client.sign_message(
             SignMessageData.model_construct(
-                message=matchers.StringMatching(".*log-error.*"), previousHash="he"
+                message=matchers.StringMatching(".*robot-version.*"),
+                previousHash="he",
+            ),
+        )
+    ).then_return(
+        SignedMessageData(
+            message="1.2.3a4",
+            messageHash="hf",
+            messageSignature="od",
+            signatureVersion=8,
+        )
+    )
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(".*log-error.*"), previousHash="hf"
             )
         )
     ).then_return(
@@ -372,26 +388,32 @@ async def test_store_log_rotates_if_cannot_get_tail_hash(
             signatureVersion=4,
         )
     )
+
     decoy.when(
-        mock_store.store_log(
-            StoredLog(
-                message="log period begun",
-                message_hash="he",
-                message_sig="lo",
-                sig_version="3",
-            )
+        mock_store.start_period(
+            [
+                StoredLog(
+                    message="log period begun",
+                    message_hash="he",
+                    message_sig="lo",
+                    sig_version="3",
+                ),
+                StoredLog(
+                    message="1.2.3a4",
+                    message_hash="hf",
+                    message_sig="od",
+                    sig_version="8",
+                ),
+                StoredLog(
+                    message="log error",
+                    message_hash="go",
+                    message_sig="od",
+                    sig_version="4",
+                ),
+            ]
         )
-    ).then_return("he")
-    decoy.when(
-        mock_store.store_log(
-            StoredLog(
-                message="log error",
-                message_hash="go",
-                message_sig="od",
-                sig_version="4",
-            )
-        )
-    ).then_return("od")
+    ).then_return("go")
+
     decoy.when(
         await mock_key_client.sign_message(
             SignMessageData.model_construct(
@@ -417,24 +439,6 @@ async def test_store_log_rotates_if_cannot_get_tail_hash(
             )
         )
     ).then_return("ee")
-    decoy.when(
-        mock_store.start_period(
-            [
-                StoredLog(
-                    message="log period begun",
-                    message_hash="he",
-                    message_sig="lo",
-                    sig_version="3",
-                ),
-                StoredLog(
-                    message="log error",
-                    message_hash="go",
-                    message_sig="od",
-                    sig_version="4",
-                ),
-            ]
-        )
-    ).then_return("go")
     result = await subject.store_log("mymessage")
     assert result == "ee"
 
@@ -495,9 +499,31 @@ async def test_rotate_happypath(
         )
     )
     decoy.when(
-        mock_store.start_period([StoredLog("start-log-period", "ee", "s2", "2")])
-    ).then_return("ee")
-    assert await subject.rotate_periods() == "ee"
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(
+                    f".*{constants.ACTION_ROBOT_VERSION}.*"
+                ),
+                previousHash="ee",
+            )
+        )
+    ).then_return(
+        SignedMessageData(
+            message="robot-version",
+            messageHash="gg",
+            messageSignature="s3",
+            signatureVersion=3,
+        )
+    )
+    decoy.when(
+        mock_store.start_period(
+            [
+                StoredLog("start-log-period", "ee", "s2", "2"),
+                StoredLog("robot-version", "gg", "s3", "3"),
+            ]
+        )
+    ).then_return("gg")
+    assert await subject.rotate_periods() == "gg"
 
 
 async def test_rotate_no_previous_period(
@@ -521,9 +547,26 @@ async def test_rotate_no_previous_period(
     ).then_return(
         SignedMessageData(
             message="start-log-period",
-            messageHash="ff",
+            messageHash="ee",
             messageSignature="s1",
             signatureVersion=1,
+        )
+    )
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(
+                    f".*{constants.ACTION_ROBOT_VERSION}.*"
+                ),
+                previousHash="ee",
+            )
+        )
+    ).then_return(
+        SignedMessageData(
+            message="robot-version",
+            messageHash="ff",
+            messageSignature="s2",
+            signatureVersion=2,
         )
     )
     decoy.when(
@@ -538,9 +581,9 @@ async def test_rotate_no_previous_period(
     ).then_return(
         SignedMessageData(
             message="error-no-period",
-            messageHash="ee",
-            messageSignature="s2",
-            signatureVersion=2,
+            messageHash="gg",
+            messageSignature="s3",
+            signatureVersion=3,
         )
     )
     decoy.when(
@@ -548,20 +591,26 @@ async def test_rotate_no_previous_period(
             [
                 StoredLog(
                     message="start-log-period",
-                    message_hash="ff",
+                    message_hash="ee",
                     message_sig="s1",
                     sig_version="1",
                 ),
                 StoredLog(
-                    message="error-no-period",
-                    message_hash="ee",
+                    message="robot-version",
+                    message_hash="ff",
                     message_sig="s2",
                     sig_version="2",
                 ),
+                StoredLog(
+                    message="error-no-period",
+                    message_hash="gg",
+                    message_sig="s3",
+                    sig_version="3",
+                ),
             ]
         )
-    ).then_return("ee")
-    assert await subject.rotate_periods() == "ee"
+    ).then_return("gg")
+    assert await subject.rotate_periods() == "gg"
 
 
 async def test_rotate_no_previous_log(
@@ -633,6 +682,23 @@ async def test_rotate_no_previous_log(
         )
     )
     decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(
+                    f".*{constants.ACTION_ROBOT_VERSION}.*"
+                ),
+                previousHash="dd",
+            )
+        )
+    ).then_return(
+        SignedMessageData(
+            message="robot-version",
+            messageHash="cc",
+            messageSignature="s4",
+            signatureVersion=4,
+        )
+    )
+    decoy.when(
         mock_store.start_period(
             [
                 StoredLog(
@@ -640,11 +706,17 @@ async def test_rotate_no_previous_log(
                     message_hash="dd",
                     message_sig="s3",
                     sig_version="3",
-                )
+                ),
+                StoredLog(
+                    message="robot-version",
+                    message_hash="cc",
+                    message_sig="s4",
+                    sig_version="4",
+                ),
             ]
         )
-    ).then_return("dd")
-    assert await subject.rotate_periods() == "dd"
+    ).then_return("cc")
+    assert await subject.rotate_periods() == "cc"
 
 
 async def test_rotate_log_happypath_handles_no_keyserver(
@@ -697,6 +769,16 @@ async def test_rotate_log_happypath_handles_no_keyserver(
         )
     ).then_raise(KeyStorageUnavailableError())
     decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(
+                    f".*{constants.ACTION_ROBOT_VERSION}.*"
+                ),
+                previousHash=None,
+            )
+        )
+    ).then_raise(KeyStorageUnavailableError())
+    decoy.when(
         mock_store.start_period(
             [
                 StoredLog(
@@ -715,10 +797,26 @@ async def test_rotate_log_happypath_handles_no_keyserver(
                     message_sig="",
                     sig_version="-1",
                 ),
+                StoredLog(
+                    message=matchers.StringMatching(
+                        f".*{constants.ACTION_ROBOT_VERSION}.*"
+                    ),
+                    message_hash="",
+                    message_sig="",
+                    sig_version="-1",
+                ),
+                StoredLog(
+                    message=matchers.StringMatching(
+                        f".*{constants.MESSAGE_LOG_SIGNING_UNAVAILABLE}.*"
+                    ),
+                    message_hash="",
+                    message_sig="",
+                    sig_version="-1",
+                ),
             ]
         )
-    ).then_return("dd")
-    assert await subject.rotate_periods() == "dd"
+    ).then_return("zz")
+    assert await subject.rotate_periods() == "zz"
 
 
 async def test_rotate_no_previous_period_handles_no_keyserver(
@@ -744,6 +842,16 @@ async def test_rotate_no_previous_period_handles_no_keyserver(
         await mock_key_client.sign_message(
             SignMessageData.model_construct(
                 message=matchers.StringMatching(
+                    f".*{constants.ACTION_ROBOT_VERSION}.*"
+                ),
+                previousHash=None,
+            )
+        )
+    ).then_raise(KeyStorageUnavailableError())
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(
                     f".*{constants.MESSAGE_NO_PREVIOUS_PERIOD}.*"
                 ),
                 previousHash=None,
@@ -756,6 +864,22 @@ async def test_rotate_no_previous_period_handles_no_keyserver(
                 StoredLog(
                     message=matchers.StringMatching(
                         f".*{constants.MESSAGE_LOG_PERIOD_START}.*"
+                    ),
+                    message_hash="",
+                    message_sig="",
+                    sig_version="-1",
+                ),
+                StoredLog(
+                    message=matchers.StringMatching(
+                        f".*{constants.MESSAGE_LOG_SIGNING_UNAVAILABLE}.*"
+                    ),
+                    message_hash="",
+                    message_sig="",
+                    sig_version="-1",
+                ),
+                StoredLog(
+                    message=matchers.StringMatching(
+                        f".*{constants.ACTION_ROBOT_VERSION}.*"
                     ),
                     message_hash="",
                     message_sig="",
@@ -865,11 +989,37 @@ async def test_rotate_no_previous_log_handles_no_key_server(
         )
     ).then_raise(KeyStorageUnavailableError())
     decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(
+                    f".*{constants.ACTION_ROBOT_VERSION}.*"
+                ),
+                previousHash=None,
+            )
+        )
+    ).then_raise(KeyStorageUnavailableError())
+    decoy.when(
         mock_store.start_period(
             [
                 StoredLog(
                     message=matchers.StringMatching(
                         f".*{constants.MESSAGE_LOG_PERIOD_START}.*"
+                    ),
+                    message_hash="",
+                    message_sig="",
+                    sig_version="-1",
+                ),
+                StoredLog(
+                    matchers.StringMatching(
+                        f".*{constants.MESSAGE_LOG_SIGNING_UNAVAILABLE}.*"
+                    ),
+                    "",
+                    "",
+                    "-1",
+                ),
+                StoredLog(
+                    message=matchers.StringMatching(
+                        f".*{constants.ACTION_ROBOT_VERSION}.*"
                     ),
                     message_hash="",
                     message_sig="",

--- a/server-utils/server_utils/audit/constants.py
+++ b/server-utils/server_utils/audit/constants.py
@@ -5,7 +5,9 @@ from typing import Final
 MESSAGE_ROBOT_BOOT: Final = "Robot started up"
 MESSAGE_LOG_PERIOD_END: Final = "Log period ended"
 MESSAGE_LOG_PERIOD_START: Final = "Log period begun"
-MESSAGE_NO_PREVIOUS_PERIOD: Final = "There was no previous log period saved. Either this is the first time this robot has booted or the previous log period was deleted."
+MESSAGE_NO_PREVIOUS_PERIOD: Final = (
+    "There was no previous log period saved. Either this is the first time this robot has booted or the previous log period was deleted."
+)
 MESSAGE_NO_PREVIOUS_LOG: Final = (
     "There was no previous log message. A log message has been deleted."
 )
@@ -16,6 +18,7 @@ ACTION_LOG_PERIOD_START: Final = "log-period-begin"
 ACTION_LOG_PERIOD_END: Final = "log-period-end"
 ACTION_LOG_LOGGING_ERROR: Final = "log-error"
 ACTION_UNSIGNED_RUNS_WARNING: Final = "unsigned-runs-warning"
+ACTION_ROBOT_VERSION: Final = "robot-version"
 
 ACCOUNT_NAME_SYSTEM: Final = "system"
 LEGAL_NAME_SYSTEM: Final = ""

--- a/server-utils/server_utils/audit/constants.py
+++ b/server-utils/server_utils/audit/constants.py
@@ -5,9 +5,7 @@ from typing import Final
 MESSAGE_ROBOT_BOOT: Final = "Robot started up"
 MESSAGE_LOG_PERIOD_END: Final = "Log period ended"
 MESSAGE_LOG_PERIOD_START: Final = "Log period begun"
-MESSAGE_NO_PREVIOUS_PERIOD: Final = (
-    "There was no previous log period saved. Either this is the first time this robot has booted or the previous log period was deleted."
-)
+MESSAGE_NO_PREVIOUS_PERIOD: Final = "There was no previous log period saved. Either this is the first time this robot has booted or the previous log period was deleted."
 MESSAGE_NO_PREVIOUS_LOG: Final = (
     "There was no previous log message. A log message has been deleted."
 )


### PR DESCRIPTION
When we rotate a period, add a special log that has the robot version in it. The log verifier wants to be able to display this.
