### PR TITLE
fix(app) protocol-runs setup reducer RTK migration

### DIFF
--- a/app/src/redux/protocol-runs/reducer/setup.ts
+++ b/app/src/redux/protocol-runs/reducer/setup.ts
@@ -1,3 +1,5 @@
+import { createReducer, isAnyOf } from '@reduxjs/toolkit'
+
 import {
   updateCameraEnablement,
   updateCameraRecoveryEnablement,
@@ -9,7 +11,7 @@ import {
 } from '../actions'
 import * as Constants from '../constants'
 
-import type { ProtocolRunAction, RunSetupStatus } from '../types'
+import type { RunSetupStatus } from '../types'
 
 const INITIAL_SETUP_STEP_STATE = {
   required: true,
@@ -33,66 +35,39 @@ export const INITIAL_RUN_SETUP_STATE: RunSetupStatus = {
   [Constants.CAMERA_SETUP_STEP_KEY]: CAMERA_INITIAL_SETUP_STATE,
 }
 
-export function setupReducer(
-  state: RunSetupStatus = INITIAL_RUN_SETUP_STATE,
-  action: ProtocolRunAction
-): RunSetupStatus {
-  switch (action.type) {
-    case updateRunSetupStepsComplete.type:
-      return Constants.SETUP_STEP_KEYS.reduce(
-        (currentState, step) => ({
-          ...currentState,
-          [step]: {
-            ...currentState[step],
-            complete:
-              action.payload.complete[step] ?? currentState[step].complete,
-          },
-        }),
-        state
-      )
-
-    case updateRunSetupStepsRequired.type:
-      return Constants.SETUP_STEP_KEYS.reduce(
-        (currentState, step) => ({
-          ...currentState,
-          [step]: {
-            ...currentState[step],
-            required:
-              action.payload.required[step] ?? currentState[step].required,
-          },
-        }),
-        state
-      )
-
-    case updateCameraEnablement.type:
-    case updateCameraRecoveryEnablement.type:
-    case updateCameraStreamEnablement.type:
-    case updateCameraUsageSettings.type: {
-      const { runId, ...rest } = action.payload
-      return {
-        ...state,
-        [Constants.CAMERA_SETUP_STEP_KEY]: {
-          ...state[Constants.CAMERA_SETUP_STEP_KEY],
-          ...rest,
-        },
+export const setupReducer = createReducer(INITIAL_RUN_SETUP_STATE, builder => {
+  builder
+    .addCase(updateRunSetupStepsComplete, (state, { payload }) => {
+      Constants.SETUP_STEP_KEYS.forEach(step => {
+        const complete = payload.complete[step]
+        if (complete != null) {
+          state[step].complete = complete
+        }
+      })
+    })
+    .addCase(updateRunSetupStepsRequired, (state, { payload }) => {
+      Constants.SETUP_STEP_KEYS.forEach(step => {
+        const required = payload.required[step]
+        if (required != null) {
+          state[step].required = required
+        }
+      })
+    })
+    .addCase(updateCameraSpecificSettings, (state, { payload }) => {
+      state[Constants.CAMERA_SETUP_STEP_KEY].cameraImageSettings[
+        payload.cameraId
+      ] = payload.cameraImageSettings
+    })
+    .addMatcher(
+      isAnyOf(
+        updateCameraEnablement,
+        updateCameraRecoveryEnablement,
+        updateCameraStreamEnablement,
+        updateCameraUsageSettings
+      ),
+      (state, action) => {
+        const { runId, ...rest } = action.payload
+        Object.assign(state[Constants.CAMERA_SETUP_STEP_KEY], rest)
       }
-    }
-
-    case updateCameraSpecificSettings.type: {
-      const { cameraId, cameraImageSettings } = action.payload
-      return {
-        ...state,
-        [Constants.CAMERA_SETUP_STEP_KEY]: {
-          ...state[Constants.CAMERA_SETUP_STEP_KEY],
-          cameraImageSettings: {
-            ...state[Constants.CAMERA_SETUP_STEP_KEY].cameraImageSettings,
-            [cameraId]: cameraImageSettings,
-          },
-        },
-      }
-    }
-
-    default:
-      return state
-  }
-}
+    )
+})


### PR DESCRIPTION
# Overview

Step 2  of work spiking out Redux to RTK migration for protocol-runs.

This step migrates existing setup reducer to use `createReducer`

## Test Plan and Hands on Testing

Tests already exist to cover function of defined `setupReducer`. This code change should generate absolutely no difference in app behavior.

## Changelog

- 1 commit implementing `createReducer` migration

## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment

Should be pretty low -- I expect anything I broke would immediately throw redux errors.