### PR TITLE
fix(api): match vacuum waste-full config to sealed-hold firmware knobs

### DIFF
--- a/api/src/opentrons/drivers/vacuum_module/abstract.py
+++ b/api/src/opentrons/drivers/vacuum_module/abstract.py
@@ -118,15 +118,12 @@ class AbstractVacuumModuleDriver(Protocol):
     async def set_waste_configs(
         self,
         enable_waste_full_detection: bool,
-        p_window_start: Optional[float] = None,
-        p_window_end: Optional[float] = None,
-        baseline_fast_factor: Optional[float] = None,
-        max_delta_per_tick: Optional[float] = None,
-        max_rise_per_tick: Optional[float] = None,
-        max_cummulative_rise: Optional[float] = None,
         p_filter_alpha: Optional[float] = None,
-        min_window_time: Optional[float] = None,
-        max_window_time: Optional[float] = None,
+        g_sealed_max: Optional[float] = None,
+        flowing_dp_mbar: Optional[float] = None,
+        stable_hold_ms: Optional[float] = None,
+        stable_hold_deep_ms: Optional[float] = None,
+        min_waste_depth_mbar: Optional[float] = None,
     ) -> None:
         """Sets the Waste Full detection algorithm parameters"""
         ...

--- a/api/src/opentrons/drivers/vacuum_module/driver.py
+++ b/api/src/opentrons/drivers/vacuum_module/driver.py
@@ -114,22 +114,22 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
     @classmethod
     def parse_get_waste_configs(cls, response: str) -> WasteConfigParameters:
         """Parse the get waste configs."""
-        pattern = r"E:(?P<E>\d) S:(?P<S>\d.+) P:(?P<P>\d.+) F:(?P<F>\d.+) D:(?P<D>\d.+) R:(?P<R>\d.+) C:(?P<C>\d.+) A:(?P<A>\d.+) M:(?P<M>\d.+) X:(?P<X>\d.+)"
+        pattern = (
+            r"E:(?P<E>\d) A:(?P<A>\d.+) G:(?P<G>\d.+) H:(?P<H>\d.+) "
+            r"T:(?P<T>\d.+) U:(?P<U>\d.+) N:(?P<N>\d.+)"
+        )
         _RE = re.compile(rf"^{GCODE.GET_WASTE_CONFIG} {pattern}$")
         match = _RE.match(response)
         if not match:
-            raise ValueError(f"Incorrect Response for get waste confis: {response}")
+            raise ValueError(f"Incorrect Response for get waste configs: {response}")
         return WasteConfigParameters(
-            bool(match.group("E")),
-            float(match.group("S")),
-            float(match.group("P")),
-            float(match.group("F")),
-            float(match.group("D")),
-            float(match.group("R")),
-            float(match.group("C")),
-            float(match.group("A")),
-            float(match.group("M")),
-            float(match.group("X")),
+            waste_detection_enabled=bool(int(match.group("E"))),
+            p_filter_alpha=float(match.group("A")),
+            g_sealed_max=float(match.group("G")),
+            flowing_dp_mbar=float(match.group("H")),
+            stable_hold_ms=float(match.group("T")),
+            stable_hold_deep_ms=float(match.group("U")),
+            min_waste_depth_mbar=float(match.group("N")),
         )
 
     @classmethod
@@ -419,29 +419,23 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
     async def set_waste_configs(
         self,
         enable_waste_full_detection: bool,
-        p_window_start: Optional[float] = None,
-        p_window_end: Optional[float] = None,
-        baseline_fast_factor: Optional[float] = None,
-        max_delta_per_tick: Optional[float] = None,
-        max_rise_per_tick: Optional[float] = None,
-        max_cummulative_rise: Optional[float] = None,
         p_filter_alpha: Optional[float] = None,
-        min_window_time: Optional[float] = None,
-        max_window_time: Optional[float] = None,
+        g_sealed_max: Optional[float] = None,
+        flowing_dp_mbar: Optional[float] = None,
+        stable_hold_ms: Optional[float] = None,
+        stable_hold_deep_ms: Optional[float] = None,
+        min_waste_depth_mbar: Optional[float] = None,
     ) -> None:
         """Sets the Waste Full detection algorithm parameters"""
 
         command = GCODE.SET_WASTE_CONFIG.build_command()
         for letter, value in (
-            ("S", p_window_start),
-            ("P", p_window_end),
-            ("F", baseline_fast_factor),
-            ("D", max_delta_per_tick),
-            ("R", max_rise_per_tick),
-            ("C", max_cummulative_rise),
             ("A", p_filter_alpha),
-            ("M", min_window_time),
-            ("X", max_window_time),
+            ("G", g_sealed_max),
+            ("H", flowing_dp_mbar),
+            ("T", stable_hold_ms),
+            ("U", stable_hold_deep_ms),
+            ("N", min_waste_depth_mbar),
         ):
             if value is not None:
                 command.add_float(letter, value, GCODE_ROUNDING_PRECISION)

--- a/api/src/opentrons/drivers/vacuum_module/driver.py
+++ b/api/src/opentrons/drivers/vacuum_module/driver.py
@@ -39,6 +39,12 @@ MAX_GAUGE_PRESSURE_MBAR = -800
 THEORETICAL_MAX_GAUGE_PRESSURE_MBAR = -1013.25
 MAX_VAC_DURATION_S = 60 * 60 * 24  # 24hrs
 
+# Waste M127 range — match firmware waste_detector.hpp configure().
+WASTE_H_MAX = 500.0
+WASTE_G_MAX = float(MAX_PUMP_RPM)
+WASTE_HOLD_MS_MAX = 1_000_000.0
+WASTE_N_MAX = 1000.0
+
 
 class VacuumModuleDriver(AbstractVacuumModuleDriver):
     """Driver for Opentrons Vacuum Module."""
@@ -429,16 +435,20 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
         """Sets the Waste Full detection algorithm parameters"""
 
         command = GCODE.SET_WASTE_CONFIG.build_command()
-        for letter, value in (
-            ("A", p_filter_alpha),
-            ("G", g_sealed_max),
-            ("H", flowing_dp_mbar),
-            ("T", stable_hold_ms),
-            ("U", stable_hold_deep_ms),
-            ("N", min_waste_depth_mbar),
+        for letter, value, lo, hi in (
+            ("A", p_filter_alpha, 0, 1.0),
+            ("G", g_sealed_max, 0, WASTE_G_MAX),
+            ("H", flowing_dp_mbar, 0, WASTE_H_MAX),
+            ("T", stable_hold_ms, 0, WASTE_HOLD_MS_MAX),
+            ("U", stable_hold_deep_ms, 0, WASTE_HOLD_MS_MAX),
+            ("N", min_waste_depth_mbar, 0, WASTE_N_MAX),
         ):
             if value is not None:
-                command.add_float(letter, value, GCODE_ROUNDING_PRECISION)
+                command.add_float(
+                    letter,
+                    max(lo, min(value, hi)),
+                    3,
+                )
         command.add_int("E", int(enable_waste_full_detection))
 
         resp = await self._connection.send_command(command)

--- a/api/src/opentrons/drivers/vacuum_module/simulator.py
+++ b/api/src/opentrons/drivers/vacuum_module/simulator.py
@@ -30,6 +30,15 @@ class SimulatingDriver(AbstractVacuumModuleDriver):
         self.target_rpm = 0
         self.current_rpm = 0
         self._pending_async_error: Optional[SerialException] = None
+        self._waste_config = WasteConfigParameters(
+            waste_detection_enabled=True,
+            p_filter_alpha=0.5,
+            g_sealed_max=0.50,
+            flowing_dp_mbar=8.0,
+            stable_hold_ms=6000.0,
+            stable_hold_deep_ms=10000.0,
+            min_waste_depth_mbar=20.0,
+        )
 
     def inject_async_error(self, error: SerialException) -> None:
         """Queue an async module error to raise on the next polled driver read."""
@@ -176,19 +185,28 @@ class SimulatingDriver(AbstractVacuumModuleDriver):
     async def set_waste_configs(
         self,
         enable_waste_full_detection: bool,
-        p_window_start: Optional[float] = None,
-        p_window_end: Optional[float] = None,
-        baseline_fast_factor: Optional[float] = None,
-        max_delta_per_tick: Optional[float] = None,
-        max_rise_per_tick: Optional[float] = None,
-        max_cummulative_rise: Optional[float] = None,
         p_filter_alpha: Optional[float] = None,
-        min_window_time: Optional[float] = None,
-        max_window_time: Optional[float] = None,
+        g_sealed_max: Optional[float] = None,
+        flowing_dp_mbar: Optional[float] = None,
+        stable_hold_ms: Optional[float] = None,
+        stable_hold_deep_ms: Optional[float] = None,
+        min_waste_depth_mbar: Optional[float] = None,
     ) -> None:
         """Sets the Waste Full detection algorithm parameters"""
-        pass
+        self._waste_config.waste_detection_enabled = enable_waste_full_detection
+        if p_filter_alpha is not None:
+            self._waste_config.p_filter_alpha = p_filter_alpha
+        if g_sealed_max is not None:
+            self._waste_config.g_sealed_max = g_sealed_max
+        if flowing_dp_mbar is not None:
+            self._waste_config.flowing_dp_mbar = flowing_dp_mbar
+        if stable_hold_ms is not None:
+            self._waste_config.stable_hold_ms = stable_hold_ms
+        if stable_hold_deep_ms is not None:
+            self._waste_config.stable_hold_deep_ms = stable_hold_deep_ms
+        if min_waste_depth_mbar is not None:
+            self._waste_config.min_waste_depth_mbar = min_waste_depth_mbar
 
     async def get_waste_configs(self) -> WasteConfigParameters:
         """Get the waste full detection configs"""
-        return WasteConfigParameters(False, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        return self._waste_config

--- a/api/src/opentrons/drivers/vacuum_module/types.py
+++ b/api/src/opentrons/drivers/vacuum_module/types.py
@@ -156,15 +156,12 @@ class WasteConfigParameters:
     """Get the waste config parameters"""
 
     waste_detection_enabled: bool
-    p_window_start: float
-    p_window_end: float
-    baseline_fast_factor: float
-    max_delta_per_tick: float
-    max_rise_per_tick: float
-    max_cummulative_rise: float
     p_filter_alpha: float
-    min_window_time: float
-    max_window_time: float
+    g_sealed_max: float
+    flowing_dp_mbar: float
+    stable_hold_ms: float
+    stable_hold_deep_ms: float
+    min_waste_depth_mbar: float
 
 
 @dataclass

--- a/api/src/opentrons/drivers/vacuum_module/types.py
+++ b/api/src/opentrons/drivers/vacuum_module/types.py
@@ -153,7 +153,19 @@ class PressureControlTunings:
 
 @dataclass
 class WasteConfigParameters:
-    """Get the waste config parameters"""
+    """Waste-full Detection config parameters.
+
+    waste_detection_enabled: Master switch.
+    p_filter_alpha: EMA on sensor B; closer to 0 = heavier filter, 1 = raw B.
+    g_sealed_max: Sealed if RPM_cmd / vacuum < G. The discriminator.
+        Lower G → harder to look sealed (fewer empty trips, more full
+        misses). Raise G to trip full more easily.
+    flowing_dp_mbar: |A−B| above this vetoes a wide-open path.
+        Hold |A−B| is mostly sensor offset;
+    stable_hold_ms: Sealed time required below −800 mbar, milliseconds.
+    stable_hold_deep_ms: Sealed time at commanded depth ≥ 800 mbar.
+    min_waste_depth_mbar: Skip detection shallower than this.
+    """
 
     waste_detection_enabled: bool
     p_filter_alpha: float

--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -121,16 +121,13 @@ DEFAULT_PRESSURE_CONTROL_TUNINGS = PressureControlTunings(
 # Waste-full detection defaults
 # See waste_detector.hpp in opentrons-modules repo for details
 DEFAULT_WASTE_CONFIG = WasteConfigParameters(
-    waste_detection_enabled=False,
-    p_window_start=0.10,
-    p_window_end=0.95,
-    baseline_fast_factor=0.75,
-    max_delta_per_tick=250.0,
-    max_rise_per_tick=3.5,
-    max_cummulative_rise=11.5,
+    waste_detection_enabled=True,
     p_filter_alpha=0.5,
-    min_window_time=700.0,  # ms
-    max_window_time=20000.0,  # ms
+    g_sealed_max=0.50,
+    flowing_dp_mbar=8.0,
+    stable_hold_ms=6000.0,
+    stable_hold_deep_ms=10000.0,
+    min_waste_depth_mbar=20.0,
 )
 
 
@@ -317,16 +314,13 @@ class VacuumModule(mod_abc.AbstractModule):
         # Waste detection parameters
         waste = DEFAULT_WASTE_CONFIG
         await self._driver.set_waste_configs(
-            waste.waste_detection_enabled,
-            waste.p_window_start,
-            waste.p_window_end,
-            waste.baseline_fast_factor,
-            waste.max_delta_per_tick,
-            waste.max_rise_per_tick,
-            waste.max_cummulative_rise,
-            waste.p_filter_alpha,
-            waste.min_window_time,
-            waste.max_window_time,
+            enable_waste_full_detection=waste.waste_detection_enabled,
+            p_filter_alpha=waste.p_filter_alpha,
+            g_sealed_max=waste.g_sealed_max,
+            flowing_dp_mbar=waste.flowing_dp_mbar,
+            stable_hold_ms=waste.stable_hold_ms,
+            stable_hold_deep_ms=waste.stable_hold_deep_ms,
+            min_waste_depth_mbar=waste.min_waste_depth_mbar,
         )
 
         # Pressure control parameters

--- a/api/tests/opentrons/drivers/vacuum_module/test_driver.py
+++ b/api/tests/opentrons/drivers/vacuum_module/test_driver.py
@@ -378,6 +378,68 @@ async def test_get_pressure_control_tunings(
     )
 
 
+async def test_set_waste_configs(
+    subject: VacuumModuleDriver, connection: AsyncMock
+) -> None:
+    """It should send M127 with sealed-hold knobs and enable."""
+    connection.send_command.return_value = "M127"
+
+    await subject.set_waste_configs(
+        True,
+        p_filter_alpha=0.5,
+        g_sealed_max=0.50,
+        flowing_dp_mbar=8.0,
+        stable_hold_ms=6000.0,
+        stable_hold_deep_ms=10000.0,
+        min_waste_depth_mbar=20.0,
+    )
+
+    set_waste = (
+        types.GCODE.SET_WASTE_CONFIG.build_command()
+        .add_float("A", 0.5)
+        .add_float("G", 0.50)
+        .add_float("H", 8.0)
+        .add_float("T", 6000.0)
+        .add_float("U", 10000.0)
+        .add_float("N", 20.0)
+        .add_int("E", 1)
+    )
+    connection.send_command.assert_any_call(set_waste)
+    connection.reset_mock()
+
+    await subject.set_waste_configs(False)
+    set_waste = types.GCODE.SET_WASTE_CONFIG.build_command().add_int("E", 0)
+    connection.send_command.assert_any_call(set_waste)
+    connection.reset_mock()
+
+
+async def test_get_waste_configs(
+    subject: VacuumModuleDriver, connection: AsyncMock
+) -> None:
+    """It should parse M128 sealed-hold knobs."""
+    connection.send_command.return_value = (
+        "M128 E:1 A:0.5 G:0.50 H:8.0 T:6000 U:10000 N:20.0"
+    )
+
+    waste = await subject.get_waste_configs()
+
+    get_waste = types.GCODE.GET_WASTE_CONFIG.build_command()
+    connection.send_command.assert_any_call(get_waste)
+    assert waste == types.WasteConfigParameters(
+        waste_detection_enabled=True,
+        p_filter_alpha=0.5,
+        g_sealed_max=0.50,
+        flowing_dp_mbar=8.0,
+        stable_hold_ms=6000.0,
+        stable_hold_deep_ms=10000.0,
+        min_waste_depth_mbar=20.0,
+    )
+
+    connection.send_command.return_value = "M128 garbage"
+    with pytest.raises(ValueError):
+        await subject.get_waste_configs()
+
+
 async def test_move_port(subject: VacuumModuleDriver, connection: AsyncMock) -> None:
     """It should forward port moves to the serial connection."""
     await subject.move_port("/dev/ot_module_vacuummodule6")

--- a/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
@@ -941,15 +941,12 @@ async def test_configure_device_applies_waste_and_pressure_defaults(
     decoy.verify(
         await mock_driver.set_waste_configs(
             enable_waste_full_detection=waste.waste_detection_enabled,
-            p_window_start=waste.p_window_start,
-            p_window_end=waste.p_window_end,
-            baseline_fast_factor=waste.baseline_fast_factor,
-            max_delta_per_tick=waste.max_delta_per_tick,
-            max_rise_per_tick=waste.max_rise_per_tick,
-            max_cummulative_rise=waste.max_cummulative_rise,
             p_filter_alpha=waste.p_filter_alpha,
-            min_window_time=waste.min_window_time,
-            max_window_time=waste.max_window_time,
+            g_sealed_max=waste.g_sealed_max,
+            flowing_dp_mbar=waste.flowing_dp_mbar,
+            stable_hold_ms=waste.stable_hold_ms,
+            stable_hold_deep_ms=waste.stable_hold_deep_ms,
+            min_waste_depth_mbar=waste.min_waste_depth_mbar,
         ),
     )
     pid = DEFAULT_PRESSURE_CONTROL_TUNINGS


### PR DESCRIPTION
# Overview

Align host M127/M128 with the vacuum-module sealed-hold firmware. 

Companion: https://github.com/Opentrons/opentrons-modules/pull/576

## Test Plan and Hands on Testing

- [x] Flex attach sent `M127 A0.5 G0.5 H8.0 T6000.0 U10000.0 N20.0 E1` and got `OK`; module enumerated idle

## Changelog

- Replace ramp/baseline waste knobs with sealed-hold fields
- Enable waste detection on attach
- This breaks old M127; (`S P F D R C M X`) are no longer sent

## Review requests

Land after or with the firmware PR so M127/M128 letters match.

## Risk assessment

Medium. New letters on old firmware will not apply the intended knobs.