### PR TITLE
fix(robot-server): grant ot-protocol group access when creating persistence

### DIFF
--- a/robot-server/robot_server/persistence/_migrations/v16_to_v17.py
+++ b/robot-server/robot_server/persistence/_migrations/v16_to_v17.py
@@ -9,16 +9,12 @@ to root, this was fine when there were no other users or groups but must be chan
 access to protocol related files.
 """
 
-import os
 from pathlib import Path
 
-from server_utils.persistence.folder_migrator import (
-    PROTOCOL_DIR_PERMISSIONS,
-    PROTOCOL_FILE_PERMISSIONS,
-    Migration,
-)
+from server_utils.persistence.folder_migrator import Migration
 
 from ..file_and_directory_names import PROTOCOLS_DIRECTORY
+from ..protocol_user_permissions import apply_protocol_user_permissions
 from ._util import copy_contents
 
 
@@ -35,11 +31,4 @@ def _migrate_permissions(dest_dir: Path) -> None:
 
     # Ensure a protocols directory is present before setting permissions
     if protocols_dir.is_dir():
-        os.chmod(protocols_dir, PROTOCOL_DIR_PERMISSIONS)
-        for item in protocols_dir.glob("**/*"):
-            if item.is_dir():
-                os.chmod(item, PROTOCOL_DIR_PERMISSIONS)
-            else:
-                # Gaurantee read permissions on migrated files to ensure accessibility, even
-                # if they were already readable under the existing umask rules.
-                os.chmod(item, PROTOCOL_FILE_PERMISSIONS)
+        apply_protocol_user_permissions(protocols_dir, recursive=True)

--- a/robot-server/robot_server/persistence/manage_persistence_directory.py
+++ b/robot-server/robot_server/persistence/manage_persistence_directory.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+from anyio import to_thread
 from typing_extensions import Final
 
 from server_utils.persistence.folder_migrator import MigrationOrchestrator
@@ -32,6 +33,7 @@ from ._migrations import (
     v18_to_v19,
 )
 from .file_and_directory_names import LATEST_VERSION_DIRECTORY
+from .protocol_user_permissions import grant_protocol_user_access
 
 _TEMP_PERSISTENCE_DIR_PREFIX: Final = "opentrons-robot-server-"
 
@@ -80,9 +82,18 @@ def make_migration_orchestrator(prepared_root: Path) -> MigrationOrchestrator:
 
 
 async def prepare_active_subdirectory(prepared_root: Path) -> Path:
-    """Return the active persistence subdirectory after preparing it, if necessary."""
+    """Return the active persistence subdirectory after preparing it, if necessary.
+
+    After migrations, grant the `ot-protocol` user access to protocol files.
+    Directories are setgid so later uploads inherit that group. oe-core's systemd-tmpfiles
+    only chowns paths that already exist at boot, so this must run here, since the first CRS
+    reset recreates the tree after tmpfiles has already finished.
+    """
     orchestrator = make_migration_orchestrator(prepared_root)
-    return await server_utils_prepare_active_subdirectory(orchestrator)
+    subdirectory = await server_utils_prepare_active_subdirectory(orchestrator)
+    await to_thread.run_sync(grant_protocol_user_access, subdirectory)
+
+    return subdirectory
 
 
 async def prepare_root(persistence_directory_root: Path | None) -> Path:

--- a/robot-server/robot_server/persistence/protocol_user_permissions.py
+++ b/robot-server/robot_server/persistence/protocol_user_permissions.py
@@ -1,0 +1,95 @@
+"""Grant the restricted protocol user access to persistence files.
+
+Protocol execution on the Flex can run as the `ot-protocol` system user. Persistence
+files are created by robot-server as root with modes `0750` / `0640`, which only
+work if those paths are also group-owned by `ot-protocol`.
+
+systemd-tmpfiles applies that group at boot for paths that already exist. This helper
+applies the same policy when robot-server creates or migrates those paths, so a
+subprocess can read them on the same boot.
+
+Directories also get the setgid bit (`02750`). On Linux, later `mkdir` / `open` under
+that tree inherit group `ot-protocol`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import pwd
+import stat
+from pathlib import Path
+
+from typing_extensions import Final
+
+from server_utils.persistence.folder_migrator import (
+    PROTOCOL_DIR_PERMISSIONS,
+    PROTOCOL_FILE_PERMISSIONS,
+)
+
+from .file_and_directory_names import DATA_FILES_DIRECTORY, PROTOCOLS_DIRECTORY
+
+PROTOCOL_USER_NAME: Final = "ot-protocol"
+_DIR_MODE_WITH_SETGID: Final = PROTOCOL_DIR_PERMISSIONS | stat.S_ISGID
+
+_log = logging.getLogger(__name__)
+
+
+def grant_protocol_user_access(version_dir: Path) -> None:
+    """Grant `ot-protocol` access to a persistence version directory.
+
+    Applies to `version_dir` itself so the user can traverse it, then recursively
+    to `protocols/` and `data_files/` when those exist. Other files in the
+    version directory, including the SQLite database, are left unchanged.
+
+    `version_dir` is setgid so children created later inherit group `ot-protocol`.
+    """
+    apply_protocol_user_permissions(version_dir, recursive=False)
+    for name in (PROTOCOLS_DIRECTORY, DATA_FILES_DIRECTORY):
+        child = version_dir / name
+        if child.exists():
+            apply_protocol_user_permissions(child, recursive=True)
+
+
+def apply_protocol_user_permissions(path: Path, *, recursive: bool = False) -> None:
+    """Set protocol-user modes, and group ownership when `ot-protocol` exists.
+
+    Directories become setgid `02750` and files become `0640`. If the
+    `ot-protocol` user is missing, only the mode bits are changed.
+    """
+    gid = _protocol_user_gid()
+    _apply_to_path(path, gid)
+    if recursive and path.is_dir():
+        for item in path.rglob("*"):
+            _apply_to_path(item, gid)
+
+
+def _protocol_user_gid() -> int | None:
+    """Return the `ot-protocol` group id, or `None` if that user does not exist."""
+    try:
+        return pwd.getpwnam(PROTOCOL_USER_NAME).pw_gid
+    except KeyError:
+        return None
+
+
+def _apply_to_path(path: Path, gid: int | None) -> None:
+    if path.is_symlink() or not path.exists():
+        return
+
+    is_dir = path.is_dir()
+    if not is_dir:
+        os.chmod(path, PROTOCOL_FILE_PERMISSIONS)
+
+    if gid is not None:
+        try:
+            os.chown(path, -1, gid)
+        except PermissionError:
+            _log.warning(
+                "Could not set group ownership of %s to %s.",
+                path,
+                PROTOCOL_USER_NAME,
+                exc_info=True,
+            )
+
+    if is_dir:
+        os.chmod(path, _DIR_MODE_WITH_SETGID)

--- a/robot-server/robot_server/runs/run_process_pyro_provider.py
+++ b/robot-server/robot_server/runs/run_process_pyro_provider.py
@@ -17,12 +17,13 @@ import Pyro5.api
 from opentrons.config import feature_flags, robot_configs
 from opentrons.util.pyro.pyro_proxy_utility import wait_for_proxy
 
+from ..persistence.protocol_user_permissions import PROTOCOL_USER_NAME
 from . import run_process_entry_point
 from .run_process import DirectedRunProcess, register_process_types
 
 _log = logging.getLogger(__name__)
 
-_RESTRICTED_USER_NAME = "ot-protocol"
+_RESTRICTED_USER_NAME = PROTOCOL_USER_NAME
 _ROOT_USER_NAME = "root"
 
 _RUN_PROXY_NAME = (

--- a/robot-server/tests/persistence/test_manage_persistence_directory.py
+++ b/robot-server/tests/persistence/test_manage_persistence_directory.py
@@ -1,0 +1,50 @@
+"""Tests for preparing the robot-server persistence directory."""
+
+import stat
+from pathlib import Path
+
+import pytest
+
+from robot_server.persistence.file_and_directory_names import (
+    DATA_FILES_DIRECTORY,
+    DB_FILE,
+    PROTOCOLS_DIRECTORY,
+)
+from robot_server.persistence.manage_persistence_directory import (
+    prepare_active_subdirectory,
+)
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+async def test_prepare_active_subdirectory_grants_protocol_user_access(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After migrations, protocol files should be readable by ot-protocol."""
+    version_dir = tmp_path / "19"
+    protocol_dir = version_dir / PROTOCOLS_DIRECTORY / "protocol-id"
+    protocol_dir.mkdir(parents=True)
+    (protocol_dir / "protocol.py").write_text("# protocol")
+    (version_dir / DATA_FILES_DIRECTORY / "file-id").mkdir(parents=True)
+    (version_dir / DATA_FILES_DIRECTORY / "file-id" / "data.csv").write_text("a,b\n")
+    db_path = version_dir / DB_FILE
+    db_path.write_bytes(b"db")
+    db_mode_before = _mode(db_path)
+
+    async def _fake_prepare(orchestrator: object) -> Path:
+        return version_dir
+
+    monkeypatch.setattr(
+        "robot_server.persistence.manage_persistence_directory.server_utils_prepare_active_subdirectory",
+        _fake_prepare,
+    )
+
+    result = await prepare_active_subdirectory(tmp_path)
+
+    assert result == version_dir
+    assert _mode(version_dir) == 0o2750
+    assert _mode(protocol_dir / "protocol.py") == 0o640
+    assert _mode(version_dir / DATA_FILES_DIRECTORY / "file-id" / "data.csv") == 0o640
+    assert _mode(db_path) == db_mode_before

--- a/robot-server/tests/persistence/test_protocol_user_permissions.py
+++ b/robot-server/tests/persistence/test_protocol_user_permissions.py
@@ -1,0 +1,143 @@
+"""Tests for granting the ot-protocol user access to persistence files."""
+
+import os
+import stat
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+
+from robot_server.persistence import protocol_user_permissions as subject
+from robot_server.persistence.file_and_directory_names import (
+    DATA_FILES_DIRECTORY,
+    DB_FILE,
+    PROTOCOLS_DIRECTORY,
+)
+
+_PWD_GETPWNAM = "robot_server.persistence.protocol_user_permissions.pwd.getpwnam"
+_OS_CHOWN = "robot_server.persistence.protocol_user_permissions.os.chown"
+
+
+class _FakePwNam(NamedTuple):
+    pw_gid: int
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def _build_version_dir(tmp_path: Path) -> Path:
+    version_dir = tmp_path / "19"
+    version_dir.mkdir()
+    (version_dir / DB_FILE).write_bytes(b"db")
+
+    protocol_dir = version_dir / PROTOCOLS_DIRECTORY / "protocol-id"
+    protocol_dir.mkdir(parents=True)
+    (protocol_dir / "protocol.py").write_text("# protocol")
+
+    data_file_dir = version_dir / DATA_FILES_DIRECTORY / "file-id"
+    data_file_dir.mkdir(parents=True)
+    (data_file_dir / "data.csv").write_text("a,b\n")
+
+    return version_dir
+
+
+def _missing_user(name: str) -> object:
+    raise KeyError(name)
+
+
+def test_grant_skips_chown_when_user_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When ot-protocol does not exist, chmod still runs and chown does not."""
+    monkeypatch.setattr(_PWD_GETPWNAM, _missing_user)
+    chown_calls: list[tuple[str, int, int]] = []
+    monkeypatch.setattr(
+        _OS_CHOWN,
+        lambda path, uid, gid: chown_calls.append((os.fspath(path), uid, gid)),
+    )
+
+    version_dir = _build_version_dir(tmp_path)
+    db_mode_before = _mode(version_dir / DB_FILE)
+
+    subject.grant_protocol_user_access(version_dir)
+
+    assert chown_calls == []
+    assert _mode(version_dir) == 0o2750
+    assert _mode(version_dir / PROTOCOLS_DIRECTORY) == 0o2750
+    assert _mode(version_dir / PROTOCOLS_DIRECTORY / "protocol-id") == 0o2750
+    assert _mode(version_dir / PROTOCOLS_DIRECTORY / "protocol-id" / "protocol.py") == (
+        0o640
+    )
+    assert _mode(version_dir / DATA_FILES_DIRECTORY / "file-id" / "data.csv") == 0o640
+    assert _mode(version_dir / DB_FILE) == db_mode_before
+
+
+def test_grant_chowns_protocol_paths_not_database(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When ot-protocol exists, chown the version dir plus protocol and data files."""
+    monkeypatch.setattr(_PWD_GETPWNAM, lambda name: _FakePwNam(pw_gid=1234))
+    chown_calls: list[tuple[Path, int, int]] = []
+    monkeypatch.setattr(
+        _OS_CHOWN,
+        lambda path, uid, gid: chown_calls.append((Path(path), uid, gid)),
+    )
+
+    version_dir = _build_version_dir(tmp_path)
+    db_path = version_dir / DB_FILE
+    db_mode_before = _mode(db_path)
+
+    subject.grant_protocol_user_access(version_dir)
+
+    chowned_paths = {path.resolve() for path, _uid, gid in chown_calls}
+    assert all(gid == 1234 for _path, _uid, gid in chown_calls)
+    assert all(uid == -1 for _path, uid, _gid in chown_calls)
+
+    assert version_dir.resolve() in chowned_paths
+    assert (version_dir / PROTOCOLS_DIRECTORY).resolve() in chowned_paths
+    assert (
+        version_dir / PROTOCOLS_DIRECTORY / "protocol-id"
+    ).resolve() in chowned_paths
+    assert (
+        version_dir / PROTOCOLS_DIRECTORY / "protocol-id" / "protocol.py"
+    ).resolve() in chowned_paths
+    assert (version_dir / DATA_FILES_DIRECTORY).resolve() in chowned_paths
+    assert (
+        version_dir / DATA_FILES_DIRECTORY / "file-id" / "data.csv"
+    ).resolve() in chowned_paths
+    assert db_path.resolve() not in chowned_paths
+    assert _mode(db_path) == db_mode_before
+
+
+def test_grant_swallows_chown_permission_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-root process should still chmod even if chown is denied."""
+    monkeypatch.setattr(_PWD_GETPWNAM, lambda name: _FakePwNam(pw_gid=1234))
+
+    def _deny_chown(path: object, uid: int, gid: int) -> None:
+        raise PermissionError(13, "Operation not permitted")
+
+    monkeypatch.setattr(_OS_CHOWN, _deny_chown)
+
+    version_dir = tmp_path / "19"
+    version_dir.mkdir()
+
+    subject.grant_protocol_user_access(version_dir)
+
+    assert _mode(version_dir) == 0o2750
+
+
+def test_grant_ignores_missing_protocol_trees(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An empty version directory should still get directory modes."""
+    monkeypatch.setattr(_PWD_GETPWNAM, _missing_user)
+
+    version_dir = tmp_path / "19"
+    version_dir.mkdir()
+
+    subject.grant_protocol_user_access(version_dir)
+
+    assert _mode(version_dir) == 0o2750

--- a/robot-server/tests/persistence/test_v16_to_v17.py
+++ b/robot-server/tests/persistence/test_v16_to_v17.py
@@ -1,0 +1,51 @@
+"""Tests for the schema 16 to 17 persistence migration."""
+
+import stat
+from pathlib import Path
+
+from robot_server.persistence._migrations.v16_to_v17 import Migration16to17
+from robot_server.persistence.file_and_directory_names import (
+    DB_FILE,
+    PROTOCOLS_DIRECTORY,
+)
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def test_migrate_applies_protocol_user_permissions(tmp_path: Path) -> None:
+    """Copied protocol files should get 02750/0640 so ot-protocol can read them."""
+    source_dir = tmp_path / "16"
+    dest_dir = tmp_path / "17"
+    source_dir.mkdir()
+    dest_dir.mkdir()
+
+    protocol_dir = source_dir / PROTOCOLS_DIRECTORY / "protocol-id"
+    protocol_dir.mkdir(parents=True)
+    (protocol_dir / "protocol.py").write_text("# protocol")
+    (source_dir / DB_FILE).write_bytes(b"db")
+    db_mode_before_copy = _mode(source_dir / DB_FILE)
+
+    Migration16to17(subdirectory="17").migrate(source_dir, dest_dir)
+
+    assert _mode(dest_dir / PROTOCOLS_DIRECTORY) == 0o2750
+    assert _mode(dest_dir / PROTOCOLS_DIRECTORY / "protocol-id") == 0o2750
+    assert (
+        _mode(dest_dir / PROTOCOLS_DIRECTORY / "protocol-id" / "protocol.py") == 0o640
+    )
+    assert _mode(dest_dir / DB_FILE) == db_mode_before_copy
+
+
+def test_migrate_skips_permissions_when_protocols_dir_missing(tmp_path: Path) -> None:
+    """A persistence tree without protocols/ should still copy other files."""
+    source_dir = tmp_path / "16"
+    dest_dir = tmp_path / "17"
+    source_dir.mkdir()
+    dest_dir.mkdir()
+    (source_dir / DB_FILE).write_bytes(b"db")
+
+    Migration16to17(subdirectory="17").migrate(source_dir, dest_dir)
+
+    assert not (dest_dir / PROTOCOLS_DIRECTORY).exists()
+    assert (dest_dir / DB_FILE).exists()


### PR DESCRIPTION
Closes [RQA-6105](https://opentrons.atlassian.net/browse/RQA-6105)

# Overview

After CRS is first enabled, the robot reboots and robot-server wipes persistence, then recreates schema `19/` as `0750 root:root`. oe-core's systemd-tmpfiles already ran earlier in that boot and only chowns paths that already exist, so it never sees the new tree. Protocol execution then runs as Linux user `ot-protocol`, which cannot traverse that directory. `POST /runs` fails with `PermissionError.` A second reboot “fixes” it because tmpfiles finally sees `19/` and sets group ot-protocol.

To fix, when robot-server finishes creating or migrating the version directory, it now applies the access policy itself: dirs `02750` (`setgid` + `0750`), files `0640`, and group `ot-protocol`. `Setgid` means later uploads inherit that group, so we do not chmod on every write. Copied files in the 16 to 17 migration still go through the helper, because copy keeps old `0700` modes and `setgid` does not rewrite existing files.

### Current behavior 

After first boot into CRS

https://github.com/user-attachments/assets/eba7ac25-e398-4442-b44e-8e62ad7697d8

### Fixed behavior

After first boot into CRS

https://github.com/user-attachments/assets/92c8dfaf-d574-41a1-8cd0-3db2056a1b5e

## Test Plan and Hands on Testing

- See videos.

## Changelog

- Fixed a bug in which users couldn't send protocols to the robot on the first boot after enabling CRS.

## Review requests

- Are we happy with the overall approach here?

## Risk assessment

- Medium...I think. We only change peristence under `robot-server`, so the blast radius is CRS + subprocess protocol execution. 

[RQA-6105]: https://opentrons.atlassian.net/browse/RQA-6105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ