### PR TITLE
fix(app): confirm audit log download with sha256

### DIFF
--- a/app-shell-odd/src/__tests__/http.test.ts
+++ b/app-shell-odd/src/__tests__/http.test.ts
@@ -1,3 +1,8 @@
+import { createHash } from 'crypto'
+import { access, mkdtemp, readFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { Readable } from 'stream'
 import isError from 'lodash/isError'
 import fetch from 'node-fetch'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -10,6 +15,25 @@ import type { Request, Response } from 'node-fetch'
 vi.mock('../config')
 vi.mock('node-fetch')
 vi.mock('../log')
+
+const DOWNLOAD_SHA256_HEADER = 'opentrons-download-sha256'
+
+function sha256Hex(contents: string): string {
+  return createHash('sha256').update(contents).digest('hex')
+}
+
+function mockDownloadResponse(
+  body: string,
+  headers: Record<string, string | null> = {}
+): void {
+  vi.mocked(fetch).mockResolvedValueOnce({
+    ok: true,
+    headers: {
+      get: (name: string) => headers[name] ?? null,
+    },
+    body: Readable.from(Buffer.from(body)),
+  } as unknown as Response)
+}
 
 describe('app-shell main http module', () => {
   beforeEach(() => {
@@ -106,6 +130,58 @@ describe('app-shell main http module', () => {
       return expect(method(request as unknown as Request)).rejects.toThrow(
         expected
       )
+    })
+  })
+
+  describe('fetchToFile', () => {
+    let destination: string
+
+    beforeEach(async () => {
+      const dir = await mkdtemp(path.join(tmpdir(), 'fetch-to-file-'))
+      destination = path.join(dir, 'logperiod.zip')
+    })
+
+    it('writes the response body to the destination', async () => {
+      mockDownloadResponse('zip-bytes')
+
+      await expect(
+        Http.fetchToFile('http://example.com/file', destination)
+      ).resolves.toBe(destination)
+      expect(await readFile(destination, 'utf8')).toBe('zip-bytes')
+    })
+
+    it('succeeds when the sha256 header matches the downloaded bytes', async () => {
+      const body = 'zip-bytes'
+      mockDownloadResponse(body, {
+        [DOWNLOAD_SHA256_HEADER]: sha256Hex(body),
+      })
+
+      await expect(
+        Http.fetchToFile('http://example.com/file', destination)
+      ).resolves.toBe(destination)
+      expect(await readFile(destination, 'utf8')).toBe(body)
+    })
+
+    it('skips hash verification when the server omits the sha256 header', async () => {
+      mockDownloadResponse('zip-bytes')
+
+      await expect(
+        Http.fetchToFile('http://example.com/file', destination)
+      ).resolves.toBe(destination)
+      expect(await readFile(destination, 'utf8')).toBe('zip-bytes')
+    })
+
+    it('rejects and deletes the file when the sha256 header does not match', async () => {
+      mockDownloadResponse('zip-bytes', {
+        [DOWNLOAD_SHA256_HEADER]: sha256Hex('different-bytes'),
+      })
+
+      await expect(
+        Http.fetchToFile('http://example.com/file', destination)
+      ).rejects.toThrow('Downloaded file hash does not match expected hash')
+      await expect(access(destination)).rejects.toMatchObject({
+        code: 'ENOENT',
+      })
     })
   })
 })

--- a/app-shell-odd/src/__tests__/http.test.ts
+++ b/app-shell-odd/src/__tests__/http.test.ts
@@ -16,10 +16,11 @@ vi.mock('../config')
 vi.mock('node-fetch')
 vi.mock('../log')
 
-const DOWNLOAD_SHA256_HEADER = 'opentrons-download-sha256'
+const CONTENT_DIGEST_HEADER = 'content-digest'
 
-function sha256Hex(contents: string): string {
-  return createHash('sha256').update(contents).digest('hex')
+function sha256ContentDigest(contents: string): string {
+  const digest = createHash('sha256').update(contents).digest('base64')
+  return `sha-256=:${digest}:`
 }
 
 function mockDownloadResponse(
@@ -150,10 +151,10 @@ describe('app-shell main http module', () => {
       expect(await readFile(destination, 'utf8')).toBe('zip-bytes')
     })
 
-    it('succeeds when the sha256 header matches the downloaded bytes', async () => {
+    it('succeeds when the Content-Digest header matches the downloaded bytes', async () => {
       const body = 'zip-bytes'
       mockDownloadResponse(body, {
-        [DOWNLOAD_SHA256_HEADER]: sha256Hex(body),
+        [CONTENT_DIGEST_HEADER]: sha256ContentDigest(body),
       })
 
       await expect(
@@ -162,7 +163,7 @@ describe('app-shell main http module', () => {
       expect(await readFile(destination, 'utf8')).toBe(body)
     })
 
-    it('skips hash verification when the server omits the sha256 header', async () => {
+    it('skips hash verification when the server omits the Content-Digest header', async () => {
       mockDownloadResponse('zip-bytes')
 
       await expect(
@@ -171,9 +172,9 @@ describe('app-shell main http module', () => {
       expect(await readFile(destination, 'utf8')).toBe('zip-bytes')
     })
 
-    it('rejects and deletes the file when the sha256 header does not match', async () => {
+    it('rejects and deletes the file when the Content-Digest header does not match', async () => {
       mockDownloadResponse('zip-bytes', {
-        [DOWNLOAD_SHA256_HEADER]: sha256Hex('different-bytes'),
+        [CONTENT_DIGEST_HEADER]: sha256ContentDigest('different-bytes'),
       })
 
       await expect(

--- a/app-shell-odd/src/http.ts
+++ b/app-shell-odd/src/http.ts
@@ -1,4 +1,5 @@
 // fetch wrapper to throw if response is not ok
+import { createHash } from 'crypto'
 import fs from 'fs'
 import { Transform } from 'stream'
 import FormData from 'form-data'
@@ -13,6 +14,8 @@ import type { Request, RequestInit, Response } from 'node-fetch'
 import type { Readable } from 'stream'
 
 const log = createLogger('http')
+
+const SHA256_HEADER = 'opentrons-download-sha256'
 
 type RequestInput = Request | string
 
@@ -76,6 +79,9 @@ export function fetchToFile(
     let downloaded = 0
     const size = Number(response.headers.get('Content-Length')) ?? null
 
+    const correctHash = response.headers.get(SHA256_HEADER)
+    const hasher = createHash('sha256')
+
     // with node-fetch, response.body will be a Node.js readable stream
     // rather than a browser-land ReadableStream
     const inputStream = response.body
@@ -86,6 +92,9 @@ export function fetchToFile(
     const progressReader = new Transform({
       transform(chunk: string | Buffer, encoding, next) {
         downloaded += chunk.length
+        if (correctHash != null) {
+          hasher.update(chunk)
+        }
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (onProgress) onProgress({ downloaded, size })
         next(null, chunk)
@@ -99,25 +108,27 @@ export function fetchToFile(
       // its callbacks when the streams are done
       pump(inputStream, progressReader, outputStream, error => {
         const handleError = (problem: Error): void => {
-          // if we error out, delete the temp dir to clean up
           log.error(`Aborting fetchToFile: ${problem.name}: ${problem.message}`)
           remove(destination).then(() => {
-            reject(error)
+            reject(problem)
           })
         }
-        const listener = (): void => {
-          handleError(
-            new LocalAbortError(
-              (options?.signal?.reason as string | null) ?? 'aborted'
-            )
-          )
-        }
-        options?.signal?.addEventListener('abort', listener, { once: true })
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (error) {
           handleError(error)
+          return
         }
-        options?.signal?.removeEventListener('abort', listener, {})
+
+        if (
+          correctHash != null &&
+          hasher.digest('hex').toLowerCase() !== correctHash?.toLowerCase()
+        ) {
+          handleError(
+            new Error('Downloaded file hash does not match expected hash')
+          )
+          return
+        }
+
         resolve(destination)
       })
     })

--- a/app-shell-odd/src/http.ts
+++ b/app-shell-odd/src/http.ts
@@ -15,7 +15,16 @@ import type { Readable } from 'stream'
 
 const log = createLogger('http')
 
-const SHA256_HEADER = 'opentrons-download-sha256'
+function parseSha256ContentDigest(header: string | null): Buffer | null {
+  if (header == null) {
+    return null
+  }
+  const match = /(?:^|,)\s*sha-256=:([A-Za-z0-9+/]+=*):/i.exec(header)
+  if (match == null) {
+    return null
+  }
+  return Buffer.from(match[1], 'base64')
+}
 
 type RequestInput = Request | string
 
@@ -79,7 +88,8 @@ export function fetchToFile(
     let downloaded = 0
     const size = Number(response.headers.get('Content-Length')) ?? null
 
-    const correctHash = response.headers.get(SHA256_HEADER)
+    const contentDigest = response.headers.get('content-digest')
+    const expectedDigest = parseSha256ContentDigest(contentDigest)
     const hasher = createHash('sha256')
 
     // with node-fetch, response.body will be a Node.js readable stream
@@ -92,7 +102,7 @@ export function fetchToFile(
     const progressReader = new Transform({
       transform(chunk: string | Buffer, encoding, next) {
         downloaded += chunk.length
-        if (correctHash != null) {
+        if (contentDigest != null) {
           hasher.update(chunk)
         }
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
@@ -120,8 +130,8 @@ export function fetchToFile(
         }
 
         if (
-          correctHash != null &&
-          hasher.digest('hex').toLowerCase() !== correctHash?.toLowerCase()
+          contentDigest != null &&
+          (expectedDigest == null || !expectedDigest.equals(hasher.digest()))
         ) {
           handleError(
             new Error('Downloaded file hash does not match expected hash')

--- a/app-shell/src/__tests__/http.test.ts
+++ b/app-shell/src/__tests__/http.test.ts
@@ -1,6 +1,8 @@
-import { mkdtemp, writeFile } from 'fs/promises'
+import { createHash } from 'crypto'
+import { access, mkdtemp, readFile, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import path from 'path'
+import { Readable } from 'stream'
 import isError from 'lodash/isError'
 import fetch from 'node-fetch'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -13,6 +15,25 @@ import type { Request, Response } from 'node-fetch'
 
 vi.mock('../config')
 vi.mock('node-fetch')
+
+const DOWNLOAD_SHA256_HEADER = 'opentrons-download-sha256'
+
+function sha256Hex(contents: string): string {
+  return createHash('sha256').update(contents).digest('hex')
+}
+
+function mockDownloadResponse(
+  body: string,
+  headers: Record<string, string | null> = {}
+): void {
+  vi.mocked(fetch).mockResolvedValueOnce({
+    ok: true,
+    headers: {
+      get: (name: string) => headers[name] ?? null,
+    },
+    body: Readable.from(Buffer.from(body)),
+  } as unknown as Response)
+}
 
 describe('app-shell main http module', () => {
   beforeEach(() => {
@@ -126,6 +147,58 @@ describe('app-shell main http module', () => {
       return expect(method(request as unknown as Request)).rejects.toThrow(
         expected
       )
+    })
+  })
+
+  describe('fetchToFile', () => {
+    let destination: string
+
+    beforeEach(async () => {
+      const dir = await mkdtemp(path.join(tmpdir(), 'fetch-to-file-'))
+      destination = path.join(dir, 'logperiod.zip')
+    })
+
+    it('writes the response body to the destination', async () => {
+      mockDownloadResponse('zip-bytes')
+
+      await expect(
+        Http.fetchToFile('http://example.com/file', destination)
+      ).resolves.toBe(destination)
+      expect(await readFile(destination, 'utf8')).toBe('zip-bytes')
+    })
+
+    it('succeeds when the sha256 header matches the downloaded bytes', async () => {
+      const body = 'zip-bytes'
+      mockDownloadResponse(body, {
+        [DOWNLOAD_SHA256_HEADER]: sha256Hex(body),
+      })
+
+      await expect(
+        Http.fetchToFile('http://example.com/file', destination)
+      ).resolves.toBe(destination)
+      expect(await readFile(destination, 'utf8')).toBe(body)
+    })
+
+    it('skips hash verification when the server omits the sha256 header', async () => {
+      mockDownloadResponse('zip-bytes')
+
+      await expect(
+        Http.fetchToFile('http://example.com/file', destination)
+      ).resolves.toBe(destination)
+      expect(await readFile(destination, 'utf8')).toBe('zip-bytes')
+    })
+
+    it('rejects and deletes the file when the sha256 header does not match', async () => {
+      mockDownloadResponse('zip-bytes', {
+        [DOWNLOAD_SHA256_HEADER]: sha256Hex('different-bytes'),
+      })
+
+      await expect(
+        Http.fetchToFile('http://example.com/file', destination)
+      ).rejects.toThrow('Downloaded file hash does not match expected hash')
+      await expect(access(destination)).rejects.toMatchObject({
+        code: 'ENOENT',
+      })
     })
   })
 })

--- a/app-shell/src/__tests__/http.test.ts
+++ b/app-shell/src/__tests__/http.test.ts
@@ -16,10 +16,11 @@ import type { Request, Response } from 'node-fetch'
 vi.mock('../config')
 vi.mock('node-fetch')
 
-const DOWNLOAD_SHA256_HEADER = 'opentrons-download-sha256'
+const CONTENT_DIGEST_HEADER = 'content-digest'
 
-function sha256Hex(contents: string): string {
-  return createHash('sha256').update(contents).digest('hex')
+function sha256ContentDigest(contents: string): string {
+  const digest = createHash('sha256').update(contents).digest('base64')
+  return `sha-256=:${digest}:`
 }
 
 function mockDownloadResponse(
@@ -167,10 +168,10 @@ describe('app-shell main http module', () => {
       expect(await readFile(destination, 'utf8')).toBe('zip-bytes')
     })
 
-    it('succeeds when the sha256 header matches the downloaded bytes', async () => {
+    it('succeeds when the Content-Digest header matches the downloaded bytes', async () => {
       const body = 'zip-bytes'
       mockDownloadResponse(body, {
-        [DOWNLOAD_SHA256_HEADER]: sha256Hex(body),
+        [CONTENT_DIGEST_HEADER]: sha256ContentDigest(body),
       })
 
       await expect(
@@ -179,7 +180,7 @@ describe('app-shell main http module', () => {
       expect(await readFile(destination, 'utf8')).toBe(body)
     })
 
-    it('skips hash verification when the server omits the sha256 header', async () => {
+    it('skips hash verification when the server omits the Content-Digest header', async () => {
       mockDownloadResponse('zip-bytes')
 
       await expect(
@@ -188,9 +189,9 @@ describe('app-shell main http module', () => {
       expect(await readFile(destination, 'utf8')).toBe('zip-bytes')
     })
 
-    it('rejects and deletes the file when the sha256 header does not match', async () => {
+    it('rejects and deletes the file when the Content-Digest header does not match', async () => {
       mockDownloadResponse('zip-bytes', {
-        [DOWNLOAD_SHA256_HEADER]: sha256Hex('different-bytes'),
+        [CONTENT_DIGEST_HEADER]: sha256ContentDigest('different-bytes'),
       })
 
       await expect(

--- a/app-shell/src/audit/index.ts
+++ b/app-shell/src/audit/index.ts
@@ -162,18 +162,28 @@ async function downloadAuditLogs(
   if (logPeriodSummaries.length === 1) {
     const logPeriodSummary = logPeriodSummaries[0]
     const fileName = `logperiod_${logPeriodSummary.startedAt.replaceAll(':', '_')}.zip`
-    const filePath = path.join(directory, fileName)
+
+    if (!directory) {
+      dispatch(
+        logPeriodDownloadCanceled({
+          logPeriodId: logPeriodSummary.id,
+        })
+      )
+      return
+    }
+
     await downloadAuditLog(
       {
         logPeriodId: logPeriodSummary.id,
         fileName,
         hostname,
         port,
-        destination: filePath,
+        destination: directory,
       },
       mainWindow,
       dispatch
     )
+    return
   }
 
   const folderName =

--- a/app-shell/src/audit/index.ts
+++ b/app-shell/src/audit/index.ts
@@ -158,6 +158,24 @@ async function downloadAuditLogs(
     directory = filePaths[0]
   }
 
+  // If there is only one log period to download, don't make a folder for it.
+  if (logPeriodSummaries.length === 1) {
+    const logPeriodSummary = logPeriodSummaries[0]
+    const fileName = `logperiod_${logPeriodSummary.startedAt.replaceAll(':', '_')}.zip`
+    const filePath = path.join(directory, fileName)
+    await downloadAuditLog(
+      {
+        logPeriodId: logPeriodSummary.id,
+        fileName,
+        hostname,
+        port,
+        destination: filePath,
+      },
+      mainWindow,
+      dispatch
+    )
+  }
+
   const folderName =
     `${robotName}-audit-logs-${new Date().toISOString()}`.replace(
       /[^a-zA-Z0-9._-]/g,

--- a/app-shell/src/http.ts
+++ b/app-shell/src/http.ts
@@ -1,8 +1,10 @@
 // fetch wrapper to throw if response is not ok
+import { createHash } from 'crypto'
 import fs from 'fs'
 import fsPromises from 'fs/promises'
 import { Transform } from 'stream'
 import FormData from 'form-data'
+import { remove } from 'fs-extra'
 import _fetch from 'node-fetch'
 import pump from 'pump'
 
@@ -10,6 +12,8 @@ import type { Request, RequestInit, Response } from 'node-fetch'
 import type { Readable } from 'stream'
 
 type RequestInput = Request | string
+
+const SHA256_HEADER = 'opentrons-download-sha256'
 
 export interface DownloadProgress {
   downloaded: number
@@ -57,6 +61,9 @@ export function fetchToFile(
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     const size = Number(response.headers.get('Content-Length')) || null
 
+    const correctHash = response.headers.get(SHA256_HEADER)
+    const hasher = createHash('sha256')
+
     // with node-fetch, response.body will be a Node.js readable stream
     // rather than a browser-land ReadableStream
     const inputStream = response.body
@@ -67,6 +74,9 @@ export function fetchToFile(
     const progressReader = new Transform({
       transform(chunk: string | Buffer, encoding, next) {
         downloaded += chunk.length
+        if (correctHash != null) {
+          hasher.update(chunk)
+        }
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (onProgress) onProgress({ downloaded, size })
         next(null, chunk)
@@ -81,9 +91,23 @@ export function fetchToFile(
       pump(inputStream, progressReader, outputStream, error => {
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (error) {
-          reject(error)
+          remove(destination).then(() => {
+            reject(error)
+          })
           return
         }
+        if (
+          correctHash != null &&
+          hasher.digest('hex').toLowerCase() !== correctHash?.toLowerCase()
+        ) {
+          remove(destination).then(() => {
+            reject(
+              new Error('Downloaded file hash does not match expected hash')
+            )
+          })
+          return
+        }
+
         resolve(destination)
       })
     })

--- a/app-shell/src/http.ts
+++ b/app-shell/src/http.ts
@@ -13,7 +13,16 @@ import type { Readable } from 'stream'
 
 type RequestInput = Request | string
 
-const SHA256_HEADER = 'opentrons-download-sha256'
+function parseSha256ContentDigest(header: string | null): Buffer | null {
+  if (header == null) {
+    return null
+  }
+  const match = /(?:^|,)\s*sha-256=:([A-Za-z0-9+/]+=*):/i.exec(header)
+  if (match == null) {
+    return null
+  }
+  return Buffer.from(match[1], 'base64')
+}
 
 export interface DownloadProgress {
   downloaded: number
@@ -61,7 +70,8 @@ export function fetchToFile(
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     const size = Number(response.headers.get('Content-Length')) || null
 
-    const correctHash = response.headers.get(SHA256_HEADER)
+    const contentDigest = response.headers.get('content-digest')
+    const expectedDigest = parseSha256ContentDigest(contentDigest)
     const hasher = createHash('sha256')
 
     // with node-fetch, response.body will be a Node.js readable stream
@@ -74,7 +84,7 @@ export function fetchToFile(
     const progressReader = new Transform({
       transform(chunk: string | Buffer, encoding, next) {
         downloaded += chunk.length
-        if (correctHash != null) {
+        if (contentDigest != null) {
           hasher.update(chunk)
         }
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
@@ -97,8 +107,8 @@ export function fetchToFile(
           return
         }
         if (
-          correctHash != null &&
-          hasher.digest('hex').toLowerCase() !== correctHash?.toLowerCase()
+          contentDigest != null &&
+          (expectedDigest == null || !expectedDigest.equals(hasher.digest()))
         ) {
           remove(destination).then(() => {
             reject(

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
@@ -182,9 +182,18 @@ export function ComplianceReadySoftwareFiles({
       } finally {
         setIsAuthorizing(false)
       }
+      const toastId = makeToast(
+        t('downloading_log_periods') as string,
+        INFO_TOAST,
+        {
+          disableTimeout: true,
+          icon: { name: 'ot-spinner', spin: true },
+        }
+      )
       void downloadLogPeriodsMutation
         .mutateAsync({ logPeriods })
         .then(downloadedPeriods => {
+          makeToast(t('files_successfully_downloaded') as string, SUCCESS_TOAST)
           // only chain a delete for periods that actually came back with a
           // deletion key; a period downloaded without one can't be deleted yet
           const deletableDownloads = downloadedPeriods.filter(
@@ -246,10 +255,14 @@ export function ComplianceReadySoftwareFiles({
             restoreDeleteModal()
           }
         })
+        .finally(() => {
+          eatToast(toastId)
+        })
     },
     [
       deleteSelectedLogPeriods,
       downloadLogPeriodsMutation,
+      eatToast,
       ensureAuthorized,
       makeToast,
       t,

--- a/app/src/organisms/Desktop/DownloadAuditLogsModal/index.tsx
+++ b/app/src/organisms/Desktop/DownloadAuditLogsModal/index.tsx
@@ -3,7 +3,15 @@ import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import NiceModal, { useModal } from '@ebay/nice-modal-react'
 
-import { Icon, Modal, PrimaryButton, StyledText } from '@opentrons/components'
+import {
+  ERROR_TOAST,
+  Icon,
+  INFO_TOAST,
+  Modal,
+  PrimaryButton,
+  StyledText,
+  SUCCESS_TOAST,
+} from '@opentrons/components'
 import { isDocumentedMutationError } from '@opentrons/react-api-client'
 
 import { getTopPortalEl } from '/app/App/portal'
@@ -12,7 +20,10 @@ import { useCurrentRobotName } from '/app/redux/robot-auth'
 import { useDownloadAndDeleteAuditLog } from '/app/resources/audit/useDownloadAndDeleteAuditLog'
 import { useIsLogDeleted } from '/app/resources/audit/useIsLogDeleted'
 
+import { useToaster } from '../../ToasterOven'
 import styles from './downloadauditlogsmodal.module.css'
+
+import type { IconProps } from '@opentrons/components'
 
 export interface DownloadAuditLogsModalProps {
   onDownload: () => void
@@ -89,14 +100,23 @@ function DownloadAuditLogsModalContent({
 }: {
   logPeriodId: string
 }): JSX.Element {
+  const { t } = useTranslation('device_details')
   const modal = useModal()
+  const { makeToast, eatToast } = useToaster()
 
   const { downloadAndDeleteAuditLog, isLoading } =
     useDownloadAndDeleteAuditLog(logPeriodId)
 
   const handleDownload = (): void => {
+    const toastIcon: IconProps = { name: 'ot-spinner', spin: true }
+    const inProgressToastId = makeToast(
+      t('downloading_log_periods') as string,
+      INFO_TOAST,
+      { disableTimeout: true, icon: toastIcon }
+    )
     downloadAndDeleteAuditLog()
       .then(() => {
+        makeToast(t('files_successfully_downloaded') as string, SUCCESS_TOAST)
         modal.resolve(true)
         modal.remove()
       })
@@ -104,8 +124,16 @@ function DownloadAuditLogsModalContent({
         if (isDocumentedMutationError(error)) {
           return
         }
+        const message =
+          error instanceof Error && error.message.length > 0
+            ? error.message
+            : String(error)
+        makeToast(message, ERROR_TOAST, { closeButton: true })
         modal.reject(error)
         modal.remove()
+      })
+      .finally(() => {
+        eatToast(inProgressToastId)
       })
   }
 

--- a/app/src/organisms/Desktop/DownloadAuditLogsModal/index.tsx
+++ b/app/src/organisms/Desktop/DownloadAuditLogsModal/index.tsx
@@ -128,7 +128,8 @@ function DownloadAuditLogsModalContent({
           error instanceof Error && error.message.length > 0
             ? error.message
             : String(error)
-        makeToast(message, ERROR_TOAST, { closeButton: true })
+        const casedMessage = message.charAt(0).toUpperCase() + message.slice(1)
+        makeToast(casedMessage, ERROR_TOAST, { closeButton: true })
         modal.reject(error)
         modal.remove()
       })

--- a/audit-server/audit_server/log_export/router.py
+++ b/audit-server/audit_server/log_export/router.py
@@ -3,6 +3,7 @@
 import json
 import tempfile
 import zipfile
+import hashlib
 from pathlib import Path
 from typing import Annotated, Final
 
@@ -53,6 +54,9 @@ _DOWNLOAD_STAGING_PREFIX: Final = "temp-download-staging-"
 # Response header carrying the one-time deletion key for a downloaded log period.
 # Must match ``LOG_PERIOD_DELETION_KEY_HEADER`` in api-client/src/audit/constants.ts.
 _DELETION_KEY_HEADER: Final = "opentrons-log-period-deletion-key"
+
+# Response header carrying the SHA-256 hash of the downloaded log period.
+_SHA256_HEADER: Final = "opentrons-download-sha256"
 
 
 @router.get(
@@ -175,6 +179,13 @@ async def download_log_period(
             zh.write(robot_log_path, arcname=robot_log_path.name)
         if serialized_log is not None:
             zh.writestr(serialized_log.filename, serialized_log.serialized_json)
+
+    hasher = hashlib.sha256()
+    with zip_file_path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    sha256_hash = hasher.hexdigest()
+    headers[_SHA256_HEADER] = sha256_hash
 
     def cleanup_files() -> None:
         zip_file_path.unlink()

--- a/audit-server/audit_server/log_export/router.py
+++ b/audit-server/audit_server/log_export/router.py
@@ -1,5 +1,6 @@
 """Route handlers for audit log export endpoints."""
 
+import base64
 import hashlib
 import json
 import tempfile
@@ -54,9 +55,6 @@ _DOWNLOAD_STAGING_PREFIX: Final = "temp-download-staging-"
 # Response header carrying the one-time deletion key for a downloaded log period.
 # Must match ``LOG_PERIOD_DELETION_KEY_HEADER`` in api-client/src/audit/constants.ts.
 _DELETION_KEY_HEADER: Final = "opentrons-log-period-deletion-key"
-
-# Response header carrying the SHA-256 hash of the downloaded log period.
-_SHA256_HEADER: Final = "opentrons-download-sha256"
 
 
 @router.get(
@@ -184,8 +182,8 @@ async def download_log_period(
     with zip_file_path.open("rb") as handle:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             hasher.update(chunk)
-    sha256_hash = hasher.hexdigest()
-    headers[_SHA256_HEADER] = sha256_hash
+    digest_b64 = base64.b64encode(hasher.digest()).decode("ascii")
+    headers["Content-Digest"] = f"sha-256=:{digest_b64}:"
 
     def cleanup_files() -> None:
         zip_file_path.unlink()

--- a/audit-server/audit_server/log_export/router.py
+++ b/audit-server/audit_server/log_export/router.py
@@ -1,9 +1,9 @@
 """Route handlers for audit log export endpoints."""
 
+import hashlib
 import json
 import tempfile
 import zipfile
-import hashlib
 from pathlib import Path
 from typing import Annotated, Final
 


### PR DESCRIPTION
# Overview

While downloading an audit log, the main process will now check a sha256 hash to confirm that the download went correctly. This should prevent a class of highly destructive bugs where audit logs could be downloaded silently unsuccessfully and then deleted from the robot.

<img width="550" height="60" alt="Screenshot 2026-09-08 at 12 29 55 PM" src="https://github.com/user-attachments/assets/a84915ae-0f1a-463e-bdf4-4cf4d7063f13" />

Also adds toasts to file downloads from the blocking modal, and changes behavior so that downloading just one audit log from the file manager no longer makes an entire separate folder just for one log.

## Test Plan and Hands on Testing

Download network requests should respond with a sha256 header. Audit log file downloads should work correctly and toast on start and end.

## Review requests

Is this the right approach to guarantee file integrity after a download?

## Risk assessment

Medium