### PR TITLE
fix(server-utils): dont write all headers

### DIFF
--- a/server-utils/server_utils/audit/audit_logger.py
+++ b/server-utils/server_utils/audit/audit_logger.py
@@ -33,6 +33,7 @@ class AuditLogger:
         auto_log_response_head: bool,
         auto_log_request_body: bool,
         auto_log_response_body: bool,
+        auto_log_request_full_headers: bool,
     ) -> None:
         """Build an audit logger object.
 
@@ -51,6 +52,7 @@ class AuditLogger:
         self.auto_log_response_head = auto_log_response_head
         self.auto_log_request_body = auto_log_request_body
         self.auto_log_response_body = auto_log_response_body
+        self.auto_log_request_full_headers = auto_log_request_full_headers
         self.did_log = False
         self.should_log = True
         self.request = request
@@ -98,11 +100,14 @@ class AuditLogger:
             self._message_chunks.append("Query parameters: none")
         return self
 
-    def append_request_head_to_message(self: Self, request: Request) -> Self:
+    def append_request_head_to_message(
+        self: Self, request: Request, full_headers: bool
+    ) -> Self:
         """Append material from the query head (aka not the body) to the message."""
         self.append_request_method_path_to_message(request)
         self.append_request_query_params_to_message(request)
-        self.append_request_headers_to_message(request)
+        if full_headers:
+            self.append_request_headers_to_message(request)
         return self
 
     async def append_request_body_to_message(self: Self, request: Request) -> Self:

--- a/server-utils/server_utils/audit/fastapi.py
+++ b/server-utils/server_utils/audit/fastapi.py
@@ -184,7 +184,9 @@ async def _handle_autolog(
     audit_logger: AuditLogger, request: Request, response: Response | None
 ) -> None:
     if audit_logger.auto_log_request_head:
-        audit_logger.append_request_head_to_message(request)
+        audit_logger.append_request_head_to_message(
+            request, audit_logger.auto_log_request_full_headers
+        )
     if audit_logger.auto_log_request_body:
         await audit_logger.append_request_body_to_message(request)
     if audit_logger.auto_log_response_head:
@@ -281,6 +283,7 @@ def get_audit_logger(
     auto_log_request_body: bool = True,
     auto_log_response_head: bool = True,
     auto_log_response_body: bool = True,
+    auto_log_request_full_headers: bool = False,
 ) -> Callable[..., Awaitable[AuditLogger]]:
     """A FastAPI dependency to log actions to the audit log.
 
@@ -346,6 +349,7 @@ def get_audit_logger(
             auto_log_response_head=auto_log_response_head,
             auto_log_request_body=auto_log_request_body,
             auto_log_response_body=auto_log_response_body,
+            auto_log_request_full_headers=auto_log_request_full_headers,
             request=request,
         )
         if action is not None:

--- a/server-utils/tests/audit/test_audit_logger.py
+++ b/server-utils/tests/audit/test_audit_logger.py
@@ -41,6 +41,7 @@ def subject(mock_client: Client, request: pytest.FixtureRequest) -> AuditLogger:
         auto_log_response_head=True,
         auto_log_request_body=True,
         auto_log_response_body=True,
+        auto_log_request_full_headers=True,
     )
 
 
@@ -60,6 +61,7 @@ def parametrized_subject(
             auto_log_response_head=True,
             auto_log_request_body=True,
             auto_log_response_body=True,
+            auto_log_request_full_headers=True,
         )
         .set_action("a")
         .set_username("u")


### PR DESCRIPTION
These are so annoying to parse and carry zero useful information. Keep the method and such, just not all the headers.

Tested on a robot and downloaded the logs.
