### PR TITLE
fix(protocol-visualization): fix PlaybackControls rendering position and hide step details col for the initial rendering

### DIFF
--- a/protocol-visualization/src/molecules/PerStepOverflowMenu/index.tsx
+++ b/protocol-visualization/src/molecules/PerStepOverflowMenu/index.tsx
@@ -1,4 +1,4 @@
-import { MenuItem, MenuList, useOnClickOutside } from '@opentrons/components'
+import { MenuItem, useOnClickOutside } from '@opentrons/components'
 
 import styles from './perstepoverflowmenu.module.css'
 
@@ -34,7 +34,7 @@ export function PerStepOverflowMenu(
 
   return (
     <div ref={perStepOverflowWrapperRef} className={styles.container}>
-      <MenuList opensUpward={true}>
+      <div className={styles.menu_list}>
         {PLAYBACK_SPEED_OPTIONS.map(option => (
           <MenuItem
             key={option.seconds}
@@ -45,7 +45,7 @@ export function PerStepOverflowMenu(
             {option.label}
           </MenuItem>
         ))}
-      </MenuList>
+      </div>
     </div>
   )
 }

--- a/protocol-visualization/src/molecules/PerStepOverflowMenu/perstepoverflowmenu.module.css
+++ b/protocol-visualization/src/molecules/PerStepOverflowMenu/perstepoverflowmenu.module.css
@@ -5,3 +5,17 @@
   bottom: 0;
   cursor: pointer;
 }
+
+.menu_list {
+  position: absolute;
+  z-index: 10;
+  right: 0;
+  bottom: 2.6rem;
+  display: flex;
+  overflow: hidden;
+  width: max-content;
+  flex-direction: column;
+  border-radius: var(--border-radius-4);
+  background-color: var(--white);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 20%);
+}

--- a/protocol-visualization/src/molecules/PlayBackControls/playbackcontrols.module.css
+++ b/protocol-visualization/src/molecules/PlayBackControls/playbackcontrols.module.css
@@ -1,19 +1,19 @@
 .container {
   position: absolute;
   z-index: 10;
-  right: var(--spacing-40);
+  right: 0;
   bottom: var(--spacing-32);
-  left: var(--spacing-40);
+  left: 0;
   display: flex;
   overflow: visible;
-  width: auto;
+  width: min(50rem, calc(100% - 2 * var(--spacing-40))); /* 800px max */
   min-width: 21.25rem; /* 340px */
-  max-width: 50rem; /* 800px */
   height: 4.5rem;
   box-sizing: border-box;
   align-items: center;
   padding: 0 var(--spacing-20);
   border-radius: var(--border-radius-full);
+  margin: 0 auto;
   background-color: var(--white);
   box-shadow: 0 0 6px 1px rgb(22 33 45 / 15%);
 }

--- a/protocol-visualization/src/organisms/VisualizerContainer/index.tsx
+++ b/protocol-visualization/src/organisms/VisualizerContainer/index.tsx
@@ -51,7 +51,9 @@ export function ProtocolVisualization(
   const [isDragging, setIsDragging] = useState<boolean>(false)
 
   const [selectedCommandId, setSelectedCommand] = useState<string | null>(null)
-  const [showStepDetails, setShowStepDetails] = useState<boolean>(true)
+  const [showStepDetails, setShowStepDetails] = useState<boolean>(
+    appType !== 'web'
+  )
 
   // for resizable columns
   const [leftWidth, setLeftWidth] = useState<number>(INITIAL_WIDTH_PX)


### PR DESCRIPTION
# Overview
fix PlaybackControls rendering position and hide step details col for the initial rendering

this branch is based on another PR for PlaybackControls

replace `MenuList` with div since MenuList doesn't support upward.
this will fix when we do CSS Modules migration.

closes AUTH-3324, AUTH-3339, and AUTH-3341


## Test Plan and Hands on Testing
- build protocol-visualization
- link protocol-visualization to oai
- generate a protocol

## Changelog
- fix CSS styling
- modify initial useState value

## Review requests


## Risk assessment
low
