### PR TITLE
Fix(api): Better error messaging during async errors during a run

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/command_executor.py
+++ b/api/src/opentrons/protocol_engine/execution/command_executor.py
@@ -168,7 +168,7 @@ class CommandExecutor:
             # TODO(mc, 2022-11-14): mark command as stopped rather than failed
             # https://opentrons.atlassian.net/browse/RCORE-390
             if isinstance(error, asyncio.CancelledError):
-                error = RunStoppedError("Run was cancelled")
+                error = RunStoppedError(f"Run was cancelled {str(error)}")
             elif isinstance(error, EStopActivatedError):
                 error = PE_EStopActivatedError(wrapping=[error])
             elif not isinstance(error, EnumeratedError):

--- a/api/src/opentrons/protocol_engine/execution/queue_worker.py
+++ b/api/src/opentrons/protocol_engine/execution/queue_worker.py
@@ -40,7 +40,7 @@ class QueueWorker:
         if self._worker_task is None:
             self._worker_task = asyncio.create_task(self._run_commands())
 
-    def cancel(self) -> None:
+    def cancel(self, msg: str = "") -> None:
         """Cancel any in-progress commands.
 
         This method is synchronous to allow synchronous callers to
@@ -51,8 +51,8 @@ class QueueWorker:
         propagate errors.
         """
         if self._worker_task:
-            self._worker_task.cancel()
-            self._command_executor.cancel_tasks("Engine cancelled")
+            self._worker_task.cancel(msg)
+            self._command_executor.cancel_tasks(f"Engine cancelled {msg}")
 
     async def join(self) -> None:
         """Wait for the worker to finish, propagating any errors."""

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -333,7 +333,7 @@ class ProtocolEngine:
         )
         return completed_command
 
-    def _stop_from_asynchronous_error(self) -> None:
+    def _stop_from_asynchronous_error(self, msg: str = "") -> None:
         try:
             action = self._state_store.commands.validate_action_allowed(
                 StopAction(from_asynchronous_error=True)
@@ -354,7 +354,7 @@ class ProtocolEngine:
         # against the E-stop exception propagating up from lower layers. But we need to
         # do this because we want to make sure non-hardware commands, like
         # `waitForDuration`, are also interrupted.
-        self._get_queue_worker.cancel()
+        self._get_queue_worker.cancel(msg)
 
     def estop(self) -> None:
         """Signal to the engine that an E-stop event occurred.
@@ -374,7 +374,7 @@ class ProtocolEngine:
         # Unlike self.request_stop(), we don't need to do
         # self._hardware_api.cancel_execution_and_running_tasks(). Since this was an
         # E-stop event, the hardware API already knows.
-        self._stop_from_asynchronous_error()
+        self._stop_from_asynchronous_error("E-stop Pressed")
 
     async def async_module_error(
         self,
@@ -424,7 +424,7 @@ class ProtocolEngine:
         ):
             return False
 
-        self._stop_from_asynchronous_error()
+        self._stop_from_asynchronous_error(f"asynchronous module error from {module_model}")
         # like self.request_stop, and unlike self.estop(), we must explicitly request that the
         # hardware stops execution, since not all asynchronous errors will cause the hardware
         # to know that it should stop.
@@ -457,7 +457,7 @@ class ProtocolEngine:
             module_model, serial
         ):
             return False
-        self._stop_from_asynchronous_error()
+        self._stop_from_asynchronous_error(f"Module {module_model} {serial} has disconnected")
         # like self.request_stop, and unlike self.estop(), we must explicitly request that the
         # hardware stops execution, since not all asynchronous errors will cause the hardware
         # to know that it should stop.

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -424,7 +424,9 @@ class ProtocolEngine:
         ):
             return False
 
-        self._stop_from_asynchronous_error(f"asynchronous module error from {module_model}")
+        self._stop_from_asynchronous_error(
+            f"asynchronous module error from {module_model}"
+        )
         # like self.request_stop, and unlike self.estop(), we must explicitly request that the
         # hardware stops execution, since not all asynchronous errors will cause the hardware
         # to know that it should stop.
@@ -457,7 +459,9 @@ class ProtocolEngine:
             module_model, serial
         ):
             return False
-        self._stop_from_asynchronous_error(f"Module {module_model} {serial} has disconnected")
+        self._stop_from_asynchronous_error(
+            f"Module {module_model} {serial} has disconnected"
+        )
         # like self.request_stop, and unlike self.estop(), we must explicitly request that the
         # hardware stops execution, since not all asynchronous errors will cause the hardware
         # to know that it should stop.

--- a/api/tests/opentrons/protocol_engine/execution/test_queue_worker.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_queue_worker.py
@@ -109,7 +109,7 @@ async def test_cancel(
         await command_executor.execute(command_id=matchers.Anything()),
         times=0,
     )
-    decoy.verify(command_executor.cancel_tasks("Engine cancelled"), times=1)
+    decoy.verify(command_executor.cancel_tasks("Engine cancelled "), times=1)
 
 
 async def test_cancel_noops_if_joined(

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -1013,7 +1013,7 @@ async def test_async_module_error_stops_on_match(
 
     decoy.verify(
         action_dispatcher.dispatch(action=validated_action),
-        queue_worker.cancel(),
+        queue_worker.cancel("asynchronous module error from thermocyclerModuleV1"),
     )
 
 
@@ -1096,7 +1096,7 @@ async def test_estop(
 
     decoy.verify(
         action_dispatcher.dispatch(action=validated_action),
-        queue_worker.cancel(),
+        queue_worker.cancel("E-stop Pressed"),
     )
 
 

--- a/robot-server/tests/integration/http_api/runs/test_play_stop_papi.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_play_stop_papi.tavern.yaml
@@ -118,7 +118,7 @@ stages:
             notes: []
             error:
               createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
-              detail: 'Run was cancelled'
+              detail: 'Run was cancelled '
               errorCode: '4000'
               errorInfo: {}
               errorType: 'RunStoppedError'

--- a/robot-server/tests/integration/http_api/runs/test_play_stop_v6.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_play_stop_v6.tavern.yaml
@@ -118,7 +118,7 @@ stages:
             notes: []
             error:
               createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
-              detail: 'Run was cancelled'
+              detail: 'Run was cancelled '
               errorCode: '4000'
               errorInfo: {}
               errorType: 'RunStoppedError'


### PR DESCRIPTION
# Overview
The has always been a race condition in protocol engine that when an asynchronous error happens, the Asyncio.cancelled error races against the Finish protocol with error but with pyro this now results in us always losing that race. 
This PR adds a string message to the cancel call so that at least the cause of the cancelation gets put into the user-facing message.