### PR TITLE
fix(app, auth-server): allow regular users to delete audit logs

### DIFF
--- a/app/src/local-resources/access-control/__tests__/utils.test.ts
+++ b/app/src/local-resources/access-control/__tests__/utils.test.ts
@@ -42,6 +42,10 @@ describe('isForbiddenError', () => {
       isForbiddenError(new Error('One or more logPeriods failed to delete'))
     ).toBe(false)
   })
+
+  it('is false for a null error', () => {
+    expect(isForbiddenError(null)).toBe(false)
+  })
 })
 
 describe('getAuditLogDeleteErrorMessage', () => {

--- a/app/src/local-resources/access-control/utils.ts
+++ b/app/src/local-resources/access-control/utils.ts
@@ -1,5 +1,3 @@
-import axios from 'axios'
-
 import type { AxiosError } from 'axios'
 import type {
   DocumentationReport,
@@ -38,7 +36,7 @@ export const ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE: DocumentationState = {
 }
 
 export function isForbiddenError(error: unknown): error is AxiosError {
-  return axios.isAxiosError(error) && error.response?.status === 403
+  return isAxiosError(error) && error.response?.status === 403
 }
 
 export function getAuditLogDeleteErrorMessage(
@@ -73,7 +71,7 @@ export function getProtocolOrRunCreationErrorMessage(
   if (isProtocolWritePermissionError(error)) {
     return permissionErrorMessage
   }
-  if (axios.isAxiosError(error)) {
+  if (isAxiosError(error)) {
     const detail = (
       error.response?.data as
         { errors?: Array<{ detail?: unknown }> } | undefined
@@ -85,4 +83,13 @@ export function getProtocolOrRunCreationErrorMessage(
     }
   }
   return generalErrorMessage
+}
+
+function isAxiosError(error: unknown): error is AxiosError {
+  return (
+    typeof error === 'object' &&
+    error != null &&
+    'isAxiosError' in error &&
+    error.isAxiosError === true
+  )
 }

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
@@ -229,15 +229,22 @@ export function ComplianceReadySoftwareFiles({
             deletionKeysByLogPeriodId
           )
         })
-        .catch((e: Error) => {
+        .then(() => {
+          setDownloadModalDismissed(true)
+        })
+        .catch((e: unknown) => {
           if (!isDocumentedMutationError(e)) {
+            const fallbackMessage =
+              e instanceof Error && e.message.length > 0
+                ? e.message
+                : t('some_logs_not_deleted')
             makeToast(
               getAuditLogDeleteErrorMessage(
                 e,
                 t(
                   'access_control:delete_audit_logs_permission_required'
                 ) as string,
-                e.message
+                fallbackMessage as string
               ),
               ERROR_TOAST
             )

--- a/app/src/resources/devices/hooks/useDeleteSelectedLogPeriods.ts
+++ b/app/src/resources/devices/hooks/useDeleteSelectedLogPeriods.ts
@@ -78,7 +78,7 @@ export function useDeleteSelectedLogPeriods(
           })
         }
 
-        if (isForbiddenError(permissionError)) {
+        if (permissionError != null && isForbiddenError(permissionError)) {
           throw permissionError
         }
         if (hasDeleteError) {

--- a/auth-server/auth_server/users/scopes.py
+++ b/auth-server/auth_server/users/scopes.py
@@ -43,6 +43,7 @@ def get_scope_set_of_account_type(
                 Scope.USERS_READ_SELF,
                 Scope.USERS_WRITE_SELF,
                 Scope.AUDIT_LOG_WRITE,
+                Scope.AUDIT_LOG_DELETE,
             }
             if not settings.requireAdminCredsWhenUpdatingRobotSoftware:
                 result.add(Scope.UPDATES_WRITE)

--- a/react-api-client/src/accessControl/__tests__/useDocumentedMutation.test.tsx
+++ b/react-api-client/src/accessControl/__tests__/useDocumentedMutation.test.tsx
@@ -212,6 +212,32 @@ describe('useDocumentedMutation', () => {
     expect(mutationFn).toHaveBeenCalledTimes(2)
   })
 
+  it('propagates a null rejection without reading isAxiosError', async () => {
+    const mutationFn = vi.fn().mockRejectedValue(null)
+
+    const { result } = renderHook(
+      () =>
+        useDocumentedMutation<number, unknown, number>(
+          createReasonNotRequiredDocumentationState(),
+          ['play_run'],
+          testMutationKey,
+          ({ variables: n }) => mutationFn(n),
+          {}
+        ),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.mutate(5)
+    })
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+    expect(result.current.error).toBeNull()
+    expect(mutationFn).toHaveBeenCalledTimes(1)
+  })
+
   it('propagates non-401 errors without prompting for login', async () => {
     const askForLogin = vi.fn()
     const mutationFn = vi.fn().mockRejectedValue({

--- a/react-api-client/src/accessControl/useDocumentedMutation.ts
+++ b/react-api-client/src/accessControl/useDocumentedMutation.ts
@@ -165,12 +165,11 @@ async function runMutation<TData, TVariables>(
           ? (documentationState.docreport ?? '')
           : '',
     })
-    .catch(async e => {
+    .catch(async (e: unknown) => {
       console.log('hit error', e)
       console.log(documentationState)
       if (
-        e.isAxiosError &&
-        e.response?.status === 401 &&
+        isAxiosUnauthorizedError(e) &&
         documentationState.accessControlEnabled
       ) {
         console.log('hit 401')
@@ -183,4 +182,15 @@ async function runMutation<TData, TVariables>(
         )
       } else throw e
     })
+}
+
+function isAxiosUnauthorizedError(error: unknown): boolean {
+  if (error == null || typeof error !== 'object') {
+    return false
+  }
+  const axiosError = error as {
+    isAxiosError?: unknown
+    response?: { status?: unknown }
+  }
+  return axiosError.isAxiosError === true && axiosError.response?.status === 401
 }


### PR DESCRIPTION
Closes [RQA-6066](https://opentrons.atlassian.net/browse/RQA-6066)

# Overview

Regular user accounts could write audit logs but not delete them after download. Only admin and service accounts got `audit_log.delete`, so a user download-and-delete hit `403`, whoops.

Once delete started succeeding, the File Manager flow would still bug out given error handling around `isAxiosError` on a `null` rejection after a `200`. The file management flow now treats null/non-object errors as non-Axios, and dismisses the modal when download-and-delete finishes.

### Current behavior

https://github.com/user-attachments/assets/adcf89a2-cc2b-41de-8b0b-380b7927a427

### Fixed behavior

https://github.com/user-attachments/assets/c0493546-99ef-49bc-a84c-9546737130e8

## Test Plan and Hands on Testing

- See videos.
- Verified the download log flow after a protocol run works, too.

## Changelog

- Fixed the account group "users" not being able to download audit logs.

## Risk assessment

- low, simple scopes addition and adjusting some of the error handling around file management flows

[RQA-6066]: https://opentrons.atlassian.net/browse/RQA-6066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ