### PR TITLE
fix(app): update device reset copy to mention redoing initial setup

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -53,7 +53,7 @@
   "choose_reset_settings": "Choose reset settings",
   "clear_all_data": "Clear all data",
   "clear_all_stored_data": "Clear all stored data",
-  "clear_all_stored_data_description": "Clears calibrations, protocols, and all settings except robot name and network settings.",
+  "clear_all_stored_data_description": "Clears calibrations, protocols, and all settings. You’ll have to redo initial setup before using the robot again.",
   "clear_calibration_data": "Clear calibration data",
   "clear_data_and_restart_robot": "Clear data and restart robot",
   "clear_individual_data": "Clear individual data",

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/DeviceResetSlideout.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/DeviceResetSlideout.test.tsx
@@ -129,7 +129,7 @@ describe('RobotSettings DeviceResetSlideout', () => {
     render()
     screen.getByText('Clear all data')
     screen.getByText(
-      'Clears calibrations, protocols, and all settings except robot name and network settings.'
+      'Clears calibrations, protocols, and all settings. You’ll have to redo initial setup before using the robot again.'
     )
     expect(screen.queryByText('Clear deck calibration')).toBeNull()
     screen.getByText('Clear pipette calibration')

--- a/app/src/organisms/ODD/RobotSettingsDashboard/__tests__/DeviceReset.test.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/__tests__/DeviceReset.test.tsx
@@ -50,7 +50,7 @@ describe('DeviceReset', () => {
     screen.getByText('Clears information about past runs of all protocols.')
     screen.getByText('Clear all stored data')
     screen.getByText(
-      'Clears calibrations, protocols, and all settings except robot name and network settings.'
+      'Clears calibrations, protocols, and all settings. You’ll have to redo initial setup before using the robot again.'
     )
     expect(
       screen.queryByText('authorized') // as in "SSH authorized keys"


### PR DESCRIPTION
Closes [RQA-6118](https://opentrons.atlassian.net/browse/RQA-6118)

# Overview

Whoops, the desktop slideout has always mentioned keeping the robot name and network connection when all settings are reset, but in practice, we do the opposite when clearing all data. The ODD always had the correct copy!

### Current behavior

<img width="1440" height="1120" alt="image" src="https://github.com/user-attachments/assets/88153aaa-474c-41e6-9f39-026244565970" />


### Fixed behavior

<img width="1022" height="762" alt="Screenshot 2026-09-09 at 1 22 14 PM" src="https://github.com/user-attachments/assets/1c27a14d-70bd-4f39-b842-2341edeb8cc2" />

## Test Plan and Hands on Testing

- See images.

## Risk assessment

- none, just copy


[RQA-6118]: https://opentrons.atlassian.net/browse/RQA-6118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ