### PR TITLE
fix(app): underline buttons in run history tab

### DIFF
--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns/index.tsx
@@ -124,10 +124,14 @@ export function RecentProtocolRuns({
             {t('run_history')}
           </StyledText>
           <div className={styles.header_actions}>
-            <BasicButton onClick={handleDownloadSelected} iconName="download">
+            <BasicButton
+              onClick={handleDownloadSelected}
+              iconName="download"
+              underLine
+            >
               {t('download_all')}
             </BasicButton>
-            <BasicButton onClick={handleClickDeleteAll}>
+            <BasicButton onClick={handleClickDeleteAll} underLine>
               {t('delete_all')}
             </BasicButton>
           </div>


### PR DESCRIPTION
# Overview

<img width="1025" height="766" alt="Screenshot 2026-09-04 at 5 10 15 PM" src="https://github.com/user-attachments/assets/ded9af2a-fada-4c2a-bcd7-80706d866c51" />

These buttons are now underlined

Fixes [RQA-6091](https://opentrons.atlassian.net/browse/RQA-6091)

## Test Plan and Hands on Testing

These buttons should be underlined

## Risk assessment

Very low

[RQA-6091]: https://opentrons.atlassian.net/browse/RQA-6091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ