### PR TITLE
fix(labware): correct eppendorf_96_wellplate_150ul well bottom shape

### DIFF
--- a/shared-data/labware/definitions/2/eppendorf_96_wellplate_150ul/1.json
+++ b/shared-data/labware/definitions/2/eppendorf_96_wellplate_150ul/1.json
@@ -1087,7 +1087,7 @@
         "G12",
         "H12"
       ],
-      "metadata": { "wellBottomShape": "u" }
+      "metadata": { "wellBottomShape": "v" }
     }
   ],
   "parameters": {


### PR DESCRIPTION
Corrects the wellBottomShape for the eppendorf_96_wellplate_150ul from u to v.

The physical labware has conical/V-bottom wells rather than U-bottom wells. The incorrect labware definition prevents the plate from being used with, for example, the 96-well aluminum block on the Temperature Module, even though it's clearly a PCR plate and fits perfectly in the block.

This changes only the wellBottomShape metadata from "u" to "v".