### PR TITLE
fix(components): keep  corners rounded when content scrolls in `ModalShell`

### DIFF
--- a/components/src/modals/ModalShell.tsx
+++ b/components/src/modals/ModalShell.tsx
@@ -161,7 +161,7 @@ const ModalArea = styled.div<
 `
 
 const ModalBody = styled.div.withConfig({
-  shouldForwardProp: prop => prop !== 'allowOverflow',
+  shouldForwardProp: prop => (prop as string) !== 'allowOverflow',
 })<{ allowOverflow: boolean }>`
   flex: ${FLEX_AUTO};
   min-height: 0;

--- a/components/src/modals/ModalShell.tsx
+++ b/components/src/modals/ModalShell.tsx
@@ -6,13 +6,16 @@ import {
   ALIGN_CENTER,
   ALIGN_END,
   CURSOR_DEFAULT,
+  DIRECTION_COLUMN,
   DISPLAY_FLEX,
+  FLEX_AUTO,
   JUSTIFY_CENTER,
   JUSTIFY_END,
   OVERFLOW_AUTO,
+  OVERFLOW_HIDDEN,
+  OVERFLOW_VISIBLE,
   POSITION_ABSOLUTE,
   POSITION_RELATIVE,
-  POSITION_STICKY,
 } from '../styles'
 import { RESPONSIVENESS, SPACING } from '../ui-style-constants'
 
@@ -25,9 +28,9 @@ export interface ModalShellProps extends StyleProps {
   children: ReactNode
   /** Optional close on outside click **/
   onOutsideClick?: MouseEventHandler
-  /** Optional sticky header */
+  /** Optional header */
   header?: ReactNode
-  /** Optional sticky footer */
+  /** Optional footer */
   footer?: ReactNode
   /** Optional full page takeover */
   fullPage?: boolean
@@ -46,9 +49,10 @@ export interface ModalShellProps extends StyleProps {
  *
  * It includes:
  * - An overlay
- * - A content area, with `overflow-y: auto` and customizable with style props
- * - An optional sticky header
- * - An optional sticky footer
+ * - A shell clipped to border-radius (overflow: hidden) so corners stay rounded
+ * - A content area that scrolls independently of the header and footer
+ * - An optional header
+ * - An optional footer
  * - An optional onOutsideClick function
  */
 export function ModalShell(props: ModalShellProps): JSX.Element {
@@ -65,6 +69,12 @@ export function ModalShell(props: ModalShellProps): JSX.Element {
     noPadding = false,
     ...styleProps
   } = props
+
+  // Keep nested clipping off when a caller opts into overflow: visible
+  // (ex, dropdown menus that must extend outside the modal).
+  const allowOverflow =
+    styleProps.overflow === OVERFLOW_VISIBLE ||
+    styleProps.overflowY === OVERFLOW_VISIBLE
 
   return (
     <Overlay
@@ -88,7 +98,7 @@ export function ModalShell(props: ModalShellProps): JSX.Element {
           {...styleProps}
         >
           {header != null ? <Header>{header}</Header> : null}
-          {children}
+          <ModalBody allowOverflow={allowOverflow}>{children}</ModalBody>
           {footer != null ? <Footer>{footer}</Footer> : null}
         </ModalArea>
       </ContentArea>
@@ -134,7 +144,9 @@ const ModalArea = styled.div<
   { isFullPage: boolean; backgroundColor?: string } & StyleProps
 >`
   position: ${POSITION_RELATIVE};
-  overflow-y: ${OVERFLOW_AUTO};
+  display: ${DISPLAY_FLEX};
+  flex-direction: ${DIRECTION_COLUMN};
+  overflow: ${OVERFLOW_HIDDEN};
   max-height: 100%;
   width: 100%;
   border-radius: ${BORDERS.borderRadius8};
@@ -148,16 +160,26 @@ const ModalArea = styled.div<
   ${styleProps as any};
 `
 
+const ModalBody = styled.div.withConfig({
+  shouldForwardProp: prop => prop !== 'allowOverflow',
+})<{ allowOverflow: boolean }>`
+  flex: ${FLEX_AUTO};
+  min-height: 0;
+  overflow-y: ${({ allowOverflow }) =>
+    allowOverflow ? OVERFLOW_VISIBLE : OVERFLOW_AUTO};
+`
+
 const Footer = styled.div`
+  flex-shrink: 0;
+  overflow: ${OVERFLOW_HIDDEN};
   background-color: ${COLORS.white};
-  position: ${POSITION_STICKY};
-  bottom: 0;
+  border-bottom-left-radius: inherit;
+  border-bottom-right-radius: inherit;
 `
 const Header = styled.div`
+  flex-shrink: 0;
+  overflow: ${OVERFLOW_HIDDEN};
   background-color: ${COLORS.white};
-  position: ${POSITION_STICKY};
-  top: 0;
-  overflow: hidden;
   border-top-left-radius: inherit;
   border-top-right-radius: inherit;
 `


### PR DESCRIPTION
Closes [RQA-6115](https://opentrons.atlassian.net/browse/RQA-6115)

# Overview

The app update modal lost their top-right and bottom-right radius because `overflow-y: auto` put the scrollbar on the same element as `border-radius`.

To fix, let's do what we do elsewhere: clip the shell with `overflow: hidden`, scroll the body instead, and inherit bottom radii on the footer the same way the header already inherits the top.

Existing callers that set `overflow: visible` (ex., Add User / Edit User dropdowns in CRS) still skip that inner clipping.

### Current behavior

<img width="1920" height="1433" alt="image (2)" src="https://github.com/user-attachments/assets/9875f0fa-6e81-4d6a-a76a-a5b24dd64cc3" />

### Fixed behavior

<img width="1021" height="768" alt="Screenshot 2026-09-09 at 5 45 14 PM" src="https://github.com/user-attachments/assets/3ab7a44a-3bf0-4d38-a03b-d506a6fe01fa" />

## Test Plan and Hands on Testing

- See images
- Smoked tested a bunch of other `ModalShell` usages in the app. There doesn't appear to be any clear regressive behavior!

## Risk assessment

- lowish - we do refactor a heavily used component, but it's easy to audit the refactors.


[RQA-6115]: https://opentrons.atlassian.net/browse/RQA-6115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ