### PR TITLE
fix(app, protocol-visualization): gate WasteChuteStaging on waste chute entities

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/index.tsx
@@ -28,6 +28,7 @@ import { getSlotInLocationStack } from '@opentrons/step-generation'
 import { getActiveLayer } from '../utils/getActiveLayer'
 import { getIsCutoutA1Active } from '../utils/getIsCutoutA1Active'
 import { getIsPipetteOverTrash } from '../utils/getIsPipetteOverTrash'
+import { partitionWasteChuteDeckFixtures } from '../utils/partitionWasteChuteDeckFixtures'
 import styles from './deckview.module.css'
 import { DeckViewDetails } from './DeckViewDetails'
 
@@ -160,13 +161,15 @@ export function DeckView(props: DeckViewProps): ReactNode {
     slot: trash.location.split('cutout')[1],
     id: trash.id,
   }))
-  const wasteChuteStagingAreaFixtures = Object.values(
-    stagingAreaEntities
-  ).filter(stagingArea => stagingArea.location === WASTE_CHUTE_CUTOUT)
   const filteredStagingAreas = {
     ...flexStackerAsStagingAreas,
     ...stagingAreaEntities,
   }
+  const {
+    stagingAreaFixtures,
+    wasteChuteOnlyFixtures,
+    wasteChuteStagingAreaFixtures,
+  } = partitionWasteChuteDeckFixtures(filteredStagingAreas, wasteChuteEntities)
 
   const stagingAreaLocations = new Set(
     Object.values(filteredStagingAreas).map(sa => sa.location)
@@ -264,7 +267,7 @@ export function DeckView(props: DeckViewProps): ReactNode {
                         />
                       ) : null
                     })}
-                    {Object.values(filteredStagingAreas).map(entity => (
+                    {stagingAreaFixtures.map(entity => (
                       <StagingAreaFixture
                         key={entity.id}
                         cutoutId={entity.location as StagingAreaLocation}
@@ -306,25 +309,23 @@ export function DeckView(props: DeckViewProps): ReactNode {
                           )
                         })
                       : null}
-                    {Object.values(wasteChuteEntities).map(
-                      ({ id, location }) => {
-                        const isPipetteOverTrash = getIsPipetteOverTrash(
-                          pipettes,
-                          id,
-                          selectedRunTimeCommand
-                        )
-                        return (
-                          <WasteChuteFixture
-                            key={id}
-                            cutoutId={location as typeof WASTE_CHUTE_CUTOUT}
-                            deckDefinition={deckDef}
-                            fixtureBaseColor={
-                              isPipetteOverTrash ? COLORS.purple30 : lightFill
-                            }
-                          />
-                        )
-                      }
-                    )}
+                    {wasteChuteOnlyFixtures.map(({ id, location }) => {
+                      const isPipetteOverTrash = getIsPipetteOverTrash(
+                        pipettes,
+                        id,
+                        selectedRunTimeCommand
+                      )
+                      return (
+                        <WasteChuteFixture
+                          key={id}
+                          cutoutId={location as typeof WASTE_CHUTE_CUTOUT}
+                          deckDefinition={deckDef}
+                          fixtureBaseColor={
+                            isPipetteOverTrash ? COLORS.purple30 : lightFill
+                          }
+                        />
+                      )
+                    })}
                     {wasteChuteStagingAreaFixtures.map(fixture => (
                       <WasteChuteStagingAreaFixture
                         key={fixture.id}

--- a/app/src/organisms/Desktop/ProtocolVisualization/utils/__tests__/partitionWasteChuteDeckFixtures.test.ts
+++ b/app/src/organisms/Desktop/ProtocolVisualization/utils/__tests__/partitionWasteChuteDeckFixtures.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { WASTE_CHUTE_CUTOUT } from '@opentrons/shared-data'
+
+import { partitionWasteChuteDeckFixtures } from '../partitionWasteChuteDeckFixtures'
+
+import type {
+  StagingAreaEntities,
+  WasteChuteEntities,
+} from '@opentrons/step-generation'
+
+const stagingAtD3: StagingAreaEntities = {
+  'staging-d4': { id: 'staging-d4', location: WASTE_CHUTE_CUTOUT },
+}
+
+const stagingAtA3: StagingAreaEntities = {
+  'staging-a4': { id: 'staging-a4', location: 'cutoutA3' },
+}
+
+const wasteChute: WasteChuteEntities = {
+  'waste-1': {
+    id: 'waste-1',
+    location: WASTE_CHUTE_CUTOUT,
+    pythonName: 'waste_chute',
+  },
+}
+
+describe('partitionWasteChuteDeckFixtures', () => {
+  it('does not treat D4 staging as waste chute when wasteChuteEntities is empty', () => {
+    const result = partitionWasteChuteDeckFixtures(stagingAtD3, {})
+
+    expect(result.wasteChuteStagingAreaFixtures).toEqual([])
+    expect(result.wasteChuteOnlyFixtures).toEqual([])
+    expect(result.stagingAreaFixtures).toEqual([stagingAtD3['staging-d4']])
+  })
+
+  it('uses waste chute staging fixture when waste chute and D3 staging are both present', () => {
+    const result = partitionWasteChuteDeckFixtures(stagingAtD3, wasteChute)
+
+    expect(result.wasteChuteStagingAreaFixtures).toEqual([
+      stagingAtD3['staging-d4'],
+    ])
+    expect(result.wasteChuteOnlyFixtures).toEqual([])
+    expect(result.stagingAreaFixtures).toEqual([])
+  })
+
+  it('uses waste chute only fixture when waste chute is present without D3 staging', () => {
+    const result = partitionWasteChuteDeckFixtures(stagingAtA3, wasteChute)
+
+    expect(result.wasteChuteStagingAreaFixtures).toEqual([])
+    expect(result.wasteChuteOnlyFixtures).toEqual([wasteChute['waste-1']])
+    expect(result.stagingAreaFixtures).toEqual([stagingAtA3['staging-a4']])
+  })
+
+  it('returns empty partitions when neither waste chute nor staging exist', () => {
+    const result = partitionWasteChuteDeckFixtures({}, {})
+
+    expect(result).toEqual({
+      stagingAreaFixtures: [],
+      wasteChuteOnlyFixtures: [],
+      wasteChuteStagingAreaFixtures: [],
+    })
+  })
+})

--- a/app/src/organisms/Desktop/ProtocolVisualization/utils/partitionWasteChuteDeckFixtures.ts
+++ b/app/src/organisms/Desktop/ProtocolVisualization/utils/partitionWasteChuteDeckFixtures.ts
@@ -1,0 +1,48 @@
+import { WASTE_CHUTE_CUTOUT } from '@opentrons/shared-data'
+
+import type {
+  StagingAreaEntities,
+  StagingAreaEntity,
+  WasteChuteEntities,
+  WasteChuteEntity,
+} from '@opentrons/step-generation'
+
+export interface WasteChuteDeckFixturePartitions {
+  stagingAreaFixtures: StagingAreaEntity[]
+  wasteChuteOnlyFixtures: WasteChuteEntity[]
+  wasteChuteStagingAreaFixtures: StagingAreaEntity[]
+}
+
+/**
+ * D4 (and other column-4) staging maps to cutoutD3, which is also the waste chute cutout.
+ * Only render WasteChuteStagingAreaFixture when a waste chute entity is present.
+ * Prefer the combined fixture over WasteChuteFixture + StagingAreaFixture when both apply.
+ */
+export function partitionWasteChuteDeckFixtures(
+  stagingAreaEntities: StagingAreaEntities,
+  wasteChuteEntities: WasteChuteEntities
+): WasteChuteDeckFixturePartitions {
+  const hasWasteChute = Object.keys(wasteChuteEntities).length > 0
+  const stagingAreas = Object.values(stagingAreaEntities)
+  const wasteChuteStagingAreaFixtures = hasWasteChute
+    ? stagingAreas.filter(
+        stagingArea => stagingArea.location === WASTE_CHUTE_CUTOUT
+      )
+    : []
+  const wasteChuteStagingIds = new Set(
+    wasteChuteStagingAreaFixtures.map(fixture => fixture.id)
+  )
+  const stagingAreaFixtures = stagingAreas.filter(
+    stagingArea => !wasteChuteStagingIds.has(stagingArea.id)
+  )
+  const wasteChuteOnlyFixtures =
+    wasteChuteStagingAreaFixtures.length > 0
+      ? []
+      : Object.values(wasteChuteEntities)
+
+  return {
+    stagingAreaFixtures,
+    wasteChuteOnlyFixtures,
+    wasteChuteStagingAreaFixtures,
+  }
+}

--- a/protocol-visualization/src/organisms/DeckView/index.tsx
+++ b/protocol-visualization/src/organisms/DeckView/index.tsx
@@ -25,6 +25,7 @@ import { getSlotInLocationStack } from '@opentrons/step-generation'
 import { getActiveLayer } from '../utils/getActiveLayer'
 import { getIsCutoutA1Active } from '../utils/getIsCutoutA1Active'
 import { getIsPipetteOverTrash } from '../utils/getIsPipetteOverTrash'
+import { partitionWasteChuteDeckFixtures } from '../utils/partitionWasteChuteDeckFixtures'
 import styles from './deckview.module.css'
 import { DeckViewDetails } from './DeckViewDetails'
 
@@ -130,9 +131,11 @@ export function DeckView(props: DeckViewProps): ReactNode {
     slot: trash.location.split('cutout')[1],
     id: trash.id,
   }))
-  const wasteChuteStagingAreaFixtures = Object.values(
-    stagingAreaEntities
-  ).filter(stagingArea => stagingArea.location === WASTE_CHUTE_CUTOUT)
+  const {
+    stagingAreaFixtures,
+    wasteChuteOnlyFixtures,
+    wasteChuteStagingAreaFixtures,
+  } = partitionWasteChuteDeckFixtures(stagingAreaEntities, wasteChuteEntities)
 
   const filteredAddressableAreas = deckDef.locations.addressableAreas.filter(
     aa => isAddressableAreaStandardSlot(aa.id, deckDef)
@@ -202,7 +205,7 @@ export function DeckView(props: DeckViewProps): ReactNode {
                         />
                       ) : null
                     })}
-                    {Object.values(stagingAreaEntities).map(entity => (
+                    {stagingAreaFixtures.map(entity => (
                       <StagingAreaFixture
                         key={entity.id}
                         cutoutId={entity.location as StagingAreaLocation}
@@ -244,25 +247,23 @@ export function DeckView(props: DeckViewProps): ReactNode {
                           )
                         })
                       : null}
-                    {Object.values(wasteChuteEntities).map(
-                      ({ id, location }) => {
-                        const isPipetteOverTrash = getIsPipetteOverTrash(
-                          pipettes,
-                          id,
-                          selectedRunTimeCommand
-                        )
-                        return (
-                          <WasteChuteFixture
-                            key={id}
-                            cutoutId={location as typeof WASTE_CHUTE_CUTOUT}
-                            deckDefinition={deckDef}
-                            fixtureBaseColor={
-                              isPipetteOverTrash ? COLORS.purple30 : lightFill
-                            }
-                          />
-                        )
-                      }
-                    )}
+                    {wasteChuteOnlyFixtures.map(({ id, location }) => {
+                      const isPipetteOverTrash = getIsPipetteOverTrash(
+                        pipettes,
+                        id,
+                        selectedRunTimeCommand
+                      )
+                      return (
+                        <WasteChuteFixture
+                          key={id}
+                          cutoutId={location as typeof WASTE_CHUTE_CUTOUT}
+                          deckDefinition={deckDef}
+                          fixtureBaseColor={
+                            isPipetteOverTrash ? COLORS.purple30 : lightFill
+                          }
+                        />
+                      )
+                    })}
                     {wasteChuteStagingAreaFixtures.map(fixture => (
                       <WasteChuteStagingAreaFixture
                         key={fixture.id}

--- a/protocol-visualization/src/organisms/utils/__tests__/partitionWasteChuteDeckFixtures.test.ts
+++ b/protocol-visualization/src/organisms/utils/__tests__/partitionWasteChuteDeckFixtures.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { WASTE_CHUTE_CUTOUT } from '@opentrons/shared-data'
+
+import { partitionWasteChuteDeckFixtures } from '../partitionWasteChuteDeckFixtures'
+
+import type {
+  StagingAreaEntities,
+  WasteChuteEntities,
+} from '@opentrons/step-generation'
+
+const stagingAtD3: StagingAreaEntities = {
+  'staging-d4': { id: 'staging-d4', location: WASTE_CHUTE_CUTOUT },
+}
+
+const stagingAtA3: StagingAreaEntities = {
+  'staging-a4': { id: 'staging-a4', location: 'cutoutA3' },
+}
+
+const wasteChute: WasteChuteEntities = {
+  'waste-1': {
+    id: 'waste-1',
+    location: WASTE_CHUTE_CUTOUT,
+    pythonName: 'waste_chute',
+  },
+}
+
+describe('partitionWasteChuteDeckFixtures', () => {
+  it('does not treat D4 staging as waste chute when wasteChuteEntities is empty', () => {
+    const result = partitionWasteChuteDeckFixtures(stagingAtD3, {})
+
+    expect(result.wasteChuteStagingAreaFixtures).toEqual([])
+    expect(result.wasteChuteOnlyFixtures).toEqual([])
+    expect(result.stagingAreaFixtures).toEqual([stagingAtD3['staging-d4']])
+  })
+
+  it('uses waste chute staging fixture when waste chute and D3 staging are both present', () => {
+    const result = partitionWasteChuteDeckFixtures(stagingAtD3, wasteChute)
+
+    expect(result.wasteChuteStagingAreaFixtures).toEqual([
+      stagingAtD3['staging-d4'],
+    ])
+    expect(result.wasteChuteOnlyFixtures).toEqual([])
+    expect(result.stagingAreaFixtures).toEqual([])
+  })
+
+  it('uses waste chute only fixture when waste chute is present without D3 staging', () => {
+    const result = partitionWasteChuteDeckFixtures(stagingAtA3, wasteChute)
+
+    expect(result.wasteChuteStagingAreaFixtures).toEqual([])
+    expect(result.wasteChuteOnlyFixtures).toEqual([wasteChute['waste-1']])
+    expect(result.stagingAreaFixtures).toEqual([stagingAtA3['staging-a4']])
+  })
+
+  it('returns empty partitions when neither waste chute nor staging exist', () => {
+    const result = partitionWasteChuteDeckFixtures({}, {})
+
+    expect(result).toEqual({
+      stagingAreaFixtures: [],
+      wasteChuteOnlyFixtures: [],
+      wasteChuteStagingAreaFixtures: [],
+    })
+  })
+})

--- a/protocol-visualization/src/organisms/utils/partitionWasteChuteDeckFixtures.ts
+++ b/protocol-visualization/src/organisms/utils/partitionWasteChuteDeckFixtures.ts
@@ -1,0 +1,48 @@
+import { WASTE_CHUTE_CUTOUT } from '@opentrons/shared-data'
+
+import type {
+  StagingAreaEntities,
+  StagingAreaEntity,
+  WasteChuteEntities,
+  WasteChuteEntity,
+} from '@opentrons/step-generation'
+
+export interface WasteChuteDeckFixturePartitions {
+  stagingAreaFixtures: StagingAreaEntity[]
+  wasteChuteOnlyFixtures: WasteChuteEntity[]
+  wasteChuteStagingAreaFixtures: StagingAreaEntity[]
+}
+
+/**
+ * D4 (and other column-4) staging maps to cutoutD3, which is also the waste chute cutout.
+ * Only render WasteChuteStagingAreaFixture when a waste chute entity is present.
+ * Prefer the combined fixture over WasteChuteFixture + StagingAreaFixture when both apply.
+ */
+export function partitionWasteChuteDeckFixtures(
+  stagingAreaEntities: StagingAreaEntities,
+  wasteChuteEntities: WasteChuteEntities
+): WasteChuteDeckFixturePartitions {
+  const hasWasteChute = Object.keys(wasteChuteEntities).length > 0
+  const stagingAreas = Object.values(stagingAreaEntities)
+  const wasteChuteStagingAreaFixtures = hasWasteChute
+    ? stagingAreas.filter(
+        stagingArea => stagingArea.location === WASTE_CHUTE_CUTOUT
+      )
+    : []
+  const wasteChuteStagingIds = new Set(
+    wasteChuteStagingAreaFixtures.map(fixture => fixture.id)
+  )
+  const stagingAreaFixtures = stagingAreas.filter(
+    stagingArea => !wasteChuteStagingIds.has(stagingArea.id)
+  )
+  const wasteChuteOnlyFixtures =
+    wasteChuteStagingAreaFixtures.length > 0
+      ? []
+      : Object.values(wasteChuteEntities)
+
+  return {
+    stagingAreaFixtures,
+    wasteChuteOnlyFixtures,
+    wasteChuteStagingAreaFixtures,
+  }
+}


### PR DESCRIPTION
## Why

Protocol Visualization treated every staging area on `cutoutD3` as a waste chute. Flex slot D4 maps to that same cutout when analysis builds staging entities, so a protocol with `load_trash_bin('A1')` and a tiprack on D4 always drew `WasteChuteStagingAreaFixture`.

End users saw a Waste chute on the deck when the protocol never loaded one. Maintainers inherit a single partition helper that matches BaseDeck's waste-chute vs staging split.

## Scope

- `partitionWasteChuteDeckFixtures` in app and protocol-visualization
- `DeckView` wiring in both packages
- Vitest coverage for the four partition cases

Out of scope: teaching `constructInvariantContextFromAnalysis` to read load-trash commands directly.

## Tradeoffs

Duplicated the helper in app and protocol-visualization to match the existing utils copy pattern, instead of extracting a shared package for one function.

## Blast Radius

Deck fixture rendering for Flex Protocol Visualization only. Protocols with a real waste chute still get `WasteChuteFixture` or `WasteChuteStagingAreaFixture`. Protocols with D4 staging and no waste chute keep a plain `StagingAreaFixture`.

## Verification

```text
pnpm vitest run --dir app src/organisms/Desktop/ProtocolVisualization/utils/__tests__/partitionWasteChuteDeckFixtures.test.ts
# 4 passed

pnpm vitest run --dir protocol-visualization src/organisms/utils/__tests__/partitionWasteChuteDeckFixtures.test.ts
# 4 passed
```

Logic repro before the gate (D4 staging, empty `wasteChuteEntities`): buggy filter count 1, fixed filter count 0.


Made with [Cursor](https://cursor.com)