### PR TITLE
fix(protocol-designer): fix remaining selectedLabwareId issue

### DIFF
--- a/protocol-designer/src/labware-ingred/reducers/index.ts
+++ b/protocol-designer/src/labware-ingred/reducers/index.ts
@@ -81,6 +81,12 @@ const selectedContainerId: Reducer<SelectedContainerId, any> = handleActions(
       state,
       action: CloseIngredientSelectorAction
     ): SelectedContainerId => null,
+    DELETE_CONTAINER: (
+      state,
+      action: DeleteContainerAction
+    ): SelectedContainerId =>
+      action.payload.labwareId === state ? null : state,
+    LOAD_FILE: (): SelectedContainerId => null,
   },
   null
 )
@@ -178,7 +184,7 @@ export const containers: Reducer<ContainersState, any> = handleActions(
     ): ContainersState => {
       const { labwareId, name } = action.payload
       // ignore renaming to whitespace
-      return name && name.trim()
+      return name?.trim()
         ? { ...state, [labwareId]: { ...state[labwareId], nickname: name } }
         : state
     },

--- a/protocol-designer/src/top-selectors/well-contents/getWellContentsAllLabware.ts
+++ b/protocol-designer/src/top-selectors/well-contents/getWellContentsAllLabware.ts
@@ -106,7 +106,7 @@ export const getWellContentsForLabwareStack = createSelector(
     highlightedWells
   ): WellContentsByLabware => {
     const selectedLabwareStack = selectedLabwareId
-      ? initialRobotState.labware[selectedLabwareId].stack
+      ? (initialRobotState.labware[selectedLabwareId]?.stack ?? [])
       : []
 
     const allLabwareIds: string[] = selectedLabwareStack ?? []


### PR DESCRIPTION
# Overview

fix remaining selectedLabwareId issue

https://opentrons-76.sentry.io/issues/7709357912/?alert_rule_id=16675182&alert_timestamp=1788433499016&alert_type=email&environment=production&notification_uuid=ec518c1f-e3a9-4361-803a-4afc133e1ebc&project=4510858233315328&referrer=alert_email

closes AUTH-3355



## Test Plan and Hands on Testing
see the above ticket


## Changelog
- add DELETE_CONTAINER and LOAD_FILE to clear id
- add a guard

## Review requests


## Risk assessment
low