### PR TITLE
fix(app, auth-server): give service accounts admin parity and lock their identity

### DIFF
--- a/app/src/local-resources/access-control/__tests__/utils.test.ts
+++ b/app/src/local-resources/access-control/__tests__/utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   getAuditLogDeleteErrorMessage,
   getProtocolOrRunCreationErrorMessage,
+  isAdminEquivalentAccountType,
   isForbiddenError,
   isProtocolWritePermissionError,
 } from '../utils'
@@ -153,5 +154,18 @@ describe('getProtocolOrRunCreationErrorMessage', () => {
         PERMISSION_ERROR
       )
     ).toBe(GENERAL_ERROR)
+  })
+})
+
+describe('isAdminEquivalentAccountType', () => {
+  it('returns true for admin and service accounts', () => {
+    expect(isAdminEquivalentAccountType('admin')).toBe(true)
+    expect(isAdminEquivalentAccountType('service')).toBe(true)
+  })
+
+  it('returns false for other account types and missing values', () => {
+    expect(isAdminEquivalentAccountType('user')).toBe(false)
+    expect(isAdminEquivalentAccountType('auditor')).toBe(false)
+    expect(isAdminEquivalentAccountType(undefined)).toBe(false)
   })
 })

--- a/app/src/local-resources/access-control/utils.ts
+++ b/app/src/local-resources/access-control/utils.ts
@@ -1,4 +1,5 @@
 import type { AxiosError } from 'axios'
+import type { AuthUserAccountType } from '@opentrons/api-client'
 import type {
   DocumentationReport,
   DocumentationState,
@@ -7,6 +8,13 @@ import type {
 const PROTOCOLS_WRITE_SCOPE = 'protocols.write'
 
 const MAX_ERROR_DETAIL_LENGTH = 255
+
+/** Admin and service accounts share the same privileged robot permissions. */
+export function isAdminEquivalentAccountType(
+  accountType: AuthUserAccountType | undefined
+): boolean {
+  return accountType === 'admin' || accountType === 'service'
+}
 
 export function isDocumentationReportValid(
   docreport: DocumentationReport,

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/PersonalAccountSettings/PersonalAccountSettingsEditForm.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/PersonalAccountSettings/PersonalAccountSettingsEditForm.tsx
@@ -17,6 +17,7 @@ export interface PersonalAccountSettingsEditFormProps {
   username: string
   fullName: string
   isSaving: boolean
+  identityReadOnly?: boolean
   onSave: (data: UpdateSelfRequest) => Promise<void>
   onCancel: () => void
 }
@@ -32,6 +33,7 @@ export function PersonalAccountSettingsEditForm({
   username,
   fullName,
   isSaving,
+  identityReadOnly = false,
   onSave,
   onCancel,
 }: PersonalAccountSettingsEditFormProps): JSX.Element {
@@ -54,7 +56,8 @@ export function PersonalAccountSettingsEditForm({
     const trimmedUsername = data.username.trim()
     const trimmedFullName = data.fullName.trim()
     const hasProfileChanges =
-      trimmedUsername !== username || trimmedFullName !== fullName
+      !identityReadOnly &&
+      (trimmedUsername !== username || trimmedFullName !== fullName)
     const hasPasswordChange = data.password !== ''
 
     if (!hasProfileChanges && !hasPasswordChange) {
@@ -63,8 +66,12 @@ export function PersonalAccountSettingsEditForm({
 
     void onSave({
       data: {
-        ...(trimmedUsername !== username ? { username: trimmedUsername } : {}),
-        ...(trimmedFullName !== fullName ? { fullName: trimmedFullName } : {}),
+        ...(!identityReadOnly && trimmedUsername !== username
+          ? { username: trimmedUsername }
+          : {}),
+        ...(!identityReadOnly && trimmedFullName !== fullName
+          ? { fullName: trimmedFullName }
+          : {}),
         ...(hasPasswordChange ? { password: data.password } : {}),
       },
     }).catch(error => {
@@ -78,7 +85,10 @@ export function PersonalAccountSettingsEditForm({
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <div className={styles.form_fields}>
-        <UserAccountIdentityFormFields control={control} />
+        <UserAccountIdentityFormFields
+          control={control}
+          readOnly={identityReadOnly}
+        />
         <UserAccountPasswordFormFields control={control} />
         <div className={styles.actions}>
           <SecondaryButton type="button" onClick={onCancel}>

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/PersonalAccountSettings/__tests__/PersonalAccountSettings.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/PersonalAccountSettings/__tests__/PersonalAccountSettings.test.tsx
@@ -304,4 +304,37 @@ describe('PersonalAccountSettings', () => {
       screen.queryByText('Unable to save account settings. Try again.')
     ).not.toBeInTheDocument()
   })
+
+  it('keeps username and legal name read-only for a service account', async () => {
+    const { container } = renderComponent({
+      perRobotAuthStates: {
+        [ROBOT_NAME]: {
+          ...MOCK_AUTH_STATE,
+          user: {
+            username: 'service',
+            fullName: 'Service Account',
+            accountType: 'service',
+          },
+        },
+      },
+      mostRecentRobotName: ROBOT_NAME,
+    })
+
+    openEditForm()
+    expect(screen.getByDisplayValue('service')).toHaveAttribute('readOnly')
+    expect(screen.getByDisplayValue('Service Account')).toHaveAttribute(
+      'readOnly'
+    )
+
+    getPasswordInputs(container).forEach(input => {
+      fireEvent.change(input, { target: { value: 'new-password' } })
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(mockUpdateSelf).toHaveBeenCalledWith({
+        data: { password: 'new-password' },
+      })
+    })
+  })
 })

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/PersonalAccountSettings/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/PersonalAccountSettings/index.tsx
@@ -112,6 +112,7 @@ export function PersonalAccountSettings({
                 username={loggedInUser.username}
                 fullName={loggedInUser.fullName}
                 isSaving={isSaving}
+                identityReadOnly={loggedInUser.accountType === 'service'}
                 onSave={handleSave}
                 onCancel={handleCancelEdit}
               />

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/UserManagementTableRow.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/UserManagementTableRow.tsx
@@ -46,6 +46,12 @@ export function UserManagementTableRow({
       action(user)
     }
 
+  const isServiceAccount = user.accountType === 'service'
+  const canEdit = !isServiceAccount
+  const canDelete = !isServiceAccount
+  const canLockOrUnlock = !isServiceAccount
+  const canResetPassword = !user.locked
+
   return (
     <ListItem type="default">
       <div className={styles.row}>
@@ -78,23 +84,27 @@ export function UserManagementTableRow({
           {showOverflowMenu ? (
             <>
               <div className={styles.overflow_menu}>
-                <MenuItem onClick={handleMenuAction(onEdit)}>
-                  {t('desktop_edit_user')}
-                </MenuItem>
-                <MenuItem onClick={handleMenuAction(onDelete)}>
-                  {t('desktop_delete_user')}
-                </MenuItem>
-                {user.locked ? (
+                {canEdit ? (
+                  <MenuItem onClick={handleMenuAction(onEdit)}>
+                    {t('desktop_edit_user')}
+                  </MenuItem>
+                ) : null}
+                {canDelete ? (
+                  <MenuItem onClick={handleMenuAction(onDelete)}>
+                    {t('desktop_delete_user')}
+                  </MenuItem>
+                ) : null}
+                {canLockOrUnlock && user.locked ? (
                   <MenuItem onClick={handleMenuAction(onActivate)}>
                     {t('desktop_unlock_user')}
                   </MenuItem>
                 ) : null}
-                {!user.locked ? (
+                {canResetPassword ? (
                   <MenuItem onClick={handleMenuAction(onResetPassword)}>
                     {t('desktop_reset_password')}
                   </MenuItem>
                 ) : null}
-                {!user.locked ? (
+                {canLockOrUnlock && !user.locked ? (
                   <MenuItem onClick={handleMenuAction(onDeactivate)}>
                     {t('desktop_lock_user')}
                   </MenuItem>

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/__tests__/UserManagement.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/__tests__/UserManagement.test.tsx
@@ -355,7 +355,9 @@ describe('UserManagement', () => {
     render()
     expandAccordion()
     fireEvent.click(
-      screen.getByRole('button', { name: 'UserManagement_overflowMenu_service' })
+      screen.getByRole('button', {
+        name: 'UserManagement_overflowMenu_service',
+      })
     )
 
     screen.getByRole('button', { name: 'Reset password' })

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/__tests__/UserManagement.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/__tests__/UserManagement.test.tsx
@@ -328,4 +328,50 @@ describe('UserManagement', () => {
       mockResetUserPassword.mock.invocationCallOrder[0]!
     )
   })
+
+  it('only allows reset password for a service account', () => {
+    vi.mocked(useUsersQuery).mockImplementation(
+      options =>
+        ({
+          data:
+            options?.enabled === false
+              ? undefined
+              : {
+                  ...MOCK_USERS_RESPONSE,
+                  data: [
+                    ...MOCK_USERS_RESPONSE.data,
+                    {
+                      username: 'service',
+                      fullName: 'Service Account',
+                      accountType: 'service' as const,
+                      locked: false,
+                      resetPassword: false,
+                    },
+                  ],
+                  meta: { cursor: 0, totalLength: 3 },
+                },
+        }) as ReturnType<typeof useUsersQuery>
+    )
+    render()
+    expandAccordion()
+    fireEvent.click(
+      screen.getByRole('button', { name: 'UserManagement_overflowMenu_service' })
+    )
+
+    screen.getByRole('button', { name: 'Reset password' })
+    expect(
+      screen.queryByRole('button', { name: 'Edit user' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Delete user' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Lock account' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', {
+        name: 'Unlock account and reset password',
+      })
+    ).not.toBeInTheDocument()
+  })
 })

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/userAccount/UserAccountFullNameField.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/userAccount/UserAccountFullNameField.tsx
@@ -10,10 +10,12 @@ import type { Control, FieldValues, Path } from 'react-hook-form'
 
 export interface UserAccountFullNameFieldProps<T extends FieldValues> {
   control: Control<T>
+  readOnly?: boolean
 }
 
 export function UserAccountFullNameField<T extends FieldValues>({
   control,
+  readOnly = false,
 }: UserAccountFullNameFieldProps<T>): JSX.Element {
   const { t } = useTranslation('device_settings')
 
@@ -34,6 +36,7 @@ export function UserAccountFullNameField<T extends FieldValues>({
           render={({ field, fieldState }) => (
             <InputField
               value={field.value}
+              readOnly={readOnly}
               error={fieldState.error?.message}
               onChange={field.onChange}
               onBlur={field.onBlur}

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/userAccount/UserAccountIdentityFormFields.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/userAccount/UserAccountIdentityFormFields.tsx
@@ -10,6 +10,7 @@ export interface UserAccountIdentityFormFieldsProps<T extends FieldValues> {
   autoFocusFirstField?: boolean
   stacked?: boolean
   usernameMaxLength?: number
+  readOnly?: boolean
 }
 
 export function UserAccountIdentityFormFields<T extends FieldValues>({
@@ -17,6 +18,7 @@ export function UserAccountIdentityFormFields<T extends FieldValues>({
   autoFocusFirstField,
   stacked = false,
   usernameMaxLength,
+  readOnly = false,
 }: UserAccountIdentityFormFieldsProps<T>): JSX.Element {
   if (stacked) {
     return (
@@ -25,8 +27,9 @@ export function UserAccountIdentityFormFields<T extends FieldValues>({
           autoFocus={autoFocusFirstField}
           control={control}
           usernameMaxLength={usernameMaxLength}
+          readOnly={readOnly}
         />
-        <UserAccountFullNameField control={control} />
+        <UserAccountFullNameField control={control} readOnly={readOnly} />
       </>
     )
   }
@@ -37,8 +40,9 @@ export function UserAccountIdentityFormFields<T extends FieldValues>({
         autoFocus={autoFocusFirstField}
         control={control}
         usernameMaxLength={usernameMaxLength}
+        readOnly={readOnly}
       />
-      <UserAccountFullNameField control={control} />
+      <UserAccountFullNameField control={control} readOnly={readOnly} />
     </div>
   )
 }

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/userAccount/UserAccountUsernameField.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/userAccount/UserAccountUsernameField.tsx
@@ -14,12 +14,14 @@ export interface UserAccountUsernameFieldProps<T extends FieldValues> {
   control: Control<T>
   autoFocus?: boolean
   usernameMaxLength?: number
+  readOnly?: boolean
 }
 
 export function UserAccountUsernameField<T extends FieldValues>({
   control,
   autoFocus,
   usernameMaxLength,
+  readOnly = false,
 }: UserAccountUsernameFieldProps<T>): JSX.Element {
   const { t } = useTranslation('device_settings')
   const requiredError = t(
@@ -81,6 +83,7 @@ export function UserAccountUsernameField<T extends FieldValues>({
             return (
               <InputField
                 autoFocus={autoFocus}
+                readOnly={readOnly}
                 value={field.value}
                 error={error}
                 caption={

--- a/app/src/organisms/Desktop/EnableCRSWizard/index.tsx
+++ b/app/src/organisms/Desktop/EnableCRSWizard/index.tsx
@@ -38,7 +38,7 @@ import type { ReactNode } from 'react'
 
 const WIZARD_MODAL_WIDTH = '31.25rem'
 const SERVICE_ACCOUNT_USERNAME = 'service'
-const SERVICE_ACCOUNT_FULL_NAME = 'Service Account (created by system)'
+const SERVICE_ACCOUNT_FULL_NAME = 'Service Account'
 const RECOVERY_ACCOUNT_USERNAME = 'recovery'
 const RECOVERY_ACCOUNT_FULL_NAME = 'Recovery Account (created by system)'
 

--- a/app/src/redux/robot-auth/__tests__/selectors.test.ts
+++ b/app/src/redux/robot-auth/__tests__/selectors.test.ts
@@ -101,8 +101,54 @@ describe('robot auth selectors', () => {
       ).toBe(true)
     })
 
-    it('returns false when the logged-in user is not an admin', () => {
+    it('returns true when the logged-in user is a service account', () => {
+      expect(
+        getIsAdminForRobot(
+          makeTestState({
+            perRobotAuthStates: {
+              robotA: {
+                user: {
+                  username: 'service',
+                  fullName: 'Service Account',
+                  accountType: 'service',
+                },
+                accessToken: 'token',
+                refreshToken: null,
+                expiresAt: null,
+              },
+            },
+            mostRecentRobotName: 'robotA',
+          }),
+          'robotA'
+        )
+      ).toBe(true)
+    })
+
+    it('returns false when the logged-in user is a regular user', () => {
       expect(getIsAdminForRobot(stateWithRobotA, 'robotA')).toBe(false)
+    })
+
+    it('returns false when the logged-in user is an auditor', () => {
+      expect(
+        getIsAdminForRobot(
+          makeTestState({
+            perRobotAuthStates: {
+              robotA: {
+                user: {
+                  username: 'auditor',
+                  fullName: 'Auditor User',
+                  accountType: 'auditor',
+                },
+                accessToken: 'token',
+                refreshToken: null,
+                expiresAt: null,
+              },
+            },
+            mostRecentRobotName: 'robotA',
+          }),
+          'robotA'
+        )
+      ).toBe(false)
     })
   })
 

--- a/app/src/redux/robot-auth/hooks.ts
+++ b/app/src/redux/robot-auth/hooks.ts
@@ -44,7 +44,7 @@ export function useUsernameForRobot(robotName: string | null): string | null {
   return useSelector(selector)
 }
 
-/** Return whether the logged-in user for the given robot is an admin. */
+/** Return whether the logged-in user has admin-equivalent privileges. */
 export function useIsAdminForRobot(robotName: string): boolean {
   const selector = useCallback(
     (state: State) => getIsAdminForRobot(state, robotName),

--- a/app/src/redux/robot-auth/slice.ts
+++ b/app/src/redux/robot-auth/slice.ts
@@ -3,6 +3,8 @@
 import { createSelector, createSlice } from '@reduxjs/toolkit'
 import isEqual from 'lodash/isEqual'
 
+import { isAdminEquivalentAccountType } from '/app/local-resources/access-control/utils'
+
 import { type ActionTypesFromSlice } from '../ActionTypesFromSlice'
 import { getLocalRobot } from '../discovery'
 
@@ -170,8 +172,11 @@ export function getLoggedInUserForRobot(
   return getAuthStateForRobot(state, robotName)?.user ?? null
 }
 
+/** True when the logged-in user has admin-equivalent privileges. */
 export function getIsAdminForRobot(state: State, robotName: string): boolean {
-  return getAuthStateForRobot(state, robotName)?.user.accountType === 'admin'
+  return isAdminEquivalentAccountType(
+    getAuthStateForRobot(state, robotName)?.user.accountType
+  )
 }
 
 /**

--- a/app/src/resources/access-control/useSignRunFlow.ts
+++ b/app/src/resources/access-control/useSignRunFlow.ts
@@ -10,6 +10,7 @@ import {
   useSignRunMutation,
 } from '@opentrons/react-api-client'
 
+import { isAdminEquivalentAccountType } from '/app/local-resources/access-control/utils'
 import { useLogout } from '/app/redux/robot-auth'
 
 import { useNotifyRunQuery } from '../runs'
@@ -68,7 +69,7 @@ export function useSignRunFlow(
 
   const requireAdmin =
     authSettings?.data.requireAdminCredsForSignoffProtocol === true
-  const isAdmin = self?.data.accountType === 'admin'
+  const isAdmin = isAdminEquivalentAccountType(self?.data.accountType)
   const canSignProtocol = !requireAdmin || isAdmin
 
   const [loginInFlight, setLoginInFlight] = useState(false)

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -25,6 +25,7 @@ from server_utils.auth.scopes import Scope, UnrecognizedScopeError, serialize_sc
 from auth_server.persistence.orm_models import User as ORMUser
 from auth_server.settings.store import SettingsStore
 from auth_server.users.is_account_locked import is_account_locked
+from auth_server.users.models import AccountType
 from auth_server.users.scopes import get_scope_set_of_user
 from auth_server.users.store import UserStore
 from auth_server.users.user_data_manager import must_reset_password, password_hash
@@ -347,6 +348,10 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
             failed_login_count=failed_login_count,
             max_attempts=max_login_attempts,
         )
+        if AccountType(user.account_type) == AccountType.SERVICE:
+            # Service accounts must remain usable for Opentrons maintenance.
+            # Failed attempts are still recorded and audited.
+            is_currently_locked = False
 
         if is_currently_locked or not password_is_correct:
             reason = (

--- a/auth-server/auth_server/users/models.py
+++ b/auth-server/auth_server/users/models.py
@@ -18,6 +18,9 @@ class AccountType(StrEnum):
     SERVICE = "service"
 
 
+# Hardcoded legal name for every new service account.
+SERVICE_ACCOUNT_FULL_NAME = "Service Account"
+
 USERNAME_MAX_LENGTH = 20
 
 Username = Annotated[

--- a/auth-server/auth_server/users/router.py
+++ b/auth-server/auth_server/users/router.py
@@ -211,7 +211,13 @@ async def delete_user(
     ],
 ) -> PydanticResponse[SimpleEmptyBody]:
     """Delete a user by its unique identifier."""
-    user_data_manager.delete_user(user.username)
+    try:
+        user_data_manager.delete_user(user.username)
+    except InvalidInputError as e:
+        raise fastapi.HTTPException(
+            status_code=fastapi.status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
     return await PydanticResponse.create(
         content=SimpleEmptyBody.model_construct(),
         status_code=fastapi.status.HTTP_200_OK,

--- a/auth-server/auth_server/users/user_data_manager.py
+++ b/auth-server/auth_server/users/user_data_manager.py
@@ -16,6 +16,7 @@ from auth_server.users.credential_characters import (
 )
 from auth_server.users.is_account_locked import is_account_locked
 from auth_server.users.models import (
+    SERVICE_ACCOUNT_FULL_NAME,
     AccountType,
     TemporaryPasswordResponse,
     UserResponse,
@@ -183,6 +184,8 @@ class UserDataManager:
         now: datetime.datetime,
     ) -> TemporaryPasswordResponse:
         """Validate inputs, check for duplicates, and create a new user."""
+        if account_type == AccountType.SERVICE:
+            full_name = SERVICE_ACCOUNT_FULL_NAME
         _validate_fields_non_empty(
             username=username,
             password=password,

--- a/auth-server/auth_server/users/user_data_manager.py
+++ b/auth-server/auth_server/users/user_data_manager.py
@@ -138,6 +138,39 @@ def _validate_fields_non_empty(
             raise InvalidInputError(f"{field_name} must not be empty")
 
 
+def _reject_disallowed_service_account_mutations(
+    existing_user: User,
+    *,
+    new_username: str | None,
+    new_full_name: str | None,
+    new_account_type: str | None,
+    new_locked: bool | None,
+) -> None:
+    """Reject identity and lock changes that service accounts do not allow."""
+    existing_type = AccountType(existing_user.account_type)
+    if (
+        new_account_type is not None
+        and AccountType(new_account_type) == AccountType.SERVICE
+        and existing_type != AccountType.SERVICE
+    ):
+        raise InvalidInputError("Cannot change an account's type to service.")
+
+    if existing_type != AccountType.SERVICE:
+        return
+
+    if new_username is not None and new_username != existing_user.username:
+        raise InvalidInputError("Service account username cannot be changed.")
+    if new_full_name is not None and new_full_name != existing_user.full_name:
+        raise InvalidInputError("Service account legal name cannot be changed.")
+    if (
+        new_account_type is not None
+        and AccountType(new_account_type) != AccountType.SERVICE
+    ):
+        raise InvalidInputError("Service account type cannot be changed.")
+    if new_locked is not None:
+        raise InvalidInputError("Service accounts cannot be locked or unlocked.")
+
+
 def must_reset_password(
     user: User, now: datetime.datetime, password_reset_time_sec: float | None
 ) -> bool:
@@ -159,12 +192,16 @@ class UserDataManager:
 
     def _to_response(self, user: User) -> UserResponse:
         settings = self._settings_store.get_settings()
-        is_failed_login_locked, _ = is_account_locked(
-            failed_login_count=self._user_store.get_failed_login_count(user.username),
-            max_attempts=settings.maxNumberOfLoginAttempts,
-        )
-
         account_type = AccountType(user.account_type)
+        is_failed_login_locked = False
+        if account_type != AccountType.SERVICE:
+            is_failed_login_locked, _ = is_account_locked(
+                failed_login_count=self._user_store.get_failed_login_count(
+                    user.username
+                ),
+                max_attempts=settings.maxNumberOfLoginAttempts,
+            )
+
         now = datetime.datetime.now(tz=datetime.UTC)
 
         return UserResponse(
@@ -229,6 +266,9 @@ class UserDataManager:
 
     def delete_user(self, username: str) -> None:
         """Delete a user or raise UserNotFoundError."""
+        user = self._user_store.get(username)
+        if user is not None and AccountType(user.account_type) == AccountType.SERVICE:
+            raise InvalidInputError("Service accounts cannot be deleted.")
         try:
             self._user_store.remove(username)
         except ValueError as e:
@@ -254,11 +294,19 @@ class UserDataManager:
             account_type=new_account_type,
         )
         _validate_username_characters(new_username)
+        existing_user = self._user_store.get(username_to_update)
+        if existing_user is not None:
+            _reject_disallowed_service_account_mutations(
+                existing_user,
+                new_username=new_username,
+                new_full_name=new_full_name,
+                new_account_type=new_account_type,
+                new_locked=new_locked,
+            )
         if new_password is not None:
             _validate_password_complexity(
                 new_password, self._settings_store.get_settings()
             )
-            existing_user = self._user_store.get(username_to_update)
             if existing_user is not None and password_hash.verify(
                 new_password, existing_user.hashed_password
             ):

--- a/auth-server/tests/conftest.py
+++ b/auth-server/tests/conftest.py
@@ -32,6 +32,16 @@ def admin_scopes_str() -> str:
 
 
 @pytest.fixture
+def service_scopes_str() -> str:
+    """All the OAuth 2 scopes that a service account should have, as a space-separated string."""
+    return serialize_scopes(
+        get_scope_set_of_account_type(
+            AccountType.SERVICE, SettingsResponseData(), must_reset_password=False
+        )
+    )
+
+
+@pytest.fixture
 def user_scopes_str() -> str:
     """All the OAuth 2 scopes that a regular user should have, as a space-separated string."""
     return serialize_scopes(

--- a/auth-server/tests/integration/test_service_account_immutability.tavern.yaml
+++ b/auth-server/tests/integration/test_service_account_immutability.tavern.yaml
@@ -1,0 +1,187 @@
+test_name: Service accounts cannot be mutated or locked out
+
+marks:
+  - usefixtures:
+      - run_server
+      - admin_access_token
+      - seed_users
+
+stages:
+  - name: Enable access control
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/settings/accessControlEnabled'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          accessControlEnabled: true
+    response:
+      status_code: 200
+      json:
+        data:
+          accessControlEnabled: true
+      strict:
+        - json:off
+
+  - name: Set the maximum number of failed login attempts
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/settings'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          maxNumberOfLoginAttempts: 3
+    response:
+      status_code: 200
+      json:
+        data:
+          maxNumberOfLoginAttempts: 3
+      strict:
+        - json:off
+
+  - name: Create a service account
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/users'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          username: service
+          password: servicepassword123
+          fullName: Should Be Ignored
+          accountType: service
+    response:
+      status_code: 201
+      json:
+        data:
+          username: service
+          fullName: Service Account
+          accountType: service
+          locked: false
+          resetPassword: false
+
+  - name: Reject renaming the service account
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/byUsername/service'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          username: renamed-service
+    response:
+      status_code: 400
+
+  - name: Reject changing the service account legal name
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/byUsername/service'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          fullName: Some Other Name
+    response:
+      status_code: 400
+
+  - name: Reject changing the service account type
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/byUsername/service'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          accountType: admin
+    response:
+      status_code: 400
+
+  - name: Reject locking the service account
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/byUsername/service'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          locked: true
+    response:
+      status_code: 400
+
+  - name: Reject deleting the service account
+    request:
+      method: DELETE
+      url: '{run_server.base_url}/auth/users/byUsername/service'
+      headers:
+        Authorization: '{admin_access_token}'
+    response:
+      status_code: 400
+
+  - name: Failed login attempt 1/3
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data: &wrong_credentials
+        client_id: opentrons_app
+        grant_type: password
+        username: service
+        password: not_the_right_password
+    response:
+      status_code: 400
+      json:
+        error: invalid_grant
+        error_description: Invalid credentials given.
+      strict:
+        - json:off
+
+  - name: Failed login attempt 2/3
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data: *wrong_credentials
+    response:
+      status_code: 400
+
+  - name: Failed login attempt 3/3
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data: *wrong_credentials
+    response:
+      status_code: 400
+
+  - name: Correct credentials still work after the failed-login limit
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: password
+        username: service
+        password: servicepassword123
+    response:
+      status_code: 200
+      json:
+        access_token: !anystr
+      strict:
+        - json:off
+
+  - name: Service account is not reported as locked
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/users/byUsername/service'
+      headers:
+        Authorization: '{admin_access_token}'
+    response:
+      status_code: 200
+      json:
+        data:
+          username: service
+          fullName: Service Account
+          accountType: service
+          locked: false
+      strict:
+        - json:off

--- a/auth-server/tests/users/test_user_data_manager.py
+++ b/auth-server/tests/users/test_user_data_manager.py
@@ -1093,10 +1093,6 @@ def test_update_user_rejects_current_password(
             now=_NOW,
         )
 
-
-# ── service account immutability ────────────────────────────────────
-
-
 def _make_service_user(
     username: str = "service",
     full_name: str = SERVICE_ACCOUNT_FULL_NAME,

--- a/auth-server/tests/users/test_user_data_manager.py
+++ b/auth-server/tests/users/test_user_data_manager.py
@@ -67,9 +67,10 @@ def _make_orm_user(
     reset_password: bool = False,
     deactivated: bool = False,
     password_set_at: datetime.datetime = _NOW,
+    user_id: int | None = None,
 ) -> User:
     """Helper to build an ORM User for mock return values."""
-    return User(
+    user = User(
         username=username,
         hashed_password=hashed_password,
         full_name=full_name,
@@ -78,6 +79,9 @@ def _make_orm_user(
         deactivated=deactivated,
         password_set_at=password_set_at,
     )
+    if user_id is not None:
+        user.id = user_id
+    return user
 
 
 # ── create_user ─────────────────────────────────────────────────────
@@ -1088,3 +1092,181 @@ def test_update_user_rejects_current_password(
             new_password=current_password,
             now=_NOW,
         )
+
+
+# ── service account immutability ────────────────────────────────────
+
+
+def _make_service_user(
+    username: str = "service",
+    full_name: str = SERVICE_ACCOUNT_FULL_NAME,
+) -> User:
+    return _make_orm_user(
+        username=username,
+        full_name=full_name,
+        account_type=AccountType.SERVICE,
+    )
+
+
+def test_delete_service_user_raises(
+    decoy: Decoy, mock_store: UserStore, manager: UserDataManager
+) -> None:
+    decoy.when(mock_store.get("service")).then_return(_make_service_user())
+    with pytest.raises(InvalidInputError, match="cannot be deleted"):
+        manager.delete_user("service")
+    decoy.verify(mock_store.remove("service"), times=0)
+
+
+@pytest.mark.parametrize(
+    ("update_kwargs", "match"),
+    [
+        ({"new_username": "renamed"}, "username cannot be changed"),
+        ({"new_full_name": "Some Other Name"}, "legal name cannot be changed"),
+        ({"new_account_type": AccountType.ADMIN}, "type cannot be changed"),
+        ({"new_locked": True}, "cannot be locked or unlocked"),
+        ({"new_locked": False}, "cannot be locked or unlocked"),
+    ],
+)
+def test_update_service_user_rejects_identity_and_lock_changes(
+    decoy: Decoy,
+    mock_store: UserStore,
+    manager: UserDataManager,
+    update_kwargs: dict[str, object],
+    match: str,
+) -> None:
+    decoy.when(mock_store.get("service")).then_return(_make_service_user())
+    with pytest.raises(InvalidInputError, match=match):
+        manager.update_user("service", now=_NOW, **update_kwargs)  # type: ignore[arg-type]
+
+
+def test_update_user_cannot_convert_to_service(
+    decoy: Decoy, mock_store: UserStore, manager: UserDataManager
+) -> None:
+    decoy.when(mock_store.get("alice")).then_return(
+        _make_orm_user(username="alice", account_type=AccountType.USER)
+    )
+    with pytest.raises(InvalidInputError, match="type to service"):
+        manager.update_user(
+            "alice", now=_NOW, new_account_type=AccountType.SERVICE
+        )
+
+
+def test_update_existing_service_legal_name_is_not_rewritten(
+    decoy: Decoy, mock_store: UserStore, manager: UserDataManager
+) -> None:
+    """Robots created before the hardcoded name keep their stored legal name."""
+    decoy.when(mock_store.get("service")).then_return(
+        _make_service_user(full_name="Service Account (created by system)")
+    )
+    with pytest.raises(InvalidInputError, match="legal name cannot be changed"):
+        manager.update_user(
+            "service", now=_NOW, new_full_name=SERVICE_ACCOUNT_FULL_NAME
+        )
+
+
+def test_update_service_user_noop_identity_fields_succeed(
+    decoy: Decoy,
+    mock_store: UserStore,
+    mock_settings: SettingsStore,
+    manager: UserDataManager,
+) -> None:
+    existing = _make_service_user()
+    decoy.when(mock_settings.get_settings()).then_return(SettingsResponseData())
+    decoy.when(mock_store.get("service")).then_return(existing)
+    decoy.when(
+        mock_store.update(
+            "service",
+            new_username="service",
+            hashed_password=None,
+            full_name=SERVICE_ACCOUNT_FULL_NAME,
+            account_type=AccountType.SERVICE,
+            reset_password=False,
+            deactivated=None,
+            now=matchers.IsA(datetime.datetime),
+        )
+    ).then_return(existing)
+
+    result = manager.update_user(
+        "service",
+        now=_NOW,
+        new_username="service",
+        new_full_name=SERVICE_ACCOUNT_FULL_NAME,
+        new_account_type=AccountType.SERVICE,
+    )
+    assert result.username == "service"
+    assert result.fullName == SERVICE_ACCOUNT_FULL_NAME
+    assert result.accountType == AccountType.SERVICE
+
+
+def test_update_service_user_allows_password_change(
+    decoy: Decoy,
+    mock_store: UserStore,
+    mock_settings: SettingsStore,
+    manager: UserDataManager,
+) -> None:
+    existing = _make_orm_user(
+        username="service",
+        full_name=SERVICE_ACCOUNT_FULL_NAME,
+        account_type=AccountType.SERVICE,
+        hashed_password=password_hash.hash("oldpassword123"),
+    )
+    decoy.when(mock_settings.get_settings()).then_return(SettingsResponseData())
+    decoy.when(mock_store.get("service")).then_return(existing)
+    decoy.when(
+        mock_store.update(
+            "service",
+            new_username=None,
+            hashed_password=matchers.IsA(str),
+            full_name=None,
+            account_type=None,
+            reset_password=False,
+            deactivated=None,
+            now=matchers.IsA(datetime.datetime),
+        )
+    ).then_return(existing)
+
+    result = manager.update_user(
+        "service", now=_NOW, new_password="newpassword2"
+    )
+    assert result.username == "service"
+
+
+def test_reset_service_user_password(
+    decoy: Decoy,
+    mock_store: UserStore,
+    mock_settings: SettingsStore,
+    manager: UserDataManager,
+) -> None:
+    decoy.when(mock_settings.get_settings()).then_return(SettingsResponseData())
+    updated = _make_service_user()
+    updated.reset_password = True
+    decoy.when(
+        mock_store.update(
+            "service",
+            hashed_password=matchers.IsA(str),
+            reset_password=True,
+            deactivated=False,
+            now=matchers.IsA(datetime.datetime),
+        )
+    ).then_return(updated)
+
+    result = manager.reset_user_password("service", now=_NOW)
+    assert result.username == "service"
+    assert result.temporaryPassword is not None
+
+
+def test_get_service_user_not_locked_by_failed_logins(
+    decoy: Decoy,
+    mock_store: UserStore,
+    mock_settings: SettingsStore,
+    manager: UserDataManager,
+) -> None:
+    decoy.when(mock_settings.get_settings()).then_return(
+        SettingsResponseData(maxNumberOfLoginAttempts=3)
+    )
+    decoy.when(mock_store.get_failed_login_count("service")).then_return(5)
+    decoy.when(mock_store.get("service")).then_return(_make_service_user())
+
+    result = manager.get_user("service")
+    assert result.locked is False
+    assert result.accountType == AccountType.SERVICE

--- a/auth-server/tests/users/test_user_data_manager.py
+++ b/auth-server/tests/users/test_user_data_manager.py
@@ -1093,6 +1093,7 @@ def test_update_user_rejects_current_password(
             now=_NOW,
         )
 
+
 def _make_service_user(
     username: str = "service",
     full_name: str = SERVICE_ACCOUNT_FULL_NAME,
@@ -1142,9 +1143,7 @@ def test_update_user_cannot_convert_to_service(
         _make_orm_user(username="alice", account_type=AccountType.USER)
     )
     with pytest.raises(InvalidInputError, match="type to service"):
-        manager.update_user(
-            "alice", now=_NOW, new_account_type=AccountType.SERVICE
-        )
+        manager.update_user("alice", now=_NOW, new_account_type=AccountType.SERVICE)
 
 
 def test_update_existing_service_legal_name_is_not_rewritten(
@@ -1221,9 +1220,7 @@ def test_update_service_user_allows_password_change(
         )
     ).then_return(existing)
 
-    result = manager.update_user(
-        "service", now=_NOW, new_password="newpassword2"
-    )
+    result = manager.update_user("service", now=_NOW, new_password="newpassword2")
     assert result.username == "service"
 
 

--- a/auth-server/tests/users/test_user_data_manager.py
+++ b/auth-server/tests/users/test_user_data_manager.py
@@ -11,6 +11,7 @@ from auth_server.settings.models import (
 )
 from auth_server.settings.store import SettingsStore
 from auth_server.users.models import (
+    SERVICE_ACCOUNT_FULL_NAME,
     AccountType,
     TemporaryPasswordResponse,
     UserResponse,
@@ -121,6 +122,121 @@ def test_create_user_success(
         resetPassword=False,
         temporaryPassword=None,
     )
+
+
+def test_create_service_user_forces_legal_name(
+    decoy: Decoy,
+    mock_store: UserStore,
+    mock_settings: SettingsStore,
+    manager: UserDataManager,
+) -> None:
+    decoy.when(mock_settings.get_settings()).then_return(SettingsResponseData())
+    expected = _make_orm_user(
+        username="service",
+        full_name=SERVICE_ACCOUNT_FULL_NAME,
+        account_type=AccountType.SERVICE,
+    )
+    decoy.when(mock_store.get("service")).then_return(None)
+    decoy.when(
+        mock_store.add(
+            username="service",
+            hashed_password=matchers.IsA(str),
+            full_name=SERVICE_ACCOUNT_FULL_NAME,
+            account_type=AccountType.SERVICE,
+            now=matchers.IsA(datetime.datetime),
+            reset_password=False,
+        )
+    ).then_return(expected)
+
+    result = manager.create_user(
+        username="service",
+        password="validpass123",
+        full_name="Some Other Name",
+        account_type=AccountType.SERVICE,
+        now=_NOW,
+    )
+    assert result == TemporaryPasswordResponse(
+        username="service",
+        fullName=SERVICE_ACCOUNT_FULL_NAME,
+        accountType=AccountType.SERVICE,
+        locked=False,
+        resetPassword=False,
+        temporaryPassword=None,
+    )
+
+
+def test_create_service_user_ignores_empty_client_legal_name(
+    decoy: Decoy,
+    mock_store: UserStore,
+    mock_settings: SettingsStore,
+    manager: UserDataManager,
+) -> None:
+    decoy.when(mock_settings.get_settings()).then_return(SettingsResponseData())
+    expected = _make_orm_user(
+        username="service",
+        full_name=SERVICE_ACCOUNT_FULL_NAME,
+        account_type=AccountType.SERVICE,
+    )
+    decoy.when(mock_store.get("service")).then_return(None)
+    decoy.when(
+        mock_store.add(
+            username="service",
+            hashed_password=matchers.IsA(str),
+            full_name=SERVICE_ACCOUNT_FULL_NAME,
+            account_type=AccountType.SERVICE,
+            now=matchers.IsA(datetime.datetime),
+            reset_password=False,
+        )
+    ).then_return(expected)
+
+    result = manager.create_user(
+        username="service",
+        password="validpass123",
+        full_name="",
+        account_type=AccountType.SERVICE,
+        now=_NOW,
+    )
+    assert result.fullName == SERVICE_ACCOUNT_FULL_NAME
+
+
+@pytest.mark.parametrize(
+    "account_type",
+    [AccountType.ADMIN, AccountType.USER, AccountType.AUDITOR],
+)
+def test_create_non_service_user_keeps_provided_legal_name(
+    decoy: Decoy,
+    mock_store: UserStore,
+    mock_settings: SettingsStore,
+    manager: UserDataManager,
+    account_type: AccountType,
+) -> None:
+    decoy.when(mock_settings.get_settings()).then_return(SettingsResponseData())
+    expected = _make_orm_user(
+        username="keep_name",
+        full_name="Provided Name",
+        account_type=account_type,
+    )
+    decoy.when(mock_store.get("keep_name")).then_return(None)
+    decoy.when(
+        mock_store.add(
+            username="keep_name",
+            hashed_password=matchers.IsA(str),
+            full_name="Provided Name",
+            account_type=account_type,
+            now=matchers.IsA(datetime.datetime),
+            reset_password=False,
+        )
+    ).then_return(expected)
+
+    result = manager.create_user(
+        username="keep_name",
+        password="validpass123",
+        full_name="Provided Name",
+        account_type=account_type,
+        now=_NOW,
+    )
+    assert result.fullName == "Provided Name"
+    assert result.accountType == account_type
 
 
 def test_create_user_hashes_password(


### PR DESCRIPTION
Closes [RQA-6064](https://opentrons.atlassian.net/browse/RQA-6064), [RQA-6073](https://opentrons.atlassian.net/browse/RQA-6073), and [RQA-6096](https://opentrons.atlassian.net/browse/RQA-6096)

# Overview

This PR is best viewed commit-by-commit.

Service accounts already received the same OAuth scopes as admins, but the app treated only admins as privileged. Logging in as service hid User Management and CRS settings, and run sign-off with “require admin credentials” logged the service user out.

This PR treats service as admin-equivalent in the desktop gates, and locks the service account’s identity so it cannot be renamed, retitled, role-changed, locked, or deleted. New CRS enables hardcode legal name Service Account. Existing robots that already have Service Account (created by system) keep that value.

Password change and admin password reset still work. Failed-login lockout does not apply to service accounts, so a few bad passwords cannot disable the Opentrons maintenance account.

https://github.com/user-attachments/assets/816ccfea-4177-482d-bb88-ac3986457c02

https://github.com/user-attachments/assets/104d981e-afb3-4463-8607-9c35dc241e81

## Test Plan and Hands on Testing

- See videos.
- Lots of tavern testing added around service account testing immutability.
- [x] User Management shows legal name **Service Account** for newly enabled CRS bots.
- [x] With “require admin credentials to sign off protocol” on, signing a run does not bounce to an admin login.
- [x] Protocol send / robot update that require admin creds succeed.
- [x] Set max attempts to 3. Fail `service` login 3+ times. Correct password still works and account is not locked.

## Changelog

- Fixed service account behavior to behave identically to admin accounts.

## Review requests

- Admin accounts cannot edit/delete/lock/unlock the service account, only reset the password. I don't think this behavior is specced explicitly, but it seems desirable. Are we ok with this change? 

## Risk assessment

- lowish-medium, the backend work was already in place, just lots of added testing and gating the UI, which is an additive change.


[RQA-6064]: https://opentrons.atlassian.net/browse/RQA-6064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-6073]: https://opentrons.atlassian.net/browse/RQA-6073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RQA-6096]: https://opentrons.atlassian.net/browse/RQA-6096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ