### PR TITLE
fix(cursor): fixes cursor sandboxing

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,7 +1,3 @@
 # Files that Cursor should attempt to completely exclude from agent features.
 # Cursor can only make a best effort, so do not rely on only this for security, like hiding API keys.
 # See also .cursorindexignore for something softer.
-
-# Chinese localization data. LLMs will "helpfully" try to keep this in sync with the
-# English data, but we want to do it ourselves.
-**/zh/**.json

--- a/.cursorindexignore
+++ b/.cursorindexignore
@@ -103,3 +103,7 @@ Dockerfile
 DOCKER.md
 docker-compose.yml
 .dockerignore
+
+# Chinese localization data. LLMs will "helpfully" try to keep this in sync with the
+# English data, but we want to do it ourselves.
+**/zh/**.json


### PR DESCRIPTION
# Overview

Cursor agents running tests would always fail due to attempting to import .zh localization files that it was banned from accessing. This would cause all test runs to fail initially and then rerun outside of the sandbox. This should cut down on our token usage somewhat and prevent cursor from jumping outside of the sandbox unnecessarily, while still keeping it from editing zh files. 

## Test Plan and Hands on Testing

Cursor should run tests unsandboxed, and should still never try to edit zh files

## Risk assessment

Low