### PR TITLE
fix(audit-server,robot-server): log robot logs

### DIFF
--- a/audit-server/audit_server/log_ingest/models.py
+++ b/audit-server/audit_server/log_ingest/models.py
@@ -18,6 +18,16 @@ class SubmitAuditLogMessageData(_StrictBaseModel):
     reason: str | None
 
 
+class SubmitSupportingFileMessageData(_StrictBaseModel):
+    """Details for a supporting-file submission."""
+
+    fileType: str
+    serverId: str
+    accountName: str
+    legalName: str
+    reason: str | None
+
+
 class SubmitExternalAuditLogMessageData(_StrictBaseModel):
     """Message body for submitting an external audit log message."""
 

--- a/audit-server/audit_server/log_ingest/router.py
+++ b/audit-server/audit_server/log_ingest/router.py
@@ -1,8 +1,10 @@
 """Route handlers for ingesting log messages."""
 
 import datetime
+import json
 from logging import getLogger
 from pathlib import Path
+from textwrap import dedent
 from typing import Annotated
 
 import fastapi
@@ -11,6 +13,7 @@ from opentrons_shared_data.errors.exceptions import (
     KeyStorageUnavailableError,
 )
 
+from server_utils.audit.constants import ACTION_STORE_RUNLOG
 from server_utils.audit.fastapi import get_supplied_user_notes, skip_audit_logger
 from server_utils.auth.resource_server.fastapi import (
     RequireAuthenticationResult,
@@ -31,6 +34,7 @@ from .models import (
     SubmitAuditLogMessageData,
     SubmitAuditLogSuccessData,
     SubmitExternalAuditLogMessageData,
+    SubmitSupportingFileMessageData,
 )
 from audit_server.log_storage.dependency import get_log_data_manager
 from audit_server.log_storage.log_data_manager import LogDataManager
@@ -169,8 +173,12 @@ async def post_external_log_message(
 @PydanticResponse.wrap_route(
     router.post,
     path="/audit/internal/storeRobotLog",
-    summary="Store a robot's run record and associate it with the"
-    " current log period, if logging is enabled.",
+    summary=dedent(
+        """Store a robot's run record and associate it with the current log period, if logging is enabled.
+
+    Callers must provide both the runlog, under the multipart/form-data key file, and a file of supporting information
+    matching {fileType: 'runrecord', serverId: str, accountName: str, legalName: str, reason: str | None}"""
+    ),
     responses={
         fastapi.status.HTTP_201_CREATED: {
             "model": SimpleBody[StoreRobotLogResponseData]
@@ -181,18 +189,34 @@ async def post_external_log_message(
                 " could not be signed."
             ),
         },
+        fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY: {
+            "description": "One of the two required files was not provided, or the supporting info did not meet requirements."
+        },
     },
 )
-async def store_robot_log(
+async def store_robot_log(  # noqa: C901
     log_data_manager: Annotated[LogDataManager, fastapi.Depends(get_log_data_manager)],
     robot_logs_directory: Annotated[Path, fastapi.Depends(get_robot_logs_directory)],
-    file: Annotated[
-        fastapi.UploadFile, fastapi.File(description="Data file to upload")
-    ],
+    file: fastapi.UploadFile,
+    supporting_info: fastapi.UploadFile,
 ) -> PydanticResponse[SimpleBody[StoreRobotLogResponseData]]:
     """Store a robot log with the current log period."""
+    supporting_message_data: SubmitSupportingFileMessageData | None = None
+    stored_file_hash: str | None = None
+    stored_file_name: str | None = None
+
+    supporting_message_data = SubmitSupportingFileMessageData.model_validate_json(
+        await supporting_info.read()
+    )
+
+    if supporting_message_data.fileType != "runrecord":
+        raise fastapi.HTTPException(
+            status_code=fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Only run records are accepted by this endpoint",
+        )
+
     try:
-        stored_robot_log = await log_data_manager.store_robot_log(
+        stored_file_hash = await log_data_manager.store_robot_log(
             robot_log=file, robot_log_path=robot_logs_directory
         )
     except KeyStorageUnavailableError as exc:
@@ -202,10 +226,32 @@ async def store_robot_log(
                 "Audit log message could not be signed: key-server is unavailable."
             ),
         ) from exc
+
+    if stored_file_hash:
+        ingest_time = datetime.datetime.now(datetime.timezone.utc)
+        message = AuditLogMessage(
+            action=ACTION_STORE_RUNLOG,
+            accountName=supporting_message_data.accountName,
+            legalName=supporting_message_data.legalName,
+            message=json.dumps(
+                {"fileHash": stored_file_hash, "filePath": stored_file_name}
+            ),
+            reason=supporting_message_data.reason,
+            loggedAt=ingest_time,
+        )
+        try:
+            await log_data_manager.store_log(message.model_dump_json(indent=None))
+        except KeyStorageUnavailableError as exc:
+            raise fastapi.HTTPException(
+                status_code=fastapi.status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=(
+                    "Audit log message could not be signed: key-server is unavailable."
+                ),
+            ) from exc
     await log_data_manager.rotate_periods()
     return await PydanticResponse.create(
         status_code=fastapi.status.HTTP_201_CREATED,
         content=SimpleBody(
-            data=StoreRobotLogResponseData(loggingEnabled=stored_robot_log is not None)
+            data=StoreRobotLogResponseData(loggingEnabled=stored_file_hash is not None)
         ),
     )

--- a/audit-server/audit_server/log_self_client.py
+++ b/audit-server/audit_server/log_self_client.py
@@ -29,6 +29,9 @@ from server_utils.audit.audit_server import (
     SubmitAuditLogSuccessData as SUSuccessData,
 )
 from server_utils.audit.audit_server import (
+    SubmitSupportingFileMessageData as SUSubmitSupportingFileMessageData,
+)
+from server_utils.audit.audit_server import (
     TotalUsageSummaryData as SUTotalUsageSummaryData,
 )
 
@@ -72,7 +75,9 @@ class LocalClient(SUClient):
         )
 
     @override
-    async def store_robot_log(self, robot_log_file: TextIO) -> StoreRobotLogSuccessData:
+    async def store_robot_log(
+        self, robot_log_file: TextIO, message: SUSubmitSupportingFileMessageData
+    ) -> StoreRobotLogSuccessData:
         raise RuntimeError(
             "Should not be calling store robot log from audit server directly"
         )

--- a/audit-server/tests/integration/conftest.py
+++ b/audit-server/tests/integration/conftest.py
@@ -5,7 +5,6 @@ import pytest
 
 from server_utils.audit.audit_server import SubmitSupportingFileMessageData
 
-
 from ..dev_server import DevServer
 
 

--- a/audit-server/tests/integration/conftest.py
+++ b/audit-server/tests/integration/conftest.py
@@ -3,6 +3,9 @@ from io import BytesIO
 import httpx
 import pytest
 
+from server_utils.audit.audit_server import SubmitSupportingFileMessageData
+
+
 from ..dev_server import DevServer
 
 
@@ -30,6 +33,19 @@ async def ensure_inactive_period(run_server: DevServer, enable_logging: None) ->
     async with httpx.AsyncClient() as client:
         response = await client.post(
             f"{run_server.base_url}/audit/internal/storeRobotLog",
-            files={"file": BytesIO(b"hello world")},
+            files={
+                "file": BytesIO(b"hello world"),
+                "supporting_info": BytesIO(
+                    SubmitSupportingFileMessageData(
+                        fileType="runrecord",
+                        serverId="123123123",
+                        accountName="steve",
+                        legalName="Steve",
+                        reason=None,
+                    )
+                    .model_dump_json()
+                    .encode("utf-8")
+                ),
+            },
         )
         response.raise_for_status()

--- a/audit-server/tests/integration/test_download_log_period.py
+++ b/audit-server/tests/integration/test_download_log_period.py
@@ -2,8 +2,8 @@ import io
 import zipfile
 
 import httpx
-from server_utils.audit.audit_server import SubmitSupportingFileMessageData
 
+from server_utils.audit.audit_server import SubmitSupportingFileMessageData
 
 from ..dev_server import DevServer
 

--- a/audit-server/tests/integration/test_download_log_period.py
+++ b/audit-server/tests/integration/test_download_log_period.py
@@ -2,6 +2,8 @@ import io
 import zipfile
 
 import httpx
+from server_utils.audit.audit_server import SubmitSupportingFileMessageData
+
 
 from ..dev_server import DevServer
 
@@ -91,7 +93,24 @@ async def test_download_log_period_not_current(run_server: DevServer) -> None:
         # post a "robot log" to force log period rotation
         response = await client.post(
             f"{run_server.base_url}/audit/internal/storeRobotLog",
-            files={"file": ("robotlog.json", io.BytesIO(b"hi"), "application/json")},
+            files={
+                "file": ("robotlog.json", io.BytesIO(b"hi"), "application/json"),
+                "supporting_info": (
+                    "supporting_info.json",
+                    io.BytesIO(
+                        SubmitSupportingFileMessageData(
+                            fileType="runrecord",
+                            serverId="123123123",
+                            accountName="steve",
+                            legalName="Steve",
+                            reason=None,
+                        )
+                        .model_dump_json()
+                        .encode("utf-8")
+                    ),
+                    "application/json",
+                ),
+            },
         )
         response.raise_for_status()
 

--- a/audit-server/tests/integration/test_store_robot_log.py
+++ b/audit-server/tests/integration/test_store_robot_log.py
@@ -1,6 +1,9 @@
+import io
 import tempfile
 
 import httpx
+
+from server_utils.audit.audit_server import SubmitSupportingFileMessageData
 
 from ..dev_server import DevServer
 
@@ -21,11 +24,21 @@ async def test_store_robot_logs(run_server: DevServer) -> None:
             },
         )
         response.raise_for_status()
-
+        supporting_info = io.BytesIO(
+            SubmitSupportingFileMessageData(
+                fileType="runrecord",
+                serverId="123123123",
+                accountName="steve",
+                legalName="Steve",
+                reason=None,
+            )
+            .model_dump_json()
+            .encode("utf-8")
+        )
         with tempfile.NamedTemporaryFile() as temp_file:
             response = await client.post(
                 f"{run_server.base_url}/audit/internal/storeRobotLog",
-                files={"file": temp_file.file},
+                files={"file": temp_file.file, "supporting_info": supporting_info},
             )
             response.raise_for_status()
             assert response.json()["data"]["loggingEnabled"]

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -37,8 +37,13 @@ from server_utils.audit.audit_server import (
 )
 from server_utils.audit.audit_server import (
     NoCurrentLogPeriodError,
+    SubmitSupportingFileMessageData,
 )
-from server_utils.audit.fastapi import get_audit_client, get_audit_logger
+from server_utils.audit.fastapi import (
+    get_audit_client,
+    get_audit_logger,
+    get_supplied_user_notes,
+)
 from server_utils.auth.resource_server.authorization_checker import (
     check as check_authorization,
 )
@@ -50,6 +55,7 @@ from server_utils.auth.resource_server.fastapi import (
     require_scopes,
 )
 from server_utils.auth.resource_server.types import (
+    AuthenticatedResult,
     AuthorizationNotRequiredResult,
     AuthorizedResult,
 )
@@ -561,6 +567,7 @@ async def update_run(  # noqa: C901
     authentication: Annotated[
         RequireAuthenticationResult, Depends(require_authentication)
     ],
+    user_notes: Annotated[str | None, Depends(get_supplied_user_notes)],
 ) -> PydanticResponse[SimpleBody[Union[Run, BadRun]]]:
     """Update a run by its ID.
 
@@ -575,6 +582,7 @@ async def update_run(  # noqa: C901
         access_control_status: Whether access control (Compliance Ready Software) is
             currently enabled on the robot.
         authentication: The authenticated user, if any.
+        user_notes: The Opentrons-User-Notes data from the request, if any.
     """
     if request_body.data.signedBy is not None:
         _require_signoff_scope(authentication)
@@ -610,7 +618,24 @@ async def update_run(  # noqa: C901
                 if run_log_entry is not None:
                     file_path, _ = run_log_entry
                     with open(file_path, "r") as fh:
-                        await audit_client.store_robot_log(robot_log_file=fh)
+                        await audit_client.store_robot_log(
+                            robot_log_file=fh,
+                            message=SubmitSupportingFileMessageData(
+                                fileType="runrecord",
+                                serverId=runId,
+                                accountName=(
+                                    authentication.username
+                                    if isinstance(authentication, AuthenticatedResult)
+                                    else "system"
+                                ),
+                                legalName=(
+                                    authentication.fullname
+                                    if isinstance(authentication, AuthenticatedResult)
+                                    else "system"
+                                ),
+                                reason=user_notes,
+                            ),
+                        )
                 staging_dir.cleanup()
 
         if run_data is None:

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -972,6 +972,7 @@ async def test_update_run_to_not_current(
         protocol_store=mock_protocol_store,
         access_control_status=False,
         authentication=AuthenticationNotRequiredResult(),
+        user_notes=None,
     )
 
     assert result.content == SimpleBody(data=expected_response)
@@ -1018,6 +1019,7 @@ async def test_update_current_none_noop(
         protocol_store=mock_protocol_store,
         access_control_status=False,
         authentication=AuthenticationNotRequiredResult(),
+        user_notes=None,
     )
 
     assert result.content == SimpleBody(data=expected_response)
@@ -1078,6 +1080,7 @@ async def test_update_run_signed_by_and_uncurrent(
         protocol_store=mock_protocol_store,
         access_control_status=False,
         authentication=AuthenticationNotRequiredResult(),
+        user_notes=None,
     )
 
     assert result.content == SimpleBody(data=uncurrent_response)
@@ -1110,6 +1113,7 @@ async def test_update_run_not_complete(
             protocol_store=mock_protocol_store,
             access_control_status=False,
             authentication=AuthenticationNotRequiredResult(),
+            user_notes=None,
         )
 
     assert exc_info.value.status_code == 409
@@ -1142,6 +1146,7 @@ async def test_update_run_signoff_required(
             protocol_store=mock_protocol_store,
             access_control_status=False,
             authentication=AuthenticationNotRequiredResult(),
+            user_notes=None,
         )
 
     assert exc_info.value.status_code == 409
@@ -1174,6 +1179,7 @@ async def test_update_to_current_not_current(
             protocol_store=mock_protocol_store,
             access_control_status=False,
             authentication=AuthenticationNotRequiredResult(),
+            user_notes=None,
         )
 
     assert exc_info.value.status_code == 409
@@ -1206,6 +1212,7 @@ async def test_update_to_current_conflict(
             protocol_store=mock_protocol_store,
             access_control_status=False,
             authentication=AuthenticationNotRequiredResult(),
+            user_notes=None,
         )
 
     assert exc_info.value.status_code == 409
@@ -1238,6 +1245,7 @@ async def test_update_to_current_missing(
             protocol_store=mock_protocol_store,
             access_control_status=False,
             authentication=AuthenticationNotRequiredResult(),
+            user_notes=None,
         )
 
     assert exc_info.value.status_code == 404
@@ -1267,6 +1275,7 @@ async def test_update_run_signed_by_requires_run_signoff_write_scope(
                 username="testuser",
                 fullname="Test User",
             ),
+            user_notes=None,
         )
 
     assert exc_info.value.required_scopes == {Scope.RUN_SIGNOFF_WRITE}
@@ -1317,6 +1326,7 @@ async def test_update_run_signed_by(
         protocol_store=mock_protocol_store,
         access_control_status=False,
         authentication=AuthenticationNotRequiredResult(),
+        user_notes=None,
     )
 
     assert result.content == SimpleBody(data=expected_response)

--- a/server-utils/server_utils/audit/audit_server.py
+++ b/server-utils/server_utils/audit/audit_server.py
@@ -7,6 +7,7 @@ audit log messages.
 from __future__ import annotations
 
 import contextlib
+import io
 import logging
 import typing
 from abc import ABC, abstractmethod
@@ -47,7 +48,7 @@ class Client(ABC):
 
     @abstractmethod
     async def store_robot_log(
-        self, robot_log_file: typing.TextIO
+        self, robot_log_file: typing.TextIO, message: SubmitSupportingFileMessageData
     ) -> StoreRobotLogSuccessData:
         """Store a robot log file and rotate the log period.
 
@@ -157,10 +158,14 @@ class LocalHTTPClient(Client):
 
     @typing.override
     async def store_robot_log(
-        self, robot_log_file: typing.TextIO
+        self, robot_log_file: typing.TextIO, message: SubmitSupportingFileMessageData
     ) -> StoreRobotLogSuccessData:
         async with self._session.post(
-            STORE_ROBOT_LOG_ENDPOINT_PATH, data={"file": robot_log_file}
+            STORE_ROBOT_LOG_ENDPOINT_PATH,
+            data={
+                "file": robot_log_file,
+                "supporting_info": io.StringIO(message.model_dump_json()),
+            },
         ) as response:
             response_bytes = await response.read()
         response.raise_for_status()
@@ -245,10 +250,10 @@ class NoOpClient(Client):
 
     @typing.override
     async def store_robot_log(
-        self, robot_log_file: typing.TextIO
+        self, robot_log_file: typing.TextIO, message: SubmitSupportingFileMessageData
     ) -> StoreRobotLogSuccessData:
         _log.info(
-            f"Store robot log (audit-server not configured): {robot_log_file.name}"
+            f"Store robot log (audit-server not configured): {robot_log_file.name}: {message.model_dump_json()}"
         )
         return StoreRobotLogSuccessData(loggingEnabled=False)
 
@@ -286,6 +291,16 @@ class NoOpClient(Client):
 
 class _StrictBaseModel(pydantic.BaseModel):
     model_config = {"strict": True}
+
+
+class SubmitSupportingFileMessageData(_StrictBaseModel):
+    """Details for a supporting-file submission."""
+
+    fileType: str
+    serverId: str
+    accountName: str
+    legalName: str
+    reason: str | None
 
 
 class SubmitAuditLogMessageData(_StrictBaseModel):

--- a/server-utils/server_utils/audit/constants.py
+++ b/server-utils/server_utils/audit/constants.py
@@ -17,6 +17,7 @@ ACTION_LOG_PERIOD_END: Final = "log-period-end"
 ACTION_LOG_LOGGING_ERROR: Final = "log-error"
 ACTION_UNSIGNED_RUNS_WARNING: Final = "unsigned-runs-warning"
 ACTION_ROBOT_VERSION: Final = "robot-version"
+ACTION_STORE_RUNLOG: Final = "store-runlog"
 
 ACCOUNT_NAME_SYSTEM: Final = "system"
 LEGAL_NAME_SYSTEM: Final = ""

--- a/server-utils/tests/audit/test_fastapi.py
+++ b/server-utils/tests/audit/test_fastapi.py
@@ -20,6 +20,7 @@ from server_utils.audit.audit_server import (
     StoreRobotLogSuccessData,
     SubmitAuditLogMessageData,
     SubmitAuditLogSuccessData,
+    SubmitSupportingFileMessageData,
     TotalUsageSummaryData,
 )
 from server_utils.audit.fastapi import (
@@ -76,7 +77,9 @@ def test_install_and_get_audit_client_via_dependency() -> None:
             raise NotImplementedError()
 
         async def store_robot_log(
-            self, robot_log_file: typing.TextIO
+            self,
+            robot_log_file: typing.TextIO,
+            supporting_info: SubmitSupportingFileMessageData,
         ) -> StoreRobotLogSuccessData:
             raise NotImplementedError
 


### PR DESCRIPTION
We were saving the robot logs to a log period but we weren't actually indicating it in any way in the logs themselves, or saving the filehash in some place that would be signed or anything.

Let's add some supporting information to the robot log upload and write a log line with the file hash that will then be itself hashed and signed, and that the log verifier can pull out of the logs.

Tested this on a machine and got an audit log with the right stuff in it.