### PR TITLE
fix(ODD): loading state copy should be level 3 bold

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/LPCRobotInMotion.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LPCRobotInMotion.tsx
@@ -39,7 +39,10 @@ export function LPCRobotInMotion(props: RobotMotionLoaderProps): JSX.Element {
       <div className={styles.container}>
         <Icon name="ot-spinner" spin className={styles.spinner} />
         {header != null ? (
-          <StyledText oddStyle="level3HeaderBold" desktopStyle="headingSmallBold">
+          <StyledText
+            oddStyle="level3HeaderBold"
+            desktopStyle="headingSmallBold"
+          >
             {header}
           </StyledText>
         ) : null}

--- a/app/src/organisms/LabwarePositionCheck/LPCRobotInMotion.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LPCRobotInMotion.tsx
@@ -1,22 +1,19 @@
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
-import styled, { css } from 'styled-components'
+import { css } from 'styled-components'
 
 import {
-  ALIGN_CENTER,
-  COLORS,
   DIRECTION_COLUMN,
-  Flex,
   Icon,
-  JUSTIFY_CENTER,
-  LegacyStyledText,
   RESPONSIVENESS,
   SPACING,
-  TYPOGRAPHY,
+  StyledText,
 } from '@opentrons/components'
 
 import { LPCContentContainer } from '/app/organisms/LabwarePositionCheck/LPCContentContainer'
 import { getIsOnDevice } from '/app/redux/config'
+
+import styles from './lpcrobotinmotion.module.css'
 
 import type { LPCWizardContentProps } from '/app/organisms/LabwarePositionCheck/types'
 
@@ -39,42 +36,25 @@ export function LPCRobotInMotion(props: RobotMotionLoaderProps): JSX.Element {
       desktopHeaderBtnCopy="NO_COPY"
       desktopFooterBtnCopy="NO_COPY"
     >
-      <Flex css={CONTAINER_STYLE}>
-        <Icon name="ot-spinner" css={SPINNER_STYLE} spin />
-        {header != null ? <LoadingText>{header}</LoadingText> : null}
-        {body != null ? (
-          <LegacyStyledText forwardedAs="p">{body}</LegacyStyledText>
+      <div className={styles.container}>
+        <Icon name="ot-spinner" spin className={styles.spinner} />
+        {header != null ? (
+          <StyledText oddStyle="level3HeaderBold" desktopStyle="headingSmallBold">
+            {header}
+          </StyledText>
         ) : null}
-      </Flex>
+        {body != null ? (
+          <StyledText
+            oddStyle="level4HeaderRegular"
+            desktopStyle="bodyDefaultRegular"
+          >
+            {body}
+          </StyledText>
+        ) : null}
+      </div>
     </LPCContentContainer>
   )
 }
-
-const LoadingText = styled.h1`
-  ${TYPOGRAPHY.h1Default}
-
-  p {
-    text-transform: lowercase;
-  }
-
-  p::first-letter {
-    text-transform: uppercase;
-  }
-
-  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    ${TYPOGRAPHY.level3HeaderBold}
-  }
-`
-
-const CONTAINER_STYLE = css`
-  padding: ${SPACING.spacing40};
-  height: 100%;
-  width: 100%;
-  flex-direction: ${DIRECTION_COLUMN};
-  justify-content: ${JUSTIFY_CENTER};
-  align-items: ${ALIGN_CENTER};
-  grid-gap: ${SPACING.spacing24};
-`
 
 // The design system makes a padding exception for this view.
 const CHILDREN_CONTAINER_STYLE = css`
@@ -85,17 +65,5 @@ const CHILDREN_CONTAINER_STYLE = css`
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     padding: 0 ${SPACING.spacing60} ${SPACING.spacing40} ${SPACING.spacing60};
     gap: ${SPACING.spacing40};
-  }
-`
-
-const SPINNER_STYLE = css`
-  width: 5rem;
-  height: 5rem;
-  color: ${COLORS.grey60};
-
-  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    width: 8rem;
-    height: 8rem;
-    color: ${COLORS.grey50};
   }
 `

--- a/app/src/organisms/LabwarePositionCheck/LPCRobotInMotion.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LPCRobotInMotion.tsx
@@ -62,7 +62,7 @@ const LoadingText = styled.h1`
   }
 
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    ${TYPOGRAPHY.level4HeaderSemiBold}
+    ${TYPOGRAPHY.level3HeaderBold}
   }
 `
 

--- a/app/src/organisms/LabwarePositionCheck/LPCRobotInMotion.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LPCRobotInMotion.tsx
@@ -41,7 +41,7 @@ export function LPCRobotInMotion(props: RobotMotionLoaderProps): JSX.Element {
         {header != null ? (
           <StyledText
             oddStyle="level3HeaderBold"
-            desktopStyle="headingSmallBold"
+            desktopStyle="headingSmallSemiBold"
           >
             {header}
           </StyledText>

--- a/app/src/organisms/LabwarePositionCheck/lpcrobotinmotion.module.css
+++ b/app/src/organisms/LabwarePositionCheck/lpcrobotinmotion.module.css
@@ -1,0 +1,24 @@
+.container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-40);
+  gap: var(--spacing-24);
+}
+
+.spinner {
+  width: 5rem;
+  height: 5rem;
+  color: var(--grey-60);
+}
+
+@media (height = 600px) and (width = 1024px) {
+  .spinner {
+    width: 8rem;
+    height: 8rem;
+    color: var(--grey-50);
+  }
+}


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-6040.
use level 3 bold.
remove use of deprecated html tags. 

## Test Plan and Hands on Testing

<img width="1033" height="770" alt="Screenshot 2026-09-08 at 4 25 46 PM" src="https://github.com/user-attachments/assets/0f361ece-96c3-433a-8a71-a4dac9669e54" />

<img width="1150" height="675" alt="Screenshot 2026-09-09 at 11 59 32 AM" src="https://github.com/user-attachments/assets/681d48ad-256d-42ea-a3a9-65e1521b90af" />


## Risk assessment

low. style changes. 