### PR TITLE
fix(app): prevent documentation modal submit from reloading the desktop

### DIFF
--- a/app/src/organisms/Desktop/DocumentationRequired/DocumentationRequired.tsx
+++ b/app/src/organisms/Desktop/DocumentationRequired/DocumentationRequired.tsx
@@ -13,6 +13,7 @@ import { ActionList } from '/app/organisms/ActionItems/ActionList'
 
 import styles from './documentationrequired.module.css'
 
+import type { FormEvent } from 'react'
 import type {
   DocumentationReport,
   DocumentedAction,
@@ -47,7 +48,9 @@ export function DocumentationRequired({
   }
 
   const trimmedNote = inputText.trim()
-  const handleConfirm = (): void => {
+  const handleConfirm = (e: FormEvent<HTMLFormElement>): void => {
+    e.preventDefault()
+
     if (trimmedNote === '') {
       setError(t('documentation_is_required') as string)
       return


### PR DESCRIPTION
Closes [RQA-6109](https://opentrons.atlassian.net/browse/RQA-6109)

# Overview

On the desktop app, confirming a documentation note that was too short showed the min-length error, then the whole UI reloaded and closed the modal. The form was submitting natively after validation, which HashRouter treats as a full page load. This stops that default submit so the error stays on screen.

### Current behavior

https://github.com/user-attachments/assets/ffa3e43f-e143-4172-9125-a76976379613

### Fixed behavior

https://github.com/user-attachments/assets/26fc414c-18e9-4b58-9e7a-c0ed4a5c4620

## Test Plan and Hands on Testing

- See videos.

## Changelog

- Fixed a bug in which confirming the documentation modal occasionally causes the desktop app to whitescreen.

## Risk assessment

- very low - only risk is if we depend on the default form behavior, which we don't seem to do!


[RQA-6109]: https://opentrons.atlassian.net/browse/RQA-6109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ