### PR TITLE
Rqa 6011

### DIFF
--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -525,13 +525,11 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         return self.__user_store.get_by_id(token.user_id)
 
     def __get_effective_token_scopes(self, token: _TokenIssuance) -> set[Scope]:
-        """Return granted token scopes, updated for current settings and user state."""
-        live_scopes = self.__get_live_scopes_for_token(token)
-        if not token.requested_scopes:
-            return live_scopes
-        return set(token.requested_scopes) & live_scopes
+        """Return granted token scopes from current settings and user state.
 
-    def __get_live_scopes_for_token(self, token: _TokenIssuance) -> set[Scope]:
+        Always follows live settings, including on tokens issued before a
+        settings change.
+        """
         user = self.__get_user_for_token(token)
         if user is None:
             return set()

--- a/auth-server/auth_server/oauth2/router.py
+++ b/auth-server/auth_server/oauth2/router.py
@@ -20,10 +20,13 @@ router = fastapi.APIRouter(prefix="/auth")
         The OAuth 2 token endpoint, as specified in RFC 6749.
 
         Omit `scope` to receive the scopes appropriate for the authenticated user
-        under current server settings. Those scopes are calculated at use time and
-        may change when settings or user state changes. Clients may optionally
-        include `scope` to request a subset of those permissions; that ceiling is
-        stored on the token and further restricted when settings or user state changes.
+        under current server settings. Clients may optionally include `scope` to
+        request a subset of those permissions at login time.
+
+        In either case, effective scopes on an issued token are recalculated at
+        use time from current settings and user state. Upadting
+        admin-credential settings therefore adds or removes scopes on existing
+        tokens without requiring a new login.
         """),
     dependencies=[fastapi.Depends(skip_audit_logger)],
 )

--- a/auth-server/tests/integration/test_protected_resource_access.tavern.yaml
+++ b/auth-server/tests/integration/test_protected_resource_access.tavern.yaml
@@ -4,6 +4,7 @@ marks:
   - usefixtures:
       - run_server
       - seed_users
+      - user_scopes_str
 
 stages:
   - name: Enable access control enabled so protected resources require a valid token
@@ -44,6 +45,9 @@ stages:
     response:
       status_code: 401
 
+  # Request-time scope narrowing is not enforced at use time (live scopes always
+  # win), so get insufficient scopes from an account type that is not authorized
+  # for users.write instead of asking an admin for a subset.
   - name: Get an access token with insufficient scopes
     request:
       method: POST
@@ -51,9 +55,8 @@ stages:
       data:
         client_id: opentrons_app
         grant_type: password
-        username: testadmin
-        password: testadminpassword
-        scope: users.read.others # Omit users.write.
+        username: testuser
+        password: testuserpassword
     response:
       status_code: 200
       json:
@@ -61,7 +64,8 @@ stages:
         refresh_token: !anystr
         expires_in: !anyint
         token_type: Bearer
-        scope: users.read.others
+        # Regular users are not authorized for users.write.
+        scope: '{user_scopes_str}'
       save:
         json:
           access_token: access_token
@@ -72,7 +76,7 @@ stages:
       url: '{run_server.base_url}/auth/users'
       json:
         data:
-          username: testuser
+          username: testuser_new
           password: testuserpassword
           fullName: Test User
           accountType: user
@@ -90,7 +94,6 @@ stages:
         grant_type: password
         username: testadmin
         password: testadminpassword
-        scope: users.write
     response:
       status_code: 200
       json:
@@ -98,7 +101,7 @@ stages:
         refresh_token: !anystr
         expires_in: !anyint
         token_type: Bearer
-        scope: users.write
+        scope: !anystr
       save:
         json:
           access_token: access_token

--- a/auth-server/tests/integration/test_protected_resource_access.tavern.yaml
+++ b/auth-server/tests/integration/test_protected_resource_access.tavern.yaml
@@ -57,6 +57,7 @@ stages:
         grant_type: password
         username: testuser
         password: testuserpassword
+        scope: users.read.others # Omit users.write.
     response:
       status_code: 200
       json:
@@ -64,7 +65,7 @@ stages:
         refresh_token: !anystr
         expires_in: !anyint
         token_type: Bearer
-        # Regular users are not authorized for users.write.
+        # scopes based on user account type and settings
         scope: '{user_scopes_str}'
       save:
         json:

--- a/auth-server/tests/integration/test_settings_update_oauth_scopes.tavern.yaml
+++ b/auth-server/tests/integration/test_settings_update_oauth_scopes.tavern.yaml
@@ -7,21 +7,7 @@ marks:
       - seed_users
 
 stages:
-  - name: Update all admin-credential requirements at once
-    request:
-      method: PATCH
-      url: '{run_server.base_url}/auth/settings'
-      headers:
-        Authorization: '{admin_access_token}'
-      json:
-        data:
-          requireAdminCredsWhenUpdatingRobotSoftware: false
-          requireAdminCredsWhenSendingProtocolToRobot: false
-          requireAdminCredsForSignoffProtocol: false
-    response:
-      status_code: 200
-
-  - name: Login should include all optional user scopes
+  - name: Login under default settings (optional scopes withheld)
     request:
       method: POST
       url: '{run_server.base_url}/auth/oauth2/token'
@@ -35,12 +21,56 @@ stages:
       verify_response_with:
         function: tests.integration.utils:verify_oauth_scopes
         extra_kwargs:
-          expected_present: updates.write protocols.write run_signoff.write
+          expected_absent: updates.write protocols.write
+          expected_present: run_signoff.write
       save:
         json:
           user_access_token: access_token
 
-  - name: Re-enable all admin-credential requirements at once
+  - name: Introspection matches login scopes when settings are unchanged
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/introspect'
+      data:
+        client_id: opentrons_app
+        token: '{user_access_token}'
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tests.integration.utils:verify_oauth_scopes
+        extra_kwargs:
+          expected_absent: updates.write protocols.write
+          expected_present: run_signoff.write
+
+  - name: Loosen all admin-credential requirements
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/settings'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          requireAdminCredsWhenUpdatingRobotSoftware: false
+          requireAdminCredsWhenSendingProtocolToRobot: false
+          requireAdminCredsForSignoffProtocol: false
+    response:
+      status_code: 200
+
+  - name: Existing token introspection should gain newly allowed scopes
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/introspect'
+      data:
+        client_id: opentrons_app
+        token: '{user_access_token}'
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tests.integration.utils:verify_oauth_scopes
+        extra_kwargs:
+          expected_present: updates.write protocols.write run_signoff.write
+
+  - name: Re-enable all admin-credential requirements
     request:
       method: PATCH
       url: '{run_server.base_url}/auth/settings'
@@ -54,7 +84,7 @@ stages:
     response:
       status_code: 200
 
-  - name: Existing token introspection should reflect updated scopes
+  - name: Existing token introspection should lose restricted scopes
     request:
       method: POST
       url: '{run_server.base_url}/auth/oauth2/introspect'


### PR DESCRIPTION
## Overview

Closes https://opentrons.atlassian.net/browse/RQA-6011. 
Always validate scopes against settings. 

## Test plan

Integration tests cover but if you really want to: 

- [ ] make -C auth-server test tests="tests/integration/test_settings_update_oauth_scopes.tavern.yaml"
- [ ]  Log in as a regular user with defaults → confirm no protocols.write
- [ ]  Set requireAdminCredsWhenSendingProtocolToRobot: false → introspect same token → protocols.write present
- [ ] Set it back to true → introspect again → protocols.write absent
- [ ] New login after loosening settings → token response includes the new scopes

## Changelog

Get scopes on an existing token from current settings and user state.
Login still validates/defaults scopes from live settings at issue time.

## Review requests

are we ok with this approach? 

## Risk assessment

low. 
