### PR TITLE
fix(app, robot-server): don't force audit downloads when enabling CRS

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
@@ -77,10 +77,8 @@ export function ComplianceReadySoftwareFiles({
   const { makeToast, eatToast } = useToaster()
   const observer = useRef<HTMLDivElement>(null)
 
-  const {
-    data: accessControlSettings,
-    isLoading: isLoadingAccessControlSettings,
-  } = useGetRobotServerAccessControlSettingsQuery()
+  const { data: accessControlSettings } =
+    useGetRobotServerAccessControlSettingsQuery()
   const requireDownloadSetting =
     accessControlSettings?.data.requireLogsToBeSavedInApp ?? false
 
@@ -93,10 +91,7 @@ export function ComplianceReadySoftwareFiles({
   const [downloadModalDismissed, setDownloadModalDismissed] = useState(false)
 
   const showRequiredDownloadModal =
-    !isLoadingAccessControlSettings &&
-    requireDownloadSetting &&
-    periods.length > 1 &&
-    !downloadModalDismissed
+    requireDownloadSetting && periods.length > 1 && !downloadModalDismissed
 
   const {
     selectedIds,

--- a/app/src/organisms/Desktop/EnableCRSWizard/useEnableCRSMutation.ts
+++ b/app/src/organisms/Desktop/EnableCRSWizard/useEnableCRSMutation.ts
@@ -9,6 +9,7 @@ import {
   getOAuth2Token,
   OAUTH2_CLIENT_ID,
   patchAccessControlEnabled,
+  postResetConfig,
   restart,
 } from '@opentrons/api-client'
 import {
@@ -44,7 +45,7 @@ const USER_NOTE =
 
 /**
  * Create initial accounts, flip the switch to enable Compliance Ready Software,
- * and restart the robot.
+ * clear run history, and restart the robot.
  *
  * We do this all in one batch at the end of the wizard to reduce the chances of it
  * getting interrupted and leaving the robot in a half-set-up state. Though it's still
@@ -118,13 +119,18 @@ export function useEnableCRSMutation(): UseMutationResult<
       token: tokenResponse.data.access_token,
     }
 
-    // Send the restart request, start tracking the restart progress through Redux,
-    // and wait for the robot to come back online.
+    // Clear the run history, send the restart request, start tracking the restart
+    // progress through Redux, and wait for the robot to come back online.
     //
-    // Note: We can't use the useRestartRobotMutation hook because it captures its
-    // HostConfig at the time the hook is called (when the component is rendered),
-    // whereas we modify our HostConfig midway through this whole procedure when we
-    // log in as the new admin account.
+    // Note: We can't use useResetRobotConfigMutation / useRestartRobotMutation
+    // because those hooks capture HostConfig at render time, whereas we modify
+    // our HostConfig midway through this procedure when we log in as the new
+    // admin account.
+    await postResetConfig(
+      hostConfigWithAccessToken,
+      { runsHistory: true },
+      USER_NOTE
+    )
     await restart(hostConfigWithAccessToken, USER_NOTE)
     for (const action of beginRobotRestartTracking(
       robotName,

--- a/app/src/pages/ODD/RunSummary/index.tsx
+++ b/app/src/pages/ODD/RunSummary/index.tsx
@@ -228,9 +228,8 @@ export function RunSummary(): JSX.Element {
   } = useIsLogDeleted(logPeriodId ?? '')
 
   const isDownloadingRequired =
-    ((accessControlEnabled?.data.accessControlEnabled ?? false) &&
-      accessControlSettings?.data.requireLogsToBeSavedInApp) ??
-    false
+    (accessControlEnabled?.data.accessControlEnabled ?? false) &&
+    (accessControlSettings?.data.requireLogsToBeSavedInApp ?? false)
   const shouldPromptDownloadLog =
     !isRunRecordLoading &&
     !isSettingsLoading &&

--- a/app/src/resources/audit/useIsSigningOrDownloadingRequired.ts
+++ b/app/src/resources/audit/useIsSigningOrDownloadingRequired.ts
@@ -26,7 +26,7 @@ export function useIsSigningOrDownloadingRequired(robotName: string): {
     accessControlSettings?.data.requireSignoffForProtocolLog
   const downloadingSetting =
     accessControlEnabled?.data.accessControlEnabled &&
-    accessControlSettings?.data.requireLogsToBeSavedInApp
+    (accessControlSettings?.data.requireLogsToBeSavedInApp ?? false)
 
   const currentRunId = useCurrentRunId()
   const { data: runRecord } = useNotifyRunQuery(currentRunId)

--- a/app/src/resources/runs/useIsDownloadAuditLogsRequired.ts
+++ b/app/src/resources/runs/useIsDownloadAuditLogsRequired.ts
@@ -27,8 +27,7 @@ export function useIsDownloadAuditLogsRequired(runId: string): {
     !runRecord?.data.signedBy
 
   const isDownloadingRequired =
-    !isAccessControlSettingsLoading &&
-    !!accessControlSettings?.data.requireLogsToBeSavedInApp
+    accessControlSettings?.data.requireLogsToBeSavedInApp ?? false
 
   const logPeriodId = runRecord?.data.logPeriodId
 

--- a/app/src/resources/runs/useIsSigningRequired.ts
+++ b/app/src/resources/runs/useIsSigningRequired.ts
@@ -36,7 +36,7 @@ export function useIsSigningRequired(): {
     isSigningRequired: isSigningRequired && !hasSignedBy,
     isDownloadingRequired:
       !!accessControlEnabled?.data.accessControlEnabled &&
-      !!accessControlSettings?.data.requireLogsToBeSavedInApp,
+      (accessControlSettings?.data.requireLogsToBeSavedInApp ?? false),
     logPeriodId: runRecord?.data.logPeriodId ?? null,
   }
 }

--- a/robot-server/robot_server/access_control/settings/models.py
+++ b/robot-server/robot_server/access_control/settings/models.py
@@ -20,7 +20,7 @@ class ResponseData(pydantic.BaseModel):
         pydantic.Field(
             description="Require logs to be saved in app.",
         ),
-    ] = True
+    ] = False
     deleteOverMaxOnDiskProtocols: Annotated[
         bool,
         pydantic.Field(

--- a/robot-server/tests/access_control/settings/test_store.py
+++ b/robot-server/tests/access_control/settings/test_store.py
@@ -88,7 +88,7 @@ def test_patch_empty_request_changes_nothing(
     subject.patch(RequestData.model_validate({"requireSignoffForProtocolLog": False}))
     result = subject.patch(RequestData.model_validate({}))
     assert result.requireSignoffForProtocolLog is False
-    assert result.requireLogsToBeSavedInApp is True
+    assert result.requireLogsToBeSavedInApp is False
     assert result.deleteOverMaxOnDiskProtocols is True
 
 

--- a/robot-server/tests/integration/http_api/access_control/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/http_api/access_control/test_settings.tavern.yaml
@@ -14,7 +14,7 @@ stages:
       json: &initial_get_settings_response
         data:
           requireSignoffForProtocolLog: true
-          requireLogsToBeSavedInApp: true
+          requireLogsToBeSavedInApp: false
           deleteOverMaxOnDiskProtocols: true
 
   - name: Change settings
@@ -24,13 +24,13 @@ stages:
       json:
         data:
           requireSignoffForProtocolLog: false
-          requireLogsToBeSavedInApp: false
+          requireLogsToBeSavedInApp: true
     response:
       status_code: 200
       json: &patch_settings_response
         data:
           requireSignoffForProtocolLog: false
-          requireLogsToBeSavedInApp: false
+          requireLogsToBeSavedInApp: true
           deleteOverMaxOnDiskProtocols: true
 
   - name: Get the settings again and make sure they're still changed
@@ -76,7 +76,7 @@ stages:
       json:
         data:
           requireSignoffForProtocolLog: true
-          requireLogsToBeSavedInApp: true
+          requireLogsToBeSavedInApp: false
           deleteOverMaxOnDiskProtocols: true
 
 ---
@@ -99,7 +99,7 @@ stages:
       json:
         data:
           requireSignoffForProtocolLog: false
-          requireLogsToBeSavedInApp: true
+          requireLogsToBeSavedInApp: false
           deleteOverMaxOnDiskProtocols: true
 
   - name: Revert it by sending null
@@ -114,5 +114,5 @@ stages:
       json:
         data:
           requireSignoffForProtocolLog: true
-          requireLogsToBeSavedInApp: true
+          requireLogsToBeSavedInApp: false
           deleteOverMaxOnDiskProtocols: true

--- a/robot-server/tests/integration/http_api/persistence/test_schema_15_to_16_migration.py
+++ b/robot-server/tests/integration/http_api/persistence/test_schema_15_to_16_migration.py
@@ -58,7 +58,7 @@ async def test_schema_15_persistence_migrates_boolean_settings_to_v16() -> None:
             ac.raise_for_status()
             assert ac.json()["data"] == {
                 "requireSignoffForProtocolLog": True,
-                "requireLogsToBeSavedInApp": True,
+                "requireLogsToBeSavedInApp": False,
                 "deleteOverMaxOnDiskProtocols": True,
             }
 


### PR DESCRIPTION
Closes [RQA-6030](https://opentrons.atlassian.net/browse/RQA-6030)

# Overview

This PR modifies the post-enable-CRS behavior to reduce friction on reboot concerning audit log behavior. Currently, we force audit log download by default immediately after reboot, because this setting defaults to `True` by default. We change the setting to default to false and ensure the app lazily assumes `false` until the network request completes, too. Some of the app UI in 289c05e77412f071c532b07e82f15b034472a9bd is updated not to blip the forced download modal until the network request completes, and the app knows the true state of that setting.

Additionally, we don't want any of the pre-CRS-enabled run history to be present in logs or recorded on the robot, so the CRS setup flow, before rebooting the robot, first clears the run history.

Note: the download setting is a default-when-unset value. Robots that never explicitly toggled it will pick up `false` after this change. Robots that already turned it on keep it on.

## Test Plan and Hands on Testing

- Upon entering CRS mode, verified that run history is now deleted.
- Verified that the "force audit log download" setting defaults to off on newly CRS enabled robots.

## Changelog

- Entering CRS mode now clears run history.
- The "force audit log download" CRS setting now defaults to off.

## Risk assessment

- low, highly auditable touch points, fortunately!


[RQA-6030]: https://opentrons.atlassian.net/browse/RQA-6030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ