### PR TITLE
fix(app): don't patch crs settings if value hasn't changed

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/ComplianceReadySoftwareSettings/index.tsx
@@ -119,6 +119,9 @@ export function ComplianceReadySoftwareSettings({
     id: AuthSettingFieldId,
     value: string
   ): Promise<void> => {
+    if (fieldValues[id] === value) {
+      return
+    }
     const authPatch = getAuthInputPatch(id, value, fieldValues)
     if (authPatch != null) {
       try {
@@ -134,6 +137,9 @@ export function ComplianceReadySoftwareSettings({
     id: AuditServerSettingFieldId,
     value: string
   ): Promise<void> => {
+    if (fieldValues[id] === value) {
+      return
+    }
     const auditPatch = getAuditInputPatch(id, value, fieldValues)
     if (auditPatch != null) {
       try {


### PR DESCRIPTION
# Overview

Checks if the value of a CRS setting has changed before sending a network request to patch it. 

https://github.com/user-attachments/assets/42df27b6-790c-46c0-9246-db5b04fbc102

Fixes [RQA-6083](https://opentrons.atlassian.net/browse/RQA-6083)

## Test Plan and Hands on Testing

On a CRS bot, double clicking a crs setting, or clicking in and out without changing it should not ask for documentation.

## Risk assessment

Low

[RQA-6083]: https://opentrons.atlassian.net/browse/RQA-6083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ