### PR TITLE
feat(components, scripts): add subpath export for opentrons/component…

### DIFF
--- a/.cursor/skills/js-package-testing/SKILL.md
+++ b/.cursor/skills/js-package-testing/SKILL.md
@@ -28,7 +28,9 @@ via `link:pack/...`, and runs a Vite demo plus Playwright + Applitools Eyes.
    - `@opentrons/protocol-visualization/styles`
    - `@opentrons/components/styles/global`
    - `@opentrons/components/styles`
-4. Wrap app in `I18nextProvider` with `protocol_visualization` namespace (see `src/i18n.ts`).
+4. Wrap app in `I18nextProvider`. Load `protocol_visualization` (local JSON) plus
+   shared component namespaces from `@opentrons/components/localization`
+   (Node-safe; do not import resources from the package root in Node).
 5. Vite: dedupe React, use `cssModulesSideEffect` plugin, `define: { 'process.env': {} }` if needed.
 
 Library runtime deps (`styled-components`, `redux`, etc.) are bundled; host app does not install them.

--- a/components/README.md
+++ b/components/README.md
@@ -14,6 +14,20 @@ export default function CowButton(props) {
 }
 ```
 
+### localization (Node-safe)
+
+Shared i18n resource objects (`shared_en_resources`, `shared_zh_resources`,
+`resources`) are available from a DOM-free subpath. Use this in Node scripts,
+tests, or SSR instead of importing from the package root (which loads React/DOM):
+
+```javascript
+import {
+  shared_en_resources,
+  shared_zh_resources,
+  resources,
+} from '@opentrons/components/localization'
+```
+
 ## setup
 
 Usage requirements for dependent projects:

--- a/components/package.json
+++ b/components/package.json
@@ -13,6 +13,11 @@
       "import": "./lib/index.mjs",
       "require": "./lib/index.js"
     },
+    "./localization": {
+      "types": "./lib/localization.d.ts",
+      "import": "./lib/localization.mjs",
+      "require": "./lib/localization.js"
+    },
     "./styles": "./lib/style.css",
     "./styles/global": "./src/styles/global.css",
     "./styles/legacy": "./src/index.module.css",

--- a/components/src/localization.ts
+++ b/components/src/localization.ts
@@ -1,0 +1,12 @@
+/**
+ * Node-safe localization exports for @opentrons/components.
+ *
+ * Import from `@opentrons/components/localization` instead of the package root
+ * when running outside a browser (scripts, tests, SSR). The root entry pulls in
+ * React/DOM code and is not safe to load in bare Node.
+ */
+export {
+  resources,
+  shared_en_resources,
+  shared_zh_resources,
+} from './assets/localization'

--- a/components/vite.config.mts
+++ b/components/vite.config.mts
@@ -12,9 +12,13 @@ import { cssModuleSideEffect } from './cssModuleSideEffect'
 export default defineConfig({
   build: {
     lib: {
-      entry: 'src/index.ts',
+      entry: {
+        index: 'src/index.ts',
+        localization: 'src/localization.ts',
+      },
       formats: ['es', 'cjs'],
-      fileName: format => `index.${format === 'es' ? 'mjs' : 'js'}`,
+      fileName: (format, entryName) =>
+        `${entryName}.${format === 'es' ? 'mjs' : 'js'}`,
     },
     outDir: 'lib',
     // Do not delete the outdir, typescript types might live there and we don't want to delete them

--- a/js-package-testing/README.md
+++ b/js-package-testing/README.md
@@ -99,6 +99,11 @@ between JS and CSS.
 `react-i18next`. Wrap your app with `I18nextProvider` and load the
 `protocol_visualization` namespace.
 
+Shared component namespaces (`command_type_summary`, `deck_configuration`,
+`protocol_command_text`) come from the Node-safe subpath
+`@opentrons/components/localization` (do not import them from the package root
+in Node — that entry loads React/DOM).
+
 Minimal example (see [`src/i18n.ts`](src/i18n.ts) and
 [`src/main.tsx`](src/main.tsx)):
 
@@ -106,12 +111,16 @@ Minimal example (see [`src/i18n.ts`](src/i18n.ts) and
 import { I18nextProvider } from 'react-i18next'
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
+import { shared_en_resources } from '@opentrons/components/localization'
 import protocolVisualizationEn from './locale/en/protocol_visualization.json'
 
 void i18n.use(initReactI18next).init({
   lng: 'en',
   resources: {
-    en: { protocol_visualization: protocolVisualizationEn },
+    en: {
+      ...shared_en_resources,
+      protocol_visualization: protocolVisualizationEn,
+    },
   },
   interpolation: { escapeValue: false },
 })
@@ -123,7 +132,7 @@ root.render(
 )
 ```
 
-Copy English strings from
+Copy English strings for `protocol_visualization` from
 [`src/locale/en/protocol_visualization.json`](src/locale/en/protocol_visualization.json)
 (keep in sync with
 [`app/src/assets/localization/en/protocol_visualization.json`](../app/src/assets/localization/en/protocol_visualization.json)).

--- a/scripts/package-json-patches.mts
+++ b/scripts/package-json-patches.mts
@@ -171,6 +171,12 @@ export function patchComponentsPackageJson(
         require: './lib/index.js',
         default: './lib/index.mjs',
       },
+      './localization': {
+        types: './lib/localization.d.ts',
+        import: './lib/localization.mjs',
+        require: './lib/localization.js',
+        default: './lib/localization.mjs',
+      },
       './styles': './lib/style.css',
       './styles/global': './src/styles/global.css',
       './styles/legacy': './src/index.module.css',

--- a/scripts/publish.mts
+++ b/scripts/publish.mts
@@ -283,6 +283,22 @@ async function smokeTestEsm(
   }
 }
 
+async function smokeTestComponentsLocalization(): Promise<void> {
+  console.log('\n=== Smoke-testing Node-safe @opentrons/components/localization ===')
+  const localizationPath = path.join(COMPONENTS_ROOT, 'lib', 'localization.mjs')
+  try {
+    const mod = await import(localizationPath)
+    if (mod.shared_en_resources == null || mod.resources == null) {
+      throw new Error('missing shared_en_resources or resources export')
+    }
+    console.log('  localization ESM smoke test PASSED')
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`\n  FATAL: localization import failed in bare Node.\n  Error: ${message}`)
+    process.exit(1)
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Temporarily patch source package.json files, pnpm pack, then restore
 // ---------------------------------------------------------------------------
@@ -419,6 +435,7 @@ async function main(): Promise<void> {
     '@opentrons/step-generation'
   )
   await smokeTestEsm(path.join(COMPONENTS_ROOT, 'lib'), '@opentrons/components')
+  await smokeTestComponentsLocalization()
   await smokeTestEsm(
     path.join(PROTOCOL_VISUALIZATION_ROOT, 'lib'),
     '@opentrons/protocol-visualization'

--- a/scripts/publish.mts
+++ b/scripts/publish.mts
@@ -284,7 +284,9 @@ async function smokeTestEsm(
 }
 
 async function smokeTestComponentsLocalization(): Promise<void> {
-  console.log('\n=== Smoke-testing Node-safe @opentrons/components/localization ===')
+  console.log(
+    '\n=== Smoke-testing Node-safe @opentrons/components/localization ==='
+  )
   const localizationPath = path.join(COMPONENTS_ROOT, 'lib', 'localization.mjs')
   try {
     const mod = await import(localizationPath)
@@ -294,7 +296,9 @@ async function smokeTestComponentsLocalization(): Promise<void> {
     console.log('  localization ESM smoke test PASSED')
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
-    console.error(`\n  FATAL: localization import failed in bare Node.\n  Error: ${message}`)
+    console.error(
+      `\n  FATAL: localization import failed in bare Node.\n  Error: ${message}`
+    )
     process.exit(1)
   }
 }


### PR DESCRIPTION
…s package

# Overview

Adds a Node-safe subpath export `@opentrons/components/localization` that ships only the shared i18n resource objects (`shared_en_resources`, `shared_zh_resources`, `resources`).

Lets Node consumers (e.g. Opentrons AI’s Fastify/Node compiler engine) reuse shared namespaces like `command_type_summary` without importing the package root, which loads React/DOM and is not Node-safe.

Wires the subpath through Vite multi-entry build, package exports, publish patches, and a publish smoke test.

Node consumers need shared i18n data like `command_type_summar`y, but importing `@opentrons/components` loads React/DOM and crashes outside the browser. This subpath exports only those resource objects so they can be reused safely in Node.

## Test Plan and Hands on Testing

Review the code and approach

## Review requests

does this approach make sense to you?

## Risk assessment

low, shouldn't affect any work, wont' be used until after merged in