### PR TITLE
fix(update-server): stop partition writes when an update session is cancelled

### DIFF
--- a/update-server/otupdate/common/session.py
+++ b/update-server/otupdate/common/session.py
@@ -2,17 +2,23 @@
 Update session object for tracking state across multiple calls
 """
 
+import asyncio
 import base64
 import enum
 import logging
 import os
 import shutil
+import threading
 import uuid
 from typing import Mapping, NamedTuple, Optional, Union
 
 from server_utils.fastapi_utils.app_state import AppState, AppStateAccessor
 
 LOG = logging.getLogger(__name__)
+
+
+class UpdateCancelled(Exception):
+    """Raised when an update session is cancelled during validate or write."""
 
 
 class Value(NamedTuple):
@@ -49,6 +55,9 @@ class UpdateSession:
 
         self._storage_path = storage_path
         self._auto_commit_and_restart = auto_commit_and_restart
+        self._cancelled = threading.Event()
+        self._pipeline_task: asyncio.Task[None] | None = None
+        self._commit_started = False
 
         self._setup_dl_area()
 
@@ -63,6 +72,50 @@ class UpdateSession:
         """Clean up the storage used by this session."""
         shutil.rmtree(self._storage_path)
         LOG.info(f"Update session: removed {self._token}")
+
+    def request_cancel(self) -> None:
+        """Signal the pipeline to stop at the next progress checkpoint."""
+        self._cancelled.set()
+
+    def check_not_cancelled(self) -> None:
+        """Raise UpdateCancelled if cancel has been requested."""
+        if self._cancelled.is_set():
+            raise UpdateCancelled()
+
+    def set_pipeline_task(self, task: asyncio.Task[None]) -> None:
+        """Record the background validate/write/commit task for this session."""
+        self._pipeline_task = task
+
+    async def wait_for_pipeline(self) -> None:
+        """Wait until the background pipeline has stopped.
+
+        Must be called after request_cancel() so the pipeline can abort. Do not
+        delete session storage until this returns.
+        """
+        task = self._pipeline_task
+        if task is None:
+            return
+        try:
+            await task
+        except Exception:
+            LOG.exception(
+                f"Update session {self._token}: pipeline finished with an error during cancel"
+            )
+
+    def start_commit(self) -> bool:
+        """Claim commit for this session.
+
+        Returns False if the session is not ready, has been cancelled, or a
+        commit is already in progress. Does not change the public stage.
+        """
+        if self._cancelled.is_set():
+            return False
+        if self._stage != Stages.DONE:
+            return False
+        if self._commit_started:
+            return False
+        self._commit_started = True
+        return True
 
     def set_stage(self, stage: Stages) -> None:
         """Convenience method to set the stage and lookup message"""
@@ -80,6 +133,7 @@ class UpdateSession:
         self.set_stage(Stages.ERROR)
 
     def set_progress(self, progress: float) -> None:
+        self.check_not_cancelled()
         self._progress = progress
 
     @property
@@ -139,6 +193,19 @@ class UpdateSession:
 
 
 _session_accessor = AppStateAccessor[UpdateSession]("otupdate_session")
+_session_lock_accessor = AppStateAccessor[asyncio.Lock]("otupdate_session_lock")
+
+
+def install_session_lock(app_state: AppState) -> None:
+    """Create the lock that serializes begin/cancel. Call during server startup."""
+    _session_lock_accessor.set_on(app_state, asyncio.Lock())
+
+
+def get_session_lock(app_state: AppState) -> asyncio.Lock:
+    """Return the lock that serializes begin/cancel."""
+    session_lock = _session_lock_accessor.get_from(app_state)
+    assert session_lock is not None, "Forgot to install_session_lock() during startup?"
+    return session_lock
 
 
 def get_current_session(app_state: AppState) -> UpdateSession | None:

--- a/update-server/otupdate/common/update.py
+++ b/update-server/otupdate/common/update.py
@@ -34,7 +34,14 @@ from server_utils.fastapi_utils.app_state import AppState, get_app_state
 from . import config, multipart, update_actions
 from .api_error import APIError, ErrorBody
 from .control import get_restart_lock, no_actions_set_error
-from .session import Stages, UpdateSession, get_current_session, set_current_session
+from .session import (
+    Stages,
+    UpdateCancelled,
+    UpdateSession,
+    get_current_session,
+    get_session_lock,
+    set_current_session,
+)
 from otupdate.openembedded.update_actions import UPDATE_PKG_OE
 
 VALID_UPDATE_PKG = UPDATE_PKG_OE
@@ -83,7 +90,6 @@ def require_session(
 async def begin(
     request: fastapi.Request,
     app_state: Annotated[AppState, fastapi.Depends(get_app_state)],
-    current_session: Annotated[Optional[UpdateSession], fastapi.Depends(get_session)],
     server_config: Annotated[config.Config, fastapi.Depends(config.get_config)],
 ) -> JSONResponse:
     """Begin (create) a session.
@@ -116,39 +122,37 @@ async def begin(
       auto_commit_and_restart?: boolean
     }
     """
-    if current_session is not None:
-        LOG.warning("begin: requested with active session")
-        raise APIError(
-            409,
-            ErrorBody(
-                error="session-already-active",
-                message="An update session is already active on this robot",
-            ),
+    async with get_session_lock(app_state):
+        if get_current_session(app_state) is not None:
+            LOG.warning("begin: requested with active session")
+            raise APIError(
+                409,
+                ErrorBody(
+                    error="session-already-active",
+                    message="An update session is already active on this robot",
+                ),
+            )
+
+        try:
+            options = await _BeginSessionOptions.parse_from_request(request)
+        except _BeginSessionOptions.ParseError as e:
+            raise APIError(
+                400,
+                ErrorBody(error="invalid-request", message=e.message_for_response),
+            ) from e
+
+        session = UpdateSession(
+            storage_path=server_config.download_storage_path,
+            auto_commit_and_restart=options.auto_commit_and_restart,
         )
-        # fixme(mm, 2026-07-06): There's a concurrency hazard here because we're checking
-        # for a preexisting session and setting the new session non-atomically. Two
-        # concurrent requests can result in two simultaneous active sessions.
-
-    try:
-        options = await _BeginSessionOptions.parse_from_request(request)
-    except _BeginSessionOptions.ParseError as e:
-        raise APIError(
-            400,
-            ErrorBody(error="invalid-request", message=e.message_for_response),
-        ) from e
-
-    session = UpdateSession(
-        storage_path=server_config.download_storage_path,
-        auto_commit_and_restart=options.auto_commit_and_restart,
-    )
-    set_current_session(app_state, session)
-    return JSONResponse(
-        status_code=201,
-        content={
-            "token": session.token,
-            "auto_commit_and_restart": session.auto_commit_and_restart,
-        },
-    )
+        set_current_session(app_state, session)
+        return JSONResponse(
+            status_code=201,
+            content={
+                "token": session.token,
+                "auto_commit_and_restart": session.auto_commit_and_restart,
+            },
+        )
 
 
 @router.get("/server/update/{session}/status", summary="Report an update's progress.")
@@ -251,11 +255,7 @@ async def commit(
     restart_lock: Annotated[asyncio.Lock, fastapi.Depends(get_restart_lock)],
 ) -> JSONResponse:
     """Serves /update/:session/commit"""
-    if session.stage != Stages.DONE:
-        # fixme(mm, 2026-07-07): This stage check is insufficient; it can allow
-        # multiple commits to run concurrently on a single session, because we
-        # non-atomically enforce Stages.DONE, do commit process, and then set
-        # Stages.READY_FOR_RESTART.
+    if not session.start_commit():
         raise APIError(
             409,
             ErrorBody(
@@ -283,16 +283,14 @@ async def commit(
 )
 async def cancel(
     app_state: Annotated[AppState, fastapi.Depends(get_app_state)],
-    session: Annotated[Optional[UpdateSession], fastapi.Depends(get_session)],
 ) -> JSONResponse:
-    if session is not None:
-        # fixme(mm, 2026-07-06):
-        #   * This is a concurrency hazard: it might close a session and delete its
-        #     storage while a background task is still using it.
-        #   * session.close() currently only cleans up storage. We also need to clean
-        #     up background tasks.
-        session.close()
-        set_current_session(app_state, None)
+    async with get_session_lock(app_state):
+        session = get_current_session(app_state)
+        if session is not None:
+            session.request_cancel()
+            await session.wait_for_pipeline()
+            session.close()
+            set_current_session(app_state, None)
     return JSONResponse(status_code=200, content={"message": "Session cancelled"})
 
 
@@ -360,15 +358,19 @@ def _begin_validate_and_write(
             session.set_progress,
             cert_path,
         )
+        session.check_not_cancelled()
 
         session.set_progress(0)
         session.set_stage(Stages.WRITING)
         await asyncio.to_thread(actions.write_update, rootfs_file, session.set_progress)
+        session.check_not_cancelled()
 
         LOG.info(f"Finished update session {session}")
         session.set_stage(Stages.DONE)
 
         if not session.auto_commit_and_restart:
+            return
+        if not session.start_commit():
             return
         await _commit(
             restart_lock,
@@ -393,13 +395,15 @@ def _begin_validate_and_write(
     async def background_task_with_error_handling() -> None:
         try:
             await background_task()
-        except Exception as exc:
-            LOG.exception(
-                f"Error in background task for session {session.token}.", exc_info=exc
-            )
-            session.set_error(getattr(exc, "short", str(type(exc))), str(exc))
+        except UpdateCancelled:
+            LOG.info(f"Update session {session.token} cancelled.")
+        except Exception as extra:
+            LOG.exception(f"Error in background task for session {session.token}.")
+            session.set_error(getattr(extra, "short", str(type(extra))), str(extra))
 
-    asyncio.create_task(background_task_with_error_handling())
+    session.set_pipeline_task(
+        asyncio.create_task(background_task_with_error_handling())
+    )
 
 
 async def _commit(

--- a/update-server/otupdate/openembedded/__init__.py
+++ b/update-server/otupdate/openembedded/__init__.py
@@ -25,6 +25,7 @@ from otupdate.common import (
     constants,
     control,
     name_management,
+    session,
     ssh_key_management,
     update,
     update_actions,
@@ -103,6 +104,7 @@ async def get_app(
     app.middleware("http")(audit_logger_middleware)
 
     config.install_config(app.state, config_obj)
+    session.install_session_lock(app.state)
     control.install_control(
         app.state,
         boot_id=boot_id,

--- a/update-server/otupdate/openembedded/update_actions.py
+++ b/update-server/otupdate/openembedded/update_actions.py
@@ -19,6 +19,7 @@ from otupdate.common.file_actions import (
     unzip_update,
     verify_signature,
 )
+from otupdate.common.session import UpdateCancelled
 from otupdate.common.update_actions import Partition, UpdateActionsInterface
 
 UPDATE_PKG_OE = ["system-update.zip"]
@@ -122,6 +123,7 @@ class RootFSInterface:
                 while True:
                     chunk = fsrc.read(chunk_size)
                     total_size += len(chunk)
+                    progress_callback(0)
                     if len(chunk) != chunk_size:
                         break
 
@@ -144,6 +146,8 @@ class RootFSInterface:
                     if len(chunk) != chunk_size:
                         break
             return True, ""
+        except UpdateCancelled:
+            raise
         except Exception:
             LOG.exception("RootFSInterface::write_update exception reading")
             return False, "Unknown error"

--- a/update-server/tests/common/test_update.py
+++ b/update-server/tests/common/test_update.py
@@ -4,8 +4,11 @@ import asyncio
 import binascii
 import hashlib
 import os
+import threading
+import time
 import zipfile
-from typing import Tuple
+from typing import Callable, Tuple
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -14,9 +17,9 @@ from tests.openembedded.conftest import (
     mock_partition_manager_valid_switch_,
 )
 
-from otupdate.common import config, file_actions, update
+from otupdate.common import config, file_actions, update, update_actions
 from otupdate.common.session import Stages, UpdateSession, get_current_session
-from otupdate.common.update_actions import UpdateActionsInterface
+from otupdate.common.update_actions import Partition, UpdateActionsInterface
 from otupdate.openembedded import OT3UpdateActions, RootFSInterface
 
 
@@ -110,6 +113,122 @@ async def test_cancel(test_cli: Tuple[UpdateServerClient, str]):
 
     resp = await test_cli[0].post("/server/update/cancel")
     assert resp.status_code == 200
+
+
+async def _wait_for_thread_event(event: threading.Event, timeout: float = 5) -> None:
+    deadline = time.monotonic() + timeout
+    while not event.is_set():
+        if time.monotonic() > deadline:
+            raise AssertionError("timed out waiting for update pipeline")
+        await asyncio.sleep(0.01)
+
+
+def _install_mock_actions(
+    test_cli: Tuple[UpdateServerClient, str],
+) -> MagicMock:
+    actions = MagicMock(spec=update_actions.UpdateActionsInterface)
+    actions.validate_update.return_value = "rootfs"
+    actions.write_update.return_value = Partition(2, "/dev/null")
+    update_actions.install_update_actions(test_cli[0].asgi_app.state, actions)
+    return actions
+
+
+async def test_concurrent_begin_only_one_succeeds(
+    test_cli: Tuple[UpdateServerClient, str],
+) -> None:
+    first, second = await asyncio.gather(
+        test_cli[0].post("/server/update/begin"),
+        test_cli[0].post("/server/update/begin"),
+    )
+    statuses = sorted(r.status_code for r in (first, second))
+    assert statuses == [201, 409]
+    assert current_session(test_cli) is not None
+
+
+async def test_cancel_during_write_skips_autocommit_and_allows_begin(
+    test_cli: Tuple[UpdateServerClient, str],
+) -> None:
+    write_started = threading.Event()
+    actions = _install_mock_actions(test_cli)
+
+    def slow_write(
+        rootfs_filepath: str,
+        progress_callback: Callable[[float], None],
+        chunk_size: int = -1,
+        file_size: object = None,
+    ) -> Partition:
+        write_started.set()
+        for i in range(1000):
+            progress_callback(i / 1000)
+            time.sleep(0.01)
+        return Partition(2, "/dev/null")
+
+    actions.write_update.side_effect = slow_write
+
+    begin = await test_cli[0].post(
+        "/server/update/begin", json={"auto_commit_and_restart": True}
+    )
+    assert begin.status_code == 201
+    token = begin.json()["token"]
+
+    upload = await test_cli[0].post(
+        session_endpoint(token, "file"),
+        files={"system-update.zip": ("system-update.zip", b"pretend this is a zip")},
+    )
+    assert upload.status_code == 201
+
+    await _wait_for_thread_event(write_started)
+
+    cancel = await test_cli[0].post("/server/update/cancel")
+    assert cancel.status_code == 200
+    assert current_session(test_cli) is None
+
+    actions.commit_update.assert_not_called()
+    actions.restart.assert_not_called()
+
+    retry = await test_cli[0].post("/server/update/begin")
+    assert retry.status_code == 201
+    assert current_session(test_cli) is not None
+    assert current_session(test_cli).token == retry.json()["token"]
+
+
+async def test_cancel_during_validate_does_not_write(
+    test_cli: Tuple[UpdateServerClient, str],
+) -> None:
+    validate_started = threading.Event()
+    actions = _install_mock_actions(test_cli)
+
+    def slow_validate(
+        filepath: str,
+        progress_callback: Callable[[float], None],
+        cert_path: object,
+    ) -> str:
+        validate_started.set()
+        for i in range(1000):
+            progress_callback(i / 1000)
+            time.sleep(0.01)
+        return "rootfs"
+
+    actions.validate_update.side_effect = slow_validate
+
+    begin = await test_cli[0].post("/server/update/begin")
+    assert begin.status_code == 201
+    token = begin.json()["token"]
+
+    upload = await test_cli[0].post(
+        session_endpoint(token, "file"),
+        files={"system-update.zip": ("system-update.zip", b"pretend this is a zip")},
+    )
+    assert upload.status_code == 201
+
+    await _wait_for_thread_event(validate_started)
+
+    cancel = await test_cli[0].post("/server/update/cancel")
+    assert cancel.status_code == 200
+    assert current_session(test_cli) is None
+    actions.write_update.assert_not_called()
+    actions.commit_update.assert_not_called()
+    actions.restart.assert_not_called()
 
 
 async def test_commit_fails_wrong_state(test_cli, update_session):

--- a/update-server/tests/openembedded/test_updater.py
+++ b/update-server/tests/openembedded/test_updater.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from otupdate.common.session import UpdateCancelled
 from otupdate.common.update_actions import Partition
 from otupdate.openembedded.update_actions import (
     OT3UpdateActions,
@@ -138,7 +139,8 @@ def test_lzma(testing_partition, tmpdir):
             calls = int(total_size / chunk_size) + 1
         else:
             calls = total_size / chunk_size
-        assert cb.call_count == calls
+        # Size-count pass and write pass each call the callback once per chunk.
+        assert cb.call_count == calls * 2
         assert success
         assert msg == ""
 
@@ -191,6 +193,45 @@ def test_write_update_fails(testing_partition, tmpdir):
         mock.Mock(return_value=1),
     ):
         success, msg = root_FS_intf.write_update(rfs_path, p, cb, chunk_size)
-        cb.assert_not_called()
+        assert all(call.args[0] == 0 for call in cb.call_args_list)
         assert not success
         assert msg != ""
+
+
+def test_write_update_aborts_during_size_count(testing_partition, tmpdir):
+    """Cancel during the xz size-count pass must propagate, not become a write failure."""
+    rfs_path = os.path.join(tmpdir, "rootfs.xz")
+    with lzma.open(rfs_path, "w") as f:
+        f.write(os.urandom(400000))
+    root_FS_intf = RootFSInterface()
+    p = Partition(2, testing_partition, "/media/mmcblk0p2")
+
+    def cb(_progress: float) -> None:
+        raise UpdateCancelled()
+
+    with mock.patch(
+        "otupdate.openembedded.update_actions.PartitionManager.get_partition_size",
+        mock.Mock(return_value=99999999),
+    ):
+        with pytest.raises(UpdateCancelled):
+            root_FS_intf.write_update(rfs_path, p, cb, 1024 * 32)
+
+
+def test_write_update_aborts_during_write_pass(testing_partition, tmpdir):
+    """Cancel once real progress starts must also propagate as UpdateCancelled."""
+    rfs_path = os.path.join(tmpdir, "rootfs.xz")
+    with lzma.open(rfs_path, "w") as f:
+        f.write(os.urandom(400000))
+    root_FS_intf = RootFSInterface()
+    p = Partition(2, testing_partition, "/media/mmcblk0p2")
+
+    def cb(progress: float) -> None:
+        if progress > 0:
+            raise UpdateCancelled()
+
+    with mock.patch(
+        "otupdate.openembedded.update_actions.PartitionManager.get_partition_size",
+        mock.Mock(return_value=99999999),
+    ):
+        with pytest.raises(UpdateCancelled):
+            root_FS_intf.write_update(rfs_path, p, cb, 1024 * 32)


### PR DESCRIPTION
# Overview

Cancel on the update server only dropped the HTTP session pointer. Validate/write still ran in a background thread, and the app always starts sessions with `auto_commit_and_restart`. After cancel, `POST /begin` succeeded, so a new session could `open()` the same unused rootfs partition while the old write was still going. The cancelled session could also finish, commit, and reboot. That is a torn inactive slot, or a boot onto a partial image. [#22435](https://github.com/Opentrons/opentrons/pull/22435) stopped the ODD from cancel/restart looping; this is the server half of the same race. The client still does the 409 to cancel to begin path, which was unsafe until cancel actually waited for the write.

To fix, the session owns the pipeline via a thread-safe cancel flag, the background task, and a lock around `begin`/`cancel`. Cancel sets the flag, waits for the task, then deletes storage and clears the session. `set_progress()` raises at the next chunk so the xz size-count and partition write abort instead of running to completion. If cancel happens during validate or write, the pipeline does not commit or reboot. If auto-commit has already started, cancel waits it out and does not tear that down. A second `begin` while a session is still active is still 409. The client's 409 to cancel to begin path now waits out the write on cancel, then `begin` succeeds.

## Test Plan and Hands on Testing

- Verified the happy path of robot updates works.
- Verified that refreshing the app halfway through an update and starting a new one still works.
- Verified that if two apps update at the same time, one succeeds and the other effectively fails.
- Verified update server logs reflect appropriate invariant actions.

## Changelog

Fixed a bug in which cancelling a robot software update did not stop the write, so a second update could overlap it and the robot could reboot onto a partial or unchanged image.

## Review requests

- Overall approach seem reasonable?

## Risk assessment

- Medium. Pretty comfortable with the test plan, but these changes touch critical update flow code, and I could be overlooking something.
