### PR TITLE
fix(app): never refetch accessControlEnabled

### DIFF
--- a/react-api-client/src/auth/settings/useAccessControlEnabledQuery.ts
+++ b/react-api-client/src/auth/settings/useAccessControlEnabledQuery.ts
@@ -33,7 +33,6 @@ export function useAccessControlEnabledQuery(
     {
       enabled: host !== null,
       staleTime: Infinity,
-      cacheTime: Infinity,
       ...options,
     }
   )

--- a/react-api-client/src/auth/settings/useAccessControlEnabledQuery.ts
+++ b/react-api-client/src/auth/settings/useAccessControlEnabledQuery.ts
@@ -30,7 +30,12 @@ export function useAccessControlEnabledQuery(
   const query = useQuery<AccessControlEnabledSettingsResponse, AxiosError>(
     accessControlEnabledQueryKey(host),
     () => getAccessControlEnabled(host!).then(response => response.data),
-    { enabled: host !== null, ...options }
+    {
+      enabled: host !== null,
+      staleTime: Infinity,
+      cacheTime: Infinity,
+      ...options,
+    }
   )
 
   return query


### PR DESCRIPTION
# Overview

Access control should be queried EXACTLY once per robot boot. This change eliminates extra unnecessary queries, since access control status never changes and is loaded on app boot. 

## Test Plan and Hands on Testing

You should practically never see an accessControlEnabled query in the network tab on the ODD, and very rarely on the desktop.

## Risk assessment

low