### PR TITLE
fix(odd): hide quick transfer in CRS mode

### DIFF
--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -116,7 +116,8 @@ export const ON_DEVICE_DISPLAY_PATHS = [
 ] as const
 
 function getPathComponent(
-  path: (typeof ON_DEVICE_DISPLAY_PATHS)[number]
+  path: (typeof ON_DEVICE_DISPLAY_PATHS)[number],
+  isCRSEnabled: boolean
 ): JSX.Element {
   switch (path) {
     case '/account':
@@ -142,7 +143,7 @@ function getPathComponent(
     case '/network-setup/wifi':
       return <ConnectViaWifi />
     case '/protocols':
-      return <ProtocolDashboard />
+      return <ProtocolDashboard isCRSEnabled={isCRSEnabled} />
     case '/protocols/:protocolId':
       return <ProtocolDetails />
     case '/quick-transfer/new':
@@ -233,13 +234,16 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
     hostConfig
   )
 
+  const isCRSEnabled =
+    accessControlEnabledQuery.data?.data.accessControlEnabled ?? false
   const isReady =
     // ensure robot-server api, etc. is up and running
     isShellReady &&
     // ensure settings query data is available for localization provider
     robotSettingsQuery.isSuccess &&
     // ensure we know whether access control is enabled or not,
-    // so on first render we can immediately show the LoggedOutOverlay, if appropriate.
+    // so on first render we can immediately show the LoggedOutOverlay
+    // and hide CRS-incompatible UI, if appropriate.
     accessControlEnabledQuery.isSuccess
   // TODO (sb:6/12/23) Create a notification manager to set up preference and order of takeover modals
   return (
@@ -291,7 +295,9 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
                               ) : null}
 
                               <SharedScrollRefProvider>
-                                <OnDeviceDisplayAppRoutes />
+                                <OnDeviceDisplayAppRoutes
+                                  isCRSEnabled={isCRSEnabled}
+                                />
                               </SharedScrollRefProvider>
                               <LoggedOutOverlayMount />
                             </RobotEncryptionKeyTakeover>
@@ -321,9 +327,15 @@ const getTargetPath = (unfinishedUnboxingFlowRoute: string | null): string => {
   return '/dashboard'
 }
 
+interface OnDeviceDisplayAppRoutesProps {
+  isCRSEnabled: boolean
+}
+
 // split to a separate function because scrollRef rerenders on every route change
 // this avoids rerendering parent providers as well
-export function OnDeviceDisplayAppRoutes(): JSX.Element {
+export function OnDeviceDisplayAppRoutes({
+  isCRSEnabled,
+}: OnDeviceDisplayAppRoutesProps): JSX.Element {
   const { isScrolling, refCallback, element } = useScrollRef()
   const location = useLocation()
   useEffect(
@@ -373,7 +385,7 @@ export function OnDeviceDisplayAppRoutes(): JSX.Element {
           element={
             <Box css={TOUCH_SCREEN_STYLE} ref={refCallback}>
               <ModalPortalRoot />
-              {getPathComponent(path)}
+              {getPathComponent(path, isCRSEnabled)}
             </Box>
           }
         />

--- a/app/src/App/__tests__/OnDeviceDisplayApp.test.tsx
+++ b/app/src/App/__tests__/OnDeviceDisplayApp.test.tsx
@@ -189,7 +189,21 @@ describe('OnDeviceDisplayApp', () => {
   })
   it('renders ProtocolDashboard component from /protocols', () => {
     render('/protocols')
-    expect(vi.mocked(ProtocolDashboard)).toHaveBeenCalled()
+    expect(vi.mocked(ProtocolDashboard)).toHaveBeenCalledWith(
+      expect.objectContaining({ isCRSEnabled: false }),
+      expect.anything()
+    )
+  })
+  it('hides CRS-incompatible ProtocolDashboard UI when access control is enabled', () => {
+    vi.mocked(useAccessControlEnabledQuery).mockReturnValue({
+      data: { data: { accessControlEnabled: true } },
+      isSuccess: true,
+    } as any)
+    render('/protocols')
+    expect(vi.mocked(ProtocolDashboard)).toHaveBeenCalledWith(
+      expect.objectContaining({ isCRSEnabled: true }),
+      expect.anything()
+    )
   })
   it('renders ProtocolDetails component from /protocols/:protocolId/setup', () => {
     render('/protocols/my-protocol-id')

--- a/app/src/pages/ODD/ProtocolDashboard/index.tsx
+++ b/app/src/pages/ODD/ProtocolDashboard/index.tsx
@@ -43,7 +43,13 @@ import type { ProtocolResource } from '@opentrons/shared-data'
 import type { ProtocolsOnDeviceSortKey } from '/app/redux/config/types'
 import type { Dispatch } from '/app/redux/types'
 
-export function ProtocolDashboard(): JSX.Element {
+export interface ProtocolDashboardProps {
+  isCRSEnabled: boolean
+}
+
+export function ProtocolDashboard({
+  isCRSEnabled,
+}: ProtocolDashboardProps): JSX.Element {
   const protocols = useAllProtocolsQuery()
   const runs = useNotifyAllRunsQuery()
   const { t } = useTranslation('protocol_info')
@@ -311,12 +317,14 @@ export function ProtocolDashboard(): JSX.Element {
           ) : pinnedProtocols.length === 0 ? (
             <NoProtocols />
           ) : null}
-          <TouchFloatingActionButton
-            buttonText={t('quick_transfer')}
-            iconName="plus"
-            onClick={handleCreateNewQuickTransfer}
-            aria-label={t('create_quick_transfer')}
-          />
+          {isCRSEnabled ? null : (
+            <TouchFloatingActionButton
+              buttonText={t('quick_transfer')}
+              iconName="plus"
+              onClick={handleCreateNewQuickTransfer}
+              aria-label={t('create_quick_transfer')}
+            />
+          )}
         </Box>
       </Flex>
     </>


### PR DESCRIPTION
[RQA-6094](https://opentrons.atlassian.net/browse/RQA-6094)

# Overview

Quick Transfer is not supported in CRS mode, but the ODD Protocols page still showed the create-quick-transfer floating button. This hides that button when access control is enabled. This button is the only entry point into QT flows, so we only need to conditionally render this one button.

We don't particularly want to perform the query for checking CRS mode on the protocols page itself, because this causes the QT button to flicker. We hoist the relevant network request to the root, and pass the boolean check to the Protocols page.

<img width="1084" height="632" alt="Screenshot 2026-09-02 at 5 13 57 PM" src="https://github.com/user-attachments/assets/af542eed-b158-4885-b704-d432a89684dc" />

## Test Plan and Hands on Testing

- See image

## Changelog

- The "Quick Transfer" launch button is no longer visible if CRS is enabled.

## Risk assessment

- very low, one more root network request made once + one conditionally rendering button

[RQA-6094]: https://opentrons.atlassian.net/browse/RQA-6094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ