### PR TITLE
fix(app): add documentation for chain live commands

### DIFF
--- a/app/src/local-resources/modules/utils/getModulePrepCommands.ts
+++ b/app/src/local-resources/modules/utils/getModulePrepCommands.ts
@@ -1,10 +1,12 @@
 import {
+  FLEX_STACKER_MODULE_TYPE,
   HEATERSHAKER_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
 import type { AttachedModule, FlexStackerModule } from '@opentrons/api-client'
+import type { DocumentedAction } from '@opentrons/react-api-client'
 import type {
   HeaterShakerCloseLatchCreateCommand,
   HeaterShakerDeactivateHeaterCreateCommand,
@@ -100,4 +102,26 @@ export function getFlexStackerPrepCommands(
       params: { moduleId: module.id },
     },
   ]
+}
+
+// The documentation modal renders RunTimeCommands, but these commands have not been
+// issued yet, so fill in the run time fields with placeholders.
+export function getFlexStackerPrepActions(
+  modules: Array<AttachedModule | null>
+): DocumentedAction[] {
+  return modules
+    .filter(
+      (module): module is FlexStackerModule =>
+        module?.moduleType === FLEX_STACKER_MODULE_TYPE
+    )
+    .flatMap(module =>
+      getFlexStackerPrepCommands(module).map(command => ({
+        ...command,
+        id: '',
+        status: 'queued' as const,
+        createdAt: '',
+        startedAt: null,
+        completedAt: null,
+      }))
+    )
 }

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupModuleAndDeck/SetupModulesList.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupModuleAndDeck/SetupModulesList.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import map from 'lodash/map'
 import { css } from 'styled-components'
@@ -20,6 +20,7 @@ import {
   TYPOGRAPHY,
   useHoverTooltip,
 } from '@opentrons/components'
+import { isDocumentedMutationError } from '@opentrons/react-api-client'
 import {
   ABSORBANCE_READER_TYPE,
   ABSORBANCE_READER_V1,
@@ -41,6 +42,7 @@ import {
 import { TertiaryButton } from '/app/atoms/buttons'
 import { StatusLabel } from '/app/atoms/StatusLabel'
 import {
+  getFlexStackerPrepActions,
   getFlexStackerPrepCommands,
   getModuleImage,
   useModuleUSBPort,
@@ -62,7 +64,7 @@ import { UnMatchedModuleWarning } from './UnMatchedModuleWarning'
 import { getFixtureImage } from './utils'
 
 import type { TFunction } from 'i18next'
-import type { AttachedModule, CommandData } from '@opentrons/api-client'
+import type { AttachedModule } from '@opentrons/api-client'
 import type {
   CutoutConfigAndCompatibility,
   CutoutFixtureId,
@@ -70,7 +72,6 @@ import type {
   ModuleModel,
   ModuleType,
 } from '@opentrons/shared-data'
-import type { ModulePrepCommandsType } from '/app/local-resources/modules'
 import type {
   ModuleRenderInfoForProtocol,
   ProtocolCalibrationStatus,
@@ -94,7 +95,6 @@ export const SetupModulesList = (props: SetupModulesListProps): JSX.Element => {
   const deckDef = getDeckDefFromRobotType(robotModel ?? FLEX_ROBOT_TYPE)
 
   const calibrationStatus = useRunCalibrationStatus(robotName, runId)
-  const { chainLiveCommands } = useChainLiveCommands()
 
   const moduleModels = map(
     moduleRenderInfoForProtocolById,
@@ -146,10 +146,10 @@ export const SetupModulesList = (props: SetupModulesListProps): JSX.Element => {
                   heaterShakerModuleFromProtocol={null}
                   isFlex={isFlex}
                   calibrationStatus={calibrationStatus}
-                  chainLiveCommands={chainLiveCommands}
                   conflictedFixture={comboFixtureConflict}
                   deckDef={deckDef}
                   robotName={robotName}
+                  runId={runId}
                   comboFixtureId={comboFixtureId}
                 />
               )
@@ -174,10 +174,10 @@ export const SetupModulesList = (props: SetupModulesListProps): JSX.Element => {
               }
               isFlex={isFlex}
               calibrationStatus={calibrationStatus}
-              chainLiveCommands={chainLiveCommands}
               conflictedFixture={conflictedFixture != null}
               deckDef={deckDef}
               robotName={robotName}
+              runId={runId}
             />
           )
         }
@@ -195,13 +195,10 @@ interface ModulesListItemProps {
   heaterShakerModuleFromProtocol: ModuleRenderInfoForProtocol | null
   isFlex: boolean
   calibrationStatus: ProtocolCalibrationStatus
-  chainLiveCommands: (
-    commands: ModulePrepCommandsType[],
-    continuePastCommandFailure: boolean
-  ) => Promise<CommandData[]>
   deckDef: DeckDefinition
   conflictedFixture: boolean
   robotName: string
+  runId: string
   comboFixtureId?: CutoutFixtureId
 }
 
@@ -213,10 +210,10 @@ export function ModulesListItem({
   attachedModuleMatch,
   isFlex,
   calibrationStatus,
-  chainLiveCommands,
   conflictedFixture,
   deckDef,
   robotName,
+  runId,
   comboFixtureId,
 }: ModulesListItemProps): JSX.Element {
   const { t } = useTranslation([
@@ -236,6 +233,14 @@ export function ModulesListItem({
 
   const { parseModuleUSBPort } = useModuleUSBPort()
 
+  // NOTE (jj 9/4/26): chainLiveCommands is only used here to home this row's Flex Stacker.
+  // If it is ever used to send other commands, this will need updating.
+  const actionsToDocument = useMemo(
+    () => getFlexStackerPrepActions([attachedModuleMatch]),
+    [attachedModuleMatch]
+  )
+  const { chainLiveCommands } = useChainLiveCommands(actionsToDocument, runId)
+
   const handleSetupModuleClick = (): void => {
     if (attachedModuleMatch !== null) {
       handleModuleWizardFlows({
@@ -251,7 +256,11 @@ export function ModulesListItem({
         getFlexStackerPrepCommands(attachedModuleMatch),
         // if the close latch command fails, we still want to home the shuttle
         true
-      )
+      ).catch(error => {
+        if (!isDocumentedMutationError(error)) {
+          console.error(`error homing stacker: ${String(error)}`)
+        }
+      })
     }
   }
 

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/ModuleTable.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/ModuleTable.tsx
@@ -10,10 +10,7 @@ import {
 
 import { getLocalRobot } from '/app/redux/discovery'
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
-import {
-  useChainLiveCommands,
-  useRunCalibrationStatus,
-} from '/app/resources/runs'
+import { useRunCalibrationStatus } from '/app/resources/runs'
 
 import { ModuleTableItem } from './ModuleTableItem'
 
@@ -51,7 +48,6 @@ export function ModuleTable(props: ModuleTableProps): JSX.Element {
   const localRobot = useSelector(getLocalRobot)
   const robotName: string = localRobot?.name ?? ''
   const calibrationStatus = useRunCalibrationStatus(robotName, runId)
-  const { chainLiveCommands } = useChainLiveCommands()
 
   return (
     <>
@@ -84,7 +80,6 @@ export function ModuleTable(props: ModuleTableProps): JSX.Element {
                   key={module.moduleId}
                   module={module}
                   calibrationStatus={calibrationStatus}
-                  chainLiveCommands={chainLiveCommands}
                   comboFixtureId={comboFixtureId}
                   conflictedFixture={
                     comboFixtureConflict
@@ -95,6 +90,7 @@ export function ModuleTable(props: ModuleTableProps): JSX.Element {
                   }
                   deckDef={deckDef}
                   robotName={robotName}
+                  runId={runId}
                 />
               )
             }
@@ -111,10 +107,10 @@ export function ModuleTable(props: ModuleTableProps): JSX.Element {
               key={module.moduleId}
               module={module}
               calibrationStatus={calibrationStatus}
-              chainLiveCommands={chainLiveCommands}
               conflictedFixture={conflictedFixture}
               deckDef={deckDef}
               robotName={robotName}
+              runId={runId}
             />
           )
         })}

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/ModuleTableItem.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/ModuleTableItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -14,6 +14,7 @@ import {
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
+import { isDocumentedMutationError } from '@opentrons/react-api-client'
 import {
   FLEX_STACKER_MODULE_TYPE,
   getFixtureDisplayName,
@@ -22,25 +23,28 @@ import {
 } from '@opentrons/shared-data'
 
 import { SmallButton } from '/app/atoms/buttons'
-import { getFlexStackerPrepCommands } from '/app/local-resources/modules'
+import {
+  getFlexStackerPrepActions,
+  getFlexStackerPrepCommands,
+} from '/app/local-resources/modules'
 import { OddInfoScreen } from '/app/molecules/ODDInfoScreen'
 import { OddModal } from '/app/molecules/OddModal'
 import { useIsDoorOpen } from '/app/organisms/DoorOpenControl/useIsDoorOpen'
 import { LocationConflictModal } from '/app/organisms/LocationConflictModal'
 import { handleModuleWizardFlows } from '/app/organisms/ModuleWizardFlows'
 import { useToaster } from '/app/organisms/ToasterOven'
+import { useChainLiveCommands } from '/app/resources/runs'
 import { getModuleTooHot } from '/app/transformations/modules'
 
 import { getDoesModuleRequireCalibration } from './utils'
 
 import type { TFunction } from 'i18next'
-import type { AttachedModule, CommandData } from '@opentrons/api-client'
+import type { AttachedModule } from '@opentrons/api-client'
 import type {
   CutoutConfig,
   CutoutFixtureId,
   DeckDefinition,
 } from '@opentrons/shared-data'
-import type { ModulePrepCommandsType } from '/app/local-resources/modules'
 import type { ProtocolCalibrationStatus } from '/app/resources/runs'
 import type { AttachedProtocolModuleMatch } from '/app/transformations/analysis'
 
@@ -92,24 +96,21 @@ export const getModuleDisplayStatus = (
 
 interface ModuleTableItemProps {
   calibrationStatus: ProtocolCalibrationStatus
-  chainLiveCommands: (
-    commands: ModulePrepCommandsType[],
-    continuePastCommandFailure: boolean
-  ) => Promise<CommandData[]>
   conflictedFixture: CutoutConfig | null
   module: AttachedProtocolModuleMatch
   deckDef: DeckDefinition
   robotName: string
+  runId: string
   comboFixtureId?: CutoutFixtureId
 }
 
 export function ModuleTableItem({
   module,
   calibrationStatus,
-  chainLiveCommands,
   conflictedFixture,
   deckDef,
   robotName,
+  runId,
   comboFixtureId,
 }: ModuleTableItemProps): JSX.Element {
   const { i18n, t } = useTranslation([
@@ -119,6 +120,14 @@ export function ModuleTableItem({
   ])
 
   const { makeSnackbar } = useToaster()
+
+  // NOTE (jj 9/4/26): chainLiveCommands is only used here to home this row's Flex Stacker.
+  // If it is ever used to send other commands, this will need updating.
+  const actionsToDocument = useMemo(
+    () => getFlexStackerPrepActions([module.attachedModuleMatch]),
+    [module.attachedModuleMatch]
+  )
+  const { chainLiveCommands } = useChainLiveCommands(actionsToDocument, runId)
 
   const handleCalibrate = (): void => {
     if (module.attachedModuleMatch != null) {
@@ -143,7 +152,14 @@ export function ModuleTableItem({
         // if the close latch command fails, we still want to home the shuttle
         true
       )
-      setShowHomeStackerWarning(false)
+        .then(() => {
+          setShowHomeStackerWarning(false)
+        })
+        .catch(error => {
+          if (!isDocumentedMutationError(error)) {
+            setShowHomeStackerWarning(false)
+          }
+        })
     }
   }
 

--- a/app/src/resources/runs/hooks.ts
+++ b/app/src/resources/runs/hooks.ts
@@ -7,7 +7,7 @@ import {
   useCreateMaintenanceRunMutation,
 } from '@opentrons/react-api-client'
 
-import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/utils'
+import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
 // TODO: refactor this so helper code doesn't spawn UI
 /* eslint-disable-next-line opentrons/no-imports-across-applications */
 import { useMaintenanceRunTakeover } from '/app/organisms/TakeoverModal'
@@ -113,7 +113,12 @@ export function useChainRunCommands(
   }
 }
 
-export function useChainLiveCommands(): {
+// NOTE (jj 9/4/26): This hook is used in exactly two places to do the same two stacker commands.
+// If you want to use this to send different sets of commands with the same hook call, this will need updating.
+export function useChainLiveCommands(
+  actionsToDocument: DocumentedAction[],
+  resetKey: string
+): {
   chainLiveCommands: (
     commands: CreateCommand[],
     continuePastCommandFailure: boolean
@@ -121,9 +126,14 @@ export function useChainLiveCommands(): {
   isCommandMutationLoading: boolean
 } {
   const [isLoading, setIsLoading] = useState(false)
-  // TODO(jj): add documentation to chainLiveCommands
+  const { documentationState } = useLinkedDocumentationState(
+    actionsToDocument,
+    resetKey
+  )
+
   const { createLiveCommand } = useCreateLiveCommandMutation(
-    ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+    documentationState,
+    actionsToDocument
   )
   return {
     chainLiveCommands: (


### PR DESCRIPTION
# Overview

`chainLiveCommands` was secretly just forwarding a fake `ACCESS_CONTROL_DISABLED` documentation state and thus trying to submit some actions without documentation. This function is pretty obscure, and only used two send two specific stacker homing actions, so we could cut corners a bit and not do any complicated action tracking - instead callsites just pass in an action list generated from those two commands. If ever we need to use this function again it will need updating, but for this week I believe this will do fine. 

## Test Plan and Hands on Testing

1. On a flex in CRS mode with a stacker attached, attempt to start a run with the stacker door open and the stacker not homed - You should get a modal asking you to home the stacker
2. Clicking submit on the modal should ask for documentation and list two actions - closing stacker latch and preparing stacker shuttle.
3. Submitting documentation should close the latch and home the shuttle. Canceling should bring you back to the modal.

## Risk assessment

Medium, this code is obscure but I don't want to break stackers. 
