### PR TITLE
fix(app): one documentation modal for unlocking user and updating password

### DIFF
--- a/app/src/assets/localization/en/audit_log.json
+++ b/app/src/assets/localization/en/audit_log.json
@@ -72,6 +72,7 @@
   "sync_system_time": "Syncing robot system time",
   "toggle_analytics": "Toggling analytics",
   "toggle_devtools": "Toggling devtools",
+  "unlock_user": "Unlocking user account",
   "update_audit_settings": "Updating audit log settings",
   "update_auth_settings": "Updating authentication settings",
   "update_camera": "Updating camera settings",

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/__tests__/UserManagement.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/__tests__/UserManagement.test.tsx
@@ -170,7 +170,9 @@ describe('UserManagement', () => {
       },
     })
 
-    expect(useUsersQuery).toHaveBeenCalledWith({ enabled: false })
+    expect(useUsersQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({ enabled: false })
+    )
     expandAccordion()
     expect(screen.queryByText('alice')).not.toBeInTheDocument()
   })

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/index.tsx
@@ -14,6 +14,7 @@ import {
 } from '@opentrons/react-api-client'
 
 import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
 import { useToaster } from '/app/organisms/ToasterOven'
 import { useUsernameForRobot } from '/app/redux/robot-auth'
 
@@ -40,6 +41,8 @@ interface UserManagementTableProps {
   onResetPassword: (user: AuthUser) => void
   onDeactivate: (user: AuthUser) => void
 }
+
+const USER_REFETCH_TIME = 10000
 
 function UserManagementTable({
   users,
@@ -90,14 +93,12 @@ export function UserManagement({
 }: UserManagementProps): JSX.Element {
   const { t } = useTranslation(['device_settings', 'shared'])
   const username = useUsernameForRobot(robotName)
-  const usersQuery = useUsersQuery({ enabled: username != null })
+  const usersQuery = useUsersQuery({
+    enabled: username != null,
+    refetchInterval: USER_REFETCH_TIME,
+  })
   const users = usersQuery?.data?.data ?? []
-  const documentationState = useDocumentationState(undefined, robotName)
-  const { deleteUser } = useDeleteUserMutation(documentationState)
-  const { resetUserPassword, isLoading: isResettingPassword } =
-    useResetUserPasswordMutation(documentationState)
-  const { updateUser, isLoading: isUpdatingUser } =
-    useUpdateUserMutation(documentationState)
+
   const [showAddUserModal, setShowAddUserModal] = useState(false)
   const [userToEdit, setUserToEdit] = useState<AuthUser | null>(null)
   const [userToDelete, setUserToDelete] = useState<AuthUser | null>(null)
@@ -109,6 +110,27 @@ export function UserManagement({
   )
   const [resetPasswordTemporaryPassword, setResetPasswordTemporaryPassword] =
     useState<string | null>(null)
+
+  const documentationState = useDocumentationState(undefined, robotName)
+  const { documentationState: linkedDocumentationState } =
+    useLinkedDocumentationState(
+      ['unlock_user', 'reset_user_password'],
+      userToActivate?.username ?? null
+    )
+
+  const { deleteUser } = useDeleteUserMutation(documentationState)
+  const { resetUserPassword, isLoading: isResettingPassword } =
+    useResetUserPasswordMutation(documentationState)
+  const { updateUser, isLoading: isUpdatingUser } =
+    useUpdateUserMutation(documentationState)
+
+  const {
+    resetUserPassword: resetPasswordAfterUnlock,
+    isLoading: isResettingPasswordAfterUnlock,
+  } = useResetUserPasswordMutation(linkedDocumentationState)
+  const { updateUser: unlockUser, isLoading: isUnlockingUser } =
+    useUpdateUserMutation(linkedDocumentationState)
+
   const { makeToast } = useToaster()
 
   const handleDeleteConfirm = (): void => {
@@ -137,11 +159,11 @@ export function UserManagement({
 
     const { username } = userToActivate
 
-    void updateUser({
+    void unlockUser({
       username,
       request: { data: { locked: false } },
     })
-      .then(() => resetUserPassword(username))
+      .then(() => resetPasswordAfterUnlock(username))
       .then(response => {
         setUserToActivate(null)
         makeToast(
@@ -281,7 +303,7 @@ export function UserManagement({
           heading={t('desktop_activate_user_modal_heading') as string}
           description={t('desktop_activate_user_modal_description') as string}
           confirmLabel={t('desktop_unlock_user') as string}
-          isConfirmDisabled={isUpdatingUser || isResettingPassword}
+          isConfirmDisabled={isUnlockingUser || isResettingPasswordAfterUnlock}
           onConfirm={handleActivateConfirm}
           onCancel={() => {
             setUserToActivate(null)

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -199,6 +199,7 @@ export type AuditLogAction =
   | 'change_language'
   | 'toggle_analytics'
   | 'download_log_period'
+  | 'unlock_user'
 
 /**
  * Type used for DocumentedActions - keys and info to enable correct rendering of actions in the 'list actions' popup in the Documentation Required Modal.


### PR DESCRIPTION
# Overview

https://github.com/user-attachments/assets/4ab5419c-458e-4734-9702-290017388646

Unlocking a user and resetting their password now shares one documentation required modal. Also adds a 10 second refetch to the users query, to catch changes to users.

Fixes [RQA-6061](https://opentrons.atlassian.net/browse/RQA-6061) [RQA-6062](https://opentrons.atlassian.net/browse/RQA-6062) and [RQA-5969](https://opentrons.atlassian.net/browse/RQA-5969)

## Test Plan and Hands on Testing

When unlocking a user, you should get only one documentation required modal listing both unlocking the user and resetting their password.

## Risk assessment

Low

[RQA-6061]: https://opentrons.atlassian.net/browse/RQA-6061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-6062]: https://opentrons.atlassian.net/browse/RQA-6062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-5969]: https://opentrons.atlassian.net/browse/RQA-5969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ