### PR TITLE
fix(app): log out admins after changing their own role

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/EditUserModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/EditUserModal.tsx
@@ -1,6 +1,7 @@
 import { createPortal } from 'react-dom'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import { useDispatch } from 'react-redux'
 
 import {
   DropdownMenu,
@@ -13,6 +14,7 @@ import { useUpdateUserMutation } from '@opentrons/react-api-client'
 
 import { getTopPortalEl } from '/app/App/portal'
 import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+import { logOut, useUsernameForRobot } from '/app/redux/robot-auth'
 import { getUsernameValidationError } from '/app/resources/auth/getUsernameValidationError'
 import { mapAuthUserMutationError } from '/app/resources/auth/mapAuthUserMutationError'
 
@@ -50,6 +52,8 @@ export function EditUserModal({
   const { t } = useTranslation(['device_settings', 'shared']) as {
     t: TFunction
   }
+  const dispatch = useDispatch()
+  const loggedInUsername = useUsernameForRobot(robotName)
   const documentationState = useDocumentationState(undefined, robotName)
   const { updateUser, isLoading: isSaving } =
     useUpdateUserMutation(documentationState)
@@ -94,6 +98,7 @@ export function EditUserModal({
   }
 
   const onSubmit = (): void => {
+    const didChangeRole = accountType !== user.accountType
     void updateUser({
       username: user.username,
       request: {
@@ -104,13 +109,16 @@ export function EditUserModal({
           ...(trimmedFullName !== user.fullName
             ? { fullName: trimmedFullName }
             : {}),
-          ...(accountType !== user.accountType ? { accountType } : {}),
+          ...(didChangeRole ? { accountType } : {}),
         },
       },
     })
       .then(() => {
         onUserUpdated?.()
         handleClose()
+        if (didChangeRole && loggedInUsername === user.username) {
+          dispatch(logOut({ robotName }))
+        }
       })
       .catch(error => {
         const formError = mapAuthUserMutationError<FormValues>(error, t)

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/EditUserModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/EditUserModal.tsx
@@ -74,9 +74,14 @@ export function EditUserModal({
       name: t(`desktop_user_role_${type}`),
       value: type,
     }))
+  const fallbackAccountType = MANAGEABLE_USER_ACCOUNT_TYPES[0] ?? 'admin'
+  const fallbackOption: DropdownOption = {
+    name: t(`desktop_user_role_${fallbackAccountType}`),
+    value: fallbackAccountType,
+  }
   const selectedAccountTypeOption =
     accountTypeOptions.find(option => option.value === accountType) ??
-    accountTypeOptions[0]!
+    fallbackOption
 
   const trimmedUsername = username.trim()
   const trimmedFullName = fullName.trim()
@@ -97,22 +102,26 @@ export function EditUserModal({
     onClose()
   }
 
-  const onSubmit = (): void => {
-    const didChangeRole = accountType !== user.accountType
-    void updateUser({
+  const onSubmit = (data: FormValues): void => {
+    const didChangeRole = data.accountType !== user.accountType
+    const submittedTrimmedUsername = data.username.trim()
+    const submittedTrimmedFullName = data.fullName.trim()
+
+    const updatePromise = updateUser({
       username: user.username,
       request: {
         data: {
-          ...(trimmedUsername !== user.username
-            ? { username: trimmedUsername }
+          ...(submittedTrimmedUsername !== user.username
+            ? { username: submittedTrimmedUsername }
             : {}),
-          ...(trimmedFullName !== user.fullName
-            ? { fullName: trimmedFullName }
+          ...(submittedTrimmedFullName !== user.fullName
+            ? { fullName: submittedTrimmedFullName }
             : {}),
-          ...(didChangeRole ? { accountType } : {}),
+          ...(didChangeRole ? { accountType: data.accountType } : {}),
         },
       },
     })
+    updatePromise
       .then(() => {
         onUserUpdated?.()
         handleClose()
@@ -131,6 +140,7 @@ export function EditUserModal({
   return createPortal(
     <ModalShell
       width="31.25rem"
+      overflow="visible"
       header={
         <WizardHeader
           title={t('desktop_edit_user')}
@@ -141,7 +151,11 @@ export function EditUserModal({
       }
     >
       <div className={styles.modal_content}>
-        <form onSubmit={handleSubmit(onSubmit)}>
+        <form
+          onSubmit={event => {
+            void handleSubmit(onSubmit)(event)
+          }}
+        >
           <div className={styles.form_fields}>
             <UserAccountIdentityFormFields
               autoFocusFirstField


### PR DESCRIPTION
Closes [RQA-6051](https://opentrons.atlassian.net/browse/RQA-6051)

# Overview

When an admin changes their user role, client-server permissions become disjoint, which causes unexpected behavior. To fix, sign out the user any time a self-imposed role change occurs.

This PR also adjusts the "Edit User" role dropdown menu to render above the modal itself, instead of shifting the content within the modal, matching the existing pattern when adding a new user. 

### Current behavior

https://github.com/user-attachments/assets/32330f1d-3afc-434a-85eb-670397f85a4e

### Fixed behavior

https://github.com/user-attachments/assets/1226a626-f703-4af4-a850-c98e1efd11f4

## Test Plan and Hands on Testing

- See videos.

## Changelog

- A user changes their own role now logs them out of their active session.

## Risk assessment

- low, changes scoped only to the `EditUserModal` component.


[RQA-6051]: https://opentrons.atlassian.net/browse/RQA-6051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ