### PR TITLE
fix(app, auth-server): require at least 1 day for CRS password reset time

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -160,6 +160,7 @@
   "desktop_password_missing_special_characters": "Password must include a special character.",
   "desktop_password_placeholder": "************************",
   "desktop_password_previously_used": "Choose a different password. This password was used recently.",
+  "desktop_password_reset_time_invalid": "Must be at least {{min}} day",
   "desktop_password_too_short": "Password must be at least {{minLength}} characters.",
   "desktop_personal_account_settings": "Personal account settings",
   "desktop_personal_account_settings_save_error": "Unable to save account settings. Try again.",

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/__tests__/ComplianceReadySoftwareSettings.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/__tests__/ComplianceReadySoftwareSettings.test.tsx
@@ -472,6 +472,33 @@ describe('ComplianceReadySoftwareSettings', () => {
     expect(mockPatchAuthSettings).not.toHaveBeenCalled()
     expect(idleLogoutField).toHaveValue(0)
   })
+
+  it('should not patch passwordResetTime when blurred value is below the minimum', async () => {
+    vi.mocked(useAuthSettingsQuery).mockReturnValue({
+      data: {
+        data: {
+          ...MOCK_AUTH_SETTINGS.data,
+          passwordResetTime: 90 * 24 * 60 * 60,
+        },
+      },
+    } as ReturnType<typeof useAuthSettingsQuery>)
+
+    render()
+    expandAccordion()
+
+    const passwordResetTimeField = screen.getByLabelText('Edit length of time')
+    expect(passwordResetTimeField).toHaveValue(90)
+
+    fireEvent.change(passwordResetTimeField, { target: { value: '0' } })
+    fireEvent.blur(passwordResetTimeField)
+
+    await waitFor(() => {
+      screen.getByText('Must be at least 1 day')
+    })
+
+    expect(mockPatchAuthSettings).not.toHaveBeenCalled()
+    expect(passwordResetTimeField).toHaveValue(0)
+  })
 })
 
 describe('RobotSettingsComplianceReady', () => {

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/__tests__/complianceReadySettingsHelper.test.ts
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/__tests__/complianceReadySettingsHelper.test.ts
@@ -121,7 +121,25 @@ describe('getAuthInputPatch', () => {
     ).toBeNull()
   })
 
+  it('should not patch passwordResetTime when value is below the minimum', () => {
+    expect(
+      getAuthInputPatch('passwordResetTime', '0', BASE_FIELD_VALUES)
+    ).toBeNull()
+    expect(
+      getAuthInputPatch('passwordResetTime', '-1', BASE_FIELD_VALUES)
+    ).toBeNull()
+    expect(
+      getAuthInputPatch('passwordResetTime', '0.5', BASE_FIELD_VALUES)
+    ).toBeNull()
+    expect(
+      getAuthInputPatch('passwordResetTime', 'abc', BASE_FIELD_VALUES)
+    ).toBeNull()
+  })
+
   it('should patch passwordResetTime with day conversion', () => {
+    expect(
+      getAuthInputPatch('passwordResetTime', '1', BASE_FIELD_VALUES)
+    ).toEqual({ data: { passwordResetTime: 1 * 24 * 60 * 60 } })
     expect(
       getAuthInputPatch('passwordResetTime', '30', BASE_FIELD_VALUES)
     ).toEqual({ data: { passwordResetTime: 30 * 24 * 60 * 60 } })

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/complianceReadySettingsHelper.ts
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/complianceReadySettingsHelper.ts
@@ -22,6 +22,7 @@ const SECONDS_PER_MINUTE = 60
 const SECONDS_PER_DAY = 24 * 60 * 60
 export const MAX_PASSWORD_COMPLEXITY_MINIMUM_LENGTH = 256
 export const MAX_NUMBER_OF_LOGIN_ATTEMPTS = 5
+export const MIN_PASSWORD_RESET_TIME_DAYS = 1
 
 export function isValidLogoutIdleTime(value: string): boolean {
   const parsedValue = Number(value)
@@ -46,6 +47,13 @@ export function isValidMaxNumberOfLoginAttempts(value: string): boolean {
     Number.isInteger(parsedValue) &&
     parsedValue > 0 &&
     parsedValue <= MAX_NUMBER_OF_LOGIN_ATTEMPTS
+  )
+}
+
+export function isValidPasswordResetTime(value: string): boolean {
+  const parsedValue = Number(value)
+  return (
+    Number.isFinite(parsedValue) && parsedValue >= MIN_PASSWORD_RESET_TIME_DAYS
   )
 }
 
@@ -159,7 +167,7 @@ export function getAuthInputPatch(
       }
       return { data: { idleLogout: Number(value) * SECONDS_PER_MINUTE } }
     case 'passwordResetTime':
-      if (value === '') {
+      if (!isValidPasswordResetTime(value)) {
         return null
       }
       return { data: { passwordResetTime: Number(value) * SECONDS_PER_DAY } }

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/index.tsx
@@ -22,8 +22,10 @@ import {
   isValidLogoutIdleTime,
   isValidMaxNumberOfLoginAttempts,
   isValidPasswordComplexityMinimumLength,
+  isValidPasswordResetTime,
   MAX_NUMBER_OF_LOGIN_ATTEMPTS,
   MAX_PASSWORD_COMPLEXITY_MINIMUM_LENGTH,
+  MIN_PASSWORD_RESET_TIME_DAYS,
 } from './complianceReadySettingsHelper'
 import {
   isAuditServerSettingKey,
@@ -227,6 +229,14 @@ export function ComplianceReadySoftwareSettings({
               label={t('desktop_length_of_time')}
               value={String(fieldValues.passwordResetTime)}
               units={t('desktop_days')}
+              min={MIN_PASSWORD_RESET_TIME_DAYS}
+              validate={value =>
+                isValidPasswordResetTime(value)
+                  ? null
+                  : t('desktop_password_reset_time_invalid', {
+                      min: MIN_PASSWORD_RESET_TIME_DAYS,
+                    })
+              }
               onBlur={value =>
                 handleAuthSettingInputBlur('passwordResetTime', value)
               }

--- a/auth-server/auth_server/settings/models.py
+++ b/auth-server/auth_server/settings/models.py
@@ -7,6 +7,8 @@ import pydantic
 
 AUTH_SERVER_AUDIT_SYSTEM_NAME = "system"
 AUTH_SERVER_AUDIT_SYSTEM_FULLNAME = "authentication subsystem"
+SECONDS_PER_DAY = 24 * 60 * 60
+MIN_PASSWORD_RESET_TIME_SEC = SECONDS_PER_DAY
 
 
 class _StrictBaseModel(pydantic.BaseModel):
@@ -29,7 +31,12 @@ class SettingsResponseData(_StrictBaseModel):
     )
     passwordResetTime: float | None = pydantic.Field(
         default=None,
-        description="Duration in seconds until password must be changed. Set to null to remove the limit.",
+        ge=MIN_PASSWORD_RESET_TIME_SEC,
+        description=(
+            "Duration in seconds until password must be changed. "
+            f"Must be at least {MIN_PASSWORD_RESET_TIME_SEC} (1 day). "
+            "Set to null to remove the limit."
+        ),
     )
     passwordComplexityMinimumLength: int | None = pydantic.Field(
         default=None,
@@ -75,7 +82,12 @@ class PatchSettingsRequestData(_StrictBaseModel):
     passwordResetTime: Annotated[
         float | None,
         pydantic.Field(
-            description="Duration in seconds until password must be changed. Set to null to remove the limit.",
+            ge=MIN_PASSWORD_RESET_TIME_SEC,
+            description=(
+                "Duration in seconds until password must be changed. "
+                f"Must be at least {MIN_PASSWORD_RESET_TIME_SEC} (1 day). "
+                "Set to null to remove the limit."
+            ),
         ),
     ] = None
     passwordComplexityMinimumLength: Annotated[

--- a/auth-server/tests/conftest.py
+++ b/auth-server/tests/conftest.py
@@ -1,4 +1,5 @@
 import time
+from pathlib import Path
 from typing import Generator
 
 import pytest
@@ -7,6 +8,10 @@ import requests
 from server_utils.auth.scopes import serialize_scopes
 from tests.dev_server import DevServer
 
+from auth_server.persistence.file_and_directory_names import (
+    DB_FILE,
+    LATEST_VERSION_DIRECTORY,
+)
 from auth_server.settings.models import SettingsResponseData
 from auth_server.users.models import (
     AccountType,
@@ -37,8 +42,29 @@ def user_scopes_str() -> str:
 
 
 @pytest.fixture
-def run_server(unused_tcp_port: int) -> Generator[DevServer, None, None]:
+def auth_persistence_directory(tmp_path: Path) -> Path:
+    """Persistence directory shared by the server process and test helpers."""
+    persistence_directory = tmp_path / "auth-persist"
+    persistence_directory.mkdir()
+    return persistence_directory
+
+
+@pytest.fixture
+def auth_db_path(auth_persistence_directory: Path) -> str:
+    """Path to the server SQLite database under the test persistence directory."""
+    return str(auth_persistence_directory / LATEST_VERSION_DIRECTORY / DB_FILE)
+
+
+@pytest.fixture
+def run_server(
+    unused_tcp_port: int,
+    auth_persistence_directory: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[DevServer, None, None]:
     """Run a dev server as a fixture scoped to the test."""
+    monkeypatch.setenv(
+        "OT_AUTH_SERVER_persistence_directory", str(auth_persistence_directory)
+    )
     with DevServer(port=unused_tcp_port) as dev_server:
         dev_server.start()
         base_url = f"http://localhost:{dev_server.port}"

--- a/auth-server/tests/integration/test_password_expiration.tavern.yaml
+++ b/auth-server/tests/integration/test_password_expiration.tavern.yaml
@@ -6,6 +6,7 @@ marks:
       - admin_access_token
       - user_scopes_str
       - seed_users
+      - auth_db_path
 
 stages:
   - name: Set a long password expiration policy
@@ -16,7 +17,7 @@ stages:
         Authorization: '{admin_access_token}'
       json:
         data:
-          passwordResetTime: 99999.0
+          passwordResetTime: 7776000.0
     response:
       status_code: 200
 
@@ -39,6 +40,12 @@ stages:
           resetPassword: false
       strict:
         - json:off
+      verify_response_with:
+        function: tests.integration.utils:backdate_password_set_at
+        extra_kwargs:
+          username: pw_expiration_user
+          days: 2
+          db_path: '{auth_db_path}'
 
   - name: Admin sees resetPassword false while expiration is far in the future
     request:
@@ -70,7 +77,7 @@ stages:
       strict:
         - json:off
 
-  - name: Set a short password expiration policy
+  - name: Set a one-day password expiration policy
     request:
       method: PATCH
       url: '{run_server.base_url}/auth/settings'
@@ -78,12 +85,11 @@ stages:
         Authorization: '{admin_access_token}'
       json:
         data:
-          passwordResetTime: 1.0
+          passwordResetTime: 86400.0
     response:
       status_code: 200
 
   - name: User login has restricted scopes after the password expires
-    delay_before: 2
     request:
       method: POST
       url: '{run_server.base_url}/auth/oauth2/token'

--- a/auth-server/tests/integration/test_settings.tavern.yaml
+++ b/auth-server/tests/integration/test_settings.tavern.yaml
@@ -49,6 +49,18 @@ stages:
           requireAdminCredsWhenSendingProtocolToRobot: true
           requireAdminCredsForSignoffProtocol: false
 
+  - name: PATCH passwordResetTime below one day is rejected
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/settings'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          passwordResetTime: 1.0
+    response:
+      status_code: 422
+
   - name: PATCH more settings
     request:
       method: PATCH

--- a/auth-server/tests/integration/utils.py
+++ b/auth-server/tests/integration/utils.py
@@ -3,9 +3,16 @@
 https://tavern.readthedocs.io/en/latest/basics.html#calling-external-functions
 """
 
-from requests import Response
+import datetime
+from pathlib import Path
 
+from requests import Response
+from sqlalchemy import create_engine, update
+
+from server_utils import sql_utils
 from server_utils.auth.scopes import parse_scopes
+
+from auth_server.persistence.orm_models import User
 
 
 def verify_oauth_scopes(
@@ -34,3 +41,27 @@ def verify_oauth_scopes(
         "Unexpected scopes present in response: "
         f"{sorted(scope.api_name for scope in unexpected)}"
     )
+
+
+def backdate_password_set_at(
+    response: Response,
+    *,
+    username: str,
+    days: int,
+    db_path: str,
+) -> None:
+    """Move a user's password_set_at into the past so expiration can be tested."""
+    engine = create_engine(sql_utils.get_connection_url(Path(db_path)))
+    try:
+        with engine.begin() as connection:
+            result = connection.execute(
+                update(User)
+                .where(User.username == username)
+                .values(
+                    password_set_at=datetime.datetime.now(tz=datetime.UTC)
+                    - datetime.timedelta(days=days)
+                )
+            )
+            assert result.rowcount == 1, f"User {username!r} was not updated"
+    finally:
+        engine.dispose()

--- a/auth-server/tests/settings/test_models.py
+++ b/auth-server/tests/settings/test_models.py
@@ -2,6 +2,7 @@ import pytest
 from pydantic import ValidationError
 
 from auth_server.settings.models import (
+    MIN_PASSWORD_RESET_TIME_SEC,
     PatchSettingsRequestData,
     SettingsResponseData,
 )
@@ -38,3 +39,32 @@ def test_settings_response_rejects_out_of_range_login_attempts(
 ) -> None:
     with pytest.raises(ValidationError):
         SettingsResponseData(maxNumberOfLoginAttempts=invalid_value)
+
+
+def test_password_reset_time_accepts_valid_values() -> None:
+    assert (
+        SettingsResponseData(
+            passwordResetTime=MIN_PASSWORD_RESET_TIME_SEC
+        ).passwordResetTime
+        == MIN_PASSWORD_RESET_TIME_SEC
+    )
+    assert SettingsResponseData(passwordResetTime=None).passwordResetTime is None
+    assert PatchSettingsRequestData(passwordResetTime=None).model_dump(
+        exclude_unset=True
+    ) == {"passwordResetTime": None}
+
+
+@pytest.mark.parametrize("invalid_value", [0, -1, 1, MIN_PASSWORD_RESET_TIME_SEC - 1])
+def test_patch_settings_rejects_password_reset_time_below_minimum(
+    invalid_value: float,
+) -> None:
+    with pytest.raises(ValidationError):
+        PatchSettingsRequestData(passwordResetTime=invalid_value)
+
+
+@pytest.mark.parametrize("invalid_value", [0, -1, 1, MIN_PASSWORD_RESET_TIME_SEC - 1])
+def test_settings_response_rejects_password_reset_time_below_minimum(
+    invalid_value: float,
+) -> None:
+    with pytest.raises(ValidationError):
+        SettingsResponseData(passwordResetTime=invalid_value)

--- a/auth-server/tests/users/test_user_data_manager.py
+++ b/auth-server/tests/users/test_user_data_manager.py
@@ -5,7 +5,10 @@ import pytest
 from decoy import Decoy, matchers
 
 from auth_server.persistence.orm_models import User
-from auth_server.settings.models import SettingsResponseData
+from auth_server.settings.models import (
+    MIN_PASSWORD_RESET_TIME_SEC,
+    SettingsResponseData,
+)
 from auth_server.settings.store import SettingsStore
 from auth_server.users.models import (
     AccountType,
@@ -485,9 +488,9 @@ def test_get_user_reset_password_true_when_password_expired(
     manager: UserDataManager,
 ) -> None:
     decoy.when(mock_settings.get_settings()).then_return(
-        SettingsResponseData(passwordResetTime=3600)
+        SettingsResponseData(passwordResetTime=MIN_PASSWORD_RESET_TIME_SEC)
     )
-    expired_at = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(hours=2)
+    expired_at = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=2)
     decoy.when(mock_store.get("expired_user")).then_return(
         _make_orm_user(username="expired_user", password_set_at=expired_at)
     )


### PR DESCRIPTION
Closes [RQA-6071](https://opentrons.atlassian.net/browse/RQA-6071) and [RQA-6057](https://opentrons.atlassian.net/browse/RQA-6057)

# Overview

Setting “require password change after a certain amount of time” to 0 days made every password expire immediately. After reset, `resetPassword` stayed true, so login failed and the admin could not change the setting from the app.

To fix, the desktop settings field now rejects values below 1 day and does not PATCH them. Additionally, the auth server now rejects `passwordResetTime` below 86400 seconds. `null` still disables the policy. It looks like there was some client-server discrepancy between minimum values, so these are harmonized, too.

<img width="905" height="161" alt="Screenshot 2026-09-01 at 12 55 07 PM" src="https://github.com/user-attachments/assets/c4a237d7-7872-4c24-a004-55d319ace934" />

## Test plan
- [x] Under "Login and security", turn on password-change-after-time and try 0. It should error out with the message shown above. 
- [x] PATCH `/auth/settings` with `passwordResetTime: 0` or `1` should return a `422`
- [x] PATCH `/auth/settings` with `passwordResetTime: 86400` should return a `200`

## Changelog

- Fixed a bug in which it is possible to set the "require password change" field to a value of 0.

## Risk assessment

- lowish, the non-test diff is quite small and auditable

[RQA-6071]: https://opentrons.atlassian.net/browse/RQA-6071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RQA-6057]: https://opentrons.atlassian.net/browse/RQA-6057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ