### PR TITLE
fix(auth-server): Invalidate tokens when an admin changes another user's username or password

### DIFF
--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -108,6 +108,16 @@ class Backend:
         """Invalidate every issued access and refresh token."""
         self._token_store.revoke_all()
 
+    def revoke_tokens_for_user(self, user_id: int) -> None:
+        """Invalidate every issued access and refresh token for one user."""
+        self._token_store.revoke_for_user(user_id)
+
+    def revoke_tokens_for_username(self, username: str) -> None:
+        """Invalidate every issued access and refresh token for the named user."""
+        user = self._user_store.get(username)
+        if user is not None:
+            self.revoke_tokens_for_user(user.id)
+
     def create_introspect_response(
         self, body_form_data: list[tuple[str, str]], headers: dict[str, str]
     ) -> fastapi.Response:
@@ -622,6 +632,9 @@ class _TokenStore:
 
     def revoke_all(self) -> None:
         self._tokens.clear()
+
+    def revoke_for_user(self, user_id: int) -> None:
+        self._tokens = [token for token in self._tokens if token.user_id != user_id]
 
     @staticmethod
     def _is_active(token: _TokenIssuance, now: datetime) -> bool:

--- a/auth-server/auth_server/users/router.py
+++ b/auth-server/auth_server/users/router.py
@@ -22,6 +22,8 @@ from server_utils.fastapi_utils.models.json_api import (
 )
 
 from auth_server.api_error import APIError
+from auth_server.oauth2.backend import Backend
+from auth_server.oauth2.fastapi_dependencies import get_oauth2_backend
 from auth_server.users.dependencies import get_user_by_username, get_user_data_manager
 from auth_server.users.models import (
     AccountType,
@@ -242,6 +244,7 @@ async def update_user(  # noqa: C901
     user_data_manager: Annotated[
         UserDataManager, fastapi.Depends(get_user_data_manager)
     ],
+    oauth2_backend: Annotated[Backend, fastapi.Depends(get_oauth2_backend)],
     audit_logger: Annotated[
         AuditLogger,
         fastapi.Depends(get_audit_logger("update user", auto_log_request_body=False)),
@@ -316,6 +319,8 @@ async def update_user(  # noqa: C901
             status_code=fastapi.status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         )
+    if _admin_update_revokes_existing_tokens(user, update_data):
+        oauth2_backend.revoke_tokens_for_username(updated_user.username)
     return await PydanticResponse.create(
         status_code=fastapi.status.HTTP_200_OK,
         content=SimpleBody(data=updated_user),
@@ -522,6 +527,21 @@ async def update_self(  # noqa: C901
         status_code=fastapi.status.HTTP_200_OK,
         content=SimpleBody(data=result),
     )
+
+
+def _admin_update_revokes_existing_tokens(
+    existing: UserResponse, update: UpdateUser
+) -> bool:
+    """Return whether an admin update should invalidate the target user's sessions.
+
+    Username and role changes end existing sessions. Legal-name edits
+    and lock/unlock do not; lock is enforced separately via the deactivated flag.
+    """
+    if update.username is not None and update.username != existing.username:
+        return True
+    if update.accountType is not None and update.accountType != existing.accountType:
+        return True
+    return False
 
 
 def _build_user_already_exists_error() -> ErrorBody[UserAlreadyExistsErrorDetails]:

--- a/auth-server/auth_server/users/router.py
+++ b/auth-server/auth_server/users/router.py
@@ -352,12 +352,14 @@ async def reset_user_password(
     user_data_manager: Annotated[
         UserDataManager, fastapi.Depends(get_user_data_manager)
     ],
+    oauth2_backend: Annotated[Backend, fastapi.Depends(get_oauth2_backend)],
 ) -> PydanticResponse[SimpleBody[TemporaryPasswordResponse]]:
     """Reset a user's password to a random temporary password."""
     result = user_data_manager.reset_user_password(
         user.username,
         now=datetime.datetime.now(tz=datetime.UTC),
     )
+    oauth2_backend.revoke_tokens_for_username(user.username)
     return await PydanticResponse.create(
         status_code=fastapi.status.HTTP_200_OK,
         content=SimpleBody(data=result),
@@ -534,10 +536,11 @@ def _admin_update_revokes_existing_tokens(
 ) -> bool:
     """Return whether an admin update should invalidate the target user's sessions.
 
-    Username and role changes end existing sessions. Legal-name edits
-    and lock/unlock do not; lock is enforced separately via the deactivated flag.
+    Username, credential, and role changes end existing sessions.
     """
     if update.username is not None and update.username != existing.username:
+        return True
+    if update.password is not None:
         return True
     if update.accountType is not None and update.accountType != existing.accountType:
         return True

--- a/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
@@ -639,7 +639,7 @@ stages:
       strict:
         - json:off
 
-  - name: Pre-rename token is still active after admin username change
+  - name: Pre-rename token is inactive after admin username change
     request:
       method: POST
       url: '{run_server.base_url}/auth/oauth2/introspect'
@@ -649,28 +649,32 @@ stages:
     response:
       status_code: 200
       json:
-        active: true
-        username: testuser_3
-        ot_fullname: Test User
+        active: false
       strict:
         - json:off
 
-  - name: GET self after admin username change returns the renamed user
+  - name: GET self after admin username change is rejected
     request:
       method: GET
       url: '{run_server.base_url}/auth/users/self'
       headers:
         authorization: 'Bearer {user_access_token}'
     response:
-      status_code: 200
+      status_code: 401
+
+  - name: PATCH self after admin username change is rejected
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        authorization: 'Bearer {user_access_token}'
       json:
         data:
-          username: testuser_3
-          fullName: Test User
-      strict:
-        - json:off
+          fullName: Should Not Apply
+    response:
+      status_code: 401
 
-  - name: Refresh token still works after username change
+  - name: Refresh token is rejected after admin username change
     request:
       method: POST
       url: '{run_server.base_url}/auth/oauth2/token'
@@ -679,27 +683,25 @@ stages:
         grant_type: refresh_token
         refresh_token: '{user_refresh_token}'
     response:
-      status_code: 200
+      status_code: 400
       json:
-        access_token: !anystr
+        error: invalid_grant
       strict:
         - json:off
-      save:
-        json:
-          refreshed_access_token: access_token
 
-  - name: GET self with the refreshed token returns the renamed user
+  - name: Renamed user can mint a new token
     request:
-      method: GET
-      url: '{run_server.base_url}/auth/users/self'
-      headers:
-        authorization: 'Bearer {refreshed_access_token}'
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: password
+        username: testuser_3
+        password: testuserpassword
     response:
       status_code: 200
       json:
-        data:
-          username: testuser_3
-          fullName: Test User
+        access_token: !anystr
       strict:
         - json:off
 
@@ -810,6 +812,205 @@ stages:
       json:
         error: invalid_grant
         opentrons_account_locked: true
+      strict:
+        - json:off
+
+---
+test_name: Changing a user's role invalidates their existing tokens
+
+marks:
+  - usefixtures:
+      - run_server
+      - admin_access_token
+      - seed_users
+
+stages:
+  - name: Log in as the regular user
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: password
+        username: testuser
+        password: testuserpassword
+    response:
+      status_code: 200
+      save:
+        json:
+          user_access_token: access_token
+          user_refresh_token: refresh_token
+
+  - name: Admin changes the user's role
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/byUsername/testuser'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          accountType: auditor
+    response:
+      status_code: 200
+      json:
+        data:
+          accountType: auditor
+      strict:
+        - json:off
+
+  - name: Pre-role-change token is inactive
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/introspect'
+      data:
+        client_id: opentrons_app
+        token: '{user_access_token}'
+    response:
+      status_code: 200
+      json:
+        active: false
+      strict:
+        - json:off
+
+  - name: GET self with the pre-role-change token is rejected
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        authorization: 'Bearer {user_access_token}'
+    response:
+      status_code: 401
+
+  - name: PATCH self with the pre-role-change token is rejected
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        authorization: 'Bearer {user_access_token}'
+      json:
+        data:
+          fullName: Should Not Apply
+    response:
+      status_code: 401
+
+  - name: Refresh with the pre-role-change token is rejected
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: refresh_token
+        refresh_token: '{user_refresh_token}'
+    response:
+      status_code: 400
+      json:
+        error: invalid_grant
+      strict:
+        - json:off
+
+  - name: User can log in with the new role
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: password
+        username: testuser
+        password: testuserpassword
+    response:
+      status_code: 200
+      json:
+        access_token: !anystr
+        scope: users.read.others
+      strict:
+        - json:off
+
+---
+test_name: Changing a user's legal name does not invalidate their existing tokens
+
+marks:
+  - usefixtures:
+      - run_server
+      - admin_access_token
+      - seed_users
+
+stages:
+  - name: Log in as the regular user
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: password
+        username: testuser
+        password: testuserpassword
+    response:
+      status_code: 200
+      save:
+        json:
+          user_access_token: access_token
+          user_refresh_token: refresh_token
+
+  - name: Admin changes the user's legal name
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/byUsername/testuser'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          fullName: Updated Legal Name
+    response:
+      status_code: 200
+      json:
+        data:
+          fullName: Updated Legal Name
+      strict:
+        - json:off
+
+  - name: Pre-change token is still active
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/introspect'
+      data:
+        client_id: opentrons_app
+        token: '{user_access_token}'
+    response:
+      status_code: 200
+      json:
+        active: true
+        username: testuser
+        ot_fullname: Updated Legal Name
+      strict:
+        - json:off
+
+  - name: GET self still works after legal name change
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        authorization: 'Bearer {user_access_token}'
+    response:
+      status_code: 200
+      json:
+        data:
+          username: testuser
+          fullName: Updated Legal Name
+      strict:
+        - json:off
+
+  - name: Refresh token still works after legal name change
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: refresh_token
+        refresh_token: '{user_refresh_token}'
+    response:
+      status_code: 200
+      json:
+        access_token: !anystr
       strict:
         - json:off
 

--- a/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
@@ -816,6 +816,117 @@ stages:
         - json:off
 
 ---
+test_name: Resetting a user's password invalidates their existing tokens
+
+marks:
+  - usefixtures:
+      - run_server
+      - admin_access_token
+      - seed_users
+
+stages:
+  - name: Log in as the regular user
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: password
+        username: testuser
+        password: testuserpassword
+    response:
+      status_code: 200
+      save:
+        json:
+          user_access_token: access_token
+          user_refresh_token: refresh_token
+
+  - name: Admin resets the user's password
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/users/byUsername/testuser/resetPassword'
+      headers:
+        Authorization: '{admin_access_token}'
+    response:
+      status_code: 200
+      save:
+        json:
+          temporary_password: data.temporaryPassword
+      json:
+        data:
+          resetPassword: true
+          temporaryPassword: !anystr
+      strict:
+        - json:off
+
+  - name: Pre-reset token is inactive
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/introspect'
+      data:
+        client_id: opentrons_app
+        token: '{user_access_token}'
+    response:
+      status_code: 200
+      json:
+        active: false
+      strict:
+        - json:off
+
+  - name: GET self with the pre-reset token is rejected
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        authorization: 'Bearer {user_access_token}'
+    response:
+      status_code: 401
+
+  - name: PATCH self with the pre-reset token is rejected
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        authorization: 'Bearer {user_access_token}'
+      json:
+        data:
+          fullName: Should Not Apply
+    response:
+      status_code: 401
+
+  - name: Refresh with the pre-reset token is rejected
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: refresh_token
+        refresh_token: '{user_refresh_token}'
+    response:
+      status_code: 400
+      json:
+        error: invalid_grant
+      strict:
+        - json:off
+
+  - name: User can log in with the temporary password
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: password
+        username: testuser
+        password: '{temporary_password}'
+    response:
+      status_code: 200
+      json:
+        access_token: !anystr
+        scope: users.read.self users.write.self
+      strict:
+        - json:off
+
+---
 test_name: Changing a user's role invalidates their existing tokens
 
 marks:


### PR DESCRIPTION
Closes [RQA-5952](https://opentrons.atlassian.net/browse/RQA-5952)

# Overview

This continues [PR #22364](https://github.com/Opentrons/opentrons/pull/22364). Lock and delete already rejected cached tokens, but admin username change and password reset did not. 

An administrator action that changes another user’s identity, credentials, or role now revokes that user’s existing access and refresh tokens. The next request fails with 401, introspection reports `active: false`, and the user must log in again (with the new username or temporary password). Legal-name edits and self-updates still leave the current session valid. Role change also reports active: false instead of only 403. 

Several new tavern tests are added to provide fully automated coverage of the requirements of this ticket.

## Test Plan and Hands on Testing

- Well covered with tavern tests now.

## Changelog

- Fixed tokens improperly persisting when an admin changes another user's username or password.

## Risk assessment

- low, the tavern provides enough E2E testing to ensure we have desired behavior. only real risk comes from any feature that depends upon this broken behavior, which seems unlikely. 


[RQA-5952]: https://opentrons.atlassian.net/browse/RQA-5952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ