### PR TITLE
fix(app): wait for queries to settle before applying update

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/UpdateRobotModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/UpdateRobotModal.tsx
@@ -81,13 +81,14 @@ export function UpdateRobotModal({
   const { updateFromFileDisabledReason } = useSelector((state: State) => {
     return getRobotUpdateDisplayInfo(state, robotName)
   })
-  const { startUpdate } = useGatedStartRobotUpdate(robotName)
+  const { startUpdate, isLoading } = useGatedStartRobotUpdate(robotName)
   const robotUpdateVersion = useSelector((state: State) => {
     return getRobotUpdateVersion(state, robotName) ?? ''
   })
 
   const isRobotBusy = useIsRobotBusy()
-  const updateDisabled = updateFromFileDisabledReason !== null || isRobotBusy
+  const updateDisabled =
+    updateFromFileDisabledReason !== null || isRobotBusy || isLoading
 
   let disabledReason: string = ''
   if (updateFromFileDisabledReason) {

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/__tests__/UpdateRobotModal.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/__tests__/UpdateRobotModal.test.tsx
@@ -8,6 +8,7 @@ import { i18n } from '/app/i18n'
 import { useIsRobotBusy } from '/app/redux-resources/robots'
 import { getDiscoverableRobotByName } from '/app/redux/discovery'
 import {
+  downloadRobotUpdate,
   getRobotUpdateDisplayInfo,
   getRobotUpdateVersion,
 } from '/app/redux/robot-update'
@@ -17,13 +18,14 @@ import { RELEASE_NOTES_URL_BASE, UpdateRobotModal } from '../UpdateRobotModal'
 import type { ComponentProps } from 'react'
 
 const mockStartUpdate = vi.hoisted(() => vi.fn(() => true))
+const mockGatedStart = vi.hoisted(() => ({
+  startUpdate: mockStartUpdate,
+  isLoading: false,
+}))
 
 vi.mock('/app/redux/robot-update')
 vi.mock('/app/local-resources/access-control/useGatedStartRobotUpdate', () => ({
-  useGatedStartRobotUpdate: () => ({
-    startUpdate: mockStartUpdate,
-    isLoading: false,
-  }),
+  useGatedStartRobotUpdate: () => mockGatedStart,
 }))
 vi.mock('/app/redux/discovery')
 vi.mock('/app/redux-resources/robots')
@@ -38,6 +40,13 @@ describe('UpdateRobotModal', () => {
   let props: ComponentProps<typeof UpdateRobotModal>
   beforeEach(() => {
     mockStartUpdate.mockClear()
+    mockStartUpdate.mockReturnValue(true)
+    mockGatedStart.isLoading = false
+    vi.mocked(downloadRobotUpdate).mockClear()
+    vi.mocked(downloadRobotUpdate).mockReturnValue({
+      type: 'robotUpdate:DOWNLOAD_UPDATE',
+      meta: { shell: true },
+    } as ReturnType<typeof downloadRobotUpdate>)
     props = {
       robotName: 'test robot',
       releaseNotes: 'test notes',
@@ -121,5 +130,31 @@ describe('UpdateRobotModal', () => {
     screen.getByText('Robot Operating System Update Available')
     screen.getByText('Not now')
     screen.getByText('Update robot now')
+  })
+
+  it('downloads then starts the update when update is allowed', () => {
+    vi.mocked(getRobotUpdateDisplayInfo).mockReturnValue({
+      autoUpdateAction: 'upgrade',
+      autoUpdateDisabledReason: null,
+      updateFromFileDisabledReason: null,
+    })
+
+    render(props)
+    fireEvent.click(screen.getByText('Update robot now'))
+
+    expect(downloadRobotUpdate).toHaveBeenCalled()
+    expect(mockStartUpdate).toHaveBeenCalled()
+  })
+
+  it('disables update while admin permission queries are loading', () => {
+    mockGatedStart.isLoading = true
+    vi.mocked(getRobotUpdateDisplayInfo).mockReturnValue({
+      autoUpdateAction: 'upgrade',
+      autoUpdateDisabledReason: null,
+      updateFromFileDisabledReason: null,
+    })
+
+    render(props)
+    expect(screen.getByText('Update robot now')).toBeDisabled()
   })
 })

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/index.tsx
@@ -82,11 +82,13 @@ const UpdateBuildroot = NiceModal.create(
       return null
     } else if (robot != null && robot.status !== UNREACHABLE) {
       return (
-        <ViewUpdateModal
-          robotName={robotName.current}
-          robot={robot}
-          closeModal={ignoreUpdate}
-        />
+        <ApiHostProvider robotName={robotName.current}>
+          <ViewUpdateModal
+            robotName={robotName.current}
+            robot={robot}
+            closeModal={ignoreUpdate}
+          />
+        </ApiHostProvider>
       )
     } else {
       return null


### PR DESCRIPTION
# Overview

Applying updates was failing without prompting for login when the CRS setting queries weren't loaded.

Fixes [RQA-6137](https://opentrons.atlassian.net/browse/RQA-6137?issueKey=RQA-6137&subProduct=jira-software)

## Test Plan and Hands on Testing

1. On a CRS bot trigger an update while not logged in
2. Click go on the update modal once its no longer disabled
3. The update should download and apply

## Risk assessment

Low

[RQA-6137]: https://opentrons.atlassian.net/browse/RQA-6137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ