### PR TITLE
fix(protocol-visualization): remove padding for oai

### DIFF
--- a/protocol-visualization/src/organisms/VisualizerContainer/visualizercontainer.module.css
+++ b/protocol-visualization/src/organisms/VisualizerContainer/visualizercontainer.module.css
@@ -3,7 +3,6 @@
   overflow: hidden;
   height: 100%;
   box-sizing: border-box;
-  padding: var(--spacing-16);
   background-color: var(--grey-10);
 }
 


### PR DESCRIPTION


# Overview
remove padding for oai

### before
<img width="2163" height="1107" alt="Screenshot 2026-09-11 at 5 52 15 PM" src="https://github.com/user-attachments/assets/b6fd0bf3-acca-4c49-bd81-b9ce561ac095" />


### after
<img width="1679" height="831" alt="Screenshot 2026-09-11 at 5 28 35 PM" src="https://github.com/user-attachments/assets/2a3fd9e5-5144-4a9a-929c-80e5335463a2" />


### AUTH-3318
<img width="1292" height="726" alt="Screenshot 2026-09-15 at 7 24 50 PM" src="https://github.com/user-attachments/assets/bdd55abc-e8e1-4f20-8d79-46a54c1ad629" />


closes AUTH-3325 and AUTH-3318


## Test Plan and Hands on Testing
none

## Changelog
- remove padding from protocol-visualization's container
- add padding to the right col

## Review requests


## Risk assessment
low
