### PR TITLE
refactor(app): ensure recovery account legal name matches formatting of service account

### DIFF
--- a/app/src/organisms/Desktop/EnableCRSWizard/index.tsx
+++ b/app/src/organisms/Desktop/EnableCRSWizard/index.tsx
@@ -43,7 +43,7 @@ const WIZARD_MODAL_WIDTH = '31.25rem'
 const SERVICE_ACCOUNT_USERNAME = 'service'
 const SERVICE_ACCOUNT_FULL_NAME = 'Service Account'
 const RECOVERY_ACCOUNT_USERNAME = 'recovery'
-const RECOVERY_ACCOUNT_FULL_NAME = 'Recovery Account (created by system)'
+const RECOVERY_ACCOUNT_FULL_NAME = 'Recovery Account'
 
 interface FormValues {
   servicePIN: string


### PR DESCRIPTION
Closes [RQA-6127](https://opentrons.atlassian.net/browse/RQA-6127)

# Overview

We recently updated the service account legal name to "Service Account" from "Service Account (created by system)", but we didn't do the same for the recovery account. The changes here are just for the sake of visual parity. Unlike the service account, recovery is a normal admin user, so there is no backend override.

Robots that already have "Recovery Account (created by system)" keep that stored name. Only newly enabled CRS robots get the shorter name.

### Current behavior

<img width="1016" height="764" alt="Screenshot 2026-09-09 at 8 52 26 PM" src="https://github.com/user-attachments/assets/554ea56a-7d72-420b-99ee-6aa824c2e397" />

### Fixed behavior

<img width="1022" height="767" alt="Screenshot 2026-09-09 at 8 52 57 PM" src="https://github.com/user-attachments/assets/e2bb0047-6edc-4cfe-9d46-5abcf00f93b0" />

## Test Plan and Hands on Testing

- See images

## Changelog

- Updated the legal name of recovery accounts to "Recovery Account."

## Risk assessment

- very low


[RQA-6127]: https://opentrons.atlassian.net/browse/RQA-6127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ