### PR TITLE
fix(odd): don't automatically pop the login modal when signing runs

### DIFF
--- a/app/src/App/DesktopApp.tsx
+++ b/app/src/App/DesktopApp.tsx
@@ -128,12 +128,13 @@ export const DesktopApp = (): JSX.Element => {
         }}
       >
         <RobotUpdateProvider>
-          <NiceModal.Provider>
-            <ErrorBoundary FallbackComponent={DesktopAppFallback}>
-              <ReactQueryDevtools />
-              <SystemLanguagePreferenceModal />
-              <Navbar routes={desktopRoutes} />
-              <ToasterOven>
+          <ToasterOven>
+            <NiceModal.Provider>
+              <ErrorBoundary FallbackComponent={DesktopAppFallback}>
+                <ReactQueryDevtools />
+                <SystemLanguagePreferenceModal />
+                <Navbar routes={desktopRoutes} />
+
                 <EmergencyStopContext.Provider
                   value={{
                     isEmergencyStopModalDismissed,
@@ -188,9 +189,9 @@ export const DesktopApp = (): JSX.Element => {
                     </Alerts>
                   </Box>
                 </EmergencyStopContext.Provider>
-              </ToasterOven>
-            </ErrorBoundary>
-          </NiceModal.Provider>
+              </ErrorBoundary>
+            </NiceModal.Provider>
+          </ToasterOven>
         </RobotUpdateProvider>
       </DocumentationRequiredModalContext.Provider>
     </LocalizationProvider>

--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -278,9 +278,9 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
                           />
                         ) : null}
 
-                        <NiceModal.Provider>
-                          <RobotEncryptionKeyTakeover>
-                            <ToasterOven>
+                        <ToasterOven>
+                          <NiceModal.Provider>
+                            <RobotEncryptionKeyTakeover>
                               <ProtocolReceiptToasts />
                               {!showModuleSetupModal ? (
                                 <ModuleAttachedToasts
@@ -294,9 +294,9 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
                                 <OnDeviceDisplayAppRoutes />
                               </SharedScrollRefProvider>
                               <LoggedOutOverlayMount />
-                            </ToasterOven>
-                          </RobotEncryptionKeyTakeover>
-                        </NiceModal.Provider>
+                            </RobotEncryptionKeyTakeover>
+                          </NiceModal.Provider>
+                        </ToasterOven>
                       </MaintenanceRunTakeover>
                     </RobotUpdateProvider>
                   </DocumentationRequiredModalContext.Provider>

--- a/app/src/local-resources/access-control/useDocumentationState.ts
+++ b/app/src/local-resources/access-control/useDocumentationState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useMemo } from 'react'
+import { useCallback, useContext, useMemo, useRef } from 'react'
 
 import {
   useAccessControlEnabledQuery,
@@ -45,6 +45,8 @@ export function useDocumentationState(
   const foundName = useCurrentRobotName()
   const currentRobotName = robotName ?? foundName
   const currentUsername = useUsernameForRobot(currentRobotName)
+  const usernameRef = useRef<string | null>(currentUsername)
+  usernameRef.current = currentUsername
 
   const accessControlEnabled =
     accessControlEnabledQuery?.data?.data?.accessControlEnabled ?? false
@@ -76,7 +78,7 @@ export function useDocumentationState(
       initialDocreport?: DocumentationReport,
       usernameOverride?: string
     ) => {
-      let username = usernameOverride ?? currentUsername
+      let username = usernameOverride ?? usernameRef.current
       if (username == null || username.length === 0) {
         console.log('calling requireLogin', currentRobotName)
         const loginResult = await requireLogin({
@@ -101,7 +103,6 @@ export function useDocumentationState(
     },
     [
       currentRobotName,
-      currentUsername,
       onPromptForDocumentation,
       minLengthOfReasonForInteraction,
       providedActionsToDocument,

--- a/app/src/organisms/Desktop/SignRunModal/SignRun.tsx
+++ b/app/src/organisms/Desktop/SignRunModal/SignRun.tsx
@@ -77,6 +77,7 @@ export function SignRunModal({
     popToast,
     eatToast,
     documentationState,
+    false,
     onSigned
   )
 

--- a/app/src/organisms/ToasterOven/ToasterOven.tsx
+++ b/app/src/organisms/ToasterOven/ToasterOven.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -52,35 +52,37 @@ export function ToasterOven({ children }: ToasterOvenProps): JSX.Element {
    * @param {MakeToastOptions} options
    * @returns {string} returns the id to allow imperative eatToast close from caller
    */
-  function makeToast(
-    message: string,
-    type: ToastType,
-    options?: MakeToastOptions
-  ): string {
-    const id = uuidv4()
-    const toastsForRemoval = toasts.map(toast => {
-      return {
-        ...toast,
-        exitNow: true,
-        zIndex: 1,
-        position: POSITION_FIXED,
-      }
-    })
-    setToasts(t => [
-      {
-        id,
-        message,
-        type,
-        zIndex: 2,
-        position: POSITION_FIXED,
-        // Allow callers to override stacking
-        ...options,
-      },
-      ...toastsForRemoval,
-    ])
+  const makeToast = useCallback(
+    (message: string, type: ToastType, options?: MakeToastOptions): string => {
+      const id = uuidv4()
 
-    return id
-  }
+      setToasts(t => {
+        const toastsForRemoval = t.map(toast => {
+          return {
+            ...toast,
+            exitNow: true,
+            zIndex: 1,
+            position: POSITION_FIXED,
+          }
+        })
+        return [
+          {
+            id,
+            message,
+            type,
+            zIndex: 2,
+            position: POSITION_FIXED,
+            // Allow callers to override stacking
+            ...options,
+          },
+          ...toastsForRemoval,
+        ]
+      })
+
+      return id
+    },
+    []
+  )
 
   const toastContainerZIndex = Math.max(
     DEFAULT_TOAST_CONTAINER_Z_INDEX,
@@ -91,31 +93,39 @@ export function ToasterOven({ children }: ToasterOvenProps): JSX.Element {
     )
   )
 
-  function makeSnackbar(
-    message: string,
-    duration?: number,
-    options?: MakeSnackbarOptions
-  ): void {
-    setSnackbar({ message, duration, ...options })
-  }
+  const makeSnackbar = useCallback(
+    (
+      message: string,
+      duration?: number,
+      options?: MakeSnackbarOptions
+    ): void => {
+      setSnackbar({ message, duration, ...options })
+    },
+    []
+  )
 
   // This function is needed to actually make the snackbar auto-close in the context of the
   // ToasterOven. It closes fine by itself in tests and storybook, but we need to eat it
   // here to remove it from the page as a whole.
-  function eatSnackbar(): void {
+  const eatSnackbar = useCallback((): void => {
     setSnackbar(null)
-  }
+  }, [])
 
   /**
    * removes (eats) a toast from toaster oven display container
    * @param {string} toastId the id of the toast to remove
    */
-  function eatToast(toastId: string): void {
+  const eatToast = useCallback((toastId: string): void => {
     setToasts(t => t.filter(toast => toast.id !== toastId))
-  }
+  }, [])
+
+  const contextValue = useMemo(
+    () => ({ eatToast, makeToast, makeSnackbar }),
+    [eatToast, makeToast, makeSnackbar]
+  )
 
   return (
-    <ToasterContext.Provider value={{ eatToast, makeToast, makeSnackbar }}>
+    <ToasterContext.Provider value={contextValue}>
       {toasts.length > 0 ? (
         <Flex
           flexDirection={DIRECTION_COLUMN_REVERSE}

--- a/app/src/pages/ODD/RunSummary/SignRun.tsx
+++ b/app/src/pages/ODD/RunSummary/SignRun.tsx
@@ -78,6 +78,7 @@ export function SignRun({
       popToast,
       eatToast,
       documentationState,
+      true,
       onSigned
     )
 
@@ -215,5 +216,6 @@ const SignRunModalImpl = NiceModal.create(
 )
 
 /** Open the ODD sign-run modal and await whether the run was signed. */
-export const showSignRunModal = (): Promise<boolean> =>
-  NiceModal.show(SignRunModalImpl)
+export const showSignRunModal = (
+  documentationState: DocumentationState
+): Promise<boolean> => NiceModal.show(SignRunModalImpl, { documentationState })

--- a/app/src/resources/access-control/useSignRunFlow.ts
+++ b/app/src/resources/access-control/useSignRunFlow.ts
@@ -118,8 +118,21 @@ export function useSignRunFlow(
         logout()
         popToast()
         queryClient.removeQueries(getSelfQueryKey(host))
-      // prompt for login on desktop only
-      // eslint-disable-next-line no-fallthrough -- just being cute :)
+        setLoginInFlight(true)
+        void showLoginModal({ robotName, uncloseable: true })
+          .then(result => {
+            if (result == null) {
+              eatToast()
+              setLoginInFlight(false)
+              return
+            }
+            setRefetchSelf(true)
+          })
+          .catch(() => {
+            eatToast()
+            setLoginInFlight(false)
+          })
+        break
       case 'idle':
         if (isOnDevice) {
           break

--- a/app/src/resources/access-control/useSignRunFlow.ts
+++ b/app/src/resources/access-control/useSignRunFlow.ts
@@ -41,6 +41,7 @@ export function useSignRunFlow(
   popToast: () => void,
   eatToast: () => void,
   documentationState: DocumentationState,
+  isOnDevice: boolean,
   onSigned?: () => void
 ): SignRunFlowResult {
   const queryClient = useQueryClient()
@@ -117,6 +118,12 @@ export function useSignRunFlow(
         logout()
         popToast()
         queryClient.removeQueries(getSelfQueryKey(host))
+      // prompt for login on desktop only
+      // eslint-disable-next-line no-fallthrough -- just being cute :)
+      case 'idle':
+        if (isOnDevice) {
+          break
+        }
         setLoginInFlight(true)
         void showLoginModal({ robotName, uncloseable: true })
           .then(result => {
@@ -131,8 +138,6 @@ export function useSignRunFlow(
             eatToast()
             setLoginInFlight(false)
           })
-        break
-      case 'idle':
         break
       // waiting for login to finish / self to settle
       case 'prompting':
@@ -152,6 +157,7 @@ export function useSignRunFlow(
     queryClient,
     robotName,
     showLoginModal,
+    isOnDevice,
   ])
 
   const signRun = useCallback(

--- a/app/src/resources/access-control/useSignRunFlow.ts
+++ b/app/src/resources/access-control/useSignRunFlow.ts
@@ -117,9 +117,6 @@ export function useSignRunFlow(
         logout()
         popToast()
         queryClient.removeQueries(getSelfQueryKey(host))
-      // prompt for login
-      // eslint-disable-next-line no-fallthrough -- just being cute :)
-      case 'idle':
         setLoginInFlight(true)
         void showLoginModal({ robotName, uncloseable: true })
           .then(result => {
@@ -134,6 +131,8 @@ export function useSignRunFlow(
             eatToast()
             setLoginInFlight(false)
           })
+        break
+      case 'idle':
         break
       // waiting for login to finish / self to settle
       case 'prompting':


### PR DESCRIPTION
# Overview

When signing runs, the ODD would automatically pop the login modal when logged out. This is unnecessary, as the lock overlay prevents users from interacting anyways. Also fixes bugs with toasts not popping from sign modal, toaster oven causing unnecessary rerenders, and signrun modal on desktop not getting the updated username after a login.

## Test Plan and Hands on Testing

1. Start a run on a crs bot from the desktop app, then cancel it.
2. The ODD should show the Sign Run modal and not the login modal. The login modal should pop up as normal on the desktop app if necessary.

## Risk assessment

Medium.