### PR TITLE
docs: update API versioning for 2.30 and robot software 10.0.0

### DIFF
--- a/docs/python-api/docs/versioning.md
+++ b/docs/python-api/docs/versioning.md
@@ -71,6 +71,7 @@ This table lists the correspondence between Protocol API versions and robot soft
 
 | API Version | Introduced in Robot Software |
 |-------------|------------------------------|
+| 2.30        | 10.0.0                       |
 | 2.29        | 9.1.1                        |
 | 2.28        | 9.0.0 / OT-2 26.6.0          |
 | 2.27        | 8.8.0                        |
@@ -104,6 +105,10 @@ This table lists the correspondence between Protocol API versions and robot soft
 | 1.0         | 3.0.0                        |
 
 ## Changes in API versions
+
+### Version 2.30
+
+- Aspirating at the [`Well.meniscus()`][opentrons.protocol_api.Well.meniscus] now works when only specifying `target="start"`. In earlier API versions, aspirating with `target="start"` and no `end_location` raised an error. See [Meniscus](robot-position.md#meniscus).
 
 ### Version 2.29
 

--- a/docs/python-api/mkdocs.yml
+++ b/docs/python-api/mkdocs.yml
@@ -166,5 +166,5 @@ extra_css:
   - ../shared/print-pdf.css
 
 extra:
-  apiLevel: 2.29
-  robot_stack_version: 9.1.0
+  apiLevel: 2.30
+  robot_stack_version: 10.0.0


### PR DESCRIPTION
# Overview

API versioning page updates for the small changes introduced in `apiLevel` 2.30.

## Test Plan and Hands on Testing

[Sandbox](https://sandbox.docs.opentrons.com/docs/api-versioning-2.30-for-10.0.0/python-api/versioning/)

## Changelog

- Update table and feature list on `versioning.md`
- Update latest version replacement values across docs site.

## Review requests

There were no other API features, right?

## Risk assessment

v low