### PR TITLE
fix(protocol-visualization): fix spotlight window header issue

### DIFF
--- a/js-package-testing/src/locale/en/protocol_visualization.json
+++ b/js-package-testing/src/locale/en/protocol_visualization.json
@@ -37,6 +37,7 @@
   "seconds_per_step": "{{seconds}}s per step",
   "slot": "Slot",
   "slot_empty": "Slot empty",
+  "slot_spotlight": "Slot Spotlight",
   "source_tips": "Source tips",
   "source_well_view": "Source well view",
   "speed": "{{speed}} RPM",

--- a/protocol-visualization/src/assets/localization/en/protocol_visualization.json
+++ b/protocol-visualization/src/assets/localization/en/protocol_visualization.json
@@ -42,6 +42,7 @@
   "seconds_per_step": "{{seconds}} s per step",
   "slot": "Slot",
   "slot_empty": "Slot empty",
+  "slot_spotlight": "Slot Spotlight",
   "source_tips": "Source tips",
   "source_well_view": "Source well view",
   "speed": "{{speed}} RPM",

--- a/protocol-visualization/src/molecules/SlotDetailsEmptyState/__tests__/SlotDetailsEmptyState.test.tsx
+++ b/protocol-visualization/src/molecules/SlotDetailsEmptyState/__tests__/SlotDetailsEmptyState.test.tsx
@@ -1,27 +1,16 @@
 import { screen } from '@testing-library/react'
-import { beforeEach, describe, it } from 'vitest'
+import { describe, it } from 'vitest'
 
 import { SlotDetailsEmptyState } from '..'
 import { renderWithProviders } from '../../../__testing-utils__'
 
-import type { ComponentProps } from 'react'
-
-const render = (props: ComponentProps<typeof SlotDetailsEmptyState>) => {
-  return renderWithProviders(<SlotDetailsEmptyState {...props} />) // TODO: add i18n rendering option
+const render = () => {
+  return renderWithProviders(<SlotDetailsEmptyState />) // TODO: add i18n rendering option
 }
 
 describe('SlotDetailsEmptyState', () => {
-  let props: ComponentProps<typeof SlotDetailsEmptyState>
-
-  beforeEach(() => {
-    props = {
-      slotId: 'A1',
-    }
-  })
-
   it('should render slot empty state', () => {
-    render(props)
-    screen.getByText('A1')
+    render()
     screen.getByText('slot_empty')
   })
 })

--- a/protocol-visualization/src/molecules/SlotDetailsEmptyState/index.tsx
+++ b/protocol-visualization/src/molecules/SlotDetailsEmptyState/index.tsx
@@ -1,30 +1,15 @@
-import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 
-import { COLORS, RobotInfoLabel, StyledText } from '@opentrons/components'
+import { COLORS, StyledText } from '@opentrons/components'
 
 import styles from './slotdetailsemptystate.module.css'
 
 import type { ReactNode } from 'react'
 
-interface SlotDetailsEmptyStateProps {
-  slotId: string
-  headerPortalEl?: HTMLElement | null
-}
-
-export function SlotDetailsEmptyState(
-  props: SlotDetailsEmptyStateProps
-): ReactNode {
-  const { slotId, headerPortalEl } = props
+export function SlotDetailsEmptyState(): ReactNode {
   const { t } = useTranslation('protocol_visualization')
-  const header = (
-    <div className={styles.slot_empty_header}>
-      <RobotInfoLabel deckLabel={slotId} />
-    </div>
-  )
   return (
     <div className={styles.slot_empty_container}>
-      {headerPortalEl != null ? createPortal(header, headerPortalEl) : header}
       <div className={styles.slot_empty_body}>
         <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey50}>
           {t('slot_empty')}

--- a/protocol-visualization/src/molecules/SlotDetailsEmptyState/slotdetailsemptystate.module.css
+++ b/protocol-visualization/src/molecules/SlotDetailsEmptyState/slotdetailsemptystate.module.css
@@ -6,12 +6,6 @@
   gap: var(--spacing-16);
 }
 
-.slot_empty_header {
-  display: flex;
-  width: 100%;
-  justify-content: flex-start;
-}
-
 .slot_empty_body {
   display: flex;
   width: 100%;

--- a/protocol-visualization/src/organisms/ModuleContainer/index.tsx
+++ b/protocol-visualization/src/organisms/ModuleContainer/index.tsx
@@ -1,7 +1,6 @@
-import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 
-import { Chip, RobotInfoLabel, StyledText } from '@opentrons/components'
+import { Chip, StyledText } from '@opentrons/components'
 import {
   ABSORBANCE_READER_TYPE,
   FLEX_STACKER_MODULE_TYPE,
@@ -23,16 +22,12 @@ interface ModuleContainerProps {
   moduleId: string
   moduleEntities: ModuleEntities
   moduleRobotState: RobotState['modules']
-  slotId: string
-  headerPortalEl?: HTMLElement | null
 }
 
 export function ModuleContainer({
   moduleId,
   moduleEntities,
   moduleRobotState,
-  slotId,
-  headerPortalEl,
 }: ModuleContainerProps): ReactNode {
   const { t } = useTranslation('protocol_visualization')
   const { model } = moduleEntities[moduleId]
@@ -228,19 +223,12 @@ export function ModuleContainer({
       )
   }
 
-  const header = (
-    <>
-      <RobotInfoLabel deckLabel={slotId} />
-      <StyledText desktopStyle="bodyDefaultSemiBold">
-        {moduleDisplayName}
-      </StyledText>
-    </>
-  )
-
   return (
     <div className={styles.container}>
       <div className={styles.main_content}>
-        {headerPortalEl != null ? createPortal(header, headerPortalEl) : header}
+        <StyledText desktopStyle="bodyDefaultSemiBold">
+          {moduleDisplayName}
+        </StyledText>
         {moduleDetails}
       </div>
     </div>

--- a/protocol-visualization/src/organisms/SlotDetails/index.tsx
+++ b/protocol-visualization/src/organisms/SlotDetails/index.tsx
@@ -31,17 +31,9 @@ interface SlotDetailsProps {
   invariantContext: InvariantContext
   analysis: ProtocolAnalysisOutput
   liquids: Liquid[]
-  headerPortalEl?: HTMLElement | null
 }
 export function SlotDetails(props: SlotDetailsProps): ReactNode {
-  const {
-    slotId,
-    robotState,
-    invariantContext,
-    analysis,
-    liquids,
-    headerPortalEl,
-  } = props
+  const { slotId, robotState, invariantContext, analysis, liquids } = props
   const { labware, modules } = robotState
   const {
     labwareEntities,
@@ -122,7 +114,6 @@ export function SlotDetails(props: SlotDetailsProps): ReactNode {
           <TipPickupSlot
             tiprackEntity={labwareEntitiesExtended[topMostLabwareOnSlot]}
             robotState={robotState}
-            headerPortalEl={headerPortalEl}
           />
         )
       case 'labware':
@@ -133,8 +124,6 @@ export function SlotDetails(props: SlotDetailsProps): ReactNode {
             commands={commands}
             liquids={liquids}
             robotState={robotState}
-            moduleEntities={moduleEntities}
-            headerPortalEl={headerPortalEl}
           />
         )
       default:
@@ -146,35 +135,18 @@ export function SlotDetails(props: SlotDetailsProps): ReactNode {
     <>
       {isSlotEmpty ? (
         <div className={styles.slot_detail_container}>
-          <SlotDetailsEmptyState
-            slotId={slotId}
-            headerPortalEl={headerPortalEl}
-          />
+          <SlotDetailsEmptyState />
         </div>
       ) : null}
       <div className={styles.slot_container}>
         <div className={styles.slot_details}>
           {renderLabwareContent()}
-          {disposalType != null ? (
-            <TipDisposalSlot
-              robotState={robotState}
-              disposalType={disposalType}
-              headerPortalEl={
-                topMostLabwareOnSlot == null ? headerPortalEl : undefined
-              }
-            />
-          ) : null}
+          {disposalType != null ? <TipDisposalSlot /> : null}
           {moduleOnSlot != null ? (
             <ModuleContainer
               moduleId={moduleOnSlot[0]}
               moduleEntities={moduleEntities}
               moduleRobotState={modules}
-              slotId={mappedSlot}
-              headerPortalEl={
-                topMostLabwareOnSlot == null && disposalType == null
-                  ? headerPortalEl
-                  : undefined
-              }
             />
           ) : null}
         </div>

--- a/protocol-visualization/src/organisms/SlotSpotlight/LabwareSlot/__tests__/LabwareSlot.test.tsx
+++ b/protocol-visualization/src/organisms/SlotSpotlight/LabwareSlot/__tests__/LabwareSlot.test.tsx
@@ -1,6 +1,10 @@
 import { screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import {
+  RobotCoordsForeignObject,
+  RobotWorkSpace,
+} from '@opentrons/components'
 import { fixture96Plate } from '@opentrons/shared-data'
 
 import { LabwareSlot } from '..'
@@ -17,6 +21,8 @@ vi.mock('@opentrons/components', async importOriginal => {
   return {
     ...actual,
     LabwareRender: vi.fn(() => <div>mock LabwareRender</div>),
+    RobotWorkSpace: vi.fn(actual.RobotWorkSpace),
+    RobotCoordsForeignObject: vi.fn(actual.RobotCoordsForeignObject),
   }
 })
 
@@ -103,6 +109,7 @@ describe('LabwareSlot', () => {
   let props: ComponentProps<typeof LabwareSlot>
 
   beforeEach(() => {
+    vi.clearAllMocks()
     props = {
       topLabwareOnSlotId: MOCK_LABWARE_ID,
       labwareEntities: createMockLabwareEntities(),
@@ -199,24 +206,29 @@ describe('LabwareSlot', () => {
       },
     }
 
-    const { container } = render(props)
+    render(props)
     expect(screen.getByLabelText('stacked')).toBeInTheDocument()
     expect(screen.getByText('Top labware in stack')).toBeInTheDocument()
 
-    const svg = container.querySelector('svg')
-    expect(svg).not.toBeNull()
-    const viewBox = svg?.getAttribute('viewBox')?.split(' ').map(Number)
-    expect(viewBox).toEqual([0, 0, 133, 90.75])
+    expect(RobotWorkSpace).toHaveBeenCalledWith(
+      expect.objectContaining({ viewBox: '0 0 133 90.75' }),
+      expect.anything()
+    )
 
-    const foreignObject = container.querySelector('foreignObject')
-    expect(foreignObject).not.toBeNull()
+    expect(RobotCoordsForeignObject).toHaveBeenCalledWith(
+      expect.objectContaining({ x: 222, y: 141.5 }),
+      expect.anything()
+    )
+
     const badgeScale = 0.5
-    const badgeX = Number(foreignObject?.getAttribute('x')) * badgeScale
-    const badgeY = Number(foreignObject?.getAttribute('y')) * badgeScale
+    const viewBoxWidth = 133
+    const viewBoxHeight = 90.75
+    const badgeX = 222 * badgeScale
+    const badgeY = 141.5 * badgeScale
     // Same relative corner inset as the legacy 235/155 placement on ANSI plates.
     expect(badgeX).toBeCloseTo(111)
     expect(badgeY).toBeCloseTo(70.75)
-    expect(badgeX).toBeLessThan(viewBox?.[2] ?? 0)
-    expect(badgeY).toBeLessThan(viewBox?.[3] ?? 0)
+    expect(badgeX).toBeLessThan(viewBoxWidth)
+    expect(badgeY).toBeLessThan(viewBoxHeight)
   })
 })

--- a/protocol-visualization/src/organisms/SlotSpotlight/LabwareSlot/__tests__/LabwareSlot.test.tsx
+++ b/protocol-visualization/src/organisms/SlotSpotlight/LabwareSlot/__tests__/LabwareSlot.test.tsx
@@ -1,10 +1,7 @@
 import { screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import {
-  RobotCoordsForeignObject,
-  RobotWorkSpace,
-} from '@opentrons/components'
+import { RobotCoordsForeignObject, RobotWorkSpace } from '@opentrons/components'
 import { fixture96Plate } from '@opentrons/shared-data'
 
 import { LabwareSlot } from '..'

--- a/protocol-visualization/src/organisms/SlotSpotlight/LabwareSlot/__tests__/LabwareSlot.test.tsx
+++ b/protocol-visualization/src/organisms/SlotSpotlight/LabwareSlot/__tests__/LabwareSlot.test.tsx
@@ -153,4 +153,70 @@ describe('LabwareSlot', () => {
     render(props)
     expect(screen.getByText('mock LabwareRender')).toBeInTheDocument()
   })
+
+  it('should keep the stacked badge inside the viewBox for short labware', () => {
+    const shortLidId = 'shortLidId'
+    const shortLidDef = {
+      ...fixture96Plate,
+      metadata: {
+        ...fixture96Plate.metadata,
+        displayName: 'Opentrons Flex Tip Rack Lid',
+      },
+      dimensions: {
+        xDimension: 121,
+        yDimension: 78.75,
+        zDimension: 17,
+      },
+      wells: {},
+      ordering: [],
+    } as LabwareDefinition2
+
+    props.topLabwareOnSlotId = shortLidId
+    props.labwareEntities = {
+      [shortLidId]: {
+        id: shortLidId,
+        labwareDefURI: 'opentrons/opentrons_flex_tiprack_lid/1',
+        def: shortLidDef,
+        pythonName: 'mock_lid',
+      },
+      lidUnderId: {
+        id: 'lidUnderId',
+        labwareDefURI: 'opentrons/opentrons_flex_tiprack_lid/1',
+        def: shortLidDef,
+        pythonName: 'mock_lid_under',
+      },
+    }
+    props.commands = []
+    props.robotState = {
+      ...createMockRobotState(),
+      labware: {
+        [shortLidId]: {
+          stack: [shortLidId, 'lidUnderId', MOCK_SLOT],
+        },
+        lidUnderId: {
+          stack: ['lidUnderId', MOCK_SLOT],
+        },
+      },
+    }
+
+    const { container } = render(props)
+    expect(screen.getByLabelText('stacked')).toBeInTheDocument()
+    expect(screen.getByText('Top labware in stack')).toBeInTheDocument()
+
+    const svg = container.querySelector('svg')
+    expect(svg).not.toBeNull()
+    const viewBox = svg?.getAttribute('viewBox')?.split(' ').map(Number)
+    expect(viewBox).toEqual([0, 0, 133, 90.75])
+
+    const foreignObject = container.querySelector('foreignObject')
+    expect(foreignObject).not.toBeNull()
+    const badgeScale = 0.5
+    const badgeX = Number(foreignObject?.getAttribute('x')) * badgeScale
+    const badgeY = Number(foreignObject?.getAttribute('y')) * badgeScale
+    // Same relative corner inset as the legacy 235/155 placement on ANSI plates.
+    expect(badgeX).toBeCloseTo(111)
+    expect(badgeY).toBeCloseTo(70.75)
+    expect(badgeX).toBeLessThan(viewBox?.[2] ?? 0)
+    expect(badgeY).toBeLessThan(viewBox?.[3] ?? 0)
+  })
 })

--- a/protocol-visualization/src/organisms/SlotSpotlight/LabwareSlot/__tests__/LabwareSlot.test.tsx
+++ b/protocol-visualization/src/organisms/SlotSpotlight/LabwareSlot/__tests__/LabwareSlot.test.tsx
@@ -10,11 +10,7 @@ import { i18n } from '../../../../i18n'
 import type { ComponentProps } from 'react'
 import type * as OpentronsComponents from '@opentrons/components'
 import type { LabwareDefinition2, RunTimeCommand } from '@opentrons/shared-data'
-import type {
-  LabwareEntities,
-  ModuleEntities,
-  RobotState,
-} from '@opentrons/step-generation'
+import type { LabwareEntities, RobotState } from '@opentrons/step-generation'
 
 vi.mock('@opentrons/components', async importOriginal => {
   const actual = await importOriginal<typeof OpentronsComponents>()
@@ -113,7 +109,6 @@ describe('LabwareSlot', () => {
       commands: [createMockLoadLabwareCommand()],
       liquids: [],
       robotState: createMockRobotState(),
-      moduleEntities: {} as ModuleEntities,
     }
   })
 
@@ -125,6 +120,13 @@ describe('LabwareSlot', () => {
   it('should render labware nickname when provided', () => {
     render(props)
     expect(screen.getByText('Test Plate')).toBeInTheDocument()
+  })
+
+  it('should render display name without nickname when displayName is absent', () => {
+    props.commands = []
+    render(props)
+    expect(screen.getByText('Mock 96 Well Plate')).toBeInTheDocument()
+    expect(screen.queryByText('Test Plate')).not.toBeInTheDocument()
   })
 
   it('should render LabwareRender component', () => {

--- a/protocol-visualization/src/organisms/SlotSpotlight/LabwareSlot/index.tsx
+++ b/protocol-visualization/src/organisms/SlotSpotlight/LabwareSlot/index.tsx
@@ -150,6 +150,25 @@ export function LabwareSlot(props: LabwareSlotContainerProps): ReactNode {
     quantity = stackQuantity
   }
 
+  const showStackedBadge = quantity > 1
+  // Match the pre-change visual size and the ANSI-plate corner inset from
+  // x=235/y=155 (scale 0.5 → ~10mm from right, ~8mm from back). Anchor to
+  // each labware's viewBox so shorter lids keep that same relative corner.
+  const stackedBadgeScale = 0.5
+  const stackedBadgeInsetXMm = 10
+  const stackedBadgeInsetYMm = 8
+  const stackedBadgeViewBoxPadMm = 12
+  const stackedBadgeX =
+    (labwareViewBox.maxX - stackedBadgeInsetXMm) / stackedBadgeScale
+  const stackedBadgeY =
+    (labwareViewBox.maxY - stackedBadgeInsetYMm) / stackedBadgeScale
+  const viewBoxWidth =
+    labwareViewBox.xDimension +
+    (showStackedBadge ? stackedBadgeViewBoxPadMm : 0)
+  const viewBoxHeight =
+    labwareViewBox.yDimension +
+    (showStackedBadge ? stackedBadgeViewBoxPadMm : 0)
+
   return (
     <div className={styles.container}>
       <div className={styles.labware_summary}>
@@ -171,7 +190,7 @@ export function LabwareSlot(props: LabwareSlotContainerProps): ReactNode {
             <div className={styles.labware_render_container}>
               <RobotWorkSpace
                 key={topLabwareOnSlotId}
-                viewBox={`${labwareViewBox.minX} ${labwareViewBox.minY} ${labwareViewBox.xDimension + (quantity > 1 ? 10 : 0)} ${labwareViewBox.yDimension + (quantity > 1 ? 5 : 0)}`}
+                viewBox={`${labwareViewBox.minX} ${labwareViewBox.minY} ${viewBoxWidth} ${viewBoxHeight}`}
               >
                 {() => (
                   <>
@@ -198,29 +217,27 @@ export function LabwareSlot(props: LabwareSlotContainerProps): ReactNode {
                         }}
                       />
                     </g>
-                    {quantity > 1 ? (
-                      <>
-                        <g transform="scale(0.5)">
-                          <RobotCoordsForeignObject
-                            width="1.5rem"
-                            height="1.25rem"
-                            x={235}
-                            y={155}
-                          >
-                            <RobotInfoLabel
-                              height="1rem"
-                              svgSize="0.875rem"
-                              highlight
-                              iconName="stacked"
-                            />
-                          </RobotCoordsForeignObject>
-                        </g>
-                      </>
+                    {showStackedBadge ? (
+                      <g transform={`scale(${stackedBadgeScale})`}>
+                        <RobotCoordsForeignObject
+                          width="1.5rem"
+                          height="1.25rem"
+                          x={stackedBadgeX}
+                          y={stackedBadgeY}
+                        >
+                          <RobotInfoLabel
+                            height="1rem"
+                            svgSize="0.875rem"
+                            highlight
+                            iconName="stacked"
+                          />
+                        </RobotCoordsForeignObject>
+                      </g>
                     ) : null}
                   </>
                 )}
               </RobotWorkSpace>
-              {quantity > 1 ? (
+              {showStackedBadge ? (
                 <div className={styles.labware_text_align}>
                   <StyledText
                     desktopStyle="captionRegular"

--- a/protocol-visualization/src/organisms/SlotSpotlight/LabwareSlot/index.tsx
+++ b/protocol-visualization/src/organisms/SlotSpotlight/LabwareSlot/index.tsx
@@ -1,17 +1,13 @@
 import { useState } from 'react'
-import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 
 import {
   COLORS,
-  Divider,
   LabwareRender,
-  MODULE_ICON_NAME_BY_TYPE,
   RobotCoordsForeignObject,
   RobotInfoLabel,
   RobotWorkSpace,
   StyledText,
-  Tag,
 } from '@opentrons/components'
 import { getLabwareViewBox } from '@opentrons/shared-data'
 import {
@@ -34,7 +30,6 @@ import type {
 import type {
   FlexStackerModuleState,
   LabwareEntities,
-  ModuleEntities,
   RobotState,
 } from '@opentrons/step-generation'
 
@@ -44,20 +39,10 @@ interface LabwareSlotContainerProps {
   commands: RunTimeCommand[]
   liquids: Liquid[]
   robotState: RobotState
-  moduleEntities: ModuleEntities
-  // when set, the header block is rendered into this element via portal
-  headerPortalEl?: HTMLElement | null
 }
 export function LabwareSlot(props: LabwareSlotContainerProps): ReactNode {
-  const {
-    topLabwareOnSlotId,
-    labwareEntities,
-    commands,
-    liquids,
-    robotState,
-    moduleEntities,
-    headerPortalEl,
-  } = props
+  const { topLabwareOnSlotId, labwareEntities, commands, liquids, robotState } =
+    props
   const { labware, pipettes, liquidState, modules } = robotState
   const { t } = useTranslation('protocol_visualization')
   const [hoveredWellName, setHoveredWellName] = useState<string | null>(null)
@@ -158,87 +143,25 @@ export function LabwareSlot(props: LabwareSlotContainerProps): ReactNode {
     id =>
       labware[id] != null && labwareEntities[id].labwareDefURI === topLabwareURI
   ).length
-  const quantity =
-    hopperGroups != null
-      ? hopperGroups.length
-      : stackQuantity > 0
-        ? stackQuantity
-        : (lidStackCommand?.params?.quantity ?? 1)
-  const adapterId = labware[topLabwareOnSlotId].stack.find(
-    id =>
-      labwareEntities[id]?.def.allowedRoles?.includes('adapter') &&
-      !labwareEntities[topLabwareOnSlotId].def.allowedRoles?.includes('adapter')
-  )
-  const stackItems =
-    labware[topLabwareOnSlotId]?.stack.filter(
-      item => item !== topLabwareOnSlotId
-    ) ?? []
-  const moduleStackItems = stackItems.filter(
-    item => moduleEntities[item] != null
-  )
-  const hasStackedLabware = stackItems.some(item => labware[item] != null)
-  const hasHopper = stackItems.includes(HOPPER_STACKER_LOCATION)
-  const showStackedIcon =
-    hasStackedLabware || (hopperGroups != null && hopperGroups.length > 1)
-
-  const header = (
-    <div className={styles.header}>
-      {/* header icon part */}
-      <div className={styles.header_icons}>
-        <RobotInfoLabel
-          key="slotLabel"
-          deckLabel={hasHopper ? t('stacker_slot', { slot }) : slot}
-        />
-        {moduleStackItems.map((item, index) => (
-          <RobotInfoLabel
-            key={`${item}-${index}`}
-            iconName={MODULE_ICON_NAME_BY_TYPE[moduleEntities[item].type]}
-          />
-        ))}
-        {showStackedIcon ? (
-          <RobotInfoLabel key="stackedIcon" iconName="stacked" />
-        ) : null}
-      </div>
-      {/* header icon part */}
-
-      {/* header text part */}
-      <div className={styles.header_container}>
-        <div className={styles.header_text}>
-          {labwareNickname != null ? (
-            <StyledText desktopStyle="captionSemiBold">
-              {labwareNickname}
-            </StyledText>
-          ) : null}
-          <StyledText desktopStyle="bodyDefaultRegular">
-            {labwareDisplayName}
-          </StyledText>
-          {isTopLabwareLid ? (
-            <StyledText desktopStyle="captionSemiBold">
-              {`With ${labwareEntities[topLabwareOnSlotId].def.metadata.displayName}`}
-            </StyledText>
-          ) : null}
-        </div>
-        {quantity > 1 ? (
-          <div className={styles.tag_container}>
-            <Tag text={t('quantity', { quantity })} type="default" />
-          </div>
-        ) : null}
-      </div>
-      {adapterId != null ? (
-        <>
-          <Divider className={styles.full_width_divider} />
-          <StyledText desktopStyle="captionSemiBold">
-            {labwareEntities[adapterId].def.metadata.displayName}
-          </StyledText>
-        </>
-      ) : null}
-      {/* header text part */}
-    </div>
-  )
+  let quantity = lidStackCommand?.params?.quantity ?? 1
+  if (hopperGroups != null) {
+    quantity = hopperGroups.length
+  } else if (stackQuantity > 0) {
+    quantity = stackQuantity
+  }
 
   return (
     <div className={styles.container}>
-      {headerPortalEl != null ? createPortal(header, headerPortalEl) : header}
+      <div className={styles.labware_summary}>
+        {labwareNickname != null && (
+          <StyledText desktopStyle="bodyDefaultSemiBold">
+            {labwareNickname}
+          </StyledText>
+        )}
+        <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
+          {labwareDisplayName}
+        </StyledText>
+      </div>
       <div className={styles.body_container}>
         <WellTooltip
           ingredNames={ingredNames}

--- a/protocol-visualization/src/organisms/SlotSpotlight/LabwareSlot/labwareslot.module.css
+++ b/protocol-visualization/src/organisms/SlotSpotlight/LabwareSlot/labwareslot.module.css
@@ -14,10 +14,10 @@
 }
 
 .body_container {
+  overflow: visible;
   padding: var(--spacing-16) var(--spacing-24);
   border-radius: var(--border-radius-4);
   background-color: var(--grey-10);
-  overflow: visible;
 }
 
 .labware_text_align {

--- a/protocol-visualization/src/organisms/SlotSpotlight/LabwareSlot/labwareslot.module.css
+++ b/protocol-visualization/src/organisms/SlotSpotlight/LabwareSlot/labwareslot.module.css
@@ -17,6 +17,7 @@
   padding: var(--spacing-16) var(--spacing-24);
   border-radius: var(--border-radius-4);
   background-color: var(--grey-10);
+  overflow: visible;
 }
 
 .labware_text_align {

--- a/protocol-visualization/src/organisms/SlotSpotlight/LabwareSlot/labwareslot.module.css
+++ b/protocol-visualization/src/organisms/SlotSpotlight/LabwareSlot/labwareslot.module.css
@@ -1,27 +1,16 @@
 .container {
   display: flex;
   flex-direction: column;
-  padding: var(--spacing-16) var(--spacing-20) var(--spacing-20);
+  padding: var(--spacing-24);
   gap: var(--spacing-16);
 }
 
-.header {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-4);
-}
-
-.header_icons {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-4);
-}
-
-.header_text {
+.labware_summary {
   display: flex;
   min-width: 0;
   flex: 1;
   flex-direction: column;
+  gap: var(--spacing-4);
 }
 
 .body_container {
@@ -30,22 +19,8 @@
   background-color: var(--grey-10);
 }
 
-.header_container {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
 .labware_text_align {
   width: 100%;
   padding-top: var(--spacing-8);
   text-align: center;
-}
-
-.tag_container {
-  height: 1.5rem;
-}
-
-.full_width_divider {
-  width: 100%;
 }

--- a/protocol-visualization/src/organisms/SlotSpotlight/TipDisposalSlot/__tests__/TipDisposalSlot.test.tsx
+++ b/protocol-visualization/src/organisms/SlotSpotlight/TipDisposalSlot/__tests__/TipDisposalSlot.test.tsx
@@ -1,41 +1,20 @@
 import { screen } from '@testing-library/react'
-import { beforeEach, describe, it } from 'vitest'
-
-import { CLEAN, EMPTY } from '@opentrons/step-generation'
+import { describe, expect, it } from 'vitest'
 
 import { TipDisposalSlot } from '..'
 import { renderWithProviders } from '../../../../__testing-utils__'
 import { i18n } from '../../../../i18n'
 
-import type { ComponentProps } from 'react'
-
-const render = (props: ComponentProps<typeof TipDisposalSlot>) => {
-  return renderWithProviders(<TipDisposalSlot {...props} />, {
+const render = () => {
+  return renderWithProviders(<TipDisposalSlot />, {
     i18nInstance: i18n,
   })
 }
 
 describe('TipDisposalSlot', () => {
-  let props: ComponentProps<typeof TipDisposalSlot>
-  beforeEach(() => {
-    props = {
-      disposalType: 'trash',
-      robotState: {
-        labware: {},
-        liquidState: {} as any,
-        pipettes: {},
-        modules: {},
-        tipState: {
-          tipracks: { mockId: { A1: CLEAN, A2: EMPTY } },
-          pipettes: {},
-        },
-      },
-    }
-  })
-  it('render text', () => {
-    render(props)
-    screen.getByText('TRASH')
-    // screen.getByText('Tips in trash')
-    // screen.getByText('1 tips')
+  it('should render the disposal body without a slot chip', () => {
+    render()
+    expect(screen.queryByText('TRASH')).not.toBeInTheDocument()
+    expect(screen.queryByText('WASTE CHUTE')).not.toBeInTheDocument()
   })
 })

--- a/protocol-visualization/src/organisms/SlotSpotlight/TipDisposalSlot/index.tsx
+++ b/protocol-visualization/src/organisms/SlotSpotlight/TipDisposalSlot/index.tsx
@@ -1,47 +1,10 @@
-import { createPortal } from 'react-dom'
-import { useTranslation } from 'react-i18next'
-
-import { RobotInfoLabel } from '@opentrons/components'
-
 import styles from './tipdisposalslot.module.css'
 
 import type { ReactNode } from 'react'
-import type { RobotState } from '@opentrons/step-generation'
 
-interface TipDisposalSlotProps {
-  robotState: RobotState
-  disposalType: 'trash' | 'wasteChute'
-  // when set, the header block is rendered into this element via portal
-  headerPortalEl?: HTMLElement | null
-}
-
-export function TipDisposalSlot({
-  robotState,
-  disposalType,
-  headerPortalEl,
-}: TipDisposalSlotProps): ReactNode {
-  const { t } = useTranslation('protocol_visualization')
-  // temporary commenting out for Rs 9.0.0
-  // const totalEmptyTips = Object.values(tipState.tipracks).reduce(
-  //   (sum, rack) =>
-  //     sum +
-  //     Object.values(rack).reduce(
-  //       (rackSum, tipVal) => rackSum + (tipVal === EMPTY ? 1 : 0),
-  //       0
-  //     ),
-  //   0
-  // )
-  const header = (
-    <div className={styles.header}>
-      <RobotInfoLabel
-        deckLabel={disposalType === 'trash' ? t('trash') : t('waste_chute')}
-      />
-    </div>
-  )
-
+export function TipDisposalSlot(): ReactNode {
   return (
     <div className={styles.container}>
-      {headerPortalEl != null ? createPortal(header, headerPortalEl) : header}
       <div className={styles.main_content}>
         {/* <div className={styles.text_container}>
           <StyledText desktopStyle="captionRegular" color={COLORS.grey60}>

--- a/protocol-visualization/src/organisms/SlotSpotlight/TipDisposalSlot/tipdisposalslot.module.css
+++ b/protocol-visualization/src/organisms/SlotSpotlight/TipDisposalSlot/tipdisposalslot.module.css
@@ -8,13 +8,6 @@
   gap: var(--spacing-8);
 }
 
-.header {
-  display: flex;
-  width: 100%;
-  align-items: center;
-  justify-content: space-between;
-}
-
 .main_content {
   gap: var(--spacing-8);
 }

--- a/protocol-visualization/src/organisms/SlotSpotlight/TipPickupSlot/__tests__/TipPickupSlot.test.tsx
+++ b/protocol-visualization/src/organisms/SlotSpotlight/TipPickupSlot/__tests__/TipPickupSlot.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import { beforeEach, describe, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { fixtureTiprack300ul } from '@opentrons/shared-data'
 import { CLEAN, DIRTY, EMPTY } from '@opentrons/step-generation'
@@ -96,8 +96,19 @@ describe('TipPickupSlot', () => {
   it('should render TipPickupSlot', () => {
     render(props)
     screen.getByText('mockNickname')
+    screen.getByText('Mock 300µL Tiprack')
     screen.getByText('mock LabwareRender')
     screen.getByTestId('robot-workspace')
+  })
+
+  it('should render display name without nickname when nickName is absent', () => {
+    props.tiprackEntity = {
+      ...createMockTiprackEntity(),
+      nickName: null,
+    }
+    render(props)
+    screen.getByText('Mock 300µL Tiprack')
+    expect(screen.queryByText('mockNickname')).not.toBeInTheDocument()
   })
 
   it('should display tips remaining count when tips are present', () => {

--- a/protocol-visualization/src/organisms/SlotSpotlight/TipPickupSlot/index.tsx
+++ b/protocol-visualization/src/organisms/SlotSpotlight/TipPickupSlot/index.tsx
@@ -1,4 +1,3 @@
-import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -22,12 +21,10 @@ import type { LabwareEntityExtended } from '../../DeckView'
 interface TipPickupSlotProps {
   tiprackEntity: LabwareEntityExtended
   robotState: RobotState
-  // when set, the header block is rendered into this element via portal
-  headerPortalEl?: HTMLElement | null
 }
 
 export function TipPickupSlot(props: TipPickupSlotProps): ReactNode {
-  const { tiprackEntity, robotState, headerPortalEl } = props
+  const { tiprackEntity, robotState } = props
   const { t } = useTranslation('protocol_visualization')
   const { id, def, nickName } = tiprackEntity
   const { tipState } = robotState
@@ -48,20 +45,16 @@ export function TipPickupSlot(props: TipPickupSlotProps): ReactNode {
     state => state !== NO
   ).length
 
-  const header = (
-    <div className={styles.header}>
-      {nickName != null ? (
-        <StyledText desktopStyle="bodyDefaultSemiBold">{nickName}</StyledText>
-      ) : null}
-      <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
-        {def.metadata.displayName}
-      </StyledText>
-    </div>
-  )
-
   return (
     <div className={styles.container}>
-      {headerPortalEl != null ? createPortal(header, headerPortalEl) : header}
+      <div className={styles.labware_summary}>
+        {nickName != null && (
+          <StyledText desktopStyle="bodyDefaultSemiBold">{nickName}</StyledText>
+        )}
+        <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
+          {def.metadata.displayName}
+        </StyledText>
+      </div>
       <div className={styles.main_content}>
         <RobotWorkSpace
           key={id}

--- a/protocol-visualization/src/organisms/SlotSpotlight/TipPickupSlot/tippickupslot.module.css
+++ b/protocol-visualization/src/organisms/SlotSpotlight/TipPickupSlot/tippickupslot.module.css
@@ -1,11 +1,11 @@
 .container {
   display: flex;
   flex-direction: column;
-  padding: var(--spacing-16) var(--spacing-20) var(--spacing-20);
+  padding: var(--spacing-24);
   gap: var(--spacing-16);
 }
 
-.header {
+.labware_summary {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-4);

--- a/protocol-visualization/src/organisms/SlotSpotlightViewer/__tests__/SlotSpotlightViewer.test.tsx
+++ b/protocol-visualization/src/organisms/SlotSpotlightViewer/__tests__/SlotSpotlightViewer.test.tsx
@@ -1,0 +1,66 @@
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SlotSpotlightViewer } from '..'
+import { renderWithProviders } from '../../../__testing-utils__'
+import { i18n } from '../../../i18n'
+
+import type { ComponentProps } from 'react'
+import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
+import type { InvariantContext, RobotState } from '@opentrons/step-generation'
+
+vi.mock('../../SlotDetails', () => ({
+  SlotDetails: () => <div>mock SlotDetails</div>,
+}))
+
+const render = (props: ComponentProps<typeof SlotSpotlightViewer>) => {
+  return renderWithProviders(<SlotSpotlightViewer {...props} />, {
+    i18nInstance: i18n,
+  })
+}
+
+const mockRobotState = {} as RobotState
+const mockInvariantContext = {} as InvariantContext
+
+describe('SlotSpotlightViewer', () => {
+  let props: ComponentProps<typeof SlotSpotlightViewer>
+
+  beforeEach(() => {
+    props = {
+      appType: 'web',
+      slotId: 'A1',
+      robotState: mockRobotState,
+      invariantContext: mockInvariantContext,
+      analysis: { commands: [] } as ProtocolAnalysisOutput,
+      liquids: [],
+      onClose: vi.fn(),
+    }
+  })
+
+  it('should render the slot label and Slot Spotlight title in the modal header', () => {
+    render(props)
+    expect(screen.getByTestId('RobotInfoLabel_A1')).toBeInTheDocument()
+    expect(screen.getByText('Slot Spotlight')).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toHaveAttribute(
+      'aria-labelledby',
+      'slot-spotlight-header'
+    )
+    expect(screen.getByText('mock SlotDetails')).toBeInTheDocument()
+  })
+
+  it('should map hopper fake locations to the real slot id on the slot label', () => {
+    props.slotId = 'hopperA4'
+    render(props)
+    expect(screen.getByTestId('RobotInfoLabel_A4')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('RobotInfoLabel_hopperA4')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should return null for the desktop app', () => {
+    props.appType = 'desktop'
+    render(props)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.queryByText('Slot Spotlight')).not.toBeInTheDocument()
+  })
+})

--- a/protocol-visualization/src/organisms/SlotSpotlightViewer/__tests__/SlotSpotlightViewer.test.tsx
+++ b/protocol-visualization/src/organisms/SlotSpotlightViewer/__tests__/SlotSpotlightViewer.test.tsx
@@ -21,6 +21,7 @@ const render = (props: ComponentProps<typeof SlotSpotlightViewer>) => {
 
 const mockRobotState = {} as RobotState
 const mockInvariantContext = {} as InvariantContext
+const mockAnalysis = {} as ProtocolAnalysisOutput
 
 describe('SlotSpotlightViewer', () => {
   let props: ComponentProps<typeof SlotSpotlightViewer>
@@ -31,7 +32,7 @@ describe('SlotSpotlightViewer', () => {
       slotId: 'A1',
       robotState: mockRobotState,
       invariantContext: mockInvariantContext,
-      analysis: { commands: [] } as ProtocolAnalysisOutput,
+      analysis: mockAnalysis,
       liquids: [],
       onClose: vi.fn(),
     }

--- a/protocol-visualization/src/organisms/SlotSpotlightViewer/index.tsx
+++ b/protocol-visualization/src/organisms/SlotSpotlightViewer/index.tsx
@@ -1,14 +1,25 @@
-import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { ModelessModal } from '@opentrons/components'
+import {
+  ModelessModal,
+  RobotInfoLabel,
+  StyledText,
+} from '@opentrons/components'
+import {
+  FAKE_HOPPER_LOCATION_MAP,
+  HOPPER_FAKE_LOCATIONS,
+} from '@opentrons/step-generation'
 
 import { SlotDetails } from '../SlotDetails'
 import styles from './slotspotlightviewer.module.css'
 
 import type { ReactNode } from 'react'
 import type { Liquid, ProtocolAnalysisOutput } from '@opentrons/shared-data'
-import type { InvariantContext, RobotState } from '@opentrons/step-generation'
+import type {
+  HopperLocationMapKey,
+  InvariantContext,
+  RobotState,
+} from '@opentrons/step-generation'
 import type { AppType } from '../../types'
 
 // Note: use the desktop app's sizes
@@ -40,17 +51,25 @@ export function SlotSpotlightViewer(
     onClose,
   } = props
   const { t } = useTranslation('protocol_visualization')
-  // the slot content renders its own header block into this element via portal
-  const [headerEl, setHeaderEl] = useState<HTMLDivElement | null>(null)
 
   if (appType === 'desktop') {
     return null
   }
 
+  let deckLabel = slotId
+  if (HOPPER_FAKE_LOCATIONS.includes(slotId)) {
+    deckLabel = FAKE_HOPPER_LOCATION_MAP[slotId as HopperLocationMapKey]
+  }
+
   return (
     <ModelessModal
       header={
-        <div ref={setHeaderEl} className={styles.header} id={HEADER_ID} />
+        <div className={styles.header} id={HEADER_ID}>
+          <RobotInfoLabel deckLabel={deckLabel} />
+          <StyledText desktopStyle="bodyLargeSemiBold">
+            {t('slot_spotlight')}
+          </StyledText>
+        </div>
       }
       aria-labelledby={HEADER_ID}
       aria-label={t('close_slot_spotlight')}
@@ -64,7 +83,6 @@ export function SlotSpotlightViewer(
         invariantContext={invariantContext}
         analysis={analysis}
         liquids={liquids}
-        headerPortalEl={headerEl}
       />
     </ModelessModal>
   )

--- a/protocol-visualization/src/organisms/SlotSpotlightViewer/slotspotlightviewer.module.css
+++ b/protocol-visualization/src/organisms/SlotSpotlightViewer/slotspotlightviewer.module.css
@@ -2,6 +2,6 @@
   display: flex;
   min-width: 0;
   flex: 1;
-  flex-direction: column;
-  gap: var(--spacing-4);
+  align-items: center;
+  gap: var(--spacing-8);
 }


### PR DESCRIPTION
# Overview
fix spotlight window header issue

### before
<img width="503" height="463" alt="Screenshot 2026-09-11 at 7 58 06 PM" src="https://github.com/user-attachments/assets/8483c3d4-c4f4-43c8-9657-4dce224082c0" />


### after
<img width="504" height="467" alt="Screenshot 2026-09-11 at 7 46 33 PM" src="https://github.com/user-attachments/assets/4a3d9e08-748e-42ff-b89e-0e099d185a6b" />


closes AUTH-3328

## Test Plan and Hands on Testing
- run `js-package-testing`

## Changelog
- update the layout of spotlight window
- define consts to align stack icon position

## Review requests


## Risk assessment
low
