### PR TITLE
fix(app, app-shell-odd): prevent ODD software updates from looping and not applying

### DIFF
--- a/app-shell-odd/src/system-update/__tests__/handler.test.ts
+++ b/app-shell-odd/src/system-update/__tests__/handler.test.ts
@@ -1001,4 +1001,23 @@ describe('update driver', () => {
         })
       })
   })
+  it('waits for download instead of erroring when the system file is not ready', () => {
+    const thisSubject = subject!
+    return thisSubject
+      .handleAction({
+        type: 'robotUpdate:READ_SYSTEM_FILE',
+        payload: { target: 'flex' },
+        meta: { shell: true },
+      })
+      .then(() => {
+        expect(dispatch).toHaveBeenCalledWith({
+          type: 'robotUpdate:CHECKING_FOR_UPDATE',
+          payload: 'flex',
+        })
+        expect(dispatch).not.toHaveBeenCalledWith({
+          type: 'robotUpdate:UNEXPECTED_ERROR',
+          payload: { message: 'System update file not downloaded' },
+        })
+      })
+  })
 })

--- a/app-shell-odd/src/system-update/handler.ts
+++ b/app-shell-odd/src/system-update/handler.ts
@@ -313,18 +313,10 @@ export function createUpdateDriver(dispatch: Dispatch): UpdateDriver {
           }
           return new Promise(resolve => {
             const details = getDetails()
-            if (details === 'ongoing') {
+            if (details === 'ongoing' || details == null) {
               dispatch({
                 type: 'robotUpdate:CHECKING_FOR_UPDATE',
                 payload: 'flex',
-              })
-              resolve()
-              return
-            }
-            if (details == null) {
-              dispatch({
-                type: 'robotUpdate:UNEXPECTED_ERROR',
-                payload: { message: 'System update file not downloaded' },
               })
               resolve()
               return

--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
@@ -237,15 +237,15 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
 
   const isCRSEnabled =
     accessControlEnabledQuery.data?.data.accessControlEnabled ?? false
+  const queriesSucceeded =
+    robotSettingsQuery.isSuccess && accessControlEnabledQuery.isSuccess
+  // After the first successful load, never return to the initial init spinner.
+  const hasCompletedInitialReadyRef = useRef(false)
+  if (isShellReady && queriesSucceeded) {
+    hasCompletedInitialReadyRef.current = true
+  }
   const isReady =
-    // ensure robot-server api, etc. is up and running
-    isShellReady &&
-    // ensure settings query data is available for localization provider
-    robotSettingsQuery.isSuccess &&
-    // ensure we know whether access control is enabled or not,
-    // so on first render we can immediately show the LoggedOutOverlay
-    // and hide CRS-incompatible UI, if appropriate.
-    accessControlEnabledQuery.isSuccess
+    hasCompletedInitialReadyRef.current || (isShellReady && queriesSucceeded)
   // TODO (sb:6/12/23) Create a notification manager to set up preference and order of takeover modals
   return (
     // to make sure that the host config stays stable and in step with the initial queries,

--- a/app/src/App/__tests__/OnDeviceDisplayApp.test.tsx
+++ b/app/src/App/__tests__/OnDeviceDisplayApp.test.tsx
@@ -240,6 +240,40 @@ describe('OnDeviceDisplayApp', () => {
     screen.getByLabelText('loading indicator')
     expect(vi.mocked(LocalizationProvider)).not.toHaveBeenCalled()
   })
+  it('does not return to the loading screen if access-control queries reset after initial ready', () => {
+    const [{ rerender }] = render('/')
+    expect(screen.queryByLabelText('loading indicator')).toBeNull()
+    expect(vi.mocked(LocalizationProvider)).toHaveBeenCalled()
+
+    vi.mocked(useAccessControlEnabledQuery).mockReturnValue({
+      data: undefined,
+      isSuccess: false,
+    } as any)
+
+    rerender(
+      <MemoryRouter initialEntries={['/']} initialIndex={0}>
+        <OnDeviceDisplayApp />
+      </MemoryRouter>
+    )
+
+    expect(screen.queryByLabelText('loading indicator')).toBeNull()
+    expect(vi.mocked(LocalizationProvider)).toHaveBeenCalled()
+  })
+  it('does not return to the loading screen if the shell becomes unready after initial ready', () => {
+    const [{ rerender }] = render('/')
+    expect(screen.queryByLabelText('loading indicator')).toBeNull()
+
+    vi.mocked(getIsShellReady).mockReturnValue(false)
+
+    rerender(
+      <MemoryRouter initialEntries={['/']} initialIndex={0}>
+        <OnDeviceDisplayApp />
+      </MemoryRouter>
+    )
+
+    expect(screen.queryByLabelText('loading indicator')).toBeNull()
+    expect(vi.mocked(LocalizationProvider)).toHaveBeenCalled()
+  })
   it('renders EmergencyStop component from /emergency-stop', () => {
     render('/emergency-stop')
     expect(vi.mocked(EmergencyStop)).toHaveBeenCalled()

--- a/app/src/organisms/UpdateRobotSoftware/__tests__/UpdateRobotSoftware.test.tsx
+++ b/app/src/organisms/UpdateRobotSoftware/__tests__/UpdateRobotSoftware.test.tsx
@@ -101,6 +101,7 @@ describe('UpdateRobotSoftware', () => {
     mockAfterError.mockClear()
     mockBeforeCommitting.mockClear()
     mockAfterCancel.mockClear()
+    vi.mocked(RobotUpdate.downloadRobotUpdate).mockClear()
     vi.mocked(CompleteUpdateSoftware).mockReturnValue(
       <div>mock CompleteUpdateSoftware</div>
     )
@@ -108,10 +109,17 @@ describe('UpdateRobotSoftware', () => {
   })
 
   it('should start the robot update through the orchestrator on mount', () => {
-    vi.mocked(getRobotUpdateSession).mockReturnValue(mockSession)
+    vi.mocked(getRobotUpdateSession).mockReturnValue(null)
     render()
     expect(mockStartUpdate).toHaveBeenCalledWith('oddtie')
     expect(RobotUpdate.downloadRobotUpdate).toHaveBeenCalled()
+  })
+
+  it('does not re-download if a session already exists', () => {
+    vi.mocked(getRobotUpdateSession).mockReturnValue(mockSession)
+    render()
+    expect(mockStartUpdate).toHaveBeenCalledWith('oddtie')
+    expect(RobotUpdate.downloadRobotUpdate).not.toHaveBeenCalled()
   })
 
   it('should render complete screen when finished', () => {

--- a/app/src/organisms/UpdateRobotSoftware/index.tsx
+++ b/app/src/organisms/UpdateRobotSoftware/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { CompleteUpdateSoftware } from '/app/organisms/UpdateRobotSoftware/CompleteUpdateSoftware'
@@ -53,7 +53,7 @@ export function UpdateRobotSoftware(
     step: null,
     error: null,
   }
-  const [isDownloading, setIsDownloading] = useState<boolean>(false)
+  const didKickOffRef = useRef(false)
   const afterCancelRef = useRef(afterCancel)
   afterCancelRef.current = afterCancel
   const hadSessionRef = useRef(session != null)
@@ -64,13 +64,17 @@ export function UpdateRobotSoftware(
   }
 
   useEffect(() => {
-    // check isDownloading to avoid dispatching again
-    if (!isDownloading) {
-      setIsDownloading(true)
-      dispatch(downloadRobotUpdate())
-      startUpdate(robotName)
+    if (didKickOffRef.current) {
+      return
     }
-  }, [dispatch, startUpdate, robotName, isDownloading])
+
+    didKickOffRef.current = true
+
+    if (session?.robotName == null) {
+      dispatch(downloadRobotUpdate())
+    }
+    startUpdate(robotName)
+  }, [dispatch, robotName, session?.robotName, startUpdate])
 
   useEffect(() => {
     if (session == null && hadSessionRef.current && !didCancelRef.current) {
@@ -79,12 +83,14 @@ export function UpdateRobotSoftware(
     }
   }, [session])
 
-  // Display Error screen
-  if (sessionError != null) {
-    afterError(sessionError)
-  }
-  let updateType:
-    'downloading' | 'validating' | 'sendingFile' | 'installing' | null = null
+  useEffect(() => {
+    if (sessionError != null) {
+      afterError(sessionError)
+    }
+  }, [afterError, sessionError])
+
+  let updateType: 'downloading' | 'validating' | 'sendingFile' | 'installing' =
+    'downloading'
   if (step === 'finished') {
     return <CompleteUpdateSoftware robotName={robotName} />
   } else {
@@ -97,8 +103,6 @@ export function UpdateRobotSoftware(
         updateType = 'installing'
         beforeCommittingSuccessfulUpdate && beforeCommittingSuccessfulUpdate()
       }
-    } else if (isDownloading) {
-      updateType = 'downloading'
     }
     return <UpdateSoftware updateType={updateType} />
   }

--- a/app/src/pages/ODD/UpdateRobot/UpdateRobot.tsx
+++ b/app/src/pages/ODD/UpdateRobot/UpdateRobot.tsx
@@ -17,6 +17,7 @@ import {
   clearRobotUpdateSession,
   downloadRobotUpdate,
   getRobotUpdateAvailable,
+  getRobotUpdateSession,
 } from '/app/redux/robot-update'
 import { useRobotUpdateContext } from '/app/resources/robot-update/RobotUpdateContext'
 
@@ -32,6 +33,7 @@ export function UpdateRobot(): JSX.Element {
       : null
   })
   const robotName = localRobot?.name != null ? localRobot.name : 'no name'
+  const session = useSelector(getRobotUpdateSession)
   const { startUpdate } = useRobotUpdateContext()
   const dispatch = useDispatch<Dispatch>()
 
@@ -64,7 +66,7 @@ export function UpdateRobot(): JSX.Element {
         </ErrorUpdateSoftware>
       ) : localRobot === null ||
         localRobot.status === UNREACHABLE ||
-        robotUpdateType !== 'upgrade' ? (
+        (robotUpdateType !== 'upgrade' && session == null) ? (
         <NoUpdateFound
           onContinue={() => {
             navigate(-1)

--- a/app/src/pages/ODD/UpdateRobot/UpdateRobotDuringOnboarding.tsx
+++ b/app/src/pages/ODD/UpdateRobot/UpdateRobotDuringOnboarding.tsx
@@ -22,6 +22,7 @@ import {
   clearRobotUpdateSession,
   downloadRobotUpdate,
   getRobotUpdateAvailable,
+  getRobotUpdateSession,
 } from '/app/redux/robot-update'
 import { useRobotUpdateContext } from '/app/resources/robot-update/RobotUpdateContext'
 
@@ -43,6 +44,7 @@ export function UpdateRobotDuringOnboarding(): JSX.Element {
       : null
   })
   const robotName = localRobot?.name != null ? localRobot.name : 'no name'
+  const session = useSelector(getRobotUpdateSession)
 
   const { unfinishedUnboxingFlowRoute } = useSelector(
     getOnDeviceDisplaySettings
@@ -102,11 +104,13 @@ export function UpdateRobotDuringOnboarding(): JSX.Element {
             />
           </Flex>
         </ErrorUpdateSoftware>
-      ) : isShowCheckingUpdates && robotUpdateType !== 'upgrade' ? (
+      ) : isShowCheckingUpdates &&
+        robotUpdateType !== 'upgrade' &&
+        session == null ? (
         <CheckUpdates />
       ) : localRobot === null ||
         localRobot.status === UNREACHABLE ||
-        robotUpdateType !== 'upgrade' ? (
+        (robotUpdateType !== 'upgrade' && session == null) ? (
         <NoUpdateFound
           onContinue={() => {
             navigate('/emergency-stop')

--- a/app/src/pages/ODD/UpdateRobot/__tests__/UpdateRobot.test.tsx
+++ b/app/src/pages/ODD/UpdateRobot/__tests__/UpdateRobot.test.tsx
@@ -119,6 +119,15 @@ describe('UpdateRobot', () => {
     screen.getByText('Your software is already up to date!')
   })
 
+  it('should keep showing the update when a session exists even if type is not upgrade', () => {
+    vi.mocked(RobotUpdate.getRobotUpdateAvailable).mockReturnValue(
+      RobotUpdate.REINSTALL
+    )
+    vi.mocked(RobotUpdate.getRobotUpdateSession).mockReturnValue(mockSession)
+    render()
+    screen.getByText('Downloading software...')
+  })
+
   it('should render mock ErrorUpdateSoftware when an error occurs', () => {
     const mockErrorSession = {
       ...mockSession,

--- a/app/src/resources/robot-update/useRobotUpdateOrchestrator/index.ts
+++ b/app/src/resources/robot-update/useRobotUpdateOrchestrator/index.ts
@@ -1,5 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react'
-import { useQueryClient } from 'react-query'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useDispatch, useSelector, useStore } from 'react-redux'
 
 import {
@@ -11,10 +10,7 @@ import {
 
 import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
 import { useAccessTokenForRobot } from '/app/redux/robot-auth/hooks'
-import {
-  clearRobotUpdateSession,
-  startRobotUpdate,
-} from '/app/redux/robot-update'
+import { startRobotUpdate } from '/app/redux/robot-update'
 import {
   getRobotUpdateSession,
   getRobotUpdateSessionRobotName,
@@ -35,15 +31,23 @@ export function useRobotUpdateOrchestrator(): {
 } {
   const dispatch = useDispatch<Dispatch>()
   const store = useStore<State>()
-  const queryClient = useQueryClient()
   const sessionRobotName = useSelector(getRobotUpdateSessionRobotName)
   const baseHostConfig = useRobotUpdateHostConfig()
   const accessToken = useAccessTokenForRobot(sessionRobotName)
 
   const abortRef = useRef<AbortController | null>(null)
-  // After AC cache reset, ignore settled docs until host is ready and queries
-  // have loaded again, otherwise create can use a stale CRS-enabled snapshot.
+  const inFlightRef = useRef(false)
+  // Ignore settled docs until the session host is ready and its AC queries
+  // have loaded. Otherwise create can see a stale "AC off" snapshot while
+  // hostConfig is still null.
   const acGateRef = useRef(false)
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort()
+      inFlightRef.current = false
+    }
+  }, [])
 
   // Values that may change mid-flow. Read via getters.
   const accessTokenRef = useRef(accessToken)
@@ -113,6 +117,10 @@ export function useRobotUpdateOrchestrator(): {
 
   const startUpdate = useCallback(
     (robotName: string, systemFile?: string) => {
+      if (inFlightRef.current) {
+        return
+      }
+
       const previousPathPrefix = getRobotUpdateSession(
         store.getState()
       )?.pathPrefix
@@ -120,6 +128,7 @@ export function useRobotUpdateOrchestrator(): {
       abortRef.current?.abort()
       const abortController = new AbortController()
       abortRef.current = abortController
+      inFlightRef.current = true
 
       // Cancel before clearing so host + documentation still match
       // the in-flight robot. Upload ignores AbortSignal, so this must be eager.
@@ -130,49 +139,37 @@ export function useRobotUpdateOrchestrator(): {
       }
 
       clearDocreport()
-      dispatch(clearRobotUpdateSession())
       dispatch(startRobotUpdate(robotName, systemFile ?? null))
 
       acGateRef.current = true
 
-      void queryClient
-        .resetQueries({
-          predicate: query => {
-            const key = query.queryKey
-            return (
-              Array.isArray(key) &&
-              (key.includes('accessControlEnabled') || key.includes('audit'))
-            )
-          },
-        })
-        .then(() => {
-          if (abortController.signal.aborted) {
-            return
+      void runRobotUpdateFlow({
+        store,
+        dispatch,
+        robotName,
+        systemFile: systemFile ?? null,
+        getAccessToken: () => {
+          if (!shouldUseAccessToken(readDocumentationState())) {
+            return null
           }
-          return runRobotUpdateFlow({
-            store,
-            dispatch,
-            robotName,
-            systemFile: systemFile ?? null,
-            getAccessToken: () => {
-              if (!shouldUseAccessToken(readDocumentationState())) {
-                return null
-              }
-              return accessTokenRef.current
-            },
-            getDocumentationState: readDocumentationState,
-            isHostConfigReady: () => hostConfigReadyRef.current,
-            getMutations: () => mutationsRef.current,
-            signal: abortController.signal,
-          })
-        })
+          return accessTokenRef.current
+        },
+        getDocumentationState: readDocumentationState,
+        isHostConfigReady: () => hostConfigReadyRef.current,
+        getMutations: () => mutationsRef.current,
+        signal: abortController.signal,
+      }).finally(() => {
+        if (abortRef.current === abortController) {
+          inFlightRef.current = false
+        }
+      })
 
       function readDocumentationState(): DocumentationState {
         const state = docsStateRef.current
         if (!acGateRef.current) {
           return state
         }
-        // Hold the gate until the post-reset host/queries have settled.
+        // Hold the gate until the session host and its AC queries have settled.
         if (!hostConfigReadyRef.current || state.isLoading) {
           return { isLoading: true }
         }
@@ -180,7 +177,7 @@ export function useRobotUpdateOrchestrator(): {
         return state
       }
     },
-    [clearDocreport, dispatch, queryClient, store]
+    [clearDocreport, dispatch, store]
   )
 
   return { startUpdate }


### PR DESCRIPTION
Closes [RQA-6097](https://opentrons.atlassian.net/browse/RQA-6097) and [RQA-6100](https://opentrons.atlassian.net/browse/RQA-6100)

# Overview

Starting a robot software update from the Flex touchscreen could bounce between the loading spinner and “Update found!” indefinitely. Behind that flicker, the update was being cancelled and restarted, so the robot often rebooted onto the same version.

The apply flow was resetting access-control queries and clearing the update session as soon as a user tapped "Update". On the ODD that unmounts the whole app, which tore down the in-flight update, cancelled the server session, and started a new one. Cancel does not stop the background write, so overlapping sessions could still reboot without a successful commit.

A second race made the early flicker worse: the ODD asked the shell for the system file immediately, before the download had produced one. Desktop waits in that case, but the ODD treated it as a hard error.

The fix here keeps the ODD mounted after first load, does not reset those queries or clear the session just to start an update, ignores duplicate starts, and waits for the file the way desktop already does. The update screen also stays on a single progress path instead of remounting back to a blank “Update found!” state.

### Current behavior

https://github.com/user-attachments/assets/544ffc22-0995-47bc-8daf-8c8b2865c59d

### Fixed behavior

https://github.com/user-attachments/assets/c297f78d-3ca6-40d1-8e1e-c1283da53558

## Test Plan and Hands on Testing

- See videos.
- Verified fix on both CRS and non-CRS bots.

## Changelog

- Fixed a bug in which attempting an update from the ODD would cause the UI to loop.

## Risk assessment

- medium. The code change is small(ish), but it sits on the Flex software-update path.


[RQA-6097]: https://opentrons.atlassian.net/browse/RQA-6097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-6100]: https://opentrons.atlassian.net/browse/RQA-6100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ