### PR TITLE
fix(app): log out CRS admins after actions that end their own session

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/EditUserModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/EditUserModal.tsx
@@ -106,14 +106,15 @@ export function EditUserModal({
     const didChangeRole = data.accountType !== user.accountType
     const submittedTrimmedUsername = data.username.trim()
     const submittedTrimmedFullName = data.fullName.trim()
+    const didChangeUsername = submittedTrimmedUsername !== user.username
+    const shouldLogOut =
+      loggedInUsername === user.username && (didChangeUsername || didChangeRole)
 
     const updatePromise = updateUser({
       username: user.username,
       request: {
         data: {
-          ...(submittedTrimmedUsername !== user.username
-            ? { username: submittedTrimmedUsername }
-            : {}),
+          ...(didChangeUsername ? { username: submittedTrimmedUsername } : {}),
           ...(submittedTrimmedFullName !== user.fullName
             ? { fullName: submittedTrimmedFullName }
             : {}),
@@ -125,7 +126,7 @@ export function EditUserModal({
       .then(() => {
         onUserUpdated?.()
         handleClose()
-        if (didChangeRole && loggedInUsername === user.username) {
+        if (shouldLogOut) {
           dispatch(logOut({ robotName }))
         }
       })

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/__tests__/UserManagement.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/__tests__/UserManagement.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom/vitest'
 
 import { fireEvent, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   useDeleteUserMutation,
@@ -14,11 +14,13 @@ import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { useToaster } from '/app/organisms/ToasterOven'
+import { logOut } from '/app/redux/robot-auth'
 
 import { UserManagement } from '..'
 
 import type { RenderResult } from '@testing-library/react'
-import type { AuthUsersResponse } from '@opentrons/api-client'
+import type { Store } from 'redux'
+import type { AuthUser, AuthUsersResponse } from '@opentrons/api-client'
 import type { State } from '/app/redux/types'
 
 vi.mock('../AddUserModal', () => ({
@@ -59,23 +61,32 @@ const MOCK_AUTH_STATE = {
   expiresAt: null,
 }
 
+const ALICE_USER: AuthUser = {
+  username: 'alice',
+  fullName: 'Alice Example',
+  accountType: 'admin',
+  locked: false,
+  resetPassword: false,
+}
+
+const BOB_USER: AuthUser = {
+  username: 'bob',
+  fullName: 'Bob Example',
+  accountType: 'user',
+  locked: true,
+  resetPassword: false,
+}
+
+const CAROL_USER: AuthUser = {
+  username: 'carol',
+  fullName: 'Carol Example',
+  accountType: 'user',
+  locked: false,
+  resetPassword: false,
+}
+
 const MOCK_USERS_RESPONSE: AuthUsersResponse = {
-  data: [
-    {
-      username: 'alice',
-      fullName: 'Alice Example',
-      accountType: 'admin',
-      locked: false,
-      resetPassword: false,
-    },
-    {
-      username: 'bob',
-      fullName: 'Bob Example',
-      accountType: 'user',
-      locked: true,
-      resetPassword: false,
-    },
-  ],
+  data: [ALICE_USER, BOB_USER],
   meta: {
     cursor: 0,
     totalLength: 2,
@@ -84,7 +95,9 @@ const MOCK_USERS_RESPONSE: AuthUsersResponse = {
 
 vi.mock('@opentrons/react-api-client')
 
-const render = (initialState: Partial<State> = {}): RenderResult => {
+const render = (
+  initialState: Partial<State> = {}
+): [RenderResult, Store<State>] => {
   return renderWithProviders(<UserManagement robotName={ROBOT_NAME} />, {
     i18nInstance: i18n,
     initialState: {
@@ -96,7 +109,7 @@ const render = (initialState: Partial<State> = {}): RenderResult => {
       },
       ...initialState,
     } as State,
-  })[0]
+  })
 }
 
 function expandAccordion(): void {
@@ -137,6 +150,10 @@ describe('UserManagement', () => {
           data: options?.enabled === false ? undefined : MOCK_USERS_RESPONSE,
         }) as ReturnType<typeof useUsersQuery>
     )
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
   })
 
   it('renders the user management accordion', () => {
@@ -212,6 +229,60 @@ describe('UserManagement', () => {
     )
     fireEvent.click(screen.getByRole('button', { name: 'Reset password' }))
     screen.getByText("Reset this user's password?")
+  })
+
+  it('logs out and shows the one-time password when the logged-in user resets their own password', async () => {
+    mockResetUserPassword.mockResolvedValue({
+      data: { temporaryPassword: 'temp-password-123' },
+    })
+    const [, store] = render()
+    expandAccordion()
+    fireEvent.click(
+      screen.getByRole('button', { name: 'UserManagement_overflowMenu_alice' })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Reset password' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Reset password' }))
+
+    await vi.waitFor(() => {
+      expect(mockResetUserPassword).toHaveBeenCalledWith('alice')
+      expect(store.dispatch).toHaveBeenCalledWith(
+        logOut({ robotName: ROBOT_NAME })
+      )
+      screen.getByText('temp-password-123')
+    })
+  })
+
+  it('does not log out when resetting another user password', async () => {
+    mockResetUserPassword.mockResolvedValue({
+      data: { temporaryPassword: 'temp-password-456' },
+    })
+    vi.mocked(useUsersQuery).mockImplementation(
+      options =>
+        ({
+          data:
+            options?.enabled === false
+              ? undefined
+              : {
+                  data: [ALICE_USER, CAROL_USER],
+                  meta: { cursor: 0, totalLength: 2 },
+                },
+        }) as ReturnType<typeof useUsersQuery>
+    )
+    const [, store] = render()
+    expandAccordion()
+    fireEvent.click(
+      screen.getByRole('button', { name: 'UserManagement_overflowMenu_carol' })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Reset password' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Reset password' }))
+
+    await vi.waitFor(() => {
+      expect(mockResetUserPassword).toHaveBeenCalledWith('carol')
+      screen.getByText('temp-password-456')
+    })
+    expect(store.dispatch).not.toHaveBeenCalledWith(
+      logOut({ robotName: ROBOT_NAME })
+    )
   })
 
   it('shows Unlock in the overflow menu only for locked users', () => {

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/__tests__/UserManagement.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/__tests__/UserManagement.test.tsx
@@ -351,8 +351,8 @@ describe('UserManagement', () => {
     screen.getByText('Lock this account?')
   })
 
-  it('locks the user when confirmed in the lock modal', async () => {
-    render()
+  it('locks the user and logs out when the logged-in user locks their own account', async () => {
+    const [, store] = render()
     expandAccordion()
     fireEvent.click(
       screen.getByRole('button', { name: 'UserManagement_overflowMenu_alice' })
@@ -365,8 +365,43 @@ describe('UserManagement', () => {
         username: 'alice',
         request: { data: { locked: true } },
       })
+      expect(store.dispatch).toHaveBeenCalledWith(
+        logOut({ robotName: ROBOT_NAME })
+      )
     })
     expect(mockUpdateUser).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not log out when locking another user account', async () => {
+    vi.mocked(useUsersQuery).mockImplementation(
+      options =>
+        ({
+          data:
+            options?.enabled === false
+              ? undefined
+              : {
+                  data: [ALICE_USER, CAROL_USER],
+                  meta: { cursor: 0, totalLength: 2 },
+                },
+        }) as ReturnType<typeof useUsersQuery>
+    )
+    const [, store] = render()
+    expandAccordion()
+    fireEvent.click(
+      screen.getByRole('button', { name: 'UserManagement_overflowMenu_carol' })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Lock account' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Lock account' }))
+
+    await vi.waitFor(() => {
+      expect(mockUpdateUser).toHaveBeenCalledWith({
+        username: 'carol',
+        request: { data: { locked: true } },
+      })
+    })
+    expect(store.dispatch).not.toHaveBeenCalledWith(
+      logOut({ robotName: ROBOT_NAME })
+    )
   })
 
   it('unlocks and resets password when confirmed in the activate modal', async () => {

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/__tests__/UserManagement.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/__tests__/UserManagement.test.tsx
@@ -221,6 +221,52 @@ describe('UserManagement', () => {
     screen.getByText('Delete this account?')
   })
 
+  it('logs out when the logged-in user deletes their own account', async () => {
+    const [, store] = render()
+    expandAccordion()
+    fireEvent.click(
+      screen.getByRole('button', { name: 'UserManagement_overflowMenu_alice' })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Delete user' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await vi.waitFor(() => {
+      expect(mockDeleteUser).toHaveBeenCalledWith('alice')
+      expect(store.dispatch).toHaveBeenCalledWith(
+        logOut({ robotName: ROBOT_NAME })
+      )
+    })
+  })
+
+  it('does not log out when deleting another user account', async () => {
+    vi.mocked(useUsersQuery).mockImplementation(
+      options =>
+        ({
+          data:
+            options?.enabled === false
+              ? undefined
+              : {
+                  data: [ALICE_USER, CAROL_USER],
+                  meta: { cursor: 0, totalLength: 2 },
+                },
+        }) as ReturnType<typeof useUsersQuery>
+    )
+    const [, store] = render()
+    expandAccordion()
+    fireEvent.click(
+      screen.getByRole('button', { name: 'UserManagement_overflowMenu_carol' })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Delete user' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await vi.waitFor(() => {
+      expect(mockDeleteUser).toHaveBeenCalledWith('carol')
+    })
+    expect(store.dispatch).not.toHaveBeenCalledWith(
+      logOut({ robotName: ROBOT_NAME })
+    )
+  })
+
   it('opens the reset password confirm modal when Reset password is selected from the overflow menu', () => {
     render()
     expandAccordion()

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useDispatch } from 'react-redux'
 
 import {
   EmptySelectorButton,
@@ -16,7 +17,7 @@ import {
 import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
 import { useToaster } from '/app/organisms/ToasterOven'
-import { useUsernameForRobot } from '/app/redux/robot-auth'
+import { logOut, useUsernameForRobot } from '/app/redux/robot-auth'
 
 import { Accordion } from '../Accordion'
 import { SettingsConfirmationModal } from '../SettingsConfirmationModal'
@@ -92,6 +93,7 @@ export function UserManagement({
   robotName,
 }: UserManagementProps): JSX.Element {
   const { t } = useTranslation(['device_settings', 'shared'])
+  const dispatch = useDispatch()
   const username = useUsernameForRobot(robotName)
   const usersQuery = useUsersQuery({
     enabled: username != null,
@@ -186,7 +188,9 @@ export function UserManagement({
       return
     }
 
-    void resetUserPassword(userToResetPassword.username)
+    const resetUsername = userToResetPassword.username
+
+    void resetUserPassword(resetUsername)
       .then(response => {
         makeToast(
           t('desktop_reset_password_success_banner') as string,
@@ -198,6 +202,9 @@ export function UserManagement({
           setResetPasswordTemporaryPassword(temporaryPassword)
         } else {
           setUserToResetPassword(null)
+        }
+        if (username === resetUsername) {
+          dispatch(logOut({ robotName }))
         }
       })
       .catch(() => {

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/index.tsx
@@ -222,8 +222,10 @@ export function UserManagement({
       return
     }
 
+    const lockedUsername = userToDeactivate.username
+
     void updateUser({
-      username: userToDeactivate.username,
+      username: lockedUsername,
       request: { data: { locked: true } },
     })
       .then(() => {
@@ -233,6 +235,9 @@ export function UserManagement({
           { closeButton: true }
         )
         setUserToDeactivate(null)
+        if (username === lockedUsername) {
+          dispatch(logOut({ robotName }))
+        }
       })
       .catch(() => {
         setUserToDeactivate(null)

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/UserManagement/index.tsx
@@ -140,7 +140,9 @@ export function UserManagement({
       return
     }
 
-    void deleteUser(userToDelete.username)
+    const deletedUsername = userToDelete.username
+
+    void deleteUser(deletedUsername)
       .then(() => {
         makeToast(
           t('desktop_delete_user_success_banner') as string,
@@ -148,6 +150,9 @@ export function UserManagement({
           { closeButton: true }
         )
         setUserToDelete(null)
+        if (username === deletedUsername) {
+          dispatch(logOut({ robotName }))
+        }
       })
       .catch(() => {
         setUserToDelete(null)


### PR DESCRIPTION
Closes [RQA-6102](https://opentrons.atlassian.net/browse/RQA-6102)

# Overview

On the desktop app for a CRS-enabled robot, if an admin resets their own password (or otherwise ends their own session), the robot invalidates the token, but the app keeps the Redux login. The account icon in the top right goes blank, and later requests fail with 401s.

This PR extends the existing self-role-change logout so the desktop session is cleared whenever an admin takes an action that makes their current token unusable, those being:
- Reset own password 
- Change own username
- Lock own account
- Delete own account

Resetting/locking/deleting/renaming another user is unchanged. After a self password reset, the one-time password modal still shows so users can copy the temp password before logging back in.

### Current behavior

https://github.com/user-attachments/assets/52ce5eff-d6bd-46f3-bd63-c19f390dacf1

### Fixed behavior

https://github.com/user-attachments/assets/6d5a8f23-dee4-4504-8a8d-b425259a9a1e

## Test Plan and Hands on Testing

- See videos.
- We're well-covered by the added unit tests here!

## Changelog

- Fixed confusing behavior when an admin-privileged user resets, renames, locks, or deletes their own account.

## Risk assessment

- low - only the self-admin paths in user management change. 

[RQA-6102]: https://opentrons.atlassian.net/browse/RQA-6102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ