### PR TITLE
fix(app): restore CRS numeric settings when documentation is cancelled

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/InputSetting.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/InputSetting.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
 
 import { COLORS, InputField, StyledText } from '@opentrons/components'
 
@@ -28,8 +28,16 @@ export function InputSetting({
   validate,
 }: InputSettingProps): JSX.Element {
   const inputId = useId()
+  const savedValueRef = useRef(value)
   const [inputValue, setInputValue] = useState(value)
   const [error, setError] = useState<string | null>(null)
+
+  savedValueRef.current = value
+
+  useEffect(() => {
+    setInputValue(value)
+    setError(null)
+  }, [value])
 
   return (
     <div className={styles.field_row}>
@@ -67,7 +75,7 @@ export function InputSetting({
             setError(validationError)
             if (validationError == null) {
               void Promise.resolve(onBlur(blurredValue)).catch(() => {
-                setInputValue(value)
+                setInputValue(savedValueRef.current)
               })
             }
           }}

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/__tests__/ComplianceReadySoftwareSettings.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/__tests__/ComplianceReadySoftwareSettings.test.tsx
@@ -422,7 +422,11 @@ describe('ComplianceReadySoftwareSettings', () => {
     fireEvent.blur(loginAttemptsField)
 
     await waitFor(() => {
-      expect(loginAttemptsField).toHaveValue(5)
+      expect(
+        screen.getByLabelText(
+          'Maximum login attempts before account deactivation'
+        )
+      ).toHaveValue(5)
     })
   })
   it('should update audit input values without patching until blur', async () => {

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/__tests__/InputSetting.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/__tests__/InputSetting.test.tsx
@@ -20,4 +20,19 @@ describe('InputSetting', () => {
       expect(input).toHaveValue(5)
     })
   })
+
+  it('updates the displayed value when the saved value changes', () => {
+    const onBlur = vi.fn()
+    const { rerender } = render(
+      <InputSetting label="Maximum login attempts" value="5" onBlur={onBlur} />
+    )
+
+    const input = screen.getByLabelText('Maximum login attempts')
+    expect(input).toHaveValue(5)
+
+    rerender(
+      <InputSetting label="Maximum login attempts" value="3" onBlur={onBlur} />
+    )
+    expect(input).toHaveValue(3)
+  })
 })

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/index.tsx
@@ -85,6 +85,7 @@ export function ComplianceReadySoftwareSettings({
   ] = useState(false)
   const [passwordComplexityToggleKey, setPasswordComplexityToggleKey] =
     useState(0)
+  const [settingsInputResetKey, setSettingsInputResetKey] = useState(0)
   const authSettingsQuery = useAuthSettingsQuery()
   const auditSettingsQuery = useAuditSettingsQuery()
   const robotServerAccessControlSettingsQuery =
@@ -110,13 +111,22 @@ export function ComplianceReadySoftwareSettings({
     ]
   )
 
+  const revertSettingsInputs = (): void => {
+    setSettingsInputResetKey(key => key + 1)
+  }
+
   const handleAuthSettingInputBlur = async (
     id: AuthSettingFieldId,
     value: string
   ): Promise<void> => {
     const authPatch = getAuthInputPatch(id, value, fieldValues)
     if (authPatch != null) {
-      await patchAuthSettings(authPatch)
+      try {
+        await patchAuthSettings(authPatch)
+      } catch (error) {
+        revertSettingsInputs()
+        throw error
+      }
     }
   }
 
@@ -126,7 +136,12 @@ export function ComplianceReadySoftwareSettings({
   ): Promise<void> => {
     const auditPatch = getAuditInputPatch(id, value, fieldValues)
     if (auditPatch != null) {
-      await patchAuditSettings(auditPatch)
+      try {
+        await patchAuditSettings(auditPatch)
+      } catch (error) {
+        revertSettingsInputs()
+        throw error
+      }
     }
   }
 
@@ -198,6 +213,7 @@ export function ComplianceReadySoftwareSettings({
           isLastSection={false}
         >
           <InputSetting
+            key={`maxNumberOfLoginAttempts-${settingsInputResetKey}`}
             label={t(
               'desktop_maximum_login_attempts_before_account_deactivation'
             )}
@@ -226,6 +242,7 @@ export function ComplianceReadySoftwareSettings({
             }}
           >
             <InputSetting
+              key={`passwordResetTime-${settingsInputResetKey}`}
               label={t('desktop_length_of_time')}
               value={String(fieldValues.passwordResetTime)}
               units={t('desktop_days')}
@@ -262,6 +279,7 @@ export function ComplianceReadySoftwareSettings({
               }}
             />
             <InputSetting
+              key={`passwordComplexityMinimumLength-${settingsInputResetKey}`}
               label={t('desktop_minimum_password_length')}
               value={String(fieldValues.passwordComplexityMinimumLength)}
               units={t('desktop_characters')}
@@ -284,6 +302,7 @@ export function ComplianceReadySoftwareSettings({
           </ComplianceReadyToggleField>
           <Divider />
           <InputSetting
+            key={`idleLogout-${settingsInputResetKey}`}
             label={t('desktop_auto_logout_inactivity_length')}
             value={String(fieldValues.idleLogout)}
             units={t('desktop_minutes')}
@@ -350,6 +369,7 @@ export function ComplianceReadySoftwareSettings({
             }}
           >
             <InputSetting
+              key={`minLengthOfReasonForInteraction-${settingsInputResetKey}`}
               label={t(
                 'desktop_minimum_length_for_documentation_for_robot_actions'
               )}


### PR DESCRIPTION
Closes [RQA-5911](https://opentrons.atlassian.net/browse/RQA-5911)

# Overview

Fixes an issue where dismissing the documentation modal did not revert the "Maximum login attempts before account deactivation" setting and other input-driven settings. Draft values were left on screen after cancel because the inputs keep local state and never remounted from the last saved setting.

https://github.com/user-attachments/assets/6f7c19b5-68bf-4ea6-864a-59a59fe2b5d2

## Test Plan and Hands on Testing

- See video.

## Changelog

- Fixed certain CRS setting fields not reverting to their old values after cancelling the documentation required CTA.

## Risk assessment

- very low, localized to settings and just some edge case handling.


[RQA-5911]: https://opentrons.atlassian.net/browse/RQA-5911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ