### PR TITLE
fix(app, protocol-visualization): fix the rendering issue of disposal location slot cases

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewLabware.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewLabware.tsx
@@ -9,6 +9,7 @@ import {
 import { getSlotInLocationStack } from '@opentrons/step-generation'
 
 import { getActiveLayer } from '../utils/getActiveLayer'
+import { isLabwareInDisposalLocation } from '../utils/isLabwareInDisposalLocation'
 import { DeckViewOverlay } from './DeckViewOverlay'
 import { LabwareCommandSummary } from './LabwareCommandSummary'
 import { LabwareOnDeck } from './LabwareOnDeck'
@@ -64,6 +65,10 @@ export function DeckViewLabware(props: DeckViewLabwareProps): JSX.Element {
           return []
         }
         const slot = getSlotInLocationStack(lw.stack)
+        // skip disposal location slots
+        if (isLabwareInDisposalLocation(slot)) {
+          return []
+        }
         const slotPosition = getPositionFromSlotId(slot, deckDef)
         const slotBoundingBox = getAddressableAreaFromSlotId(
           slot,

--- a/app/src/organisms/Desktop/ProtocolVisualization/utils/__tests__/isLabwareInDisposalLocation.test.ts
+++ b/app/src/organisms/Desktop/ProtocolVisualization/utils/__tests__/isLabwareInDisposalLocation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
+  MOVABLE_TRASH_ADDRESSABLE_AREAS,
+} from '@opentrons/shared-data'
+
+import { isLabwareInDisposalLocation } from '../isLabwareInDisposalLocation'
+
+describe('isLabwareInDisposalLocation', () => {
+  it('returns true for gripper waste chute where disposed tip rack lids stack', () => {
+    expect(
+      isLabwareInDisposalLocation(GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA)
+    ).toBe(true)
+  })
+
+  it.each(MOVABLE_TRASH_ADDRESSABLE_AREAS)(
+    'returns true for movable trash %s',
+    trashSlot => {
+      expect(isLabwareInDisposalLocation(trashSlot)).toBe(true)
+    }
+  )
+
+  it('returns true for OT-2 fixed trash', () => {
+    expect(isLabwareInDisposalLocation('fixedTrash')).toBe(true)
+  })
+
+  it('returns false for ordinary deck slots', () => {
+    expect(isLabwareInDisposalLocation('D4')).toBe(false)
+    expect(isLabwareInDisposalLocation('A1')).toBe(false)
+  })
+})

--- a/app/src/organisms/Desktop/ProtocolVisualization/utils/isLabwareInDisposalLocation.ts
+++ b/app/src/organisms/Desktop/ProtocolVisualization/utils/isLabwareInDisposalLocation.ts
@@ -1,0 +1,14 @@
+import {
+  GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
+  MOVABLE_TRASH_ADDRESSABLE_AREAS,
+} from '@opentrons/shared-data'
+
+import type { AddressableAreaName } from '@opentrons/shared-data'
+
+export const isLabwareInDisposalLocation = (slot: string): boolean => {
+  return (
+    slot === GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA ||
+    MOVABLE_TRASH_ADDRESSABLE_AREAS.includes(slot as AddressableAreaName) ||
+    slot === 'fixedTrash'
+  )
+}

--- a/protocol-visualization/src/organisms/DeckView/DeckViewLabware.tsx
+++ b/protocol-visualization/src/organisms/DeckView/DeckViewLabware.tsx
@@ -9,6 +9,7 @@ import {
 import { getSlotInLocationStack } from '@opentrons/step-generation'
 
 import { getActiveLayer } from '../utils/getActiveLayer'
+import { isLabwareInDisposalLocation } from '../utils/isLabwareInDisposalLocation'
 import { DeckViewOverlay } from './DeckViewOverlay'
 import { LabwareCommandSummary } from './LabwareCommandSummary'
 import { LabwareOnDeck } from './LabwareOnDeck'
@@ -61,6 +62,10 @@ export function DeckViewLabware(props: DeckViewLabwareProps): ReactNode {
           return []
         }
         const slot = getSlotInLocationStack(lw.stack)
+        // skip disposal location slots
+        if (isLabwareInDisposalLocation(slot)) {
+          return []
+        }
         const slotPosition = getPositionFromSlotId(slot, deckDef)
         const slotBoundingBox = getAddressableAreaFromSlotId(
           slot,

--- a/protocol-visualization/src/organisms/utils/__tests__/isLabwareInDisposalLocation.test.ts
+++ b/protocol-visualization/src/organisms/utils/__tests__/isLabwareInDisposalLocation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
+  MOVABLE_TRASH_ADDRESSABLE_AREAS,
+} from '@opentrons/shared-data'
+
+import { isLabwareInDisposalLocation } from '../isLabwareInDisposalLocation'
+
+describe('isLabwareInDisposalLocation', () => {
+  it('returns true for gripper waste chute where disposed tip rack lids stack', () => {
+    expect(
+      isLabwareInDisposalLocation(GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA)
+    ).toBe(true)
+  })
+
+  it.each(MOVABLE_TRASH_ADDRESSABLE_AREAS)(
+    'returns true for movable trash %s',
+    trashSlot => {
+      expect(isLabwareInDisposalLocation(trashSlot)).toBe(true)
+    }
+  )
+
+  it('returns true for OT-2 fixed trash', () => {
+    expect(isLabwareInDisposalLocation('fixedTrash')).toBe(true)
+  })
+
+  it('returns false for ordinary deck slots', () => {
+    expect(isLabwareInDisposalLocation('D4')).toBe(false)
+    expect(isLabwareInDisposalLocation('A1')).toBe(false)
+  })
+})

--- a/protocol-visualization/src/organisms/utils/isLabwareInDisposalLocation.ts
+++ b/protocol-visualization/src/organisms/utils/isLabwareInDisposalLocation.ts
@@ -1,0 +1,14 @@
+import {
+  GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
+  MOVABLE_TRASH_ADDRESSABLE_AREAS,
+} from '@opentrons/shared-data'
+
+import type { AddressableAreaName } from '@opentrons/shared-data'
+
+export const isLabwareInDisposalLocation = (slot: string): boolean => {
+  return (
+    slot === GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA ||
+    MOVABLE_TRASH_ADDRESSABLE_AREAS.includes(slot as AddressableAreaName) ||
+    slot === 'fixedTrash'
+  )
+}


### PR DESCRIPTION




# Overview
fix the rendering issue of disposal location slot cases
use the PD's `isLabwareInTrash` (`protocol-designer/src/pages/Designer/utils.ts`)

for protocol visualization, it is using the same code as well the desktop since the protocol visualization components in app will be replaced with `protocol-visualization` package in the future.

### before
<img width="934" height="718" alt="Screenshot 2026-09-10 at 11 36 33 AM" src="https://github.com/user-attachments/assets/f17cf2d1-16b0-425c-bf09-5e06f09c8022" />


### after
<img width="933" height="730" alt="Screenshot 2026-09-10 at 11 37 02 AM" src="https://github.com/user-attachments/assets/c3298283-e4a2-439c-821b-60b849c95ea7" />

closes RQA-5909

## Test Plan and Hands on Testing
- run the app
- import the protocol that is attached to the ticket
- visualize the protocol

## Changelog
- add a new util function to check slot to skip disposal location slot
- add tests for the above util function

## Review requests


## Risk assessment
low
