### PR TITLE
fix(app): missing zh translations for documentation required

### DIFF
--- a/app/src/assets/localization/zh/index.ts
+++ b/app/src/assets/localization/zh/index.ts
@@ -3,8 +3,10 @@ import { shared_zh_resources } from '@opentrons/components'
 import access_control from './access_control.json'
 import anonymous from './anonymous.json'
 import app_settings from './app_settings.json'
+import audit_log from './audit_log.json'
 import branded from './branded.json'
 import change_pipette from './change_pipette.json'
+import command_type_summary from './command_type_summary.json'
 import device_details from './device_details.json'
 import device_settings from './device_settings.json'
 import devices_landing from './devices_landing.json'
@@ -24,6 +26,7 @@ import protocol_details from './protocol_details.json'
 import protocol_info from './protocol_info.json'
 import protocol_list from './protocol_list.json'
 import protocol_setup from './protocol_setup.json'
+import protocol_visualization from './protocol_visualization.json'
 import quick_transfer from './quick_transfer.json'
 import robot_calibration from './robot_calibration.json'
 import robot_controls from './robot_controls.json'
@@ -35,8 +38,10 @@ export const zh = {
   access_control,
   anonymous,
   app_settings,
+  audit_log,
   branded,
   change_pipette,
+  command_type_summary,
   device_details,
   device_settings,
   devices_landing,
@@ -56,6 +61,7 @@ export const zh = {
   protocol_info,
   protocol_list,
   protocol_setup,
+  protocol_visualization,
   quick_transfer,
   robot_calibration,
   robot_controls,

--- a/app/src/organisms/ODD/DocumentationRequired/DocumentationRequired.tsx
+++ b/app/src/organisms/ODD/DocumentationRequired/DocumentationRequired.tsx
@@ -80,7 +80,7 @@ export function DocumentationRequired({
           buttonText={t('shared:confirm')}
           onClickButton={handleConfirm}
           secondaryButtonProps={{
-            buttonText: 'View actions',
+            buttonText: t('view_actions'),
             buttonType: 'tertiaryHighLight',
             iconName: 'information',
             iconPlacement: 'startIcon',


### PR DESCRIPTION
# Overview

Adds missing zh localization files to the index
<img width="1333" height="805" alt="Screenshot 2026-09-10 at 3 07 52 PM" src="https://github.com/user-attachments/assets/a0afa2c3-b2cb-4935-83bf-4caee7022de7" />


Fixes [RQA-6129](https://opentrons.atlassian.net/jira/for-you?tab=assigned&selectedIssue=RQA-6129)

## Risk assessment

low

[RQA-6129]: https://opentrons.atlassian.net/browse/RQA-6129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ