### PR TITLE
fix(app): add 8px border radius to labware card

### DIFF
--- a/app/src/organisms/Desktop/Labware/LabwareCard/index.tsx
+++ b/app/src/organisms/Desktop/Labware/LabwareCard/index.tsx
@@ -5,6 +5,7 @@ import startCase from 'lodash/startCase'
 import {
   ALIGN_CENTER,
   ALIGN_FLEX_END,
+  BORDERS,
   Box,
   COLORS,
   DIRECTION_COLUMN,
@@ -58,6 +59,7 @@ export function LabwareCard(props: LabwareCardProps): ReactNode {
       role="link"
       backgroundColor={COLORS.white}
       color={COLORS.black90}
+      borderRadius={BORDERS.borderRadius8}
       paddingLeft={SPACING.spacing16}
       paddingY={SPACING.spacing16}
       height="auto"


### PR DESCRIPTION
# Overview

Add 8px border radius to labware card. This PR closes [RUXD-2929.](https://opentrons.atlassian.net/browse/RUXD-2929).

## Test Plan and Hands on Testing

Open the run app and open the Labware tab and review labware cards.

## Changelog

Add 8px border radius to labware card.

## Risk assessment

Low
