### PR TITLE
fix(app): allow user to dismiss audit log download modal from file browser

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
@@ -44,7 +44,10 @@ const TOAST_STYLE: MakeToastOptions = {
   width: '80%',
 }
 
-const DELETE_LOG_PERIODS_ACTIONS: DocumentedAction[] = ['delete_log_periods']
+const DELETE_LOG_PERIODS_ACTIONS: DocumentedAction[] = [
+  'download_log_period',
+  'delete_log_periods',
+]
 
 interface ComplianceReadySoftwareFilesProps {
   robotName: string
@@ -87,10 +90,13 @@ export function ComplianceReadySoftwareFiles({
     [logPeriodSummariesData?.data]
   )
 
+  const [downloadModalDismissed, setDownloadModalDismissed] = useState(false)
+
   const showRequiredDownloadModal =
     !isLoadingAccessControlSettings &&
     requireDownloadSetting &&
-    periods.length > 1
+    periods.length > 1 &&
+    !downloadModalDismissed
 
   const {
     selectedIds,
@@ -357,6 +363,10 @@ export function ComplianceReadySoftwareFiles({
           isLoading={
             isAuthorizing || downloadLogPeriodsMutation.isLoading || isDeleting
           }
+          onClose={() => {
+            setDownloadModalDismissed(true)
+          }}
+          closeOnOutsideClick
         />
       )}
       <div className={fileManagerStyles.file_management_group}>

--- a/app/src/organisms/Desktop/DownloadAuditLogsModal/index.tsx
+++ b/app/src/organisms/Desktop/DownloadAuditLogsModal/index.tsx
@@ -17,11 +17,15 @@ import styles from './downloadauditlogsmodal.module.css'
 export interface DownloadAuditLogsModalProps {
   onDownload: () => void
   isLoading: boolean
+  closeOnOutsideClick?: boolean
+  onClose?: () => void
 }
 
 export function DownloadAuditLogsModal({
   onDownload,
   isLoading,
+  closeOnOutsideClick = false,
+  onClose,
 }: DownloadAuditLogsModalProps): JSX.Element {
   const { t } = useTranslation('access_control')
 
@@ -29,8 +33,9 @@ export function DownloadAuditLogsModal({
     <Modal
       type="warning"
       title={t('download_audit_logs')}
-      closeOnOutsideClick={false}
+      closeOnOutsideClick={closeOnOutsideClick}
       childrenPadding="var(--spacing-24)"
+      onClose={onClose}
     >
       <div className={styles.content}>
         <StyledText desktopStyle="bodyDefaultRegular">


### PR DESCRIPTION
# Overview
The download logs modal that pops up automatically in the file browser is a weird backup case for if the download from a run went wrong, or if the robot had to fully reboot. In these cases, being able to dismiss the modal is desirable to fix whatever the underlying problem with downloads was. Before this PR, users could get stuck on the file browser screen and have to quit the app completely to dismiss it. Downloading after a run is still a required blocking action, so the modal is not dismissible there, only in the file browser settings screen. Also updates the actions to include 'downloading audit logs'.

https://github.com/user-attachments/assets/087a4984-368b-4b84-8906-327bdba2d7b1

<img width="787" height="508" alt="Screenshot 2026-09-01 at 11 49 19 AM" src="https://github.com/user-attachments/assets/ed40aef7-55cc-4da7-b76e-b46c310f5ed2" />

## Test Plan and Hands on Testing

Restart a robot during a protocol run. The next time the robot boots, there should be a banner that brings you to the file management screen in settings. The 'download logs' modal that appears automatically should now be dismissible. Clicking 'download' should ask for documentation, and list 'downloading audit logs' and 'deleting log periods'

## Review requests

Does this behavior make sense

## Risk assessment

Low