### PR TITLE
perf(app, robot-server): coalesce CRS jog audit records

### DIFF
--- a/.cursor/skills/protocol-authoring/SKILL.md
+++ b/.cursor/skills/protocol-authoring/SKILL.md
@@ -197,6 +197,7 @@ D  [ D1 ]  [ D2 ]  [ D3 ]  [ D4 ]
 | `flex_8channel_50`    | 8        | 1–50 µL   |
 | `flex_8channel_200`   | 8        | 1–200 µL  |
 | `flex_8channel_1000`  | 8        | 5–1000 µL |
+| `flex_96channel_200`  | 96       | 1–200 µL  |
 | `flex_96channel_1000` | 96       | 5–1000 µL |
 
 ### OT-2

--- a/app/src/assets/localization/en/audit_log.json
+++ b/app/src/assets/localization/en/audit_log.json
@@ -49,6 +49,7 @@
   "home_gantry": "Homing gantry",
   "home_pipettes": "Homing pipettes",
   "home_robot": "Homing gantry",
+  "jog_pipette": "Jogging pipette",
   "launching_error_recovery": "Launching error recovery",
   "left_mount": "left mount",
   "lpc_flow": "Launching labware position check",

--- a/app/src/local-resources/access-control/__tests__/useCoalescedJogAudit.test.ts
+++ b/app/src/local-resources/access-control/__tests__/useCoalescedJogAudit.test.ts
@@ -37,32 +37,58 @@ describe('useCoalescedJogAudit', () => {
       useCoalescedJogAudit(commandDocState, mockAddActionToDocument)
     )
 
-  it('posts one coalesced jog_pipette record on flush after successful jogs', () => {
+  it('posts one jog_pipette record per successful jog on flush', () => {
     const { result } = renderAuditHook()
 
     act(() => {
       result.current.recordJog('x', 1, 1)
       result.current.recordJog('x', 1, 0.1)
-      result.current.recordJog('x', 1, 0.1)
-      result.current.recordJog('y', 1, 0.1)
       result.current.recordJog('y', 1, 0.1)
       result.current.flush()
     })
 
-    expect(mockPostLogMessage).toHaveBeenCalledTimes(1)
-    expect(mockPostLogMessage).toHaveBeenCalledWith({
+    expect(mockPostLogMessage).toHaveBeenCalledTimes(3)
+    expect(mockPostLogMessage).toHaveBeenNthCalledWith(1, {
       action: 'jog_pipette',
-      message: 'Jogged X: 1.2mm, Y: 0.2mm, Z: 0mm',
+      message: 'Jogged X: 1.0mm',
     })
+    expect(mockPostLogMessage).toHaveBeenNthCalledWith(2, {
+      action: 'jog_pipette',
+      message: 'Jogged X: 0.1mm',
+    })
+    expect(mockPostLogMessage).toHaveBeenNthCalledWith(3, {
+      action: 'jog_pipette',
+      message: 'Jogged Y: 0.1mm',
+    })
+    expect(mockAddActionToDocument).toHaveBeenCalledTimes(1)
     expect(mockAddActionToDocument).toHaveBeenCalledWith('jog_pipette')
   })
 
-  it('does not post when net displacement is zero', () => {
+  it('still posts when jogs cancel out to net zero', () => {
     const { result } = renderAuditHook()
 
     act(() => {
       result.current.recordJog('x', 1, 1)
       result.current.recordJog('x', -1, 1)
+      result.current.flush()
+    })
+
+    expect(mockPostLogMessage).toHaveBeenCalledTimes(2)
+    expect(mockPostLogMessage).toHaveBeenNthCalledWith(1, {
+      action: 'jog_pipette',
+      message: 'Jogged X: 1.0mm',
+    })
+    expect(mockPostLogMessage).toHaveBeenNthCalledWith(2, {
+      action: 'jog_pipette',
+      message: 'Jogged X: -1.0mm',
+    })
+  })
+
+  it('does not record a zero-distance jog', () => {
+    const { result } = renderAuditHook()
+
+    act(() => {
+      result.current.recordJog('x', 1, 0)
       result.current.flush()
     })
 

--- a/app/src/local-resources/access-control/__tests__/useCoalescedJogAudit.test.ts
+++ b/app/src/local-resources/access-control/__tests__/useCoalescedJogAudit.test.ts
@@ -1,0 +1,111 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { usePostLogMessageMutation } from '@opentrons/react-api-client'
+
+import {
+  ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+  createReasonNotRequiredDocumentationState,
+} from '../__fixtures__/documentationState'
+import { useCoalescedJogAudit } from '../useCoalescedJogAudit'
+
+import type { DocumentationState } from '@opentrons/react-api-client'
+
+vi.mock('@opentrons/react-api-client', () => ({
+  usePostLogMessageMutation: vi.fn(),
+}))
+
+describe('useCoalescedJogAudit', () => {
+  const mockPostLogMessage = vi.fn()
+  const mockAddActionToDocument = vi.fn()
+  const enabledDocState = createReasonNotRequiredDocumentationState()
+
+  beforeEach(() => {
+    vi.mocked(usePostLogMessageMutation).mockReturnValue({
+      postLogMessage: mockPostLogMessage,
+    } as any)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const renderAuditHook = (
+    commandDocState: DocumentationState = enabledDocState
+  ) =>
+    renderHook(() =>
+      useCoalescedJogAudit(commandDocState, mockAddActionToDocument)
+    )
+
+  it('posts one coalesced jog_pipette record on flush after successful jogs', () => {
+    const { result } = renderAuditHook()
+
+    act(() => {
+      result.current.recordJog('x', 1, 1)
+      result.current.recordJog('x', 1, 0.1)
+      result.current.recordJog('x', 1, 0.1)
+      result.current.recordJog('y', 1, 0.1)
+      result.current.recordJog('y', 1, 0.1)
+      result.current.flush()
+    })
+
+    expect(mockPostLogMessage).toHaveBeenCalledTimes(1)
+    expect(mockPostLogMessage).toHaveBeenCalledWith({
+      action: 'jog_pipette',
+      message: 'Jogged X: 1.2mm, Y: 0.2mm, Z: 0mm',
+    })
+    expect(mockAddActionToDocument).toHaveBeenCalledWith('jog_pipette')
+  })
+
+  it('does not post when net displacement is zero', () => {
+    const { result } = renderAuditHook()
+
+    act(() => {
+      result.current.recordJog('x', 1, 1)
+      result.current.recordJog('x', -1, 1)
+      result.current.flush()
+    })
+
+    expect(mockPostLogMessage).not.toHaveBeenCalled()
+    expect(mockAddActionToDocument).not.toHaveBeenCalled()
+  })
+
+  it('does not post when access control is disabled', () => {
+    const { result } = renderAuditHook(
+      ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+    )
+
+    act(() => {
+      result.current.recordJog('x', 1, 1)
+      result.current.flush()
+    })
+
+    expect(mockPostLogMessage).not.toHaveBeenCalled()
+    expect(mockAddActionToDocument).not.toHaveBeenCalled()
+  })
+
+  it('does not post after reset, even if jogs were recorded', () => {
+    const { result } = renderAuditHook()
+
+    act(() => {
+      result.current.recordJog('z', -1, 10)
+      result.current.reset()
+      result.current.flush()
+    })
+
+    expect(mockPostLogMessage).not.toHaveBeenCalled()
+    expect(mockAddActionToDocument).not.toHaveBeenCalled()
+  })
+
+  it('clears the accumulator so a second flush is a no-op', () => {
+    const { result } = renderAuditHook()
+
+    act(() => {
+      result.current.recordJog('x', 1, 1)
+      result.current.flush()
+      result.current.flush()
+    })
+
+    expect(mockPostLogMessage).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/src/local-resources/access-control/useCoalescedJogAudit.ts
+++ b/app/src/local-resources/access-control/useCoalescedJogAudit.ts
@@ -15,51 +15,55 @@ export interface UseCoalescedJogAuditResult {
   flush: () => void
 }
 
-interface JogDisplacement {
-  x: number
-  y: number
-  z: number
+interface RecordedJog {
+  axis: CoalescedJogAxis
+  distanceMm: number
 }
 
 const JOG_PIPETTE_ACTION = 'jog_pipette'
-const ZERO_DISPLACEMENT: JogDisplacement = { x: 0, y: 0, z: 0 }
 
 /**
- * Accumulates successful jog displacements and writes one signed
- * External-jog_pipette record when the user leaves the jog UI.
- * Reuses the flow's existing commandDocState so it does not re-prompt.
+ * Accumulates each successful jog and writes one signed External-jog_pipette
+ * record per press when the user leaves the jog UI. Reuses the flow's
+ * existing commandDocState so it does not re-prompt.
  */
 export function useCoalescedJogAudit(
   commandDocState: DocumentationState,
   addActionToDocument: (action: DocumentedAction) => void
 ): UseCoalescedJogAuditResult {
-  const displacementRef = useRef<JogDisplacement>({ ...ZERO_DISPLACEMENT })
+  const jogsRef = useRef<RecordedJog[]>([])
   const { postLogMessage } = usePostLogMessageMutation(
     commandDocState,
     JOG_PIPETTE_ACTION
   )
 
   const reset = useCallback(() => {
-    displacementRef.current = { ...ZERO_DISPLACEMENT }
+    jogsRef.current = []
   }, [])
 
   const recordJog = useCallback(
     (axis: CoalescedJogAxis, dir: number, step: number) => {
-      displacementRef.current[axis] += dir * step
+      const distanceMm = dir * step
+      if (distanceMm === 0) {
+        return
+      }
+      jogsRef.current.push({ axis, distanceMm })
     },
     []
   )
 
   const flush = useCallback(() => {
-    const displacement = displacementRef.current
+    const jogs = jogsRef.current
     if (
       commandDocState.isLoading === false &&
       commandDocState.accessControlEnabled === true &&
-      hasNetDisplacement(displacement)
+      jogs.length > 0
     ) {
-      postLogMessage({
-        action: JOG_PIPETTE_ACTION,
-        message: formatCoalescedJogMessage(displacement),
+      jogs.forEach(jog => {
+        postLogMessage({
+          action: JOG_PIPETTE_ACTION,
+          message: formatJogMessage(jog),
+        })
       })
       addActionToDocument(JOG_PIPETTE_ACTION)
     }
@@ -69,28 +73,6 @@ export function useCoalescedJogAudit(
   return { recordJog, reset, flush }
 }
 
-function formatCoalescedJogMessage(displacement: JogDisplacement): string {
-  return `Jogged X: ${formatAxisMm(displacement.x)}, Y: ${formatAxisMm(
-    displacement.y
-  )}, Z: ${formatAxisMm(displacement.z)}`
-}
-
-function roundToTenth(value: number): number {
-  return Math.round(value * 10) / 10
-}
-
-function formatAxisMm(value: number): string {
-  const rounded = roundToTenth(value)
-  if (rounded === 0) {
-    return '0mm'
-  }
-  return `${rounded.toFixed(1)}mm`
-}
-
-function hasNetDisplacement(displacement: JogDisplacement): boolean {
-  return (
-    roundToTenth(displacement.x) !== 0 ||
-    roundToTenth(displacement.y) !== 0 ||
-    roundToTenth(displacement.z) !== 0
-  )
+function formatJogMessage({ axis, distanceMm }: RecordedJog): string {
+  return `Jogged ${axis.toUpperCase()}: ${distanceMm.toFixed(1)}mm`
 }

--- a/app/src/local-resources/access-control/useCoalescedJogAudit.ts
+++ b/app/src/local-resources/access-control/useCoalescedJogAudit.ts
@@ -1,0 +1,96 @@
+import { useCallback, useRef } from 'react'
+
+import { usePostLogMessageMutation } from '@opentrons/react-api-client'
+
+import type {
+  DocumentationState,
+  DocumentedAction,
+} from '@opentrons/react-api-client'
+
+export type CoalescedJogAxis = 'x' | 'y' | 'z'
+
+export interface UseCoalescedJogAuditResult {
+  recordJog: (axis: CoalescedJogAxis, dir: number, step: number) => void
+  reset: () => void
+  flush: () => void
+}
+
+interface JogDisplacement {
+  x: number
+  y: number
+  z: number
+}
+
+const JOG_PIPETTE_ACTION = 'jog_pipette'
+const ZERO_DISPLACEMENT: JogDisplacement = { x: 0, y: 0, z: 0 }
+
+/**
+ * Accumulates successful jog displacements and writes one signed
+ * External-jog_pipette record when the user leaves the jog UI.
+ * Reuses the flow's existing commandDocState so it does not re-prompt.
+ */
+export function useCoalescedJogAudit(
+  commandDocState: DocumentationState,
+  addActionToDocument: (action: DocumentedAction) => void
+): UseCoalescedJogAuditResult {
+  const displacementRef = useRef<JogDisplacement>({ ...ZERO_DISPLACEMENT })
+  const { postLogMessage } = usePostLogMessageMutation(
+    commandDocState,
+    JOG_PIPETTE_ACTION
+  )
+
+  const reset = useCallback(() => {
+    displacementRef.current = { ...ZERO_DISPLACEMENT }
+  }, [])
+
+  const recordJog = useCallback(
+    (axis: CoalescedJogAxis, dir: number, step: number) => {
+      displacementRef.current[axis] += dir * step
+    },
+    []
+  )
+
+  const flush = useCallback(() => {
+    const displacement = displacementRef.current
+    if (
+      commandDocState.isLoading === false &&
+      commandDocState.accessControlEnabled === true &&
+      hasNetDisplacement(displacement)
+    ) {
+      postLogMessage({
+        action: JOG_PIPETTE_ACTION,
+        message: formatCoalescedJogMessage(displacement),
+      })
+      addActionToDocument(JOG_PIPETTE_ACTION)
+    }
+    reset()
+  }, [addActionToDocument, commandDocState, postLogMessage, reset])
+
+  return { recordJog, reset, flush }
+}
+
+function formatCoalescedJogMessage(displacement: JogDisplacement): string {
+  return `Jogged X: ${formatAxisMm(displacement.x)}, Y: ${formatAxisMm(
+    displacement.y
+  )}, Z: ${formatAxisMm(displacement.z)}`
+}
+
+function roundToTenth(value: number): number {
+  return Math.round(value * 10) / 10
+}
+
+function formatAxisMm(value: number): string {
+  const rounded = roundToTenth(value)
+  if (rounded === 0) {
+    return '0mm'
+  }
+  return `${rounded.toFixed(1)}mm`
+}
+
+function hasNetDisplacement(displacement: JogDisplacement): boolean {
+  return (
+    roundToTenth(displacement.x) !== 0 ||
+    roundToTenth(displacement.y) !== 0 ||
+    roundToTenth(displacement.z) !== 0
+  )
+}

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import { useDeleteMaintenanceRunMutation } from '@opentrons/react-api-client'
 import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
+import { useCoalescedJogAudit } from '/app/local-resources/access-control/useCoalescedJogAudit'
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
 
 import {
@@ -47,8 +48,10 @@ type UseDropTipSetupCommandsParams = UseDTWithTypeParams & {
   setErrorDetails: (errorDetails: SetRobotErrorDetailsParams) => void
   toggleIsExiting: () => void
   fixitCommandTypeUtils?: FixitCommandTypeUtils
+  commandDocState: DocumentationState
   deletionDocState: DocumentationState
   actionsToDocument: DocumentedAction[]
+  addActionToDocument: (action: DocumentedAction) => void
 }
 
 export interface UseDropTipCommandsResult {
@@ -58,6 +61,7 @@ export interface UseDropTipCommandsResult {
     isPredefinedLocation: boolean // Is a predefined location in "choose location."
   ) => Promise<void>
   handleJog: (axis: Axis, dir: Sign, step: StepSize) => void
+  flushJogAudit: () => void
   blowoutOrDropTip: (
     currentRoute: DropTipFlowsRoute,
     proceed: () => void
@@ -76,14 +80,20 @@ export function useDropTipCommands({
   instrumentModelSpecs,
   robotType,
   fixitCommandTypeUtils,
+  commandDocState,
   deletionDocState,
   actionsToDocument,
+  addActionToDocument,
 }: UseDropTipSetupCommandsParams): UseDropTipCommandsResult {
   const isFlex = robotType === FLEX_ROBOT_TYPE
   const [hasSeenClose, setHasSeenClose] = useState(false)
   const [jogQueue, setJogQueue] = useState<Array<() => Promise<void>>>([])
   const [isJogging, setIsJogging] = useState(false)
   const pipetteId = fixitCommandTypeUtils?.pipetteId ?? null
+  const { recordJog, flush: flushJogAudit } = useCoalescedJogAudit(
+    commandDocState,
+    addActionToDocument
+  )
 
   const { deleteMaintenanceRun } = useDeleteMaintenanceRunMutation(
     deletionDocState,
@@ -104,6 +114,7 @@ export function useDropTipCommands({
         return Promise.resolve()
       } else {
         if (!hasSeenClose) {
+          flushJogAudit()
           setHasSeenClose(true)
           toggleIsExiting()
           if (activeMaintenanceRunId == null) {
@@ -218,6 +229,7 @@ export function useDropTipCommands({
         timeout: JOG_COMMAND_TIMEOUT_MS,
       })
         .then(() => {
+          recordJog(axis, dir, step)
           resolve()
         })
         .catch((error: Error) => {
@@ -367,6 +379,7 @@ export function useDropTipCommands({
     handleCleanUpAndClose,
     moveToAddressableArea,
     handleJog,
+    flushJogAudit,
     blowoutOrDropTip,
     handleMustHome,
   }

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipWithType.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipWithType.ts
@@ -75,8 +75,10 @@ export function useDropTipWithType(
     setErrorDetails,
     toggleIsExiting,
     fixitCommandTypeUtils,
+    commandDocState,
     deletionDocState,
     actionsToDocument,
+    addActionToDocument,
   })
 
   return {

--- a/app/src/organisms/DropTipWizardFlows/steps/JogToPosition.tsx
+++ b/app/src/organisms/DropTipWizardFlows/steps/JogToPosition.tsx
@@ -27,9 +27,24 @@ export const JogToPosition = ({
   isOnDevice,
   modalStyle,
   proceed,
+  issuedCommandsType,
 }: JogToPositionProps): JSX.Element | null => {
-  const { handleJog } = dropTipCommands
+  const { handleJog, flushJogAudit } = dropTipCommands
   const { t } = useTranslation('drop_tip_wizard')
+
+  const handleConfirm = (): void => {
+    if (issuedCommandsType !== 'fixit') {
+      flushJogAudit()
+    }
+    void proceed()
+  }
+
+  const handleGoBack = (): void => {
+    if (issuedCommandsType !== 'fixit') {
+      flushJogAudit()
+    }
+    goBackRunValid()
+  }
 
   return (
     <>
@@ -57,9 +72,9 @@ export const JogToPosition = ({
       >
         <JogControls jog={handleJog} isOnDevice={isOnDevice} height="100%" />
         <DropTipFooterButtons
-          primaryBtnOnClick={proceed}
+          primaryBtnOnClick={handleConfirm}
           primaryBtnTextOverride={t('shared:confirm_position')}
-          secondaryBtnOnClick={goBackRunValid}
+          secondaryBtnOnClick={handleGoBack}
         />
       </Flex>
     </>

--- a/app/src/organisms/LabwarePositionCheck/__fixtures__/MockLPCContentContainer.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__fixtures__/MockLPCContentContainer.tsx
@@ -8,6 +8,7 @@ export const MockLPCContentContainer: Mock = vi.fn(
   ({
     header,
     onClickButton,
+    onClickBack,
     oddHeaderBtnCopy,
     desktopFooterBtnCopy,
     secondaryButtonProps,
@@ -32,6 +33,9 @@ export const MockLPCContentContainer: Mock = vi.fn(
           data-type={secondaryButtonProps?.buttonType}
           data-has-click={String(!!secondaryButtonProps?.onClick)}
         />
+        {onClickBack != null && (
+          <button data-testid="back-button" onClick={onClickBack} />
+        )}
         {children}
       </div>
     )

--- a/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/__tests__/useHandleClose.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/__tests__/useHandleClose.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useChainMaintenanceCommands } from '/app/resources/maintenance_runs'
 
@@ -13,10 +13,12 @@ describe('useHandleClose', () => {
   const mockMaintenanceRunId = 'mock_maintenance_run'
   const mockOnCloseClick = vi.fn()
   const mockChainRunCommands = vi.fn(() => Promise.resolve())
+  const mockFlushJogAudit = vi.fn()
 
   const mockProps = {
     maintenanceRunId: mockMaintenanceRunId,
     onCloseClick: mockOnCloseClick,
+    flushJogAudit: mockFlushJogAudit,
   } as any
 
   beforeEach(() => {
@@ -32,6 +34,10 @@ describe('useHandleClose', () => {
     vi.mocked(useChainMaintenanceCommands).mockReturnValue({
       chainRunCommands: mockChainRunCommands,
     } as any)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
   })
 
   it('should initialize with isExiting as false', () => {
@@ -56,6 +62,7 @@ describe('useHandleClose', () => {
       true
     )
     expect(mockOnCloseClick).toHaveBeenCalled()
+    expect(mockFlushJogAudit).toHaveBeenCalled()
   })
 
   it('should call onCloseClick even if chainRunCommands fails', async () => {
@@ -70,6 +77,7 @@ describe('useHandleClose', () => {
     expect(result.current.isExiting).toBe(true)
     expect(mockChainRunCommands).toHaveBeenCalled()
     expect(mockOnCloseClick).toHaveBeenCalled()
+    expect(mockFlushJogAudit).toHaveBeenCalled()
   })
 
   it('should set isExiting to true and call onCloseClick when handleCloseNoHome is called', async () => {
@@ -82,5 +90,6 @@ describe('useHandleClose', () => {
     expect(result.current.isExiting).toBe(true)
     expect(mockChainRunCommands).not.toHaveBeenCalled()
     expect(mockOnCloseClick).toHaveBeenCalled()
+    expect(mockFlushJogAudit).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/__tests__/useHandleJog.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/__tests__/useHandleJog.test.ts
@@ -1,9 +1,10 @@
 import { useSelector } from 'react-redux'
 import { act, renderHook } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useCreateMaintenanceCommandMutation } from '@opentrons/react-api-client'
 
+import { useCoalescedJogAudit } from '/app/local-resources/access-control/useCoalescedJogAudit'
 import { selectActivePipette } from '/app/redux/protocol-runs'
 
 import { moveRelativeCommand, moveToWellCommands } from '../commands'
@@ -12,6 +13,7 @@ import { useHandleJog } from '../useHandleJog'
 vi.mock('react-redux')
 vi.mock('/app/redux/protocol-runs')
 vi.mock('@opentrons/react-api-client')
+vi.mock('/app/local-resources/access-control/useCoalescedJogAudit')
 vi.mock('../commands')
 
 describe('useHandleJog', () => {
@@ -23,6 +25,9 @@ describe('useHandleJog', () => {
   const mockSetErrorMessage = vi.fn()
   const mockChainLPCCommands = vi.fn(() => Promise.resolve())
   const mockCreateSilentCommand = vi.fn()
+  const mockRecordJog = vi.fn()
+  const mockResetJogAudit = vi.fn()
+  const mockFlushJogAudit = vi.fn()
 
   const mockCommandResult = {
     data: {
@@ -65,7 +70,16 @@ describe('useHandleJog', () => {
     vi.mocked(useCreateMaintenanceCommandMutation).mockReturnValue({
       createMaintenanceCommand: mockCreateSilentCommand,
     } as any)
+    vi.mocked(useCoalescedJogAudit).mockReturnValue({
+      recordJog: mockRecordJog,
+      reset: mockResetJogAudit,
+      flush: mockFlushJogAudit,
+    })
     mockCreateSilentCommand.mockResolvedValue(mockCommandResult)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
   })
 
   it('should initialize with empty queue', () => {
@@ -73,6 +87,7 @@ describe('useHandleJog', () => {
 
     expect(result.current).toHaveProperty('handleJog')
     expect(result.current).toHaveProperty('resetJog')
+    expect(result.current).toHaveProperty('flushJogAudit')
   })
 
   it('should issue a jog command when handleJog is called', async () => {
@@ -98,6 +113,7 @@ describe('useHandleJog', () => {
     await vi.runAllTimersAsync()
 
     expect(mockOnSuccess).toHaveBeenCalledWith({ x: 10, y: 20, z: 30 })
+    expect(mockRecordJog).toHaveBeenCalledWith('x', 1, 1)
   })
 
   it('should queue multiple jog commands and process them sequentially', async () => {
@@ -187,6 +203,7 @@ describe('useHandleJog', () => {
     expect(mockSetErrorMessage).toHaveBeenCalledWith(
       'Error issuing jog command: Command failed'
     )
+    expect(mockRecordJog).not.toHaveBeenCalled()
   })
 
   it('should set error message when pipette is not found', async () => {
@@ -238,6 +255,7 @@ describe('useHandleJog', () => {
       ],
       false
     )
+    expect(mockResetJogAudit).toHaveBeenCalled()
 
     act(() => {
       result.current.handleJog('z', 1, 0.1)

--- a/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/index.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/index.ts
@@ -93,7 +93,10 @@ export function useLPCCommands(
     setErrorMessage,
     chainLPCCommands,
   })
-  const handleConditionalCleanupUtils = useHandleClose(props)
+  const handleConditionalCleanupUtils = useHandleClose({
+    ...props,
+    flushJogAudit: handleJogUtils.flushJogAudit,
+  })
   const handleProbeCommands = useHandleProbeCommands({
     ...props,
     chainLPCCommands,

--- a/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/useHandleClose.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/useHandleClose.ts
@@ -19,7 +19,10 @@ export function useHandleClose({
   commandDocState,
   actionsToDocument,
   addActionToDocument,
-}: UseLPCCommandChildProps): UseHandleConditionalCleanupResult {
+  flushJogAudit,
+}: UseLPCCommandChildProps & {
+  flushJogAudit: () => void
+}): UseHandleConditionalCleanupResult {
   const [isExiting, setIsExiting] = useState(false)
   const { chainRunCommands } = useChainMaintenanceCommands(
     commandDocState,
@@ -28,6 +31,7 @@ export function useHandleClose({
   )
 
   const handleHomeAndClose = (): Promise<void> => {
+    flushJogAudit()
     setIsExiting(true)
     const cleanupCommands: CreateCommand[] = [...retractSafelyAndHomeCommands()]
 
@@ -41,6 +45,7 @@ export function useHandleClose({
   }
 
   const handleCloseNoHome = (): Promise<void> => {
+    flushJogAudit()
     setIsExiting(true)
 
     return new Promise(() => {

--- a/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/useHandleJog.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/useHandleJog.ts
@@ -4,6 +4,7 @@ import debounce from 'lodash/debounce'
 
 import { useCreateMaintenanceCommandMutation } from '@opentrons/react-api-client'
 
+import { useCoalescedJogAudit } from '/app/local-resources/access-control/useCoalescedJogAudit'
 import { selectActivePipette } from '/app/redux/protocol-runs'
 
 import { moveRelativeCommand, moveToWellCommands } from './commands'
@@ -34,6 +35,7 @@ export interface UseHandleJogResult {
     pipetteId: string,
     offset?: VectorOffset | null
   ) => Promise<void>
+  flushJogAudit: () => void
 }
 
 // TODO(jh, 01-21-25): Extract the throttling logic into its own hook that lives elsewhere and is used by other Jog flows.
@@ -49,6 +51,11 @@ export function useHandleJog({
 }: UseHandleJogProps): UseHandleJogResult {
   const pipette = useSelector(selectActivePipette(runId))
   const pipetteId = pipette?.id
+  const {
+    recordJog,
+    reset: resetJogAudit,
+    flush: flushJogAudit,
+  } = useCoalescedJogAudit(commandDocState, addActionToDocument)
   const { createMaintenanceCommand: createSilentCommand } =
     useCreateMaintenanceCommandMutation(
       commandDocState,
@@ -89,6 +96,7 @@ export function useHandleJog({
         timeout: JOG_COMMAND_TIMEOUT_MS,
       })
         .then(data => {
+          recordJog(axis, dir, step)
           onSuccess?.((data?.data?.result?.position ?? null) as Vector3D | null)
         })
         .catch((e: Error) => {
@@ -112,7 +120,13 @@ export function useHandleJog({
         processNextInQueue()
       }, DEBOUNCE_TIME_MS)
     }
-  }, [pipetteId, maintenanceRunId, createSilentCommand, setErrorMessage])
+  }, [
+    pipetteId,
+    maintenanceRunId,
+    createSilentCommand,
+    setErrorMessage,
+    recordJog,
+  ])
 
   // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -156,6 +170,7 @@ export function useHandleJog({
       offset?: VectorOffset | null
     ): Promise<void> => {
       queueRef.current = []
+      resetJogAudit()
 
       const resetJogCommands = [
         ...moveToWellCommands(offsetLocationDetails, pipetteId, offset),
@@ -165,8 +180,8 @@ export function useHandleJog({
         Promise.resolve()
       )
     },
-    [chainLPCCommands]
+    [chainLPCCommands, resetJogAudit]
   )
 
-  return { handleJog, resetJog }
+  return { handleJog, resetJog, flushJogAudit }
 }

--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/CheckLabware/__tests__/CheckLabware.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/CheckLabware/__tests__/CheckLabware.test.tsx
@@ -1,6 +1,6 @@
 import { useDispatch } from 'react-redux'
 import { screen } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
@@ -79,6 +79,7 @@ describe('CheckLabware', () => {
   let mockHandleJog: Mock
   let mockResetJog: Mock
   let mockHandleResetLwModulesOnDeck: Mock
+  let mockFlushJogAudit: Mock
   let props: ComponentProps<typeof CheckLabware>
 
   beforeEach(() => {
@@ -97,6 +98,7 @@ describe('CheckLabware', () => {
       })
     mockResetJog = vi.fn().mockResolvedValue(undefined)
     mockHandleResetLwModulesOnDeck = vi.fn().mockResolvedValue(undefined)
+    mockFlushJogAudit = vi.fn()
 
     props = {
       runId: 'test-run-id',
@@ -107,6 +109,7 @@ describe('CheckLabware', () => {
         handleJog: mockHandleJog,
         resetJog: mockResetJog,
         handleResetLwModulesOnDeck: mockHandleResetLwModulesOnDeck,
+        flushJogAudit: mockFlushJogAudit,
       } as any,
       handleAddConfirmedWorkingVector: vi.fn(),
     } as any
@@ -145,6 +148,10 @@ describe('CheckLabware', () => {
     vi.mocked(goBackEditOffsetSubstep).mockReturnValue({
       type: 'GO_BACK_EDIT_OFFSET_SUBSTEP',
     } as any)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
   })
 
   const render = (propsToRender: ComponentProps<typeof CheckLabware>) => {
@@ -211,6 +218,7 @@ describe('CheckLabware', () => {
     expect(mockDispatch).toHaveBeenCalledWith(
       proceedEditOffsetSubstep(props.runId, true)
     )
+    expect(mockFlushJogAudit).toHaveBeenCalled()
   })
 
   it('calls handleAddConfirmedWorkingVector on ODD when confirm is clicked', async () => {
@@ -221,5 +229,15 @@ describe('CheckLabware', () => {
     primaryButton.click()
 
     expect(props.handleAddConfirmedWorkingVector).toHaveBeenCalled()
+    expect(mockFlushJogAudit).toHaveBeenCalled()
+  })
+
+  it('flushes coalesced jog audit and goes back when back is clicked', () => {
+    render(props)
+
+    screen.getByTestId('back-button').click()
+
+    expect(mockFlushJogAudit).toHaveBeenCalled()
+    expect(mockToggleRobotMoving).toHaveBeenCalledWith(true)
   })
 })

--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/CheckLabware/index.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/CheckLabware/index.tsx
@@ -52,8 +52,13 @@ interface CheckLabwareProps extends EditOffsetContentProps {
 
 export function CheckLabware(props: CheckLabwareProps): JSX.Element {
   const { runId, commandUtils, contentHeader } = props
-  const { toggleRobotMoving, handleJog, resetJog, handleResetLwModulesOnDeck } =
-    commandUtils
+  const {
+    toggleRobotMoving,
+    handleJog,
+    resetJog,
+    handleResetLwModulesOnDeck,
+    flushJogAudit,
+  } = commandUtils
   const { t } = useTranslation('labware_position_check')
   const { t: commandTextT } = useTranslation('protocol_command_text')
   const dispatch = useDispatch()
@@ -114,6 +119,7 @@ export function CheckLabware(props: CheckLabwareProps): JSX.Element {
     })
 
   const handleGoBack = (): void => {
+    flushJogAudit()
     void toggleRobotMoving(true)
       .then(() => handleResetLwModulesOnDeck(offsetLocationDetails))
       .then(() => {
@@ -177,10 +183,12 @@ function CheckLabwareContentODD(props: CheckLabwareContentProps): JSX.Element {
     isLwTiprack,
     liveOffset,
     setJoggedPosition,
+    commandUtils,
   } = props
   const [showOddJogControls, setShowOddJogControls] = useState(false)
 
   const handleProceed = (): void => {
+    commandUtils.flushJogAudit()
     handleAddConfirmedWorkingVector()
   }
 
@@ -271,6 +279,7 @@ function CheckLabwareContentDesktop(
   const dispatch = useDispatch()
 
   const handleProceed = (): void => {
+    commandUtils.flushJogAudit()
     dispatch(proceedEditOffsetSubstep(runId, true))
   }
 

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -135,6 +135,7 @@ export type AuditLogAction =
   | 'detach_gripper'
   | 'recalibrate_gripper'
   | 'lpc_flow'
+  | 'jog_pipette'
   | 'drop_tips'
   | 'end_calibration'
   | 'add_module'

--- a/react-api-client/src/maintenance_runs/__tests__/useCreateMaintenanceCommandMutation.test.tsx
+++ b/react-api-client/src/maintenance_runs/__tests__/useCreateMaintenanceCommandMutation.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { act, renderHook, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createMaintenanceCommand } from '@opentrons/api-client'
 
@@ -11,11 +11,21 @@ import { useHost } from '../../api'
 
 import type * as React from 'react'
 import type { HostConfig } from '@opentrons/api-client'
+import type { CreateCommand } from '@opentrons/shared-data'
 
 vi.mock('@opentrons/api-client')
 vi.mock('../../api/useHost')
 
 const HOST_CONFIG: HostConfig = { hostname: 'localhost' }
+const MOCK_COMMAND_DATA = { id: 'command-id' }
+const MOCK_MOVE_RELATIVE_COMMAND: CreateCommand = {
+  commandType: 'moveRelative',
+  params: {
+    pipetteId: 'pipette-id',
+    axis: 'x',
+    distance: 0.1,
+  },
+}
 
 describe('useCreateMaintenanceCommandMutation hook', () => {
   let wrapper: React.FunctionComponent<{ children: React.ReactNode }>
@@ -28,6 +38,10 @@ describe('useCreateMaintenanceCommandMutation hook', () => {
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     )
     wrapper = clientProvider
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
   })
 
   it('should issue the given command to the given run when callback is called', async () => {
@@ -91,5 +105,62 @@ describe('useCreateMaintenanceCommandMutation hook', () => {
     await waitFor(() => {
       expect(result.current.data).toBe('something')
     })
+  })
+
+  it('should add non-jog commands to actions to document', async () => {
+    const addActionToDocument = vi.fn()
+    vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
+    vi.mocked(createMaintenanceCommand).mockResolvedValue({
+      data: { data: MOCK_COMMAND_DATA },
+    } as any)
+
+    const { result } = renderHook(
+      () =>
+        useCreateMaintenanceCommandMutation(
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+          ['lpc_flow'],
+          addActionToDocument
+        ),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.createMaintenanceCommand({
+        maintenanceRunId: MAINTENANCE_RUN_ID,
+        command: mockAnonLoadCommand,
+      })
+    })
+    await waitFor(() => {
+      expect(addActionToDocument).toHaveBeenCalledWith(MOCK_COMMAND_DATA)
+    })
+  })
+
+  it('should not add a moveRelative command to actions to document', async () => {
+    const addActionToDocument = vi.fn()
+    vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
+    vi.mocked(createMaintenanceCommand).mockResolvedValue({
+      data: { data: MOCK_COMMAND_DATA },
+    } as any)
+
+    const { result } = renderHook(
+      () =>
+        useCreateMaintenanceCommandMutation(
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+          ['lpc_flow'],
+          addActionToDocument
+        ),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.createMaintenanceCommand({
+        maintenanceRunId: MAINTENANCE_RUN_ID,
+        command: MOCK_MOVE_RELATIVE_COMMAND,
+      })
+    })
+    await waitFor(() => {
+      expect(result.current.data).toEqual({ data: MOCK_COMMAND_DATA })
+    })
+    expect(addActionToDocument).not.toHaveBeenCalled()
   })
 })

--- a/react-api-client/src/maintenance_runs/useCreateMaintenanceCommandMutation.ts
+++ b/react-api-client/src/maintenance_runs/useCreateMaintenanceCommandMutation.ts
@@ -78,15 +78,19 @@ export function useCreateMaintenanceCommandMutation(
         userNotes
       )
         .then(response => {
-          queryClient
-            .invalidateQueries(getQueryKey(host, 'maintenance_runs'))
-            .catch((e: Error) => {
-              console.error(
-                `error invalidating maintenance runs query: ${e.message}`
-              )
-            })
+          // Jogs are high-frequency, so documenting each press fills the
+          // end-of-flow modal and refetches maintenance runs on every tick.
+          if (command.commandType !== 'moveRelative') {
+            queryClient
+              .invalidateQueries(getQueryKey(host, 'maintenance_runs'))
+              .catch((e: Error) => {
+                console.error(
+                  `error invalidating maintenance runs query: ${e.message}`
+                )
+              })
 
-          addActionToDocument(response.data.data)
+            addActionToDocument(response.data.data)
+          }
           return response.data
         })
         .catch((e: any) => {

--- a/react-api-client/src/runs/__tests__/useCreateCommandMutation.test.tsx
+++ b/react-api-client/src/runs/__tests__/useCreateCommandMutation.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { act, renderHook, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createCommand } from '@opentrons/api-client'
 
@@ -11,11 +11,21 @@ import { useHost } from '../../api'
 
 import type * as React from 'react'
 import type { HostConfig } from '@opentrons/api-client'
+import type { CreateCommand } from '@opentrons/shared-data'
 
 vi.mock('@opentrons/api-client')
 vi.mock('../../api/useHost')
 
 const HOST_CONFIG: HostConfig = { hostname: 'localhost' }
+const MOCK_COMMAND_DATA = { id: 'command-id' }
+const MOCK_MOVE_RELATIVE_COMMAND: CreateCommand = {
+  commandType: 'moveRelative',
+  params: {
+    pipetteId: 'pipette-id',
+    axis: 'x',
+    distance: 0.1,
+  },
+}
 
 describe('useCreateCommandMutation hook', () => {
   let wrapper: React.FunctionComponent<{ children: React.ReactNode }>
@@ -28,6 +38,10 @@ describe('useCreateCommandMutation hook', () => {
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     )
     wrapper = clientProvider
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
   })
 
   it('should issue the given command to the given run when callback is called', async () => {
@@ -87,5 +101,62 @@ describe('useCreateCommandMutation hook', () => {
     await waitFor(() => {
       expect(result.current.data).toBe('something')
     })
+  })
+
+  it('should add non-jog commands to actions to document', async () => {
+    const addActionToDocument = vi.fn()
+    vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
+    vi.mocked(createCommand).mockResolvedValue({
+      data: { data: MOCK_COMMAND_DATA },
+    } as any)
+
+    const { result } = renderHook(
+      () =>
+        useCreateCommandMutation(
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+          [],
+          addActionToDocument
+        ),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.createCommand({
+        runId: RUN_ID_1,
+        command: mockAnonLoadCommand,
+      })
+    })
+    await waitFor(() => {
+      expect(addActionToDocument).toHaveBeenCalledWith(MOCK_COMMAND_DATA)
+    })
+  })
+
+  it('should not add a moveRelative command to actions to document', async () => {
+    const addActionToDocument = vi.fn()
+    vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
+    vi.mocked(createCommand).mockResolvedValue({
+      data: { data: MOCK_COMMAND_DATA },
+    } as any)
+
+    const { result } = renderHook(
+      () =>
+        useCreateCommandMutation(
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+          [],
+          addActionToDocument
+        ),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.createCommand({
+        runId: RUN_ID_1,
+        command: MOCK_MOVE_RELATIVE_COMMAND,
+      })
+    })
+    await waitFor(() => {
+      expect(result.current.data).toEqual({ data: MOCK_COMMAND_DATA })
+    })
+    expect(addActionToDocument).not.toHaveBeenCalled()
   })
 })

--- a/react-api-client/src/runs/useCreateCommandMutation.ts
+++ b/react-api-client/src/runs/useCreateCommandMutation.ts
@@ -53,12 +53,16 @@ export function useCreateCommandMutation(
       },
       userNotes
     ).then(response => {
-      queryClient
-        .invalidateQueries(getQueryKey(host, 'runs'))
-        .catch((e: Error) => {
-          console.error(`error invalidating runs query: ${e.message}`)
-        })
-      addActionToDocument(response.data.data)
+      // Jogs are high-frequency, so documenting each press fills the
+      // end-of-flow modal and refetches protocol runs on every tick.
+      if (command.commandType !== 'moveRelative') {
+        queryClient
+          .invalidateQueries(getQueryKey(host, 'runs'))
+          .catch((e: Error) => {
+            console.error(`error invalidating runs query: ${e.message}`)
+          })
+        addActionToDocument(response.data.data)
+      }
       return response.data
     })
   })

--- a/robot-server/robot_server/maintenance_runs/router/commands_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/commands_router.py
@@ -17,6 +17,7 @@ from opentrons.protocol_engine import (
     errors as pe_errors,
 )
 from opentrons.protocol_engine.errors import CommandDoesNotExistError
+from server_utils.audit.audit_logger import AuditLogger
 from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
@@ -119,7 +120,6 @@ async def get_current_run_from_url(
     },
     dependencies=[
         Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
-        Depends(get_audit_logger("execute command in maintenance run")),
     ],
 )
 async def create_run_command(
@@ -131,6 +131,9 @@ async def create_run_command(
     check_estop: Annotated[bool, Depends(require_estop_in_good_state)],
     hardware_state_store: Annotated[
         HardwareStateStore, Depends(get_hardware_state_store)
+    ],
+    audit_logger: Annotated[
+        AuditLogger, Depends(get_audit_logger("execute command in maintenance run"))
     ],
     waitUntilComplete: Annotated[
         bool,
@@ -189,11 +192,17 @@ async def create_run_command(
         run_id: Run identification to attach command to.
         hardware_state_store: The hardware state store.
         requiresClosedDoor: If True, reject the command when the door is open.
+        audit_logger: Records the command for audit when access control is enabled.
     """
     # TODO(mc, 2022-05-26): increment the HTTP API version so that default
     # behavior is to pass through `command_intent` without overriding it
     command_intent = pe_commands.CommandIntent.SETUP
     command_create = request_body.data.model_copy(update={"intent": command_intent})
+
+    # Jog presses are frequent and signing each one after waitUntilComplete makes
+    # the HTTP response lag the physical move.
+    if request_body.data.commandType == "moveRelative":
+        audit_logger.skip_persist()
 
     if requiresClosedDoor and hardware_state_store.door_state == DoorState.OPEN:
         raise MaintenanceCommandDoorOpen(

--- a/robot-server/tests/maintenance_runs/router/test_commands_router.py
+++ b/robot-server/tests/maintenance_runs/router/test_commands_router.py
@@ -17,6 +17,8 @@ from opentrons.protocol_engine import (
     errors as pe_errors,
 )
 from opentrons.protocol_engine.errors import CommandDoesNotExistError
+from opentrons.protocol_engine.types import MovementAxis
+from server_utils.audit.audit_logger import AuditLogger
 from server_utils.fastapi_utils.models.json_api import MultiBodyMeta, RequestModel
 
 from robot_server.errors.error_responses import ApiError
@@ -42,6 +44,12 @@ from robot_server.runs.command_models import (
     CommandLinkMeta,
 )
 from robot_server.runs.run_models import RunCommandSummary
+
+
+@pytest.fixture
+def mock_audit_logger(decoy: Decoy) -> AuditLogger:
+    """Get a fake AuditLogger dependency."""
+    return decoy.mock(cls=AuditLogger)
 
 
 async def test_get_current_run_from_url(
@@ -84,6 +92,7 @@ async def test_create_run_command(
     decoy: Decoy,
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     hardware_state_store: HardwareStateStore,
+    mock_audit_logger: AuditLogger,
 ) -> None:
     """It should add the requested command to the ProtocolEngine and return it."""
     command_request = pe_commands.WaitForResumeCreate(
@@ -121,16 +130,19 @@ async def test_create_run_command(
         timeout=None,
         check_estop=True,
         hardware_state_store=hardware_state_store,
+        audit_logger=mock_audit_logger,
     )
 
     assert result.content.data == command_once_added
     assert result.status_code == 201
+    decoy.verify(mock_audit_logger.skip_persist(), times=0)
 
 
 async def test_create_run_command_blocking_completion(
     decoy: Decoy,
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     hardware_state_store: HardwareStateStore,
+    mock_audit_logger: AuditLogger,
 ) -> None:
     """It should be able to create a command and wait for it to execute."""
     command_request = pe_commands.WaitForResumeCreate(
@@ -165,6 +177,7 @@ async def test_create_run_command_blocking_completion(
         run_orchestrator_store=mock_maintenance_run_orchestrator_store,
         check_estop=True,
         hardware_state_store=hardware_state_store,
+        audit_logger=mock_audit_logger,
     )
 
     assert result.content.data == command_once_completed
@@ -175,6 +188,7 @@ async def test_create_run_command_door_open_blocks_by_default(
     decoy: Decoy,
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     hardware_state_store: HardwareStateStore,
+    mock_audit_logger: AuditLogger,
 ) -> None:
     """It should return a 409 by default when the door is open."""
     command_request = pe_commands.HomeCreate(params=pe_commands.HomeParams())
@@ -190,6 +204,7 @@ async def test_create_run_command_door_open_blocks_by_default(
             timeout=None,
             check_estop=True,
             hardware_state_store=hardware_state_store,
+            audit_logger=mock_audit_logger,
         )
 
     assert exc_info.value.status_code == 409
@@ -200,6 +215,7 @@ async def test_create_run_command_door_open_allows_when_opted_out(
     decoy: Decoy,
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     hardware_state_store: HardwareStateStore,
+    mock_audit_logger: AuditLogger,
 ) -> None:
     """It should allow commands through when requiresClosedDoor is False, even if the door is open."""
     command_request = pe_commands.HomeCreate(params=pe_commands.HomeParams())
@@ -238,10 +254,72 @@ async def test_create_run_command_door_open_allows_when_opted_out(
         check_estop=True,
         hardware_state_store=hardware_state_store,
         requiresClosedDoor=False,
+        audit_logger=mock_audit_logger,
     )
 
     assert result.content.data == command_once_added
     assert result.status_code == 201
+
+
+async def test_create_run_command_skips_audit_for_move_relative(
+    decoy: Decoy,
+    mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
+    hardware_state_store: HardwareStateStore,
+    mock_audit_logger: AuditLogger,
+) -> None:
+    """It should skip audit persist for jog (moveRelative) commands."""
+    command_request = pe_commands.MoveRelativeCreate(
+        params=pe_commands.MoveRelativeParams(
+            pipetteId="pipette-id",
+            axis=MovementAxis.X,
+            distance=0.1,
+        )
+    )
+    command_once_added = pe_commands.MoveRelative(
+        id="command-id",
+        key="command-key",
+        createdAt=datetime(year=2021, month=1, day=1),
+        status=pe_commands.CommandStatus.QUEUED,
+        params=pe_commands.MoveRelativeParams(
+            pipetteId="pipette-id",
+            axis=MovementAxis.X,
+            distance=0.1,
+        ),
+    )
+
+    decoy.when(
+        await mock_maintenance_run_orchestrator_store.add_command_and_wait_for_interval(
+            request=pe_commands.MoveRelativeCreate(
+                params=pe_commands.MoveRelativeParams(
+                    pipetteId="pipette-id",
+                    axis=MovementAxis.X,
+                    distance=0.1,
+                ),
+                intent=pe_commands.CommandIntent.SETUP,
+            ),
+            wait_until_complete=False,
+            timeout=None,
+        )
+    ).then_return(command_once_added)
+
+    decoy.when(
+        await mock_maintenance_run_orchestrator_store.get_command("command-id")
+    ).then_return(command_once_added)
+
+    result = await create_run_command(
+        run_id="run-id",
+        request_body=RequestModel(data=command_request),
+        waitUntilComplete=False,
+        run_orchestrator_store=mock_maintenance_run_orchestrator_store,
+        timeout=None,
+        check_estop=True,
+        hardware_state_store=hardware_state_store,
+        audit_logger=mock_audit_logger,
+    )
+
+    assert result.content.data == command_once_added
+    assert result.status_code == 201
+    decoy.verify(mock_audit_logger.skip_persist())
 
 
 async def test_get_run_commands(

--- a/server-utils/server_utils/audit/audit_logger.py
+++ b/server-utils/server_utils/audit/audit_logger.py
@@ -57,6 +57,19 @@ class AuditLogger:
         self.should_log = True
         self.request = request
 
+    def skip_persist(self: Self) -> Self:
+        """Do not sign or store an audit record for this request.
+
+        Use this when the route is audited in general but this particular
+        request should not wait on audit-server persist. 
+        Middleware will return the HTTP response as soon as the handler finishes.
+
+        This is not a substitute for ``skip_audit_logger()``, which marks an
+        entire route as never audited.
+        """
+        self.should_log = False
+        return self
+
     def set_action_from_request(self: Self, request: Request) -> Self:
         """Set the action to log based on the request.
 
@@ -276,10 +289,10 @@ class AuditLogger:
         if isinstance(auth_details, AuthenticatedResult):
             self._fullname = auth_details.fullname
             self._username = auth_details.username
+            return self
         else:
             _LOG.warning(f"Will not send audit log because auth was {auth_details}")
-            self.should_log = False
-        return self
+            return self.skip_persist()
 
     def set_user_note(self: Self, user_note: str | None) -> Self:
         """Set the user note to be included in the log."""

--- a/server-utils/server_utils/audit/audit_logger.py
+++ b/server-utils/server_utils/audit/audit_logger.py
@@ -61,7 +61,7 @@ class AuditLogger:
         """Do not sign or store an audit record for this request.
 
         Use this when the route is audited in general but this particular
-        request should not wait on audit-server persist. 
+        request should not wait on audit-server persist.
         Middleware will return the HTTP response as soon as the handler finishes.
 
         This is not a substitute for ``skip_audit_logger()``, which marks an

--- a/server-utils/tests/audit/test_audit_logger.py
+++ b/server-utils/tests/audit/test_audit_logger.py
@@ -267,6 +267,18 @@ async def test_audit_logger_does_not_log_if_not_authenticated(
     decoy.verify(await mock_client.submit_log_message(matchers.Anything()), times=0)
 
 
+async def test_audit_logger_skip_persist_does_not_submit(
+    parametrized_subject: AuditLogger,
+    mock_client: Client,
+    decoy: Decoy,
+) -> None:
+    """skip_persist should prevent audit-server persist for this request."""
+    parametrized_subject.append_message_chunk("m")
+    parametrized_subject.skip_persist()
+    await parametrized_subject.log()
+    decoy.verify(await mock_client.submit_log_message(matchers.Anything()), times=0)
+
+
 async def test_audit_logger_uses_auth_result(
     parametrized_subject: AuditLogger,
     mock_client: Client,


### PR DESCRIPTION
Closes [RQA-6024](https://opentrons.atlassian.net/browse/RQA-6024)

# Overview

Best viewed commit-by-commit.

On CRS robots, every LPC / drop-tip jog was `POST /maintenance_runs/.../commands` with `waitUntilComplete: true`. After the gantry stopped, audit middleware still waited on key-server sign + persist before returning 201, so the UI stayed locked. That felt especially bad on the ODD.

This PR stops signing each moveRelative on the command POST. Successful jogsare queued and written as signed `External-jog_pipette` records when the user leaves the jog UI with one row per press, ex: `Jogged X: 1.0mm`.

On a high level, here's what's different in order to achieve this end:
- Maintenance-run `moveRelative` skips audit persist. It's a lot of one-off special casing, see review requests.
- The client no longer appends every jog to `actionsToDocument` (that was filling the end-of-flow modal and refetching runs on every press).
- Modern LPC (desktop + ODD) and standalone drop-tip setup coalesce successful jogs and flush on Confirm, Go back, and flow close. 
- Reuses the flow’s existing `commandDocState`, so we do not re-prompt for a reason.

## Test Plan and Hands on Testing

- Smoke-tested LPC and Drop tip wizard on the ODD. I didn't benchmark, but there's very noticeable latency improvements after these changes!
- Verified the new jog log entry appears in the logs.

## Changelog

- Cleaned up CRS logs related to jog actions, reducing latency when jogging when CRS is enabled.

## Review requests

- The special casing of the `moveRelative` command doesn't feel great...we may want something more robust, like a command descriptor that omits it from the formal audit process, but then again, we're only dealing with one command at this point in time. Are we ok with not architecting out something more permanent now? Do we foresee needing to extend audit exceptions for specific commands in the near future?

## Risk assessment

- lowish-medium. There's a lot of code, but it's all additive given it's a lot of special casing of one specific code path. 


[RQA-6024]: https://opentrons.atlassian.net/browse/RQA-6024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ