### PR TITLE
fix(odd): dqa fix subtext size

### DIFF
--- a/app/src/organisms/ODD/DocumentationRequired/documentationrequired.module.css
+++ b/app/src/organisms/ODD/DocumentationRequired/documentationrequired.module.css
@@ -39,6 +39,12 @@
   flex-direction: column;
 }
 
+.text_area_field_fill textarea {
+  font-size: var(--font-size-22);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-28);
+}
+
 .keyboard_container {
   position: fixed;
   right: 0;

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupStep/index.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupStep/index.tsx
@@ -1,22 +1,9 @@
-import { css } from 'styled-components'
+import clsx from 'clsx'
 
-import {
-  ALIGN_CENTER,
-  BORDERS,
-  Btn,
-  COLORS,
-  DIRECTION_COLUMN,
-  Flex,
-  Icon,
-  JUSTIFY_END,
-  NO_WRAP,
-  SPACING,
-  StyledText,
-  truncateString,
-  TYPOGRAPHY,
-} from '@opentrons/components'
+import { Icon, StyledText, truncateString } from '@opentrons/components'
 
 import { useToaster } from '../../../ToasterOven'
+import styles from './protocolsetupstep.module.css'
 
 const CSV_FILE_MAX_LENGTH = 18 // truncated text + three dots
 
@@ -48,6 +35,13 @@ export interface ProtocolSetupStepProps {
   fontSize?: string
 }
 
+const ROW_STATUS_CLASS: Record<ProtocolSetupStepStatus, string> = {
+  ready: styles.row_ready,
+  'not ready': styles.row_not_ready,
+  general: styles.row_general,
+  inform: styles.row_inform,
+}
+
 export function ProtocolSetupStep({
   onClickSetupStep,
   status,
@@ -61,15 +55,8 @@ export function ProtocolSetupStep({
   description,
   hasRightIcon = true,
   hasLeftIcon = true,
-  fontSize = 'p',
 }: ProtocolSetupStepProps): JSX.Element {
   const isInteractionDisabled = interactionDisabled || disabled
-  const backgroundColorByStepStatus = {
-    ready: COLORS.green35,
-    'not ready': COLORS.yellow35,
-    general: COLORS.grey35,
-    inform: COLORS.grey35,
-  }
   const { makeSnackbar } = useToaster()
 
   const makeDisabledReasonSnackbar = (): void => {
@@ -78,99 +65,73 @@ export function ProtocolSetupStep({
     }
   }
 
-  let backgroundColor: string
-  if (!disabled) {
-    switch (status) {
-      case 'general':
-        backgroundColor = COLORS.blue35
-        break
-      case 'ready':
-        backgroundColor = COLORS.green40
-        break
-      case 'inform':
-        backgroundColor = COLORS.grey50
-        break
-      default:
-        backgroundColor = COLORS.yellow40
-    }
-  } else backgroundColor = ''
-
-  const PUSHED_STATE_STYLE = css`
-    &:active {
-      background-color: ${backgroundColor};
-    }
-  `
-
   const isToggle = detail === 'On' || detail === 'Off'
+  const showStatusIcon =
+    status !== 'general' && !disabled && status !== 'inform' && hasLeftIcon
 
   return (
-    <Btn
+    <button
+      type="button"
+      className={styles.button}
       onClick={() => {
         !isInteractionDisabled
           ? onClickSetupStep()
           : makeDisabledReasonSnackbar()
       }}
-      width="100%"
       data-testid={`SetupButton_${title}`}
     >
-      <Flex
-        alignItems={ALIGN_CENTER}
-        backgroundColor={
-          disabled ? COLORS.grey35 : backgroundColorByStepStatus[status]
-        }
-        borderRadius={BORDERS.borderRadius16}
-        gridGap={SPACING.spacing16}
-        padding={`${SPACING.spacing20} ${SPACING.spacing24}`}
-        css={PUSHED_STATE_STYLE}
+      <div
+        className={clsx(
+          styles.row,
+          disabled ? styles.row_disabled : ROW_STATUS_CLASS[status]
+        )}
       >
-        {status !== 'general' &&
-        !disabled &&
-        status !== 'inform' &&
-        hasLeftIcon ? (
+        {showStatusIcon ? (
           <Icon
-            color={status === 'ready' ? COLORS.green60 : COLORS.yellow60}
-            size="2rem"
             name={status === 'ready' ? 'ot-check' : 'ot-alert'}
+            className={clsx(
+              styles.status_icon,
+              status === 'ready'
+                ? styles.status_icon_ready
+                : styles.status_icon_not_ready
+            )}
           />
         ) : null}
-        <Flex
-          flexDirection={DIRECTION_COLUMN}
-          textAlign={TYPOGRAPHY.textAlignLeft}
-        >
+        <div className={styles.title_column}>
           <StyledText
             oddStyle="level4HeaderSemiBold"
-            color={disabled ? COLORS.grey50 : COLORS.black90}
+            className={disabled ? styles.title_disabled : styles.title_enabled}
           >
             {title}
           </StyledText>
           {description != null ? (
             <StyledText
               oddStyle="bodyTextRegular"
-              color={disabled ? COLORS.grey50 : COLORS.grey60}
-              maxWidth="35rem"
-              style={{
-                overflowWrap: 'anywhere',
-                whiteSpace: 'normal',
-                wordBreak: 'normal',
-              }}
+              className={clsx(
+                styles.description,
+                disabled
+                  ? styles.description_disabled
+                  : styles.description_enabled
+              )}
             >
               {description}
             </StyledText>
           ) : null}
-        </Flex>
-        <Flex
-          flex="1"
-          justifyContent={JUSTIFY_END}
-          padding={
-            isToggle ? `${SPACING.spacing12} ${SPACING.spacing10}` : 'undefined'
-          }
+        </div>
+        <div
+          className={clsx(styles.detail_column, {
+            [styles.detail_column_toggle]: isToggle,
+          })}
         >
           <StyledText
             oddStyle="bodyTextRegular"
-            textAlign={TYPOGRAPHY.textAlignRight}
-            color={interactionDisabled ? COLORS.grey50 : COLORS.black90}
-            maxWidth="20rem"
-            css={clipDetail ? CLIPPED_TEXT_STYLE : undefined}
+            className={clsx(
+              styles.detail,
+              interactionDisabled
+                ? styles.detail_disabled
+                : styles.detail_enabled,
+              { [styles.detail_clipped]: clipDetail }
+            )}
           >
             {title === 'CSV File' && detail != null
               ? truncateString(detail, CSV_FILE_MAX_LENGTH)
@@ -178,23 +139,11 @@ export function ProtocolSetupStep({
             {subDetail != null && detail != null ? <br /> : null}
             {subDetail}
           </StyledText>
-        </Flex>
+        </div>
         {interactionDisabled || !hasRightIcon ? null : (
-          <Icon
-            marginLeft={SPACING.spacing8}
-            name="more"
-            size="3rem"
-            // Required to prevent inconsistent component height.
-            style={{ backgroundColor: 'initial' }}
-          />
+          <Icon name="more" className={styles.more_icon} />
         )}
-      </Flex>
-    </Btn>
+      </div>
+    </button>
   )
 }
-
-const CLIPPED_TEXT_STYLE = css`
-  white-space: ${NO_WRAP};
-  overflow: hidden;
-  text-overflow: ellipsis;
-`

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupStep/index.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupStep/index.tsx
@@ -145,7 +145,7 @@ export function ProtocolSetupStep({
           </StyledText>
           {description != null ? (
             <StyledText
-              oddStyle="level4HeaderRegular"
+              oddStyle="bodyTextRegular"
               color={disabled ? COLORS.grey50 : COLORS.grey60}
               maxWidth="35rem"
               style={{
@@ -166,7 +166,7 @@ export function ProtocolSetupStep({
           }
         >
           <StyledText
-            oddStyle="level4HeaderSemiBold"
+            oddStyle="bodyTextRegular"
             textAlign={TYPOGRAPHY.textAlignRight}
             color={interactionDisabled ? COLORS.grey50 : COLORS.black90}
             maxWidth="20rem"

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupStep/protocolsetupstep.module.css
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupStep/protocolsetupstep.module.css
@@ -1,0 +1,131 @@
+.button {
+  width: 100%;
+  padding: 0;
+  border: none;
+  appearance: none;
+  background-color: transparent;
+  cursor: default;
+  text-align: inherit;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  padding: var(--spacing-20) var(--spacing-24);
+  border-radius: var(--border-radius-16);
+  gap: var(--spacing-16);
+}
+
+.row_disabled {
+  background-color: var(--grey-35);
+}
+
+.row_ready {
+  background-color: var(--green-35);
+}
+
+.row_ready:active {
+  background-color: var(--green-40);
+}
+
+.row_not_ready {
+  background-color: var(--yellow-35);
+}
+
+.row_not_ready:active {
+  background-color: var(--yellow-40);
+}
+
+.row_general {
+  background-color: var(--grey-35);
+}
+
+.row_general:active {
+  background-color: var(--blue-35);
+}
+
+.row_inform {
+  background-color: var(--grey-35);
+}
+
+.row_inform:active {
+  background-color: var(--grey-50);
+}
+
+.status_icon {
+  width: 2rem;
+  height: 2rem;
+}
+
+.status_icon_ready {
+  color: var(--green-60);
+}
+
+.status_icon_not_ready {
+  color: var(--yellow-60);
+}
+
+.title_column {
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+}
+
+.title_disabled {
+  color: var(--grey-50);
+}
+
+.title_enabled {
+  color: var(--black-90);
+}
+
+.description {
+  max-width: 35rem;
+  overflow-wrap: anywhere;
+  white-space: normal;
+  word-break: normal;
+}
+
+.description_disabled {
+  color: var(--grey-50);
+}
+
+.description_enabled {
+  color: var(--grey-60);
+}
+
+.detail_column {
+  display: flex;
+  flex: 1;
+  justify-content: flex-end;
+}
+
+.detail_column_toggle {
+  padding: var(--spacing-12) var(--spacing-10);
+}
+
+.detail {
+  max-width: 20rem;
+  text-align: right;
+}
+
+.detail_disabled {
+  color: var(--grey-50);
+}
+
+.detail_enabled {
+  color: var(--black-90);
+}
+
+.detail_clipped {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.more_icon {
+  width: 3rem;
+  height: 3rem;
+  margin-left: var(--spacing-8);
+  background-color: initial;
+}


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-6039.
closes https://opentrons.atlassian.net/browse/RQA-6119. 

change text style for subtext. 
removed deprecated styled components and moved styles to css file. 
fix css for text area. 

## Test Plan and Hands on Testing

<img width="1030" height="610" alt="Screenshot 2026-09-10 at 11 10 36 AM" src="https://github.com/user-attachments/assets/4be7665a-f040-422b-93b3-c8959958b9eb" />

<img width="1022" height="595" alt="Screenshot 2026-09-10 at 1 21 18 PM" src="https://github.com/user-attachments/assets/bd405531-2a66-4b26-9cec-cff513768731" />

## Risk assessment

low. 
