### PR TITLE
fix(audit-server): actually log the robot log name

### DIFF
--- a/audit-server/audit_server/log_ingest/router.py
+++ b/audit-server/audit_server/log_ingest/router.py
@@ -203,7 +203,6 @@ async def store_robot_log(  # noqa: C901
     """Store a robot log with the current log period."""
     supporting_message_data: SubmitSupportingFileMessageData | None = None
     stored_file_hash: str | None = None
-    stored_file_name: str | None = None
 
     supporting_message_data = SubmitSupportingFileMessageData.model_validate_json(
         await supporting_info.read()
@@ -216,7 +215,7 @@ async def store_robot_log(  # noqa: C901
         )
 
     try:
-        stored_file_hash = await log_data_manager.store_robot_log(
+        stored_file_details = await log_data_manager.store_robot_log(
             robot_log=file, robot_log_path=robot_logs_directory
         )
     except KeyStorageUnavailableError as exc:
@@ -227,14 +226,15 @@ async def store_robot_log(  # noqa: C901
             ),
         ) from exc
 
-    if stored_file_hash:
+    if stored_file_details:
+        stored_file_hash, stored_file_path = stored_file_details
         ingest_time = datetime.datetime.now(datetime.timezone.utc)
         message = AuditLogMessage(
             action=ACTION_STORE_RUNLOG,
             accountName=supporting_message_data.accountName,
             legalName=supporting_message_data.legalName,
             message=json.dumps(
-                {"fileHash": stored_file_hash, "filePath": stored_file_name}
+                {"fileHash": stored_file_hash, "filePath": stored_file_path}
             ),
             reason=supporting_message_data.reason,
             loggedAt=ingest_time,
@@ -252,6 +252,8 @@ async def store_robot_log(  # noqa: C901
     return await PydanticResponse.create(
         status_code=fastapi.status.HTTP_201_CREATED,
         content=SimpleBody(
-            data=StoreRobotLogResponseData(loggingEnabled=stored_file_hash is not None)
+            data=StoreRobotLogResponseData(
+                loggingEnabled=stored_file_details is not None
+            )
         ),
     )

--- a/audit-server/audit_server/log_storage/log_data_manager.py
+++ b/audit-server/audit_server/log_storage/log_data_manager.py
@@ -91,7 +91,7 @@ class LogDataManager:
 
     async def store_robot_log(
         self, robot_log: UploadFile, robot_log_path: Path
-    ) -> str | None:
+    ) -> tuple[str, str] | None:
         """Store a robot log to the active period."""
         if not self._settings.get_logging_enabled():
             return None
@@ -193,7 +193,7 @@ class LogDataManager:
 
     async def _do_store_robot_log(
         self, robot_log: UploadFile, robot_log_dir_path: Path
-    ) -> str:
+    ) -> tuple[str, str]:
         contents_bytes = await robot_log.read()
         contents = contents_bytes.decode("utf-8")
         signed_contents, signing_exec = await self._sign_log(contents, None)
@@ -213,7 +213,7 @@ class LogDataManager:
 
         robot_log_hash = self._store.store_robot_log(signed_contents, robot_log_path)
 
-        return robot_log_hash
+        return robot_log_hash, robot_log_path.name
 
     def _build_system_message(self, action: str, message: str) -> str:
         """Build an audit log message originated by the system.

--- a/audit-server/tests/log_storage/test_log_data_manager.py
+++ b/audit-server/tests/log_storage/test_log_data_manager.py
@@ -231,12 +231,15 @@ async def test_store_robot_log_stores_file(
                 "eeeeee"
             )
             assert not temp_path.is_file()
-            stored_hash = await subject.store_robot_log(
+            stored_details = await subject.store_robot_log(
                 UploadFile(temp_file.file, filename=temp_file.name),  # type: ignore[arg-type]
                 Path(temp_dir),
             )
+            assert stored_details is not None
+            stored_hash, stored_name = stored_details
             assert stored_hash == "eeeeee"
             assert temp_path.is_file()
+            assert stored_name == temp_path.name
 
 
 async def test_store_robot_log_renames_file(
@@ -273,12 +276,15 @@ async def test_store_robot_log_renames_file(
                 "eeeeee"
             )
             assert not temp_path.is_file()
-            stored_hash = await subject.store_robot_log(
+            stored_details = await subject.store_robot_log(
                 UploadFile(temp_file.file, filename=temp_file.name),  # type: ignore[arg-type]
                 Path(temp_dir),
             )
+            assert stored_details is not None
+            stored_hash, stored_name = stored_details
             assert stored_hash == "eeeeee"
             assert temp_path.is_file()
+            assert temp_path.name == stored_name
 
             # It should it handle it for the first copy
             copied_temp_path = temp_path.with_stem(f"{temp_path.stem}_copy")
@@ -286,12 +292,15 @@ async def test_store_robot_log_renames_file(
                 mock_store.store_robot_log(robot_log, copied_temp_path)
             ).then_return("iiiiii")
             temp_file.seek(0)
-            stored_hash = await subject.store_robot_log(
+            stored_details = await subject.store_robot_log(
                 UploadFile(temp_file.file, filename=temp_file.name),  # type: ignore[arg-type]
                 Path(temp_dir),
             )
+            assert stored_details is not None
+            stored_hash, stored_name = stored_details
             assert stored_hash == "iiiiii"
             assert copied_temp_path.is_file()
+            assert copied_temp_path.name == stored_name
 
             # Trying the same file a third time should make _copy_copy
             copied_copied_temp_path = copied_temp_path.with_stem(
@@ -301,12 +310,15 @@ async def test_store_robot_log_renames_file(
                 mock_store.store_robot_log(robot_log, copied_copied_temp_path)
             ).then_return("oooooo")
             temp_file.seek(0)
-            stored_hash = await subject.store_robot_log(
+            stored_details = await subject.store_robot_log(
                 UploadFile(temp_file.file, filename=temp_file.name),  # type: ignore[arg-type]
                 Path(temp_dir),
             )
+            assert stored_details is not None
+            stored_hash, stored_name = stored_details
             assert stored_hash == "oooooo"
             assert copied_copied_temp_path.is_file()
+            assert copied_copied_temp_path.name == stored_name
 
 
 async def test_store_robot_log_raises_keyserver_unavailable(


### PR DESCRIPTION
Oops! Now with tests. Here's an example.
[logperiod_2026-09-04T17_51_28.055775Z.zip](https://github.com/user-attachments/files/31846071/logperiod_2026-09-04T17_51_28.055775Z.zip)
