### PR TITLE
fix(auth-server): allow CRS auditor accounts to log in after setting a password

### DIFF
--- a/auth-server/auth_server/users/scopes.py
+++ b/auth-server/auth_server/users/scopes.py
@@ -30,10 +30,17 @@ def get_scope_set_of_account_type(
             return set(Scope)  # All scopes.
 
         elif account_type == AccountType.AUDITOR:
-            # Auditors should have read-only access to everything. Our read-only endpoints are
-            # mostly accessible without authentication, but there are some exceptions. This
-            # just needs to have the scopes to cover those exceptions.
-            return {Scope.USERS_READ_OTHERS}
+            # Auditors should have read-only access to the robot. Most read endpoints
+            # do not require authentication; these scopes cover the exceptions.
+            #
+            # USERS_READ_OTHERS: list and read other users.
+            # USERS_READ_SELF: GET /auth/users/self after login.
+            # USERS_WRITE_SELF: change own password and profile.
+            return {
+                Scope.USERS_READ_OTHERS,
+                Scope.USERS_READ_SELF,
+                Scope.USERS_WRITE_SELF,
+            }
 
         elif account_type == AccountType.USER:
             result = {

--- a/auth-server/tests/integration/test_reset_password_flow.tavern.yaml
+++ b/auth-server/tests/integration/test_reset_password_flow.tavern.yaml
@@ -257,3 +257,179 @@ stages:
         error: invalid_grant
         error_description: Invalid credentials given.
         opentrons_login_attempts_remaining: !anyint
+
+---
+test_name: Auditor first login can fetch and update self after setting a password
+
+marks:
+  - usefixtures:
+      - run_server
+      - admin_access_token
+      - seed_users
+
+stages:
+  - name: Enable access control mode
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/settings/accessControlEnabled'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          accessControlEnabled: true
+    response:
+      status_code: 200
+      strict:
+        - json:off
+
+  - name: Create an auditor without a password
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/users'
+      json:
+        data:
+          username: auditor_login
+          fullName: Auditor Login User
+          accountType: auditor
+      headers:
+        Authorization: '{admin_access_token}'
+    response:
+      status_code: 201
+      save:
+        json:
+          temporary_password: data.temporaryPassword
+      json:
+        data:
+          username: auditor_login
+          fullName: Auditor Login User
+          accountType: auditor
+          locked: false
+          resetPassword: true
+          temporaryPassword: !anystr
+
+  - name: Auditor logs in with the temporary password and only gets self scopes
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: password
+        username: auditor_login
+        password: '{temporary_password}'
+    response:
+      status_code: 200
+      save:
+        json:
+          auditor_access_token: access_token
+      json:
+        access_token: !anystr
+        refresh_token: !anystr
+        token_type: Bearer
+        expires_in: !anyint
+        scope: users.read.self users.write.self
+
+  - name: Auditor can GET self while resetPassword is true
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        authorization: 'Bearer {auditor_access_token}'
+    response:
+      status_code: 200
+      json:
+        data:
+          username: auditor_login
+          fullName: Auditor Login User
+          accountType: auditor
+          locked: false
+          resetPassword: true
+
+  - name: Auditor sets a new password via update self
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        authorization: 'Bearer {auditor_access_token}'
+      json:
+        data:
+          password: chosenpassword456
+    response:
+      status_code: 200
+      json:
+        data:
+          username: auditor_login
+          fullName: Auditor Login User
+          accountType: auditor
+          locked: false
+          resetPassword: false
+
+  - name: Auditor can log in with the new password and gets auditor scopes
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: password
+        username: auditor_login
+        password: chosenpassword456
+    response:
+      status_code: 200
+      save:
+        json:
+          auditor_access_token: access_token
+      json:
+        access_token: !anystr
+        refresh_token: !anystr
+        token_type: Bearer
+        expires_in: !anyint
+        scope: users.read.others users.read.self users.write.self
+
+  - name: Auditor can GET self after logging in with the new password
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        authorization: 'Bearer {auditor_access_token}'
+    response:
+      status_code: 200
+      json:
+        data:
+          username: auditor_login
+          fullName: Auditor Login User
+          accountType: auditor
+          locked: false
+          resetPassword: false
+
+  - name: Auditor can update their own profile
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        authorization: 'Bearer {auditor_access_token}'
+      json:
+        data:
+          fullName: Updated Auditor Name
+    response:
+      status_code: 200
+      json:
+        data:
+          username: auditor_login
+          fullName: Updated Auditor Name
+          accountType: auditor
+          locked: false
+          resetPassword: false
+
+  - name: Auditor can still read other users
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/users/byUsername/testadmin'
+      headers:
+        authorization: 'Bearer {auditor_access_token}'
+    response:
+      status_code: 200
+      json:
+        data:
+          username: testadmin
+          accountType: admin
+      strict:
+        - json:off

--- a/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
@@ -1032,7 +1032,7 @@ stages:
       status_code: 200
       json:
         access_token: !anystr
-        scope: users.read.others
+        scope: users.read.others users.read.self users.write.self
       strict:
         - json:off
 


### PR DESCRIPTION
Closes [RQA-6124](https://opentrons.atlassian.net/browse/RQA-6124)

# Overview

CRS auditor accounts could complete the forced first-login password reset, then failed to sign in with the new password. Turns out that account type didn't have `Scope.USERS_READ_SELF`, whoops. 

We also add `Scope.USERS_WRITE_SELF`, so auditors can update their own password. We add a bunch of tavern testing, too!

### Current behavior

https://github.com/user-attachments/assets/b5ae2a8b-9e0c-4212-9b94-46ccc83af89b

### Fixed behavior

https://github.com/user-attachments/assets/4cf3ef05-67c8-4ff2-96b0-eca5ff5dc066


## Test Plan and Hands on Testing

- Verified that the auditor account type can now log in after setting setting a password.
- Tavern testing!

## Changelog

- Fixed a bug in which auditor accounts could not log in after setting a new password.

## Review requests

- Should auditor accounts be able to update their own password? I'm not sure if the lack of this scope was an oversight or simply missed during devleopment.

## Risk assessment

- very low, quite auditable changes and a lot more testing.


[RQA-6124]: https://opentrons.atlassian.net/browse/RQA-6124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ