### PR TITLE
fix(app): fix missing pinyin candidate display

### DIFF
--- a/app/src/atoms/AccordionKeyboard/accordionkeyboard.module.css
+++ b/app/src/atoms/AccordionKeyboard/accordionkeyboard.module.css
@@ -1,5 +1,6 @@
 .accordion_container {
   display: flex;
+  overflow: visible;
   width: 100%;
   flex-direction: column;
   background-color: var(--transparent);
@@ -30,6 +31,7 @@
 }
 
 .accordion_body {
+  overflow: visible;
   width: 100%;
   background-color: var(--grey-35);
   pointer-events: auto;


### PR DESCRIPTION
# Overview

Pinyin candidate UI was getting cut off by accordion keyboard. This fixes that. 

Fixes [RQA-6132](https://opentrons.atlassian.net/browse/RQA-6132)

## Test Plan and Hands on Testing

Type on the on screen keyboard with your language set to mandarin, the candidate UI should show up.

## Risk assessment

Low

[RQA-6132]: https://opentrons.atlassian.net/browse/RQA-6132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ