### PR TITLE
fix(app): fix margin on download audit log banner

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotOverview.tsx
@@ -103,7 +103,7 @@ export function RobotOverview({
               <ReachableBanner robot={robot} />
             </Box>
             <UpdateRobotBanner robot={robot} marginBottom={SPACING.spacing8} />
-            <SignAndDownloadRunBanner robotName={robotName} />
+            <SignAndDownloadRunBanner robotName={robotName} onRobotOverview />
             {showRecoveryBanner ? (
               <ErrorRecoveryBanner
                 recoveryIntent={recoveryIntent}

--- a/app/src/organisms/Desktop/Devices/SignAndDownloadRunBanner/SignAndDownloadRunBanner.tsx
+++ b/app/src/organisms/Desktop/Devices/SignAndDownloadRunBanner/SignAndDownloadRunBanner.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next'
+import clsx from 'clsx'
 
 import { InlineNotification } from '@opentrons/components'
 
@@ -21,10 +22,12 @@ const COPY_BY_BANNER_TYPE = {
 
 export interface SignAndDownloadRunBannerProps {
   robotName: string
+  onRobotOverview?: boolean
 }
 
 export function SignAndDownloadRunBanner({
   robotName,
+  onRobotOverview = false,
 }: SignAndDownloadRunBannerProps): JSX.Element {
   const { t } = useTranslation('access_control')
 
@@ -41,7 +44,11 @@ export function SignAndDownloadRunBanner({
 
   return (
     // reserves room for the robot card's overflow menu in the top right corner
-    <div className={styles.banner_wrapper}>
+    <div
+      className={clsx(styles.banner_wrapper, {
+        [styles.displayed_on_robot_overview]: onRobotOverview,
+      })}
+    >
       <InlineNotification
         type="alert"
         heading={t(headingKey)}

--- a/app/src/organisms/Desktop/Devices/SignAndDownloadRunBanner/signanddownloadrunbanner.module.css
+++ b/app/src/organisms/Desktop/Devices/SignAndDownloadRunBanner/signanddownloadrunbanner.module.css
@@ -4,8 +4,6 @@
   padding-right: var(--spacing-24);
 }
 
-/* the doubled selector outweighs InlineNotification's own styled-components
-   class, which is injected into the document after this stylesheet */
-.notification.notification {
-  padding: var(--spacing-4) var(--spacing-8) var(--spacing-4) var(--spacing-12);
+.displayed_on_robot_overview {
+  margin-bottom: var(--spacing-10);
 }


### PR DESCRIPTION
# Overview

<img width="923" height="236" alt="Screenshot 2026-09-04 at 5 39 06 PM" src="https://github.com/user-attachments/assets/a229ad24-6a89-4349-b2c4-d5cb74f028d3" />

Fixes the margin between audit log banner and the robot name

Fixes [RQA-6058](https://opentrons.atlassian.net/browse/RQA-6058)

## Test Plan and Hands on Testing

The margin between the audit log banner and the robot name should be 10px.

## Risk assessment

Very low

[RQA-6058]: https://opentrons.atlassian.net/browse/RQA-6058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ