### PR TITLE
fix(app): dismiss run on ODD when moving on from splash screen

### DIFF
--- a/api-client/src/runs/signRun.ts
+++ b/api-client/src/runs/signRun.ts
@@ -1,15 +1,16 @@
 import { PATCH, request } from '../request'
 
 import type { ResponsePromise } from '../request'
-import type { EmptyResponse, HostConfig } from '../types'
+import type { HostConfig } from '../types'
+import type { Run } from './types'
 
 export function signRun(
   config: HostConfig,
   runId: string,
   name: string,
   userNotes: string
-): ResponsePromise<EmptyResponse> {
-  return request<EmptyResponse, { data: { signedBy: string } }>(
+): ResponsePromise<Run> {
+  return request<Run, { data: { signedBy: string } }>(
     PATCH,
     `/runs/${runId}`,
     config,

--- a/app/src/molecules/ODDInfoScreen/OddInfoScreen.tsx
+++ b/app/src/molecules/ODDInfoScreen/OddInfoScreen.tsx
@@ -103,6 +103,7 @@ export function OddInfoScreen(props: OddInfoScreenProps): JSX.Element {
         alignItems={ALIGN_CENTER}
         justifyContent={JUSTIFY_CENTER}
         gridGap={SPACING.spacing4}
+        textAlign={TYPOGRAPHY.textAlignCenter}
         width="100%"
       >
         <StyledText

--- a/app/src/pages/ODD/RunSummary/index.tsx
+++ b/app/src/pages/ODD/RunSummary/index.tsx
@@ -386,14 +386,6 @@ export function RunSummary(): JSX.Element {
     </Flex>
   )
 
-  // if (shouldPromptSignRun && !showSplash) {
-  //   return <SignRun runId={runId} documentationState={documentationState} />
-  // }
-
-  // if (shouldPromptDownloadLog && !showSplash) {
-  //   return <DownloadAuditLogsModal />
-  // }
-
   return (
     <Btn
       display={DISPLAY_FLEX}

--- a/app/src/pages/ODD/RunSummary/index.tsx
+++ b/app/src/pages/ODD/RunSummary/index.tsx
@@ -34,19 +34,15 @@ import {
   WRAP,
 } from '@opentrons/components'
 import {
-  useAccessControlEnabledQuery,
   useErrorRecoverySettings,
-  useGetRobotServerAccessControlSettingsQuery,
   useProtocolQuery,
   useRunCommandErrors,
 } from '@opentrons/react-api-client'
 
-import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { lastRunCommandPromptedErrorRecovery } from '/app/local-resources/commands'
 import { isTerminalRunStatus } from '/app/local-resources/runs/utils'
 import { RunTimer } from '/app/molecules/RunTimer'
 import { handleTipsAttachedModal } from '/app/organisms/DropTipWizardFlows'
-import { DownloadAuditLogsModal } from '/app/organisms/ODD/DownloadAuditLogsModal'
 import { RunFailedModal } from '/app/organisms/ODD/RunningProtocol'
 import { useRunControls } from '/app/organisms/RunTimeControl/hooks'
 import {
@@ -65,7 +61,6 @@ import {
   useTrackEvent,
 } from '/app/redux/analytics'
 import { getLocalRobot } from '/app/redux/discovery'
-import { useIsLogDeleted } from '/app/resources/audit/useIsLogDeleted'
 import { useRunGeneratedDataFiles } from '/app/resources/dataFiles/useRunGeneratedDataFiles'
 import { useTipAttachmentStatus } from '/app/resources/instruments'
 import {
@@ -80,8 +75,6 @@ import {
 } from '/app/resources/runs'
 import { onDeviceDisplayFormatTimestamp } from '/app/transformations/runs'
 
-import { SignRun } from './SignRun'
-
 import type { IconName } from '@opentrons/components'
 import type { OnDeviceRouteParams } from '/app/App/types'
 import type { PipetteWithTip } from '/app/resources/instruments'
@@ -92,19 +85,17 @@ export function RunSummary(): JSX.Element {
   >() as OnDeviceRouteParams
   const { t } = useTranslation('run_details')
   const navigate = useNavigate()
-  const { data: runRecord, isLoading: isRunRecordLoading } = useNotifyRunQuery(
-    runId,
-    {
-      staleTime: Infinity,
-      onError: () => {
-        // in case the run is remotely deleted by a desktop app, navigate to the dash
-        navigate('/dashboard')
-      },
-    }
-  )
+  const { data: runRecord } = useNotifyRunQuery(runId, {
+    staleTime: Infinity,
+    onError: () => {
+      // in case the run is remotely deleted by a desktop app, navigate to the dash
+      navigate('/dashboard')
+    },
+  })
   const isRunCurrent = useIsRunCurrent(runId)
   const runStatus = runRecord?.data.status ?? null
   const didRunSucceed = runStatus === RUN_STATUS_SUCCEEDED
+  const wasRunCanceled = runStatus === RUN_STATUS_STOPPED
   const protocolId = runRecord?.data.protocolId ?? null
   const { data: protocolRecord } = useProtocolQuery(protocolId, {
     staleTime: Infinity,
@@ -127,7 +118,9 @@ export function RunSummary(): JSX.Element {
       : EMPTY_TIMESTAMP
 
   const [showSplash, setShowSplash] = useState(
-    runStatus === RUN_STATUS_FAILED || runStatus === RUN_STATUS_SUCCEEDED
+    runStatus === RUN_STATUS_FAILED ||
+      runStatus === RUN_STATUS_SUCCEEDED ||
+      runStatus === RUN_STATUS_STOPPED
   )
   const localRobot = useSelector(getLocalRobot)
   const robotName = localRobot?.name ?? 'no name'
@@ -156,7 +149,6 @@ export function RunSummary(): JSX.Element {
   const trackEvent = useTrackEvent()
   const { trackEventWithRobotSerial } = useTrackEventWithRobotSerial()
 
-  const documentationState = useDocumentationState()
   const { closeCurrentRun } = useCloseCurrentRun()
   // Close the current run only if it's active and then execute the onSuccess callback. Prefer this wrapper over
   // closeCurrentRun directly, since the callback is swallowed if currentRun is null.
@@ -187,57 +179,14 @@ export function RunSummary(): JSX.Element {
       enabled: isTerminalRunStatus(runStatus) && isRunCurrent,
     }
   )
-  // TODO(jh, 08-14-24): The backend never returns the "user cancelled a run" error and cancelledWithoutRecovery becomes unnecessary.
-  const cancelledWithoutRecovery =
-    !enteredER && runStatus === RUN_STATUS_STOPPED
+  // TODO(jh, 08-14-24): The backend never returns the "user canceled a run" error and canceledWithoutRecovery becomes unnecessary.
+  const canceledWithoutRecovery = !enteredER && runStatus === RUN_STATUS_STOPPED
   const hasCommandErrors =
     commandErrorList != null && commandErrorList.data.length > 0
   const disableErrorDetailsBtn = !(
-    (hasCommandErrors && !cancelledWithoutRecovery) ||
+    (hasCommandErrors && !canceledWithoutRecovery) ||
     (runRecord?.data.errors != null && runRecord?.data.errors.length > 0)
   )
-
-  const {
-    data: accessControlEnabled,
-    isLoading: isAccessControlEnabledLoading,
-  } = useAccessControlEnabledQuery()
-  const {
-    data: accessControlSettings,
-    isLoading: isAccessControlSettingsLoading,
-  } = useGetRobotServerAccessControlSettingsQuery()
-  const isSettingsLoading =
-    isAccessControlEnabledLoading || isAccessControlSettingsLoading
-  const isSigningRequired =
-    (accessControlEnabled?.data.accessControlEnabled ?? false) &&
-    (accessControlSettings?.data.requireSignoffForProtocolLog ?? false)
-  const hasSignedBy =
-    runRecord?.data.signedBy != null && runRecord.data.signedBy !== ''
-  // Wait for runRecord after sign (cache cleared) so we don't re-prompt
-  // while signedBy is still missing from the refetch.
-  const shouldPromptSignRun =
-    !isRunRecordLoading &&
-    !isSettingsLoading &&
-    isSigningRequired &&
-    !hasSignedBy
-
-  const logPeriodId = runRecord?.data.logPeriodId ?? null
-  const {
-    isLoading: isLogDeletedLoading,
-    isDeleted: isLogDeleted,
-    isError: isLogDeletedError,
-  } = useIsLogDeleted(logPeriodId ?? '')
-
-  const isDownloadingRequired =
-    (accessControlEnabled?.data.accessControlEnabled ?? false) &&
-    (accessControlSettings?.data.requireLogsToBeSavedInApp ?? false)
-  const shouldPromptDownloadLog =
-    !isRunRecordLoading &&
-    !isSettingsLoading &&
-    isDownloadingRequired &&
-    !shouldPromptSignRun &&
-    !isLogDeletedLoading &&
-    !isLogDeletedError &&
-    !isLogDeleted
 
   let headerText: string | null = null
   if (runStatus === RUN_STATUS_SUCCEEDED) {
@@ -270,7 +219,7 @@ export function RunSummary(): JSX.Element {
       iconColor = COLORS.red50
     } else if (runStatus === RUN_STATUS_STOPPED) {
       iconName = 'ot-alert'
-      iconColor = COLORS.red50
+      iconColor = COLORS.yellow50
     }
 
     return iconName != null && iconColor != null ? (
@@ -310,7 +259,7 @@ export function RunSummary(): JSX.Element {
     setShowRunAgainSpinner(true)
     reset({
       onError: () => {
-        // e.g. user cancelled the documentation modal
+        // e.g. user canceled the documentation modal
         setShowRunAgainSpinner(false)
       },
     })
@@ -385,7 +334,10 @@ export function RunSummary(): JSX.Element {
     robotType: robotType,
   })
   const outputFileIds = useRunGeneratedDataFiles(runId)
+
+  const [splashClicked, setSplashClicked] = useState(false)
   const handleClickSplash = (): void => {
+    setSplashClicked(true)
     trackProtocolRunEvent({
       name: ANALYTICS_PROTOCOL_RUN_ACTION.FINISH,
       properties: robotAnalyticsData ?? undefined,
@@ -395,11 +347,18 @@ export function RunSummary(): JSX.Element {
       transactionId: runId,
       amount: numberOfImages,
     })
-    setShowSplash(false)
+    closeCurrentRunIfValid(() => {
+      setShowSplash(false)
+      setSplashClicked(false)
+    })
   }
 
   const buildReturnToWithSpinnerText = (): JSX.Element => (
-    <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="16rem">
+    <Flex
+      justifyContent={JUSTIFY_SPACE_BETWEEN}
+      width="100%"
+      gap={SPACING.spacing8}
+    >
       {t('return_to_dashboard')}
       <Icon
         name="ot-spinner"
@@ -411,7 +370,11 @@ export function RunSummary(): JSX.Element {
     </Flex>
   )
   const buildRunAgainWithSpinnerText = (): JSX.Element => (
-    <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="16rem">
+    <Flex
+      justifyContent={JUSTIFY_SPACE_BETWEEN}
+      width="100%"
+      gap={SPACING.spacing8}
+    >
       {t('run_again')}
       <Icon
         name="ot-spinner"
@@ -423,13 +386,13 @@ export function RunSummary(): JSX.Element {
     </Flex>
   )
 
-  if (shouldPromptSignRun && !showSplash) {
-    return <SignRun runId={runId} documentationState={documentationState} />
-  }
+  // if (shouldPromptSignRun && !showSplash) {
+  //   return <SignRun runId={runId} documentationState={documentationState} />
+  // }
 
-  if (shouldPromptDownloadLog && !showSplash) {
-    return <DownloadAuditLogsModal />
-  }
+  // if (shouldPromptDownloadLog && !showSplash) {
+  //   return <DownloadAuditLogsModal />
+  // }
 
   return (
     <Btn
@@ -463,13 +426,25 @@ export function RunSummary(): JSX.Element {
               <SplashHeader>
                 {didRunSucceed
                   ? t('run_completed_splash')
-                  : t('run_failed_splash')}
+                  : wasRunCanceled
+                    ? t('run_canceled_splash')
+                    : t('run_failed_splash')}
               </SplashHeader>
             </Flex>
             <Flex width="49rem" justifyContent={JUSTIFY_CENTER}>
               <SplashBody>{protocolName}</SplashBody>
             </Flex>
           </SplashFrame>
+          {splashClicked ? (
+            <Flex
+              position={POSITION_ABSOLUTE}
+              top="0"
+              left="0"
+              width="100%"
+              height="100%"
+              backgroundColor={`${COLORS.black90}${COLORS.opacity40HexCode}`}
+            />
+          ) : null}
         </Flex>
       ) : (
         <Flex
@@ -550,17 +525,18 @@ export function RunSummary(): JSX.Element {
               }
               css={showRunAgainSpinner ? RUN_AGAIN_CLICKED_STYLE : undefined}
             />
-            <EqualWidthButton
-              iconName="info"
-              buttonType="alert"
-              onClick={handleViewErrorDetails}
-              buttonText={
-                hasCommandErrors && runStatus === RUN_STATUS_SUCCEEDED
-                  ? t('view_warning_details')
-                  : t('view_error_details')
-              }
-              disabled={disableErrorDetailsBtn}
-            />
+            {!disableErrorDetailsBtn && (
+              <EqualWidthButton
+                iconName="info"
+                buttonType="alert"
+                onClick={handleViewErrorDetails}
+                buttonText={
+                  hasCommandErrors && runStatus === RUN_STATUS_SUCCEEDED
+                    ? t('view_warning_details')
+                    : t('view_error_details')
+                }
+              />
+            )}
           </ButtonContainer>
         </Flex>
       )}
@@ -581,7 +557,7 @@ const SplashBody = styled.h4`
   -webkit-line-clamp: 4;
   overflow: hidden;
   overflow-wrap: ${OVERFLOW_WRAP_BREAK_WORD};
-  font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
+  font-weight: ${TYPOGRAPHY.fontWeightBold};
   text-align: ${TYPOGRAPHY.textAlignCenter};
   text-transform: ${TYPOGRAPHY.textTransformCapitalize};
   font-size: ${TYPOGRAPHY.fontSize32};

--- a/app/src/resources/runs/useCloseCurrentRun.ts
+++ b/app/src/resources/runs/useCloseCurrentRun.ts
@@ -44,8 +44,13 @@ export function useCloseCurrentRun(): {
   } = useIsSigningRequired()
 
   const actionsToDocument: DocumentedAction[] = useMemo(
-    () => (isSigningRequired ? ['sign_run', 'dismiss_run'] : ['dismiss_run']),
-    [isSigningRequired]
+    () =>
+      isSigningRequired
+        ? isDownloadingRequired
+          ? ['sign_run']
+          : ['sign_run', 'dismiss_run']
+        : ['dismiss_run'],
+    [isSigningRequired, isDownloadingRequired]
   )
   const { documentationState } = useLinkedDocumentationState(
     actionsToDocument,

--- a/react-api-client/src/runs/useDismissCurrentRunMutation.ts
+++ b/react-api-client/src/runs/useDismissCurrentRunMutation.ts
@@ -41,12 +41,15 @@ export function useDismissCurrentRunMutation(
     ['dismiss_run'],
     ({ userNotes, variables: runId }: DocumentedMutationParameters<string>) =>
       dismissCurrentRun(host!, runId, userNotes).then(response => {
-        queryClient.removeQueries(getQueryKey(host, 'runs', runId))
         queryClient
-          .invalidateQueries(getQueryKey(host, 'runs'))
+          .invalidateQueries(getQueryKey(host, 'runs', 'details'))
           .catch((e: Error) => {
             console.error(`error invalidating runs query: ${e.message}`)
           })
+        queryClient.setQueryData(
+          getQueryKey(host, 'runs', runId, 'details'),
+          response.data
+        )
         return response.data
       }),
     options

--- a/react-api-client/src/runs/useSignRunMutation.ts
+++ b/react-api-client/src/runs/useSignRunMutation.ts
@@ -10,26 +10,18 @@ import type {
   UseMutationOptions,
   UseMutationResult,
 } from 'react-query'
-import type { EmptyResponse } from '@opentrons/api-client'
+import type { Run } from '@opentrons/api-client'
 import type { DocumentationState } from '../accessControl'
 import type { DocumentedMutationParameters } from '../accessControl/types'
 
-export type UseSignRunMutationOptions = UseMutationOptions<
-  EmptyResponse,
-  unknown,
-  string
->
+export type UseSignRunMutationOptions = UseMutationOptions<Run, unknown, string>
 
 export type UseSignRunMutationResult = UseMutationResult<
-  EmptyResponse,
+  Run,
   unknown,
   { runId: string; name: string }
 > & {
-  signRun: UseMutateFunction<
-    EmptyResponse,
-    unknown,
-    { runId: string; name: string }
-  >
+  signRun: UseMutateFunction<Run, unknown, { runId: string; name: string }>
 }
 
 export function useSignRunMutation(
@@ -40,7 +32,7 @@ export function useSignRunMutation(
   const queryClient = useQueryClient()
 
   const mutation = useDocumentedMutation<
-    EmptyResponse,
+    Run,
     unknown,
     { runId: string; name: string }
   >(
@@ -51,9 +43,12 @@ export function useSignRunMutation(
       variables: { runId, name },
     }: DocumentedMutationParameters<{ runId: string; name: string }>) =>
       signRun(host!, runId, name, userNotes).then(response => {
-        queryClient.removeQueries(getQueryKey(host, 'runs', runId))
+        queryClient.setQueryData(
+          getQueryKey(host, 'runs', runId, 'details'),
+          response.data
+        )
         queryClient
-          .invalidateQueries(getQueryKey(host, 'runs'))
+          .invalidateQueries(getQueryKey(host, 'runs', 'details'))
           .catch((e: Error) => {
             console.error(`error invalidating runs query: ${e.message}`)
           })


### PR DESCRIPTION
# Overview

Changes the post-protocol-run flow on ODD to dismiss the run when the user taps to dismiss the 'Run Succeeded/Run Failed' modal. This prevents the desktop app from giving surprise 'Ending Protocol Run' documentation popups in CRS unless required. Also adds a 'Run Canceled' splash screen and fixes design drift on the RunSummary page on ODD as well as some weird UI jittering.

https://github.com/user-attachments/assets/c28519d3-bc70-4cd1-bbe2-8f1411adfa17

The core flow still includes one uncloseable 'ending protocol run' popup after action on the ODD - when downloading logs on the desktop is required. Otherwise this fixes [RQA-6123](https://opentrons.atlassian.net/browse/RQA-6123)

## Test Plan and Hands on Testing

End of run flow should work as follows on the ODD:
1. For all runs, the splash screen should pop up with 'Run Succeeded'/'Run Failed'/'Run Canceled'. 
2. If signing is required, tapping the splash screen should prompt to sign the run, and signing should then ask for documentation. The actions listed should be 'signing run' and 'ending protocol run' if downloading is not required, or just 'signing run' if downloading is required
3. If downloading is required, the 'download on desktop' modal should then appear. Switching to the desktop should prompt immediately with an uncloseable 'ending protocol run' documentation modal and then the download logs modal.
4. Once downloaded/signed/dismissed, all modals should be clear and the ODD should be on the run summary page

[See this flowchart I made for details](https://www.figma.com/board/rFv1B0NgP2JI9oAGhNup99/CRS-Ending-Run-Flow?node-id=0-1&t=WRSBL9tj1ygcOeBw-1)

<img width="737" height="770" alt="Screenshot 2026-09-10 at 4 34 33 PM" src="https://github.com/user-attachments/assets/b8eb6009-c4e0-4bcb-a78f-ea968432c0c4" />

## Changelog

Canceling runs on the ODD now shows a splash screen.

## Risk assessment

Medium. Closing runs is weird.

[RQA-6123]: https://opentrons.atlassian.net/browse/RQA-6123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ