### PR TITLE
fix(components): fix resize bar hover color

### DIFF
--- a/components/src/molecules/ResizableContainer/resizablecontainer.module.css
+++ b/components/src/molecules/ResizableContainer/resizablecontainer.module.css
@@ -31,6 +31,6 @@
   bottom: 0;
   left: 3px;
   width: 2px;
-  background-color: var(--blue-50);
+  background-color: var(--grey-40);
   content: '';
 }


### PR DESCRIPTION


# Overview
fix resize bar hover color


https://github.com/user-attachments/assets/b62da889-05d0-4fb7-b04f-1697914eff6e



closes AUTH-3338


## Test Plan and Hands on Testing
- run storybook
- go to ResizableContainer


## Changelog
- change resize bar from blue-50 to grey-40

## Review requests

## Risk assessment
low
