### PR TITLE
fix(app): fix border radius on run history menu

### DIFF
--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns/HistoricalProtocolRunOverflowMenu.tsx
@@ -8,6 +8,7 @@ import { css } from 'styled-components'
 import {
   ALIGN_CENTER,
   ALIGN_FLEX_END,
+  BORDERS,
   Box,
   COLORS,
   DIRECTION_COLUMN,
@@ -272,7 +273,7 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
     <Flex
       whiteSpace={NO_WRAP}
       zIndex={10}
-      borderRadius="4px 4px 0px 0px"
+      borderRadius={BORDERS.borderRadius8}
       boxShadow="0px 1px 3px rgba(0, 0, 0, 0.2)"
       position={POSITION_ABSOLUTE}
       backgroundColor={COLORS.white}


### PR DESCRIPTION
# Overview

<img width="1022" height="768" alt="Screenshot 2026-09-04 at 5 22 59 PM" src="https://github.com/user-attachments/assets/bd96b393-7314-4bba-a7f0-886a97c79cfb" />

Fixes dropdown on run history tab to have proper border radius.

## Test Plan and Hands on Testing

Dropdown on run history tab should have proper border radius.

## Risk assessment

Very low